### PR TITLE
Add EIP-1459 DNS-based bootnode discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,9 +406,20 @@ DiscV4Service (UDP)
           --> block headers, account/storage queries available
 ```
 
+### Peer seeding
+
+Both discv4 (EL) and libp2p (CL) get their initial peer lists from three sources, merged at startup:
+
+1. **Hardcoded fallback** in `NetworkConfig` — a handful of IPv4 bootnodes and CL multiaddrs that ship with the binary.
+2. **On-disk cache** (`PeerCache`, `CLPeerCache`) — peers that responded successfully on a prior run, loaded from `~/.ethp2p/*-peers.cache`.
+3. **EIP-1459 DNS-based ENR trees** — each network can list `enrtree://<base32-pubkey>@<domain>` URLs in `NetworkConfig.elEnrTreeUrls` / `clEnrTreeUrls`. At startup the daemon walks each tree over DNS TXT records, verifies the root record's secp256k1 signature against the embedded pubkey, and decodes the leaf ENRs. Results are merged into the EL bootnode list and the CL peer list. Mainnet currently pins the Ethereum Foundation canonical tree (`all.mainnet.ethdisco.net`); the resolver is implemented in `networking/dns/DnsEnrResolver`.
+
+DNS resolution is best-effort: on timeout, missing TXT records, or signature mismatch the daemon logs a warning and starts up with whatever the hardcoded + cached sources provide. Per-tree deadline defaults to 10 s.
+
 ### Key dependencies
 
 - **Tuweni 2.7.2** -- RLP encoding, SECP256K1, byte utilities
 - **Netty 4.2.x (modified)** -- NIO transport. Uses a modified Netty archive based on 4.2 that has been rewritten in Kotlin. This is a proof-of-concept for migrating the Java codebase to Kotlin to enable use in a Compose Multiplatform project
 - **BouncyCastle** -- SECP256K1 crypto provider
 - **jvm-libp2p** -- beacon chain P2P networking (consensus module)
+- **dnsjava 3.6** -- TXT-record resolution for EIP-1459 ENR tree walks

--- a/app/src/main/java/com/jaeckel/ethp2p/app/Main.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/Main.java
@@ -197,13 +197,23 @@ public final class Main {
         List<Enr> dnsClEnrs = clFuture.join();
 
         List<InetSocketAddress> mergedBootnodes = new ArrayList<>(network.bootnodes());
+        // Dedupe by (host, port) so trees that overlap with the hardcoded list
+        // (or contain internal duplicates) don't produce repeated dial attempts.
+        Set<String> seenHostPort = new java.util.HashSet<>();
+        for (InetSocketAddress sa : mergedBootnodes) {
+            seenHostPort.add(sa.getAddress().getHostAddress() + ":" + sa.getPort());
+        }
+        int bootnodesBeforeDns = mergedBootnodes.size();
         for (Enr enr : dnsElEnrs) {
             // discv4 speaks UDP; fall back to the TCP endpoint only if UDP is missing.
-            enr.udpAddress().or(enr::tcpAddress).ifPresent(mergedBootnodes::add);
+            enr.udpAddress().or(enr::tcpAddress).ifPresent(sa -> {
+                String key = sa.getAddress().getHostAddress() + ":" + sa.getPort();
+                if (seenHostPort.add(key)) mergedBootnodes.add(sa);
+            });
         }
-        if (!dnsElEnrs.isEmpty()) {
+        if (mergedBootnodes.size() > bootnodesBeforeDns) {
             log.info("[main] DNS discovery added {} EL bootnode(s) (total: {})",
-                    mergedBootnodes.size() - network.bootnodes().size(), mergedBootnodes.size());
+                    mergedBootnodes.size() - bootnodesBeforeDns, mergedBootnodes.size());
         }
 
         // 4. RLPx connector

--- a/app/src/main/java/com/jaeckel/ethp2p/app/Main.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/Main.java
@@ -3,10 +3,12 @@ package com.jaeckel.ethp2p.app;
 import com.jaeckel.ethp2p.consensus.BeaconLightClient;
 import com.jaeckel.ethp2p.consensus.BeaconSyncState;
 import com.jaeckel.ethp2p.core.crypto.NodeKey;
+import com.jaeckel.ethp2p.core.enr.Enr;
 import com.jaeckel.ethp2p.core.types.BlockHeader;
 import com.jaeckel.ethp2p.networking.NetworkConfig;
 import com.jaeckel.ethp2p.networking.discv4.DiscV4Service;
 import com.jaeckel.ethp2p.networking.discv4.KademliaTable;
+import com.jaeckel.ethp2p.networking.dns.DnsEnrResolver;
 import com.jaeckel.ethp2p.networking.eth.messages.BlockHeadersMessage;
 import com.jaeckel.ethp2p.networking.rlpx.RLPxConnector;
 import org.apache.tuweni.bytes.Bytes;
@@ -24,6 +26,7 @@ import java.nio.channels.SocketChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -177,6 +180,27 @@ public final class Main {
         // 3. Peer cache
         PeerCache peerCache = new PeerCache(cacheFile(network.name()));
 
+        // 3a. EIP-1459 DNS-based peer discovery. Best-effort: on any failure (timeout,
+        // missing TXT, bad signature) the resolver returns an empty list and we fall
+        // through to the hardcoded + cached peers. Resolved separately per layer so
+        // EL-tree entries only feed discv4 bootnodes and CL-tree entries only feed
+        // the libp2p peer list.
+        DnsEnrResolver dnsResolver = new DnsEnrResolver();
+        List<Enr> dnsElEnrs = dnsResolver.resolveAllFromStrings(
+                network.elEnrTreeUrls(), Duration.ofSeconds(10));
+        List<Enr> dnsClEnrs = dnsResolver.resolveAllFromStrings(
+                network.clEnrTreeUrls(), Duration.ofSeconds(10));
+
+        List<InetSocketAddress> mergedBootnodes = new ArrayList<>(network.bootnodes());
+        for (Enr enr : dnsElEnrs) {
+            // discv4 speaks UDP; fall back to the TCP endpoint only if UDP is missing.
+            enr.udpAddress().or(enr::tcpAddress).ifPresent(mergedBootnodes::add);
+        }
+        if (!dnsElEnrs.isEmpty()) {
+            log.info("[main] DNS discovery added {} EL bootnode(s) (total: {})",
+                    mergedBootnodes.size() - network.bootnodes().size(), mergedBootnodes.size());
+        }
+
         // 4. RLPx connector
         Set<String> attempted = ConcurrentHashMap.newKeySet();
         Map<String, Long> backoff = new ConcurrentHashMap<>();
@@ -231,7 +255,7 @@ public final class Main {
         }
 
         // 6. discv4 discovery
-        DiscV4Service discV4 = new DiscV4Service(nodeKey, network.bootnodes(), entry -> {
+        DiscV4Service discV4 = new DiscV4Service(nodeKey, mergedBootnodes, entry -> {
             if (entry.tcpPort() > 0 && attempted.size() < 2000) {
                 String nodeIdHex = entry.nodeId().toHexString();
                 if (blacklistedNodeIds.contains(nodeIdHex)) {
@@ -278,6 +302,18 @@ public final class Main {
         // Append configured peers after cached ones (cached peers are tried first)
         for (String peer : network.clPeerMultiaddrs()) {
             if (!clPeers.contains(peer)) clPeers.add(peer);
+        }
+        // Append DNS-discovered CL peers (from enrtree:// resolution above). Deduped
+        // against cached + configured entries.
+        int clPeersBeforeDns = clPeers.size();
+        for (Enr enr : dnsClEnrs) {
+            enr.toLibp2pMultiaddr().ifPresent(ma -> {
+                if (!clPeers.contains(ma)) clPeers.add(ma);
+            });
+        }
+        if (clPeers.size() > clPeersBeforeDns) {
+            log.info("[main] DNS discovery added {} CL peer(s) (total: {})",
+                    clPeers.size() - clPeersBeforeDns, clPeers.size());
         }
         BeaconLightClient beaconLightClient = new BeaconLightClient(
                 clPeers,

--- a/app/src/main/java/com/jaeckel/ethp2p/app/Main.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/Main.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 
@@ -182,14 +183,18 @@ public final class Main {
 
         // 3a. EIP-1459 DNS-based peer discovery. Best-effort: on any failure (timeout,
         // missing TXT, bad signature) the resolver returns an empty list and we fall
-        // through to the hardcoded + cached peers. Resolved separately per layer so
-        // EL-tree entries only feed discv4 bootnodes and CL-tree entries only feed
-        // the libp2p peer list.
+        // through to the hardcoded + cached peers. Run EL and CL resolution concurrently
+        // on virtual threads so total startup cost is max(elTimeout, clTimeout), not
+        // sum. Layers stay separated so EL-tree entries only feed discv4 bootnodes and
+        // CL-tree entries only feed the libp2p peer list.
         DnsEnrResolver dnsResolver = new DnsEnrResolver();
-        List<Enr> dnsElEnrs = dnsResolver.resolveAllFromStrings(
-                network.elEnrTreeUrls(), Duration.ofSeconds(10));
-        List<Enr> dnsClEnrs = dnsResolver.resolveAllFromStrings(
-                network.clEnrTreeUrls(), Duration.ofSeconds(10));
+        Duration dnsDeadline = Duration.ofSeconds(10);
+        CompletableFuture<List<Enr>> elFuture = CompletableFuture.supplyAsync(
+                () -> dnsResolver.resolveAllFromStrings(network.elEnrTreeUrls(), dnsDeadline));
+        CompletableFuture<List<Enr>> clFuture = CompletableFuture.supplyAsync(
+                () -> dnsResolver.resolveAllFromStrings(network.clEnrTreeUrls(), dnsDeadline));
+        List<Enr> dnsElEnrs = elFuture.join();
+        List<Enr> dnsClEnrs = clFuture.join();
 
         List<InetSocketAddress> mergedBootnodes = new ArrayList<>(network.bootnodes());
         for (Enr enr : dnsElEnrs) {

--- a/core/src/main/java/com/jaeckel/ethp2p/core/enr/Enr.java
+++ b/core/src/main/java/com/jaeckel/ethp2p/core/enr/Enr.java
@@ -53,11 +53,17 @@ public final class Enr {
             reader.skipNext(); // signature
             // Second element: sequence number
             seqHolder[0] = reader.readLong();
-            // Remaining: key-value pairs
+            // Remaining: key-value pairs. Most pairs are (string, bytes) — e.g. ip, tcp,
+            // secp256k1 — but modern ENRs carry list-valued pairs too (eth2, attnets,
+            // syncnets, …). Preserve simple bytes values for the fields we consume and
+            // skip list values we don't model.
             while (!reader.isComplete()) {
                 String key = reader.readString();
-                Bytes value = reader.readValue();
-                pairs.put(key, value);
+                if (reader.nextIsList()) {
+                    reader.skipNext();
+                } else {
+                    pairs.put(key, reader.readValue());
+                }
             }
             return null;
         });

--- a/core/src/test/java/com/jaeckel/ethp2p/core/enr/EnrTest.java
+++ b/core/src/test/java/com/jaeckel/ethp2p/core/enr/EnrTest.java
@@ -60,6 +60,40 @@ class EnrTest {
     }
 
     @Test
+    void tolerateListValuedPairs() {
+        // Build a synthetic ENR with an "eth2"-style list-valued pair. A naive decoder
+        // that only handles byte values would throw on the list; ours should skip the
+        // list value and still recover the flat fields (ip, tcp, secp256k1).
+        org.apache.tuweni.bytes.Bytes ip = org.apache.tuweni.bytes.Bytes.fromHexString("03932500"); // 3.147.37.0
+        org.apache.tuweni.bytes.Bytes tcp = org.apache.tuweni.bytes.Bytes.fromHexString("2328");     // 9000
+        org.apache.tuweni.bytes.Bytes key = org.apache.tuweni.bytes.Bytes.fromHexString(
+                "02197590fab436299291f568e5b82253c306463855c3a61c60f69c4acad1429180");                    // 33B compressed
+
+        org.apache.tuweni.bytes.Bytes rlp = org.apache.tuweni.rlp.RLP.encodeList(w -> {
+            w.writeValue(org.apache.tuweni.bytes.Bytes.wrap(new byte[0])); // empty signature
+            w.writeLong(0);                                                // seq
+            // eth2 value as a nested list — what would've blown up the old decoder
+            w.writeString("eth2");
+            w.writeList(inner -> {
+                inner.writeValue(org.apache.tuweni.bytes.Bytes.fromHexString("deadbeef"));
+                inner.writeLong(42);
+            });
+            w.writeString("ip");
+            w.writeValue(ip);
+            w.writeString("secp256k1");
+            w.writeValue(key);
+            w.writeString("tcp");
+            w.writeValue(tcp);
+        });
+
+        Enr enr = Enr.decode(rlp);
+        assertTrue(enr.tcpAddress().isPresent());
+        assertEquals(9000, enr.tcpAddress().get().getPort());
+        assertEquals("3.147.37.0", enr.tcpAddress().get().getAddress().getHostAddress());
+        assertTrue(enr.compressedSecp256k1().isPresent());
+    }
+
+    @Test
     void enrWithoutTcpReturnsEmptyMultiaddr() {
         // ENR that only has UDP (no "tcp" key) should return empty
         // Use an ENR string where tcp is missing — we simulate by checking the last ENR

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ snappy = "1.1.10.7"
 milagro = "0.4.0"
 jvm-libp2p = "1.2.2-RELEASE"
 trueblocks-kotlin = "main-SNAPSHOT"
+dnsjava = "3.6.2"
 
 [libraries]
 tuweni-bytes        = { module = "io.consensys.tuweni:tuweni-bytes",       version.ref = "tuweni" }
@@ -37,3 +38,4 @@ junit-jupiter       = { module = "org.junit.jupiter:junit-jupiter" }
 milagro             = { module = "org.miracl.milagro.amcl:milagro-crypto-java", version.ref = "milagro" }
 jvm-libp2p          = { module = "io.libp2p:jvm-libp2p",                   version.ref = "jvm-libp2p" }
 trueblocks-kotlin   = { module = "com.github.biafra23:trueblocks-kotlin", version.ref = "trueblocks-kotlin" }
+dnsjava             = { module = "dnsjava:dnsjava",                       version.ref = "dnsjava" }

--- a/networking/build.gradle.kts
+++ b/networking/build.gradle.kts
@@ -9,8 +9,16 @@ dependencies {
     implementation(libs.bouncycastle)
     implementation(libs.snappy)
     implementation(libs.slf4j.api)
+    implementation(libs.dnsjava)
 
     testImplementation(platform(libs.junit.bom))
     testImplementation(libs.junit.jupiter)
     testRuntimeOnly(libs.logback.classic)
+}
+
+tasks.register<JavaExec>("dnsSmoke") {
+    group = "verification"
+    description = "Live DNS smoke test against the Ethereum Foundation EL tree"
+    classpath = sourceSets["test"].runtimeClasspath
+    mainClass = "com.jaeckel.ethp2p.networking.dns.DnsSmokeTest"
 }

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/NetworkConfig.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/NetworkConfig.java
@@ -27,7 +27,9 @@ public record NetworkConfig(
         byte[] currentForkVersion,      // 4 bytes: current fork version for signing domain
         List<String> clPeerMultiaddrs,  // libp2p multiaddrs of known CL peers
         String beaconApiUrl,            // HTTP API URL for local beacon node (e.g. http://172.17.0.1:5052)
-        long clGenesisTime              // beacon chain genesis time (seconds since epoch) for wall-clock period estimation
+        long clGenesisTime,             // beacon chain genesis time (seconds since epoch) for wall-clock period estimation
+        List<String> elEnrTreeUrls,     // EIP-1459 enrtree:// URLs for execution-layer discv4 peers
+        List<String> clEnrTreeUrls      // EIP-1459 enrtree:// URLs for consensus-layer libp2p peers
 ) {
 
     // -------------------------------------------------------------------------
@@ -103,7 +105,13 @@ public record NetworkConfig(
                     "/ip4/16.63.94.117/tcp/9000/p2p/16Uiu2HAmSd7qzG5joNgvEYYcgVvg1y9MiYjpMHMvzRzaWYqXxkCM"
             ),
             "http://localhost:5052",
-            1606824023L // mainnet beacon genesis: 2020-12-01 12:00:23 UTC
+            1606824023L, // mainnet beacon genesis: 2020-12-01 12:00:23 UTC
+            // EIP-1459 ENR tree URLs — DNS-seeded discv4 bootnodes (EL) and libp2p peers (CL).
+            // EL: Ethereum Foundation canonical tree used by all EL clients.
+            List.of("enrtree://AKA3AM6LPBYEUDMVNU3BSVQJ5AD45Y7YPOHJLEF6W26QOE4VTUDPE@all.mainnet.ethdisco.net"),
+            // CL: no canonical single tree; each CL client team (Lighthouse, Lodestar, Nimbus, Teku)
+            // publishes their own. Empty for now — add entries once a tree URL is pinned and verified.
+            List.of()
     );
 
     public static final NetworkConfig SEPOLIA = new NetworkConfig(
@@ -131,7 +139,9 @@ public record NetworkConfig(
                     "/ip4/18.185.193.198/tcp/9000/p2p/16Uiu2HAm3mfkjmLPtqnSJzNtKxbDuVjVRXidz5UinaZNpjCCKAkS"
             ),
             null,
-            1655733600L // sepolia beacon genesis: 2022-06-20 14:00:00 UTC
+            1655733600L, // sepolia beacon genesis: 2022-06-20 14:00:00 UTC
+            List.of(), // EL ENR trees — not pinned
+            List.of()  // CL ENR trees — not pinned
     );
 
     public static final NetworkConfig HOLESKY = new NetworkConfig(
@@ -156,7 +166,9 @@ public record NetworkConfig(
                     "/ip4/159.69.35.70/tcp/9000/p2p/16Uiu2HAmFMfXsymWEK6BFPQNPW3nPz57uB3TKpVNFDmeoW7WXNUA"
             ),
             null,
-            1695902400L // holesky beacon genesis: 2023-09-28 12:00:00 UTC
+            1695902400L, // holesky beacon genesis: 2023-09-28 12:00:00 UTC
+            List.of(), // EL ENR trees — not pinned
+            List.of()  // CL ENR trees — not pinned
     );
 
     // Frontier (genesis) fork IDs — CRC32(genesis_hash), forkNext = first fork block

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/dns/DnsEnrResolver.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/dns/DnsEnrResolver.java
@@ -1,0 +1,277 @@
+package com.jaeckel.ethp2p.networking.dns;
+
+import com.jaeckel.ethp2p.core.enr.Enr;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.crypto.Hash;
+import org.apache.tuweni.crypto.SECP256K1;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xbill.DNS.Lookup;
+import org.xbill.DNS.Record;
+import org.xbill.DNS.TXTRecord;
+import org.xbill.DNS.Type;
+
+import java.math.BigInteger;
+import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * EIP-1459 DNS ENR tree resolver.
+ *
+ * <p>Walks an {@code enrtree://} tree anchored at a DNS domain, verifies the
+ * root TXT record against the tree operator's secp256k1 public key, and returns
+ * the list of ENRs at the leaves. Failures are logged and do not propagate —
+ * the resolver returns whatever it successfully resolved.
+ *
+ * <p>Only the ENR subtree ({@code e=}) is walked; the link subtree ({@code l=})
+ * is ignored because this client doesn't chase cross-tree links.
+ */
+public final class DnsEnrResolver {
+
+    private static final Logger log = LoggerFactory.getLogger(DnsEnrResolver.class);
+
+    private static final String ROOT_PREFIX = "enrtree-root:v1 ";
+    private static final String BRANCH_PREFIX = "enrtree-branch:";
+    private static final String LEAF_PREFIX = "enr:";
+
+    /** Maximum total TXT lookups (branch + leaf) per tree. Caps DNS traffic even when
+     *  a tree is large or malformed. 512 comfortably covers dev/seed needs. */
+    static final int DEFAULT_MAX_NODES = 512;
+    /** Maximum branch depth to walk. */
+    static final int DEFAULT_MAX_DEPTH = 16;
+
+    private final TxtResolver txtResolver;
+    private final int maxNodes;
+    private final int maxDepth;
+
+    public DnsEnrResolver() {
+        this(DnsEnrResolver::defaultTxtLookup, DEFAULT_MAX_NODES, DEFAULT_MAX_DEPTH);
+    }
+
+    /** Package-private for tests. */
+    DnsEnrResolver(TxtResolver resolver, int maxNodes, int maxDepth) {
+        this.txtResolver = resolver;
+        this.maxNodes = maxNodes;
+        this.maxDepth = maxDepth;
+    }
+
+    /** Resolve every tree URL in parallel and concatenate successful ENR lists. */
+    public List<Enr> resolveAll(List<EnrTreeUrl> urls, Duration timeout) {
+        if (urls == null || urls.isEmpty()) return List.of();
+        long start = System.nanoTime();
+        long deadline = start + timeout.toNanos();
+        List<Enr> all = java.util.Collections.synchronizedList(new ArrayList<>());
+
+        // Each resolve() call respects the deadline and returns partial results, so
+        // the ExecutorService's close() (which waits on submitted tasks) is bounded
+        // by the per-tree walk rather than the timeout we're trying to enforce here.
+        try (ExecutorService exec = Executors.newVirtualThreadPerTaskExecutor()) {
+            for (EnrTreeUrl url : urls) {
+                exec.submit(() -> {
+                    try {
+                        all.addAll(resolve(url, deadline));
+                    } catch (Exception e) {
+                        log.warn("[dns] {} failed: {}", url.domain(), e.getMessage());
+                    }
+                });
+            }
+        }
+        log.info("[dns] resolved {} ENR(s) from {} tree(s) in {} ms",
+                all.size(), urls.size(), (System.nanoTime() - start) / 1_000_000);
+        return new ArrayList<>(all);
+    }
+
+    /** Resolve a single tree with no deadline. Throws on hard failures. */
+    public List<Enr> resolve(EnrTreeUrl url) throws Exception {
+        return resolve(url, Long.MAX_VALUE);
+    }
+
+    /**
+     * Resolve a single tree, returning partial results if {@code deadlineNanos} expires.
+     * Throws only if the root record is missing or its signature doesn't verify — any
+     * subtree fetch failure is logged and the walk continues with remaining nodes.
+     */
+    public List<Enr> resolve(EnrTreeUrl url, long deadlineNanos) throws Exception {
+        String rootTxt = txtResolver.lookup(url.domain());
+        Root root = parseAndVerifyRoot(rootTxt, url.publicKey());
+
+        List<Enr> enrs = new ArrayList<>();
+        Set<String> visited = new HashSet<>();
+        Deque<HashNode> queue = new ArrayDeque<>();
+        queue.push(new HashNode(root.eRoot, 0));
+        int fetches = 0;
+
+        while (!queue.isEmpty()) {
+            if (System.nanoTime() > deadlineNanos) {
+                log.info("[dns] {} deadline reached after {} lookups, {} ENRs collected",
+                        url.domain(), fetches, enrs.size());
+                break;
+            }
+            if (fetches >= maxNodes) {
+                log.warn("[dns] {} hit maxNodes={} cap after collecting {} ENRs", url.domain(), maxNodes, enrs.size());
+                break;
+            }
+            HashNode node = queue.pop();
+            if (!visited.add(node.hash)) continue;
+            if (node.depth > maxDepth) continue;
+
+            fetches++;
+            String txt;
+            try {
+                txt = txtResolver.lookup(node.hash + "." + url.domain());
+            } catch (Exception e) {
+                log.warn("[dns] subnode {}.{} failed: {}", node.hash, url.domain(), e.getMessage());
+                continue;
+            }
+            if (txt.startsWith(BRANCH_PREFIX)) {
+                String list = txt.substring(BRANCH_PREFIX.length());
+                for (String child : list.split(",")) {
+                    child = child.trim();
+                    if (!child.isEmpty()) queue.push(new HashNode(child, node.depth + 1));
+                }
+            } else if (txt.startsWith(LEAF_PREFIX)) {
+                try {
+                    enrs.add(Enr.fromEnrString(txt));
+                } catch (Exception e) {
+                    log.debug("[dns] skipping invalid ENR at {}: {}", node.hash, e.getMessage());
+                }
+            } else {
+                log.warn("[dns] unexpected record at {}.{}: {}", node.hash, url.domain(),
+                        truncate(txt, 60));
+            }
+        }
+        return enrs;
+    }
+
+    // ---- root record parse + signature verify ----
+
+    record Root(String eRoot, String lRoot, long seq) {}
+
+    private record HashNode(String hash, int depth) {}
+
+    /**
+     * Verify the root-record ECDSA signature against the tree's expected pubkey,
+     * then return the parsed fields.
+     *
+     * <p>Per EIP-1459 §3, the signed message is the record string minus the
+     * trailing {@code " sig=<base64>"} segment; the signature is 65 bytes
+     * {@code r||s||v} base64url-no-padding, over {@code keccak256(message)}.
+     */
+    static Root parseAndVerifyRoot(String txt, SECP256K1.PublicKey expected) {
+        if (txt == null || !txt.startsWith(ROOT_PREFIX)) {
+            throw new IllegalArgumentException("not an enrtree-root:v1 record: " + truncate(txt, 60));
+        }
+        int sigIdx = txt.lastIndexOf(" sig=");
+        if (sigIdx < 0) {
+            throw new IllegalArgumentException("root record missing sig= field");
+        }
+        String signed = txt.substring(0, sigIdx);
+        String sigB64 = txt.substring(sigIdx + " sig=".length()).trim();
+
+        // Parse k=v tokens of the signed portion.
+        String body = signed.substring(ROOT_PREFIX.length());
+        String eRoot = null, lRoot = null;
+        long seq = -1;
+        for (String tok : body.split(" ")) {
+            if (tok.isEmpty()) continue;
+            int eq = tok.indexOf('=');
+            if (eq < 0) continue;
+            String k = tok.substring(0, eq);
+            String v = tok.substring(eq + 1);
+            switch (k) {
+                case "e" -> eRoot = v;
+                case "l" -> lRoot = v;
+                case "seq" -> seq = Long.parseLong(v);
+                default -> { /* ignore unknown */ }
+            }
+        }
+        if (eRoot == null || lRoot == null || seq < 0) {
+            throw new IllegalArgumentException("root missing e/l/seq: " + truncate(signed, 80));
+        }
+
+        byte[] sigBytes = Base64.getUrlDecoder().decode(padBase64(sigB64));
+        if (sigBytes.length != 65) {
+            throw new IllegalArgumentException("expected 65-byte signature, got " + sigBytes.length);
+        }
+        Bytes32 hash = Hash.keccak256(Bytes.wrap(signed.getBytes()));
+        BigInteger r = new BigInteger(1, java.util.Arrays.copyOfRange(sigBytes, 0, 32));
+        BigInteger s = new BigInteger(1, java.util.Arrays.copyOfRange(sigBytes, 32, 64));
+        byte v = sigBytes[64];
+        SECP256K1.Signature sig = SECP256K1.Signature.create(v, r, s);
+
+        SECP256K1.PublicKey recovered = SECP256K1.PublicKey.recoverFromHashAndSignature(hash, sig);
+        if (recovered == null || !recovered.equals(expected)) {
+            throw new IllegalStateException("root signature does not match tree public key");
+        }
+        return new Root(eRoot, lRoot, seq);
+    }
+
+    // ---- dnsjava lookup ----
+
+    /** Abstraction so tests can inject a fake TXT resolver. */
+    @FunctionalInterface
+    interface TxtResolver {
+        String lookup(String name) throws Exception;
+    }
+
+    private static String defaultTxtLookup(String name) throws Exception {
+        Lookup lookup = new Lookup(name, Type.TXT);
+        Record[] records = lookup.run();
+        if (lookup.getResult() != Lookup.SUCCESSFUL || records == null || records.length == 0) {
+            throw new IllegalStateException(
+                    "TXT lookup failed for " + name + ": " + lookup.getErrorString());
+        }
+        // Each TXTRecord may contain multiple string segments; EIP-1459 records may
+        // also be split across multiple TXT RRs for the same name when they exceed
+        // 255 chars. Concatenate all segments of all matching records.
+        StringBuilder sb = new StringBuilder();
+        for (Record r : records) {
+            if (!(r instanceof TXTRecord txt)) continue;
+            for (Object seg : txt.getStrings()) sb.append(seg);
+        }
+        return sb.toString();
+    }
+
+    // ---- small utilities ----
+
+    private static String padBase64(String s) {
+        int rem = s.length() % 4;
+        if (rem == 0) return s;
+        return s + "====".substring(rem);
+    }
+
+    private static String truncate(String s, int n) {
+        if (s == null) return "null";
+        return s.length() <= n ? s : s.substring(0, n) + "...";
+    }
+
+    /**
+     * Convenience: take tree URLs as strings, parse each, resolve all in parallel,
+     * return the combined ENR list. Logs and skips unparseable URLs.
+     */
+    public List<Enr> resolveAllFromStrings(List<String> urlStrings, Duration timeout) {
+        if (urlStrings == null || urlStrings.isEmpty()) return Collections.emptyList();
+        List<EnrTreeUrl> parsed = new ArrayList<>(urlStrings.size());
+        for (String s : urlStrings) {
+            try {
+                parsed.add(EnrTreeUrl.parse(s));
+            } catch (Exception e) {
+                log.warn("[dns] invalid enrtree URL '{}': {}", s, e.getMessage());
+            }
+        }
+        return resolveAll(parsed, timeout);
+    }
+}

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/dns/DnsEnrResolver.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/dns/DnsEnrResolver.java
@@ -22,12 +22,9 @@ import java.util.Collections;
 import java.util.Deque;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 
 /**
  * EIP-1459 DNS ENR tree resolver.
@@ -228,30 +225,38 @@ public final class DnsEnrResolver {
         String lookup(String name) throws Exception;
     }
 
+    /** Per-DNS-query timeout. Caps blocking on a single unresponsive nameserver so
+     *  the overall deadline in {@link #resolveAll} can actually fire. */
+    private static final Duration LOOKUP_TIMEOUT = Duration.ofSeconds(3);
+
     private static String defaultTxtLookup(String name) throws Exception {
         Lookup lookup = new Lookup(name, Type.TXT);
+        org.xbill.DNS.SimpleResolver resolver = new org.xbill.DNS.SimpleResolver();
+        resolver.setTimeout(LOOKUP_TIMEOUT);
+        lookup.setResolver(resolver);
         Record[] records = lookup.run();
         if (lookup.getResult() != Lookup.SUCCESSFUL || records == null || records.length == 0) {
             throw new IllegalStateException(
                     "TXT lookup failed for " + name + ": " + lookup.getErrorString());
         }
-        // EIP-1459 §3: a single record may be split into multiple 255-char segments
-        // that MUST be concatenated in wire order. Multiple TXT RRs at the same name
-        // are not contemplated by the spec in practice, but resolvers can return
-        // them in non-deterministic order — sort by RR content so the output is
-        // stable regardless of DNS packet ordering. Segment order within each RR
-        // is preserved.
-        List<String> perRecord = new ArrayList<>();
+        // EIP-1459 treats a single TXT RR (possibly split into multiple 255-char
+        // segments) as the authoritative record. Multiple TXT RRs at the same name
+        // would represent distinct values, and concatenating across them would
+        // corrupt the record and break signature verification. If the resolver
+        // returns more than one, log and use the first.
+        List<TXTRecord> txts = new ArrayList<>();
         for (Record r : records) {
-            if (!(r instanceof TXTRecord txt)) continue;
-            StringBuilder sb = new StringBuilder();
-            for (Object seg : txt.getStrings()) sb.append(seg);
-            perRecord.add(sb.toString());
+            if (r instanceof TXTRecord txt) txts.add(txt);
         }
-        if (perRecord.size() > 1) {
-            java.util.Collections.sort(perRecord);
+        if (txts.isEmpty()) {
+            throw new IllegalStateException("no TXT records for " + name);
         }
-        return String.join("", perRecord);
+        if (txts.size() > 1) {
+            log.warn("[dns] {} returned {} TXT records; using the first", name, txts.size());
+        }
+        StringBuilder sb = new StringBuilder();
+        for (Object seg : txts.get(0).getStrings()) sb.append(seg);
+        return sb.toString();
     }
 
     // ---- small utilities ----

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/dns/DnsEnrResolver.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/dns/DnsEnrResolver.java
@@ -13,6 +13,7 @@ import org.xbill.DNS.TXTRecord;
 import org.xbill.DNS.Type;
 
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -206,7 +207,7 @@ public final class DnsEnrResolver {
         if (sigBytes.length != 65) {
             throw new IllegalArgumentException("expected 65-byte signature, got " + sigBytes.length);
         }
-        Bytes32 hash = Hash.keccak256(Bytes.wrap(signed.getBytes()));
+        Bytes32 hash = Hash.keccak256(Bytes.wrap(signed.getBytes(StandardCharsets.UTF_8)));
         BigInteger r = new BigInteger(1, java.util.Arrays.copyOfRange(sigBytes, 0, 32));
         BigInteger s = new BigInteger(1, java.util.Arrays.copyOfRange(sigBytes, 32, 64));
         byte v = sigBytes[64];
@@ -234,15 +235,23 @@ public final class DnsEnrResolver {
             throw new IllegalStateException(
                     "TXT lookup failed for " + name + ": " + lookup.getErrorString());
         }
-        // Each TXTRecord may contain multiple string segments; EIP-1459 records may
-        // also be split across multiple TXT RRs for the same name when they exceed
-        // 255 chars. Concatenate all segments of all matching records.
-        StringBuilder sb = new StringBuilder();
+        // EIP-1459 §3: a single record may be split into multiple 255-char segments
+        // that MUST be concatenated in wire order. Multiple TXT RRs at the same name
+        // are not contemplated by the spec in practice, but resolvers can return
+        // them in non-deterministic order — sort by RR content so the output is
+        // stable regardless of DNS packet ordering. Segment order within each RR
+        // is preserved.
+        List<String> perRecord = new ArrayList<>();
         for (Record r : records) {
             if (!(r instanceof TXTRecord txt)) continue;
+            StringBuilder sb = new StringBuilder();
             for (Object seg : txt.getStrings()) sb.append(seg);
+            perRecord.add(sb.toString());
         }
-        return sb.toString();
+        if (perRecord.size() > 1) {
+            java.util.Collections.sort(perRecord);
+        }
+        return String.join("", perRecord);
     }
 
     // ---- small utilities ----

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/dns/EnrTreeUrl.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/dns/EnrTreeUrl.java
@@ -84,6 +84,9 @@ public final class EnrTreeUrl {
             if (bits >= 8) {
                 bits -= 8;
                 out.write((buffer >> bits) & 0xFF);
+                // Mask off the bits we just emitted; keeps `buffer` from overflowing
+                // a 32-bit int on long inputs.
+                buffer &= (1 << bits) - 1;
             }
         }
         return out.toByteArray();

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/dns/EnrTreeUrl.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/dns/EnrTreeUrl.java
@@ -1,0 +1,107 @@
+package com.jaeckel.ethp2p.networking.dns;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.crypto.SECP256K1;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * EIP-1459 ENR tree URL: {@code enrtree://<base32-pubkey>@<domain>}.
+ *
+ * <p>The base32-encoded public key is the 33-byte compressed secp256k1 key for
+ * the tree's operator. The DNS tree rooted at {@code <domain>} is authoritative
+ * iff its root TXT record's signature recovers to this key.
+ */
+public final class EnrTreeUrl {
+
+    private static final String PREFIX = "enrtree://";
+
+    private final SECP256K1.PublicKey publicKey;
+    private final String domain;
+
+    public EnrTreeUrl(SECP256K1.PublicKey publicKey, String domain) {
+        this.publicKey = Objects.requireNonNull(publicKey);
+        this.domain = Objects.requireNonNull(domain);
+    }
+
+    public static EnrTreeUrl parse(String url) {
+        if (url == null || !url.startsWith(PREFIX)) {
+            throw new IllegalArgumentException("expected enrtree:// URL, got: " + url);
+        }
+        String rest = url.substring(PREFIX.length());
+        int at = rest.indexOf('@');
+        if (at <= 0 || at == rest.length() - 1) {
+            throw new IllegalArgumentException("missing '@' or empty part in: " + url);
+        }
+        String base32Key = rest.substring(0, at);
+        String domain = rest.substring(at + 1);
+
+        byte[] compressed = base32Decode(base32Key);
+        if (compressed.length != 33) {
+            throw new IllegalArgumentException(
+                    "expected 33-byte compressed secp256k1 key, got " + compressed.length + " bytes");
+        }
+        SECP256K1.PublicKey pubkey = decompressSecp256k1(compressed);
+        return new EnrTreeUrl(pubkey, domain);
+    }
+
+    public SECP256K1.PublicKey publicKey() {
+        return publicKey;
+    }
+
+    public String domain() {
+        return domain;
+    }
+
+    @Override
+    public String toString() {
+        return "EnrTreeUrl{domain=" + domain + "}";
+    }
+
+    // ---- helpers ----
+
+    /**
+     * RFC 4648 base32 decoder, case-insensitive, accepts '=' padding or no padding.
+     */
+    static byte[] base32Decode(String s) {
+        if (s == null) throw new IllegalArgumentException("null input");
+        String up = s.toUpperCase(Locale.ROOT);
+        int end = up.indexOf('=');
+        if (end >= 0) up = up.substring(0, end);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        int buffer = 0, bits = 0;
+        for (int i = 0; i < up.length(); i++) {
+            char c = up.charAt(i);
+            int val;
+            if (c >= 'A' && c <= 'Z') val = c - 'A';
+            else if (c >= '2' && c <= '7') val = 26 + (c - '2');
+            else throw new IllegalArgumentException("invalid base32 character: " + c);
+            buffer = (buffer << 5) | val;
+            bits += 5;
+            if (bits >= 8) {
+                bits -= 8;
+                out.write((buffer >> bits) & 0xFF);
+            }
+        }
+        return out.toByteArray();
+    }
+
+    /**
+     * Decompress a 33-byte compressed secp256k1 point into a {@link SECP256K1.PublicKey}.
+     * Mirrors the decompression pattern used by {@code Enr.publicKey()}.
+     */
+    static SECP256K1.PublicKey decompressSecp256k1(byte[] compressed) {
+        try {
+            org.bouncycastle.asn1.x9.X9ECParameters curve =
+                    org.bouncycastle.asn1.sec.SECNamedCurves.getByName("secp256k1");
+            org.bouncycastle.math.ec.ECPoint point = curve.getCurve().decodePoint(compressed);
+            byte[] encoded = point.getEncoded(false); // 0x04 || x || y
+            return SECP256K1.PublicKey.fromBytes(Bytes.wrap(encoded, 1, 64));
+        } catch (Exception e) {
+            throw new IllegalArgumentException("invalid compressed secp256k1 point", e);
+        }
+    }
+}

--- a/networking/src/test/java/com/jaeckel/ethp2p/networking/dns/DnsEnrResolverSigTest.java
+++ b/networking/src/test/java/com/jaeckel/ethp2p/networking/dns/DnsEnrResolverSigTest.java
@@ -8,6 +8,7 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.security.Security;
 import java.util.Base64;
 
@@ -32,7 +33,7 @@ class DnsEnrResolverSigTest {
 
     private static String buildSignedRoot(SECP256K1.KeyPair keyPair, String eHash, String lHash, long seq) {
         String signed = "enrtree-root:v1 e=" + eHash + " l=" + lHash + " seq=" + seq;
-        Bytes32 hash = Hash.keccak256(Bytes.wrap(signed.getBytes()));
+        Bytes32 hash = Hash.keccak256(Bytes.wrap(signed.getBytes(StandardCharsets.UTF_8)));
         SECP256K1.Signature sig = SECP256K1.signHashed(hash, keyPair);
         byte[] r = padTo32(sig.r().toByteArray());
         byte[] s = padTo32(sig.s().toByteArray());

--- a/networking/src/test/java/com/jaeckel/ethp2p/networking/dns/DnsEnrResolverSigTest.java
+++ b/networking/src/test/java/com/jaeckel/ethp2p/networking/dns/DnsEnrResolverSigTest.java
@@ -1,0 +1,106 @@
+package com.jaeckel.ethp2p.networking.dns;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.crypto.Hash;
+import org.apache.tuweni.crypto.SECP256K1;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.security.Security;
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Hermetic tests for the root-record signature verifier. Generates a fresh
+ * keypair, signs a fabricated root record in-test, and asserts that
+ * {@link DnsEnrResolver#parseAndVerifyRoot(String, SECP256K1.PublicKey)}
+ * accepts the exact bytes and rejects single-bit flips or the wrong signer.
+ */
+class DnsEnrResolverSigTest {
+
+    @BeforeAll
+    static void setup() {
+        if (Security.getProvider("BC") == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+    }
+
+    private static String buildSignedRoot(SECP256K1.KeyPair keyPair, String eHash, String lHash, long seq) {
+        String signed = "enrtree-root:v1 e=" + eHash + " l=" + lHash + " seq=" + seq;
+        Bytes32 hash = Hash.keccak256(Bytes.wrap(signed.getBytes()));
+        SECP256K1.Signature sig = SECP256K1.signHashed(hash, keyPair);
+        byte[] r = padTo32(sig.r().toByteArray());
+        byte[] s = padTo32(sig.s().toByteArray());
+        byte[] sigBytes = new byte[65];
+        System.arraycopy(r, 0, sigBytes, 0, 32);
+        System.arraycopy(s, 0, sigBytes, 32, 32);
+        sigBytes[64] = (byte) sig.v();
+        String sigB64 = Base64.getUrlEncoder().withoutPadding().encodeToString(sigBytes);
+        return signed + " sig=" + sigB64;
+    }
+
+    private static byte[] padTo32(byte[] in) {
+        if (in.length == 32) return in;
+        byte[] out = new byte[32];
+        // BigInteger.toByteArray may emit a leading 0x00 or be shorter than 32 bytes
+        int src = in.length > 32 ? in.length - 32 : 0;
+        int dst = 32 - (in.length - src);
+        System.arraycopy(in, src, out, dst, in.length - src);
+        return out;
+    }
+
+    @Test
+    void acceptsValidRoot() {
+        SECP256K1.KeyPair kp = SECP256K1.KeyPair.random();
+        String root = buildSignedRoot(kp,
+                "JWXYDBZXG3IZNBHNJKAPP7QPQEBA", "FDXN3SN67NA5PPNEKTH6OC6OM4", 42L);
+        assertDoesNotThrow(() -> DnsEnrResolver.parseAndVerifyRoot(root, kp.publicKey()));
+    }
+
+    @Test
+    void rejectsFlippedSignatureByte() {
+        SECP256K1.KeyPair kp = SECP256K1.KeyPair.random();
+        String root = buildSignedRoot(kp,
+                "JWXYDBZXG3IZNBHNJKAPP7QPQEBA", "FDXN3SN67NA5PPNEKTH6OC6OM4", 1L);
+        // Flip a byte inside the base64 signature field
+        int sigIdx = root.indexOf(" sig=") + " sig=".length();
+        char orig = root.charAt(sigIdx);
+        char flipped = (orig == 'A') ? 'B' : 'A';
+        String tampered = root.substring(0, sigIdx) + flipped + root.substring(sigIdx + 1);
+        Throwable t = assertThrows(RuntimeException.class,
+                () -> DnsEnrResolver.parseAndVerifyRoot(tampered, kp.publicKey()));
+        assertTrue(
+                t instanceof IllegalStateException || t instanceof IllegalArgumentException,
+                "expected verification failure, got: " + t);
+    }
+
+    @Test
+    void rejectsWrongSigner() {
+        SECP256K1.KeyPair signer = SECP256K1.KeyPair.random();
+        SECP256K1.KeyPair wrongExpected = SECP256K1.KeyPair.random();
+        String root = buildSignedRoot(signer,
+                "JWXYDBZXG3IZNBHNJKAPP7QPQEBA", "FDXN3SN67NA5PPNEKTH6OC6OM4", 1L);
+        assertThrows(IllegalStateException.class,
+                () -> DnsEnrResolver.parseAndVerifyRoot(root, wrongExpected.publicKey()));
+    }
+
+    @Test
+    void rejectsMissingSigField() {
+        SECP256K1.KeyPair kp = SECP256K1.KeyPair.random();
+        assertThrows(IllegalArgumentException.class,
+                () -> DnsEnrResolver.parseAndVerifyRoot(
+                        "enrtree-root:v1 e=AAAA l=BBBB seq=1", kp.publicKey()));
+    }
+
+    @Test
+    void rejectsNonRootPrefix() {
+        SECP256K1.KeyPair kp = SECP256K1.KeyPair.random();
+        assertThrows(IllegalArgumentException.class,
+                () -> DnsEnrResolver.parseAndVerifyRoot("enr:foo sig=bar", kp.publicKey()));
+    }
+}

--- a/networking/src/test/java/com/jaeckel/ethp2p/networking/dns/DnsEnrResolverTreeTest.java
+++ b/networking/src/test/java/com/jaeckel/ethp2p/networking/dns/DnsEnrResolverTreeTest.java
@@ -9,6 +9,7 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.security.Security;
 import java.util.Base64;
 import java.util.HashMap;
@@ -39,7 +40,7 @@ class DnsEnrResolverTreeTest {
 
     private static String signRoot(SECP256K1.KeyPair kp, String e, String l, long seq) {
         String signed = "enrtree-root:v1 e=" + e + " l=" + l + " seq=" + seq;
-        Bytes32 hash = Hash.keccak256(Bytes.wrap(signed.getBytes()));
+        Bytes32 hash = Hash.keccak256(Bytes.wrap(signed.getBytes(StandardCharsets.UTF_8)));
         SECP256K1.Signature sig = SECP256K1.signHashed(hash, kp);
         byte[] r = padTo32(sig.r().toByteArray());
         byte[] s = padTo32(sig.s().toByteArray());

--- a/networking/src/test/java/com/jaeckel/ethp2p/networking/dns/DnsEnrResolverTreeTest.java
+++ b/networking/src/test/java/com/jaeckel/ethp2p/networking/dns/DnsEnrResolverTreeTest.java
@@ -1,0 +1,145 @@
+package com.jaeckel.ethp2p.networking.dns;
+
+import com.jaeckel.ethp2p.core.enr.Enr;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.crypto.Hash;
+import org.apache.tuweni.crypto.SECP256K1;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.security.Security;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests the tree walk with an in-memory {@link DnsEnrResolver.TxtResolver} that
+ * serves a small fabricated tree: signed root → branch → two ENR leaves. Verifies
+ * the walk decodes both leaves, dedupes when a branch references the same hash
+ * twice, and respects the depth cap.
+ */
+class DnsEnrResolverTreeTest {
+
+    @BeforeAll
+    static void setup() {
+        if (Security.getProvider("BC") == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+    }
+
+    /** Lighthouse mainnet ENR — reused for fixture leaves; content doesn't matter for the walk. */
+    private static final String LEAF_ENR =
+            "enr:-Iu4QLm7bZGdAt9NSeJG0cEnJohWcQTQaI9wFLu3Q7eHIDfrI4cwtzvEW3F3VbG9XdFXlrHyFGeXPn9snTCQJ9bnMRABgmlkgnY0gmlwhAOTJQCJc2VjcDI1NmsxoQIZdZD6tDYpkpEfVo5bgiU8MGRjhcOmHGD2nErK0UKRrIN0Y3CCIyiDdWRwgiMo";
+
+    private static String signRoot(SECP256K1.KeyPair kp, String e, String l, long seq) {
+        String signed = "enrtree-root:v1 e=" + e + " l=" + l + " seq=" + seq;
+        Bytes32 hash = Hash.keccak256(Bytes.wrap(signed.getBytes()));
+        SECP256K1.Signature sig = SECP256K1.signHashed(hash, kp);
+        byte[] r = padTo32(sig.r().toByteArray());
+        byte[] s = padTo32(sig.s().toByteArray());
+        byte[] sigBytes = new byte[65];
+        System.arraycopy(r, 0, sigBytes, 0, 32);
+        System.arraycopy(s, 0, sigBytes, 32, 32);
+        sigBytes[64] = (byte) sig.v();
+        return signed + " sig=" + Base64.getUrlEncoder().withoutPadding().encodeToString(sigBytes);
+    }
+
+    private static byte[] padTo32(byte[] in) {
+        if (in.length == 32) return in;
+        byte[] out = new byte[32];
+        int src = in.length > 32 ? in.length - 32 : 0;
+        int dst = 32 - (in.length - src);
+        System.arraycopy(in, src, out, dst, in.length - src);
+        return out;
+    }
+
+    @Test
+    void walksBranchAndDecodesTwoLeaves() throws Exception {
+        String domain = "tree.example";
+        SECP256K1.KeyPair kp = SECP256K1.KeyPair.random();
+
+        String branchHash = "BRANCH1";
+        String leafHash1 = "LEAF1";
+        String leafHash2 = "LEAF2";
+
+        Map<String, String> records = new HashMap<>();
+        records.put(domain, signRoot(kp, branchHash, "LINK", 1L));
+        records.put(branchHash + "." + domain, "enrtree-branch:" + leafHash1 + "," + leafHash2);
+        records.put(leafHash1 + "." + domain, LEAF_ENR);
+        records.put(leafHash2 + "." + domain, LEAF_ENR);
+
+        DnsEnrResolver.TxtResolver fake = name -> {
+            String v = records.get(name);
+            if (v == null) throw new IllegalStateException("no record for " + name);
+            return v;
+        };
+
+        DnsEnrResolver resolver = new DnsEnrResolver(fake, 100, 8);
+        EnrTreeUrl url = new EnrTreeUrl(kp.publicKey(), domain);
+
+        List<Enr> result = resolver.resolve(url);
+        assertEquals(2, result.size(), "expected two leaves");
+        for (Enr enr : result) {
+            assertTrue(enr.tcpAddress().isPresent(), "each leaf should decode to an address-bearing ENR");
+        }
+    }
+
+    @Test
+    void dedupesRepeatedChildHash() throws Exception {
+        String domain = "dup.example";
+        SECP256K1.KeyPair kp = SECP256K1.KeyPair.random();
+
+        String branchHash = "BR";
+        String leafHash = "L1";
+
+        Map<String, String> records = new HashMap<>();
+        records.put(domain, signRoot(kp, branchHash, "LINK", 1L));
+        // Branch lists the same leaf twice — should still be visited once.
+        records.put(branchHash + "." + domain, "enrtree-branch:" + leafHash + "," + leafHash);
+        records.put(leafHash + "." + domain, LEAF_ENR);
+
+        DnsEnrResolver.TxtResolver fake = name -> {
+            String v = records.get(name);
+            if (v == null) throw new IllegalStateException("no record for " + name);
+            return v;
+        };
+
+        DnsEnrResolver resolver = new DnsEnrResolver(fake, 100, 8);
+        EnrTreeUrl url = new EnrTreeUrl(kp.publicKey(), domain);
+
+        List<Enr> result = resolver.resolve(url);
+        assertEquals(1, result.size(), "duplicate child hash should be visited once");
+    }
+
+    @Test
+    void respectsDepthCap() throws Exception {
+        String domain = "deep.example";
+        SECP256K1.KeyPair kp = SECP256K1.KeyPair.random();
+
+        Map<String, String> records = new HashMap<>();
+        // Root → B1 → B2 → B3 → L1. With maxDepth=2 we should stop before reaching L1.
+        records.put(domain, signRoot(kp, "B1", "LINK", 1L));
+        records.put("B1." + domain, "enrtree-branch:B2");
+        records.put("B2." + domain, "enrtree-branch:B3");
+        records.put("B3." + domain, "enrtree-branch:L1");
+        records.put("L1." + domain, LEAF_ENR);
+
+        DnsEnrResolver.TxtResolver fake = name -> {
+            String v = records.get(name);
+            if (v == null) throw new IllegalStateException("no record for " + name);
+            return v;
+        };
+
+        DnsEnrResolver resolver = new DnsEnrResolver(fake, 100, 2);
+        EnrTreeUrl url = new EnrTreeUrl(kp.publicKey(), domain);
+
+        List<Enr> result = resolver.resolve(url);
+        assertEquals(0, result.size(), "depth cap should prevent reaching any leaves");
+    }
+}

--- a/networking/src/test/java/com/jaeckel/ethp2p/networking/dns/DnsSmokeTest.java
+++ b/networking/src/test/java/com/jaeckel/ethp2p/networking/dns/DnsSmokeTest.java
@@ -1,0 +1,29 @@
+package com.jaeckel.ethp2p.networking.dns;
+
+import com.jaeckel.ethp2p.core.enr.Enr;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+
+import java.security.Security;
+import java.time.Duration;
+import java.util.List;
+
+public class DnsSmokeTest {
+    public static void main(String[] args) {
+        Security.addProvider(new BouncyCastleProvider());
+        String treeUrl = "enrtree://AKA3AM6LPBYEUDMVNU3BSVQJ5AD45Y7YPOHJLEF6W26QOE4VTUDPE@all.mainnet.ethdisco.net";
+        long t0 = System.currentTimeMillis();
+        List<Enr> enrs = new DnsEnrResolver().resolveAllFromStrings(List.of(treeUrl), Duration.ofSeconds(15));
+        long t = System.currentTimeMillis() - t0;
+        System.out.println("Resolved " + enrs.size() + " ENRs in " + t + "ms");
+        int withTcp = 0, withMa = 0;
+        for (Enr e : enrs) {
+            if (e.tcpAddress().isPresent()) withTcp++;
+            if (e.toLibp2pMultiaddr().isPresent()) withMa++;
+        }
+        System.out.println("  with tcpAddress: " + withTcp);
+        System.out.println("  with libp2pMultiaddr: " + withMa);
+        if (!enrs.isEmpty()) {
+            System.out.println("Sample: " + enrs.get(0));
+        }
+    }
+}

--- a/networking/src/test/java/com/jaeckel/ethp2p/networking/dns/EnrTreeUrlTest.java
+++ b/networking/src/test/java/com/jaeckel/ethp2p/networking/dns/EnrTreeUrlTest.java
@@ -1,0 +1,64 @@
+package com.jaeckel.ethp2p.networking.dns;
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.security.Security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class EnrTreeUrlTest {
+
+    @BeforeAll
+    static void setup() {
+        if (Security.getProvider("BC") == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+    }
+
+    /** Ethereum Foundation canonical mainnet EL tree. */
+    private static final String MAINNET_EL =
+            "enrtree://AKA3AM6LPBYEUDMVNU3BSVQJ5AD45Y7YPOHJLEF6W26QOE4VTUDPE@all.mainnet.ethdisco.net";
+
+    @Test
+    void parsesCanonicalMainnetTree() {
+        EnrTreeUrl url = EnrTreeUrl.parse(MAINNET_EL);
+        assertEquals("all.mainnet.ethdisco.net", url.domain());
+        // pubkey decoded successfully (33-byte compressed → 64-byte uncompressed SECP256K1 point)
+        assertEquals(64, url.publicKey().bytes().size());
+    }
+
+    @Test
+    void rejectsMissingScheme() {
+        assertThrows(IllegalArgumentException.class,
+                () -> EnrTreeUrl.parse("AKA3@example.com"));
+    }
+
+    @Test
+    void rejectsMissingAt() {
+        assertThrows(IllegalArgumentException.class,
+                () -> EnrTreeUrl.parse("enrtree://AKA3EXAMPLE.COM"));
+    }
+
+    @Test
+    void rejectsEmptyDomain() {
+        assertThrows(IllegalArgumentException.class,
+                () -> EnrTreeUrl.parse("enrtree://AKA3@"));
+    }
+
+    @Test
+    void rejectsShortKey() {
+        // Valid base32 but decodes to fewer than 33 bytes
+        assertThrows(IllegalArgumentException.class,
+                () -> EnrTreeUrl.parse("enrtree://AAAAAA@example.com"));
+    }
+
+    @Test
+    void base32DecodesKnownValue() {
+        // RFC 4648 test vector: "foobar" → "MZXW6YTBOI======" (16 chars unpadded)
+        byte[] decoded = EnrTreeUrl.base32Decode("MZXW6YTBOI");
+        assertEquals("foobar", new String(decoded));
+    }
+}

--- a/networking/src/test/java/com/jaeckel/ethp2p/networking/dns/EnrTreeUrlTest.java
+++ b/networking/src/test/java/com/jaeckel/ethp2p/networking/dns/EnrTreeUrlTest.java
@@ -8,6 +8,7 @@ import java.security.Security;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class EnrTreeUrlTest {
 
@@ -60,5 +61,30 @@ class EnrTreeUrlTest {
         // RFC 4648 test vector: "foobar" → "MZXW6YTBOI======" (16 chars unpadded)
         byte[] decoded = EnrTreeUrl.base32Decode("MZXW6YTBOI");
         assertEquals("foobar", new String(decoded));
+    }
+
+    @Test
+    void base32DecodesFullRfc4648Vectors() {
+        // Cover the full RFC 4648 §10 test vector set to catch overflow in the 5-bit
+        // accumulator when inputs exceed what fits in an int without masking.
+        assertEquals("",        new String(EnrTreeUrl.base32Decode("")));
+        assertEquals("f",       new String(EnrTreeUrl.base32Decode("MY")));
+        assertEquals("fo",      new String(EnrTreeUrl.base32Decode("MZXQ")));
+        assertEquals("foo",     new String(EnrTreeUrl.base32Decode("MZXW6")));
+        assertEquals("foob",    new String(EnrTreeUrl.base32Decode("MZXW6YQ")));
+        assertEquals("fooba",   new String(EnrTreeUrl.base32Decode("MZXW6YTB")));
+        assertEquals("foobar",  new String(EnrTreeUrl.base32Decode("MZXW6YTBOI")));
+    }
+
+    @Test
+    void base32DecodesLongInput() {
+        // 53-char input (the canonical mainnet tree pubkey) must decode to 33 bytes.
+        // This would fail quietly if the 5-bit accumulator was not masked on emit.
+        byte[] decoded = EnrTreeUrl.base32Decode("AKA3AM6LPBYEUDMVNU3BSVQJ5AD45Y7YPOHJLEF6W26QOE4VTUDPE");
+        assertEquals(33, decoded.length);
+        // Compressed secp256k1 points start with 0x02 or 0x03.
+        assertTrue((decoded[0] & 0xFF) == 0x02 || (decoded[0] & 0xFF) == 0x03,
+                "first byte of decoded pubkey should be 0x02 or 0x03; got 0x"
+                        + Integer.toHexString(decoded[0] & 0xFF));
     }
 }


### PR DESCRIPTION
## Summary

Adds EIP-1459 DNS-based peer discovery to augment the hardcoded bootnode and CL-peer lists at startup. The resolver walks an `enrtree://<pubkey>@<domain>` DNS tree, verifies the root record's ECDSA signature against the embedded pubkey, and returns the leaf ENRs. Results are merged into `DiscV4Service`'s bootnodes (EL) and `BeaconLightClient`'s CL peers (CL) for the selected network.

Static bootnode/peer lists age fast — if every hardcoded entry goes offline a fresh client has nothing to reach. EIP-1459 distributes a dynamically-maintained tree of ENRs over DNS, signed by the tree operator, so clients can refresh their seed without shipping new binaries.

## What's in the PR

- **`networking/dns/EnrTreeUrl`** — parses `enrtree://<base32-pubkey>@<domain>`, decompresses the 33-byte secp256k1 key.
- **`networking/dns/DnsEnrResolver`** — TXT-based tree walker using dnsjava. Verifies the root signature (`keccak256(record minus " sig=<b64>")`, 65-byte r‖s‖v base64url), traverses branches, decodes leaves via the existing `Enr.fromEnrString`. Respects a per-tree deadline so it returns partial results rather than blocking startup.
- **`NetworkConfig`** — two new record fields: `elEnrTreeUrls`, `clEnrTreeUrls`. Mainnet pins the Ethereum Foundation tree (`all.mainnet.ethdisco.net`); CL trees are empty for now (no single canonical tree — add once a client-team tree is pinned and verified).
- **`Main.runDaemon`** — resolves EL and CL trees in parallel at startup with a 10 s timeout each. Results are partitioned by the originating tree's layer, deduped, then merged into the bootnode list (passed to `DiscV4Service`) and the CL peer list (passed to `BeaconLightClient`). Failures log and fall through silently.

## Incidental fix: `Enr.decode` list-value tolerance

Modern mainnet ENRs carry list-valued pairs (`eth2` per EIP-2364, `attnets`, `syncnets`). The old decoder called `reader.readValue()` unconditionally and threw on lists — which made the EF tree return zero decodable ENRs in smoke testing. The decoder now checks `nextIsList()` and skips unknown list values while preserving the flat-valued fields we consume (`ip`, `tcp`, `udp`, `secp256k1`). Covered by a new `EnrTest.tolerateListValuedPairs` test.

## Tests

- **`EnrTreeUrlTest`** — parses the canonical EF tree URL, rejects malformed shapes, RFC-4648 base32 vector.
- **`DnsEnrResolverSigTest`** — hermetic: generates a keypair, signs a fabricated root in-test, asserts accept-on-match, reject-on-flipped-signature-byte, reject-on-wrong-signer, reject-on-missing-sig.
- **`DnsEnrResolverTreeTest`** — fake `TxtResolver`; asserts branch walk, dedup of repeated child hashes, depth cap.
- **`EnrTest.tolerateListValuedPairs`** — synthetic ENR with list-valued `eth2` entry + flat ip/tcp/secp256k1; must decode the flat fields.
- **`:networking:dnsSmoke`** — manual Gradle task + `DnsSmokeTest` class that hits the real EF tree. Not run in CI; useful when tuning caps or endpoints.

## Smoke result

Against `all.mainnet.ethdisco.net`:

```
[dns] all.mainnet.ethdisco.net deadline reached after 347 lookups, 317 ENRs collected
[dns] resolved 317 ENR(s) from 1 tree(s) in 16050 ms
Resolved 317 ENRs in 16114ms
  with tcpAddress: 317
  with libp2pMultiaddr: 317
Sample: ENR{seq=1754528441838, udp=/174.138.121.74:30303, tcp=/174.138.121.74:30303}
```

## Test plan

- [x] `./gradlew test` — all modules green.
- [x] `./gradlew :networking:dnsSmoke` — 317 ENRs from the EF tree.
- [ ] `./gradlew :app:run` on a machine with UDP:53 egress. Expect startup log `[main] DNS discovery added <N> EL bootnode(s) …`. Peers from the DNS tree should appear in `./gradlew :app:run -Pargs=peers`.
- [ ] Offline / DNS-blocked machine: daemon should still start with cached + configured peers and log the resolver warning.

## Out of scope (follow-up)

- CL tree URLs — left empty until we can pin client-team trees and verify they return usable ENRs.
- Testnet trees — fields added, entries empty.
- Persistent disk cache of resolved ENRs. Sub-second cached re-queries make this unnecessary for now.
- Periodic re-resolution at runtime — startup-only is sufficient; `CLPeerCache` handles runtime churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)