### PR TITLE
android: wire BeaconLightClient + get-account query into the app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ app/devp2p.log
 app/devlibp2p.log
 .gradle-home/
 app/cacheDir/
+
+# Kotlin incremental-compile scratch + ad-hoc daemon logs
+.kotlin/
+*.log

--- a/android-app/build.gradle.kts
+++ b/android-app/build.gradle.kts
@@ -8,8 +8,16 @@ plugins {
 // same fully-qualified classes; the JVM tolerates the shadowing but the dexer
 // doesn't. vertx-core (transitive via tuweni-crypto) drags upstream netty in,
 // so strip it project-wide and rely on the fork.
+//
+// log4j-api is excluded because its `LogManager.getLogger()` no-args overload
+// uses StackWalker to name the logger after the caller class, and Android's
+// StackWalker returns null `getDeclaringClass()` for some frames — every
+// discovery class with `static final Logger LOG = LogManager.getLogger()`
+// blows up at <clinit>. Replaced with a tiny shim under
+// src/main/java/org/apache/logging/log4j that routes to slf4j.
 configurations.all {
     exclude(group = "io.netty")
+    exclude(group = "org.apache.logging.log4j")
 }
 
 android {
@@ -76,6 +84,10 @@ android {
             // file as upstream netty-common; just take the first one.
             pickFirsts += setOf(
                 "META-INF/native-image/io.netty/netty-common/native-image.properties",
+                // jvm-libp2p drags in four bouncycastle jars (bcprov, bcpkix,
+                // bctls, bcutil) that all ship the same OSGI manifest under
+                // META-INF/versions/9; the file is metadata-only.
+                "META-INF/versions/9/OSGI-INF/MANIFEST.MF",
             )
         }
     }
@@ -86,12 +98,18 @@ dependencies {
 
     implementation(project(":core"))
     implementation(project(":networking"))
+    implementation(project(":consensus"))
 
     // core/networking expose tuweni and netty only as `implementation`, so
     // add what the service code references directly.
     implementation(libs.tuweni.bytes)
     implementation(libs.tuweni.crypto)
     implementation(libs.netty.transport)
+
+    // consensus stack — BeaconLightClient, libp2p, BLS, snappy.
+    implementation(libs.jvm.libp2p)
+    implementation(libs.milagro)
+    implementation(libs.snappy)
 
     implementation(libs.bouncycastle)
     implementation(libs.slf4j.api)

--- a/android-app/build.gradle.kts
+++ b/android-app/build.gradle.kts
@@ -93,6 +93,22 @@ android {
     }
 }
 
+// Two-layer setup so AGP can compile against class-file-65 dependencies
+// (ConsenSys discovery 26.4.0 and its transitive Vert.x, plus our own
+// :networking module pinned to JVM 21 for discovery) while still emitting
+// Java 17 bytecode for our own sources:
+//
+//   1. jvmToolchain(21) — Gradle uses a Java 21 toolchain to *run* javac.
+//      JDK 17's javac cannot parse class file 65, so without this we'd get
+//      "class file has wrong version 65.0, should be 61.0" at parse time.
+//
+//   2. compileOptions stays at JavaVersion.VERSION_17 — javac targets
+//      Java 17 bytecode, our output is class file 61 (D8/ART-friendly),
+//      and we don't admit Java 18+ language features.
+kotlin {
+    jvmToolchain(21)
+}
+
 dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.3")
 
@@ -113,8 +129,11 @@ dependencies {
 
     implementation(libs.bouncycastle)
     implementation(libs.slf4j.api)
-    // slf4j-android binding would be nicer, but slf4j-simple keeps the POC self-contained
-    runtimeOnly("org.slf4j:slf4j-simple:2.0.12")
+    // The SLF4J service provider is in-tree (com.jaeckel.ethp2p.android.log
+    // .AppSlf4jProvider) and registered via META-INF/services. It tees every
+    // SLF4J call to logcat *and* the in-app LogBuffer so the Logs tab can
+    // render output from consensus / networking / libp2p alongside our own
+    // android.util.Log calls. No third-party binding needed.
 
     // Jetpack Compose UI (BOM pins all compose-* versions together)
     implementation(platform(libs.androidx.compose.bom))

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/AndroidCLPeerCache.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/AndroidCLPeerCache.java
@@ -1,0 +1,110 @@
+package com.jaeckel.ethp2p.android;
+
+import android.util.Log;
+
+import java.io.BufferedReader;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Android-native CL peer cache. Mirrors {@code CLPeerCache} in the :app module
+ * but uses {@code android.util.Log} and {@code java.io} streams instead of
+ * {@code java.nio.file.Files}, matching {@link AndroidPeerCache}.
+ *
+ * <p>Format: one libp2p multiaddr per line, e.g.
+ * {@code /ip4/1.2.3.4/tcp/9000/p2p/16Uiu2...}. Peers are evicted after
+ * {@link #FAILURE_THRESHOLD} consecutive failures.
+ */
+public final class AndroidCLPeerCache {
+
+    private static final String TAG = "ethp2p.cl-cache";
+
+    public static final int FAILURE_THRESHOLD = 3;
+
+    private final Path cacheFile;
+    private final Set<String> seen = ConcurrentHashMap.newKeySet();
+    private final Map<String, Integer> failures = new ConcurrentHashMap<>();
+
+    public AndroidCLPeerCache(Path cacheFile) {
+        this.cacheFile = cacheFile;
+    }
+
+    public synchronized void add(String multiaddr) {
+        if (multiaddr == null || multiaddr.isEmpty()) return;
+        failures.remove(multiaddr);
+        if (!seen.add(multiaddr)) return;
+        try (FileOutputStream out = new FileOutputStream(cacheFile.toFile(), true)) {
+            out.write((multiaddr + "\n").getBytes(StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            Log.w(TAG, "write failed: " + e.getMessage());
+        }
+    }
+
+    public void markFailure(String multiaddr) {
+        if (multiaddr == null || multiaddr.isEmpty()) return;
+        if (!seen.contains(multiaddr)) return;
+        int count = failures.merge(multiaddr, 1, Integer::sum);
+        if (count >= FAILURE_THRESHOLD) {
+            if (seen.remove(multiaddr)) {
+                failures.remove(multiaddr);
+                rewriteFile();
+                Log.i(TAG, "evicted peer after " + count + " failures: " + multiaddr);
+            }
+        }
+    }
+
+    public List<String> load() {
+        List<String> result = new ArrayList<>();
+        if (!cacheFile.toFile().exists()) return result;
+        try (BufferedReader r = new BufferedReader(new InputStreamReader(
+                new FileInputStream(cacheFile.toFile()), StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = r.readLine()) != null) {
+                line = line.strip();
+                if (line.isEmpty() || !line.startsWith("/")) continue;
+                result.add(line);
+                seen.add(line);
+            }
+            if (!result.isEmpty()) {
+                Log.i(TAG, "loaded " + result.size() + " cached CL peer(s)");
+            }
+        } catch (IOException e) {
+            Log.w(TAG, "read failed: " + e.getMessage());
+        }
+        return result;
+    }
+
+    public synchronized void clear() {
+        seen.clear();
+        failures.clear();
+        if (!cacheFile.toFile().delete() && cacheFile.toFile().exists()) {
+            Log.w(TAG, "failed to delete cache file " + cacheFile);
+        }
+    }
+
+    private synchronized void rewriteFile() {
+        List<String> lines = new ArrayList<>(seen);
+        Collections.sort(lines);
+        try (Writer w = new OutputStreamWriter(
+                new FileOutputStream(cacheFile.toFile(), false), StandardCharsets.UTF_8)) {
+            for (String line : lines) {
+                w.write(line);
+                w.write('\n');
+            }
+        } catch (IOException e) {
+            Log.w(TAG, "rewrite failed: " + e.getMessage());
+        }
+    }
+}

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/AndroidCLPeerCache.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/AndroidCLPeerCache.java
@@ -1,6 +1,6 @@
 package com.jaeckel.ethp2p.android;
 
-import android.util.Log;
+import com.jaeckel.ethp2p.android.log.LogBuffer;
 
 import java.io.BufferedReader;
 import java.io.FileInputStream;
@@ -48,7 +48,7 @@ public final class AndroidCLPeerCache {
         try (FileOutputStream out = new FileOutputStream(cacheFile.toFile(), true)) {
             out.write((multiaddr + "\n").getBytes(StandardCharsets.UTF_8));
         } catch (IOException e) {
-            Log.w(TAG, "write failed: " + e.getMessage());
+            LogBuffer.w(TAG, "write failed: " + e.getMessage());
         }
     }
 
@@ -60,7 +60,7 @@ public final class AndroidCLPeerCache {
             if (seen.remove(multiaddr)) {
                 failures.remove(multiaddr);
                 rewriteFile();
-                Log.i(TAG, "evicted peer after " + count + " failures: " + multiaddr);
+                LogBuffer.i(TAG, "evicted peer after " + count + " failures: " + multiaddr);
             }
         }
     }
@@ -78,10 +78,10 @@ public final class AndroidCLPeerCache {
                 seen.add(line);
             }
             if (!result.isEmpty()) {
-                Log.i(TAG, "loaded " + result.size() + " cached CL peer(s)");
+                LogBuffer.i(TAG, "loaded " + result.size() + " cached CL peer(s)");
             }
         } catch (IOException e) {
-            Log.w(TAG, "read failed: " + e.getMessage());
+            LogBuffer.w(TAG, "read failed: " + e.getMessage());
         }
         return result;
     }
@@ -90,7 +90,7 @@ public final class AndroidCLPeerCache {
         seen.clear();
         failures.clear();
         if (!cacheFile.toFile().delete() && cacheFile.toFile().exists()) {
-            Log.w(TAG, "failed to delete cache file " + cacheFile);
+            LogBuffer.w(TAG, "failed to delete cache file " + cacheFile);
         }
     }
 
@@ -104,7 +104,7 @@ public final class AndroidCLPeerCache {
                 w.write('\n');
             }
         } catch (IOException e) {
-            Log.w(TAG, "rewrite failed: " + e.getMessage());
+            LogBuffer.w(TAG, "rewrite failed: " + e.getMessage());
         }
     }
 }

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/AndroidPeerCache.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/AndroidPeerCache.java
@@ -1,6 +1,6 @@
 package com.jaeckel.ethp2p.android;
 
-import android.util.Log;
+import com.jaeckel.ethp2p.android.log.LogBuffer;
 
 import java.io.BufferedReader;
 import java.io.FileInputStream;
@@ -53,7 +53,7 @@ public final class AndroidPeerCache {
         try (FileOutputStream out = new FileOutputStream(cacheFile.toFile(), true)) {
             out.write(line.getBytes(StandardCharsets.UTF_8));
         } catch (IOException e) {
-            Log.w(TAG, "write failed: " + e.getMessage());
+            LogBuffer.w(TAG, "write failed: " + e.getMessage());
         }
     }
 
@@ -64,7 +64,7 @@ public final class AndroidPeerCache {
     public synchronized void clear() {
         seen.clear();
         if (!cacheFile.toFile().delete() && cacheFile.toFile().exists()) {
-            Log.w(TAG, "failed to delete cache file " + cacheFile);
+            LogBuffer.w(TAG, "failed to delete cache file " + cacheFile);
         }
     }
 
@@ -81,7 +81,7 @@ public final class AndroidPeerCache {
                     int firstSep = line.indexOf(SEP);
                     int secondSep = line.indexOf(SEP, firstSep + 1);
                     if (firstSep < 0 || secondSep < 0) {
-                        Log.w(TAG, "skipping malformed peer line");
+                        LogBuffer.w(TAG, "skipping malformed peer line");
                         continue;
                     }
                     String ip = line.substring(0, firstSep);
@@ -90,11 +90,11 @@ public final class AndroidPeerCache {
                     result.add(new CachedPeer(new InetSocketAddress(ip, port), pubKeyHex));
                     seen.add(ip + SEP + port);
                 } catch (Exception e) {
-                    Log.w(TAG, "skipping malformed peer line: " + e.getMessage());
+                    LogBuffer.w(TAG, "skipping malformed peer line: " + e.getMessage());
                 }
             }
         } catch (IOException e) {
-            Log.w(TAG, "read failed: " + e.getMessage());
+            LogBuffer.w(TAG, "read failed: " + e.getMessage());
         }
         return result;
     }

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/EthP2PApplication.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/EthP2PApplication.java
@@ -11,9 +11,22 @@ public final class EthP2PApplication extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
-        // Android ships a stripped-down provider also named "BC" that lacks ECDSA.
-        // Replace it with the full BouncyCastle we bundle so Tuweni's SECP256K1 works.
+        // Android ships a stripped-down "BC" provider that lacks ECDSA.
+        // Replace it with the full BouncyCastle we bundle so Tuweni's
+        // SECP256K1 / Hash.keccak256 / etc. resolve.
+        //
+        // Critically, append (addProvider) rather than insertProviderAt(1).
+        // Default Android provider order has AndroidOpenSSL (BoringSSL-backed)
+        // at position 1 — which is what we want for unqualified
+        // Cipher.getInstance("AES/CTR/NoPadding") and "AES/GCM/NoPadding"
+        // calls inside the discv5 library. Boosting BC to position 1 puts BC
+        // on the AES path, where its CTR/GCM implementation does not
+        // round-trip correctly with discv5 peers in practice (an empirical
+        // finding from the Portal Client Samba port). Keeping AndroidOpenSSL
+        // at the top and BC at the bottom: AES routes via AndroidOpenSSL,
+        // SECP256K1 falls through to BC because no upper provider supplies
+        // it on Android.
         Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME);
-        Security.insertProviderAt(new BouncyCastleProvider(), 1);
+        Security.addProvider(new BouncyCastleProvider());
     }
 }

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/MainActivity.kt
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/MainActivity.kt
@@ -18,18 +18,24 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -37,14 +43,22 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.future.await
 import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.math.RoundingMode
 
 class MainActivity : ComponentActivity() {
 
@@ -143,9 +157,13 @@ private fun NodeScreen(
     onOpenNetworkSettings: () -> Unit,
     onClearCaches: () -> Unit,
 ) {
+    // Snapshot + uptime tick are owned by the parent so both tabs can read
+    // them — the Query tab needs `beaconState` to decide whether to warn the
+    // user that responses can't be cryptographically verified yet.
     var snapshot by remember { mutableStateOf<NodeService.Snapshot?>(null) }
     var running by remember { mutableStateOf(NodeService.isRunning()) }
     var now by remember { mutableStateOf(System.currentTimeMillis()) }
+    var selectedTab by remember { mutableStateOf(0) }
     val online = rememberIsOnline()
 
     LaunchedEffect(Unit) {
@@ -155,7 +173,6 @@ private fun NodeScreen(
             delay(2000)
         }
     }
-    // Tick once a second so the uptime readout doesn't jump in 2-second steps.
     LaunchedEffect(Unit) {
         while (isActive) {
             now = System.currentTimeMillis()
@@ -163,45 +180,302 @@ private fun NodeScreen(
         }
     }
 
-    Column(
-        Modifier
+    Column(Modifier.fillMaxSize()) {
+        TabRow(selectedTabIndex = selectedTab) {
+            Tab(
+                selected = selectedTab == 0,
+                onClick = { selectedTab = 0 },
+                text = { Text("Status") }
+            )
+            Tab(
+                selected = selectedTab == 1,
+                onClick = { selectedTab = 1 },
+                text = { Text("Query") }
+            )
+        }
+        when (selectedTab) {
+            0 -> StatusTab(
+                snapshot = snapshot,
+                running = running,
+                now = now,
+                online = online,
+                serviceProvider = serviceProvider,
+                onToggle = onToggle,
+                onOpenNetworkSettings = onOpenNetworkSettings,
+                onClearCaches = onClearCaches,
+            )
+            else -> QueryTab(
+                snapshot = snapshot,
+                running = running,
+                serviceProvider = serviceProvider,
+            )
+        }
+    }
+}
+
+@Composable
+private fun StatusTab(
+    snapshot: NodeService.Snapshot?,
+    running: Boolean,
+    now: Long,
+    online: Boolean,
+    serviceProvider: () -> NodeService?,
+    onToggle: () -> Unit,
+    onOpenNetworkSettings: () -> Unit,
+    onClearCaches: () -> Unit,
+) {
+    // Single LazyColumn for the whole tab so EL stats + beacon stats + peer
+    // list scroll together — a nested LazyColumn inside a non-scrolling
+    // Column would only scroll the peers.
+    LazyColumn(
+        modifier = Modifier
             .fillMaxSize()
             .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         if (!online) {
-            OfflineBanner(onOpenNetworkSettings)
+            item { OfflineBanner(onOpenNetworkSettings) }
         }
 
-        Button(
-            onClick = onToggle,
-            enabled = running || online,
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            Text(if (running) "Stop node" else "Start node")
+        item {
+            Button(
+                onClick = onToggle,
+                enabled = running || online,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(if (running) "Stop node" else "Start node")
+            }
         }
 
-        OutlinedButton(
-            onClick = onClearCaches,
-            enabled = serviceProvider() != null,
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            Text("Clear peer caches")
+        item {
+            OutlinedButton(
+                onClick = onClearCaches,
+                enabled = serviceProvider() != null,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Clear peer caches")
+            }
         }
 
         val s = snapshot
         if (s == null || !s.running) {
-            Text(
-                if (online) "Tap Start to launch the node."
-                else "Connect to the internet before starting the node."
-            )
+            item {
+                Text(
+                    if (online) "Tap Start to launch the node."
+                    else "Connect to the internet before starting the node."
+                )
+            }
         } else {
-            StatusRow("uptime", formatUptime(now - s.startTimeMs))
-            StatusSummary(s)
-            HorizontalDivider()
-            Text("READY peers (${s.readyPeerList.size})", style = MaterialTheme.typography.titleSmall)
-            PeerList(s.readyPeerList)
+            item { StatusRow("uptime", formatUptime(now - s.startTimeMs)) }
+            item { StatusSummary(s) }
+            item { HorizontalDivider() }
+            item { Text("Beacon (consensus)", style = MaterialTheme.typography.titleSmall) }
+            item { BeaconSummary(s) }
+            item { HorizontalDivider() }
+            item {
+                Text("READY peers (${s.readyPeerList.size})",
+                    style = MaterialTheme.typography.titleSmall)
+            }
+            items(s.readyPeerList) { p -> PeerRow(p) }
         }
+    }
+}
+
+private sealed interface QueryState {
+    data object Idle : QueryState
+    data object Loading : QueryState
+    data class Success(val result: NodeService.AccountQueryResult) : QueryState
+    data class Failure(val message: String) : QueryState
+}
+
+@Composable
+private fun QueryTab(
+    snapshot: NodeService.Snapshot?,
+    running: Boolean,
+    serviceProvider: () -> NodeService?,
+) {
+    var address by remember { mutableStateOf("") }
+    var state by remember { mutableStateOf<QueryState>(QueryState.Idle) }
+    val scope = rememberCoroutineScope()
+
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        if (!running) {
+            item {
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.errorContainer,
+                        contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                    )
+                ) {
+                    Text(
+                        "Node is not running. Start it from the Status tab " +
+                            "before issuing a query.",
+                        modifier = Modifier.padding(12.dp),
+                        fontSize = 13.sp
+                    )
+                }
+            }
+        } else {
+            val beaconState = snapshot?.beaconState
+            // Anything but SYNCED means we cannot match the peer's state root
+            // against a beacon-attested anchor — flag that so the user knows
+            // balances/nonces are peer-claimed, not cryptographically verified.
+            if (beaconState != "SYNCED") {
+                item { ConsensusUnsyncedBanner(beaconState ?: "STOPPED") }
+            }
+        }
+
+        item {
+            OutlinedTextField(
+                value = address,
+                onValueChange = { address = it.trim() },
+                label = { Text("Account address") },
+                placeholder = { Text("0x…") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+                enabled = state !is QueryState.Loading,
+            )
+        }
+
+        item {
+            Button(
+                onClick = {
+                    val svc = serviceProvider()
+                    if (svc == null) {
+                        state = QueryState.Failure("Service not bound")
+                        return@Button
+                    }
+                    state = QueryState.Loading
+                    scope.launch {
+                        state = try {
+                            // Bounce off the IO dispatcher because requestAccount
+                            // will block the calling thread on the snap peer
+                            // future internally; we don't want to occupy the
+                            // main dispatcher while peers respond (~hundreds of
+                            // ms in the happy path, 30s timeout on retry).
+                            val result = withContext(Dispatchers.IO) {
+                                svc.requestAccount(address).await()
+                            }
+                            QueryState.Success(result)
+                        } catch (t: Throwable) {
+                            QueryState.Failure(
+                                t.cause?.message ?: t.message
+                                    ?: t::class.java.simpleName
+                            )
+                        }
+                    }
+                },
+                enabled = running && address.isNotEmpty() && state !is QueryState.Loading,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Get account")
+            }
+        }
+
+        when (val st = state) {
+            is QueryState.Idle -> { /* nothing */ }
+            is QueryState.Loading -> item { LoadingRow() }
+            is QueryState.Success -> item { AccountResultPanel(st.result) }
+            is QueryState.Failure -> item { ErrorPanel(st.message) }
+        }
+    }
+}
+
+@Composable
+private fun LoadingRow() {
+    Row(
+        Modifier.fillMaxWidth(),
+        verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        CircularProgressIndicator(modifier = Modifier.height(20.dp))
+        Spacer(Modifier.height(4.dp))
+        Text("Querying snap peer…", fontSize = 13.sp)
+    }
+}
+
+@Composable
+private fun ConsensusUnsyncedBanner(state: String) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.errorContainer,
+            contentColor = MaterialTheme.colorScheme.onErrorContainer,
+        )
+    ) {
+        Column(Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text("Consensus layer not synced",
+                style = MaterialTheme.typography.titleSmall)
+            Text(
+                "Beacon state is $state. Until the light client catches up, " +
+                    "responses are peer-claimed and cannot be cryptographically " +
+                    "verified against a beacon-attested state root.",
+                fontSize = 12.sp
+            )
+        }
+    }
+}
+
+@Composable
+private fun ErrorPanel(message: String) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.errorContainer,
+            contentColor = MaterialTheme.colorScheme.onErrorContainer,
+        )
+    ) {
+        Column(Modifier.padding(12.dp)) {
+            Text("Query failed", style = MaterialTheme.typography.titleSmall)
+            Text(message, fontSize = 12.sp, fontFamily = FontFamily.Monospace)
+        }
+    }
+}
+
+@Composable
+private fun AccountResultPanel(r: NodeService.AccountQueryResult) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text("Result", style = MaterialTheme.typography.titleSmall)
+        StatusRow("address", shortenHash(r.address))
+        StatusRow("exists", r.exists.toString())
+        if (r.exists) {
+            StatusRow("balance (ETH)", formatEth(r.balanceWei))
+            StatusRow("balance (wei)", r.balanceWei ?: "—")
+            StatusRow("nonce", r.nonce.toString())
+            r.storageRootHex?.let { StatusRow("storageRoot", shortenHash(it)) }
+            r.codeHashHex?.let { StatusRow("codeHash", shortenHash(it)) }
+        }
+        StatusRow("block #", r.blockNumber.toString())
+        r.peerStateRootHex?.let { StatusRow("peer stateRoot", shortenHash(it)) }
+        HorizontalDivider()
+        Text("Verification", style = MaterialTheme.typography.titleSmall)
+        StatusRow("peer proof valid", r.peerProofValid.toString())
+        StatusRow("beacon-verified", r.beaconChainVerified.toString())
+        if (r.beaconChainVerified) {
+            r.verifyMethod?.let { StatusRow("method", it) }
+            StatusRow("matched slot", r.matchedBeaconSlot.toString())
+            StatusRow("BLS verified", r.blsVerified.toString())
+        } else {
+            r.failReason?.let { StatusRow("fail reason", it) }
+        }
+    }
+}
+
+/** Format a wei amount (decimal string) as ETH with 6-decimal precision. */
+private fun formatEth(weiDecimal: String?): String {
+    if (weiDecimal == null) return "—"
+    return try {
+        val wei = BigInteger(weiDecimal)
+        val eth = BigDecimal(wei).divide(BigDecimal.TEN.pow(18), 6, RoundingMode.DOWN)
+        eth.toPlainString()
+    } catch (_: NumberFormatException) {
+        weiDecimal
     }
 }
 
@@ -294,6 +568,23 @@ private fun StatusSummary(s: NodeService.Snapshot) {
 }
 
 @Composable
+private fun BeaconSummary(s: NodeService.Snapshot) {
+    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        StatusRow("state", s.beaconState)
+        StatusRow("bootstrapped", s.beaconBootstrapped.toString())
+        StatusRow("CL peers connected", s.clPeersConnected.toString())
+        StatusRow("CL peers (light_client)", s.clPeersLightClient.toString())
+        StatusRow("CL peers cached", s.clPeersCached.toString())
+        StatusRow("finalized slot", if (s.finalizedSlot == 0L) "—" else s.finalizedSlot.toString())
+        StatusRow("execution block", if (s.executionBlockNumber == 0L) "—" else s.executionBlockNumber.toString())
+        s.executionBlockHashHex?.let { StatusRow("execution hash", shortenHash(it)) }
+    }
+}
+
+private fun shortenHash(hex: String): String =
+    if (hex.length <= 18) hex else hex.substring(0, 10) + "…" + hex.substring(hex.length - 8)
+
+@Composable
 private fun StatusRow(label: String, value: String) {
     Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
         Text(label, fontFamily = FontFamily.Monospace, fontSize = 13.sp)
@@ -302,22 +593,18 @@ private fun StatusRow(label: String, value: String) {
 }
 
 @Composable
-private fun PeerList(peers: List<com.jaeckel.ethp2p.networking.rlpx.RLPxConnector.PeerInfo>) {
-    LazyColumn(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-        items(peers) { p ->
-            Column {
-                Text(
-                    "${p.remoteAddress()}  snap=${p.snapSupported()}",
-                    fontFamily = FontFamily.Monospace,
-                    fontSize = 12.sp
-                )
-                Text(
-                    p.clientId() ?: "(no clientId)",
-                    fontFamily = FontFamily.Monospace,
-                    fontSize = 11.sp,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-        }
+private fun PeerRow(p: com.jaeckel.ethp2p.networking.rlpx.RLPxConnector.PeerInfo) {
+    Column {
+        Text(
+            "${p.remoteAddress()}  snap=${p.snapSupported()}",
+            fontFamily = FontFamily.Monospace,
+            fontSize = 12.sp
+        )
+        Text(
+            p.clientId() ?: "(no clientId)",
+            fontFamily = FontFamily.Monospace,
+            fontSize = 11.sp,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
     }
 }

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/MainActivity.kt
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/MainActivity.kt
@@ -16,6 +16,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -25,6 +26,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -40,18 +43,27 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.jaeckel.ethp2p.android.log.LogBuffer
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -59,6 +71,9 @@ import kotlinx.coroutines.withContext
 import java.math.BigDecimal
 import java.math.BigInteger
 import java.math.RoundingMode
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 class MainActivity : ComponentActivity() {
 
@@ -168,8 +183,14 @@ private fun NodeScreen(
 
     LaunchedEffect(Unit) {
         while (isActive) {
+            // snapshot() walks the connector's active handler list, sorts
+            // ready peers, and prunes the backoff map. Cheap on a phone but
+            // not free — keep it off the main thread so a pause inside the
+            // sort or a brief lock contention with Netty's READY transitions
+            // can't blow the frame budget.
+            val s = withContext(Dispatchers.Default) { serviceProvider()?.snapshot() }
             running = NodeService.isRunning()
-            snapshot = serviceProvider()?.snapshot()
+            snapshot = s
             delay(2000)
         }
     }
@@ -192,6 +213,11 @@ private fun NodeScreen(
                 onClick = { selectedTab = 1 },
                 text = { Text("Query") }
             )
+            Tab(
+                selected = selectedTab == 2,
+                onClick = { selectedTab = 2 },
+                text = { Text("Logs") }
+            )
         }
         when (selectedTab) {
             0 -> StatusTab(
@@ -204,11 +230,12 @@ private fun NodeScreen(
                 onOpenNetworkSettings = onOpenNetworkSettings,
                 onClearCaches = onClearCaches,
             )
-            else -> QueryTab(
+            1 -> QueryTab(
                 snapshot = snapshot,
                 running = running,
                 serviceProvider = serviceProvider,
             )
+            else -> LogsTab()
         }
     }
 }
@@ -224,59 +251,66 @@ private fun StatusTab(
     onOpenNetworkSettings: () -> Unit,
     onClearCaches: () -> Unit,
 ) {
-    // Single LazyColumn for the whole tab so EL stats + beacon stats + peer
-    // list scroll together — a nested LazyColumn inside a non-scrolling
-    // Column would only scroll the peers.
-    LazyColumn(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp)
-    ) {
-        if (!online) {
-            item { OfflineBanner(onOpenNetworkSettings) }
-        }
-
-        item {
-            Button(
-                onClick = onToggle,
-                enabled = running || online,
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                Text(if (running) "Stop node" else "Start node")
+    // SelectionContainer wraps the whole tab so long-pressing any text
+    // (peer rows, stats, hashes) lets the user copy from the standard
+    // Android selection toolbar. Buttons stay tappable — selection only
+    // engages on Text composables.
+    //
+    // Single LazyColumn so EL stats + beacon stats + peer list scroll
+    // together — a nested LazyColumn inside a non-scrolling Column
+    // would only scroll the peers.
+    SelectionContainer {
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            if (!online) {
+                item { OfflineBanner(onOpenNetworkSettings) }
             }
-        }
 
-        item {
-            OutlinedButton(
-                onClick = onClearCaches,
-                enabled = serviceProvider() != null,
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                Text("Clear peer caches")
-            }
-        }
-
-        val s = snapshot
-        if (s == null || !s.running) {
             item {
-                Text(
-                    if (online) "Tap Start to launch the node."
-                    else "Connect to the internet before starting the node."
-                )
+                Button(
+                    onClick = onToggle,
+                    enabled = running || online,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(if (running) "Stop node" else "Start node")
+                }
             }
-        } else {
-            item { StatusRow("uptime", formatUptime(now - s.startTimeMs)) }
-            item { StatusSummary(s) }
-            item { HorizontalDivider() }
-            item { Text("Beacon (consensus)", style = MaterialTheme.typography.titleSmall) }
-            item { BeaconSummary(s) }
-            item { HorizontalDivider() }
+
             item {
-                Text("READY peers (${s.readyPeerList.size})",
-                    style = MaterialTheme.typography.titleSmall)
+                OutlinedButton(
+                    onClick = onClearCaches,
+                    enabled = serviceProvider() != null,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text("Clear peer caches")
+                }
             }
-            items(s.readyPeerList) { p -> PeerRow(p) }
+
+            val s = snapshot
+            if (s == null || !s.running) {
+                item {
+                    Text(
+                        if (online) "Tap Start to launch the node."
+                        else "Connect to the internet before starting the node."
+                    )
+                }
+            } else {
+                item { StatusRow("uptime", formatUptime(now - s.startTimeMs)) }
+                item { StatusSummary(s) }
+                item { HorizontalDivider() }
+                item { Text("Beacon (consensus)", style = MaterialTheme.typography.titleSmall) }
+                item { BeaconSummary(s) }
+                item { HorizontalDivider() }
+                item {
+                    Text("READY peers (${s.readyPeerList.size})",
+                        style = MaterialTheme.typography.titleSmall)
+                }
+                items(s.readyPeerList) { p -> PeerRow(p) }
+            }
         }
     }
 }
@@ -387,6 +421,168 @@ private fun QueryTab(
     }
 }
 
+/**
+ * Live log viewer fed by [LogBuffer]. Auto-follows the tail when the user
+ * is parked at the bottom and pauses follow as soon as they scroll up;
+ * a "Jump to latest" button reappears so they can resume.
+ *
+ * <p>Selection is enabled (long-press → standard Android selection toolbar
+ * with Copy / Share). The toolbar above also exposes "Copy all" — useful
+ * when the buffer has thousands of lines and dragging selection handles
+ * across them is impractical.
+ */
+@Composable
+private fun LogsTab() {
+    // Poll the LogBuffer's monotonic version counter rather than the buffer
+    // itself — re-snapshotting only on change keeps the recomposition cost
+    // bounded even when the consensus stack is logging dozens of lines/sec.
+    var entries by remember { mutableStateOf<List<LogBuffer.Entry>>(emptyList()) }
+    var lastVersion by remember { mutableLongStateOf(-1L) }
+    LaunchedEffect(Unit) {
+        while (isActive) {
+            val v = LogBuffer.version()
+            if (v != lastVersion) {
+                entries = LogBuffer.snapshot()
+                lastVersion = v
+            }
+            // 250ms ≈ 4 Hz refresh — fast enough to feel live, slow enough
+            // not to thrash the LazyColumn during log bursts.
+            delay(250)
+        }
+    }
+
+    val listState = rememberLazyListState()
+    val scope = rememberCoroutineScope()
+    val clipboard = LocalClipboardManager.current
+
+    // Auto-follow: ON when the bottom is visible, OFF the moment the user
+    // scrolls away. derivedStateOf keeps recomposition off the hot path —
+    // we only re-evaluate when the LazyColumn's layout info actually
+    // changes.
+    val atBottom by remember {
+        derivedStateOf {
+            val info = listState.layoutInfo
+            val last = info.visibleItemsInfo.lastOrNull()
+            last == null || last.index >= info.totalItemsCount - 1
+        }
+    }
+    var autoFollow by remember { mutableStateOf(true) }
+    LaunchedEffect(listState) {
+        snapshotFlow { atBottom }
+            .distinctUntilChanged()
+            .collect { autoFollow = it }
+    }
+
+    // Pin to the latest item whenever a new line arrives AND we're following.
+    // Using scrollToItem (instant) rather than animateScrollToItem keeps
+    // pace with rapid log streams without queuing animations.
+    LaunchedEffect(entries.size, autoFollow) {
+        if (autoFollow && entries.isNotEmpty()) {
+            listState.scrollToItem(entries.size - 1)
+        }
+    }
+
+    Box(Modifier.fillMaxSize()) {
+        Column(Modifier.fillMaxSize()) {
+            Row(
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 8.dp, vertical = 4.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    "${entries.size} line${if (entries.size == 1) "" else "s"}" +
+                        if (autoFollow) " · live" else " · paused",
+                    fontSize = 12.sp,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.weight(1f),
+                )
+                OutlinedButton(
+                    onClick = {
+                        clipboard.setText(AnnotatedString(formatLogs(entries)))
+                    },
+                    enabled = entries.isNotEmpty(),
+                ) { Text("Copy all") }
+                OutlinedButton(
+                    onClick = { LogBuffer.clear() },
+                    enabled = entries.isNotEmpty(),
+                ) { Text("Clear") }
+            }
+            HorizontalDivider()
+            // SelectionContainer here gives a long-press → Copy gesture on
+            // any visible line. It's compatible with LazyColumn — selection
+            // tracks across items as you drag the handle.
+            SelectionContainer(Modifier.fillMaxSize()) {
+                LazyColumn(
+                    state = listState,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(horizontal = 8.dp),
+                ) {
+                    // Keying by sequence keeps the user's scroll position
+                    // anchored to a specific log line as older entries fall
+                    // off the front of the ring buffer.
+                    items(entries, key = { it.sequence }) { entry ->
+                        LogLineRow(entry)
+                    }
+                }
+            }
+        }
+        // "Jump to latest" floats over the list when the user has scrolled
+        // up to read older lines. Clicking it scrolls to the end and (via
+        // the auto-follow LaunchedEffect above, since atBottom flips back
+        // to true) resumes live tailing.
+        if (!autoFollow) {
+            Button(
+                onClick = {
+                    scope.launch {
+                        if (entries.isNotEmpty()) listState.scrollToItem(entries.size - 1)
+                    }
+                },
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(16.dp),
+            ) { Text("Jump to latest ↓") }
+        }
+    }
+}
+
+private val LOG_TIME_FORMAT = SimpleDateFormat("HH:mm:ss.SSS", Locale.US)
+
+@Composable
+private fun LogLineRow(entry: LogBuffer.Entry) {
+    // Color by level so warnings / errors visually pop against a wall of INFO.
+    val levelColor = when (entry.level) {
+        'E' -> MaterialTheme.colorScheme.error
+        'W' -> Color(0xFFB58900) // dim amber — readable on both light/dark
+        'D' -> MaterialTheme.colorScheme.onSurfaceVariant
+        'V' -> MaterialTheme.colorScheme.onSurfaceVariant
+        else -> MaterialTheme.colorScheme.onSurface  // 'I' and unknown
+    }
+    val ts = LOG_TIME_FORMAT.format(Date(entry.timestampMillis))
+    // Logger names like "com.jaeckel.ethp2p.consensus.BeaconLightClient" are
+    // long; strip the package for display while keeping the full name in the
+    // copy-all output so debugging context isn't lost.
+    val shortTag = entry.tag.substringAfterLast('.')
+    Text(
+        text = "$ts ${entry.level} $shortTag: ${entry.message}",
+        fontSize = 11.sp,
+        fontFamily = FontFamily.Monospace,
+        color = levelColor,
+    )
+}
+
+/** Render the buffer in `adb logcat -v threadtime`-ish format for clipboard. */
+private fun formatLogs(entries: List<LogBuffer.Entry>): String = buildString {
+    for (e in entries) {
+        append(LOG_TIME_FORMAT.format(Date(e.timestampMillis)))
+        append(' ').append(e.level)
+        append(' ').append(e.tag).append(": ").append(e.message)
+        append('\n')
+    }
+}
+
 @Composable
 private fun LoadingRow() {
     Row(
@@ -440,30 +636,71 @@ private fun ErrorPanel(message: String) {
 
 @Composable
 private fun AccountResultPanel(r: NodeService.AccountQueryResult) {
-    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-        Text("Result", style = MaterialTheme.typography.titleSmall)
-        StatusRow("address", shortenHash(r.address))
-        StatusRow("exists", r.exists.toString())
-        if (r.exists) {
-            StatusRow("balance (ETH)", formatEth(r.balanceWei))
-            StatusRow("balance (wei)", r.balanceWei ?: "—")
-            StatusRow("nonce", r.nonce.toString())
-            r.storageRootHex?.let { StatusRow("storageRoot", shortenHash(it)) }
-            r.codeHashHex?.let { StatusRow("codeHash", shortenHash(it)) }
+    val clipboard = LocalClipboardManager.current
+    SelectionContainer {
+        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Row(
+                Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text("Result", style = MaterialTheme.typography.titleSmall)
+                // DisableSelection is implicit on Buttons; the explicit
+                // copy is a one-tap convenience that pastes the *full*
+                // hex (not the shortened form) for every field.
+                OutlinedButton(
+                    onClick = { clipboard.setText(AnnotatedString(formatAccountResult(r))) },
+                ) { Text("Copy") }
+            }
+            // Show full hex — selection range copy needs the full string,
+            // and shortenHash() makes that impossible. Long lines wrap.
+            StatusRow("address", r.address)
+            StatusRow("exists", r.exists.toString())
+            if (r.exists) {
+                StatusRow("balance (ETH)", formatEth(r.balanceWei))
+                StatusRow("balance (wei)", r.balanceWei ?: "—")
+                StatusRow("nonce", r.nonce.toString())
+                r.storageRootHex?.let { StatusRow("storageRoot", it) }
+                r.codeHashHex?.let { StatusRow("codeHash", it) }
+            }
+            StatusRow("block #", r.blockNumber.toString())
+            r.peerStateRootHex?.let { StatusRow("peer stateRoot", it) }
+            HorizontalDivider()
+            Text("Verification", style = MaterialTheme.typography.titleSmall)
+            StatusRow("peer proof valid", r.peerProofValid.toString())
+            StatusRow("beacon-verified", r.beaconChainVerified.toString())
+            if (r.beaconChainVerified) {
+                r.verifyMethod?.let { StatusRow("method", it) }
+                StatusRow("matched slot", r.matchedBeaconSlot.toString())
+                StatusRow("BLS verified", r.blsVerified.toString())
+            } else {
+                r.failReason?.let { StatusRow("fail reason", it) }
+            }
         }
-        StatusRow("block #", r.blockNumber.toString())
-        r.peerStateRootHex?.let { StatusRow("peer stateRoot", shortenHash(it)) }
-        HorizontalDivider()
-        Text("Verification", style = MaterialTheme.typography.titleSmall)
-        StatusRow("peer proof valid", r.peerProofValid.toString())
-        StatusRow("beacon-verified", r.beaconChainVerified.toString())
-        if (r.beaconChainVerified) {
-            r.verifyMethod?.let { StatusRow("method", it) }
-            StatusRow("matched slot", r.matchedBeaconSlot.toString())
-            StatusRow("BLS verified", r.blsVerified.toString())
-        } else {
-            r.failReason?.let { StatusRow("fail reason", it) }
-        }
+    }
+}
+
+/** Format an AccountQueryResult as a plain-text JSON-ish blob for clipboard. */
+private fun formatAccountResult(r: NodeService.AccountQueryResult): String = buildString {
+    appendLine("address=${r.address}")
+    appendLine("exists=${r.exists}")
+    if (r.exists) {
+        appendLine("balanceWei=${r.balanceWei}")
+        appendLine("balanceETH=${formatEth(r.balanceWei)}")
+        appendLine("nonce=${r.nonce}")
+        r.storageRootHex?.let { appendLine("storageRoot=$it") }
+        r.codeHashHex?.let { appendLine("codeHash=$it") }
+    }
+    appendLine("blockNumber=${r.blockNumber}")
+    r.peerStateRootHex?.let { appendLine("peerStateRoot=$it") }
+    appendLine("peerProofValid=${r.peerProofValid}")
+    appendLine("beaconChainVerified=${r.beaconChainVerified}")
+    if (r.beaconChainVerified) {
+        r.verifyMethod?.let { appendLine("verifyMethod=$it") }
+        appendLine("matchedBeaconSlot=${r.matchedBeaconSlot}")
+        appendLine("blsVerified=${r.blsVerified}")
+    } else {
+        r.failReason?.let { appendLine("failReason=$it") }
     }
 }
 

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -10,11 +10,19 @@ import android.os.Binder;
 import android.os.IBinder;
 import android.util.Log;
 
+import com.jaeckel.ethp2p.consensus.BeaconLightClient;
+import com.jaeckel.ethp2p.consensus.BeaconSyncState;
+import com.jaeckel.ethp2p.consensus.libp2p.BeaconP2PService;
+import com.jaeckel.ethp2p.consensus.proof.MerklePatriciaVerifier;
 import com.jaeckel.ethp2p.core.crypto.NodeKey;
 import com.jaeckel.ethp2p.networking.NetworkConfig;
 import com.jaeckel.ethp2p.networking.discv4.DiscV4Service;
 import com.jaeckel.ethp2p.networking.discv5.DiscV5Service;
 import com.jaeckel.ethp2p.networking.rlpx.RLPxConnector;
+import com.jaeckel.ethp2p.networking.snap.messages.AccountRangeMessage;
+
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.crypto.Hash;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.crypto.SECP256K1;
@@ -26,6 +34,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -66,11 +75,16 @@ public final class NodeService extends Service {
     private DiscV5Service discV5;
     private RLPxConnector connector;
     private AndroidPeerCache peerCache;
+    private AndroidCLPeerCache clPeerCache;
+    private BeaconLightClient beaconLightClient;
+    private BeaconSyncState beaconSyncState;
+    private long clGenesisTime;
     private volatile int cachedPeerCount;
+    private volatile int cachedClPeerCount;
     private volatile long startTimeMs;
-    // Eth2-fork-digest-matching peers seen via discv5 since start. A counter
-    // rather than a collection because the UI only displays the number; when
-    // we integrate BeaconLightClient on Android this can feed a real peer sink.
+    // Eth2-fork-digest-matching peers seen via discv5 since start. Bumped on
+    // each ENR match so we can show fork-digest filter progress in the UI even
+    // before BLC has connected to anything.
     private final java.util.concurrent.atomic.AtomicInteger clPeersDiscovered =
             new java.util.concurrent.atomic.AtomicInteger();
 
@@ -93,11 +107,142 @@ public final class NodeService extends Service {
             int blacklistedPeers,
             int discv5Peers,          // total live nodes in the discv5 routing table
             int clPeersDiscovered,    // discv5 peers whose eth2 field matches our fork digest
+            // Beacon light client status (filled in only when BLC is wired up)
+            String beaconState,       // "STOPPED", "SYNCING", "CATCHING_UP", "SYNCED"
+            boolean beaconBootstrapped,
+            int clPeersConnected,
+            int clPeersLightClient,
+            int clPeersCached,
+            long finalizedSlot,
+            long executionBlockNumber,
+            String executionBlockHashHex, // null until first finality update
             List<RLPxConnector.PeerInfo> readyPeerList) {}
+
+    /** Result of a get-account query. Mirrors the JVM daemon's JSON response shape. */
+    public record AccountQueryResult(
+            String address,                  // 0x-prefixed checksum-form input
+            boolean exists,                  // false when the account isn't in the trie
+            long nonce,                      // -1 when !exists
+            String balanceWei,               // decimal string (BigInteger.toString); null when !exists
+            String storageRootHex,           // null when !exists
+            String codeHashHex,              // null when !exists
+            long blockNumber,                // peer-reported block number the proof is anchored to
+            String peerStateRootHex,         // 0x… root the proof was built against
+            boolean peerProofValid,          // proof verifies against peerStateRoot
+            boolean beaconChainVerified,     // peerStateRoot matches a beacon-attested root
+            boolean blsVerified,             // beacon match was BLS-signed (vs. unverified header)
+            long matchedBeaconSlot,          // -1 when not matched
+            String verifyMethod,             // "stateRootMatch" or null
+            String failReason                // null when verified
+    ) {}
 
     @Override
     public IBinder onBind(Intent intent) {
         return binder;
+    }
+
+    /**
+     * Run a get-account query against any active READY+snap peer and verify
+     * the returned proof against the beacon-attested state root window.
+     *
+     * <p>Only the {@code stateRootMatch} verification path is implemented —
+     * the JVM daemon also tries a header-chain fallback when the peer's block
+     * is ahead of finalized, but that requires fetching headers via eth/68
+     * and verifying their parent chain back to a beacon-known anchor; not
+     * worth the porting effort for the POC.
+     */
+    public CompletableFuture<AccountQueryResult> requestAccount(String hexAddress) {
+        if (!RUNNING.get() || connector == null) {
+            return CompletableFuture.failedFuture(
+                    new IllegalStateException("Node is not running"));
+        }
+        if (hexAddress == null) {
+            return CompletableFuture.failedFuture(
+                    new IllegalArgumentException("Address is required"));
+        }
+        String hex = hexAddress.strip();
+        if (hex.startsWith("0x") || hex.startsWith("0X")) hex = hex.substring(2);
+        if (hex.length() != 40) {
+            return CompletableFuture.failedFuture(
+                    new IllegalArgumentException("Address must be 20 bytes (40 hex chars)"));
+        }
+        final String hexAddrFinal = hex;
+        Bytes address;
+        try {
+            address = Bytes.fromHexString(hex);
+        } catch (Exception e) {
+            return CompletableFuture.failedFuture(
+                    new IllegalArgumentException("Invalid hex address: " + e.getMessage()));
+        }
+        Bytes32 accountHash = Hash.keccak256(address);
+        BeaconSyncState bss = beaconSyncState;
+        return connector.requestAccount(address).thenApply(result ->
+                buildAccountResult("0x" + hexAddrFinal, address, accountHash, result, bss));
+    }
+
+    private static AccountQueryResult buildAccountResult(String addr,
+                                                          Bytes address,
+                                                          Bytes32 accountHash,
+                                                          AccountRangeMessage.DecodeResult result,
+                                                          BeaconSyncState bss) {
+        AccountRangeMessage.AccountData found = null;
+        for (AccountRangeMessage.AccountData a : result.accounts()) {
+            if (a.accountHash().equals(accountHash)) {
+                found = a;
+                break;
+            }
+        }
+        long nonce = found != null ? found.nonce() : -1;
+        String balance = found != null ? found.balance().toString() : null;
+
+        boolean peerProofValid = false;
+        if (result.stateRoot() != null && !result.proof().isEmpty()) {
+            List<byte[]> proofBytes = new ArrayList<>(result.proof().size());
+            for (Bytes b : result.proof()) proofBytes.add(b.toArrayUnsafe());
+            peerProofValid = MerklePatriciaVerifier.verify(
+                    result.stateRoot().toArrayUnsafe(),
+                    address.toArrayUnsafe(),
+                    proofBytes, nonce, balance);
+        }
+
+        boolean beaconChainVerified = false;
+        boolean blsVerified = false;
+        long matchedSlot = -1;
+        String verifyMethod = null;
+        if (bss != null && result.stateRoot() != null) {
+            BeaconSyncState.SlottedStateRoot match =
+                    bss.findStateRoot(result.stateRoot().toArrayUnsafe());
+            if (match != null) {
+                beaconChainVerified = true;
+                matchedSlot = match.slot();
+                blsVerified = match.blsVerified();
+                verifyMethod = "stateRootMatch";
+            }
+        }
+
+        String failReason = null;
+        if (!beaconChainVerified) {
+            if (result.stateRoot() == null) failReason = "noPeerStateRoot";
+            else if (!peerProofValid) failReason = "peerProofInvalid";
+            else if (bss == null || !bss.isSynced()) failReason = "beaconNotSynced";
+            else failReason = "stateRootMismatch";
+        }
+
+        return new AccountQueryResult(
+                addr,
+                found != null,
+                nonce,
+                balance,
+                found != null ? found.storageRoot().toHexString() : null,
+                found != null ? found.codeHash().toHexString() : null,
+                result.blockNumber(),
+                result.stateRoot() != null ? result.stateRoot().toHexString() : null,
+                peerProofValid,
+                beaconChainVerified,
+                blsVerified,
+                matchedSlot,
+                verifyMethod,
+                failReason);
     }
 
     @Override
@@ -123,12 +268,18 @@ public final class NodeService extends Service {
 
     private void startNode() {
         AndroidPeerCache localCache = null;
+        AndroidCLPeerCache localClCache = null;
         RLPxConnector localConnector = null;
         DiscV4Service localDisc = null;
         DiscV5Service localDiscV5 = null;
+        BeaconLightClient localBlc = null;
+        BeaconSyncState localBeaconState = null;
         int localCachedCount = 0;
+        int localCachedClCount = 0;
+        long localGenesisTime = 0L;
         try {
             NetworkConfig network = NetworkConfig.byName("mainnet");
+            localGenesisTime = network.clGenesisTime();
             Path keyFile = new java.io.File(getFilesDir(), "nodekey.hex").toPath();
             NodeKey nodeKey = NodeKey.loadOrGenerate(keyFile);
             Log.i(TAG, "Node ID: " + nodeKey.nodeId().toHexString());
@@ -204,39 +355,88 @@ public final class NodeService extends Service {
             // discv5 — CL peer discovery. Runs on a separate UDP port from discv4.
             // Callback filters ENRs by eth2 fork digest (current OR prior — same
             // dual-accept behaviour the JVM daemon uses so a mis-pinned current
-            // fork doesn't silently discard every peer). Matches are counted for
-            // display. No BeaconLightClient consumer on Android yet, so discovered
-            // peers aren't connected — the counter only verifies discv5 is reaching
-            // the CL DHT. When BeaconService lands, this callback feeds it.
+            // fork doesn't silently discard every peer). Matches are counted,
+            // saved to the on-disk CL peer cache, and (once BLC is up) added to
+            // its live peer pool via blcRef.
             List<byte[]> acceptedForkDigests = network.acceptedForkDigests();
+            // Seed CL peer cache before BLC is constructed so cached peers are
+            // available at startup. Cache file lives next to nodekey/peers.cache
+            // in the app's filesDir; same eviction-on-failure semantics as JVM.
+            Path clCacheFile = new java.io.File(getFilesDir(), "cl-peers.cache").toPath();
+            localClCache = new AndroidCLPeerCache(clCacheFile);
+            List<String> clCached = localClCache.load();
+            localCachedClCount = clCached.size();
+
+            final AndroidCLPeerCache clCacheRef = localClCache;
+            final java.util.concurrent.atomic.AtomicReference<BeaconLightClient> blcRef =
+                    new java.util.concurrent.atomic.AtomicReference<>();
             localDiscV5 = new DiscV5Service(nodeKey, network.clDiscv5Bootnodes(), enr -> {
                 var eth2 = enr.eth2();
                 if (eth2.isEmpty()) return;
                 byte[] peerDigest = eth2.get().forkDigest();
+                boolean match = false;
                 for (byte[] accepted : acceptedForkDigests) {
                     if (java.util.Arrays.equals(peerDigest, accepted)) {
-                        clPeersDiscovered.incrementAndGet();
-                        return;
+                        match = true;
+                        break;
                     }
                 }
+                if (!match) return;
+                clPeersDiscovered.incrementAndGet();
+                enr.toLibp2pMultiaddr().ifPresent(ma -> {
+                    clCacheRef.add(ma);
+                    BeaconLightClient blc = blcRef.get();
+                    if (blc != null) blc.addPeer(ma);
+                });
             });
+
+            // Beacon light client. Same construction shape as Main.runDaemon:
+            // seed with cached peers + network's configured CL multiaddrs,
+            // attach the cache as success/failure callbacks so live updates
+            // reach disk, apply EIP-7892 BPO parameters. Gossipsub stays off
+            // (battery cost is steeper on a phone).
+            localBeaconState = new BeaconSyncState();
+            List<String> clPeers = new ArrayList<>(clCached);
+            for (String peer : network.clPeerMultiaddrs()) {
+                if (!clPeers.contains(peer)) clPeers.add(peer);
+            }
+            localBlc = new BeaconLightClient(
+                    clPeers,
+                    network.checkpointRoot(),
+                    network.checkpointSlot(),
+                    network.currentForkVersion(),
+                    network.genesisValidatorsRoot(),
+                    localBeaconState,
+                    null,                     // beaconApiUrl: no local beacon node on a phone
+                    clCacheRef::add,          // onPeerSuccess
+                    clCacheRef::markFailure,  // onPeerFailure
+                    network.clGenesisTime());
+            localBlc.setBlobParameters(
+                    network.activeBlobParamsEpoch(),
+                    network.activeBlobParamsMaxBlobs());
+            blcRef.set(localBlc);
 
             // Publish atomically vs. shutdown() — if shutdown won the race
             // while we were constructing, we own every resource above, so we
             // have to close them ourselves instead of letting shutdown do it.
-            // disc.start() runs inside the same synchronized block so shutdown
-            // cannot close the service between publish and start.
-            if (!startAndPublish(localCache, localConnector, localDisc, localDiscV5, localCachedCount)) {
+            // disc.start() / blc.start() run inside the same synchronized block
+            // so shutdown cannot close the service between publish and start.
+            if (!startAndPublish(localCache, localClCache, localConnector, localDisc, localDiscV5,
+                    localBlc, localBeaconState, localGenesisTime,
+                    localCachedCount, localCachedClCount)) {
                 Log.i(TAG, "shutdown raced boot; tearing down constructed resources");
+                closeQuietly(localBlc);
                 closeQuietly(localDiscV5);
                 closeQuietly(localDisc);
                 closeQuietly(localConnector);
                 return;
             }
             Log.i(TAG, "discv4 started on UDP " + DEFAULT_PORT
-                    + (this.discV5 != null ? ", discv5 on UDP 9000" : " (discv5 unavailable)"));
+                    + (this.discV5 != null ? ", discv5 on UDP 9000" : " (discv5 unavailable)")
+                    + ", beacon LC seeded with " + clPeers.size() + " CL peer(s)");
         } catch (Exception e) {
             Log.e(TAG, "node boot failed", e);
+            closeQuietly(localBlc);
             closeQuietly(localDiscV5);
             closeQuietly(localDisc);
             closeQuietly(localConnector);
@@ -247,6 +447,8 @@ public final class NodeService extends Service {
             backoff.clear();
             blacklistedNodeIds.clear();
             cachedPeerCount = 0;
+            cachedClPeerCount = 0;
+            clGenesisTime = 0L;
             startTimeMs = 0L;
             RUNNING.set(false);
             stopForeground(STOP_FOREGROUND_REMOVE);
@@ -255,15 +457,21 @@ public final class NodeService extends Service {
     }
 
     private synchronized boolean startAndPublish(AndroidPeerCache cache,
+                                                 AndroidCLPeerCache clCache,
                                                  RLPxConnector conn,
                                                  DiscV4Service disc,
                                                  DiscV5Service disc5,
-                                                 int cachedCount) throws Exception {
+                                                 BeaconLightClient blc,
+                                                 BeaconSyncState beaconState,
+                                                 long genesisTime,
+                                                 int cachedCount,
+                                                 int cachedClCount) throws Exception {
         if (!RUNNING.get()) return false;
         disc.start(DEFAULT_PORT);
-        // discv5 is diagnostic-only on Android (no BLC consumer yet), so a
-        // start failure (UDP 9000 busy, permission denied, …) must not take
-        // down EL: log and keep going with discV5=null.
+        // discv5 only feeds the CL peer cache on Android (BLC also reads from
+        // hardcoded multiaddrs and the cached pool), so a start failure
+        // (UDP 9000 busy, permission denied, …) must not take down EL or BLC:
+        // log and keep going with discV5=null.
         DiscV5Service startedDiscV5 = disc5;
         try {
             disc5.start(9000);
@@ -272,11 +480,22 @@ public final class NodeService extends Service {
             closeQuietly(disc5);
             startedDiscV5 = null;
         }
+        // blc.start() spins up the libp2p host (TCP) and a sync thread that
+        // bootstraps from the first responsive peer, then polls finality every
+        // 12s. Throws IllegalStateException if already running, which can't
+        // happen here (we just constructed it) — but propagate any startup
+        // failure so the caller can tear down cleanly.
+        blc.start();
         this.peerCache = cache;
+        this.clPeerCache = clCache;
         this.connector = conn;
         this.discV4 = disc;
         this.discV5 = startedDiscV5;
+        this.beaconLightClient = blc;
+        this.beaconSyncState = beaconState;
+        this.clGenesisTime = genesisTime;
         this.cachedPeerCount = cachedCount;
+        this.cachedClPeerCount = cachedClCount;
         return true;
     }
 
@@ -298,6 +517,12 @@ public final class NodeService extends Service {
     public synchronized void shutdown() {
         Log.i(TAG, "shutdown requested from UI");
         RUNNING.set(false);
+        // Close BLC first: its libp2p host's outbound dials hold references
+        // through to the discv5 callback's blcRef, and the sync thread can
+        // be in the middle of an addPeer call when shutdown fires.
+        closeQuietly(beaconLightClient);
+        beaconLightClient = null;
+        beaconSyncState = null;
         closeQuietly(connector);
         connector = null;
         closeQuietly(discV5);
@@ -305,10 +530,13 @@ public final class NodeService extends Service {
         closeQuietly(discV4);
         discV4 = null;
         peerCache = null;
+        clPeerCache = null;
         attempted.clear();
         backoff.clear();
         blacklistedNodeIds.clear();
         cachedPeerCount = 0;
+        cachedClPeerCount = 0;
+        clGenesisTime = 0L;
         startTimeMs = 0L;
         clPeersDiscovered.set(0);
         stopForeground(STOP_FOREGROUND_REMOVE);
@@ -329,6 +557,7 @@ public final class NodeService extends Service {
         backoff.clear();
         blacklistedNodeIds.clear();
         cachedPeerCount = 0;
+        cachedClPeerCount = 0;
         if (peerCache != null) {
             peerCache.clear();
         } else {
@@ -339,15 +568,26 @@ public final class NodeService extends Service {
                 Log.w(TAG, "failed to delete " + cacheFile);
             }
         }
+        if (clPeerCache != null) {
+            clPeerCache.clear();
+        } else {
+            java.io.File clCacheFile = new java.io.File(getFilesDir(), "cl-peers.cache");
+            if (clCacheFile.exists() && !clCacheFile.delete()) {
+                Log.w(TAG, "failed to delete " + clCacheFile);
+            }
+        }
     }
 
     public Snapshot snapshot() {
         boolean running = RUNNING.get();
         int discv5Live = discV5 != null ? discV5.liveNodeCount() : 0;
+        BeaconStats bs = beaconStatsSnapshot();
         if (!running || connector == null) {
             return new Snapshot(running, startTimeMs, 0, 0, 0, 0,
                     cachedPeerCount, attempted.size(), countActiveBackoff(),
                     blacklistedNodeIds.size(), discv5Live, clPeersDiscovered.get(),
+                    bs.state, bs.bootstrapped, bs.connected, bs.lc,
+                    cachedClPeerCount, bs.finalizedSlot, bs.execBlockNum, bs.execBlockHashHex,
                     List.of());
         }
         List<RLPxConnector.PeerInfo> active = connector.getActivePeers();
@@ -367,7 +607,37 @@ public final class NodeService extends Service {
         return new Snapshot(true, startTimeMs, tableSize, active.size(), ready.size(), snapCount,
                 cachedPeerCount, attempted.size(), countActiveBackoff(),
                 blacklistedNodeIds.size(), discv5Live, clPeersDiscovered.get(),
+                bs.state, bs.bootstrapped, bs.connected, bs.lc,
+                cachedClPeerCount, bs.finalizedSlot, bs.execBlockNum, bs.execBlockHashHex,
                 ready);
+    }
+
+    /** Per-snapshot beacon view, computed once so the record fields stay consistent. */
+    private record BeaconStats(String state, boolean bootstrapped, int connected, int lc,
+                               long finalizedSlot, long execBlockNum, String execBlockHashHex) {}
+
+    private BeaconStats beaconStatsSnapshot() {
+        BeaconLightClient blc = beaconLightClient;
+        BeaconSyncState bss = beaconSyncState;
+        if (blc == null || bss == null) {
+            return new BeaconStats("STOPPED", false, 0, 0, 0L, 0L, null);
+        }
+        List<BeaconP2PService.PeerInfo> peers = blc.getConnectedPeers();
+        int lc = 0;
+        for (BeaconP2PService.PeerInfo p : peers) {
+            if (p.supportsLightClient()) lc++;
+        }
+        byte[] execHash = bss.getExecutionBlockHash();
+        String execHashHex = execHash == null ? null
+                : org.apache.tuweni.bytes.Bytes.wrap(execHash).toHexString();
+        return new BeaconStats(
+                bss.getSyncState(clGenesisTime).name(),
+                blc.isBootstrapped(),
+                peers.size(),
+                lc,
+                bss.getFinalizedSlot(),
+                bss.getExecutionBlockNumber(),
+                execHashHex);
     }
 
     private int countActiveBackoff() {
@@ -389,6 +659,7 @@ public final class NodeService extends Service {
     @Override
     public synchronized void onDestroy() {
         Log.i(TAG, "Stopping node");
+        closeQuietly(beaconLightClient);
         closeQuietly(connector);
         closeQuietly(discV5);
         closeQuietly(discV4);

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -1,5 +1,6 @@
 package com.jaeckel.ethp2p.android;
 
+import android.annotation.SuppressLint;
 import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
@@ -8,7 +9,7 @@ import android.content.Intent;
 import android.content.pm.ServiceInfo;
 import android.os.Binder;
 import android.os.IBinder;
-import android.util.Log;
+import com.jaeckel.ethp2p.android.log.LogBuffer;
 
 import com.jaeckel.ethp2p.consensus.BeaconLightClient;
 import com.jaeckel.ethp2p.consensus.BeaconSyncState;
@@ -18,6 +19,7 @@ import com.jaeckel.ethp2p.core.crypto.NodeKey;
 import com.jaeckel.ethp2p.networking.NetworkConfig;
 import com.jaeckel.ethp2p.networking.discv4.DiscV4Service;
 import com.jaeckel.ethp2p.networking.discv5.DiscV5Service;
+import com.jaeckel.ethp2p.networking.eth.messages.BlockHeadersMessage;
 import com.jaeckel.ethp2p.networking.rlpx.RLPxConnector;
 import com.jaeckel.ethp2p.networking.snap.messages.AccountRangeMessage;
 
@@ -36,6 +38,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -55,6 +58,14 @@ public final class NodeService extends Service {
     // abusive on a phone (battery, data, NAT table, file descriptors). attempted
     // is removed only when a peer drops, so this bounds in-flight dial churn.
     private static final int MAX_ATTEMPTED = 200;
+    // Same bound the JVM daemon uses (CommandHandler.MAX_HEADER_CHAIN_GAP).
+    // Caps how many headers we'll fetch to bridge from the beacon-finalized
+    // block to the peer's head — i.e. the maximum gap the headerChain
+    // verification path will tolerate. In normal operation the gap is small
+    // (snap peers track head, BLC finality lags by ~12.8 minutes ≈ 64 blocks),
+    // but the bound has to cover catch-up after the phone wakes from doze.
+    private static final int MAX_HEADER_CHAIN_GAP = 8192;
+    private static final long HEADER_CHAIN_TIMEOUT_SEC = 60;
 
     // Static so MainActivity can reflect the correct button state after a
     // configuration change — the activity instance is recreated, but the
@@ -143,14 +154,36 @@ public final class NodeService extends Service {
 
     /**
      * Run a get-account query against any active READY+snap peer and verify
-     * the returned proof against the beacon-attested state root window.
+     * the returned proof against the beacon-attested state root.
      *
-     * <p>Only the {@code stateRootMatch} verification path is implemented —
-     * the JVM daemon also tries a header-chain fallback when the peer's block
-     * is ahead of finalized, but that requires fetching headers via eth/68
-     * and verifying their parent chain back to a beacon-known anchor; not
-     * worth the porting effort for the POC.
+     * <p>Two verification methods, mirroring the JVM daemon
+     * ({@code CommandHandler#buildVerificationJson} for {@code get-account}):
+     * <ul>
+     *   <li><b>headerChain</b> (load-bearing path) — fetch the contiguous
+     *       header range {@code [finalizedBlock .. peerBlock]} via eth/68
+     *       from the same peer that served the proof, verify the
+     *       parent-hash chain, and require the first header's stateRoot
+     *       to equal the BLC-finalized execution stateRoot and the last
+     *       header's stateRoot to equal the peer-reported stateRoot. This
+     *       is what succeeds in normal operation, because snap peers serve
+     *       proofs at their head while the BLC's attested-root window
+     *       trails finalized + a few recent optimistic slots.</li>
+     *   <li><b>stateRootMatch</b> (fast-path shortcut) — if the peer's
+     *       reported stateRoot happens to be one the BLC has already
+     *       attested ({@link BeaconSyncState#findStateRoot}), skip the
+     *       header fetch entirely. Rare in practice: only fires when the
+     *       peer's head briefly aligns with a slot the BLC has just seen.</li>
+     * </ul>
+     * The shortcut is checked first so that when it does fire we save a
+     * round-trip; otherwise we fall through to the headerChain path.
      */
+    // CompletableFuture.failedFuture (Java 9, hidden behind Android API 31)
+    // and orTimeout (also gated to API 31) are backported to minSdk 29 via
+    // desugar_jdk_libs 2.1.3 — see android-app/build.gradle.kts. Lint flags
+    // them anyway because its API database doesn't track desugar coverage
+    // for every CF method. Suppress at the method level rather than file —
+    // a future use of a *genuinely* unbackported API should still trip.
+    @SuppressLint("NewApi")
     public CompletableFuture<AccountQueryResult> requestAccount(String hexAddress) {
         if (!RUNNING.get() || connector == null) {
             return CompletableFuture.failedFuture(
@@ -176,15 +209,31 @@ public final class NodeService extends Service {
         }
         Bytes32 accountHash = Hash.keccak256(address);
         BeaconSyncState bss = beaconSyncState;
-        return connector.requestAccount(address).thenApply(result ->
-                buildAccountResult("0x" + hexAddrFinal, address, accountHash, result, bss));
+        RLPxConnector conn = connector;
+        return connector.requestAccount(address).thenCompose(result ->
+                buildAccountResult("0x" + hexAddrFinal, address, accountHash, result, bss, conn));
     }
 
-    private static AccountQueryResult buildAccountResult(String addr,
-                                                          Bytes address,
-                                                          Bytes32 accountHash,
-                                                          AccountRangeMessage.DecodeResult result,
-                                                          BeaconSyncState bss) {
+    /**
+     * Mutable verification scratchpad. Keeps the two verification methods
+     * (headerChain + stateRootMatch) from threading 5 separate parameters
+     * through the async chain.
+     */
+    private static final class Verification {
+        boolean beaconChainVerified;
+        boolean blsVerified;
+        long matchedSlot = -1;
+        String verifyMethod;
+        String failReason;
+    }
+
+    private static CompletableFuture<AccountQueryResult> buildAccountResult(
+            String addr,
+            Bytes address,
+            Bytes32 accountHash,
+            AccountRangeMessage.DecodeResult result,
+            BeaconSyncState bss,
+            RLPxConnector connector) {
         AccountRangeMessage.AccountData found = null;
         for (AccountRangeMessage.AccountData a : result.accounts()) {
             if (a.accountHash().equals(accountHash)) {
@@ -192,6 +241,7 @@ public final class NodeService extends Service {
                 break;
             }
         }
+        final AccountRangeMessage.AccountData foundFinal = found;
         long nonce = found != null ? found.nonce() : -1;
         String balance = found != null ? found.balance().toString() : null;
 
@@ -204,30 +254,87 @@ public final class NodeService extends Service {
                     address.toArrayUnsafe(),
                     proofBytes, nonce, balance);
         }
+        final boolean peerProofValidFinal = peerProofValid;
 
-        boolean beaconChainVerified = false;
-        boolean blsVerified = false;
-        long matchedSlot = -1;
-        String verifyMethod = null;
+        Verification v = new Verification();
+
+        // Fast-path shortcut: if the BLC has already attested the peer's
+        // exact stateRoot, we're done — no header fetch needed. Rare, but
+        // free to check.
         if (bss != null && result.stateRoot() != null) {
             BeaconSyncState.SlottedStateRoot match =
                     bss.findStateRoot(result.stateRoot().toArrayUnsafe());
             if (match != null) {
-                beaconChainVerified = true;
-                matchedSlot = match.slot();
-                blsVerified = match.blsVerified();
-                verifyMethod = "stateRootMatch";
+                v.beaconChainVerified = true;
+                v.matchedSlot = match.slot();
+                v.blsVerified = match.blsVerified();
+                v.verifyMethod = "stateRootMatch";
+                return CompletableFuture.completedFuture(
+                        finalizeResult(addr, foundFinal, result, peerProofValidFinal, v));
             }
         }
 
-        String failReason = null;
-        if (!beaconChainVerified) {
-            if (result.stateRoot() == null) failReason = "noPeerStateRoot";
-            else if (!peerProofValid) failReason = "peerProofInvalid";
-            else if (bss == null || !bss.isSynced()) failReason = "beaconNotSynced";
-            else failReason = "stateRootMismatch";
+        // Main verification path: headerChain. Walk the failure ladder
+        // (mirrors CommandHandler.buildVerificationJson) — only run the
+        // fetch + chain verification if every prerequisite holds.
+        if (result.stateRoot() == null) {
+            v.failReason = "noPeerStateRoot";
+        } else if (!peerProofValid) {
+            v.failReason = "peerProofInvalid";
+        } else if (bss == null || !bss.isSynced()) {
+            v.failReason = "beaconNotSynced";
+        } else {
+            long peerBlockNumber = result.blockNumber();
+            long finalizedBlock = bss.getExecutionBlockNumber();
+            byte[] beaconRoot = bss.getVerifiedExecutionStateRoot();
+
+            if (peerBlockNumber <= 0) {
+                v.failReason = "noPeerBlockNumber";
+            } else if (finalizedBlock <= 0 || beaconRoot == null) {
+                v.failReason = "beaconBlockUnavailable";
+            } else if (peerBlockNumber <= finalizedBlock) {
+                v.failReason = "peerBlockBehindFinalized";
+            } else if (peerBlockNumber - finalizedBlock > MAX_HEADER_CHAIN_GAP) {
+                v.failReason = "headerChainGapTooLarge";
+            } else {
+                // headerChain: fetch [finalized .. peerBlock] inclusive
+                // from a single peer and verify the chain end-to-end.
+                final long finalizedSlot = bss.getFinalizedSlot();
+                LogBuffer.i(TAG, "[verify] headerChain: peerBlock=" + peerBlockNumber
+                        + ", finalizedBlock=" + finalizedBlock
+                        + ", gap=" + (peerBlockNumber - finalizedBlock));
+                return verifyHeaderChainBatched(
+                                connector, finalizedBlock, peerBlockNumber,
+                                beaconRoot, result.stateRoot().toArrayUnsafe())
+                        .handle((chainValid, ex) -> {
+                            if (ex != null) {
+                                LogBuffer.i(TAG, "[verify] headerChain error: " + ex.getMessage());
+                                v.failReason = "headerChainError";
+                            } else if (Boolean.TRUE.equals(chainValid)) {
+                                v.beaconChainVerified = true;
+                                v.matchedSlot = finalizedSlot;
+                                v.blsVerified = true;
+                                v.verifyMethod = "headerChain";
+                                v.failReason = null;
+                            } else {
+                                v.failReason = "headerChainInvalid";
+                            }
+                            return finalizeResult(addr, foundFinal, result, peerProofValidFinal, v);
+                        });
+            }
         }
 
+        return CompletableFuture.completedFuture(
+                finalizeResult(addr, foundFinal, result, peerProofValidFinal, v));
+    }
+
+    private static AccountQueryResult finalizeResult(String addr,
+                                                      AccountRangeMessage.AccountData found,
+                                                      AccountRangeMessage.DecodeResult result,
+                                                      boolean peerProofValid,
+                                                      Verification v) {
+        long nonce = found != null ? found.nonce() : -1;
+        String balance = found != null ? found.balance().toString() : null;
         return new AccountQueryResult(
                 addr,
                 found != null,
@@ -238,11 +345,73 @@ public final class NodeService extends Service {
                 result.blockNumber(),
                 result.stateRoot() != null ? result.stateRoot().toHexString() : null,
                 peerProofValid,
-                beaconChainVerified,
-                blsVerified,
-                matchedSlot,
-                verifyMethod,
-                failReason);
+                v.beaconChainVerified,
+                v.blsVerified,
+                v.matchedSlot,
+                v.verifyMethod,
+                v.failReason);
+    }
+
+    /**
+     * Fetch headers in a single batch and verify the chain end-to-end.
+     * Returns a future that completes with {@code true} iff:
+     * <ul>
+     *   <li>the first header's stateRoot equals the beacon-finalized root,</li>
+     *   <li>the last header's stateRoot equals the peer's reported root,</li>
+     *   <li>and every header's hash equals the next header's parentHash.</li>
+     * </ul>
+     */
+    @SuppressLint("NewApi") // CompletableFuture.orTimeout — see requestAccount
+    private static CompletableFuture<Boolean> verifyHeaderChainBatched(
+            RLPxConnector connector, long finalizedBlock, long peerBlock,
+            byte[] beaconStateRoot, byte[] peerStateRoot) {
+        long totalLong = peerBlock - finalizedBlock + 1;
+        if (totalLong < 2 || totalLong > MAX_HEADER_CHAIN_GAP) {
+            LogBuffer.i(TAG, "[verify] headerChain gap " + totalLong
+                    + " out of range [2, " + MAX_HEADER_CHAIN_GAP + "]");
+            return CompletableFuture.completedFuture(false);
+        }
+        int total = (int) totalLong;
+        LogBuffer.i(TAG, "[verify] Fetching " + total + " headers from #"
+                + finalizedBlock + " to #" + peerBlock);
+        return connector.requestBlockHeadersBatched(finalizedBlock, total)
+                .orTimeout(HEADER_CHAIN_TIMEOUT_SEC, TimeUnit.SECONDS)
+                .thenApply(headers -> {
+                    boolean valid = verifyHeaderChain(headers, beaconStateRoot, peerStateRoot);
+                    LogBuffer.i(TAG, "[verify] Full header chain (" + headers.size()
+                            + " blocks) valid: " + valid);
+                    return valid;
+                });
+    }
+
+    /**
+     * Pure verification of a contiguous header range. Identical algorithm to
+     * {@code CommandHandler#verifyHeaderChain} in the JVM daemon.
+     */
+    private static boolean verifyHeaderChain(List<BlockHeadersMessage.VerifiedHeader> headers,
+                                              byte[] expectedFirstStateRoot,
+                                              byte[] expectedLastStateRoot) {
+        if (headers.isEmpty()) return false;
+
+        byte[] firstStateRoot = headers.get(0).header().stateRoot.toArrayUnsafe();
+        if (!java.util.Arrays.equals(firstStateRoot, expectedFirstStateRoot)) return false;
+
+        byte[] lastStateRoot = headers.get(headers.size() - 1).header().stateRoot.toArrayUnsafe();
+        if (!java.util.Arrays.equals(lastStateRoot, expectedLastStateRoot)) return false;
+
+        for (int i = 0; i < headers.size() - 1; i++) {
+            Bytes32 currentHash = headers.get(i).hash();
+            Bytes32 nextParent = headers.get(i + 1).header().parentHash;
+            if (!currentHash.equals(nextParent)) {
+                LogBuffer.i(TAG, "[verify] hash chain break at index " + i
+                        + ": block #" + headers.get(i).header().number
+                        + " hash=" + currentHash.toShortHexString()
+                        + " != block #" + headers.get(i + 1).header().number
+                        + " parentHash=" + nextParent.toShortHexString());
+                return false;
+            }
+        }
+        return true;
     }
 
     @Override
@@ -251,7 +420,7 @@ public final class NodeService extends Service {
         // restart race with stopService). Guard so we don't boot two copies
         // of the node racing for the same UDP/TCP ports.
         if (!RUNNING.compareAndSet(false, true)) {
-            Log.i(TAG, "start requested but node is already running");
+            LogBuffer.i(TAG, "start requested but node is already running");
             return START_NOT_STICKY;
         }
         startTimeMs = System.currentTimeMillis();
@@ -282,7 +451,7 @@ public final class NodeService extends Service {
             localGenesisTime = network.clGenesisTime();
             Path keyFile = new java.io.File(getFilesDir(), "nodekey.hex").toPath();
             NodeKey nodeKey = NodeKey.loadOrGenerate(keyFile);
-            Log.i(TAG, "Node ID: " + nodeKey.nodeId().toHexString());
+            LogBuffer.i(TAG, "Node ID: " + nodeKey.nodeId().toHexString());
 
             Path cacheFile = new java.io.File(getFilesDir(), "peers.cache").toPath();
             localCache = new AndroidPeerCache(cacheFile);
@@ -293,7 +462,7 @@ public final class NodeService extends Service {
             localConnector = new RLPxConnector(nodeKey, DEFAULT_PORT, network,
                     headers -> {
                         if (!headers.isEmpty()) {
-                            Log.i(TAG, "Received " + headers.size() + " block header(s)");
+                            LogBuffer.i(TAG, "Received " + headers.size() + " block header(s)");
                         }
                     },
                     cacheRef::add);
@@ -313,7 +482,7 @@ public final class NodeService extends Service {
                         attempted.remove(peerKey);
                     });
                 } catch (Exception e) {
-                    Log.w(TAG, "cached peer connect failed: " + e.getMessage());
+                    LogBuffer.w(TAG, "cached peer connect failed: " + e.getMessage());
                     attempted.remove(peerKey);
                 }
             }
@@ -347,7 +516,7 @@ public final class NodeService extends Service {
                         attempted.remove(peerKey);
                     });
                 } catch (Exception e) {
-                    Log.w(TAG, "discovered peer connect failed: " + e.getMessage());
+                    LogBuffer.w(TAG, "discovered peer connect failed: " + e.getMessage());
                     attempted.remove(peerKey);
                 }
             });
@@ -424,18 +593,18 @@ public final class NodeService extends Service {
             if (!startAndPublish(localCache, localClCache, localConnector, localDisc, localDiscV5,
                     localBlc, localBeaconState, localGenesisTime,
                     localCachedCount, localCachedClCount)) {
-                Log.i(TAG, "shutdown raced boot; tearing down constructed resources");
+                LogBuffer.i(TAG, "shutdown raced boot; tearing down constructed resources");
                 closeQuietly(localBlc);
                 closeQuietly(localDiscV5);
                 closeQuietly(localDisc);
                 closeQuietly(localConnector);
                 return;
             }
-            Log.i(TAG, "discv4 started on UDP " + DEFAULT_PORT
+            LogBuffer.i(TAG, "discv4 started on UDP " + DEFAULT_PORT
                     + (this.discV5 != null ? ", discv5 on UDP 9000" : " (discv5 unavailable)")
                     + ", beacon LC seeded with " + clPeers.size() + " CL peer(s)");
         } catch (Exception e) {
-            Log.e(TAG, "node boot failed", e);
+            LogBuffer.e(TAG, "node boot failed", e);
             closeQuietly(localBlc);
             closeQuietly(localDiscV5);
             closeQuietly(localDisc);
@@ -476,7 +645,7 @@ public final class NodeService extends Service {
         try {
             disc5.start(9000);
         } catch (Throwable t) {
-            Log.w(TAG, "discv5 start failed, continuing without CL discovery: " + t.getMessage());
+            LogBuffer.w(TAG, "discv5 start failed, continuing without CL discovery: " + t.getMessage());
             closeQuietly(disc5);
             startedDiscV5 = null;
         }
@@ -514,9 +683,26 @@ public final class NodeService extends Service {
      * the service instance may linger until the activity unbinds, but the node
      * is no longer running.
      */
-    public synchronized void shutdown() {
-        Log.i(TAG, "shutdown requested from UI");
+    public void shutdown() {
+        LogBuffer.i(TAG, "shutdown requested from UI");
+        // Flip RUNNING + clear the foreground notification synchronously so
+        // the UI button flips and the notification disappears immediately.
+        // The expensive close chain (libp2p host.stop().join(), Netty
+        // shutdownGracefully, syncThread.join) runs on a worker — doing it
+        // on the UI thread blocks main for seconds and ANRs.
         RUNNING.set(false);
+        stopForeground(STOP_FOREGROUND_REMOVE);
+        stopSelf();
+        new Thread(this::doShutdown, "ethp2p-shutdown").start();
+    }
+
+    /**
+     * Worker-thread close chain. Synchronized so it serializes against
+     * {@link #startAndPublish}: a fast Stop → Start sequence will block
+     * boot at {@code startAndPublish} until UDP 30303 / 9000 are released,
+     * instead of failing with bind-in-use.
+     */
+    private synchronized void doShutdown() {
         // Close BLC first: its libp2p host's outbound dials hold references
         // through to the discv5 callback's blcRef, and the sync thread can
         // be in the middle of an addPeer call when shutdown fires.
@@ -539,8 +725,7 @@ public final class NodeService extends Service {
         clGenesisTime = 0L;
         startTimeMs = 0L;
         clPeersDiscovered.set(0);
-        stopForeground(STOP_FOREGROUND_REMOVE);
-        stopSelf();
+        LogBuffer.i(TAG, "node shutdown complete");
     }
 
     /**
@@ -553,27 +738,37 @@ public final class NodeService extends Service {
      * a cache, and clearing them would race with the per-peer close callback.
      */
     public void clearCaches() {
-        Log.i(TAG, "clearing peer caches from UI");
+        LogBuffer.i(TAG, "clearing peer caches from UI");
+        // File deletes are fast in the happy case but still IO; keep the UI
+        // thread off them so a slow flash + cache-file fsync can't ANR.
+        new Thread(this::doClearCaches, "ethp2p-clear-caches").start();
+    }
+
+    private void doClearCaches() {
         backoff.clear();
         blacklistedNodeIds.clear();
         cachedPeerCount = 0;
         cachedClPeerCount = 0;
-        if (peerCache != null) {
-            peerCache.clear();
+        // Capture references — doShutdown can null these out concurrently
+        // if the user taps Clear and Stop in quick succession.
+        AndroidPeerCache pc = peerCache;
+        if (pc != null) {
+            pc.clear();
         } else {
             // Node is stopped: no live AndroidPeerCache instance exists, so
             // delete the on-disk file directly.
             java.io.File cacheFile = new java.io.File(getFilesDir(), "peers.cache");
             if (cacheFile.exists() && !cacheFile.delete()) {
-                Log.w(TAG, "failed to delete " + cacheFile);
+                LogBuffer.w(TAG, "failed to delete " + cacheFile);
             }
         }
-        if (clPeerCache != null) {
-            clPeerCache.clear();
+        AndroidCLPeerCache clpc = clPeerCache;
+        if (clpc != null) {
+            clpc.clear();
         } else {
             java.io.File clCacheFile = new java.io.File(getFilesDir(), "cl-peers.cache");
             if (clCacheFile.exists() && !clCacheFile.delete()) {
-                Log.w(TAG, "failed to delete " + clCacheFile);
+                LogBuffer.w(TAG, "failed to delete " + clCacheFile);
             }
         }
     }
@@ -657,13 +852,15 @@ public final class NodeService extends Service {
     }
 
     @Override
-    public synchronized void onDestroy() {
-        Log.i(TAG, "Stopping node");
-        closeQuietly(beaconLightClient);
-        closeQuietly(connector);
-        closeQuietly(discV5);
-        closeQuietly(discV4);
+    public void onDestroy() {
+        LogBuffer.i(TAG, "Stopping node (onDestroy)");
+        // Same fire-and-forget pattern as shutdown(): the system gives us a
+        // brief window to return from onDestroy and we don't want to spend
+        // it blocking on libp2p host shutdown / Netty graceful drain. The
+        // worker holds the same lock as startAndPublish, so a subsequent
+        // service start can't race with a half-finished close.
         RUNNING.set(false);
+        new Thread(this::doShutdown, "ethp2p-shutdown").start();
         super.onDestroy();
     }
 

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -285,8 +285,12 @@ public final class NodeService extends Service {
             v.failReason = "beaconNotSynced";
         } else {
             long peerBlockNumber = result.blockNumber();
-            long finalizedBlock = bss.getExecutionBlockNumber();
-            byte[] beaconRoot = bss.getVerifiedExecutionStateRoot();
+            // Read block number + state root from one atomic snapshot — reading them via
+            // two separate getters can pair a block number with a state root from a
+            // different finalized payload if an update lands between the calls.
+            BeaconSyncState.FinalizedExecution fin = bss.getFinalizedExecution();
+            long finalizedBlock = fin.blockNumber();
+            byte[] beaconRoot = fin.stateRoot();
 
             if (peerBlockNumber <= 0) {
                 v.failReason = "noPeerBlockNumber";
@@ -814,8 +818,16 @@ public final class NodeService extends Service {
     private BeaconStats beaconStatsSnapshot() {
         BeaconLightClient blc = beaconLightClient;
         BeaconSyncState bss = beaconSyncState;
+        // clGenesisTime is set last in startAndPublish (after blc/bss are visible), so a
+        // snapshot can race in with blc/bss non-null but genesis time still 0. Passing 0 to
+        // getSyncState computes the period from epoch 0 → a wildly wrong (huge) wall period
+        // → misclassified sync state. Treat genesis-not-ready as still STARTING.
+        long genesis = clGenesisTime;
         if (blc == null || bss == null) {
             return new BeaconStats("STOPPED", false, 0, 0, 0L, 0L, null);
+        }
+        if (genesis <= 0L) {
+            return new BeaconStats("STARTING", false, 0, 0, 0L, 0L, null);
         }
         List<BeaconP2PService.PeerInfo> peers = blc.getConnectedPeers();
         int lc = 0;
@@ -826,7 +838,7 @@ public final class NodeService extends Service {
         String execHashHex = execHash == null ? null
                 : org.apache.tuweni.bytes.Bytes.wrap(execHash).toHexString();
         return new BeaconStats(
-                bss.getSyncState(clGenesisTime).name(),
+                bss.getSyncState(genesis).name(),
                 blc.isBootstrapped(),
                 peers.size(),
                 lc,

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/log/AppSlf4jProvider.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/log/AppSlf4jProvider.java
@@ -1,0 +1,119 @@
+package com.jaeckel.ethp2p.android.log;
+
+import org.slf4j.ILoggerFactory;
+import org.slf4j.IMarkerFactory;
+import org.slf4j.Logger;
+import org.slf4j.Marker;
+import org.slf4j.event.Level;
+import org.slf4j.helpers.BasicMDCAdapter;
+import org.slf4j.helpers.BasicMarkerFactory;
+import org.slf4j.helpers.LegacyAbstractLogger;
+import org.slf4j.helpers.MessageFormatter;
+import org.slf4j.spi.MDCAdapter;
+import org.slf4j.spi.SLF4JServiceProvider;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * SLF4J 2.x service provider that captures every log call from the
+ * consensus / networking / libp2p stack. Each call is teed to:
+ * <ul>
+ *   <li>{@code android.util.Log} — so {@code adb logcat} keeps working,</li>
+ *   <li>{@link LogBuffer} — so the in-app Logs tab can render it.</li>
+ * </ul>
+ *
+ * <p>Registered via {@code META-INF/services/org.slf4j.spi.SLF4JServiceProvider}.
+ * Replaces the previous {@code slf4j-simple} runtime binding (which wrote
+ * to stderr — invisible on Android and unreachable from the UI process).
+ */
+public final class AppSlf4jProvider implements SLF4JServiceProvider {
+
+    /** Must be a prefix of the slf4j-api version on the classpath. */
+    public static final String REQUESTED_API_VERSION = "2.0.99";
+
+    private final ILoggerFactory loggerFactory = new AppLoggerFactory();
+    private final IMarkerFactory markerFactory = new BasicMarkerFactory();
+    private final MDCAdapter mdcAdapter = new BasicMDCAdapter();
+
+    @Override public ILoggerFactory getLoggerFactory() { return loggerFactory; }
+    @Override public IMarkerFactory getMarkerFactory() { return markerFactory; }
+    @Override public MDCAdapter getMDCAdapter() { return mdcAdapter; }
+    @Override public String getRequestedApiVersion() { return REQUESTED_API_VERSION; }
+    @Override public void initialize() { /* nothing to bootstrap */ }
+
+    static final class AppLoggerFactory implements ILoggerFactory {
+        private final ConcurrentMap<String, Logger> cache = new ConcurrentHashMap<>();
+        @Override public Logger getLogger(String name) {
+            return cache.computeIfAbsent(name, AppLogger::new);
+        }
+    }
+
+    static final class AppLogger extends LegacyAbstractLogger {
+        private static final long serialVersionUID = 1L;
+
+        AppLogger(String name) {
+            this.name = name;
+        }
+
+        // We don't filter by level — let consumers (logcat / UI) gate display.
+        // TRACE is suppressed because libp2p is *very* chatty at trace level
+        // and would dominate the ring buffer otherwise.
+        @Override public boolean isTraceEnabled() { return false; }
+        @Override public boolean isDebugEnabled() { return true; }
+        @Override public boolean isInfoEnabled()  { return true; }
+        @Override public boolean isWarnEnabled()  { return true; }
+        @Override public boolean isErrorEnabled() { return true; }
+
+        @Override
+        protected String getFullyQualifiedCallerName() {
+            return AppLogger.class.getName();
+        }
+
+        @Override
+        protected void handleNormalizedLoggingCall(Level level, Marker marker,
+                                                   String messagePattern,
+                                                   Object[] arguments,
+                                                   Throwable throwable) {
+            String formatted = MessageFormatter.basicArrayFormat(messagePattern, arguments);
+
+            // Tee to logcat so `adb logcat` continues to work.
+            int prio = switch (level) {
+                case TRACE -> android.util.Log.VERBOSE;
+                case DEBUG -> android.util.Log.DEBUG;
+                case INFO  -> android.util.Log.INFO;
+                case WARN  -> android.util.Log.WARN;
+                case ERROR -> android.util.Log.ERROR;
+            };
+            String shortTag = shortenTagForLogcat(name);
+            if (throwable != null) {
+                android.util.Log.println(prio, shortTag,
+                        formatted + "\n" + android.util.Log.getStackTraceString(throwable));
+            } else {
+                android.util.Log.println(prio, shortTag, formatted);
+            }
+
+            // Ring buffer keeps the full logger name so the in-app viewer
+            // can show "BeaconLightClient" rather than the truncated tag.
+            char ch = switch (level) {
+                case TRACE -> 'V';
+                case DEBUG -> 'D';
+                case INFO  -> 'I';
+                case WARN  -> 'W';
+                case ERROR -> 'E';
+            };
+            LogBuffer.append(ch, name, formatted, throwable);
+        }
+
+        /**
+         * Logcat tags are capped at 23 chars on API 25 and earlier; some
+         * device manufacturers still enforce that on newer versions.
+         * Strip the package and truncate.
+         */
+        private static String shortenTagForLogcat(String loggerName) {
+            int dot = loggerName.lastIndexOf('.');
+            String simple = dot >= 0 ? loggerName.substring(dot + 1) : loggerName;
+            return simple.length() > 23 ? simple.substring(0, 23) : simple;
+        }
+    }
+}

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/log/LogBuffer.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/log/LogBuffer.java
@@ -1,0 +1,110 @@
+package com.jaeckel.ethp2p.android.log;
+
+import androidx.annotation.GuardedBy;
+import androidx.annotation.Nullable;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * In-process bounded ring buffer of log records, fed by both
+ * {@code android.util.Log} (via the public tee helpers on this class) and
+ * SLF4J (via {@link AppSlf4jProvider}). Read by the in-app Logs tab.
+ *
+ * <p>Reads are O(n) snapshot copies; writes are constant-time. A monotonic
+ * version counter is bumped on every mutation so the UI can poll cheaply
+ * for change without comparing buffer contents.
+ */
+public final class LogBuffer {
+
+    /** Capacity of the ring buffer. ~3 MB at typical 600-char lines. */
+    public static final int MAX_LINES = 5000;
+
+    /**
+     * @param sequence monotonic id assigned at append time. Stable across
+     *                 ring-buffer rotation — used by the in-app viewer as
+     *                 the LazyColumn item key so scroll position survives
+     *                 entries falling off the front.
+     */
+    public record Entry(long sequence, long timestampMillis, char level,
+                        String tag, String message) {}
+
+    private static final Object LOCK = new Object();
+    @GuardedBy("LOCK")
+    private static final ArrayDeque<Entry> BUFFER = new ArrayDeque<>(MAX_LINES);
+    private static final AtomicLong VERSION = new AtomicLong();
+    private static final AtomicLong SEQUENCE = new AtomicLong();
+
+    private LogBuffer() {}
+
+    /** Monotonic counter; bumps on every append or clear. */
+    public static long version() {
+        return VERSION.get();
+    }
+
+    /** Snapshot of the buffer in chronological (oldest-first) order. */
+    public static List<Entry> snapshot() {
+        synchronized (LOCK) {
+            return new ArrayList<>(BUFFER);
+        }
+    }
+
+    public static void clear() {
+        synchronized (LOCK) {
+            BUFFER.clear();
+        }
+        VERSION.incrementAndGet();
+    }
+
+    /** Append a record. Called from the SLF4J provider and the Log tee helpers. */
+    public static void append(char level, String tag, String message, @Nullable Throwable t) {
+        String full = (t == null) ? message
+                : message + "\n" + android.util.Log.getStackTraceString(t);
+        Entry entry = new Entry(SEQUENCE.incrementAndGet(),
+                System.currentTimeMillis(), level, tag, full);
+        synchronized (LOCK) {
+            BUFFER.addLast(entry);
+            while (BUFFER.size() > MAX_LINES) BUFFER.pollFirst();
+        }
+        VERSION.incrementAndGet();
+    }
+
+    // -------- tee helpers replacing android.util.Log inside the app -------
+    //
+    // Call sites that previously used `android.util.Log` switch to
+    // `LogBuffer` so their output appears in both logcat and the in-app
+    // Logs tab. Logger output from the consensus/networking modules
+    // (slf4j) is captured by AppSlf4jProvider directly — there's no need
+    // to touch those call sites.
+
+    public static void v(String tag, String msg) {
+        android.util.Log.v(tag, msg);
+        append('V', tag, msg, null);
+    }
+    public static void d(String tag, String msg) {
+        android.util.Log.d(tag, msg);
+        append('D', tag, msg, null);
+    }
+    public static void i(String tag, String msg) {
+        android.util.Log.i(tag, msg);
+        append('I', tag, msg, null);
+    }
+    public static void w(String tag, String msg) {
+        android.util.Log.w(tag, msg);
+        append('W', tag, msg, null);
+    }
+    public static void w(String tag, String msg, Throwable t) {
+        android.util.Log.w(tag, msg, t);
+        append('W', tag, msg, t);
+    }
+    public static void e(String tag, String msg) {
+        android.util.Log.e(tag, msg);
+        append('E', tag, msg, null);
+    }
+    public static void e(String tag, String msg, Throwable t) {
+        android.util.Log.e(tag, msg, t);
+        append('E', tag, msg, t);
+    }
+}

--- a/android-app/src/main/java/org/apache/logging/log4j/LogManager.java
+++ b/android-app/src/main/java/org/apache/logging/log4j/LogManager.java
@@ -1,0 +1,32 @@
+package org.apache.logging.log4j;
+
+/**
+ * Minimal stand-in for log4j-api's {@code LogManager}. The real one's
+ * {@code getLogger()} no-args overload uses {@link java.lang.StackWalker}
+ * to derive the caller class name, and on Android the walker returns null
+ * {@code getDeclaringClass()} for some frames — so log4j throws
+ * {@code UnsupportedOperationException} during static init of every
+ * discovery class that has a {@code static final Logger LOG = LogManager.getLogger();}.
+ *
+ * <p>Here {@code getLogger()} just defaults to a fixed name and skips the
+ * stack walk entirely. Names are routed to slf4j (which the Android app
+ * already binds to slf4j-simple).
+ */
+public final class LogManager {
+
+    private LogManager() {}
+
+    public static Logger getLogger() {
+        return new Slf4jBackedLogger(org.slf4j.LoggerFactory.getLogger("log4j-default"));
+    }
+
+    public static Logger getLogger(Class<?> clazz) {
+        return new Slf4jBackedLogger(org.slf4j.LoggerFactory.getLogger(
+                clazz != null ? clazz : LogManager.class));
+    }
+
+    public static Logger getLogger(String name) {
+        return new Slf4jBackedLogger(org.slf4j.LoggerFactory.getLogger(
+                name != null ? name : "log4j-default"));
+    }
+}

--- a/android-app/src/main/java/org/apache/logging/log4j/Logger.java
+++ b/android-app/src/main/java/org/apache/logging/log4j/Logger.java
@@ -1,0 +1,39 @@
+package org.apache.logging.log4j;
+
+import org.apache.logging.log4j.util.Supplier;
+
+/**
+ * Minimal stand-in for log4j-api's {@code Logger}. Only the method overloads
+ * actually invoked by the consensys discovery 26.4.0 jar are declared.
+ *
+ * <p>Implementations should treat {@code "{}"} placeholders the same way slf4j
+ * does (which happens to match log4j 2 message format) so existing call sites
+ * just work when their bytecode is dexed against this interface.
+ */
+public interface Logger {
+
+    void trace(String msg);
+    void trace(String fmt, Object a);
+    void trace(String fmt, Object a, Object b);
+    void trace(String msg, Throwable t);
+    void trace(Supplier<?> msgSupplier);
+    void trace(Supplier<?> msgSupplier, Throwable t);
+
+    void debug(String msg);
+    void debug(String fmt, Object a);
+    void debug(String fmt, Object a, Object b);
+    void debug(String fmt, Object a, Object b, Object c);
+    void debug(String msg, Throwable t);
+    void debug(String fmt, Supplier<?>... args);
+    void debug(Supplier<?> msgSupplier);
+
+    void info(String msg);
+    void info(String fmt, Object a);
+
+    void warn(String msg);
+    void warn(String fmt, Object a, Object b);
+    void warn(String fmt, Object a, Object b, Object c);
+
+    void error(String fmt, Object a);
+    void error(String msg, Throwable t);
+}

--- a/android-app/src/main/java/org/apache/logging/log4j/Slf4jBackedLogger.java
+++ b/android-app/src/main/java/org/apache/logging/log4j/Slf4jBackedLogger.java
@@ -1,0 +1,68 @@
+package org.apache.logging.log4j;
+
+import org.apache.logging.log4j.util.Supplier;
+
+/**
+ * Routes {@link Logger} calls to slf4j. Lazy {@link Supplier} args are
+ * resolved only when the corresponding level is enabled, matching log4j-api's
+ * own behaviour.
+ *
+ * <p>log4j 2 and slf4j both use {@code "{}"} placeholders, so format strings
+ * pass through unchanged.
+ */
+final class Slf4jBackedLogger implements Logger {
+
+    private final org.slf4j.Logger inner;
+
+    Slf4jBackedLogger(org.slf4j.Logger inner) {
+        this.inner = inner;
+    }
+
+    // ----- TRACE -----
+    @Override public void trace(String msg) { inner.trace(msg); }
+    @Override public void trace(String fmt, Object a) { inner.trace(fmt, a); }
+    @Override public void trace(String fmt, Object a, Object b) { inner.trace(fmt, a, b); }
+    @Override public void trace(String msg, Throwable t) { inner.trace(msg, t); }
+    @Override public void trace(Supplier<?> msgSupplier) {
+        if (inner.isTraceEnabled()) inner.trace(String.valueOf(msgSupplier.get()));
+    }
+    @Override public void trace(Supplier<?> msgSupplier, Throwable t) {
+        if (inner.isTraceEnabled()) inner.trace(String.valueOf(msgSupplier.get()), t);
+    }
+
+    // ----- DEBUG -----
+    @Override public void debug(String msg) { inner.debug(msg); }
+    @Override public void debug(String fmt, Object a) { inner.debug(fmt, a); }
+    @Override public void debug(String fmt, Object a, Object b) { inner.debug(fmt, a, b); }
+    @Override public void debug(String fmt, Object a, Object b, Object c) { inner.debug(fmt, a, b, c); }
+    @Override public void debug(String msg, Throwable t) { inner.debug(msg, t); }
+    @Override public void debug(String fmt, Supplier<?>... args) {
+        if (!inner.isDebugEnabled()) return;
+        inner.debug(fmt, resolve(args));
+    }
+    @Override public void debug(Supplier<?> msgSupplier) {
+        if (inner.isDebugEnabled()) inner.debug(String.valueOf(msgSupplier.get()));
+    }
+
+    // ----- INFO -----
+    @Override public void info(String msg) { inner.info(msg); }
+    @Override public void info(String fmt, Object a) { inner.info(fmt, a); }
+
+    // ----- WARN -----
+    @Override public void warn(String msg) { inner.warn(msg); }
+    @Override public void warn(String fmt, Object a, Object b) { inner.warn(fmt, a, b); }
+    @Override public void warn(String fmt, Object a, Object b, Object c) { inner.warn(fmt, a, b, c); }
+
+    // ----- ERROR -----
+    @Override public void error(String fmt, Object a) { inner.error(fmt, a); }
+    @Override public void error(String msg, Throwable t) { inner.error(msg, t); }
+
+    private static Object[] resolve(Supplier<?>[] args) {
+        if (args == null) return new Object[0];
+        Object[] out = new Object[args.length];
+        for (int i = 0; i < args.length; i++) {
+            out[i] = args[i] == null ? null : args[i].get();
+        }
+        return out;
+    }
+}

--- a/android-app/src/main/java/org/apache/logging/log4j/util/Supplier.java
+++ b/android-app/src/main/java/org/apache/logging/log4j/util/Supplier.java
@@ -1,0 +1,13 @@
+package org.apache.logging.log4j.util;
+
+/**
+ * Stand-in for log4j-api's {@code Supplier}. Only present so we can compile
+ * and load the discovery library without dragging in the full log4j-api jar
+ * — log4j's {@code LogManager.getLogger()} no-args overload uses
+ * {@link java.lang.StackWalker} to derive a logger name, and Android returns
+ * null {@code getDeclaringClass()} for some frames so the call throws.
+ */
+@FunctionalInterface
+public interface Supplier<T> {
+    T get();
+}

--- a/android-app/src/main/resources/META-INF/services/org.slf4j.spi.SLF4JServiceProvider
+++ b/android-app/src/main/resources/META-INF/services/org.slf4j.spi.SLF4JServiceProvider
@@ -1,0 +1,1 @@
+com.jaeckel.ethp2p.android.log.AppSlf4jProvider

--- a/app/src/main/java/com/jaeckel/ethp2p/app/CommandHandler.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/CommandHandler.java
@@ -812,8 +812,12 @@ public class CommandHandler {
             // used to turn into a 3-boolean blob that was impossible to debug.
             long peerBlockNumber = accountResult.blockNumber();
             if (!beaconChainVerified) {
-                long finalizedBlockNum = beaconSyncState.getExecutionBlockNumber();
-                byte[] beaconRoot = beaconSyncState.getVerifiedExecutionStateRoot();
+                // Atomic snapshot: block number + state root must come from the same
+                // finalized payload, since the header chain is anchored at the block
+                // number and required to terminate at the state root.
+                BeaconSyncState.FinalizedExecution fin = beaconSyncState.getFinalizedExecution();
+                long finalizedBlockNum = fin.blockNumber();
+                byte[] beaconRoot = fin.stateRoot();
                 if (usedStateRoot == null) {
                     failReason = "noPeerStateRoot";
                 } else if (!storageProofValid) {
@@ -1065,8 +1069,11 @@ public class CommandHandler {
             }
         }
 
-        long finalizedBlockNum = beaconSyncState.getExecutionBlockNumber();
-        byte[] beaconRoot = beaconSyncState.getVerifiedExecutionStateRoot();
+        // Atomic snapshot — see note at the get-storage verification path. Block number
+        // and state root must describe the same finalized payload.
+        BeaconSyncState.FinalizedExecution fin = beaconSyncState.getFinalizedExecution();
+        long finalizedBlockNum = fin.blockNumber();
+        byte[] beaconRoot = fin.stateRoot();
         long finalizedPeriod = beaconSyncState.getFinalizedPeriod();
         long wallClockPeriod = BeaconChainSpec.currentPeriod(clGenesisTime);
         long periodLag = wallClockPeriod - finalizedPeriod;

--- a/app/src/main/java/com/jaeckel/ethp2p/app/Main.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/Main.java
@@ -448,6 +448,8 @@ public final class Main {
         } catch (BindException e) {
             System.err.println("Cannot bind IPC socket " + socketPath + ": " + e.getMessage());
             System.err.println("Is another instance already running?");
+            beaconLightClient.close();
+            connector.close();
             discV5.close();
             discV4.close();
             fileLock.release();
@@ -456,6 +458,8 @@ public final class Main {
             return;
         } catch (Exception e) {
             System.err.println("Failed to start IPC server: " + e.getMessage());
+            beaconLightClient.close();
+            connector.close();
             discV5.close();
             discV4.close();
             fileLock.release();

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconSyncState.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconSyncState.java
@@ -127,6 +127,25 @@ public class BeaconSyncState {
     }
 
     /**
+     * The finalized execution payload's (block number, state root) read from a single
+     * atomic snapshot. {@code stateRoot} is null if not yet synced.
+     */
+    public record FinalizedExecution(long blockNumber, byte[] stateRoot) {}
+
+    /**
+     * Returns the finalized execution block number and state root from one atomic read.
+     * <p>Callers that need both (e.g. header-chain verification anchors the chain at
+     * {@code blockNumber} and requires its state root to equal {@code stateRoot}) MUST use
+     * this rather than {@link #getExecutionBlockNumber()} + {@link #getVerifiedExecutionStateRoot()}
+     * separately: the underlying {@code InnerState} can be replaced between two reads, pairing a
+     * block number with a state root from a different payload.
+     */
+    public FinalizedExecution getFinalizedExecution() {
+        InnerState s = state.get();
+        return new FinalizedExecution(s.executionBlockNumber(), s.executionStateRoot());
+    }
+
+    /**
      * Returns the latest finalized beacon slot, or 0 if not yet synced.
      */
     public long getFinalizedSlot() {

--- a/core/src/main/java/com/jaeckel/ethp2p/core/crypto/NodeKey.java
+++ b/core/src/main/java/com/jaeckel/ethp2p/core/crypto/NodeKey.java
@@ -7,6 +7,7 @@ import org.apache.tuweni.crypto.SECP256K1;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.Security;
@@ -43,14 +44,18 @@ public final class NodeKey {
      */
     public static NodeKey loadOrGenerate(Path file) throws IOException {
         if (Files.exists(file)) {
-            String hex = Files.readString(file).strip();
+            // Files.readString / writeString are in JDK 11 but not in the
+            // Android core-library-desugaring minimal NIO subset, so use the
+            // byte-oriented Files APIs (always available via desugar) and
+            // decode/encode as UTF-8 ourselves.
+            String hex = new String(Files.readAllBytes(file), StandardCharsets.UTF_8).strip();
             Bytes32 privBytes = Bytes32.fromHexString(hex);
             SECP256K1.SecretKey secret = SECP256K1.SecretKey.fromBytes(privBytes);
             SECP256K1.KeyPair kp = SECP256K1.KeyPair.fromSecretKey(secret);
             return new NodeKey(kp);
         }
         NodeKey key = generate();
-        Files.writeString(file, key.privateKeyHex());
+        Files.write(file, key.privateKeyHex().getBytes(StandardCharsets.UTF_8));
         return key;
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-tuweni = "2.7.2"
+tuweni = "2.7.2-jvm17.1"
 discovery = "26.4.0"
 #netty-kotlin = "c5a8303903"
 netty-kotlin = "main-SNAPSHOT"
@@ -24,12 +24,12 @@ kotlin-android      = { id = "org.jetbrains.kotlin.android",         version.ref
 compose-compiler    = { id = "org.jetbrains.kotlin.plugin.compose",  version.ref = "kotlin" }
 
 [libraries]
-tuweni-bytes        = { module = "io.consensys.tuweni:tuweni-bytes",       version.ref = "tuweni" }
-tuweni-rlp          = { module = "io.consensys.tuweni:tuweni-rlp",         version.ref = "tuweni" }
-tuweni-crypto       = { module = "io.consensys.tuweni:tuweni-crypto",      version.ref = "tuweni" }
-tuweni-merkle-trie  = { module = "io.consensys.tuweni:tuweni-merkle-trie", version.ref = "tuweni" }
-tuweni-ssz          = { module = "io.consensys.tuweni:tuweni-ssz",         version.ref = "tuweni" }
-tuweni-units        = { module = "io.consensys.tuweni:tuweni-units",       version.ref = "tuweni" }
+tuweni-bytes        = { module = "com.github.biafra23.tuweni-kotlin:tuweni-bytes",       version.ref = "tuweni" }
+tuweni-rlp          = { module = "com.github.biafra23.tuweni-kotlin:tuweni-rlp",         version.ref = "tuweni" }
+tuweni-crypto       = { module = "com.github.biafra23.tuweni-kotlin:tuweni-crypto",      version.ref = "tuweni" }
+tuweni-merkle-trie  = { module = "com.github.biafra23.tuweni-kotlin:tuweni-merkle-trie", version.ref = "tuweni" }
+tuweni-ssz          = { module = "com.github.biafra23.tuweni-kotlin:tuweni-ssz",         version.ref = "tuweni" }
+tuweni-units        = { module = "com.github.biafra23.tuweni-kotlin:tuweni-units",       version.ref = "tuweni" }
 
 netty-transport     = { module = "com.github.biafra23.netty-kotlin:netty-transport",               version.ref = "netty-kotlin" }
 netty-codec         = { module = "com.github.biafra23.netty-kotlin:netty-codec",                   version.ref = "netty-kotlin" }
@@ -49,7 +49,7 @@ milagro             = { module = "org.miracl.milagro.amcl:milagro-crypto-java", 
 jvm-libp2p          = { module = "io.libp2p:jvm-libp2p",                   version.ref = "jvm-libp2p" }
 trueblocks-kotlin   = { module = "com.github.biafra23:trueblocks-kotlin", version.ref = "trueblocks-kotlin" }
 dnsjava             = { module = "dnsjava:dnsjava",                       version.ref = "dnsjava" }
-discovery           = { module = "io.consensys.protocols:discovery",      version.ref = "discovery" }
+discovery           = { module = "io.consensys.protocols:discovery",       version.ref = "discovery" }
 
 androidx-compose-bom              = { module = "androidx.compose:compose-bom", version.ref = "compose-bom" }
 androidx-activity-compose         = { module = "androidx.activity:activity-compose", version.ref = "activity-compose" }

--- a/networking/build.gradle.kts
+++ b/networking/build.gradle.kts
@@ -5,8 +5,7 @@ java {
     // Java 21 class files as input and rewrites them for the Android runtime,
     // so this keeps working on android-app (minSdk 29) provided the library
     // doesn't use Java 21 runtime APIs (SequencedCollection, scoped values,
-    // structured concurrency). Verified at integration time; fall back to an
-    // in-tree discv5 port if assembleDebug rejects it.
+    // structured concurrency).
     sourceCompatibility = JavaVersion.VERSION_21
     targetCompatibility = JavaVersion.VERSION_21
 }
@@ -29,6 +28,14 @@ dependencies {
     // Android. android-app already strips io.netty group-wide; mirror that here
     // so the JVM daemon also resolves to the fork.
     //
+    // Same story for io.consensys.tuweni: discovery transitively pulls upstream
+    // tuweni 2.7.0, but we resolve tuweni via the JitPack fork
+    // (com.github.biafra23.tuweni-kotlin, recompiled to Java 17 bytecode). The
+    // fork kept the original org.apache.tuweni.* package names, so both jars
+    // ship identical FQCNs under different coordinates — Gradle can't dedupe
+    // them and D8's checkDebugDuplicateClasses fails. The fork is a >=2.7.0
+    // recompile of the same classes, so it satisfies everything discovery needs.
+    //
     // log4j is NOT excluded: several of the library's internal classes
     // (IdentitySchemaV4Interpreter etc.) reference org.apache.logging.log4j.LogManager
     // in their <clinit>, so stripping it NoClassDefFoundErrors the whole library
@@ -36,6 +43,7 @@ dependencies {
     // satisfies the library's static init.
     implementation(libs.discovery) {
         exclude(group = "io.netty")
+        exclude(group = "io.consensys.tuweni")
     }
 
     testImplementation(platform(libs.junit.bom))


### PR DESCRIPTION
Stacked on #10 — retarget to \`main\` once that merges.

## Summary

- Pull `:consensus`, `jvm-libp2p`, `milagro`, and `snappy` into `android-app` so the BeaconLightClient runs in-process on Android.
- `NodeService` starts BLC alongside discv4/discv5/RLPx and surfaces beacon state, finalized slot, EL block, and CL peer counters in the status snapshot. Adds an in-process `requestAccount(address)` that runs against READY+snap peers and verifies the proof against the beacon-attested state-root window.
- New **Query** tab in `MainActivity` with an address field, a "consensus not synced" banner, and rendered `AccountQueryResult`.
- `AndroidCLPeerCache` mirrors the daemon's `CLPeerCache` using `android.util.Log` + `java.io` streams (same shape as `AndroidPeerCache`).
- Shim `org.apache.logging.log4j` → slf4j: log4j-api's no-args `getLogger()` walks the stack and Android's `StackWalker` returns null `getDeclaringClass()` for some frames, blowing up every `<clinit>` in jvm-libp2p / discovery.
- `pickFirst` the bouncycastle OSGI `MANIFEST.MF` (four bc jars all ship the same metadata file).
- `NodeKey.loadOrGenerate`: byte-oriented `Files` API so it works under core-library-desugaring (no `Files.readString`/`writeString`).

## Test plan

- [ ] APK builds (`./gradlew :android-app:assembleDebug`)
- [ ] App launches and reaches the Status tab without crashing on `<clinit>`
- [ ] Status tab shows non-zero `clPeersDiscovered` after a few minutes
- [ ] BLC reaches `state: SYNCED` (may take a while on cold start)
- [ ] After SYNCED, Query tab against a known address (e.g. `0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045`) returns a verified result
- [ ] Query tab shows the unsynced banner when BLC isn't SYNCED yet
- [ ] No regressions in the JVM daemon (`./gradlew :app:run` still reaches SYNCED on mainnet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)