### PR TITLE
Phase 1: SNAP-backed state oracle with proof verification

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,12 +2,20 @@ dependencies {
     implementation(project(":core"))
     implementation(project(":networking"))
     implementation(project(":consensus"))
+    implementation(project(":myotis-evm"))
     implementation(libs.tuweni.bytes)
     implementation(libs.tuweni.rlp)
     implementation(libs.tuweni.crypto)
     implementation(libs.trueblocks.kotlin)
     implementation(libs.slf4j.api)
     runtimeOnly(libs.logback.classic)
+
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.junit.jupiter)
+}
+
+tasks.test {
+    useJUnitPlatform()
 }
 
 tasks.register<JavaExec>("run") {

--- a/app/src/main/java/com/jaeckel/ethp2p/app/snap/EthHandlerSnapPeer.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/snap/EthHandlerSnapPeer.java
@@ -41,23 +41,13 @@ public final class EthHandlerSnapPeer implements SnapPeer {
         for (PathSet p : paths) {
             wirePaths.add(new GetTrieNodesMessage.PathSet(p.accountPath(), p.storagePaths()));
         }
-        CompletableFuture<TrieNodesMessage.DecodeResult> fut =
-                handler.requestTrieNodesAsync(stateRoot, wirePaths);
-        if (fut == null) {
-            return CompletableFuture.failedFuture(
-                    new IllegalStateException("peer not READY"));
-        }
-        return fut.thenApply(TrieNodesMessage.DecodeResult::nodes);
+        return handler.requestTrieNodesAsync(stateRoot, wirePaths)
+                .thenApply(TrieNodesMessage.DecodeResult::nodes);
     }
 
     @Override
     public CompletableFuture<List<Bytes>> getByteCodes(List<Bytes32> hashes) {
-        CompletableFuture<ByteCodesMessage.DecodeResult> fut =
-                handler.requestByteCodesAsync(hashes);
-        if (fut == null) {
-            return CompletableFuture.failedFuture(
-                    new IllegalStateException("peer not READY"));
-        }
-        return fut.thenApply(ByteCodesMessage.DecodeResult::codes);
+        return handler.requestByteCodesAsync(hashes)
+                .thenApply(ByteCodesMessage.DecodeResult::codes);
     }
 }

--- a/app/src/main/java/com/jaeckel/ethp2p/app/snap/EthHandlerSnapPeer.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/snap/EthHandlerSnapPeer.java
@@ -1,0 +1,63 @@
+package com.jaeckel.ethp2p.app.snap;
+
+import com.jaeckel.ethp2p.networking.eth.EthHandler;
+import com.jaeckel.ethp2p.networking.snap.messages.ByteCodesMessage;
+import com.jaeckel.ethp2p.networking.snap.messages.GetTrieNodesMessage;
+import com.jaeckel.ethp2p.networking.snap.messages.TrieNodesMessage;
+import io.myotis.evm.world.SnapPeer;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * {@link SnapPeer} adapter over a single {@link EthHandler}.
+ *
+ * <p>{@code :myotis-evm} doesn't depend on {@code :networking} (and shouldn't
+ * — the wallet's local EVM machinery is independent of the wire protocol).
+ * The adapter lives here in {@code :app}, where both modules are already on
+ * the classpath, and translates between {@link SnapPeer.PathSet} and the
+ * {@link GetTrieNodesMessage.PathSet} type the wire layer speaks.
+ *
+ * <p>Multi-peer fallback is the oracle's responsibility, not this adapter's.
+ * Construct one {@code EthHandlerSnapPeer} per peer, hand a
+ * {@code Supplier<SnapPeer>} that picks among them to
+ * {@code SnapBackedStateOracle}, and the oracle will rotate on
+ * {@code InvalidProof} / IO failures.
+ */
+public final class EthHandlerSnapPeer implements SnapPeer {
+
+    private final EthHandler handler;
+
+    public EthHandlerSnapPeer(EthHandler handler) {
+        this.handler = handler;
+    }
+
+    @Override
+    public CompletableFuture<List<Bytes>> getTrieNodes(Bytes32 stateRoot, List<PathSet> paths) {
+        List<GetTrieNodesMessage.PathSet> wirePaths = new ArrayList<>(paths.size());
+        for (PathSet p : paths) {
+            wirePaths.add(new GetTrieNodesMessage.PathSet(p.accountPath(), p.storagePaths()));
+        }
+        CompletableFuture<TrieNodesMessage.DecodeResult> fut =
+                handler.requestTrieNodesAsync(stateRoot, wirePaths);
+        if (fut == null) {
+            return CompletableFuture.failedFuture(
+                    new IllegalStateException("peer not READY"));
+        }
+        return fut.thenApply(TrieNodesMessage.DecodeResult::nodes);
+    }
+
+    @Override
+    public CompletableFuture<List<Bytes>> getByteCodes(List<Bytes32> hashes) {
+        CompletableFuture<ByteCodesMessage.DecodeResult> fut =
+                handler.requestByteCodesAsync(hashes);
+        if (fut == null) {
+            return CompletableFuture.failedFuture(
+                    new IllegalStateException("peer not READY"));
+        }
+        return fut.thenApply(ByteCodesMessage.DecodeResult::codes);
+    }
+}

--- a/core/src/main/java/com/jaeckel/ethp2p/core/trie/HexPrefix.java
+++ b/core/src/main/java/com/jaeckel/ethp2p/core/trie/HexPrefix.java
@@ -1,0 +1,92 @@
+package com.jaeckel.ethp2p.core.trie;
+
+/**
+ * Compact (hex-prefix) encoding used inside Modified Merkle Patricia Trie
+ * leaf and extension nodes.
+ *
+ * <p>The first nibble of the encoded path holds two bits:
+ * <pre>
+ *   0x00 — extension, even-length nibbles
+ *   0x10 — extension, odd-length nibbles  (low nibble = first path nibble)
+ *   0x20 — leaf,      even-length nibbles
+ *   0x30 — leaf,      odd-length nibbles  (low nibble = first path nibble)
+ * </pre>
+ *
+ * <p>Even-length encodings carry a padding nibble of zero in the second
+ * position; odd-length encodings carry the first path nibble in the second
+ * position so all subsequent bytes are pairs.
+ *
+ * <p>Reference: Ethereum Yellow Paper, Appendix C.
+ */
+public final class HexPrefix {
+
+    private HexPrefix() {}
+
+    /** Result of decoding a hex-prefix path. */
+    public record Decoded(boolean leaf, byte[] nibbles) {}
+
+    /** Decode a compact-encoded path into ({@code isLeaf}, raw nibble array). */
+    public static Decoded decode(byte[] encoded) {
+        if (encoded.length == 0) {
+            throw new IllegalArgumentException("empty hex-prefix path");
+        }
+        int flag = (encoded[0] & 0xff) >>> 4;
+        if (flag > 3) {
+            throw new IllegalArgumentException("invalid hex-prefix flag nibble: " + flag);
+        }
+        boolean leaf = (flag & 0x02) != 0;
+        boolean odd = (flag & 0x01) != 0;
+
+        int totalNibbles = encoded.length * 2 - (odd ? 1 : 2);
+        if (totalNibbles < 0) totalNibbles = 0;
+        byte[] nibbles = new byte[totalNibbles];
+        int n = 0;
+        // Odd: first nibble is encoded[0] & 0x0f. Even: skip the padding nibble.
+        if (odd) {
+            nibbles[n++] = (byte) (encoded[0] & 0x0f);
+        }
+        for (int i = 1; i < encoded.length; i++) {
+            int b = encoded[i] & 0xff;
+            nibbles[n++] = (byte) (b >>> 4);
+            nibbles[n++] = (byte) (b & 0x0f);
+        }
+        return new Decoded(leaf, nibbles);
+    }
+
+    /** Encode raw nibbles + leaf flag into the compact hex-prefix form. */
+    public static byte[] encode(byte[] nibbles, boolean leaf) {
+        for (byte n : nibbles) {
+            if ((n & 0xf0) != 0) throw new IllegalArgumentException("not a nibble: " + n);
+        }
+        boolean odd = (nibbles.length & 1) == 1;
+        int flag = (leaf ? 2 : 0) | (odd ? 1 : 0);
+        int outLen = (nibbles.length + (odd ? 1 : 2)) / 2;
+        byte[] out = new byte[outLen];
+        int srcIdx;
+        if (odd) {
+            out[0] = (byte) ((flag << 4) | (nibbles[0] & 0x0f));
+            srcIdx = 1;
+        } else {
+            out[0] = (byte) (flag << 4);
+            srcIdx = 0;
+        }
+        int dstIdx = 1;
+        while (srcIdx < nibbles.length) {
+            int high = nibbles[srcIdx++] & 0x0f;
+            int low = nibbles[srcIdx++] & 0x0f;
+            out[dstIdx++] = (byte) ((high << 4) | low);
+        }
+        return out;
+    }
+
+    /** Convert raw bytes to a nibble array (each byte → high nibble then low nibble). */
+    public static byte[] toNibbles(byte[] bytes) {
+        byte[] out = new byte[bytes.length * 2];
+        for (int i = 0; i < bytes.length; i++) {
+            int b = bytes[i] & 0xff;
+            out[2 * i] = (byte) (b >>> 4);
+            out[2 * i + 1] = (byte) (b & 0x0f);
+        }
+        return out;
+    }
+}

--- a/core/src/main/java/com/jaeckel/ethp2p/core/trie/HexPrefix.java
+++ b/core/src/main/java/com/jaeckel/ethp2p/core/trie/HexPrefix.java
@@ -38,7 +38,6 @@ public final class HexPrefix {
         boolean odd = (flag & 0x01) != 0;
 
         int totalNibbles = encoded.length * 2 - (odd ? 1 : 2);
-        if (totalNibbles < 0) totalNibbles = 0;
         byte[] nibbles = new byte[totalNibbles];
         int n = 0;
         // Odd: first nibble is encoded[0] & 0x0f. Even: skip the padding nibble.

--- a/core/src/main/java/com/jaeckel/ethp2p/core/trie/MerklePatriciaProofVerifier.java
+++ b/core/src/main/java/com/jaeckel/ethp2p/core/trie/MerklePatriciaProofVerifier.java
@@ -1,0 +1,207 @@
+package com.jaeckel.ethp2p.core.trie;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.crypto.Hash;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Verifier for inclusion and exclusion proofs against the Ethereum Modified
+ * Merkle Patricia Trie.
+ *
+ * <p>Given a trusted {@code root} (32-byte keccak-256 of the root node), an
+ * unhashed {@code key} (e.g. an account hash or storage slot hash for the
+ * Ethereum state / storage tries), and a list of RLP-encoded trie nodes,
+ * this class decides whether the proof is consistent with the root and, if
+ * so, returns the value associated with the key (or absence, for an
+ * exclusion proof).
+ *
+ * <p>The walk descends from the root:
+ * <ul>
+ *   <li>The current expected node hash is matched against
+ *       {@code keccak256(node-rlp)}. A mismatch is an invalid proof.
+ *   <li><strong>Branch (17 entries):</strong> consume one nibble of the
+ *       remaining path and descend into that child slot, or read the value
+ *       at index 16 if the path is exhausted.
+ *   <li><strong>Leaf (2 entries, leaf flag):</strong> the encoded path's
+ *       nibbles must equal the remaining path nibbles for a Found result;
+ *       any divergence is an exclusion proof.
+ *   <li><strong>Extension (2 entries, extension flag):</strong> the encoded
+ *       path is a prefix of the remaining path; consume those nibbles and
+ *       descend into the second element.
+ * </ul>
+ *
+ * <p>Children referenced by 32-byte hash require another node in the proof;
+ * embedded children (RLP lists shorter than 32 bytes encoded) are decoded
+ * directly without a hash step.
+ *
+ * <p>This is the trust anchor for SNAP-served state.
+ */
+public final class MerklePatriciaProofVerifier {
+
+    /** keccak256(rlp("")) — the conventional root of an empty trie. */
+    public static final Bytes32 EMPTY_TRIE_ROOT = Bytes32.fromHexString(
+            "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421");
+
+    /** Outcome of a verification attempt. */
+    public sealed interface Result {
+        /** Proof verifies and the key is present with this value. */
+        record Found(Bytes value) implements Result {}
+        /** Proof verifies and the key is provably absent. */
+        record Absent() implements Result {}
+        /** Proof did not verify; {@code reason} explains why. */
+        record Invalid(String reason) implements Result {}
+    }
+
+    private MerklePatriciaProofVerifier() {}
+
+    /**
+     * Verify a proof. {@code key} is the un-hashed key — the Ethereum state
+     * trie hashes account addresses with keccak256 before insertion, so for
+     * the state trie callers pass {@code keccak256(address).toArrayUnsafe()}
+     * (32 bytes); the verifier converts those bytes to nibbles internally.
+     */
+    public static Result verify(Bytes32 root, byte[] key, List<Bytes> proofNodes) {
+        if (key.length == 0) {
+            return new Result.Invalid("empty key");
+        }
+        if (proofNodes == null || proofNodes.isEmpty()) {
+            // The empty trie has a well-known root. With no proof nodes we can
+            // only assert absence if the root says the trie is empty.
+            if (EMPTY_TRIE_ROOT.equals(root)) return new Result.Absent();
+            return new Result.Invalid("empty proof for non-empty root");
+        }
+
+        // Index proof nodes by their keccak256 hash so descent picks the next
+        // node by hash match. The wire returns nodes in walk order, but a
+        // hash-keyed map tolerates clients that don't (and lets us share
+        // intermediate nodes across multiple key proofs in a future batched
+        // verification API).
+        Map<Bytes32, Bytes> byHash = new HashMap<>(proofNodes.size());
+        for (Bytes n : proofNodes) {
+            byHash.put(Bytes32.wrap(Hash.keccak256(n).toArrayUnsafe()), n);
+        }
+
+        byte[] path = HexPrefix.toNibbles(key);
+        return descendByHash(root, path, 0, byHash);
+    }
+
+    /** Descend into a node addressed by hash; the proof must contain it. */
+    private static Result descendByHash(Bytes32 expectedHash, byte[] path, int idx, Map<Bytes32, Bytes> byHash) {
+        Bytes nodeRlp = byHash.get(expectedHash);
+        if (nodeRlp == null) {
+            return new Result.Invalid("missing node " + expectedHash + " (path idx=" + idx + ")");
+        }
+        return interpret(nodeRlp, path, idx, byHash);
+    }
+
+    /** Descend into a node already in hand (embedded sub-32-byte child). */
+    private static Result descendEmbedded(Bytes nodeRlp, byte[] path, int idx, Map<Bytes32, Bytes> byHash) {
+        return interpret(nodeRlp, path, idx, byHash);
+    }
+
+    /** Interpret an RLP-encoded node at the given path position. */
+    private static Result interpret(Bytes nodeRlp, byte[] path, int idx, Map<Bytes32, Bytes> byHash) {
+        List<Bytes> items;
+        try {
+            items = RlpItems.split(nodeRlp);
+        } catch (IllegalArgumentException e) {
+            return new Result.Invalid("malformed node RLP: " + e.getMessage());
+        }
+        if (items.size() == 17) return interpretBranch(items, path, idx, byHash);
+        if (items.size() == 2) return interpretShort(items, path, idx, byHash);
+        return new Result.Invalid("unexpected node arity: " + items.size());
+    }
+
+    /** Branch: 17 raw RLP items — 16 child slots + 1 value at slot 16. */
+    private static Result interpretBranch(List<Bytes> items, byte[] path, int idx, Map<Bytes32, Bytes> byHash) {
+        if (idx == path.length) {
+            // Path exhausted; the value at slot 16 is what we want. The 17th
+            // item is always a value (RLP-encoded byte string).
+            Bytes valueItem = items.get(16);
+            Bytes value = stripBytesHeader(valueItem);
+            return value.isEmpty() ? new Result.Absent() : new Result.Found(value);
+        }
+        int nibble = path[idx] & 0x0f;
+        Bytes childItem = items.get(nibble);
+        // Branch slots are either an empty bytes value (0x80), a 32-byte hash
+        // wrapped as RLP bytes (header 0xa0 + 32 bytes), or an embedded list.
+        if (RlpItems.isList(childItem)) {
+            return descendEmbedded(childItem, path, idx + 1, byHash);
+        }
+        Bytes child = stripBytesHeader(childItem);
+        if (child.isEmpty()) return new Result.Absent();
+        if (child.size() != 32) {
+            return new Result.Invalid("branch child " + nibble + " is " + child.size()
+                    + " bytes; expected 32-byte hash or embedded list");
+        }
+        return descendByHash(Bytes32.wrap(child), path, idx + 1, byHash);
+    }
+
+    /** Leaf or extension: 2 raw RLP items — encoded-path + (value | next-hash | embedded-list). */
+    private static Result interpretShort(List<Bytes> items, byte[] path, int idx, Map<Bytes32, Bytes> byHash) {
+        Bytes encodedPath = stripBytesHeader(items.get(0));
+        HexPrefix.Decoded decoded = HexPrefix.decode(encodedPath.toArrayUnsafe());
+        byte[] nodeNibbles = decoded.nibbles();
+
+        // Remaining path must start with the node's nibbles; otherwise the
+        // queried key cannot live below this node.
+        int remaining = path.length - idx;
+        if (nodeNibbles.length > remaining) return new Result.Absent();
+        for (int i = 0; i < nodeNibbles.length; i++) {
+            if (nodeNibbles[i] != path[idx + i]) return new Result.Absent();
+        }
+        int newIdx = idx + nodeNibbles.length;
+
+        Bytes second = items.get(1);
+        if (decoded.leaf()) {
+            if (newIdx != path.length) {
+                // Leaf claims the key ends here, but our path has more nibbles
+                // than the leaf consumes — a different key would live below.
+                return new Result.Absent();
+            }
+            return new Result.Found(stripBytesHeader(second));
+        }
+        // Extension: descend into child.
+        if (RlpItems.isList(second)) {
+            return descendEmbedded(second, path, newIdx, byHash);
+        }
+        Bytes child = stripBytesHeader(second);
+        if (child.size() != 32) {
+            return new Result.Invalid("extension child is " + child.size()
+                    + " bytes; expected 32-byte hash or embedded list");
+        }
+        return descendByHash(Bytes32.wrap(child), path, newIdx, byHash);
+    }
+
+    /**
+     * Strip the RLP header from a raw RLP-bytes item, returning just the
+     * payload. Lists pass through unchanged — the caller checks for that
+     * separately.
+     */
+    private static Bytes stripBytesHeader(Bytes item) {
+        if (item.isEmpty()) return item;
+        int first = item.get(0) & 0xff;
+        if (first < 0x80) {
+            // Single byte value.
+            return item;
+        }
+        if (first <= 0xb7) {
+            int len = first - 0x80;
+            return len == 0 ? Bytes.EMPTY : item.slice(1, len);
+        }
+        if (first <= 0xbf) {
+            int lenOfLen = first - 0xb7;
+            int payloadLen = 0;
+            for (int i = 0; i < lenOfLen; i++) {
+                payloadLen = (payloadLen << 8) | (item.get(1 + i) & 0xff);
+            }
+            return item.slice(1 + lenOfLen, payloadLen);
+        }
+        // It's a list — return as-is; the caller decided how to handle it.
+        return item;
+    }
+}

--- a/core/src/main/java/com/jaeckel/ethp2p/core/trie/RlpItems.java
+++ b/core/src/main/java/com/jaeckel/ethp2p/core/trie/RlpItems.java
@@ -1,0 +1,103 @@
+package com.jaeckel.ethp2p.core.trie;
+
+import org.apache.tuweni.bytes.Bytes;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Splits an RLP-encoded list into its child items, returning each child as
+ * the raw RLP bytes (header + payload). The standard Tuweni
+ * {@code RLPReader} is callback-based and does not expose an
+ * "embedded child as raw bytes" view, which the MPT verifier needs to
+ * interpret in-line trie nodes recursively without re-encoding.
+ *
+ * <p>Reference: Ethereum Yellow Paper, Appendix B (RLP).
+ */
+final class RlpItems {
+
+    private RlpItems() {}
+
+    /**
+     * Take {@code listRlp}, which must be an RLP-encoded list, and return the
+     * raw bytes of each child item (each itself a valid RLP item).
+     */
+    static List<Bytes> split(Bytes listRlp) {
+        if (listRlp.isEmpty()) throw new IllegalArgumentException("empty RLP");
+        int first = listRlp.get(0) & 0xff;
+        int payloadStart;
+        int payloadLen;
+        if (first >= 0xc0 && first <= 0xf7) {
+            payloadStart = 1;
+            payloadLen = first - 0xc0;
+        } else if (first >= 0xf8) {
+            int lenOfLen = first - 0xf7;
+            payloadStart = 1 + lenOfLen;
+            payloadLen = readBigEndianInt(listRlp, 1, lenOfLen);
+        } else {
+            throw new IllegalArgumentException("not an RLP list (first byte=0x"
+                    + Integer.toHexString(first) + ")");
+        }
+        if (payloadStart + payloadLen > listRlp.size()) {
+            throw new IllegalArgumentException("RLP list payload runs past end");
+        }
+        List<Bytes> out = new ArrayList<>();
+        int pos = payloadStart;
+        int end = payloadStart + payloadLen;
+        while (pos < end) {
+            int itemLen = itemLength(listRlp, pos);
+            out.add(listRlp.slice(pos, itemLen));
+            pos += itemLen;
+        }
+        if (pos != end) {
+            throw new IllegalArgumentException("trailing bytes inside RLP list");
+        }
+        return out;
+    }
+
+    /** Total length (header + payload) of the RLP item starting at {@code offset}. */
+    private static int itemLength(Bytes data, int offset) {
+        int first = data.get(offset) & 0xff;
+        if (first <= 0x7f) {
+            // Single byte item, the byte itself is the value.
+            return 1;
+        }
+        if (first <= 0xb7) {
+            // Short string.
+            return 1 + (first - 0x80);
+        }
+        if (first <= 0xbf) {
+            int lenOfLen = first - 0xb7;
+            int payloadLen = readBigEndianInt(data, offset + 1, lenOfLen);
+            return 1 + lenOfLen + payloadLen;
+        }
+        if (first <= 0xf7) {
+            return 1 + (first - 0xc0);
+        }
+        // Long list.
+        int lenOfLen = first - 0xf7;
+        int payloadLen = readBigEndianInt(data, offset + 1, lenOfLen);
+        return 1 + lenOfLen + payloadLen;
+    }
+
+    private static int readBigEndianInt(Bytes data, int offset, int len) {
+        if (len <= 0 || len > 4) {
+            throw new IllegalArgumentException("RLP length-of-length must be 1-4 bytes (got " + len + ")");
+        }
+        if (offset + len > data.size()) {
+            throw new IllegalArgumentException("RLP length runs past end");
+        }
+        int v = 0;
+        for (int i = 0; i < len; i++) {
+            v = (v << 8) | (data.get(offset + i) & 0xff);
+        }
+        if (v < 0) throw new IllegalArgumentException("RLP length overflows int");
+        return v;
+    }
+
+    /** Detects whether the RLP item at {@code item.get(0)} is a list (0xc0..0xff). */
+    static boolean isList(Bytes item) {
+        if (item.isEmpty()) return false;
+        return (item.get(0) & 0xff) >= 0xc0;
+    }
+}

--- a/core/src/test/java/com/jaeckel/ethp2p/core/trie/HexPrefixTest.java
+++ b/core/src/test/java/com/jaeckel/ethp2p/core/trie/HexPrefixTest.java
@@ -1,0 +1,81 @@
+package com.jaeckel.ethp2p.core.trie;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HexFormat;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test vectors come from the Ethereum Yellow Paper Appendix C and the
+ * canonical hex-prefix description: https://ethereum.org/en/developers/docs/data-structures-and-encoding/patricia-merkle-trie/
+ */
+class HexPrefixTest {
+
+    @Test
+    void encodeEvenExtension() {
+        // Nibbles [1, 2, 3, 4], extension (leaf=false). Even-length, flag=0x00.
+        // Output: 0x00 || 0x12 || 0x34
+        byte[] enc = HexPrefix.encode(new byte[]{1, 2, 3, 4}, false);
+        assertEquals("001234", HexFormat.of().formatHex(enc));
+    }
+
+    @Test
+    void encodeOddExtension() {
+        // Nibbles [1, 2, 3], extension. Odd-length, flag=0x10. First nibble in
+        // low half of byte 0. Output: 0x11 || 0x23
+        byte[] enc = HexPrefix.encode(new byte[]{1, 2, 3}, false);
+        assertEquals("1123", HexFormat.of().formatHex(enc));
+    }
+
+    @Test
+    void encodeEvenLeaf() {
+        // Nibbles [1, 2, 3, 4], leaf (leaf=true). Even, flag=0x20.
+        // Output: 0x20 || 0x12 || 0x34
+        byte[] enc = HexPrefix.encode(new byte[]{1, 2, 3, 4}, true);
+        assertEquals("201234", HexFormat.of().formatHex(enc));
+    }
+
+    @Test
+    void encodeOddLeaf() {
+        // Nibbles [0xf, 1, c, b, 8], leaf. Odd, flag=0x30. First nibble = 0xf.
+        // Output: 0x3f || 0x1c || 0xb8
+        byte[] enc = HexPrefix.encode(new byte[]{0xf, 1, 0xc, 0xb, 8}, true);
+        assertEquals("3f1cb8", HexFormat.of().formatHex(enc));
+    }
+
+    @Test
+    void decodeOddLeafRoundtrip() {
+        byte[] nibbles = {0xa, 0xb, 0xc};
+        byte[] enc = HexPrefix.encode(nibbles, true);
+        HexPrefix.Decoded d = HexPrefix.decode(enc);
+        assertTrue(d.leaf());
+        assertArrayEquals(nibbles, d.nibbles());
+    }
+
+    @Test
+    void decodeEvenExtensionRoundtrip() {
+        byte[] nibbles = {1, 2, 3, 4, 5, 6};
+        byte[] enc = HexPrefix.encode(nibbles, false);
+        HexPrefix.Decoded d = HexPrefix.decode(enc);
+        assertFalse(d.leaf());
+        assertArrayEquals(nibbles, d.nibbles());
+    }
+
+    @Test
+    void decodeEmptyEvenIsLeaf() {
+        // Just the flag byte 0x20 — even-length leaf with zero nibbles.
+        HexPrefix.Decoded d = HexPrefix.decode(new byte[]{0x20});
+        assertTrue(d.leaf());
+        assertEquals(0, d.nibbles().length);
+    }
+
+    @Test
+    void toNibblesSplitsByteByByte() {
+        byte[] nibs = HexPrefix.toNibbles(new byte[]{(byte) 0xab, (byte) 0xcd});
+        assertArrayEquals(new byte[]{0xa, 0xb, 0xc, 0xd}, nibs);
+    }
+}

--- a/core/src/test/java/com/jaeckel/ethp2p/core/trie/MerklePatriciaProofVerifierTest.java
+++ b/core/src/test/java/com/jaeckel/ethp2p/core/trie/MerklePatriciaProofVerifierTest.java
@@ -1,0 +1,281 @@
+package com.jaeckel.ethp2p.core.trie;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.crypto.Hash;
+import org.apache.tuweni.rlp.RLP;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.security.Security;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * Verifies the proof verifier against hand-constructed tries.
+ *
+ * <p>Each test builds a small trie programmatically (RLP-encoding the nodes,
+ * computing keccak256 hashes), then hands the verifier the trusted root and
+ * the proof bytes. This avoids relying on an external trie implementation
+ * for fixtures while still exercising every code path.
+ */
+class MerklePatriciaProofVerifierTest {
+
+    @BeforeAll
+    static void registerBouncyCastle() {
+        if (Security.getProvider("BC") == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+    }
+
+    // ---- Single-leaf trie --------------------------------------------------
+
+    @Test
+    void singleLeafTrieFindsValue() {
+        // Trie with one entry: key=0x1234, value=32-byte 0xaa.
+        byte[] key = hex("1234");
+        Bytes value = Bytes.wrap(repeat((byte) 0xaa, 32));
+
+        // Leaf node: [hexPrefix(key_nibbles, leaf=true), value]
+        byte[] encodedPath = HexPrefix.encode(HexPrefix.toNibbles(key), true);
+        Bytes leafRlp = RLP.encodeList(w -> {
+            w.writeValue(Bytes.wrap(encodedPath));
+            w.writeValue(value);
+        });
+        Bytes32 root = keccak(leafRlp);
+
+        var result = MerklePatriciaProofVerifier.verify(root, key, List.of(leafRlp));
+        var found = assertInstanceOf(MerklePatriciaProofVerifier.Result.Found.class, result);
+        assertEquals(value, found.value());
+    }
+
+    @Test
+    void singleLeafTrieDifferentKeyIsAbsent() {
+        // Same trie as above but query a different key sharing the prefix.
+        byte[] storedKey = hex("1234");
+        byte[] queriedKey = hex("1235");
+        Bytes value = Bytes.wrap(repeat((byte) 0xaa, 32));
+
+        byte[] encodedPath = HexPrefix.encode(HexPrefix.toNibbles(storedKey), true);
+        Bytes leafRlp = RLP.encodeList(w -> {
+            w.writeValue(Bytes.wrap(encodedPath));
+            w.writeValue(value);
+        });
+        Bytes32 root = keccak(leafRlp);
+
+        var result = MerklePatriciaProofVerifier.verify(root, queriedKey, List.of(leafRlp));
+        assertInstanceOf(MerklePatriciaProofVerifier.Result.Absent.class, result);
+    }
+
+    // ---- Empty trie --------------------------------------------------------
+
+    @Test
+    void emptyTrieAnyKeyIsAbsent() {
+        var result = MerklePatriciaProofVerifier.verify(
+                MerklePatriciaProofVerifier.EMPTY_TRIE_ROOT,
+                hex("deadbeef"),
+                List.of());
+        assertInstanceOf(MerklePatriciaProofVerifier.Result.Absent.class, result);
+    }
+
+    @Test
+    void emptyProofForNonEmptyRootIsInvalid() {
+        Bytes32 fakeRoot = Bytes32.fromHexString(
+                "0x1111111111111111111111111111111111111111111111111111111111111111");
+        var result = MerklePatriciaProofVerifier.verify(fakeRoot, hex("aa"), List.of());
+        assertInstanceOf(MerklePatriciaProofVerifier.Result.Invalid.class, result);
+    }
+
+    // ---- Extension + branch + two leaves -----------------------------------
+
+    @Test
+    void twoLeafTrieFindsBothKeys() {
+        var trie = buildTwoLeafTrie();
+
+        var r1 = MerklePatriciaProofVerifier.verify(
+                trie.root, trie.key1, List.of(trie.extension, trie.branch, trie.leaf1));
+        assertEquals(trie.value1,
+                assertInstanceOf(MerklePatriciaProofVerifier.Result.Found.class, r1).value());
+
+        var r2 = MerklePatriciaProofVerifier.verify(
+                trie.root, trie.key2, List.of(trie.extension, trie.branch, trie.leaf2));
+        assertEquals(trie.value2,
+                assertInstanceOf(MerklePatriciaProofVerifier.Result.Found.class, r2).value());
+    }
+
+    @Test
+    void twoLeafTrieKeyOutsideBranchIsAbsent() {
+        var trie = buildTwoLeafTrie();
+        // Key shares the [1,2,3] prefix but lands on an empty branch slot.
+        byte[] absentKey = hex("1239");
+        var result = MerklePatriciaProofVerifier.verify(
+                trie.root, absentKey, List.of(trie.extension, trie.branch));
+        assertInstanceOf(MerklePatriciaProofVerifier.Result.Absent.class, result);
+    }
+
+    @Test
+    void twoLeafTrieKeyOutsideExtensionIsAbsent() {
+        var trie = buildTwoLeafTrie();
+        // Key doesn't even match the root extension's prefix [1,2,3].
+        byte[] absentKey = hex("abcd");
+        var result = MerklePatriciaProofVerifier.verify(
+                trie.root, absentKey, List.of(trie.extension));
+        assertInstanceOf(MerklePatriciaProofVerifier.Result.Absent.class, result);
+    }
+
+    // ---- Proof tampering ---------------------------------------------------
+
+    @Test
+    void tamperedNodeFailsVerification() {
+        var trie = buildTwoLeafTrie();
+        // Replace one byte of leaf1's value, breaking its hash.
+        byte[] tampered = trie.leaf1.toArray();
+        tampered[tampered.length - 1] ^= 0x01;
+        Bytes tamperedLeaf = Bytes.wrap(tampered);
+
+        var result = MerklePatriciaProofVerifier.verify(
+                trie.root, trie.key1, List.of(trie.extension, trie.branch, tamperedLeaf));
+        // The leaf's hash no longer matches what the branch points at, so the
+        // descent into branch[4] looks for a node whose hash doesn't exist in
+        // the proof — surfaces as Invalid("missing node ...").
+        assertInstanceOf(MerklePatriciaProofVerifier.Result.Invalid.class, result);
+    }
+
+    @Test
+    void missingProofNodeFailsVerification() {
+        var trie = buildTwoLeafTrie();
+        // Drop the branch from the proof, leaving extension → ??? for descent.
+        var result = MerklePatriciaProofVerifier.verify(
+                trie.root, trie.key1, List.of(trie.extension, trie.leaf1));
+        assertInstanceOf(MerklePatriciaProofVerifier.Result.Invalid.class, result);
+    }
+
+    // ---- Embedded sub-32-byte child ---------------------------------------
+
+    @Test
+    void embeddedLeafInBranchVerifies() {
+        // Build a trie where the leaf nodes are small enough to be embedded
+        // (RLP < 32 bytes). Use 1-byte values.
+        byte[] key1 = hex("12");
+        byte[] key2 = hex("13");
+        Bytes value1 = Bytes.fromHexString("0x42");
+        Bytes value2 = Bytes.fromHexString("0xab");
+
+        // Both keys have nibbles [1, X]. Root branch consumes nibble 1 — wait,
+        // actually the root *itself* is a branch in this layout, not preceded
+        // by an extension, since the keys diverge at the very first nibble
+        // position. With keys [1,2] and [1,3] they share prefix [1] and
+        // diverge at nibble 2/3, so we still need an extension([1])->branch.
+        byte[] leaf1Path = HexPrefix.encode(new byte[0], true);   // empty path leaf
+        byte[] leaf2Path = HexPrefix.encode(new byte[0], true);
+        Bytes leaf1Rlp = RLP.encodeList(w -> {
+            w.writeValue(Bytes.wrap(leaf1Path));
+            w.writeValue(value1);
+        });
+        Bytes leaf2Rlp = RLP.encodeList(w -> {
+            w.writeValue(Bytes.wrap(leaf2Path));
+            w.writeValue(value2);
+        });
+        // These leaves are small (a few bytes); they will be embedded in the
+        // branch as RLP lists rather than referenced by hash.
+
+        Bytes branchRlp = RLP.encodeList(w -> {
+            for (int i = 0; i < 2; i++) w.writeValue(Bytes.EMPTY);
+            // slot[2] = leaf1, slot[3] = leaf2 (embedded).
+            w.writeRLP(leaf1Rlp);
+            w.writeRLP(leaf2Rlp);
+            for (int i = 4; i < 16; i++) w.writeValue(Bytes.EMPTY);
+            w.writeValue(Bytes.EMPTY); // slot[16]
+        });
+        // The branch itself is small enough (~30 bytes with 1-byte values) it
+        // would also be embedded if it had a parent — but here it's the root.
+        Bytes32 branchHash = keccak(branchRlp);
+        byte[] extPath = HexPrefix.encode(new byte[]{1}, false);
+        Bytes extRlp = RLP.encodeList(w -> {
+            w.writeValue(Bytes.wrap(extPath));
+            w.writeValue(branchHash);
+        });
+        Bytes32 root = keccak(extRlp);
+
+        var r1 = MerklePatriciaProofVerifier.verify(root, key1, List.of(extRlp, branchRlp));
+        // Note: leaf1Rlp and leaf2Rlp are NOT in the proof — they're embedded.
+        assertEquals(value1,
+                assertInstanceOf(MerklePatriciaProofVerifier.Result.Found.class, r1).value());
+
+        var r2 = MerklePatriciaProofVerifier.verify(root, key2, List.of(extRlp, branchRlp));
+        assertEquals(value2,
+                assertInstanceOf(MerklePatriciaProofVerifier.Result.Found.class, r2).value());
+    }
+
+    // ---- helpers -----------------------------------------------------------
+
+    private record TwoLeafTrie(
+            byte[] key1, byte[] key2,
+            Bytes value1, Bytes value2,
+            Bytes leaf1, Bytes leaf2,
+            Bytes branch, Bytes extension,
+            Bytes32 root) {}
+
+    /**
+     * Build a trie with two leaves sharing prefix [1,2,3]:
+     *   key1 = 0x1234 → 32-byte 0xaa value (leaf1, hashed)
+     *   key2 = 0x1235 → 32-byte 0xbb value (leaf2, hashed)
+     * Structure: extension([1,2,3]) → branch with slot[4]=leaf1Hash, slot[5]=leaf2Hash.
+     */
+    private static TwoLeafTrie buildTwoLeafTrie() {
+        byte[] key1 = hex("1234");
+        byte[] key2 = hex("1235");
+        Bytes value1 = Bytes.wrap(repeat((byte) 0xaa, 32));
+        Bytes value2 = Bytes.wrap(repeat((byte) 0xbb, 32));
+
+        // Leaf nodes: empty path (branch consumes the last nibble), value-bearing.
+        byte[] emptyLeafPath = HexPrefix.encode(new byte[0], true); // [0x20]
+        Bytes leaf1 = RLP.encodeList(w -> {
+            w.writeValue(Bytes.wrap(emptyLeafPath));
+            w.writeValue(value1);
+        });
+        Bytes leaf2 = RLP.encodeList(w -> {
+            w.writeValue(Bytes.wrap(emptyLeafPath));
+            w.writeValue(value2);
+        });
+        Bytes32 hash1 = keccak(leaf1);
+        Bytes32 hash2 = keccak(leaf2);
+
+        // Branch: 17 entries. slot[4]=hash1, slot[5]=hash2, all others empty.
+        Bytes branch = RLP.encodeList(w -> {
+            for (int i = 0; i < 4; i++) w.writeValue(Bytes.EMPTY);
+            w.writeValue(hash1);
+            w.writeValue(hash2);
+            for (int i = 6; i < 16; i++) w.writeValue(Bytes.EMPTY);
+            w.writeValue(Bytes.EMPTY); // slot[16]
+        });
+        Bytes32 branchHash = keccak(branch);
+
+        // Extension: path = [1,2,3] (odd nibbles), child = branchHash.
+        byte[] extPath = HexPrefix.encode(new byte[]{1, 2, 3}, false); // [0x11, 0x23]
+        Bytes extension = RLP.encodeList(w -> {
+            w.writeValue(Bytes.wrap(extPath));
+            w.writeValue(branchHash);
+        });
+        Bytes32 root = keccak(extension);
+
+        return new TwoLeafTrie(key1, key2, value1, value2, leaf1, leaf2, branch, extension, root);
+    }
+
+    private static Bytes32 keccak(Bytes rlp) {
+        return Bytes32.wrap(Hash.keccak256(rlp).toArrayUnsafe());
+    }
+
+    private static byte[] hex(String s) {
+        return java.util.HexFormat.of().parseHex(s);
+    }
+
+    private static byte[] repeat(byte b, int n) {
+        byte[] out = new byte[n];
+        java.util.Arrays.fill(out, b);
+        return out;
+    }
+}

--- a/docs/phase1-design.md
+++ b/docs/phase1-design.md
@@ -40,20 +40,35 @@ needs. For per-account lookups Phase 1 needs the lower-bandwidth pair:
 
 Encoders / decoders + RLP roundtrip tests. No protocol wiring yet.
 
-### 2 — Proof verifier
+### 2 — Proof verifier (done)
 
 Goal: given a `stateRoot`, a key (account hash or storage slot hash), an
 expected value, and a Merkle-Patricia-Trie proof, decide whether the proof
 verifies.
 
-Decision (open): use Tuweni's `tuweni-merkle-trie` (already in the version
-catalog) or roll our own. A small spike will tell us whether Tuweni's API
-covers the path of "verify a proof for a given root + key" cleanly. If yes,
-this is a thin wrapper. If not, we hand-roll — the algorithm is
-well-specified and not large.
+Decision: **hand-rolled** in `:core` at
+`com.jaeckel.ethp2p.core.trie.MerklePatriciaProofVerifier`. The catalog
+entry for `io.consensys.tuweni:tuweni-merkle-trie:2.7.2` was aspirational
+— that artifact does not exist in any version of ConsenSys Tuweni we can
+resolve, and the alternative would be downgrading to Apache Tuweni 2.4.x
+(unmaintained) or pulling in a heavier MPT library. The verifier is ~150
+lines of straightforward Yellow-Paper-Appendix-D code.
 
-The verifier is the Phase 1 trust anchor. Test vectors come from a hand-
-crafted trie + Geth-generated proofs.
+Components:
+- `HexPrefix.java` — compact path codec (4-flag header + nibble pack).
+- `RlpItems.java` — splits an RLP list into raw child item bytes (Tuweni's
+  `RLPReader` is callback-based and doesn't expose embedded children as
+  raw RLP, which we need for in-line trie nodes).
+- `MerklePatriciaProofVerifier.java` — descend from a trusted root through
+  branch / extension / leaf nodes, supporting both 32-byte hashed and
+  embedded children, returning `Found(value)` / `Absent` / `Invalid(reason)`.
+
+Tests cover single-leaf inclusion, exclusion via different key, empty trie,
+extension+branch+two-leaf inclusion, exclusion at the branch level, exclusion
+above the extension, embedded sub-32-byte children, tampered-node detection,
+and missing-node detection. Hand-built tries (programmatic RLP + keccak256)
+rather than external fixtures so the tests are reproducible and the
+correctness pattern is visible in the test source.
 
 ### 3 — SNAP protocol client
 
@@ -102,23 +117,25 @@ so CI can skip them when no peer is available.
 
 ## Open decisions
 
-- **Proof verifier source.** Tuweni vs. hand-rolled — settle in commit 2.
+- **Proof verifier source.** ~~Tuweni vs. hand-rolled — settle in commit 2.~~
+  Settled: hand-rolled in `:core`. See section 2 above.
+- **Where the verifier lives.** ~~`:core` vs `:networking` vs `:myotis-evm`.~~
+  Settled: `:core`. Generic utility shared across modules.
 - **`GetTrieNodes` vs `GetAccountRange` for single-account fetches.** The
   plan specifies `GetTrieNodes` because it returns just the proof path, not
   a 128 KB range. We may discover that mainnet peers serve `GetTrieNodes`
   inconsistently and need to fall back to `GetAccountRange` with a tight
-  hash window.
-- **Where the verifier lives.** `:core` adds it as a generic utility;
-  `:networking` keeps it next to the wire types; `:myotis-evm` owns it as a
-  private dependency. `:core` is the most natural home (the consensus
-  module also benefits from MPT verification).
+  hash window. Decide when commit 3 hits real peers.
 - **Threading model.** Phase 0 uses `Runnable::run` in the no-arg ctor and
   documents that production callers must pass a worker pool. Phase 1's
   oracle blocks on real network IO; the executor must run on a non-UI
   thread. Concrete recommendation lands in commit 4.
 
-## What this commit ships
+## What this branch has shipped so far
 
-Just step 1 — the four new SNAP wire types and their roundtrip tests.
-Nothing changes for callers of Phase 0; the new types are not wired
-anywhere yet.
+- Commit 1 (`be8331f`): four SNAP wire types + roundtrip tests.
+- Commit 2 (this one): MPT proof verifier in `:core` + hex-prefix codec
+  + RLP-item splitter, all unit-tested.
+
+Next: commit 3 wires `snap/1` capability into the eth handshake and adds
+the `SnapHandler` request multiplexer.

--- a/docs/phase1-design.md
+++ b/docs/phase1-design.md
@@ -70,19 +70,40 @@ and missing-node detection. Hand-built tries (programmatic RLP + keccak256)
 rather than external fixtures so the tests are reproducible and the
 correctness pattern is visible in the test source.
 
-### 3 — SNAP protocol client
+### 3 — SNAP protocol client (done)
 
-The Phase 0 `:networking` work has the eth/67-68 sub-protocol but no `snap/1`
-client wiring beyond message types. Tasks:
+`:networking` already negotiated `snap/1` in HELLO and had request/response
+plumbing for `GetAccountRange` / `GetStorageRanges` (range-style sync).
+Phase 1 commit 3 extends `EthHandler` with the lower-bandwidth pair:
 
-- Announce `snap/1` capability in the eth handshake.
-- `SnapHandler` (NioInboundHandler) that routes incoming `TrieNodes` /
-  `ByteCodes` responses to pending request futures keyed by request id.
-- Outbound API: `client.getTrieNodes(stateRoot, paths) -> CompletableFuture<List<Bytes>>`
-  and `client.getByteCodes(hashes) -> CompletableFuture<List<Bytes>>`.
-- Per-peer rate limiting and timeout handling.
-- Peer disconnection on protocol violation (proof verification failure
-  surfaces as a peer score decrement; not the wire layer's concern).
+- `requestByteCodesAsync(hashes)` — issues `GetByteCodes`, returns a
+  `CompletableFuture<ByteCodesMessage.DecodeResult>` keyed by request id;
+  10-second timeout.
+- `requestTrieNodesAsync(stateRoot, paths)` — issues `GetTrieNodes`,
+  returns a `CompletableFuture<TrieNodesMessage.DecodeResult>`; 10-second
+  timeout.
+- Inbound dispatch in `channelRead` routes the four new message codes
+  (0x25 GetByteCodes / 0x26 ByteCodes / 0x27 GetTrieNodes / 0x28 TrieNodes
+  under eth/68's offset; auto-shifted for eth/69) to handlers that either
+  complete the matching pending future or respond with empty when serving.
+- Wallet-side serving is intentionally empty — we ship `encodeEmpty(reqId)`
+  responses to incoming `GetByteCodes` / `GetTrieNodes` so peers don't time
+  out, mirroring the existing `GetAccountRange` / `GetStorageRanges`
+  policy.
+
+A dedicated `SnapHandler` class is intentionally not extracted: snap/1
+shares the same RLPx connection and `ChannelHandlerContext` as eth/68, and
+splitting them now would require a parallel multiplexer with no immediate
+benefit. A future commit may extract it once the surface is large enough
+to justify the restructure.
+
+Out of scope for commit 3 (deferred to integration testing in commit 5):
+- Per-peer rate limiting (the existing eth/snap path doesn't have it
+  either; defer until we observe a peer that needs it).
+- Proof-verification-failure handling. The verifier lives in `:core`
+  (commit 2); the oracle in `:myotis-evm` (commit 4) is what owns the
+  peer-score-decrement / retry logic since that's an EVM-execution
+  concern, not a wire concern.
 
 ### 4 — `SnapBackedStateOracle`
 
@@ -134,8 +155,12 @@ so CI can skip them when no peer is available.
 ## What this branch has shipped so far
 
 - Commit 1 (`be8331f`): four SNAP wire types + roundtrip tests.
-- Commit 2 (this one): MPT proof verifier in `:core` + hex-prefix codec
+- Commit 2 (`5e430d2`): MPT proof verifier in `:core` + hex-prefix codec
   + RLP-item splitter, all unit-tested.
+- Commit 3 (this one): `EthHandler` outbound + inbound wiring for the four
+  new snap/1 message codes. 37/37 `:networking` tests still pass.
 
-Next: commit 3 wires `snap/1` capability into the eth handshake and adds
-the `SnapHandler` request multiplexer.
+Next: commit 4 wires `SnapBackedStateOracle` in `:myotis-evm` — combines
+the wire client (commit 1+3), the verifier (commit 2), and the oracle
+contract from Phase 0. After that, commit 5 adds the mainnet integration
+tests.

--- a/docs/phase1-design.md
+++ b/docs/phase1-design.md
@@ -1,0 +1,124 @@
+# Phase 1 — SNAP-backed state oracle
+
+Phase 0 proved that Besu's EVM runs end-to-end against a `SnapStateOracle`.
+Phase 1 replaces the fixture oracle with a real one that fetches state on
+demand from devp2p `snap/1` peers and verifies every response against the
+trusted `stateRoot`.
+
+> **Scope:** correctness, not speed. One synchronous round trip per SLOAD
+> is acceptable in Phase 1 (1–5 s per call). Phase 2 adds prefetching.
+
+## Acceptance criteria (from the original plan)
+
+- `DefaultEvmExecutor.callView` works end-to-end against mainnet.
+- Three integration tests passing against a known-good `stateRoot` from a
+  recent block:
+  - USDC `balanceOf(vitalik.eth)`
+  - DAI `balanceOf(vitalik.eth)`
+  - ENS Public Resolver `addr(namehash("vitalik.eth"))`
+- Latency measurement recorded.
+
+## Work breakdown
+
+The work spans `:networking` (protocol), `:core` or a new utility (proof
+verifier), and `:myotis-evm` (oracle wiring + integration tests). Sequencing
+is bottom-up so each piece is testable on its own before the network round
+trip is involved.
+
+### 1 — SNAP wire types (this commit)
+
+Phase 0 of the SNAP work shipped `GetAccountRange` / `AccountRange` /
+`GetStorageRanges` / `StorageRanges` because that's what range-style sync
+needs. For per-account lookups Phase 1 needs the lower-bandwidth pair:
+
+| Code | Name             | Purpose |
+|------|------------------|---------|
+| 0x26 | `GetTrieNodes`   | Request specific trie nodes by `(account, path)` pairs. |
+| 0x27 | `TrieNodes`      | Response with the requested nodes. |
+| 0x24 | `GetByteCodes`   | Request bytecode by code hash. |
+| 0x25 | `ByteCodes`      | Response with concatenated bytecodes. |
+
+Encoders / decoders + RLP roundtrip tests. No protocol wiring yet.
+
+### 2 — Proof verifier
+
+Goal: given a `stateRoot`, a key (account hash or storage slot hash), an
+expected value, and a Merkle-Patricia-Trie proof, decide whether the proof
+verifies.
+
+Decision (open): use Tuweni's `tuweni-merkle-trie` (already in the version
+catalog) or roll our own. A small spike will tell us whether Tuweni's API
+covers the path of "verify a proof for a given root + key" cleanly. If yes,
+this is a thin wrapper. If not, we hand-roll — the algorithm is
+well-specified and not large.
+
+The verifier is the Phase 1 trust anchor. Test vectors come from a hand-
+crafted trie + Geth-generated proofs.
+
+### 3 — SNAP protocol client
+
+The Phase 0 `:networking` work has the eth/67-68 sub-protocol but no `snap/1`
+client wiring beyond message types. Tasks:
+
+- Announce `snap/1` capability in the eth handshake.
+- `SnapHandler` (NioInboundHandler) that routes incoming `TrieNodes` /
+  `ByteCodes` responses to pending request futures keyed by request id.
+- Outbound API: `client.getTrieNodes(stateRoot, paths) -> CompletableFuture<List<Bytes>>`
+  and `client.getByteCodes(hashes) -> CompletableFuture<List<Bytes>>`.
+- Per-peer rate limiting and timeout handling.
+- Peer disconnection on protocol violation (proof verification failure
+  surfaces as a peer score decrement; not the wire layer's concern).
+
+### 4 — `SnapBackedStateOracle`
+
+Implements `io.myotis.evm.world.SnapStateOracle`. For each call:
+
+1. Issue the SNAP request via the client.
+2. Verify the proof against the trusted `stateRoot` (or the `codeHash` for
+   bytecode).
+3. On verification failure: deprioritise the peer, retry with another peer
+   (cap retries; fail with `EvmExecutionError.InvalidProof` after).
+4. Cache `(stateRoot, address, slot) → value` in-memory for the duration
+   of the call.
+
+This lives in `:myotis-evm/world/SnapBackedStateOracle.java` (alongside
+`FixtureSnapStateOracle`). The `DefaultEvmExecutor` doesn't change — only
+the oracle the wallet hands it does.
+
+### 5 — Mainnet integration tests
+
+Separate Gradle source set (`src/integrationTest/java`) so they don't run
+on every `:test` invocation. Each test:
+
+1. Connects to a real SNAP peer (or runs against a local Geth/Besu).
+2. Picks a recent finalised `stateRoot` (could be sourced via `:consensus`
+   light client or hard-coded with the corresponding block number for the
+   test).
+3. Runs `callView` for the three target contracts.
+4. Compares the result with `eth_call` from a public RPC at the same block.
+
+Acceptable for these tests to be `@EnabledIfEnvironmentVariable(MAINNET=1)`
+so CI can skip them when no peer is available.
+
+## Open decisions
+
+- **Proof verifier source.** Tuweni vs. hand-rolled — settle in commit 2.
+- **`GetTrieNodes` vs `GetAccountRange` for single-account fetches.** The
+  plan specifies `GetTrieNodes` because it returns just the proof path, not
+  a 128 KB range. We may discover that mainnet peers serve `GetTrieNodes`
+  inconsistently and need to fall back to `GetAccountRange` with a tight
+  hash window.
+- **Where the verifier lives.** `:core` adds it as a generic utility;
+  `:networking` keeps it next to the wire types; `:myotis-evm` owns it as a
+  private dependency. `:core` is the most natural home (the consensus
+  module also benefits from MPT verification).
+- **Threading model.** Phase 0 uses `Runnable::run` in the no-arg ctor and
+  documents that production callers must pass a worker pool. Phase 1's
+  oracle blocks on real network IO; the executor must run on a non-UI
+  thread. Concrete recommendation lands in commit 4.
+
+## What this commit ships
+
+Just step 1 — the four new SNAP wire types and their roundtrip tests.
+Nothing changes for callers of Phase 0; the new types are not wired
+anywhere yet.

--- a/docs/phase1-design.md
+++ b/docs/phase1-design.md
@@ -105,21 +105,52 @@ Out of scope for commit 3 (deferred to integration testing in commit 5):
   peer-score-decrement / retry logic since that's an EVM-execution
   concern, not a wire concern.
 
-### 4 — `SnapBackedStateOracle`
+### 4 — `SnapBackedStateOracle` (done)
 
-Implements `io.myotis.evm.world.SnapStateOracle`. For each call:
+Implements `io.myotis.evm.world.SnapStateOracle` against a `SnapPeer`
+abstraction defined in the same package. The peer interface is intentionally
+minimal — `getTrieNodes(stateRoot, paths)` and `getByteCodes(hashes)`,
+returning raw bytes — so `:myotis-evm` can stay decoupled from
+`:networking`. The wallet integration plugs in an `EthHandler`-backed
+implementation when constructing the oracle.
 
-1. Issue the SNAP request via the client.
-2. Verify the proof against the trusted `stateRoot` (or the `codeHash` for
-   bytecode).
-3. On verification failure: deprioritise the peer, retry with another peer
-   (cap retries; fail with `EvmExecutionError.InvalidProof` after).
-4. Cache `(stateRoot, address, slot) → value` in-memory for the duration
-   of the call.
+For each call:
 
-This lives in `:myotis-evm/world/SnapBackedStateOracle.java` (alongside
-`FixtureSnapStateOracle`). The `DefaultEvmExecutor` doesn't change — only
-the oracle the wallet hands it does.
+1. `fetchAccount` — keccak256(address) → account-only path set →
+   `getTrieNodes` → MPT verifier against the world stateRoot → decode
+   `[nonce, balance, storageRoot, codeHash]` from the leaf value. The
+   internal helper also captures `storageRoot` for downstream storage
+   fetches.
+2. `fetchStorage` — chain on `fetchAccountWithRoot` to pick up the
+   storageRoot, then issue a path set carrying the account hash + slot
+   hash, verify against the storageRoot, decode the RLP integer.
+   Empty storage root short-circuits to zero without a network round trip.
+3. `fetchBytecode` — bytecode cache check first; on miss, `getByteCodes`,
+   keccak256 the response, match against the requested codeHash; surface
+   `EvmExecutionError.InvalidProof` on mismatch.
+
+Retry policy: a `Supplier<SnapPeer>` is consulted at the start of every
+attempt. On any failure (proof invalid, IO timeout, hash mismatch) we
+rotate to the next peer, up to `maxAttempts` (default 3). The supplier is
+free to track peer scores externally — the oracle doesn't dictate that.
+
+Tests build hand-crafted single-leaf tries, encode the proofs by hand,
+register them with an in-memory `FixturePeer`, then run the oracle through
+its three entry points. Eight tests cover: account hit, account absent,
+account retry-on-bad-proof + retry budget exhaustion, storage hit, storage
+on empty trie, bytecode hit + cache hit, bytecode hash mismatch, empty-code
+short-circuit. 29/29 `:myotis-evm` tests now pass (Phase 0's 21 + the new 8).
+
+`DefaultEvmExecutor` and `SyncStateView` from Phase 0 already consume
+`SnapStateOracle`, so the executor needs no changes — wallet integration
+is "construct `SnapBackedStateOracle` instead of `FixtureSnapStateOracle`."
+
+What's still missing for the public-API "wallet integration" piece: an
+`EthHandler`-backed `SnapPeer`. That's a thin adapter (translate
+`SnapPeer.PathSet` to `GetTrieNodesMessage.PathSet`, call
+`requestTrieNodesAsync`, project the response). It belongs in `:app` (or
+wherever the daemon wires things up) since `:myotis-evm` doesn't depend on
+`:networking`. Adapter + mainnet integration tests come together in commit 5.
 
 ### 5 — Mainnet integration tests
 
@@ -157,10 +188,12 @@ so CI can skip them when no peer is available.
 - Commit 1 (`be8331f`): four SNAP wire types + roundtrip tests.
 - Commit 2 (`5e430d2`): MPT proof verifier in `:core` + hex-prefix codec
   + RLP-item splitter, all unit-tested.
-- Commit 3 (this one): `EthHandler` outbound + inbound wiring for the four
-  new snap/1 message codes. 37/37 `:networking` tests still pass.
+- Commit 3 (`0a21c47`): `EthHandler` outbound + inbound wiring for the
+  four new snap/1 message codes.
+- Commit 4 (this one): `SnapBackedStateOracle` in `:myotis-evm` — combines
+  the verifier + the SnapPeer abstraction with proof-verification + retry
+  semantics. 8 new tests; 29/29 `:myotis-evm` tests pass.
 
-Next: commit 4 wires `SnapBackedStateOracle` in `:myotis-evm` — combines
-the wire client (commit 1+3), the verifier (commit 2), and the oracle
-contract from Phase 0. After that, commit 5 adds the mainnet integration
-tests.
+Next: commit 5 adds (a) an `EthHandler`-backed `SnapPeer` adapter in `:app`
+and (b) the mainnet integration tests (USDC / DAI / ENS) that close out
+Phase 1's acceptance criteria.

--- a/docs/phase1-design.md
+++ b/docs/phase1-design.md
@@ -152,20 +152,48 @@ What's still missing for the public-API "wallet integration" piece: an
 wherever the daemon wires things up) since `:myotis-evm` doesn't depend on
 `:networking`. Adapter + mainnet integration tests come together in commit 5.
 
-### 5 — Mainnet integration tests
+### 5 — Mainnet integration tests (scaffolding done; bootstrap pending)
 
-Separate Gradle source set (`src/integrationTest/java`) so they don't run
-on every `:test` invocation. Each test:
+Two pieces shipped in commit 5:
 
-1. Connects to a real SNAP peer (or runs against a local Geth/Besu).
-2. Picks a recent finalised `stateRoot` (could be sourced via `:consensus`
-   light client or hard-coded with the corresponding block number for the
-   test).
-3. Runs `callView` for the three target contracts.
-4. Compares the result with `eth_call` from a public RPC at the same block.
+**EthHandlerSnapPeer adapter (`:app/snap`).** Translates between
+`io.myotis.evm.world.SnapPeer.PathSet` and
+`com.jaeckel.ethp2p.networking.snap.messages.GetTrieNodesMessage.PathSet`,
+and wraps `EthHandler.requestTrieNodesAsync` /
+`EthHandler.requestByteCodesAsync` for the `:myotis-evm` consumer. Lives
+in `:app` rather than `:myotis-evm` because the latter is intentionally
+decoupled from `:networking`. The adapter is mechanical type translation —
+its real coverage comes from the integration test below.
 
-Acceptable for these tests to be `@EnabledIfEnvironmentVariable(MAINNET=1)`
-so CI can skip them when no peer is available.
+**Integration test source set (`:myotis-evm/src/integrationTest`).** A
+separate Gradle source set + task (`./gradlew :myotis-evm:integrationTest`)
+that's not bound to `check`. Tests are gated with
+`@EnabledIfEnvironmentVariable(MYOTIS_MAINNET=1)` so the unit suite stays
+offline. `MainnetCallViewIT` defines three tests covering the original
+Phase 1 acceptance corpus:
+
+- USDC `balanceOf(vitalik.eth)` (ERC-20 storage proof end-to-end)
+- DAI `balanceOf(vitalik.eth)` (different storage layout, validates the
+  oracle isn't accidentally USDC-shaped)
+- ENS Public Resolver `addr(namehash("vitalik.eth"))` (multi-call walk:
+  read account → read storage slot → return address)
+
+Each test reads `MYOTIS_INTEGRATION_*` env vars (peer enode, state root,
+block number/timestamp, base fee), constructs `DefaultEvmExecutor` against
+`SnapBackedStateOracle`, calls `callView`, and decodes the result. For
+USDC the test optionally cross-checks the value against an externally-
+provided `eth_call` result via `MYOTIS_INTEGRATION_VITALIK_USDC_BALANCE`.
+
+**What's not done in this commit:** the `connectToMainnetPeer()` helper
+inside the test currently throws `UnsupportedOperationException`. Standing
+up an `EthHandler` from inside a JUnit fixture means reproducing
+`:app:Main`'s bootstrap (NodeKey, NetworkConfig, RLPxConnector,
+ChainHead). The simpler path is to extract that wiring into a reusable
+`MainnetSnapClient` helper in `:app` — that's a non-trivial refactor of
+the daemon code and is intentionally out of scope here. The test compiles,
+the gating works (`./gradlew :myotis-evm:integrationTest` without
+`MYOTIS_MAINNET=1` reports 3 ignored / 0 failures), and the acceptance
+criterion is reachable as soon as the bootstrap helper exists.
 
 ## Open decisions
 
@@ -190,10 +218,16 @@ so CI can skip them when no peer is available.
   + RLP-item splitter, all unit-tested.
 - Commit 3 (`0a21c47`): `EthHandler` outbound + inbound wiring for the
   four new snap/1 message codes.
-- Commit 4 (this one): `SnapBackedStateOracle` in `:myotis-evm` — combines
+- Commit 4 (`2adb2dd`): `SnapBackedStateOracle` in `:myotis-evm` — combines
   the verifier + the SnapPeer abstraction with proof-verification + retry
-  semantics. 8 new tests; 29/29 `:myotis-evm` tests pass.
+  semantics.
+- Commit 5 (this one): `EthHandlerSnapPeer` adapter in `:app/snap` +
+  `MainnetCallViewIT` integration-test scaffolding (env-gated, three target
+  contracts). Final piece pending: a reusable `EthHandler` bootstrap
+  helper so the `connectToMainnetPeer()` stub becomes runnable.
 
-Next: commit 5 adds (a) an `EthHandler`-backed `SnapPeer` adapter in `:app`
-and (b) the mainnet integration tests (USDC / DAI / ENS) that close out
-Phase 1's acceptance criteria.
+Phase 1 status: structurally complete (every component compiles, every
+unit test passes, every layer has the integration shape it needs). The
+`connectToMainnetPeer` bootstrap is the last gate before the acceptance
+criterion ("integration tests pass against a real SNAP peer") can be
+declared met.

--- a/myotis-evm/build.gradle.kts
+++ b/myotis-evm/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
     implementation(libs.tuweni.bytes)
     implementation(libs.tuweni.units)
     implementation(libs.tuweni.crypto)
+    implementation(libs.tuweni.rlp)
 
     // BouncyCastle: Tuweni's Hash.keccak256 dispatches through JCA, which
     // requires BouncyCastle to be registered as a security provider.

--- a/myotis-evm/build.gradle.kts
+++ b/myotis-evm/build.gradle.kts
@@ -46,3 +46,49 @@ dependencies {
 tasks.test {
     useJUnitPlatform()
 }
+
+// ----------------------------------------------------------------------------
+// Mainnet integration tests
+//
+// Closes Phase 1's acceptance criterion: USDC / DAI / ENS public-resolver
+// balanceOf/addr against a real SNAP peer at a verified state root, results
+// compared with eth_call from a public RPC at the same block.
+//
+// Gated by env var MYOTIS_MAINNET=1 so `./gradlew :myotis-evm:test` (the unit
+// suite) stays offline. Run explicitly via `./gradlew :myotis-evm:integrationTest`
+// after providing a peer + state root via env vars (see the test class for
+// the contract).
+// ----------------------------------------------------------------------------
+sourceSets {
+    create("integrationTest") {
+        java.srcDir("src/integrationTest/java")
+        resources.srcDir("src/integrationTest/resources")
+        compileClasspath += sourceSets["main"].output
+        runtimeClasspath += sourceSets["main"].output
+    }
+}
+
+configurations {
+    "integrationTestImplementation" {
+        extendsFrom(configurations["testImplementation"])
+    }
+    "integrationTestRuntimeOnly" {
+        extendsFrom(configurations["testRuntimeOnly"])
+    }
+}
+
+dependencies {
+    "integrationTestImplementation"(project(":app"))
+    "integrationTestImplementation"(project(":networking"))
+    "integrationTestImplementation"(libs.tuweni.bytes)
+}
+
+tasks.register<Test>("integrationTest") {
+    description = "Phase 1 mainnet integration tests (env-gated, requires MYOTIS_MAINNET=1)."
+    group = "verification"
+    testClassesDirs = sourceSets["integrationTest"].output.classesDirs
+    classpath = sourceSets["integrationTest"].runtimeClasspath
+    useJUnitPlatform()
+    // Don't bind to `./gradlew check` — operators run this on demand.
+    shouldRunAfter("test")
+}

--- a/myotis-evm/src/integrationTest/java/io/myotis/evm/integration/MainnetCallViewIT.java
+++ b/myotis-evm/src/integrationTest/java/io/myotis/evm/integration/MainnetCallViewIT.java
@@ -1,0 +1,198 @@
+package io.myotis.evm.integration;
+
+import io.myotis.evm.Address;
+import io.myotis.evm.BlockContext;
+import io.myotis.evm.DefaultEvmExecutor;
+import io.myotis.evm.abi.AbiDecoder;
+import io.myotis.evm.abi.AbiEncoder;
+import io.myotis.evm.abi.FunctionSignature;
+import io.myotis.evm.ens.Namehash;
+import io.myotis.evm.world.BytecodeCache;
+import io.myotis.evm.world.SnapBackedStateOracle;
+import io.myotis.evm.world.SnapPeer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import java.math.BigInteger;
+import java.util.HexFormat;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Phase 1 acceptance test — closes the loop on the original Phase 1 plan:
+ *
+ * <blockquote>
+ *   "Run callView against mainnet for USDC balanceOf(vitalik.eth), DAI
+ *    balanceOf(vitalik.eth), ENS Public Resolver addr(namehash("vitalik.eth")).
+ *    Confirm results match RPC eth_call. Acceptance criteria: integration
+ *    tests pass, executed against a real SNAP peer."
+ * </blockquote>
+ *
+ * <p>The test is env-gated:
+ *
+ * <ul>
+ *   <li>{@code MYOTIS_MAINNET=1} — flip the kill switch
+ *   <li>{@code MYOTIS_INTEGRATION_PEER_ENODE} — enode URL of a snap/1 peer
+ *   <li>{@code MYOTIS_INTEGRATION_STATE_ROOT} — 0x-prefixed 32-byte hex,
+ *       a recent verified mainnet state root (the operator picks one
+ *       finalised by sync committee; the test does not re-derive it)
+ *   <li>{@code MYOTIS_INTEGRATION_BLOCK_NUMBER} — block number for that root
+ *   <li>{@code MYOTIS_INTEGRATION_BLOCK_TIMESTAMP} — Unix seconds for fork
+ *       selection in {@code EvmFactory.buildForBlock}
+ *   <li>{@code MYOTIS_INTEGRATION_BASE_FEE_WEI} — block base fee
+ *   <li>{@code MYOTIS_INTEGRATION_VITALIK_USDC_BALANCE} (optional) —
+ *       expected USDC balance for cross-checking against eth_call output
+ *       from a public RPC at the same block
+ * </ul>
+ *
+ * <p>The test suite is intentionally <em>not</em> wired into
+ * {@code ./gradlew check}; operators run it explicitly via
+ * {@code ./gradlew :myotis-evm:integrationTest} after supplying the env vars.
+ */
+@EnabledIfEnvironmentVariable(named = "MYOTIS_MAINNET", matches = "1")
+class MainnetCallViewIT {
+
+    private static final Address USDC = Address.fromHex("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
+    private static final Address DAI  = Address.fromHex("0x6B175474E89094C44Da98b954EedeAC495271d0F");
+    /**
+     * ENS Public Resolver v2 (the common one most names point at).
+     * vitalik.eth → 0xd8da6BF26964aF9D7eEd9e03E53415D37aA96045 should resolve via this.
+     */
+    private static final Address ENS_PUBLIC_RESOLVER =
+            Address.fromHex("0x231b0Ee14048e9dCcD1d247744d114a4EB5E8E63");
+
+    private static final Address VITALIK = Address.fromHex("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
+
+    @Test
+    void usdcBalanceOfVitalik() throws Exception {
+        DefaultEvmExecutor executor = mainnetExecutor();
+        BlockContext ctx = mainnetBlockContext();
+
+        FunctionSignature balanceOf = FunctionSignature.of("balanceOf(address)");
+        byte[] calldata = AbiEncoder.encodeCall(balanceOf, AbiEncoder.address(VITALIK));
+
+        byte[] result = executor.callView(USDC, calldata, ctx)
+                .get(60, TimeUnit.SECONDS);
+        assertEquals(32, result.length, "balanceOf must return one uint256");
+        BigInteger balance = AbiDecoder.uint256(result, 0);
+        assertTrue(balance.signum() >= 0, "balance is non-negative");
+
+        String expected = System.getenv("MYOTIS_INTEGRATION_VITALIK_USDC_BALANCE");
+        if (expected != null && !expected.isBlank()) {
+            assertEquals(new BigInteger(expected), balance,
+                    "USDC.balanceOf(vitalik.eth) does not match the expected value " +
+                    "set via MYOTIS_INTEGRATION_VITALIK_USDC_BALANCE");
+        }
+    }
+
+    @Test
+    void daiBalanceOfVitalik() throws Exception {
+        DefaultEvmExecutor executor = mainnetExecutor();
+        BlockContext ctx = mainnetBlockContext();
+
+        FunctionSignature balanceOf = FunctionSignature.of("balanceOf(address)");
+        byte[] calldata = AbiEncoder.encodeCall(balanceOf, AbiEncoder.address(VITALIK));
+
+        byte[] result = executor.callView(DAI, calldata, ctx)
+                .get(60, TimeUnit.SECONDS);
+        assertEquals(32, result.length);
+        BigInteger balance = AbiDecoder.uint256(result, 0);
+        assertTrue(balance.signum() >= 0);
+    }
+
+    @Test
+    void ensPublicResolverAddrForVitalikEth() throws Exception {
+        DefaultEvmExecutor executor = mainnetExecutor();
+        BlockContext ctx = mainnetBlockContext();
+
+        // Classic on-chain ENS path (no CCIP-Read): call addr(node) on the
+        // public resolver. node = namehash("vitalik.eth").
+        byte[] node = Namehash.of("vitalik.eth");
+        FunctionSignature addr = FunctionSignature.of("addr(bytes32)");
+        byte[] calldata = AbiEncoder.encodeCall(addr, AbiEncoder.bytes32(node));
+
+        byte[] result = executor.callView(ENS_PUBLIC_RESOLVER, calldata, ctx)
+                .get(60, TimeUnit.SECONDS);
+        assertEquals(32, result.length, "addr(bytes32) returns one address");
+        Address resolved = AbiDecoder.address(result, 0);
+        assertEquals(VITALIK, resolved,
+                "ENS public resolver should map vitalik.eth → " + VITALIK);
+    }
+
+    // ---- Wiring ------------------------------------------------------------
+
+    /**
+     * Build a {@link DefaultEvmExecutor} backed by a real SNAP peer.
+     *
+     * <p>This stub is deliberately incomplete: standing up a discv4-discovered,
+     * eth/68- and snap/1-handshaked {@code EthHandler} from inside a test is a
+     * non-trivial reproduction of {@code :app}'s {@code Main}. The simplest
+     * path for an operator is to run the daemon via
+     * {@code ./gradlew :app:run} until it has at least one snap-capable peer,
+     * then expose that peer's {@code EthHandler} (or an enode-addressable
+     * connection helper) here.
+     *
+     * <p>For now this method throws {@code UnsupportedOperationException} so
+     * the test fails fast with a clear pointer to what's missing — and so the
+     * compile path is exercised on every build, catching API drift in the
+     * adapter / oracle / executor before it lands.
+     */
+    private static DefaultEvmExecutor mainnetExecutor() {
+        SnapPeer peer = connectToMainnetPeer();
+        return new DefaultEvmExecutor(
+                new SnapBackedStateOracle(() -> peer, BytecodeCache.inMemory()),
+                BytecodeCache.inMemory(),
+                java.util.concurrent.Executors.newSingleThreadExecutor(r -> {
+                    Thread t = new Thread(r, "myotis-evm-it");
+                    t.setDaemon(true);
+                    return t;
+                }));
+    }
+
+    private static SnapPeer connectToMainnetPeer() {
+        String enode = System.getenv("MYOTIS_INTEGRATION_PEER_ENODE");
+        assertNotNull(enode,
+                "MYOTIS_INTEGRATION_PEER_ENODE must be set; see class Javadoc");
+        // TODO(phase1.commit5+): stand up an EthHandler against the configured
+        // enode and wrap it with com.jaeckel.ethp2p.app.snap.EthHandlerSnapPeer.
+        // Reuse :app's RLPxConnector / ChainHead glue once it's factored out
+        // of Main into a reusable test fixture.
+        throw new UnsupportedOperationException(
+                "EthHandler bootstrap from a test is not yet implemented; "
+                        + "see TODO in MainnetCallViewIT.connectToMainnetPeer.");
+    }
+
+    private static BlockContext mainnetBlockContext() {
+        byte[] stateRoot = parseHex32(env("MYOTIS_INTEGRATION_STATE_ROOT"));
+        long blockNumber = Long.parseLong(env("MYOTIS_INTEGRATION_BLOCK_NUMBER"));
+        long timestamp = Long.parseLong(env("MYOTIS_INTEGRATION_BLOCK_TIMESTAMP"));
+        BigInteger baseFee = new BigInteger(env("MYOTIS_INTEGRATION_BASE_FEE_WEI"));
+        return new BlockContext(
+                stateRoot,
+                blockNumber,
+                timestamp,
+                baseFee,
+                Address.ZERO,
+                new byte[32],
+                BigInteger.ONE,
+                30_000_000L);
+    }
+
+    private static String env(String name) {
+        String v = System.getenv(name);
+        assertNotNull(v, name + " must be set; see class Javadoc");
+        return v;
+    }
+
+    private static byte[] parseHex32(String hex) {
+        String s = hex.startsWith("0x") || hex.startsWith("0X") ? hex.substring(2) : hex;
+        if (s.length() != 64) {
+            throw new IllegalArgumentException(
+                    "expected 32-byte hex (64 chars), got " + s.length() + ": " + hex);
+        }
+        return HexFormat.of().parseHex(s);
+    }
+}

--- a/myotis-evm/src/main/java/io/myotis/evm/world/SnapBackedStateOracle.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/world/SnapBackedStateOracle.java
@@ -1,0 +1,291 @@
+package io.myotis.evm.world;
+
+import com.jaeckel.ethp2p.core.trie.MerklePatriciaProofVerifier;
+import io.myotis.evm.Address;
+import io.myotis.evm.CryptoProviders;
+import io.myotis.evm.EvmExecutionError;
+import io.myotis.evm.EvmExecutionException;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.crypto.Hash;
+import org.apache.tuweni.rlp.RLP;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.function.Supplier;
+
+/**
+ * {@link SnapStateOracle} backed by a real {@link SnapPeer} connection.
+ *
+ * <p>For each call:
+ * <ol>
+ *   <li>Issue the SNAP request via the peer.
+ *   <li>Verify the proof against {@code stateRoot} using the MPT verifier in
+ *       {@code :core} (or, for bytecode, hash the response and match against
+ *       {@code codeHash}).
+ *   <li>On verification failure, request a different peer from the supplier
+ *       and try again, up to {@link #maxAttempts}.
+ *   <li>After the retry budget is exhausted, fail with
+ *       {@link EvmExecutionError.InvalidProof} (or
+ *       {@link EvmExecutionError.StateUnavailable} if the peer never
+ *       answered).
+ * </ol>
+ *
+ * <p>Bytecode is cached via the supplied {@link BytecodeCache}; the cache is
+ * checked before issuing any request. State is not cached here — the
+ * per-call cache lives in {@link SyncStateView}.
+ *
+ * <p>The peer abstraction lets tests substitute a fixture peer and lets the
+ * wallet integration provide an {@code EthHandler}-backed implementation
+ * without {@code :myotis-evm} taking a dependency on {@code :networking}.
+ */
+public final class SnapBackedStateOracle implements SnapStateOracle {
+
+    private static final Logger log = LoggerFactory.getLogger(SnapBackedStateOracle.class);
+
+    /** Default number of peers to try before giving up on a single fetch. */
+    public static final int DEFAULT_MAX_ATTEMPTS = 3;
+
+    private static final byte[] EMPTY_CODE_HASH;
+    static {
+        CryptoProviders.ensureRegistered();
+        EMPTY_CODE_HASH = Hash.keccak256(Bytes.EMPTY).toArrayUnsafe();
+    }
+
+    private final Supplier<SnapPeer> peerSupplier;
+    private final BytecodeCache bytecodeCache;
+    private final int maxAttempts;
+
+    public SnapBackedStateOracle(Supplier<SnapPeer> peerSupplier, BytecodeCache bytecodeCache) {
+        this(peerSupplier, bytecodeCache, DEFAULT_MAX_ATTEMPTS);
+    }
+
+    public SnapBackedStateOracle(
+            Supplier<SnapPeer> peerSupplier,
+            BytecodeCache bytecodeCache,
+            int maxAttempts) {
+        this.peerSupplier = peerSupplier;
+        this.bytecodeCache = bytecodeCache;
+        this.maxAttempts = maxAttempts;
+    }
+
+    @Override
+    public CompletableFuture<AccountState> fetchAccount(byte[] stateRoot, Address address) {
+        return fetchAccountWithRoot(stateRoot, address)
+                .thenApply(AccountWithStorageRoot::account);
+    }
+
+    @Override
+    public CompletableFuture<BigInteger> fetchStorage(byte[] stateRoot, Address address, BigInteger slot) {
+        Bytes32 root = Bytes32.wrap(stateRoot.clone());
+        Bytes addressBytes = Bytes.wrap(address.toByteArray());
+        Bytes32 accountHash = Bytes32.wrap(Hash.keccak256(addressBytes).toArrayUnsafe());
+        Bytes32 slotKey = paddedSlotKey(slot);
+        Bytes32 slotHash = Bytes32.wrap(Hash.keccak256(slotKey).toArrayUnsafe());
+
+        // Storage proofs anchor at the account's storageRoot, not the world
+        // stateRoot — so we need the account record first. The per-call
+        // SyncStateView cache means this account fetch happens only once
+        // even when the EVM does many SLOADs against the same contract.
+        return fetchAccountWithRoot(stateRoot, address).thenCompose(awr -> {
+            Bytes32 storageRoot = awr.storageRoot();
+            if (MerklePatriciaProofVerifier.EMPTY_TRIE_ROOT.equals(storageRoot)) {
+                // Account has no storage at all; every slot is zero.
+                return CompletableFuture.completedFuture(BigInteger.ZERO);
+            }
+            return tryWithRetries(peer -> peer
+                    .getTrieNodes(root, List.of(SnapPeer.PathSet.storageSlot(accountHash, slotHash)))
+                    .thenApply(nodes -> verifyAndDecodeStorage(storageRoot, slotHash, address, nodes)));
+        });
+    }
+
+    @Override
+    public CompletableFuture<byte[]> fetchBytecode(byte[] codeHash) {
+        var cached = bytecodeCache.get(codeHash);
+        if (cached.isPresent()) return CompletableFuture.completedFuture(cached.get());
+        if (Arrays.equals(codeHash, EMPTY_CODE_HASH)) {
+            return CompletableFuture.completedFuture(new byte[0]);
+        }
+
+        Bytes32 hash = Bytes32.wrap(codeHash.clone());
+        return tryWithRetries(peer -> peer
+                .getByteCodes(List.of(hash))
+                .thenApply(codes -> {
+                    if (codes.isEmpty()) {
+                        throw new EvmExecutionException(
+                                new EvmExecutionError.BytecodeUnavailable(codeHash));
+                    }
+                    Bytes returned = codes.get(0);
+                    byte[] code = returned.toArrayUnsafe();
+                    byte[] actualHash = Hash.keccak256(returned).toArrayUnsafe();
+                    if (!Arrays.equals(actualHash, codeHash)) {
+                        throw new EvmExecutionException(
+                                new EvmExecutionError.InvalidProof(
+                                        new byte[32], Address.ZERO,
+                                        "bytecode hash mismatch: expected 0x"
+                                                + HexFormat.of().formatHex(codeHash)
+                                                + " got 0x" + HexFormat.of().formatHex(actualHash)));
+                    }
+                    bytecodeCache.put(codeHash, code);
+                    return code;
+                }));
+    }
+
+    /**
+     * Internal helper: fetch the account record AND its storage root, since
+     * {@link AccountState} doesn't expose the latter publicly. The MPT proof
+     * verification happens inside the retry loop so a peer that returns a
+     * mismatched proof is rotated out of consideration immediately.
+     */
+    private CompletableFuture<AccountWithStorageRoot> fetchAccountWithRoot(byte[] stateRoot, Address address) {
+        Bytes32 root = Bytes32.wrap(stateRoot.clone());
+        Bytes addressBytes = Bytes.wrap(address.toByteArray());
+        Bytes32 accountHash = Bytes32.wrap(Hash.keccak256(addressBytes).toArrayUnsafe());
+
+        return tryWithRetries(peer -> peer
+                .getTrieNodes(root, List.of(SnapPeer.PathSet.account(accountHash)))
+                .thenApply(nodes -> verifyAndDecodeAccount(root, accountHash, address, nodes)));
+    }
+
+    /**
+     * Run {@code op} against successive peers until it succeeds or we hit
+     * {@link #maxAttempts}. {@link EvmExecutionError.InvalidProof} and
+     * generic IO failures both trigger retries with the next peer; the last
+     * failure surfaces if every attempt fails.
+     */
+    private <T> CompletableFuture<T> tryWithRetries(java.util.function.Function<SnapPeer, CompletableFuture<T>> op) {
+        CompletableFuture<T> result = new CompletableFuture<>();
+        attempt(op, 0, null, result);
+        return result;
+    }
+
+    private <T> void attempt(
+            java.util.function.Function<SnapPeer, CompletableFuture<T>> op,
+            int attemptIdx,
+            Throwable lastError,
+            CompletableFuture<T> sink) {
+        if (attemptIdx >= maxAttempts) {
+            sink.completeExceptionally(lastError != null ? lastError
+                    : new EvmExecutionException(new EvmExecutionError.InvalidProof(
+                            new byte[32], Address.ZERO,
+                            "exhausted " + maxAttempts + " peer attempts")));
+            return;
+        }
+        SnapPeer peer = peerSupplier.get();
+        if (peer == null) {
+            sink.completeExceptionally(lastError != null ? lastError
+                    : new EvmExecutionException(new EvmExecutionError.StateUnavailable(
+                            new byte[32], Address.ZERO, null)));
+            return;
+        }
+        CompletableFuture<T> future;
+        try {
+            future = op.apply(peer);
+        } catch (Throwable t) {
+            log.warn("[snap-oracle] attempt {} threw synchronously: {}", attemptIdx, t.getMessage());
+            attempt(op, attemptIdx + 1, t, sink);
+            return;
+        }
+        future.whenComplete((value, error) -> {
+            if (error == null) {
+                sink.complete(value);
+                return;
+            }
+            log.warn("[snap-oracle] attempt {} failed: {}", attemptIdx, error.getMessage());
+            attempt(op, attemptIdx + 1, unwrap(error), sink);
+        });
+    }
+
+    private static Throwable unwrap(Throwable t) {
+        return t instanceof CompletionException && t.getCause() != null ? t.getCause() : t;
+    }
+
+    private AccountWithStorageRoot verifyAndDecodeAccount(
+            Bytes32 stateRoot, Bytes32 accountHash, Address address, List<Bytes> proofNodes) {
+        var result = MerklePatriciaProofVerifier.verify(
+                stateRoot, accountHash.toArrayUnsafe(), proofNodes);
+        if (result instanceof MerklePatriciaProofVerifier.Result.Invalid invalid) {
+            throw new EvmExecutionException(new EvmExecutionError.InvalidProof(
+                    stateRoot.toArrayUnsafe(), address, invalid.reason()));
+        }
+        if (result instanceof MerklePatriciaProofVerifier.Result.Absent) {
+            return new AccountWithStorageRoot(
+                    new AccountState(address, 0L, BigInteger.ZERO, EMPTY_CODE_HASH),
+                    MerklePatriciaProofVerifier.EMPTY_TRIE_ROOT);
+        }
+        Bytes value = ((MerklePatriciaProofVerifier.Result.Found) result).value();
+        // Account leaf value is RLP-encoded [nonce, balance, storageRoot, codeHash].
+        return RLP.decodeList(value, reader -> {
+            long nonce = reader.readLong();
+            BigInteger balance = reader.readBigInteger();
+            Bytes32 storageRoot = Bytes32.wrap(reader.readValue());
+            Bytes32 codeHash = Bytes32.wrap(reader.readValue());
+            return new AccountWithStorageRoot(
+                    new AccountState(address, nonce, balance, codeHash.toArrayUnsafe()),
+                    storageRoot);
+        });
+    }
+
+    private BigInteger verifyAndDecodeStorage(
+            Bytes32 storageRoot, Bytes32 slotHash, Address address, List<Bytes> proofNodes) {
+        var result = MerklePatriciaProofVerifier.verify(
+                storageRoot, slotHash.toArrayUnsafe(), proofNodes);
+        if (result instanceof MerklePatriciaProofVerifier.Result.Invalid invalid) {
+            throw new EvmExecutionException(new EvmExecutionError.InvalidProof(
+                    storageRoot.toArrayUnsafe(), address, invalid.reason()));
+        }
+        if (result instanceof MerklePatriciaProofVerifier.Result.Absent) {
+            return BigInteger.ZERO;
+        }
+        Bytes value = ((MerklePatriciaProofVerifier.Result.Found) result).value();
+        // Storage leaves carry RLP-encoded uint256 (the trimmed-leading-zeros
+        // big-endian encoding). The verifier already strips the outer RLP
+        // header; the inner item is itself RLP-wrapped, so strip again.
+        if (value.isEmpty()) return BigInteger.ZERO;
+        Bytes raw = stripIntegerHeader(value);
+        return raw.isEmpty() ? BigInteger.ZERO : new BigInteger(1, raw.toArrayUnsafe());
+    }
+
+    /**
+     * Storage trie values are stored as {@code rlp(trimmed_uint256)} — the
+     * leaf-value bytes carry an RLP integer encoding. Strip the header.
+     */
+    private static Bytes stripIntegerHeader(Bytes raw) {
+        if (raw.isEmpty()) return raw;
+        int first = raw.get(0) & 0xff;
+        if (first < 0x80) return raw;
+        if (first <= 0xb7) {
+            int len = first - 0x80;
+            return len == 0 ? Bytes.EMPTY : raw.slice(1, len);
+        }
+        // Long string — should never happen for a uint256, but handle gracefully.
+        int lenLen = first - 0xb7;
+        return raw.slice(1 + lenLen);
+    }
+
+    /** Storage trie keys are keccak256 of the 32-byte zero-padded slot index. */
+    private static Bytes32 paddedSlotKey(BigInteger slot) {
+        byte[] padded = new byte[32];
+        byte[] raw = slot.toByteArray();
+        if (raw.length > 32) {
+            // BigInteger may emit a sign byte; strip a leading zero if present.
+            if (raw.length == 33 && raw[0] == 0) {
+                System.arraycopy(raw, 1, padded, 0, 32);
+            } else {
+                throw new IllegalArgumentException("slot exceeds 256 bits");
+            }
+        } else {
+            System.arraycopy(raw, 0, padded, 32 - raw.length, raw.length);
+        }
+        return Bytes32.wrap(padded);
+    }
+
+    /** Internal helper: AccountState's public API doesn't carry storageRoot. */
+    private record AccountWithStorageRoot(AccountState account, Bytes32 storageRoot) {}
+}

--- a/myotis-evm/src/main/java/io/myotis/evm/world/SnapPeer.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/world/SnapPeer.java
@@ -1,0 +1,60 @@
+package io.myotis.evm.world;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Abstraction over a snap/1-capable peer connection.
+ *
+ * <p>{@code :myotis-evm} stays decoupled from {@code :networking} on purpose;
+ * the wallet integration plugs an implementation of this interface backed by
+ * an {@code EthHandler} (or a pool of them) when constructing the
+ * {@link SnapBackedStateOracle}. Tests use an in-memory fixture
+ * implementation.
+ *
+ * <p>Both methods return raw response bytes — the oracle is responsible for
+ * verifying them (proof verification for trie nodes, hash matching for
+ * bytecode).
+ */
+public interface SnapPeer {
+
+    /**
+     * One {@code GetTrieNodes} path set per the snap/1 spec: an account path
+     * followed by zero or more storage paths within that account's storage
+     * trie. Paths are full keccak256 hashes (32 bytes) for leaf-node lookups.
+     */
+    record PathSet(Bytes accountPath, List<Bytes> storagePaths) {
+
+        public PathSet {
+            Objects.requireNonNull(accountPath, "accountPath");
+            Objects.requireNonNull(storagePaths, "storagePaths");
+        }
+
+        public static PathSet account(Bytes32 accountHash) {
+            return new PathSet(accountHash, List.of());
+        }
+
+        public static PathSet storageSlot(Bytes32 accountHash, Bytes32 slotHash) {
+            return new PathSet(accountHash, List.of(slotHash));
+        }
+    }
+
+    /**
+     * Issue a snap/1 GetTrieNodes request. Returns the raw trie nodes the
+     * peer responds with. The caller must verify each node against
+     * {@code stateRoot} via the MPT verifier; nodes whose hash doesn't fit
+     * the implied path are an indictment of the peer.
+     */
+    CompletableFuture<List<Bytes>> getTrieNodes(Bytes32 stateRoot, List<PathSet> paths);
+
+    /**
+     * Issue a snap/1 GetByteCodes request. Returns the raw bytecode blobs in
+     * the same order as {@code hashes}. The caller must verify each blob's
+     * keccak256 matches the requested hash.
+     */
+    CompletableFuture<List<Bytes>> getByteCodes(List<Bytes32> hashes);
+}

--- a/myotis-evm/src/test/java/io/myotis/evm/world/SnapBackedStateOracleTest.java
+++ b/myotis-evm/src/test/java/io/myotis/evm/world/SnapBackedStateOracleTest.java
@@ -1,0 +1,332 @@
+package io.myotis.evm.world;
+
+import com.jaeckel.ethp2p.core.trie.HexPrefix;
+import io.myotis.evm.Address;
+import io.myotis.evm.EvmExecutionError;
+import io.myotis.evm.EvmExecutionException;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.crypto.Hash;
+import org.apache.tuweni.rlp.RLP;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.security.Security;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Tests for {@link SnapBackedStateOracle} using hand-built proofs.
+ *
+ * <p>Each test constructs a small trie with known leaves, stores the trie
+ * nodes in a {@link FixturePeer}, then asks the oracle to fetch — exercising
+ * the verifier + decoder pipeline end-to-end. The retry loop is exercised by
+ * a peer that returns wrong data on the first attempt.
+ */
+class SnapBackedStateOracleTest {
+
+    @BeforeAll
+    static void registerBouncyCastle() {
+        if (Security.getProvider("BC") == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+    }
+
+    // ---- Account fetches ---------------------------------------------------
+
+    @Test
+    void fetchAccountReturnsDecodedFields() throws Exception {
+        // One-account trie: address=0xab..., nonce=42, balance=1e18, codeHash=keccak256("").
+        Address addr = Address.fromHex("0xabcdef0102030405060708090a0b0c0d0e0f1011");
+        long nonce = 42L;
+        BigInteger balance = new BigInteger("1000000000000000000");
+        Bytes32 codeHash = Bytes32.wrap(Hash.keccak256(Bytes.EMPTY).toArrayUnsafe());
+        Bytes32 storageRoot = TrieFixture.EMPTY_TRIE_ROOT;
+
+        Bytes accountValue = encodeAccount(nonce, balance, storageRoot, codeHash);
+        var trie = TrieFixture.singleLeaf(keccak(addr.toByteArray()), accountValue);
+
+        FixturePeer peer = new FixturePeer();
+        peer.addTrieNodes(trie.root, trie.proof);
+
+        var oracle = new SnapBackedStateOracle(() -> peer, BytecodeCache.inMemory());
+        AccountState got = oracle.fetchAccount(trie.root.toArrayUnsafe(), addr).get();
+        assertEquals(addr, got.address());
+        assertEquals(nonce, got.nonce());
+        assertEquals(balance, got.balance());
+        assertArrayEquals(codeHash.toArrayUnsafe(), got.codeHash());
+    }
+
+    @Test
+    void fetchAccountAbsentReturnsEmptyDefault() throws Exception {
+        // Trie holds key 0x11..; we ask for a key that lands on an empty branch slot.
+        Address present = Address.fromHex("0x1111111111111111111111111111111111111111");
+        Address absent = Address.fromHex("0x9999999999999999999999999999999999999999");
+
+        Bytes accountValue = encodeAccount(0L, BigInteger.ZERO,
+                TrieFixture.EMPTY_TRIE_ROOT,
+                Bytes32.wrap(Hash.keccak256(Bytes.EMPTY).toArrayUnsafe()));
+        var trie = TrieFixture.singleLeaf(keccak(present.toByteArray()), accountValue);
+
+        FixturePeer peer = new FixturePeer();
+        peer.addTrieNodes(trie.root, trie.proof);
+
+        var oracle = new SnapBackedStateOracle(() -> peer, BytecodeCache.inMemory());
+        AccountState got = oracle.fetchAccount(trie.root.toArrayUnsafe(), absent).get();
+        assertEquals(0L, got.nonce());
+        assertEquals(BigInteger.ZERO, got.balance());
+        assertArrayEquals(
+                Hash.keccak256(Bytes.EMPTY).toArrayUnsafe(),
+                got.codeHash());
+    }
+
+    @Test
+    void fetchAccountWithInvalidProofRetriesThenFails() {
+        // Peer always returns garbage proof nodes that don't hash to the requested root.
+        Address addr = Address.fromHex("0xabcdef0102030405060708090a0b0c0d0e0f1011");
+        Bytes32 root = Bytes32.fromHexString(
+                "0x1111111111111111111111111111111111111111111111111111111111111111");
+        Bytes garbage = RLP.encodeList(w -> {
+            w.writeValue(Bytes.fromHexString("0x20"));
+            w.writeValue(Bytes.fromHexString("0xdead"));
+        });
+        FixturePeer peer = new FixturePeer();
+        peer.addTrieNodes(root, List.of(garbage)); // hash won't match the (fake) root
+
+        AtomicInteger attempts = new AtomicInteger();
+        Supplier<SnapPeer> supplier = () -> {
+            attempts.incrementAndGet();
+            return peer;
+        };
+
+        var oracle = new SnapBackedStateOracle(supplier, BytecodeCache.inMemory(), 3);
+        try {
+            oracle.fetchAccount(root.toArrayUnsafe(), addr).get();
+            fail("expected fetchAccount to fail");
+        } catch (Exception e) {
+            Throwable cause = e instanceof ExecutionException ? e.getCause() : e;
+            var eee = assertInstanceOf(EvmExecutionException.class, cause);
+            assertInstanceOf(EvmExecutionError.InvalidProof.class, eee.error());
+        }
+        // Supplier was consulted once per attempt.
+        assertEquals(3, attempts.get());
+    }
+
+    // ---- Storage fetch -----------------------------------------------------
+
+    @Test
+    void fetchStorageReturnsValue() throws Exception {
+        // Storage trie holds a single slot.
+        Address addr = Address.fromHex("0xabcdef0102030405060708090a0b0c0d0e0f1011");
+        BigInteger slot = BigInteger.valueOf(7);
+        BigInteger value = new BigInteger("1234567890123456789");
+
+        Bytes32 slotKey = paddedSlot(slot);
+        Bytes32 slotHash = Bytes32.wrap(Hash.keccak256(slotKey).toArrayUnsafe());
+        Bytes valueRlp = RLP.encode(w -> w.writeBigInteger(value));
+        var storageTrie = TrieFixture.singleLeaf(slotHash, valueRlp);
+
+        // Account trie points at storageTrie.root for our address.
+        Bytes accountValue = encodeAccount(0L, BigInteger.ZERO,
+                storageTrie.root,
+                Bytes32.wrap(Hash.keccak256(Bytes.EMPTY).toArrayUnsafe()));
+        var accountTrie = TrieFixture.singleLeaf(keccak(addr.toByteArray()), accountValue);
+
+        FixturePeer peer = new FixturePeer();
+        // Real snap peers serve both walks indexed by stateRoot + path-set
+        // shape; the fixture mimics that with two registers.
+        peer.addAccountProof(accountTrie.root, accountTrie.proof);
+        peer.addStorageProof(accountTrie.root, storageTrie.proof);
+
+        var oracle = new SnapBackedStateOracle(() -> peer, BytecodeCache.inMemory());
+        BigInteger got = oracle.fetchStorage(accountTrie.root.toArrayUnsafe(), addr, slot).get();
+        assertEquals(value, got);
+    }
+
+    @Test
+    void fetchStorageOnEmptyTrieReturnsZero() throws Exception {
+        // Account exists with EMPTY storage root → any slot is zero, no second request needed.
+        Address addr = Address.fromHex("0xabcdef0102030405060708090a0b0c0d0e0f1011");
+        Bytes accountValue = encodeAccount(1L, BigInteger.TEN,
+                TrieFixture.EMPTY_TRIE_ROOT,
+                Bytes32.wrap(Hash.keccak256(Bytes.EMPTY).toArrayUnsafe()));
+        var trie = TrieFixture.singleLeaf(keccak(addr.toByteArray()), accountValue);
+
+        FixturePeer peer = new FixturePeer();
+        peer.addTrieNodes(trie.root, trie.proof);
+
+        var oracle = new SnapBackedStateOracle(() -> peer, BytecodeCache.inMemory());
+        BigInteger got = oracle.fetchStorage(
+                trie.root.toArrayUnsafe(), addr, BigInteger.valueOf(42)).get();
+        assertEquals(BigInteger.ZERO, got);
+    }
+
+    // ---- Bytecode fetch ----------------------------------------------------
+
+    @Test
+    void fetchBytecodeChecksHashAndCaches() throws Exception {
+        byte[] code = {0x60, 0x00, 0x60, 0x00, (byte) 0xfd}; // PUSH1 0; PUSH1 0; REVERT
+        byte[] codeHash = Hash.keccak256(Bytes.wrap(code)).toArrayUnsafe();
+
+        FixturePeer peer = new FixturePeer();
+        peer.addByteCode(Bytes32.wrap(codeHash), Bytes.wrap(code));
+
+        var cache = BytecodeCache.inMemory();
+        var oracle = new SnapBackedStateOracle(() -> peer, cache);
+        byte[] got = oracle.fetchBytecode(codeHash).get();
+        assertArrayEquals(code, got);
+
+        // Cache hit on second call: peer wasn't queried again. Detect by clearing
+        // the peer's bytecode map and confirming we still get the right bytes.
+        peer.clearByteCodes();
+        byte[] gotAgain = oracle.fetchBytecode(codeHash).get();
+        assertArrayEquals(code, gotAgain);
+    }
+
+    @Test
+    void fetchBytecodeRejectsHashMismatch() {
+        // Peer returns a different bytecode than requested; oracle must not accept it.
+        byte[] requestedHash = Hash.keccak256(Bytes.wrap(new byte[]{1, 2, 3})).toArrayUnsafe();
+        byte[] returnedCode = {9, 9, 9}; // hash doesn't match requestedHash
+
+        FixturePeer peer = new FixturePeer();
+        peer.addByteCode(Bytes32.wrap(requestedHash), Bytes.wrap(returnedCode));
+
+        var oracle = new SnapBackedStateOracle(() -> peer, BytecodeCache.inMemory(), 2);
+        try {
+            oracle.fetchBytecode(requestedHash).get();
+            fail("expected hash-mismatch failure");
+        } catch (Exception e) {
+            Throwable cause = e instanceof ExecutionException ? e.getCause() : e;
+            var eee = assertInstanceOf(EvmExecutionException.class, cause);
+            assertInstanceOf(EvmExecutionError.InvalidProof.class, eee.error());
+        }
+    }
+
+    @Test
+    void fetchBytecodeReturnsEmptyForEmptyCodeHash() throws Exception {
+        byte[] emptyHash = Hash.keccak256(Bytes.EMPTY).toArrayUnsafe();
+        // No peer interaction needed — handler short-circuits.
+        var oracle = new SnapBackedStateOracle(() -> { throw new AssertionError("peer should not be called"); },
+                BytecodeCache.inMemory());
+        byte[] got = oracle.fetchBytecode(emptyHash).get();
+        assertEquals(0, got.length);
+    }
+
+    // ---- Helpers -----------------------------------------------------------
+
+    private static Bytes32 keccak(byte[] data) {
+        return Bytes32.wrap(Hash.keccak256(Bytes.wrap(data)).toArrayUnsafe());
+    }
+
+    private static Bytes encodeAccount(long nonce, BigInteger balance, Bytes32 storageRoot, Bytes32 codeHash) {
+        return RLP.encodeList(w -> {
+            w.writeLong(nonce);
+            w.writeBigInteger(balance);
+            w.writeValue(storageRoot);
+            w.writeValue(codeHash);
+        });
+    }
+
+    private static Bytes32 paddedSlot(BigInteger slot) {
+        byte[] padded = new byte[32];
+        byte[] raw = slot.toByteArray();
+        System.arraycopy(raw, 0, padded, 32 - raw.length, raw.length);
+        return Bytes32.wrap(padded);
+    }
+
+    /** Trie fixture: a single-leaf trie storing one (key, value) pair. */
+    private static final class TrieFixture {
+        static final Bytes32 EMPTY_TRIE_ROOT = Bytes32.fromHexString(
+                "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421");
+
+        final Bytes32 root;
+        final List<Bytes> proof;
+
+        TrieFixture(Bytes32 root, List<Bytes> proof) {
+            this.root = root;
+            this.proof = proof;
+        }
+
+        static TrieFixture singleLeaf(Bytes32 key, Bytes value) {
+            byte[] keyNibbles = HexPrefix.toNibbles(key.toArrayUnsafe());
+            byte[] encodedPath = HexPrefix.encode(keyNibbles, true);
+            Bytes leaf = RLP.encodeList(w -> {
+                w.writeValue(Bytes.wrap(encodedPath));
+                w.writeValue(value);
+            });
+            Bytes32 root = Bytes32.wrap(Hash.keccak256(leaf).toArrayUnsafe());
+            return new TrieFixture(root, List.of(leaf));
+        }
+    }
+
+    /** In-memory {@link SnapPeer} that returns pre-arranged proof bytes. */
+    private static final class FixturePeer implements SnapPeer {
+        private final Map<Bytes32, List<Bytes>> accountProofsByRoot = new HashMap<>();
+        private final Map<Bytes32, List<Bytes>> storageProofsByRoot = new HashMap<>();
+        private final Map<Bytes32, Bytes> codeByHash = new HashMap<>();
+
+        void addAccountProof(Bytes32 stateRoot, List<Bytes> nodes) {
+            accountProofsByRoot.put(stateRoot, new ArrayList<>(nodes));
+        }
+
+        void addStorageProof(Bytes32 stateRoot, List<Bytes> nodes) {
+            storageProofsByRoot.put(stateRoot, new ArrayList<>(nodes));
+        }
+
+        /**
+         * Convenience that registers the same proof for both lookup shapes —
+         * fine when a test only does one kind of fetch.
+         */
+        void addTrieNodes(Bytes32 stateRoot, List<Bytes> nodes) {
+            addAccountProof(stateRoot, nodes);
+            addStorageProof(stateRoot, nodes);
+        }
+
+        void addByteCode(Bytes32 codeHash, Bytes code) {
+            codeByHash.put(codeHash, code);
+        }
+
+        void clearByteCodes() {
+            codeByHash.clear();
+        }
+
+        @Override
+        public CompletableFuture<List<Bytes>> getTrieNodes(Bytes32 stateRoot, List<PathSet> paths) {
+            // Real peers walk both the account trie and (when requested) the
+            // account's storage trie, returning all the proof nodes either
+            // walk traversed. We approximate by dispatching on the path set
+            // shape: account-only requests get the account proof, requests
+            // that include a storage path get the storage proof. The verifier
+            // catches any mismatch via hash-of-node checks.
+            boolean isStorageRequest = !paths.isEmpty() && !paths.get(0).storagePaths().isEmpty();
+            Map<Bytes32, List<Bytes>> map = isStorageRequest ? storageProofsByRoot : accountProofsByRoot;
+            List<Bytes> nodes = map.get(stateRoot);
+            return CompletableFuture.completedFuture(nodes != null ? nodes : List.of());
+        }
+
+        @Override
+        public CompletableFuture<List<Bytes>> getByteCodes(List<Bytes32> hashes) {
+            List<Bytes> result = new ArrayList<>(hashes.size());
+            for (Bytes32 h : hashes) {
+                Bytes code = codeByHash.get(h);
+                if (code != null) result.add(code);
+            }
+            return CompletableFuture.completedFuture(result);
+        }
+    }
+}

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/EthHandler.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/EthHandler.java
@@ -935,7 +935,8 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
     public CompletableFuture<ByteCodesMessage.DecodeResult> requestByteCodesAsync(
             java.util.List<org.apache.tuweni.bytes.Bytes32> hashes) {
         ChannelHandlerContext ctx = readyCtx;
-        if (ctx == null || state != State.READY) return null;
+        if (ctx == null || state != State.READY) return CompletableFuture.failedFuture(
+            new IllegalStateException("EthHandler not READY"));
         if (!snapNegotiated) return CompletableFuture.failedFuture(
             new UnsupportedOperationException("snap/1 not negotiated with this peer"));
 
@@ -965,7 +966,8 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
             org.apache.tuweni.bytes.Bytes32 stateRoot,
             java.util.List<GetTrieNodesMessage.PathSet> paths) {
         ChannelHandlerContext ctx = readyCtx;
-        if (ctx == null || state != State.READY) return null;
+        if (ctx == null || state != State.READY) return CompletableFuture.failedFuture(
+            new IllegalStateException("EthHandler not READY"));
         if (!snapNegotiated) return CompletableFuture.failedFuture(
             new UnsupportedOperationException("snap/1 not negotiated with this peer"));
 

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/EthHandler.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/EthHandler.java
@@ -6,9 +6,13 @@ import com.jaeckel.ethp2p.networking.NetworkConfig;
 import com.jaeckel.ethp2p.networking.eth.messages.*;
 import com.jaeckel.ethp2p.networking.rlpx.RLPxHandler;
 import com.jaeckel.ethp2p.networking.snap.messages.AccountRangeMessage;
+import com.jaeckel.ethp2p.networking.snap.messages.ByteCodesMessage;
 import com.jaeckel.ethp2p.networking.snap.messages.GetAccountRangeMessage;
+import com.jaeckel.ethp2p.networking.snap.messages.GetByteCodesMessage;
 import com.jaeckel.ethp2p.networking.snap.messages.GetStorageRangesMessage;
+import com.jaeckel.ethp2p.networking.snap.messages.GetTrieNodesMessage;
 import com.jaeckel.ethp2p.networking.snap.messages.StorageRangesMessage;
+import com.jaeckel.ethp2p.networking.snap.messages.TrieNodesMessage;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import org.slf4j.Logger;
@@ -57,10 +61,20 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
     // snap/1 message codes depend on negotiated eth version:
     //   eth/67-68: protocol length 17, snap base = 0x10 + 17 = 0x21
     //   eth/69:    protocol length 18 (adds BlockRangeUpdate at 0x11), snap base = 0x10 + 18 = 0x22
+    //
+    // Snap message ids (offsets from snapBase) per the snap/1 wire spec:
+    //   0x00 GetAccountRange / 0x01 AccountRange
+    //   0x02 GetStorageRanges / 0x03 StorageRanges
+    //   0x04 GetByteCodes    / 0x05 ByteCodes
+    //   0x06 GetTrieNodes    / 0x07 TrieNodes
     private int snapGetAccountRange  = 0x21; // updated after Hello negotiation
     private int snapAccountRange     = 0x22;
     private int snapGetStorageRanges = 0x23;
     private int snapStorageRanges    = 0x24;
+    private int snapGetByteCodes     = 0x25;
+    private int snapByteCodes        = 0x26;
+    private int snapGetTrieNodes     = 0x27;
+    private int snapTrieNodes        = 0x28;
 
     public enum State { AWAITING_HELLO, AWAITING_STATUS, READY }
     private volatile State state = State.AWAITING_HELLO;
@@ -90,6 +104,10 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
             pendingSnapRequests = new ConcurrentHashMap<>();
     private final ConcurrentMap<Long, CompletableFuture<StorageRangesMessage.DecodeResult>>
             pendingStorageRequests = new ConcurrentHashMap<>();
+    private final ConcurrentMap<Long, CompletableFuture<ByteCodesMessage.DecodeResult>>
+            pendingByteCodeRequests = new ConcurrentHashMap<>();
+    private final ConcurrentMap<Long, CompletableFuture<TrieNodesMessage.DecodeResult>>
+            pendingTrieNodeRequests = new ConcurrentHashMap<>();
 
 
     // Cache received headers so we can serve them back to peers (by block number)
@@ -237,6 +255,10 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
             snapAccountRange     = snapBase + 1;
             snapGetStorageRanges = snapBase + 2;
             snapStorageRanges    = snapBase + 3;
+            snapGetByteCodes     = snapBase + 4;
+            snapByteCodes        = snapBase + 5;
+            snapGetTrieNodes     = snapBase + 6;
+            snapTrieNodes        = snapBase + 7;
             log.info("[eth] snap base offset: 0x{} (eth length={})",
                 Integer.toHexString(snapBase), ethProtocolLength);
             snapNegotiated = hello.capabilities.stream()
@@ -447,6 +469,14 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
                     handleSnapStorageRanges(msg);
                 } else if (msg.code() == snapGetStorageRanges) {
                     handleSnapGetStorageRanges(ctx, msg);
+                } else if (msg.code() == snapByteCodes) {
+                    handleSnapByteCodes(msg);
+                } else if (msg.code() == snapGetByteCodes) {
+                    handleSnapGetByteCodes(ctx, msg);
+                } else if (msg.code() == snapTrieNodes) {
+                    handleSnapTrieNodes(msg);
+                } else if (msg.code() == snapGetTrieNodes) {
+                    handleSnapGetTrieNodes(ctx, msg);
                 } else {
                     log.debug("[eth] Unhandled message 0x{} ({} bytes) from {}",
                         Integer.toHexString(msg.code()), msg.payload().length, remoteAddress);
@@ -523,6 +553,78 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
             log.debug("[snap] Responded with empty StorageRanges (reqId={})", snapReqId);
         } catch (Exception e) {
             log.debug("[snap] Failed to respond to GetStorageRanges: {}", e.getMessage());
+        }
+    }
+
+    private void handleSnapByteCodes(RLPxHandler.RLPxMessage msg) {
+        long snapReqId = -1;
+        try {
+            snapReqId = ByteCodesMessage.extractRequestId(msg.payload());
+        } catch (Exception ignored) {}
+        try {
+            ByteCodesMessage.DecodeResult decoded = ByteCodesMessage.decode(msg.payload());
+            log.info("[snap] ByteCodes: {} entries (reqId={})",
+                decoded.codes().size(), decoded.requestId());
+            CompletableFuture<ByteCodesMessage.DecodeResult> f =
+                pendingByteCodeRequests.remove(decoded.requestId());
+            if (f != null) f.complete(decoded);
+        } catch (Exception e) {
+            log.error("[snap] Failed to decode ByteCodes (reqId={}): {}",
+                snapReqId, e.getMessage());
+            if (snapReqId >= 0) {
+                CompletableFuture<ByteCodesMessage.DecodeResult> f =
+                    pendingByteCodeRequests.remove(snapReqId);
+                if (f != null) f.completeExceptionally(e);
+            }
+        }
+    }
+
+    private void handleSnapGetByteCodes(ChannelHandlerContext ctx, RLPxHandler.RLPxMessage msg) {
+        // We never serve bytecode — answer with an empty list so the peer
+        // doesn't time out and disconnect us.
+        try {
+            long snapReqId = GetByteCodesMessage.decode(msg.payload()).requestId();
+            byte[] emptyResponse = ByteCodesMessage.encodeEmpty(snapReqId);
+            rlpxHandler.sendMessage(ctx, snapByteCodes, emptyResponse);
+            log.debug("[snap] Responded with empty ByteCodes (reqId={})", snapReqId);
+        } catch (Exception e) {
+            log.debug("[snap] Failed to respond to GetByteCodes: {}", e.getMessage());
+        }
+    }
+
+    private void handleSnapTrieNodes(RLPxHandler.RLPxMessage msg) {
+        long snapReqId = -1;
+        try {
+            snapReqId = TrieNodesMessage.extractRequestId(msg.payload());
+        } catch (Exception ignored) {}
+        try {
+            TrieNodesMessage.DecodeResult decoded = TrieNodesMessage.decode(msg.payload());
+            log.info("[snap] TrieNodes: {} nodes (reqId={})",
+                decoded.nodes().size(), decoded.requestId());
+            CompletableFuture<TrieNodesMessage.DecodeResult> f =
+                pendingTrieNodeRequests.remove(decoded.requestId());
+            if (f != null) f.complete(decoded);
+        } catch (Exception e) {
+            log.error("[snap] Failed to decode TrieNodes (reqId={}): {}",
+                snapReqId, e.getMessage());
+            if (snapReqId >= 0) {
+                CompletableFuture<TrieNodesMessage.DecodeResult> f =
+                    pendingTrieNodeRequests.remove(snapReqId);
+                if (f != null) f.completeExceptionally(e);
+            }
+        }
+    }
+
+    private void handleSnapGetTrieNodes(ChannelHandlerContext ctx, RLPxHandler.RLPxMessage msg) {
+        // Same policy as GetByteCodes: empty response so the peer doesn't
+        // time out. We're a wallet, not a serving full node.
+        try {
+            long snapReqId = GetTrieNodesMessage.decode(msg.payload()).requestId();
+            byte[] emptyResponse = TrieNodesMessage.encodeEmpty(snapReqId);
+            rlpxHandler.sendMessage(ctx, snapTrieNodes, emptyResponse);
+            log.debug("[snap] Responded with empty TrieNodes (reqId={})", snapReqId);
+        } catch (Exception e) {
+            log.debug("[snap] Failed to respond to GetTrieNodes: {}", e.getMessage());
         }
     }
 
@@ -818,6 +920,63 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
             stateRoot.toShortHexString());
         rlpxHandler.sendMessage(ctx, snapGetStorageRanges, payload);
         return future;
+    }
+
+    /**
+     * Fetch bytecode by code hash via snap/1 GetByteCodes.
+     *
+     * <p>Bytecode is immutable, so this request does not need a state root —
+     * the caller must verify the response by hashing each returned blob and
+     * matching against the originally-requested hash.
+     *
+     * @param hashes 32-byte keccak256 hashes of the bytecodes to fetch
+     * @return future completing with the ByteCodes decode result, or null if not READY
+     */
+    public CompletableFuture<ByteCodesMessage.DecodeResult> requestByteCodesAsync(
+            java.util.List<org.apache.tuweni.bytes.Bytes32> hashes) {
+        ChannelHandlerContext ctx = readyCtx;
+        if (ctx == null || state != State.READY) return null;
+        if (!snapNegotiated) return CompletableFuture.failedFuture(
+            new UnsupportedOperationException("snap/1 not negotiated with this peer"));
+
+        long reqId = requestId.getAndIncrement();
+        CompletableFuture<ByteCodesMessage.DecodeResult> future = new CompletableFuture<>();
+        pendingByteCodeRequests.put(reqId, future);
+        byte[] payload = GetByteCodesMessage.encode(reqId, hashes, 128 * 1024L);
+        log.info("[snap] GetByteCodes reqId={} hashes={}", reqId, hashes.size());
+        rlpxHandler.sendMessage(ctx, snapGetByteCodes, payload);
+        return future.orTimeout(10, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Fetch trie nodes via snap/1 GetTrieNodes for the given path sets.
+     *
+     * <p>Each {@link GetTrieNodesMessage.PathSet} addresses one account in
+     * the world state trie; subsequent storage paths within the set are
+     * looked up in that account's storage trie. The caller is responsible
+     * for verifying every returned node against {@code stateRoot} via the
+     * MPT proof verifier in {@code :core}.
+     *
+     * @param stateRoot the trusted state root to query against
+     * @param paths     path sets the peer should resolve
+     * @return future completing with the TrieNodes decode result, or null if not READY
+     */
+    public CompletableFuture<TrieNodesMessage.DecodeResult> requestTrieNodesAsync(
+            org.apache.tuweni.bytes.Bytes32 stateRoot,
+            java.util.List<GetTrieNodesMessage.PathSet> paths) {
+        ChannelHandlerContext ctx = readyCtx;
+        if (ctx == null || state != State.READY) return null;
+        if (!snapNegotiated) return CompletableFuture.failedFuture(
+            new UnsupportedOperationException("snap/1 not negotiated with this peer"));
+
+        long reqId = requestId.getAndIncrement();
+        CompletableFuture<TrieNodesMessage.DecodeResult> future = new CompletableFuture<>();
+        pendingTrieNodeRequests.put(reqId, future);
+        byte[] payload = GetTrieNodesMessage.encode(reqId, stateRoot, paths, 128 * 1024L);
+        log.info("[snap] GetTrieNodes reqId={} root={} paths={}",
+            reqId, stateRoot.toShortHexString(), paths.size());
+        rlpxHandler.sendMessage(ctx, snapGetTrieNodes, payload);
+        return future.orTimeout(10, TimeUnit.SECONDS);
     }
 
     public String getClientId() { return clientId; }

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/snap/messages/ByteCodesMessage.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/snap/messages/ByteCodesMessage.java
@@ -7,7 +7,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * snap/1 ByteCodes response (absolute message code 0x25).
+ * snap/1 ByteCodes response (snap message id 0x05; absolute code 0x26
+ * under eth/68's protocol length 17).
  *
  * <p>Wire format: {@code [reqId, [bytecode, ...]]}
  *

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/snap/messages/ByteCodesMessage.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/snap/messages/ByteCodesMessage.java
@@ -1,0 +1,75 @@
+package com.jaeckel.ethp2p.networking.snap.messages;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.rlp.RLP;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * snap/1 ByteCodes response (absolute message code 0x25).
+ *
+ * <p>Wire format: {@code [reqId, [bytecode, ...]]}
+ *
+ * <p>Entries are returned in the same order as the requested code hashes.
+ * Per the spec, peers may serve a prefix and stop early once the response
+ * size cap is reached; missing entries are not zero-filled, the response
+ * simply ends.
+ *
+ * <p>The caller is responsible for hashing each returned bytecode and
+ * matching it against the originally-requested hash. Mismatches indicate a
+ * malicious or buggy peer.
+ */
+public final class ByteCodesMessage {
+
+    private ByteCodesMessage() {}
+
+    public record DecodeResult(long requestId, List<Bytes> codes) {}
+
+    /** Extract just the request ID without fully decoding. */
+    public static long extractRequestId(byte[] rlp) {
+        return RLP.decodeList(Bytes.wrap(rlp), reader -> reader.readLong());
+    }
+
+    /** Encode an empty response (peer declined to serve). */
+    public static byte[] encodeEmpty(long requestId) {
+        return RLP.encodeList(w -> {
+            w.writeLong(requestId);
+            w.writeList(codes -> {});
+        }).toArrayUnsafe();
+    }
+
+    /** Encode a populated response. */
+    public static byte[] encode(long requestId, List<Bytes> codes) {
+        return RLP.encodeList(w -> {
+            w.writeLong(requestId);
+            w.writeList(listWriter -> {
+                for (Bytes c : codes) listWriter.writeValue(c);
+            });
+        }).toArrayUnsafe();
+    }
+
+    public static DecodeResult decode(byte[] rlp) {
+        List<Bytes> codes = new ArrayList<>();
+        long[] reqId = {0L};
+
+        RLP.decodeList(Bytes.wrap(rlp), reader -> {
+            reqId[0] = reader.readLong();
+            // The codes field can be a list (the normal case) or an empty
+            // bytes value (some clients use 0x80 for an empty response).
+            if (!reader.isComplete() && reader.nextIsList()) {
+                reader.readList(codeReader -> {
+                    while (!codeReader.isComplete()) {
+                        codes.add(codeReader.readValue());
+                    }
+                    return null;
+                });
+            } else if (!reader.isComplete()) {
+                reader.readValue();
+            }
+            return null;
+        });
+
+        return new DecodeResult(reqId[0], codes);
+    }
+}

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/snap/messages/GetByteCodesMessage.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/snap/messages/GetByteCodesMessage.java
@@ -1,0 +1,58 @@
+package com.jaeckel.ethp2p.networking.snap.messages;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.rlp.RLP;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * snap/1 GetByteCodes request (absolute message code 0x24).
+ *
+ * <p>Wire format: {@code [reqId, [hash, ...], responseBytes]}
+ *
+ * <p>Each {@code hash} is the keccak256 of the bytecode being requested. The
+ * response ({@link ByteCodesMessage}) contains the bytecodes in the same
+ * order as the requested hashes; missing entries are returned as empty.
+ *
+ * <p>Bytecode is immutable forever, so this request does not need a state
+ * root — the {@code codeHash} alone is the integrity anchor.
+ */
+public final class GetByteCodesMessage {
+
+    private GetByteCodesMessage() {}
+
+    public record DecodeResult(long requestId, List<Bytes32> hashes, long responseBytes) {}
+
+    /** Encode a GetByteCodes request. */
+    public static byte[] encode(long requestId, List<Bytes32> hashes, long responseBytes) {
+        return RLP.encodeList(w -> {
+            w.writeLong(requestId);
+            w.writeList(listWriter -> {
+                for (Bytes32 h : hashes) listWriter.writeValue(h);
+            });
+            w.writeLong(responseBytes);
+        }).toArrayUnsafe();
+    }
+
+    public static DecodeResult decode(byte[] rlp) {
+        List<Bytes32> hashes = new ArrayList<>();
+        long[] reqId = {0L};
+        long[] respBytes = {0L};
+
+        RLP.decodeList(Bytes.wrap(rlp), reader -> {
+            reqId[0] = reader.readLong();
+            reader.readList(hashReader -> {
+                while (!hashReader.isComplete()) {
+                    hashes.add(Bytes32.wrap(hashReader.readValue()));
+                }
+                return null;
+            });
+            respBytes[0] = reader.readLong();
+            return null;
+        });
+
+        return new DecodeResult(reqId[0], hashes, respBytes[0]);
+    }
+}

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/snap/messages/GetByteCodesMessage.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/snap/messages/GetByteCodesMessage.java
@@ -8,7 +8,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * snap/1 GetByteCodes request (absolute message code 0x24).
+ * snap/1 GetByteCodes request (snap message id 0x04; absolute code 0x25
+ * under eth/68's protocol length 17).
  *
  * <p>Wire format: {@code [reqId, [hash, ...], responseBytes]}
  *

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/snap/messages/GetTrieNodesMessage.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/snap/messages/GetTrieNodesMessage.java
@@ -8,7 +8,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * snap/1 GetTrieNodes request (absolute message code 0x26).
+ * snap/1 GetTrieNodes request (snap message id 0x06; absolute code 0x27
+ * under eth/68's protocol length 17).
  *
  * <p>Wire format:
  * {@code [reqId, stateRoot, [[accountPath, storagePath, storagePath, ...], ...], responseBytes]}

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/snap/messages/GetTrieNodesMessage.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/snap/messages/GetTrieNodesMessage.java
@@ -1,0 +1,97 @@
+package com.jaeckel.ethp2p.networking.snap.messages;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.rlp.RLP;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * snap/1 GetTrieNodes request (absolute message code 0x26).
+ *
+ * <p>Wire format:
+ * {@code [reqId, stateRoot, [[accountPath, storagePath, storagePath, ...], ...], responseBytes]}
+ *
+ * <p>Each {@link PathSet} requests one or more trie nodes belonging to a
+ * single account. The first byte string in a set is the path to a node in
+ * the world state trie (typically the {@code keccak256(address)} of the
+ * account being queried, in raw 32-byte form for a leaf request); each
+ * subsequent byte string is a path inside that account's storage trie.
+ *
+ * <p>For the per-account / per-slot fetches Phase 1 issues, paths are
+ * always full 32-byte keccak256 hashes — leaf requests. Internal-node
+ * requests would use shorter byte strings, but we don't need them.
+ */
+public final class GetTrieNodesMessage {
+
+    private GetTrieNodesMessage() {}
+
+    /**
+     * One account's path request. {@code accountPath} is required;
+     * {@code storagePaths} may be empty (account-only fetch) or carry one
+     * or more storage trie paths within that account.
+     */
+    public record PathSet(Bytes accountPath, List<Bytes> storagePaths) {
+
+        /** Convenience: build a leaf-account-only request from a 32-byte address hash. */
+        public static PathSet account(Bytes32 accountHash) {
+            return new PathSet(accountHash, List.of());
+        }
+
+        /** Convenience: build a single-storage-slot request. */
+        public static PathSet storageSlot(Bytes32 accountHash, Bytes32 slotHash) {
+            return new PathSet(accountHash, List.of(slotHash));
+        }
+    }
+
+    public record DecodeResult(long requestId, Bytes32 stateRoot, List<PathSet> paths, long responseBytes) {}
+
+    /** Encode a GetTrieNodes request. */
+    public static byte[] encode(long requestId, Bytes32 stateRoot,
+                                List<PathSet> paths, long responseBytes) {
+        return RLP.encodeList(w -> {
+            w.writeLong(requestId);
+            w.writeValue(stateRoot);
+            w.writeList(setListWriter -> {
+                for (PathSet set : paths) {
+                    setListWriter.writeList(setWriter -> {
+                        setWriter.writeValue(set.accountPath());
+                        for (Bytes p : set.storagePaths()) setWriter.writeValue(p);
+                    });
+                }
+            });
+            w.writeLong(responseBytes);
+        }).toArrayUnsafe();
+    }
+
+    public static DecodeResult decode(byte[] rlp) {
+        List<PathSet> paths = new ArrayList<>();
+        long[] reqId = {0L};
+        Bytes32[] root = {Bytes32.ZERO};
+        long[] respBytes = {0L};
+
+        RLP.decodeList(Bytes.wrap(rlp), reader -> {
+            reqId[0] = reader.readLong();
+            root[0] = Bytes32.wrap(reader.readValue());
+            reader.readList(setListReader -> {
+                while (!setListReader.isComplete()) {
+                    setListReader.readList(setReader -> {
+                        Bytes accountPath = setReader.readValue();
+                        List<Bytes> storagePaths = new ArrayList<>();
+                        while (!setReader.isComplete()) {
+                            storagePaths.add(setReader.readValue());
+                        }
+                        paths.add(new PathSet(accountPath, storagePaths));
+                        return null;
+                    });
+                }
+                return null;
+            });
+            respBytes[0] = reader.readLong();
+            return null;
+        });
+
+        return new DecodeResult(reqId[0], root[0], paths, respBytes[0]);
+    }
+}

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/snap/messages/TrieNodesMessage.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/snap/messages/TrieNodesMessage.java
@@ -1,0 +1,75 @@
+package com.jaeckel.ethp2p.networking.snap.messages;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.rlp.RLP;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * snap/1 TrieNodes response (absolute message code 0x27).
+ *
+ * <p>Wire format: {@code [reqId, [trieNode, ...]]}
+ *
+ * <p>Trie nodes are returned in the same order as the paths in the
+ * corresponding {@link GetTrieNodesMessage}. Per the spec, peers may serve
+ * a prefix and stop early once the response size cap is reached; missing
+ * entries are not zero-filled.
+ *
+ * <p>The caller verifies each returned node by hashing it (keccak256) and
+ * confirming the hash matches the trie position the request implied.
+ * Mismatches indicate a malicious or buggy peer.
+ */
+public final class TrieNodesMessage {
+
+    private TrieNodesMessage() {}
+
+    public record DecodeResult(long requestId, List<Bytes> nodes) {}
+
+    /** Extract just the request ID without fully decoding. */
+    public static long extractRequestId(byte[] rlp) {
+        return RLP.decodeList(Bytes.wrap(rlp), reader -> reader.readLong());
+    }
+
+    /** Encode an empty response (peer declined to serve). */
+    public static byte[] encodeEmpty(long requestId) {
+        return RLP.encodeList(w -> {
+            w.writeLong(requestId);
+            w.writeList(nodes -> {});
+        }).toArrayUnsafe();
+    }
+
+    /** Encode a populated response. */
+    public static byte[] encode(long requestId, List<Bytes> nodes) {
+        return RLP.encodeList(w -> {
+            w.writeLong(requestId);
+            w.writeList(listWriter -> {
+                for (Bytes n : nodes) listWriter.writeValue(n);
+            });
+        }).toArrayUnsafe();
+    }
+
+    public static DecodeResult decode(byte[] rlp) {
+        List<Bytes> nodes = new ArrayList<>();
+        long[] reqId = {0L};
+
+        RLP.decodeList(Bytes.wrap(rlp), reader -> {
+            reqId[0] = reader.readLong();
+            // The nodes field can be a list (the normal case) or an empty
+            // bytes value (some clients use 0x80 for an empty response).
+            if (!reader.isComplete() && reader.nextIsList()) {
+                reader.readList(nodeReader -> {
+                    while (!nodeReader.isComplete()) {
+                        nodes.add(nodeReader.readValue());
+                    }
+                    return null;
+                });
+            } else if (!reader.isComplete()) {
+                reader.readValue();
+            }
+            return null;
+        });
+
+        return new DecodeResult(reqId[0], nodes);
+    }
+}

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/snap/messages/TrieNodesMessage.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/snap/messages/TrieNodesMessage.java
@@ -7,7 +7,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * snap/1 TrieNodes response (absolute message code 0x27).
+ * snap/1 TrieNodes response (snap message id 0x07; absolute code 0x28
+ * under eth/68's protocol length 17).
  *
  * <p>Wire format: {@code [reqId, [trieNode, ...]]}
  *

--- a/networking/src/test/java/com/jaeckel/ethp2p/networking/snap/messages/SnapMessagesRoundTripTest.java
+++ b/networking/src/test/java/com/jaeckel/ethp2p/networking/snap/messages/SnapMessagesRoundTripTest.java
@@ -1,0 +1,158 @@
+package com.jaeckel.ethp2p.networking.snap.messages;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * RLP roundtrip tests for the four snap/1 wire types Phase 1 introduces.
+ *
+ * <p>The tests exercise encode → decode with hand-built fixtures plus a few
+ * edge cases (empty lists, single-account vs multi-storage path sets) so the
+ * decoder is verified before it has to face peer-supplied bytes.
+ */
+class SnapMessagesRoundTripTest {
+
+    private static final Bytes32 STATE_ROOT = Bytes32.fromHexString(
+            "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421");
+    private static final Bytes32 ACCOUNT_HASH = Bytes32.fromHexString(
+            "0x1111111111111111111111111111111111111111111111111111111111111111");
+    private static final Bytes32 SLOT_HASH = Bytes32.fromHexString(
+            "0x2222222222222222222222222222222222222222222222222222222222222222");
+    private static final Bytes32 CODE_HASH_A = Bytes32.fromHexString(
+            "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470");
+    private static final Bytes32 CODE_HASH_B = Bytes32.fromHexString(
+            "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef");
+
+    // ---- GetByteCodes ------------------------------------------------------
+
+    @Test
+    void getByteCodesRoundTrip() {
+        byte[] enc = GetByteCodesMessage.encode(42L, List.of(CODE_HASH_A, CODE_HASH_B), 1024L);
+        GetByteCodesMessage.DecodeResult d = GetByteCodesMessage.decode(enc);
+        assertEquals(42L, d.requestId());
+        assertEquals(2, d.hashes().size());
+        assertEquals(CODE_HASH_A, d.hashes().get(0));
+        assertEquals(CODE_HASH_B, d.hashes().get(1));
+        assertEquals(1024L, d.responseBytes());
+    }
+
+    @Test
+    void getByteCodesEmptyList() {
+        byte[] enc = GetByteCodesMessage.encode(7L, List.of(), 0L);
+        GetByteCodesMessage.DecodeResult d = GetByteCodesMessage.decode(enc);
+        assertEquals(7L, d.requestId());
+        assertTrue(d.hashes().isEmpty());
+        assertEquals(0L, d.responseBytes());
+    }
+
+    // ---- ByteCodes ---------------------------------------------------------
+
+    @Test
+    void byteCodesRoundTrip() {
+        Bytes code1 = Bytes.fromHexString("0x600160005260206000f3");
+        Bytes code2 = Bytes.fromHexString("0xfe");
+        byte[] enc = ByteCodesMessage.encode(42L, List.of(code1, code2));
+        ByteCodesMessage.DecodeResult d = ByteCodesMessage.decode(enc);
+        assertEquals(42L, d.requestId());
+        assertEquals(2, d.codes().size());
+        assertEquals(code1, d.codes().get(0));
+        assertEquals(code2, d.codes().get(1));
+    }
+
+    @Test
+    void byteCodesEmptyResponse() {
+        byte[] enc = ByteCodesMessage.encodeEmpty(99L);
+        ByteCodesMessage.DecodeResult d = ByteCodesMessage.decode(enc);
+        assertEquals(99L, d.requestId());
+        assertTrue(d.codes().isEmpty());
+    }
+
+    @Test
+    void byteCodesExtractRequestId() {
+        byte[] enc = ByteCodesMessage.encode(123L, List.of(Bytes.fromHexString("0xab")));
+        assertEquals(123L, ByteCodesMessage.extractRequestId(enc));
+    }
+
+    // ---- GetTrieNodes ------------------------------------------------------
+
+    @Test
+    void getTrieNodesAccountOnlyRoundTrip() {
+        var paths = List.of(GetTrieNodesMessage.PathSet.account(ACCOUNT_HASH));
+        byte[] enc = GetTrieNodesMessage.encode(11L, STATE_ROOT, paths, 65536L);
+        GetTrieNodesMessage.DecodeResult d = GetTrieNodesMessage.decode(enc);
+        assertEquals(11L, d.requestId());
+        assertEquals(STATE_ROOT, d.stateRoot());
+        assertEquals(1, d.paths().size());
+        assertEquals(ACCOUNT_HASH, d.paths().get(0).accountPath());
+        assertTrue(d.paths().get(0).storagePaths().isEmpty());
+        assertEquals(65536L, d.responseBytes());
+    }
+
+    @Test
+    void getTrieNodesStorageSlotRoundTrip() {
+        var paths = List.of(GetTrieNodesMessage.PathSet.storageSlot(ACCOUNT_HASH, SLOT_HASH));
+        byte[] enc = GetTrieNodesMessage.encode(12L, STATE_ROOT, paths, 65536L);
+        GetTrieNodesMessage.DecodeResult d = GetTrieNodesMessage.decode(enc);
+        assertEquals(12L, d.requestId());
+        assertEquals(1, d.paths().size());
+        var set = d.paths().get(0);
+        assertEquals(ACCOUNT_HASH, set.accountPath());
+        assertEquals(1, set.storagePaths().size());
+        assertEquals(SLOT_HASH, Bytes32.wrap(set.storagePaths().get(0)));
+    }
+
+    @Test
+    void getTrieNodesMultiSetRoundTrip() {
+        Bytes32 accountB = Bytes32.fromHexString(
+                "0x3333333333333333333333333333333333333333333333333333333333333333");
+        Bytes32 slot1 = Bytes32.fromHexString(
+                "0x4444444444444444444444444444444444444444444444444444444444444444");
+        Bytes32 slot2 = Bytes32.fromHexString(
+                "0x5555555555555555555555555555555555555555555555555555555555555555");
+        var paths = List.of(
+                GetTrieNodesMessage.PathSet.account(ACCOUNT_HASH),
+                new GetTrieNodesMessage.PathSet(accountB, List.of(slot1, slot2)));
+        byte[] enc = GetTrieNodesMessage.encode(13L, STATE_ROOT, paths, 131072L);
+        GetTrieNodesMessage.DecodeResult d = GetTrieNodesMessage.decode(enc);
+        assertEquals(2, d.paths().size());
+        assertEquals(ACCOUNT_HASH, d.paths().get(0).accountPath());
+        assertEquals(accountB, d.paths().get(1).accountPath());
+        assertEquals(2, d.paths().get(1).storagePaths().size());
+    }
+
+    // ---- TrieNodes ---------------------------------------------------------
+
+    @Test
+    void trieNodesRoundTrip() {
+        // Realistic-looking branch and leaf nodes; the codec doesn't care about
+        // structure, only that it preserves the bytes.
+        Bytes branch = Bytes.fromHexString("0xf85180a0" + "11".repeat(32) + "808080808080808080808080808080");
+        Bytes leaf = Bytes.fromHexString("0xc220ab");
+        byte[] enc = TrieNodesMessage.encode(21L, List.of(branch, leaf));
+        TrieNodesMessage.DecodeResult d = TrieNodesMessage.decode(enc);
+        assertEquals(21L, d.requestId());
+        assertEquals(2, d.nodes().size());
+        assertEquals(branch, d.nodes().get(0));
+        assertEquals(leaf, d.nodes().get(1));
+    }
+
+    @Test
+    void trieNodesEmptyResponse() {
+        byte[] enc = TrieNodesMessage.encodeEmpty(99L);
+        TrieNodesMessage.DecodeResult d = TrieNodesMessage.decode(enc);
+        assertEquals(99L, d.requestId());
+        assertTrue(d.nodes().isEmpty());
+    }
+
+    @Test
+    void trieNodesExtractRequestId() {
+        byte[] enc = TrieNodesMessage.encode(456L, List.of(Bytes.fromHexString("0xab")));
+        assertEquals(456L, TrieNodesMessage.extractRequestId(enc));
+    }
+}


### PR DESCRIPTION
## Summary

Implements Phase 1 of the SNAP-backed state oracle, replacing the fixture oracle with a real implementation that fetches Ethereum state on-demand from devp2p snap/1 peers and verifies every response against the trusted state root. This closes the loop on the original Phase 1 acceptance criteria: running `callView` against mainnet for USDC/DAI balance queries and ENS resolver lookups.

## Key Changes

### Core: Merkle-Patricia-Trie Proof Verifier
- **`MerklePatriciaProofVerifier.java`** — Hand-rolled MPT proof verifier (~207 lines) that validates inclusion/exclusion proofs against a trusted root. Supports branch, extension, and leaf nodes with both 32-byte hashed and embedded children. Returns `Found(value)`, `Absent`, or `Invalid(reason)` results.
- **`HexPrefix.java`** — Compact path encoding/decoding for MPT leaf and extension nodes (4-flag header + nibble packing per Yellow Paper Appendix C).
- **`RlpItems.java`** — RLP list splitter that exposes child items as raw RLP bytes, enabling recursive interpretation of in-line trie nodes without re-encoding.
- **Comprehensive test coverage** — `MerklePatriciaProofVerifierTest` and `HexPrefixTest` with hand-built tries (programmatic RLP + keccak256) covering single-leaf inclusion, exclusion via different keys, empty tries, extension+branch+two-leaf structures, and tampered-node detection.

### Networking: SNAP Protocol Extensions
- **Four new snap/1 message types** for per-account/per-slot fetches:
  - `GetByteCodesMessage` / `ByteCodesMessage` (codes 0x25/0x26) — Request/response bytecode by hash
  - `GetTrieNodesMessage` / `TrieNodesMessage` (codes 0x27/0x28) — Request/response trie nodes by path
- **`EthHandler` integration** — Added request/response plumbing with 10-second timeouts, pending request maps, and inbound dispatch routing for the four new message codes (auto-adjusted for eth/67-69 protocol versions).
- **RLP roundtrip tests** — `SnapMessagesRoundTripTest` validates encode/decode for all four message types with edge cases (empty lists, single vs. multi-path sets).

### EVM: State Oracle Implementation
- **`SnapBackedStateOracle.java`** — Real oracle implementation that:
  - Issues SNAP requests via a pluggable `SnapPeer` supplier (enabling multi-peer fallback)
  - Verifies proofs against `stateRoot` using `MerklePatriciaProofVerifier`
  - Retries up to 3 times (configurable) on verification failure, requesting different peers
  - Caches bytecode via supplied `BytecodeCache`; state is cached per-call in `SyncStateView`
  - Returns `EvmExecutionError.InvalidProof` or `StateUnavailable` on exhausted retries
- **`SnapPeer` interface** — Abstraction over snap/1 peer connections (decouples `:myotis-evm` from `:networking`); tests use in-memory fixture, wallet integration plugs `EthHandler`-backed implementation.
- **Comprehensive unit tests** — `SnapBackedStateOracleTest` with 332 lines covering:
  - Account fetches with decoded nonce/balance/codeHash fields
  - Absent account handling (returns empty default)
  - Storage slot fetches with empty-storage optimization
  - Bytecode fetches with caching
  - Retry logic on invalid proofs (3 attempts via supplier)
  - Hand-built proofs using `TrieFixture` helper

### Integration Tests
- **`MainnetCallViewIT.java`** — Phase 1 acceptance test (env-gated by `MYOTIS_MAINNET=1`) that:
  - Executes `callView` against mainnet for USDC `

https://claude.ai/code/session_01GhcPYmMi6z3YGrZSe5wuA3