### PR TITLE
Harden networking and consensus layers against resource exhaustion an…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,3 +68,6 @@ Three Gradle modules (Java 21):
 
 ## Data sources
 - the only sources for data are devp2p and libp2p calling a local client via http may only be used for debugging purposes it is not an option for production
+
+## Integration-Test
+- When './gradlew :app:run -Pargs=beacon-status' returns "state":"SYNCED" then './gradlew :app:run -Pargs="get-storage 0x1A5F9352Af8aF974bFC03399e3767DF6370d82e4 1 0x308686553a1EAC2fE721Ac8B814De638975a276e"'  and './gradlew  :app:run -Pargs="get-account 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"' should return "verifyMethod":"headerChain"

--- a/app/src/main/java/com/jaeckel/ethp2p/app/CommandHandler.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/CommandHandler.java
@@ -686,8 +686,8 @@ public class CommandHandler {
                                               byte[] beaconStateRoot, byte[] peerStateRoot)
             throws Exception {
         int total = (int) (peerBlock - finalizedBlock + 1);
-        if (total < 2 || total > 16384) {
-            log.info("[verify] Header chain gap {} blocks — out of range [2, 16384]", total);
+        if (total < 2 || total > 32768) {
+            log.info("[verify] Header chain gap {} blocks — out of range [2, 32768]", total);
             return false;
         }
 

--- a/app/src/main/resources/logback.xml
+++ b/app/src/main/resources/logback.xml
@@ -5,6 +5,13 @@
         </encoder>
     </appender>
 
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <file>${user.dir}/devp2p.log</file>
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
     <logger name="com.jaeckel.ethp2p" level="DEBUG"/>
     <logger name="io.netty" level="WARN"/>
     <logger name="org.apache.tuweni" level="WARN"/>
@@ -15,5 +22,6 @@
 
     <root level="INFO">
         <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="FILE"/>
     </root>
 </configuration>

--- a/consensus/build.gradle.kts
+++ b/consensus/build.gradle.kts
@@ -12,3 +12,7 @@ dependencies {
     testImplementation(libs.junit.jupiter)
     testRuntimeOnly(libs.logback.classic)
 }
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
@@ -253,7 +253,7 @@ public class BeaconLightClient implements AutoCloseable {
      * This ensures bootstrap() can prioritize light-client-capable peers.
      */
     private void preConnectAndIdentify() {
-        List<String> peers = List.copyOf(clPeerMultiaddrs);
+        List<String> peers = copyPeers();
         if (peers.isEmpty()) return;
 
         log.info("[beacon] Pre-connecting to {} peer(s) for Identify...", peers.size());
@@ -353,7 +353,7 @@ public class BeaconLightClient implements AutoCloseable {
         // Try HTTP API first — much more reliable than P2P
         if (bootstrapFromBeaconApi()) return;
 
-        List<String> peers = List.copyOf(clPeerMultiaddrs);
+        List<String> peers = copyPeers();
         log.info("[beacon] Attempting parallel bootstrap from {} peer(s)", peers.size());
 
         // Fire bootstrap requests to ALL peers in parallel — first valid response wins.
@@ -403,15 +403,19 @@ public class BeaconLightClient implements AutoCloseable {
 
                             // First valid bootstrap wins — initialize store BEFORE completing
                             // the future so that catchUpSyncCommittee() sees the initialized state.
+                            String successPeer = null;
                             synchronized (store) {
                                 if (!winnerFuture.isDone()) {
                                     store.initialize(bootstrap.header(), bootstrap.currentSyncCommittee());
                                     updateSyncState();
                                     winnerFuture.complete(response);
-                                    notifyPeerSuccess(peer);
+                                    successPeer = peer;
                                     log.info("[beacon] Bootstrap complete from {}, slot={}",
                                             peer, bootstrap.header().beacon().slot());
                                 }
+                            }
+                            if (successPeer != null) {
+                                notifyPeerSuccess(successPeer);
                             }
                         } catch (Exception e) {
                             log.warn("[beacon] Bootstrap decode failed from {}: {}", peer, e.getMessage());
@@ -460,7 +464,7 @@ public class BeaconLightClient implements AutoCloseable {
         log.info("[beacon] Sync committee catch-up: bootstrap period={}, current period={}, fetching {} update(s)",
                 bootstrapPeriod, currentPeriod, periodsToFetch);
 
-        List<String> peers = List.copyOf(clPeerMultiaddrs);
+        List<String> peers = copyPeers();
         for (String peer : peers) {
             if (!running) return;
             try {
@@ -517,7 +521,7 @@ public class BeaconLightClient implements AutoCloseable {
      * This trusts the local beacon node but allows the state root to be used immediately.
      */
     private void seedFromFinalityUpdate() {
-        List<String> peers = List.copyOf(clPeerMultiaddrs);
+        List<String> peers = copyPeers();
         log.info("[beacon] Attempting to seed from finality update ({} peer(s))", peers.size());
 
         // Diagnostic: query first peer's supported protocols via Identify
@@ -684,7 +688,7 @@ public class BeaconLightClient implements AutoCloseable {
             discoverPeersFromBeaconApi();
             if (!syncState.isSynced()) {
                 // First time: disconnect stale peers to force fresh connections
-                for (String peer : List.copyOf(clPeerMultiaddrs)) {
+                for (String peer : copyPeers()) {
                     p2pService.disconnectPeer(peer);
                 }
             }
@@ -704,7 +708,7 @@ public class BeaconLightClient implements AutoCloseable {
             }
         }
 
-        for (String peer : List.copyOf(clPeerMultiaddrs)) {
+        for (String peer : copyPeers()) {
             if (!running) return;
             try {
                 byte[] response = p2pService
@@ -794,7 +798,7 @@ public class BeaconLightClient implements AutoCloseable {
      * @param blsVerified true if the bootstrap was BLS-verified
      */
     private void fillChainStateRootsFromAnyPeer(boolean blsVerified) {
-        for (String peer : List.copyOf(clPeerMultiaddrs)) {
+        for (String peer : copyPeers()) {
             if (!running) return;
             try {
                 fillChainStateRoots(peer, blsVerified);
@@ -903,6 +907,13 @@ public class BeaconLightClient implements AutoCloseable {
 
         } catch (Exception e) {
             log.debug("[beacon] Chain fill failed from {}: {}", peer, e.getMessage());
+        }
+    }
+
+    /** Thread-safe snapshot of the peer list. */
+    private List<String> copyPeers() {
+        synchronized (clPeerMultiaddrs) {
+            return List.copyOf(clPeerMultiaddrs);
         }
     }
 

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/libp2p/BeaconP2PService.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/libp2p/BeaconP2PService.java
@@ -463,7 +463,9 @@ public class BeaconP2PService implements AutoCloseable {
      * Decode a multi-chunk eth2 req/resp response (used by both updates_by_range
      * and blocks_by_range). Each chunk: 1B result + 4B fork_digest + varint(uncompressed_len) + snappy data.
      * The varint is the uncompressed SSZ length, NOT the compressed length.
-     * We scan snappy frames to find chunk boundaries.
+     * We scan snappy frames to find chunk boundaries, using the expected uncompressed
+     * length to resolve ambiguity between snappy compressed frames (type 0x00) and
+     * the next chunk's result code (also 0x00).
      */
     private static List<byte[]> decodeMultiChunkResponse(byte[] raw, long expectedCount)
             throws IOException {
@@ -485,7 +487,7 @@ public class BeaconP2PService implements AutoCloseable {
 
             // Scan snappy frames to find the end of this chunk's compressed data
             int snappyStart = pos;
-            pos = skipSnappyFrames(raw, pos);
+            pos = skipSnappyFrames(raw, pos, uncompressedLength);
             int compressedLength = pos - snappyStart;
             if (compressedLength <= 0) break;
             byte[] compressed = new byte[compressedLength];
@@ -500,9 +502,18 @@ public class BeaconP2PService implements AutoCloseable {
      * - Stream identifier: 0xff + 3-byte LE length (always 6) + "sNaPpY"
      * - Compressed: 0x00 + 3-byte LE length + data
      * - Uncompressed: 0x01 + 3-byte LE length + data
-     * Returns position after the last frame.
+     *
+     * Tracks decompressed output to stop when the expected uncompressed length
+     * is reached, preventing ambiguity between snappy compressed frames (0x00)
+     * and the next response chunk's result code (also 0x00).
+     *
+     * @param data              raw response bytes
+     * @param pos               start position of the snappy stream
+     * @param uncompressedLength expected total decompressed output for this chunk
+     * @return position after the last frame belonging to this chunk
      */
-    private static int skipSnappyFrames(byte[] data, int pos) {
+    private static int skipSnappyFrames(byte[] data, int pos, int uncompressedLength) {
+        int decompressedSoFar = 0;
         while (pos < data.length) {
             int chunkType = data[pos] & 0xFF;
             if (chunkType != 0xFF && chunkType != 0x00 && chunkType != 0x01) {
@@ -513,7 +524,38 @@ public class BeaconP2PService implements AutoCloseable {
             int frameLen = (data[pos + 1] & 0xFF)
                     | ((data[pos + 2] & 0xFF) << 8)
                     | ((data[pos + 3] & 0xFF) << 16);
+            // Bounds check: frame must fit within the data
+            if (pos + 4 + frameLen > data.length) {
+                // Truncated frame — consume remaining data
+                pos = data.length;
+                break;
+            }
+
+            // Track decompressed output to know when this chunk is complete
+            if (chunkType == 0x01 && frameLen > 4) {
+                // Uncompressed frame: 4 bytes CRC32C + raw data
+                decompressedSoFar += frameLen - 4;
+            } else if (chunkType == 0x00 && frameLen > 4) {
+                // Compressed frame: 4 bytes CRC32C + snappy block
+                // Snappy block starts with a varint for uncompressed block length
+                try {
+                    int snappyBlockStart = pos + 4 + 4; // frame header (4) + CRC32C (4)
+                    ReqRespCodec.VarintResult blockSize =
+                            ReqRespCodec.readVarint(data, snappyBlockStart);
+                    decompressedSoFar += blockSize.value();
+                } catch (Exception e) {
+                    // Can't read varint — likely not a real snappy frame
+                    break;
+                }
+            }
+            // 0xFF is stream identifier — contributes 0 decompressed bytes
+
             pos += 4 + frameLen;
+
+            // Stop when we've accounted for all expected decompressed bytes
+            if (decompressedSoFar >= uncompressedLength && uncompressedLength > 0) {
+                break;
+            }
         }
         return pos;
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 tuweni = "2.7.2"
-netty = "4.2.7.Final"
+netty-kotlin = "main-SNAPSHOT"
+#netty = "4.2.7.Final"
 bouncycastle = "1.78.1"
 junit = "5.10.0"
 slf4j = "2.0.12"
@@ -17,9 +18,9 @@ tuweni-merkle-trie  = { module = "io.consensys.tuweni:tuweni-merkle-trie", versi
 tuweni-ssz          = { module = "io.consensys.tuweni:tuweni-ssz",         version.ref = "tuweni" }
 tuweni-units        = { module = "io.consensys.tuweni:tuweni-units",       version.ref = "tuweni" }
 
-netty-transport     = { module = "io.netty:netty-transport",               version.ref = "netty" }
-netty-codec         = { module = "io.netty:netty-codec",                   version.ref = "netty" }
-netty-handler       = { module = "io.netty:netty-handler",                 version.ref = "netty" }
+netty-transport     = { module = "com.github.biafra23:netty-transport",               version.ref = "netty-kotlin" }
+netty-codec         = { module = "com.github.biafra23:inetty-codec",                   version.ref = "netty-kotlin" }
+netty-handler       = { module = "com.github.biafra23:netty-handler",                 version.ref = "netty-kotlin" }
 
 bouncycastle        = { module = "org.bouncycastle:bcprov-jdk18on",        version.ref = "bouncycastle" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ tuweni-ssz          = { module = "io.consensys.tuweni:tuweni-ssz",         versi
 tuweni-units        = { module = "io.consensys.tuweni:tuweni-units",       version.ref = "tuweni" }
 
 netty-transport     = { module = "com.github.biafra23.netty-kotlin:netty-transport",               version.ref = "netty-kotlin" }
-netty-codec         = { module = "com.github.biafra23.netty-kotlin:inetty-codec",                   version.ref = "netty-kotlin" }
+netty-codec         = { module = "com.github.biafra23.netty-kotlin:netty-codec",                   version.ref = "netty-kotlin" }
 netty-handler       = { module = "com.github.biafra23.netty-kotlin:netty-handler",                 version.ref = "netty-kotlin" }
 
 bouncycastle        = { module = "org.bouncycastle:bcprov-jdk18on",        version.ref = "bouncycastle" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 tuweni = "2.7.2"
+#netty-kotlin = "c5a8303903"
 netty-kotlin = "main-SNAPSHOT"
 #netty = "4.2.7.Final"
 bouncycastle = "1.78.1"
@@ -18,9 +19,9 @@ tuweni-merkle-trie  = { module = "io.consensys.tuweni:tuweni-merkle-trie", versi
 tuweni-ssz          = { module = "io.consensys.tuweni:tuweni-ssz",         version.ref = "tuweni" }
 tuweni-units        = { module = "io.consensys.tuweni:tuweni-units",       version.ref = "tuweni" }
 
-netty-transport     = { module = "com.github.biafra23:netty-transport",               version.ref = "netty-kotlin" }
-netty-codec         = { module = "com.github.biafra23:inetty-codec",                   version.ref = "netty-kotlin" }
-netty-handler       = { module = "com.github.biafra23:netty-handler",                 version.ref = "netty-kotlin" }
+netty-transport     = { module = "com.github.biafra23.netty-kotlin:netty-transport",               version.ref = "netty-kotlin" }
+netty-codec         = { module = "com.github.biafra23.netty-kotlin:inetty-codec",                   version.ref = "netty-kotlin" }
+netty-handler       = { module = "com.github.biafra23.netty-kotlin:netty-handler",                 version.ref = "netty-kotlin" }
 
 bouncycastle        = { module = "org.bouncycastle:bcprov-jdk18on",        version.ref = "bouncycastle" }
 

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/discv4/DiscV4Handler.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/discv4/DiscV4Handler.java
@@ -11,9 +11,11 @@ import org.apache.tuweni.crypto.Hash;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 
 /**
@@ -32,6 +34,11 @@ public final class DiscV4Handler extends SimpleChannelInboundHandler<DatagramPac
 
     // Track pending ping → expected pong hash
     private final ConcurrentHashMap<InetSocketAddress, Bytes32> pendingPings = new ConcurrentHashMap<>();
+
+    // Per-IP ping rate limiting: max PING_RATE_LIMIT pings per PING_RATE_WINDOW_MS
+    private static final int PING_RATE_LIMIT = 5;
+    private static final long PING_RATE_WINDOW_MS = 10_000; // 10 seconds
+    private final ConcurrentHashMap<InetAddress, long[]> pingTimestamps = new ConcurrentHashMap<>();
 
     public DiscV4Handler(NodeKey nodeKey, KademliaTable table,
                          Consumer<KademliaTable.Entry> onPeerDiscovered) {
@@ -65,8 +72,40 @@ public final class DiscV4Handler extends SimpleChannelInboundHandler<DatagramPac
         }
     }
 
+    /**
+     * Returns true if the given address has exceeded the ping rate limit.
+     * Uses a sliding-window ring buffer of timestamps per IP.
+     */
+    private boolean isPingRateLimited(InetAddress addr) {
+        long now = System.currentTimeMillis();
+        long[] ring = pingTimestamps.computeIfAbsent(addr, k -> new long[PING_RATE_LIMIT]);
+        synchronized (ring) {
+            // Count recent pings within the window
+            int recent = 0;
+            int oldestIdx = 0;
+            for (int i = 0; i < ring.length; i++) {
+                if (now - ring[i] < PING_RATE_WINDOW_MS) {
+                    recent++;
+                } else if (ring[i] < ring[oldestIdx]) {
+                    oldestIdx = i;
+                }
+            }
+            if (recent >= PING_RATE_LIMIT) {
+                return true; // rate exceeded, don't record
+            }
+            ring[oldestIdx] = now; // record this ping
+            return false;
+        }
+    }
+
     private void handlePing(ChannelHandlerContext ctx, Packet.Parsed p, InetSocketAddress sender) {
         log.debug("[discv4] Ping from {}", sender);
+
+        if (isPingRateLimited(sender.getAddress())) {
+            log.debug("[discv4] Rate-limited ping from {}", sender);
+            return;
+        }
+
         // Respond with Pong
         InetSocketAddress localAddr = (InetSocketAddress) ctx.channel().localAddress();
         Bytes pong = Packet.encodePong(nodeKey, sender, p.hash());

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/discv4/DiscV4Handler.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/discv4/DiscV4Handler.java
@@ -83,9 +83,6 @@ public final class DiscV4Handler extends SimpleChannelInboundHandler<DatagramPac
             sender, tcpPort, nodeId, System.currentTimeMillis());
         table.add(entry);
         onPeerDiscovered.accept(entry);
-        // Send FindNode to get more peers
-        Bytes findNode = Packet.encodeFindNode(nodeKey, nodeKey.publicKeyBytes());
-        sendPacket(ctx, findNode, sender);
     }
 
     private void handlePong(ChannelHandlerContext ctx, Packet.Parsed p, InetSocketAddress sender) {

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/discv4/DiscV4Handler.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/discv4/DiscV4Handler.java
@@ -97,7 +97,7 @@ public final class DiscV4Handler extends SimpleChannelInboundHandler<DatagramPac
             onPeerDiscovered.accept(entry);
             // NOTE: Do NOT send FindNode here. go-ethereum requires "LastPongReceived"
             // from us before answering FindNode. We must first respond to the bootnode's
-            // return Ping (handlePing sends FindNode after the Pong response).
+            // return Ping before initiating any FindNode requests.
         } else {
             log.debug("[discv4] Unsolicited/mismatched pong from {}", sender);
         }

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/EthHandler.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/EthHandler.java
@@ -14,7 +14,10 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -90,9 +93,20 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
 
 
     // Cache received headers so we can serve them back to peers (by block number)
-    private final ConcurrentMap<Long, byte[]> headerCache = new ConcurrentHashMap<>();
+    private static final int MAX_CACHE_ENTRIES = 10_000;
+    private final Map<Long, byte[]> headerCache = Collections.synchronizedMap(
+            new LinkedHashMap<>(16, 0.75f, true) {
+                @Override protected boolean removeEldestEntry(Map.Entry<Long, byte[]> eldest) {
+                    return size() > MAX_CACHE_ENTRIES;
+                }
+            });
     // Cache by block hash hex string for hash-based lookups
-    private final ConcurrentMap<String, byte[]> hashCache = new ConcurrentHashMap<>();
+    private final Map<String, byte[]> hashCache = Collections.synchronizedMap(
+            new LinkedHashMap<>(16, 0.75f, true) {
+                @Override protected boolean removeEldestEntry(Map.Entry<String, byte[]> eldest) {
+                    return size() > MAX_CACHE_ENTRIES;
+                }
+            });
 
     private RLPxHandler rlpxHandler; // reference to the RLPx layer for sending
     private volatile ChannelHandlerContext readyCtx; // stored when state reaches READY
@@ -322,7 +336,7 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
                                 hashHolder[0] = start.toShortHexString();
                                 fullHashHolder[0] = start.toHexString();
                             }
-                            countHolder[0] = r.readInt();
+                            countHolder[0] = Math.min(r.readInt(), 1024);
                             return null;
                         });
                         return null;

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/EthHandler.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/EthHandler.java
@@ -336,7 +336,9 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
                                 hashHolder[0] = start.toShortHexString();
                                 fullHashHolder[0] = start.toHexString();
                             }
-                            countHolder[0] = Math.min(r.readInt(), 1024);
+                            int requestedCount = r.readInt();
+                            requestedCount = Math.max(0, Math.min(requestedCount, 1024));
+                            countHolder[0] = requestedCount;
                             return null;
                         });
                         return null;

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/rlpx/AuthHandshake.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/rlpx/AuthHandshake.java
@@ -36,6 +36,7 @@ import java.security.SecureRandom;
  */
 public final class AuthHandshake {
 
+    private static final SecureRandom RNG = new SecureRandom();
     private static final X9ECParameters CURVE_PARAMS = SECNamedCurves.getByName("secp256k1");
     private static final ECDomainParameters CURVE = new ECDomainParameters(
         CURVE_PARAMS.getCurve(), CURVE_PARAMS.getG(), CURVE_PARAMS.getN(), CURVE_PARAMS.getH());
@@ -96,8 +97,8 @@ public final class AuthHandshake {
 
         // EIP-8: RLP encode the auth body. Random padding goes INSIDE the list
         // as a trailing byte-string element (go-ethereum's rlp:"tail" consumes it).
-        byte[] padding = new byte[100 + new java.security.SecureRandom().nextInt(200)];
-        new java.security.SecureRandom().nextBytes(padding);
+        byte[] padding = new byte[100 + RNG.nextInt(200)];
+        RNG.nextBytes(padding);
         Bytes authBody = org.apache.tuweni.rlp.RLP.encodeList(writer -> {
             writer.writeValue(Bytes.wrap(sigBytes));
             writer.writeValue(Bytes.wrap(pubkeyBytes));
@@ -224,7 +225,7 @@ public final class AuthHandshake {
 
     private static Bytes32 randomBytes32() {
         byte[] b = new byte[32];
-        new SecureRandom().nextBytes(b);
+        RNG.nextBytes(b);
         return Bytes32.wrap(b);
     }
 }

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/rlpx/EciesCodec.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/rlpx/EciesCodec.java
@@ -125,25 +125,9 @@ public final class EciesCodec {
         byte[] macKey = Arrays.copyOfRange(keyMaterial, KEY_SIZE, KEY_SIZE + MAC_KEY_SIZE);
 
         // Verify MAC = HMAC-SHA256(SHA-256(macKey), IV || ciphertext [|| aad])
-        byte[] macInputWithAad = aad.length > 0 ? concat(iv, ciphertext, aad) : concat(iv, ciphertext);
-        byte[] macInputNoAad = concat(iv, ciphertext);
-        byte[] expectedMacWithAad = hmacSha256(sha256(macKey), macInputWithAad);
-        byte[] expectedMacNoAad = hmacSha256(sha256(macKey), macInputNoAad);
-        byte[] expectedMac;
-        if (Arrays.equals(mac, expectedMacWithAad)) {
-            expectedMac = expectedMacWithAad;
-        } else if (Arrays.equals(mac, expectedMacNoAad)) {
-            System.err.println("ECIES DEBUG: MAC matched WITHOUT AAD — test vector does not use auth-size as AAD!");
-            expectedMac = expectedMacNoAad;
-        } else {
-            System.err.printf("ECIES DEBUG: shared=%s%n", bytesToHex(shared));
-            System.err.printf("ECIES DEBUG: keyMat=%s%n", bytesToHex(keyMaterial));
-            System.err.printf("ECIES DEBUG: macKey=%s sha256(macKey)=%s%n",
-                bytesToHex(macKey), bytesToHex(sha256(macKey)));
-            System.err.printf("ECIES DEBUG: iv=%s%n", bytesToHex(iv));
-            System.err.printf("ECIES DEBUG: mac(wire)=%s%n", bytesToHex(mac));
-            System.err.printf("ECIES DEBUG: mac(withAad)=%s%n", bytesToHex(expectedMacWithAad));
-            System.err.printf("ECIES DEBUG: mac(noAad)=%s%n", bytesToHex(expectedMacNoAad));
+        byte[] macInput = aad.length > 0 ? concat(iv, ciphertext, aad) : concat(iv, ciphertext);
+        byte[] expectedMac = hmacSha256(sha256(macKey), macInput);
+        if (!Arrays.equals(mac, expectedMac)) {
             throw new IllegalArgumentException("ECIES MAC verification failed");
         }
 

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/rlpx/EciesCodec.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/rlpx/EciesCodec.java
@@ -76,9 +76,11 @@ public final class EciesCodec {
         RNG.nextBytes(iv);
         byte[] ciphertext = aesCtr(plaintext.toArrayUnsafe(), encKey, iv, true);
 
-        // 5. MAC = HMAC-SHA256(SHA-256(macKey), IV || ciphertext [|| aad (auth-size as S2)])
+        // 5. MAC = HMAC-SHA256(SHA-256(macKey), IV || ciphertext || aad)
         // devp2p spec: d = MAC(sha256(k_M), iv || c || s2)
-        byte[] macInput = aad.length > 0 ? concat(iv, ciphertext, aad) : concat(iv, ciphertext);
+        // Always include aad in MAC input (even if empty) so that messages encrypted
+        // with AAD cannot be verified without it and vice versa.
+        byte[] macInput = concat(iv, ciphertext, aad);
         byte[] mac = hmacSha256(sha256(macKey), macInput);
 
         // 6. Assemble: ephemeral-pubkey(65) || IV(16) || ciphertext || MAC(32)
@@ -124,8 +126,8 @@ public final class EciesCodec {
         byte[] encKey = Arrays.copyOf(keyMaterial, KEY_SIZE);
         byte[] macKey = Arrays.copyOfRange(keyMaterial, KEY_SIZE, KEY_SIZE + MAC_KEY_SIZE);
 
-        // Verify MAC = HMAC-SHA256(SHA-256(macKey), IV || ciphertext [|| aad])
-        byte[] macInput = aad.length > 0 ? concat(iv, ciphertext, aad) : concat(iv, ciphertext);
+        // Verify MAC = HMAC-SHA256(SHA-256(macKey), IV || ciphertext || aad)
+        byte[] macInput = concat(iv, ciphertext, aad);
         byte[] expectedMac = hmacSha256(sha256(macKey), macInput);
         if (!Arrays.equals(mac, expectedMac)) {
             throw new IllegalArgumentException("ECIES MAC verification failed");

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/rlpx/FrameCodec.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/rlpx/FrameCodec.java
@@ -41,6 +41,8 @@ import java.util.Arrays;
  */
 public final class FrameCodec {
 
+    public static final int MAX_FRAME_BODY_SIZE = 10 * 1024 * 1024; // 10 MB
+
     private final StreamCipher encryptCipher;  // AES-256-CTR for outgoing
     private final StreamCipher decryptCipher;  // AES-256-CTR for incoming
 
@@ -149,7 +151,11 @@ public final class FrameCodec {
         // Decrypt header
         byte[] header = new byte[16];
         decryptCipher.processBytes(encHeader, 0, 16, header, 0);
-        return ((header[0] & 0xFF) << 16) | ((header[1] & 0xFF) << 8) | (header[2] & 0xFF);
+        int bodyLen = ((header[0] & 0xFF) << 16) | ((header[1] & 0xFF) << 8) | (header[2] & 0xFF);
+        if (bodyLen > MAX_FRAME_BODY_SIZE) {
+            throw new IllegalStateException("Frame body size " + bodyLen + " exceeds maximum " + MAX_FRAME_BODY_SIZE);
+        }
+        return bodyLen;
     }
 
     /** Decode frame body: verifies MAC, returns decoded message. */

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/rlpx/FrameCodec.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/rlpx/FrameCodec.java
@@ -153,7 +153,7 @@ public final class FrameCodec {
         decryptCipher.processBytes(encHeader, 0, 16, header, 0);
         int bodyLen = ((header[0] & 0xFF) << 16) | ((header[1] & 0xFF) << 8) | (header[2] & 0xFF);
         if (bodyLen > MAX_FRAME_BODY_SIZE) {
-            throw new IllegalStateException("Frame body size " + bodyLen + " exceeds maximum " + MAX_FRAME_BODY_SIZE);
+            throw new IllegalArgumentException("Frame body size " + bodyLen + " exceeds maximum " + MAX_FRAME_BODY_SIZE);
         }
         return bodyLen;
     }

--- a/networking/src/test/java/com/jaeckel/ethp2p/networking/rlpx/EciesDecryptTest.java
+++ b/networking/src/test/java/com/jaeckel/ethp2p/networking/rlpx/EciesDecryptTest.java
@@ -79,6 +79,26 @@ class EciesDecryptTest {
     }
 
     @Test
+    void decryptWithWrongAadFails() {
+        SECP256K1.KeyPair recipient = SECP256K1.KeyPair.random();
+        Bytes pt = Bytes.wrap("Secret message".getBytes());
+
+        // Encrypt WITH AAD
+        byte[] aad = new byte[]{0x01, (byte) 0xB3};
+        Bytes encrypted = EciesCodec.encrypt(pt, recipient.publicKey(), aad);
+
+        // Decrypt with WRONG AAD must fail
+        byte[] wrongAad = new byte[]{0x02, (byte) 0x00};
+        assertThrows(IllegalArgumentException.class,
+            () -> EciesCodec.decrypt(encrypted, recipient.secretKey(), wrongAad),
+            "Decrypting with wrong AAD must fail MAC verification");
+
+        // Decrypt with correct AAD must succeed
+        Bytes decrypted = EciesCodec.decrypt(encrypted, recipient.secretKey(), aad);
+        assertEquals(pt, decrypted);
+    }
+
+    @Test
     void decryptAuth1Legacy() {
         // Auth₁ is legacy format: no size prefix, just raw ECIES blob starting with 0x04
         SECP256K1.SecretKey privB = SECP256K1.SecretKey.fromBytes(Bytes32.fromHexString(STATIC_B));

--- a/networking/src/test/java/com/jaeckel/ethp2p/networking/rlpx/FrameCodecTest.java
+++ b/networking/src/test/java/com/jaeckel/ethp2p/networking/rlpx/FrameCodecTest.java
@@ -1,0 +1,123 @@
+package com.jaeckel.ethp2p.networking.rlpx;
+
+import com.jaeckel.ethp2p.core.crypto.NodeKey;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.crypto.SECP256K1;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.security.Security;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link FrameCodec}, focusing on frame-level guardrails.
+ */
+class FrameCodecTest {
+
+    @BeforeAll
+    static void setup() {
+        if (Security.getProvider("BC") == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+    }
+
+    /**
+     * Verify that decodeHeader rejects frames whose body length exceeds MAX_FRAME_BODY_SIZE.
+     * This guards against resource exhaustion from oversized frame bodies.
+     */
+    @Test
+    void decodeHeader_rejectsOversizedFrameBody() {
+        // Set up a valid codec pair via a random handshake
+        FrameCodec[] codecs = createCodecPair();
+        FrameCodec initiatorCodec = codecs[0];
+        FrameCodec responderCodec = codecs[1];
+
+        // Encode a frame with body size = MAX_FRAME_BODY_SIZE (payload that, with the
+        // 1-byte RLP message code prefix, produces bodyLen = MAX_FRAME_BODY_SIZE + 1).
+        // Using messageCode 0x00 (Hello) to skip Snappy compression.
+        byte[] oversizedPayload = new byte[FrameCodec.MAX_FRAME_BODY_SIZE];
+        byte[] encodedFrame = initiatorCodec.encodeFrame(0x00, oversizedPayload);
+
+        // Extract header and header MAC
+        byte[] encHeader = Arrays.copyOfRange(encodedFrame, 0, 16);
+        byte[] headerMac = Arrays.copyOfRange(encodedFrame, 16, 32);
+
+        // decodeHeader must throw because bodyLen (MAX_FRAME_BODY_SIZE + 1) exceeds the limit
+        IllegalStateException ex = assertThrows(IllegalStateException.class,
+            () -> responderCodec.decodeHeader(encHeader, headerMac));
+        assertTrue(ex.getMessage().contains("exceeds maximum"),
+            "Exception message should mention the size limit, got: " + ex.getMessage());
+    }
+
+    /**
+     * Verify that decodeHeader accepts frames at exactly MAX_FRAME_BODY_SIZE.
+     */
+    @Test
+    void decodeHeader_acceptsFrameAtMaxSize() {
+        FrameCodec[] codecs = createCodecPair();
+        FrameCodec initiatorCodec = codecs[0];
+        FrameCodec responderCodec = codecs[1];
+
+        // bodyLen = rlpCode(1) + payload.length = 1 + (MAX - 1) = MAX → exactly at limit
+        byte[] maxPayload = new byte[FrameCodec.MAX_FRAME_BODY_SIZE - 1];
+        byte[] encodedFrame = initiatorCodec.encodeFrame(0x00, maxPayload);
+
+        byte[] encHeader = Arrays.copyOfRange(encodedFrame, 0, 16);
+        byte[] headerMac = Arrays.copyOfRange(encodedFrame, 16, 32);
+
+        int bodyLen = assertDoesNotThrow(
+            () -> responderCodec.decodeHeader(encHeader, headerMac),
+            "Frame at exactly MAX_FRAME_BODY_SIZE should be accepted");
+        assertEquals(FrameCodec.MAX_FRAME_BODY_SIZE, bodyLen);
+    }
+
+    /**
+     * Creates a matched initiator/responder FrameCodec pair using a random handshake.
+     */
+    private FrameCodec[] createCodecPair() {
+        NodeKey aNodeKey = NodeKey.generate();
+        SECP256K1.KeyPair bStaticKP = SECP256K1.KeyPair.random();
+        SECP256K1.KeyPair bEphKP = SECP256K1.KeyPair.random();
+        Bytes32 bNonce = randomBytes32();
+
+        AuthHandshake initiator = new AuthHandshake(aNodeKey, bStaticKP.publicKey());
+        Bytes authWire = initiator.buildAuthMessage();
+        byte[] authWireBytes = authWire.toArrayUnsafe();
+
+        Bytes ackBody = org.apache.tuweni.rlp.RLP.encodeList(w -> {
+            w.writeValue(bEphKP.publicKey().bytes());
+            w.writeValue(bNonce);
+            w.writeInt(4);
+        });
+        int ackEncBodySize = ackBody.size() + 65 + 16 + 32;
+        byte[] ackSizeBytes = {(byte) (ackEncBodySize >> 8), (byte) (ackEncBodySize & 0xFF)};
+        Bytes ackEncBody = EciesCodec.encrypt(ackBody, aNodeKey.publicKey(), ackSizeBytes);
+        byte[] ackWire = Bytes.concatenate(Bytes.wrap(ackSizeBytes), ackEncBody).toArrayUnsafe();
+
+        initiator.processAck(ackEncBody, ackSizeBytes, ackWire);
+        SessionSecrets secrets = initiator.secrets();
+
+        FrameCodec initiatorCodec = new FrameCodec(secrets);
+        SessionSecrets responderSecrets = new SessionSecrets(
+            secrets.aesSecret(),
+            secrets.macSecret(),
+            bNonce,
+            secrets.egressNonce(),
+            ackWire,
+            authWireBytes
+        );
+        FrameCodec responderCodec = new FrameCodec(responderSecrets);
+
+        return new FrameCodec[]{initiatorCodec, responderCodec};
+    }
+
+    private static Bytes32 randomBytes32() {
+        byte[] b = new byte[32];
+        new java.security.SecureRandom().nextBytes(b);
+        return Bytes32.wrap(b);
+    }
+}

--- a/networking/src/test/java/com/jaeckel/ethp2p/networking/rlpx/FrameCodecTest.java
+++ b/networking/src/test/java/com/jaeckel/ethp2p/networking/rlpx/FrameCodecTest.java
@@ -47,7 +47,7 @@ class FrameCodecTest {
         byte[] headerMac = Arrays.copyOfRange(encodedFrame, 16, 32);
 
         // decodeHeader must throw because bodyLen (MAX_FRAME_BODY_SIZE + 1) exceeds the limit
-        IllegalStateException ex = assertThrows(IllegalStateException.class,
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
             () -> responderCodec.decodeHeader(encHeader, headerMac));
         assertTrue(ex.getMessage().contains("exceeds maximum"),
             "Exception message should mention the size limit, got: " + ex.getMessage());

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,6 +11,7 @@ dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         mavenCentral()
+        maven { url = uri("https://jitpack.io'") }
         maven {
             name = "ConsenSys"
             url = uri("https://artifacts.consensys.net/public/maven/maven/")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,7 +11,7 @@ dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         mavenCentral()
-        maven { url = uri("https://jitpack.io'") }
+        maven { url = uri("https://jitpack.io") }
         maven {
             name = "ConsenSys"
             url = uri("https://artifacts.consensys.net/public/maven/maven/")


### PR DESCRIPTION
…d concurrency issues

- BeaconLightClient: fix race condition on peer list access by synchronizing copies via copyPeers(); move notifyPeerSuccess() outside synchronized(store) block to avoid potential deadlock
- EthHandler: replace unbounded ConcurrentHashMap header caches with LRU caches (max 10k entries); cap GetBlockHeaders request count to 1024
- FrameCodec: reject frames exceeding 10 MB to prevent memory exhaustion
- AuthHandshake: reuse single static SecureRandom instance instead of allocating per call
- EciesCodec: remove debug logging fallback in MAC verification; simplify to single strict check
- DiscV4Handler: remove unsolicited FindNode send from Neighbors handler