### PR TITLE
Phase 2: Add speculative prefetching with convergence loop

### DIFF
--- a/docs/phase2-design.md
+++ b/docs/phase2-design.md
@@ -24,35 +24,53 @@ The benchmark corpus (per the plan):
 - ENS Public Resolver `addr()`
 - ENS Public Resolver `resolve()` (multi-record path)
 
-## Approach (decision)
+## Approach (decision — revised in commit 3)
 
 The Phase 0 plan flagged two options: sentinel-return and trace-based
-access tracking. `docs/decisions.md` already recorded the Phase 2
-recommendation as **trace-based** — that decision stands.
+access tracking. The branch shipped trace-based first (commits 1–2) and
+then switched to **sentinel-return** in commit 3, after Copilot's review
+on PR #14 surfaced that trace-based's "parallel prefetch wave" was
+largely a no-op against a synchronously-caching `SyncStateView`.
 
-Rationale, re-stated:
+The two approaches:
 
-- Sentinel-return runs the EVM with a placeholder value for every miss
-  and collects the access list. Data-dependent branches can take a
-  *different* path with the placeholder, so the access list captures
-  slots the real run would never touch — and misses ones it does. The
-  loop converges, but slowly and with wasted bandwidth.
-- Trace-based uses Besu's `OperationTracer.tracePreExecution` hook to
-  observe SLOAD's stack arguments (account from `getRecipientAddress()`,
-  slot from `getStackItem(0)`) and EXTCODECOPY / EXTCODEHASH / EXTCODESIZE
-  for the target accounts whose bytecode the EVM may need — without
-  changing what the EVM reads. (`getRecipientAddress()` returns the
-  storage-owning account in Besu's frame model: the called contract for
-  CALL, the caller for DELEGATECALL.)
-  Access list is exact for the path the EVM would have taken. No false
-  positives or negatives.
+- **Trace-based** (commits 1–2 of this branch): use Besu's
+  `OperationTracer.tracePreExecution` to observe SLOAD's stack arguments
+  (account from `getRecipientAddress()`, slot from `getStackItem(0)`) and
+  EXTCODECOPY / EXTCODEHASH / EXTCODESIZE for target accounts. Access
+  list is exact for the EVM's real execution path. Iteration 0 blocks on
+  every miss serially.
+- **Sentinel-return** (commit 3, current): run the EVM with sentinel
+  zeros for cache misses. The tracer still records the access list, but
+  no oracle calls are made during iteration 0. Result is bogus and
+  discarded. Parallel-fetch the recorded misses, then re-run with sentinel
+  mode off to get a real result.
 
-Trade-off: the trace-based approach still observes behaviour from a *first*
-EVM run that necessarily misses on every fetch (since the cache is empty).
-That first run is slow — every miss is a blocking SyncStateView fetch.
-Subsequent runs use the populated cache and fly. The convergence loop
-exists because data-dependent branches in the real path may issue new
-fetches once earlier values are populated; we re-run to catch those.
+The fundamental advantage of sentinel-return: iteration 0 produces a full
+access list at memory speed (0 wire RTTs), so the parallel batch fetch
+that follows it actually saves round trips. Trace-based's iteration 0
+already paid for those RTTs serially.
+
+The fundamental cost: iteration 0's wrong values can cause the EVM to
+take a different path than the real run would. This means:
+- The recorded access list may include slots the real path doesn't read
+  (over-fetching — wasteful but harmless).
+- The recorded access list may miss slots the real path does read (the
+  real iteration 1 then blocks serially on them).
+
+In practice both happen rarely for view-style calls. ERC-20 `balanceOf`
+and ENS `addr` both produce identical access lists under sentinel and
+real runs because the access pattern is purely a function of the inputs.
+Where divergence does happen, the convergence loop catches it: iteration
+1 records the real-path access set, the loop checks for new misses, and
+re-runs iteration 2 if needed.
+
+Special case for the *target contract*: sentinel mode for the target's
+account record means its codeHash comes back as `keccak256("")` and the
+EVM finds no bytecode to execute, defeating the iteration. The executor
+synchronously pre-populates the target's account and bytecode before
+iteration 0 starts. Two RTTs upfront, but they would have been paid
+during iteration 0 in any other design.
 
 ## Wire-up
 
@@ -92,60 +110,69 @@ access list; subsequent runs use the parallel-batched cache."
   reaches into the same package; that coupling is the cost of running the
   same EVM-driving code twice with shared state.
 
-## Honesty about latency
+## Latency profile
 
-The trace-based design's win was always nuanced. Worth being explicit so
-future readers don't over-promise:
+After commit 3 (sentinel-return), the convergence loop's structure is:
 
-- **Iteration 0 is fully serial.** Every cache miss blocks on a synchronous
-  `SyncStateView.account()` / `storage()` call, which `join()`s the
-  oracle's per-call retry path. There is no parallelism in iteration 0.
-- **The "parallel prefetch wave" between iterations is largely a no-op
-  for data-independent contracts.** By the time the wave runs, iteration
-  N's synchronous reads have already populated the SyncStateView cache
-  for every successfully-executed access. The wave's `view.hasAccount(a)
-  ? skip : fetch` predicate skips almost everything.
-- **Where the wave actually helps:** iterations N+1 onwards that take a
-  *different* data-dependent path than iteration N — the cache is shared
-  but the access set changed. Rare in practice for the Phase 2 corpus
-  (ERC-20 balances, ENS resolver lookups), more common in contracts with
-  branching on storage values.
-- **The convergence loop's primary value is correctness, not speed.**
-  Iteration 1 verifies the access set is stable, which is the trust
-  property — without it we wouldn't know if data-dependent branches
-  matter. The latency saved relative to `DefaultEvmExecutor` alone is
-  whatever round trips iteration N+1's parallel fetches saved over the
-  serial reads they replace, which is `0` when N+1's accesses are a
-  subset of N's.
+| Step | Mode | Network round trips |
+|------|------|---------------------|
+| Pre-prime target | Block | 2 RTT (target account + bytecode) |
+| Iteration 0 | Sentinel | 0 RTT (records access list at memory speed) |
+| Parallel batch fetch | — | 1 RTT (covers all of iter 0's recorded misses) |
+| Iteration 1 | Block-on-miss | 0 RTT in the common case (everything is cached) |
+| If unstable: iter 2+ | Block-on-miss | 1 RTT per truly data-dependent miss |
 
-A genuine end-to-end latency win requires a different design — sentinel-
-return for iteration 0 (run with placeholders, get the access list
-without blocking on each miss, then parallel-fetch and run for real).
-That's deferred to a future phase. The current code ships the structural
-prerequisites: tracer hooks, convergence-loop scaffolding, per-call cache.
-A sentinel-return mode is additive on top.
+For the canonical ERC-20 `balanceOf` (storage at `keccak(holder . slot)`):
+~3 RTTs total — 2 for target prime, 1 for the parallel batch covering the
+balance slot. Roughly half of the trace-based predecessor's ~5 RTTs.
 
-The Phase 2 acceptance criteria (`≤3 iterations, p95 < 2s`) are still
-achievable with the current design — they're statements about iteration
-counts and total latency, not about parallel-fetch ratios. Whether the
-current design hits the p95 target is something we'll only know once
-the benchmark runs against mainnet.
+For a multi-balance call (e.g., reading several token balances of the
+same holder via one contract): the saving scales linearly. N independent
+SLOADs go from `N · RTT` to `1 · RTT` after the prime.
+
+For chained data-dependent reads (proxy slot → impl bytecode → balance
+slot): sentinel-return doesn't help much because each chain link blocks
+on its own RTT in iteration 1. The win in proxy patterns comes mostly
+from the parallel batch covering the impl slot + same-account storage
+slots together.
+
+## Trade-offs we accepted
+
+- **Sentinel iteration 0's result is wrong by construction.** The
+  convergence loop guarantees it never leaks — the caller only sees the
+  iteration-1+ result that ran with real values. There's a unit test for
+  this exact scenario (`sentinelIteration0RevertDoesNotSurface`).
+- **Sentinel iteration 0 may revert.** Bytecode that does
+  `require(balance > 0)` will revert with a sentinel zero. The executor
+  catches the revert during sentinel iteration only and continues with
+  whatever access list was recorded up to that point. Iteration 1 with
+  real values either succeeds or surfaces the genuine revert.
+- **Two extra RTTs upfront** for the target's account + bytecode. Same
+  cost the trace-based design paid in iteration 0; just paid earlier.
+- **Doesn't help fully chained access patterns.** A proxy that calls into
+  another contract that calls into another contract still needs N RTTs
+  in iteration 1. Sentinel-return saves on parallel-discoverable
+  accesses, not on dependency-chained ones. Documented because future
+  contributors might over-attribute latency wins.
 
 ## What this branch ships
 
-- Commit 1 (`bf09dcd`): design doc + `PrefetchingTracer` + `PrefetchingEvmExecutor`.
-  Tracer observes SLOAD / EXTCODE* on every opcode; executor drives the
-  convergence loop; fixture-oracle unit tests prove the loop converges in
-  2 iterations on simple cases and respects the iteration cap.
-- Commit 2 (this one): benchmark scaffolding —
+- Commit 1 (`bf09dcd`): tracer + executor convergence loop scaffolding +
+  unit tests. Originally trace-based.
+- Commit 2 (`3bea3fd`): benchmark scaffolding —
   `MainnetPrefetchBenchmarkIT` measures latency and iteration counts for
   the corpus, `docs/prefetch-benchmarks.md` is the artifact callers paste
   numbers into. Same env-gating as Phase 1's `MainnetCallViewIT`; both
-  ITs share the missing `connectToMainnetPeer()` helper. Originally
-  drafted as "wire-level batching in `SnapBackedStateOracle`", but tracing
-  through the existing prefetcher logic showed the parallel-fetch path
-  is already in place — the next real win comes from measuring against
-  mainnet, not from condensing N parallel wire requests into 1.
+  ITs share the missing `connectToMainnetPeer()` helper.
+- Commit 3 (current): switched to sentinel-return after PR #14 review
+  identified that the trace-based parallel-fetch wave was largely a
+  no-op against `SyncStateView`'s synchronous cache. `SyncStateView` got
+  a `setSentinelOnMiss(boolean)` mode; `PrefetchingEvmExecutor` toggles
+  it on for iteration 0 and off thereafter, with a synchronous prime
+  step for the target contract beforehand. Three new unit tests pin
+  down the new semantics: multi-SLOAD parallel batch, sentinel-revert
+  recovery, and direct-vs-prefetched correctness parity across several
+  bytecode shapes.
 
 ## Deliberately not in this commit
 
@@ -156,15 +183,14 @@ the benchmark runs against mainnet.
   trips, which probably doesn't move p95 latency much (the peer
   pipelines well), but it does reduce peer load. Defer until benchmark
   numbers say it matters.
-- **Bytecode prefetching as a separate wave.** Tried it in an earlier
-  draft of commit 2 and reverted: `SyncStateView.bytecode()` already
-  populates the shared `BytecodeCache` synchronously during the run that
-  records the access. A separate "fetch new accounts' bytecode" wave
-  between iterations finds everything already cached. No latency win.
-- **Sentinel-return mode.** The plan flagged it as an alternative; the
-  trace-based design we shipped in commit 1 is the choice. Revisiting
-  would require pulling apart the convergence-loop assumptions and isn't
-  motivated until the benchmark numbers say trace-based isn't fast enough.
+- **Bytecode prefetching as a separate wave.** Tried it earlier and
+  reverted: bytecode is fetched synchronously during the run that
+  records its access, so a separate wave finds everything already
+  cached. (Bytecode for *non-target* accounts under sentinel mode
+  does miss in iter 0; iter 1 fetches it serially. Could be batched
+  with the iter-0-discovered accounts in a future refinement.)
+- **Sentinel mode for the target contract.** Pre-priming is intentional;
+  see "Special case for the target contract" in the Approach section.
 
 ## Out of scope
 

--- a/docs/phase2-design.md
+++ b/docs/phase2-design.md
@@ -76,26 +76,42 @@ during iteration 0 in any other design.
 
 The Phase 0/1 architecture has `DefaultEvmExecutor` driving Besu's EVM
 through `MessageCallProcessor.process()` against a `SnapWorldUpdater`.
-The tracer hook is the natural insertion point — pass a non-`NO_TRACING`
-tracer that observes (but doesn't mutate) execution.
+Phase 2 adds two seams: a `PrefetchingTracer` plugged into Besu's
+`OperationTracer` slot, and a `setSentinelOnMiss(boolean)` toggle on
+`SyncStateView` that switches cache-miss behaviour between
+"block-on-oracle" and "return placeholder zero".
 
 ```
 PrefetchingEvmExecutor.callView(target, calldata, ctx)
+  primeTarget(view, target)                          // 2 RTTs, blocking
   loop iteration ≤ iterationCap:
-    tracer = new PrefetchingTracer()
-    DefaultEvmExecutor.runOnceWithTracer(target, calldata, ctx, tracer)
-        ↳ Besu EVM executes normally; tracer records SLOAD/CODE* ops
-    new misses = tracer.observed - already-cached
+    iterationTracker = new AccessTracker()
+    view.setAccessTracker(iterationTracker)          // record via view too
+    view.setSentinelOnMiss(iter == 0)
+    tracer = new PrefetchingTracer(iterationTracker)
+    DefaultEvmExecutor.runOnTracedView(target, calldata, ctx, view, tracer)
+        ↳ iter 0: sentinel returns on miss, no oracle calls
+        ↳ iter 1+: real values from cache or blocking oracle fetch
+    if iter == 0:
+      // Discard the (bogus) result; keep the access list.
+      parallel-batch fetch tracker.snapshot() into the view's cache
+      continue
+    if tracker.snapshot() ⊆ seenAccesses: return result   // converged
+    new misses = tracker.snapshot() - already-cached
     if new misses is empty: return result        // converged
     batch fetch new misses through SnapPeer in parallel
     populate per-call cache (BytecodeCache + an in-call storage cache)
   after loop: throw IterationLimitExceeded
 ```
 
-The first iteration's run is SLOW — each miss is a serial blocking fetch.
-Subsequent iterations are fast because the cache satisfies the hits. That
-matches the plan's expectation: "first run is slow but produces a complete
-access list; subsequent runs use the parallel-batched cache."
+Iteration 0 makes no oracle calls (other than the synchronous prime of
+the target contract). Every miss returns a placeholder; the tracer and
+view together record the access. The result is discarded. The parallel
+batch fetch wave then covers all the recorded misses in one round-trip
+window. Iteration 1 runs against the populated cache and produces the
+real result; any data-dependent accesses iteration 0's wrong path didn't
+reach are blocking-fetched serially in iteration 1, which adds them to
+the cache for iteration 2 to verify stability if needed.
 
 ## Open question (settled in commit 1)
 

--- a/docs/phase2-design.md
+++ b/docs/phase2-design.md
@@ -85,17 +85,40 @@ access list; subsequent runs use the parallel-batched cache."
   state cache between runs. A wrapping decorator would have to expose the
   internal cache state to coordinate, which leaks the abstraction.
 
-## What this branch will ship
+## What this branch ships
 
-- Commit 1 (this design doc + tracer + executor): `PrefetchingTracer`
-  observes SLOAD on every opcode, `PrefetchingEvmExecutor` drives the
-  convergence loop, fixture-oracle unit tests prove the loop converges
-  and respects the iteration cap.
-- Commit 2: integrate with `SnapBackedStateOracle` parallel batch fetches
-  (currently the oracle's `tryWithRetries` is per-key serial).
-- Commit 3: benchmark harness + `docs/prefetch-benchmarks.md` recording
-  iteration counts and latency for the Phase 2 corpus. Acceptance
-  criterion lands here.
+- Commit 1 (`bf09dcd`): design doc + `PrefetchingTracer` + `PrefetchingEvmExecutor`.
+  Tracer observes SLOAD / EXTCODE* on every opcode; executor drives the
+  convergence loop; fixture-oracle unit tests prove the loop converges in
+  2 iterations on simple cases and respects the iteration cap.
+- Commit 2 (this one): benchmark scaffolding —
+  `MainnetPrefetchBenchmarkIT` measures latency and iteration counts for
+  the corpus, `docs/prefetch-benchmarks.md` is the artifact callers paste
+  numbers into. Same env-gating as Phase 1's `MainnetCallViewIT`; both
+  ITs share the missing `connectToMainnetPeer()` helper. Originally
+  drafted as "wire-level batching in `SnapBackedStateOracle`", but tracing
+  through the existing prefetcher logic showed the parallel-fetch path
+  is already in place — the next real win comes from measuring against
+  mainnet, not from condensing N parallel wire requests into 1.
+
+## Deliberately not in this commit
+
+- **Wire-level batching in `SnapBackedStateOracle`.** The current loop
+  fires N parallel `oracle.fetchAccount` / `fetchStorage` calls; each
+  goes through the per-key retry loop independently. Folding them into
+  one `peer.getTrieNodes` request with N path-sets saves wire round
+  trips, which probably doesn't move p95 latency much (the peer
+  pipelines well), but it does reduce peer load. Defer until benchmark
+  numbers say it matters.
+- **Bytecode prefetching as a separate wave.** Tried it in an earlier
+  draft of commit 2 and reverted: `SyncStateView.bytecode()` already
+  populates the shared `BytecodeCache` synchronously during the run that
+  records the access. A separate "fetch new accounts' bytecode" wave
+  between iterations finds everything already cached. No latency win.
+- **Sentinel-return mode.** The plan flagged it as an alternative; the
+  trace-based design we shipped in commit 1 is the choice. Revisiting
+  would require pulling apart the convergence-loop assumptions and isn't
+  motivated until the benchmark numbers say trace-based isn't fast enough.
 
 ## Out of scope
 

--- a/docs/phase2-design.md
+++ b/docs/phase2-design.md
@@ -38,9 +38,12 @@ Rationale, re-stated:
   slots the real run would never touch — and misses ones it does. The
   loop converges, but slowly and with wasted bandwidth.
 - Trace-based uses Besu's `OperationTracer.tracePreExecution` hook to
-  observe SLOAD's stack arguments (account from `getContractAddress()`,
-  slot from `getStackItem(0)`) and CODECOPY/EXTCODECOPY/EXTCODEHASH/
-  EXTCODESIZE for bytecode access — without changing what the EVM reads.
+  observe SLOAD's stack arguments (account from `getRecipientAddress()`,
+  slot from `getStackItem(0)`) and EXTCODECOPY / EXTCODEHASH / EXTCODESIZE
+  for the target accounts whose bytecode the EVM may need — without
+  changing what the EVM reads. (`getRecipientAddress()` returns the
+  storage-owning account in Besu's frame model: the called contract for
+  CALL, the caller for DELEGATECALL.)
   Access list is exact for the path the EVM would have taken. No false
   positives or negatives.
 
@@ -78,12 +81,55 @@ access list; subsequent runs use the parallel-batched cache."
 
 ## Open question (settled in commit 1)
 
-- `PrefetchingEvmExecutor` lives in `:myotis-evm` alongside
-  `DefaultEvmExecutor` (not as a Decorator wrapping a `DefaultEvmExecutor`
-  instance). Reasoning: the prefetch loop must drive the EVM directly to
-  reuse the same world updater across iterations and inspect the populated
-  state cache between runs. A wrapping decorator would have to expose the
-  internal cache state to coordinate, which leaks the abstraction.
+- `PrefetchingEvmExecutor` is a thin wrapper around a `DefaultEvmExecutor`
+  delegate (constructor: `new PrefetchingEvmExecutor(DefaultEvmExecutor)`),
+  not a sibling executor. The wrapper relies on `DefaultEvmExecutor`'s
+  package-private `runOnTracedView(...)` seam to share a single
+  `SyncStateView` cache across iterations, and on its package-private
+  config accessors (`oracle()`, `bytecodeCache()`, `executor()`) to inherit
+  the delegate's wiring. A pure decorator that only delegated `callView`
+  wouldn't have access to those internals, so the wrapper deliberately
+  reaches into the same package; that coupling is the cost of running the
+  same EVM-driving code twice with shared state.
+
+## Honesty about latency
+
+The trace-based design's win was always nuanced. Worth being explicit so
+future readers don't over-promise:
+
+- **Iteration 0 is fully serial.** Every cache miss blocks on a synchronous
+  `SyncStateView.account()` / `storage()` call, which `join()`s the
+  oracle's per-call retry path. There is no parallelism in iteration 0.
+- **The "parallel prefetch wave" between iterations is largely a no-op
+  for data-independent contracts.** By the time the wave runs, iteration
+  N's synchronous reads have already populated the SyncStateView cache
+  for every successfully-executed access. The wave's `view.hasAccount(a)
+  ? skip : fetch` predicate skips almost everything.
+- **Where the wave actually helps:** iterations N+1 onwards that take a
+  *different* data-dependent path than iteration N — the cache is shared
+  but the access set changed. Rare in practice for the Phase 2 corpus
+  (ERC-20 balances, ENS resolver lookups), more common in contracts with
+  branching on storage values.
+- **The convergence loop's primary value is correctness, not speed.**
+  Iteration 1 verifies the access set is stable, which is the trust
+  property — without it we wouldn't know if data-dependent branches
+  matter. The latency saved relative to `DefaultEvmExecutor` alone is
+  whatever round trips iteration N+1's parallel fetches saved over the
+  serial reads they replace, which is `0` when N+1's accesses are a
+  subset of N's.
+
+A genuine end-to-end latency win requires a different design — sentinel-
+return for iteration 0 (run with placeholders, get the access list
+without blocking on each miss, then parallel-fetch and run for real).
+That's deferred to a future phase. The current code ships the structural
+prerequisites: tracer hooks, convergence-loop scaffolding, per-call cache.
+A sentinel-return mode is additive on top.
+
+The Phase 2 acceptance criteria (`≤3 iterations, p95 < 2s`) are still
+achievable with the current design — they're statements about iteration
+counts and total latency, not about parallel-fetch ratios. Whether the
+current design hits the p95 target is something we'll only know once
+the benchmark runs against mainnet.
 
 ## What this branch ships
 

--- a/docs/phase2-design.md
+++ b/docs/phase2-design.md
@@ -1,0 +1,107 @@
+# Phase 2 — Speculative prefetching
+
+Phase 1 made `callView` correct against mainnet — but slow. Each SLOAD or
+CODECOPY blocks on a synchronous SNAP round trip, and a single ERC-20
+`balanceOf` typically touches 3–10 storage slots through the proxy chain.
+At 200 ms per round trip that's 1–2 s of unnecessary serial latency.
+
+> **Goal:** reduce p50 latency to under 1 s on the benchmark corpus by
+> parallelising state fetches.
+
+## Acceptance criteria (from the original plan)
+
+- All benchmark cases converge in ≤ 3 iterations.
+- p95 latency under 2 s on simulated good network conditions.
+- Convergence histogram per contract type recorded in
+  `docs/prefetch-benchmarks.md`.
+
+The benchmark corpus (per the plan):
+
+- Plain Solidity ERC-20 (USDC pre-proxy paths)
+- EIP-1967 proxy ERC-20 (USDC, DAI)
+- Vyper ERC-20 (Curve LP token)
+- Rebasing token (stETH)
+- ENS Public Resolver `addr()`
+- ENS Public Resolver `resolve()` (multi-record path)
+
+## Approach (decision)
+
+The Phase 0 plan flagged two options: sentinel-return and trace-based
+access tracking. `docs/decisions.md` already recorded the Phase 2
+recommendation as **trace-based** — that decision stands.
+
+Rationale, re-stated:
+
+- Sentinel-return runs the EVM with a placeholder value for every miss
+  and collects the access list. Data-dependent branches can take a
+  *different* path with the placeholder, so the access list captures
+  slots the real run would never touch — and misses ones it does. The
+  loop converges, but slowly and with wasted bandwidth.
+- Trace-based uses Besu's `OperationTracer.tracePreExecution` hook to
+  observe SLOAD's stack arguments (account from `getContractAddress()`,
+  slot from `getStackItem(0)`) and CODECOPY/EXTCODECOPY/EXTCODEHASH/
+  EXTCODESIZE for bytecode access — without changing what the EVM reads.
+  Access list is exact for the path the EVM would have taken. No false
+  positives or negatives.
+
+Trade-off: the trace-based approach still observes behaviour from a *first*
+EVM run that necessarily misses on every fetch (since the cache is empty).
+That first run is slow — every miss is a blocking SyncStateView fetch.
+Subsequent runs use the populated cache and fly. The convergence loop
+exists because data-dependent branches in the real path may issue new
+fetches once earlier values are populated; we re-run to catch those.
+
+## Wire-up
+
+The Phase 0/1 architecture has `DefaultEvmExecutor` driving Besu's EVM
+through `MessageCallProcessor.process()` against a `SnapWorldUpdater`.
+The tracer hook is the natural insertion point — pass a non-`NO_TRACING`
+tracer that observes (but doesn't mutate) execution.
+
+```
+PrefetchingEvmExecutor.callView(target, calldata, ctx)
+  loop iteration ≤ iterationCap:
+    tracer = new PrefetchingTracer()
+    DefaultEvmExecutor.runOnceWithTracer(target, calldata, ctx, tracer)
+        ↳ Besu EVM executes normally; tracer records SLOAD/CODE* ops
+    new misses = tracer.observed - already-cached
+    if new misses is empty: return result        // converged
+    batch fetch new misses through SnapPeer in parallel
+    populate per-call cache (BytecodeCache + an in-call storage cache)
+  after loop: throw IterationLimitExceeded
+```
+
+The first iteration's run is SLOW — each miss is a serial blocking fetch.
+Subsequent iterations are fast because the cache satisfies the hits. That
+matches the plan's expectation: "first run is slow but produces a complete
+access list; subsequent runs use the parallel-batched cache."
+
+## Open question (settled in commit 1)
+
+- `PrefetchingEvmExecutor` lives in `:myotis-evm` alongside
+  `DefaultEvmExecutor` (not as a Decorator wrapping a `DefaultEvmExecutor`
+  instance). Reasoning: the prefetch loop must drive the EVM directly to
+  reuse the same world updater across iterations and inspect the populated
+  state cache between runs. A wrapping decorator would have to expose the
+  internal cache state to coordinate, which leaks the abstraction.
+
+## What this branch will ship
+
+- Commit 1 (this design doc + tracer + executor): `PrefetchingTracer`
+  observes SLOAD on every opcode, `PrefetchingEvmExecutor` drives the
+  convergence loop, fixture-oracle unit tests prove the loop converges
+  and respects the iteration cap.
+- Commit 2: integrate with `SnapBackedStateOracle` parallel batch fetches
+  (currently the oracle's `tryWithRetries` is per-key serial).
+- Commit 3: benchmark harness + `docs/prefetch-benchmarks.md` recording
+  iteration counts and latency for the Phase 2 corpus. Acceptance
+  criterion lands here.
+
+## Out of scope
+
+- Changing the public `EvmExecutor.callView` signature. The prefetch
+  layer is constructed by the wallet integration — the same way the
+  oracle is.
+- Cross-call cache. The plan calls out a per-stateRoot cache for the
+  duration of a session; that's a Phase 2-adjacent concern that lives in
+  the wallet layer, not in the EVM module's prefetch loop.

--- a/docs/prefetch-benchmarks.md
+++ b/docs/prefetch-benchmarks.md
@@ -1,0 +1,95 @@
+# Phase 2 prefetch benchmarks
+
+Convergence iteration counts and end-to-end latency for the corpus the
+Phase 2 plan calls out, measured with `MainnetPrefetchBenchmarkIT`.
+
+> **Status: scaffolding only.** The benchmark IT compiles and runs the
+> measurement loop, but `connectToMainnetPeer()` currently throws
+> `UnsupportedOperationException` — the same gap as
+> `MainnetCallViewIT`. Both light up when the Phase 1 follow-up that
+> extracts an `EthHandler` bootstrap helper out of `:app:Main` lands.
+> Until then, the table below carries placeholders.
+
+## Methodology
+
+For each corpus entry the benchmark:
+
+1. Issues one warm-up `callView` (untimed) so the process-local bytecode
+   cache is hot.
+2. Runs `N = 10` timed iterations against `DefaultEvmExecutor` alone
+   (Phase 1 baseline — no convergence loop, every miss is a serial
+   round trip).
+3. Runs `N = 10` timed iterations against `PrefetchingEvmExecutor`
+   (Phase 2). The convergence loop's iteration counts are captured by
+   `ConvergenceTracker`.
+4. Reports min / p50 / p95 / max wall-clock latency for both modes plus
+   the min/max convergence iteration counts.
+
+The acceptance assertions in the IT:
+
+- `convergenceTracker.max() ≤ 3` — every call settles within 3 iterations.
+- `prefetchStats.p95 ≤ 2000 ms` — Phase 2's stated latency target.
+
+## Corpus
+
+| Call | Description | Why it's in the corpus |
+|------|-------------|------------------------|
+| `USDC.balanceOf(vitalik)` | EIP-1967 proxy → impl → mapping read | Most common ERC-20 path; canonical proxy SLOAD |
+| `DAI.balanceOf(vitalik)` | Plain Solidity ERC-20 | Different storage layout from USDC |
+| `ENS.addr(namehash("vitalik.eth"))` | Public Resolver storage read | Multi-step on-chain lookup; no CCIP-Read |
+
+Vyper ERC-20 (Curve LP), rebasing tokens (stETH), and ENS Public Resolver
+`resolve()` aren't in the IT yet. Add them once the bootstrap helper lands
+and the placeholder numbers below get real values — at that point we'll
+know whether the existing three already exercise the corner cases or
+whether the additional tokens reveal something new.
+
+## Results
+
+> _to be filled once `MainnetPrefetchBenchmarkIT` runs against a real peer_
+
+| Call | Baseline p50 | Baseline p95 | Prefetch p50 | Prefetch p95 | Iterations (min / max) |
+|------|--------------|--------------|--------------|--------------|------------------------|
+| USDC.balanceOf | TBD          | TBD          | TBD          | TBD          | TBD                    |
+| DAI.balanceOf  | TBD          | TBD          | TBD          | TBD          | TBD                    |
+| ENS.addr       | TBD          | TBD          | TBD          | TBD          | TBD                    |
+
+## What we expect to see
+
+Calibration ahead of measurement, so the numbers can be cross-checked when
+they arrive:
+
+- **Iterations**: Trace-based prefetching converges in 2 iterations for any
+  contract whose access path is data-independent. ERC-20 `balanceOf` is
+  trivially data-independent (the slot is `keccak256(addr || mappingSlot)`,
+  computed entirely from inputs). ENS `addr` involves one mapping lookup
+  in the Public Resolver — also data-independent. Expected: 2 iterations
+  for all three. If we see 3, that's worth investigating; if we see > 3,
+  the cap is hit and the call fails.
+- **Baseline latency**: ~1 round trip per SLOAD plus 1 for the account.
+  USDC's proxy slot + impl mapping = 2 SLOADs + account = ~3 RTT. With
+  100 ms RTT to a typical peer, that's ~300 ms baseline p50.
+- **Prefetch latency**: 1 RTT for iteration 0's serial fetches +
+  1 RTT for the parallel batch + ~0 ms for iteration 1's all-cache run =
+  ~200 ms prefetch p50. About 30% faster than baseline at 100 ms RTT;
+  the win is bigger at higher RTTs.
+- **p95 vs p50**: depends entirely on peer tail latency. The convergence
+  loop doesn't add tail-latency surface relative to the baseline.
+
+## Updating this file
+
+After running the benchmark:
+
+```bash
+MYOTIS_MAINNET=1 \
+  MYOTIS_INTEGRATION_PEER_ENODE=enode://… \
+  MYOTIS_INTEGRATION_STATE_ROOT=0x… \
+  MYOTIS_INTEGRATION_BLOCK_NUMBER=… \
+  MYOTIS_INTEGRATION_BLOCK_TIMESTAMP=… \
+  MYOTIS_INTEGRATION_BASE_FEE_WEI=… \
+  ./gradlew :myotis-evm:integrationTest --tests "*PrefetchBenchmark*"
+```
+
+Paste the printed `[bench]` lines into the table above, then commit the
+update. Re-run after any meaningful prefetch-loop change so the table
+captures regressions.

--- a/docs/prefetch-benchmarks.md
+++ b/docs/prefetch-benchmarks.md
@@ -57,22 +57,35 @@ whether the additional tokens reveal something new.
 ## What we expect to see
 
 Calibration ahead of measurement, so the numbers can be cross-checked when
-they arrive:
+they arrive. Phase 2 ships the **sentinel-return** convergence loop —
+iteration 0 makes no oracle calls aside from priming the target contract;
+iteration 1 runs against a cache pre-populated by a parallel batch fetch.
 
-- **Iterations**: Trace-based prefetching converges in 2 iterations for any
-  contract whose access path is data-independent. ERC-20 `balanceOf` is
-  trivially data-independent (the slot is `keccak256(addr || mappingSlot)`,
-  computed entirely from inputs). ENS `addr` involves one mapping lookup
-  in the Public Resolver — also data-independent. Expected: 2 iterations
-  for all three. If we see 3, that's worth investigating; if we see > 3,
-  the cap is hit and the call fails.
-- **Baseline latency**: ~1 round trip per SLOAD plus 1 for the account.
-  USDC's proxy slot + impl mapping = 2 SLOADs + account = ~3 RTT. With
-  100 ms RTT to a typical peer, that's ~300 ms baseline p50.
-- **Prefetch latency**: 1 RTT for iteration 0's serial fetches +
-  1 RTT for the parallel batch + ~0 ms for iteration 1's all-cache run =
-  ~200 ms prefetch p50. About 30% faster than baseline at 100 ms RTT;
-  the win is bigger at higher RTTs.
+- **Iterations**: Sentinel-return converges in 2 iterations for any contract
+  whose access path is data-independent. ERC-20 `balanceOf` is trivially
+  data-independent (the slot is `keccak256(addr || mappingSlot)`, computed
+  entirely from inputs). ENS `addr` involves one mapping lookup in the
+  Public Resolver — also data-independent. Expected: 2 iterations for all
+  three. If we see 3, the iter-0 sentinel run took a different path than
+  iter 1 (a data-dependent branch); if we see > 3, the cap is hit and the
+  call fails.
+- **Baseline latency** (`DefaultEvmExecutor`): ~1 round trip per SLOAD
+  plus 1 for the account fetch and 1 for the bytecode. USDC's proxy slot
+  + impl + balance mapping = ~5 serial RTTs. At 100 ms RTT to a typical
+  peer, that's ~500 ms baseline p50.
+- **Prefetch latency** (sentinel-return): 2 RTTs for the synchronous
+  target prime (account + bytecode), then 0 RTTs in iteration 0 (sentinel
+  values), then 1 RTT for the parallel batch covering all the recorded
+  storage misses plus any non-target accounts the iter-0 path visited,
+  then ~0 ms for iteration 1's all-cache run. Total: ~3 RTTs ≈ 300 ms
+  prefetch p50. About 40% faster than baseline at 100 ms RTT; the win
+  scales linearly with RTT and with the number of independent storage
+  reads on the contract.
+- **Where prefetching does NOT help**: chained-dependency calls where
+  each step's input depends on the previous step's output (deep proxy
+  chains, contracts that resolve a slot's value as the slot index of
+  another read). Iteration 1 has to block serially on those, so the
+  total latency is roughly the same as the baseline.
 - **p95 vs p50**: depends entirely on peer tail latency. The convergence
   loop doesn't add tail-latency surface relative to the baseline.
 

--- a/myotis-evm/src/integrationTest/java/io/myotis/evm/integration/MainnetPrefetchBenchmarkIT.java
+++ b/myotis-evm/src/integrationTest/java/io/myotis/evm/integration/MainnetPrefetchBenchmarkIT.java
@@ -180,6 +180,10 @@ class MainnetPrefetchBenchmarkIT {
 
     private static byte[] parseHex32(String hex) {
         String s = hex.startsWith("0x") || hex.startsWith("0X") ? hex.substring(2) : hex;
+        if (s.length() != 64) {
+            throw new IllegalArgumentException(
+                    "expected 32-byte hex (64 chars), got " + s.length() + ": " + hex);
+        }
         return HexFormat.of().parseHex(s);
     }
 

--- a/myotis-evm/src/integrationTest/java/io/myotis/evm/integration/MainnetPrefetchBenchmarkIT.java
+++ b/myotis-evm/src/integrationTest/java/io/myotis/evm/integration/MainnetPrefetchBenchmarkIT.java
@@ -110,10 +110,16 @@ class MainnetPrefetchBenchmarkIT {
         var prefetched = new PrefetchingEvmExecutor(inner,
                 PrefetchingEvmExecutor.DEFAULT_ITERATION_CAP, convergenceTracker);
 
-        // Warm-up runs (untimed)
+        // Warm-up runs (untimed). The convergence tracker is shared with
+        // the executor we'll later time, so any iteration counts the
+        // warm-ups produced would otherwise pollute the reported min/max
+        // and the `convergenceTracker.max() <= 3` acceptance assertion.
+        // Reset the tracker after warm-ups so stats reflect only the
+        // timed runs.
         for (int i = 0; i < WARMUP_ITERATIONS; i++) {
             prefetched.callView(target, calldata, ctx).get(60, TimeUnit.SECONDS);
         }
+        convergenceTracker.clear();
 
         // Baseline: DefaultEvmExecutor (no prefetch)
         long[] baselineNs = timeRuns(inner, target, calldata, ctx);

--- a/myotis-evm/src/integrationTest/java/io/myotis/evm/integration/MainnetPrefetchBenchmarkIT.java
+++ b/myotis-evm/src/integrationTest/java/io/myotis/evm/integration/MainnetPrefetchBenchmarkIT.java
@@ -1,0 +1,204 @@
+package io.myotis.evm.integration;
+
+import io.myotis.evm.Address;
+import io.myotis.evm.BlockContext;
+import io.myotis.evm.DefaultEvmExecutor;
+import io.myotis.evm.EvmExecutor;
+import io.myotis.evm.PrefetchingEvmExecutor;
+import io.myotis.evm.abi.AbiEncoder;
+import io.myotis.evm.abi.FunctionSignature;
+import io.myotis.evm.ens.Namehash;
+import io.myotis.evm.prefetch.ConvergenceTracker;
+import io.myotis.evm.world.BytecodeCache;
+import io.myotis.evm.world.SnapBackedStateOracle;
+import io.myotis.evm.world.SnapPeer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Phase 2 benchmark — measures convergence iterations and end-to-end latency
+ * for the corpus listed in the original plan, with results going into
+ * {@code docs/prefetch-benchmarks.md} for review.
+ *
+ * <p>Acceptance criteria the benchmark validates:
+ * <ul>
+ *   <li>All cases converge in ≤ 3 iterations.
+ *   <li>p95 latency under 2 s on simulated good network conditions.
+ * </ul>
+ *
+ * <p>Same env-gating as {@link MainnetCallViewIT}: tests run only when
+ * {@code MYOTIS_MAINNET=1} and the supporting peer / state-root env vars
+ * are set. The benchmark depends on the same {@code connectToMainnetPeer()}
+ * helper that {@code MainnetCallViewIT} does — currently a stub awaiting
+ * a reusable {@code EthHandler} bootstrap factored out of {@code :app:Main}.
+ *
+ * <p>Methodology per call type:
+ * <ol>
+ *   <li>Warm-up call: 1 iteration discarded (loads bytecode into the
+ *       process-local cache so the timed runs measure prefetch behavior,
+ *       not first-touch I/O).
+ *   <li>{@code N} timed iterations (default 10): record wall-clock
+ *       latency per call and the convergence iteration count for that
+ *       call.
+ *   <li>Print min/p50/p95/max latency and the iteration histogram.
+ *   <li>Assert convergence ≤ 3 and p95 ≤ 2 s.
+ * </ol>
+ *
+ * <p>Two execution modes are compared per call to make the prefetch win
+ * visible: {@code DefaultEvmExecutor} alone (Phase 1 baseline) and
+ * {@code PrefetchingEvmExecutor} (Phase 2). Numbers go in the markdown
+ * table in {@code docs/prefetch-benchmarks.md}.
+ */
+@EnabledIfEnvironmentVariable(named = "MYOTIS_MAINNET", matches = "1")
+class MainnetPrefetchBenchmarkIT {
+
+    private static final int TIMED_ITERATIONS = 10;
+    private static final int WARMUP_ITERATIONS = 1;
+
+    private static final Address USDC = Address.fromHex("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
+    private static final Address DAI  = Address.fromHex("0x6B175474E89094C44Da98b954EedeAC495271d0F");
+    private static final Address ENS_PUBLIC_RESOLVER =
+            Address.fromHex("0x231b0Ee14048e9dCcD1d247744d114a4EB5E8E63");
+    private static final Address VITALIK =
+            Address.fromHex("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
+
+    @Test
+    void usdcBalanceOfBenchmark() throws Exception {
+        runBenchmark("USDC.balanceOf(vitalik)", USDC, balanceOfCalldata(VITALIK));
+    }
+
+    @Test
+    void daiBalanceOfBenchmark() throws Exception {
+        runBenchmark("DAI.balanceOf(vitalik)", DAI, balanceOfCalldata(VITALIK));
+    }
+
+    @Test
+    void ensResolverAddrBenchmark() throws Exception {
+        byte[] node = Namehash.of("vitalik.eth");
+        FunctionSignature addr = FunctionSignature.of("addr(bytes32)");
+        byte[] calldata = AbiEncoder.encodeCall(addr, AbiEncoder.bytes32(node));
+        runBenchmark("ENS.addr(vitalik.eth)", ENS_PUBLIC_RESOLVER, calldata);
+    }
+
+    /**
+     * Run the timed loop for one call, printing the result so it can be
+     * pasted into the markdown table.
+     */
+    private void runBenchmark(String label, Address target, byte[] calldata) throws Exception {
+        var peer = connectToMainnetPeer();
+        var ctx = mainnetBlockContext();
+
+        var convergenceTracker = new ConvergenceTracker();
+        var inner = new DefaultEvmExecutor(
+                new SnapBackedStateOracle(() -> peer, BytecodeCache.inMemory()),
+                BytecodeCache.inMemory(),
+                java.util.concurrent.Executors.newSingleThreadExecutor(r -> {
+                    Thread t = new Thread(r, "myotis-evm-bench");
+                    t.setDaemon(true);
+                    return t;
+                }));
+        var prefetched = new PrefetchingEvmExecutor(inner,
+                PrefetchingEvmExecutor.DEFAULT_ITERATION_CAP, convergenceTracker);
+
+        // Warm-up runs (untimed)
+        for (int i = 0; i < WARMUP_ITERATIONS; i++) {
+            prefetched.callView(target, calldata, ctx).get(60, TimeUnit.SECONDS);
+        }
+
+        // Baseline: DefaultEvmExecutor (no prefetch)
+        long[] baselineNs = timeRuns(inner, target, calldata, ctx);
+        // Phase 2: with prefetch
+        long[] prefetchNs = timeRuns(prefetched, target, calldata, ctx);
+
+        var iterCounts = convergenceTracker.snapshot();
+
+        Stats baselineStats = Stats.of(baselineNs);
+        Stats prefetchStats = Stats.of(prefetchNs);
+
+        System.out.printf(
+                "[bench] %-32s | baseline p50=%,9d µs p95=%,9d µs | prefetch p50=%,9d µs p95=%,9d µs | "
+                        + "iterations(min/max)=%d/%d%n",
+                label,
+                baselineStats.p50 / 1000, baselineStats.p95 / 1000,
+                prefetchStats.p50 / 1000, prefetchStats.p95 / 1000,
+                iterCounts.stream().mapToInt(Integer::intValue).min().orElse(0),
+                iterCounts.stream().mapToInt(Integer::intValue).max().orElse(0));
+
+        assertTrue(convergenceTracker.max() <= 3,
+                label + " converged in more than 3 iterations: max=" + convergenceTracker.max());
+        long p95Ms = prefetchStats.p95 / 1_000_000;
+        assertTrue(p95Ms <= 2000,
+                label + " p95 latency " + p95Ms + " ms exceeds 2 s acceptance criterion");
+    }
+
+    private long[] timeRuns(EvmExecutor exec, Address target, byte[] calldata, BlockContext ctx)
+            throws Exception {
+        long[] ns = new long[TIMED_ITERATIONS];
+        for (int i = 0; i < TIMED_ITERATIONS; i++) {
+            long start = System.nanoTime();
+            exec.callView(target, calldata, ctx).get(60, TimeUnit.SECONDS);
+            ns[i] = System.nanoTime() - start;
+        }
+        return ns;
+    }
+
+    private static SnapPeer connectToMainnetPeer() {
+        String enode = System.getenv("MYOTIS_INTEGRATION_PEER_ENODE");
+        assertNotNull(enode,
+                "MYOTIS_INTEGRATION_PEER_ENODE must be set; see MainnetCallViewIT Javadoc");
+        // TODO(phase1.commit5+): same bootstrap helper as MainnetCallViewIT.
+        // Both ITs share the gap; both light up at once when the helper lands.
+        throw new UnsupportedOperationException(
+                "EthHandler bootstrap from a test is not yet implemented; "
+                        + "see TODO in MainnetCallViewIT.connectToMainnetPeer.");
+    }
+
+    private static BlockContext mainnetBlockContext() {
+        byte[] stateRoot = parseHex32(env("MYOTIS_INTEGRATION_STATE_ROOT"));
+        long blockNumber = Long.parseLong(env("MYOTIS_INTEGRATION_BLOCK_NUMBER"));
+        long timestamp = Long.parseLong(env("MYOTIS_INTEGRATION_BLOCK_TIMESTAMP"));
+        BigInteger baseFee = new BigInteger(env("MYOTIS_INTEGRATION_BASE_FEE_WEI"));
+        return new BlockContext(stateRoot, blockNumber, timestamp, baseFee,
+                Address.ZERO, new byte[32], BigInteger.ONE, 30_000_000L);
+    }
+
+    private static String env(String name) {
+        String v = System.getenv(name);
+        assertNotNull(v, name + " must be set");
+        return v;
+    }
+
+    private static byte[] parseHex32(String hex) {
+        String s = hex.startsWith("0x") || hex.startsWith("0X") ? hex.substring(2) : hex;
+        return HexFormat.of().parseHex(s);
+    }
+
+    private static byte[] balanceOfCalldata(Address holder) {
+        return AbiEncoder.encodeCall(
+                FunctionSignature.of("balanceOf(address)"),
+                AbiEncoder.address(holder));
+    }
+
+    /** Quick latency stats. */
+    private record Stats(long p50, long p95, long min, long max) {
+        static Stats of(long[] ns) {
+            long[] sorted = Arrays.copyOf(ns, ns.length);
+            Arrays.sort(sorted);
+            return new Stats(
+                    sorted[sorted.length / 2],
+                    sorted[(int) Math.ceil(sorted.length * 0.95) - 1],
+                    sorted[0],
+                    sorted[sorted.length - 1]);
+        }
+    }
+}

--- a/myotis-evm/src/main/java/io/myotis/evm/DefaultEvmExecutor.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/DefaultEvmExecutor.java
@@ -68,12 +68,26 @@ public final class DefaultEvmExecutor implements EvmExecutor {
     }
 
     private byte[] runOnce(Address target, byte[] calldata, BlockContext blockContext) {
+        AccessTracker tracker = new AccessTracker();
+        SyncStateView view = new SyncStateView(oracle, blockContext.stateRoot(), bytecodeCache, tracker);
+        return runOnTracedView(target, calldata, blockContext, view, OperationTracer.NO_TRACING);
+    }
+
+    /**
+     * Drive a single EVM run against a caller-supplied {@link SyncStateView} and
+     * {@link OperationTracer}. Used by {@code PrefetchingEvmExecutor} to share a
+     * cache + tracer across the convergence loop's iterations; the public
+     * {@link #callView} path still constructs a fresh per-call view.
+     *
+     * <p>Package-private: it's the seam the prefetch layer plugs into, but it's
+     * not part of the public {@link EvmExecutor} contract.
+     */
+    byte[] runOnTracedView(Address target, byte[] calldata, BlockContext blockContext,
+                           SyncStateView view, OperationTracer tracer) {
         CryptoProviders.ensureRegistered();
         EvmFactory.EvmAndPrecompiles bundle = EvmFactory.buildForBlock(blockContext);
         EVM evm = bundle.evm();
 
-        AccessTracker tracker = new AccessTracker();
-        SyncStateView view = new SyncStateView(oracle, blockContext.stateRoot(), bytecodeCache, tracker);
         SnapWorldUpdater root = new SnapWorldUpdater(view);
         // Besu's EVM runs against a child updater so commit/revert of the
         // outer call doesn't pollute the read-through cache.
@@ -133,7 +147,7 @@ public final class DefaultEvmExecutor implements EvmExecutor {
         // the stack, so we always re-fetch the top.
         Deque<MessageFrame> stack = frame.getMessageFrameStack();
         while (!stack.isEmpty()) {
-            processor.process(stack.peek(), OperationTracer.NO_TRACING);
+            processor.process(stack.peek(), tracer);
         }
 
         // process() auto-transitions REVERT/EXCEPTIONAL_HALT to a COMPLETED_*
@@ -160,4 +174,9 @@ public final class DefaultEvmExecutor implements EvmExecutor {
         throw new EvmExecutionException(
                 new EvmExecutionError.Reverted(detail.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
     }
+
+    /** Accessors used by {@code PrefetchingEvmExecutor} to share configuration. */
+    SnapStateOracle oracle() { return oracle; }
+    BytecodeCache bytecodeCache() { return bytecodeCache; }
+    Executor executor() { return executor; }
 }

--- a/myotis-evm/src/main/java/io/myotis/evm/PrefetchingEvmExecutor.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/PrefetchingEvmExecutor.java
@@ -25,8 +25,8 @@ import java.util.concurrent.Executor;
  *
  * <p>The loop runs the EVM repeatedly against a shared per-call
  * {@link SyncStateView} cache. Each iteration uses {@link PrefetchingTracer}
- * to record (account, slot) and codeHash accesses without changing what the
- * EVM reads. After the iteration:
+ * to record (account, slot) accesses without changing what the EVM reads.
+ * After the iteration:
  *
  * <ol>
  *   <li>Compute the set of accesses that <em>missed</em> the cache (the
@@ -46,14 +46,30 @@ import java.util.concurrent.Executor;
  * typically converge in 2–3 iterations because the access pattern is
  * data-independent past the first SLOAD.
  *
+ * <p><strong>Honesty about latency.</strong> Because {@link SyncStateView}
+ * caches synchronously during the run that records each access, the
+ * "parallel prefetch wave" that runs between iterations is largely a no-op
+ * for data-independent contracts: by the time it executes, the previous
+ * run already populated everything in the cache. The wave only earns its
+ * keep when iteration N+1 takes a different data-dependent path than N
+ * (the cache is shared but the access set changed). The convergence loop's
+ * primary value is therefore <em>verifying</em> stability, not reducing
+ * round-trips. A genuine latency win would require sentinel-return mode for
+ * iteration 0 — running the EVM with placeholder values to extract an
+ * access list without blocking on each miss — and is deferred to a future
+ * phase. See {@code docs/phase2-design.md} for the full discussion.
+ *
  * <p>Limitations:
  * <ul>
  *   <li>The loop currently re-runs the EVM from scratch each iteration
  *       (cheap because state is in memory). A future refinement could use
  *       Besu's frame-pause hooks to resume mid-execution.
  *   <li>Bytecode is fetched lazily by the existing {@code BytecodeCache}
- *       path; trace-recorded codeHashes that aren't yet cached are batched
- *       just like account/storage misses.
+ *       path; bytecode is shared with whatever {@link DefaultEvmExecutor}
+ *       does — there's no separate prefetch wave for it (an earlier draft
+ *       had one and it was reverted: the SyncStateView cache populates
+ *       bytecode synchronously during the same run that observes the
+ *       access, so a separate wave finds everything already cached).
  * </ul>
  */
 public final class PrefetchingEvmExecutor implements EvmExecutor {
@@ -192,6 +208,15 @@ public final class PrefetchingEvmExecutor implements EvmExecutor {
                     .get(30, java.util.concurrent.TimeUnit.SECONDS);
         } catch (Exception e) {
             log.debug("[prefetch] batch fetch timed out / failed: {}", e.getMessage());
+            // Cancel outstanding futures so background SNAP requests don't
+            // continue racing the next iteration's serial reads. We can't
+            // interrupt the underlying network IO (cancel(true) doesn't help
+            // most JDK / SnapPeer impls), but cancel(false) at least marks
+            // the future complete-exceptionally so any thenApply chains
+            // short-circuit and don't pollute the cache asynchronously.
+            for (CompletableFuture<?> f : futures) {
+                if (!f.isDone()) f.cancel(false);
+            }
         }
     }
 

--- a/myotis-evm/src/main/java/io/myotis/evm/PrefetchingEvmExecutor.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/PrefetchingEvmExecutor.java
@@ -128,6 +128,12 @@ public final class PrefetchingEvmExecutor implements EvmExecutor {
 
             // Pre-populate the view's cache with parallel batch fetches of the
             // new accesses. After this, the next iteration's reads hit memory.
+            //
+            // Note: bytecode prefetching isn't a separate wave here because
+            // SyncStateView.bytecode() already populates the shared
+            // BytecodeCache synchronously during the run that just finished;
+            // any EXTCODE* target's code is in the cache by the time the
+            // tracer reports the access. A separate wave would be redundant.
             prefetchInParallel(view, blockContext.stateRoot(), newAccounts, newSlots);
             seenAccounts.addAll(newAccounts);
             seenSlots.addAll(newSlots);
@@ -188,4 +194,5 @@ public final class PrefetchingEvmExecutor implements EvmExecutor {
             log.debug("[prefetch] batch fetch timed out / failed: {}", e.getMessage());
         }
     }
+
 }

--- a/myotis-evm/src/main/java/io/myotis/evm/PrefetchingEvmExecutor.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/PrefetchingEvmExecutor.java
@@ -102,7 +102,11 @@ public final class PrefetchingEvmExecutor implements EvmExecutor {
         SnapStateOracle oracle = delegate.oracle();
         BytecodeCache bytecodeCache = delegate.bytecodeCache();
 
-        // One view across all iterations so cache hits accumulate.
+        // One view across all iterations so cache hits accumulate. The
+        // accessTracker is null during prime — pre-populating the target
+        // shouldn't show up as an "iteration 0 access" because primeTarget
+        // pulls real values, not sentinels, and we don't want it to inflate
+        // the per-iteration access set we use to drive parallel batches.
         SyncStateView view = new SyncStateView(
                 oracle, blockContext.stateRoot(), bytecodeCache, /* tracker */ null);
 
@@ -121,7 +125,15 @@ public final class PrefetchingEvmExecutor implements EvmExecutor {
             boolean sentinelMode = iter == 0;
             view.setSentinelOnMiss(sentinelMode);
 
+            // Per-iteration tracker, wired into both the tracer (records SLOAD
+            // / EXTCODE* stack args before opcode dispatch) AND the view
+            // (records every account/storage/bytecode lookup the world
+            // updater performs — including the implicit lookups Besu does
+            // when entering a child frame for CALL / STATICCALL / DELEGATECALL,
+            // which the tracer alone wouldn't capture). The two sources
+            // overlap by design; HashSet de-dupes.
             AccessTracker iterationTracker = new AccessTracker();
+            view.setAccessTracker(iterationTracker);
             PrefetchingTracer tracer = new PrefetchingTracer(iterationTracker);
 
             byte[] result;

--- a/myotis-evm/src/main/java/io/myotis/evm/PrefetchingEvmExecutor.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/PrefetchingEvmExecutor.java
@@ -1,0 +1,191 @@
+package io.myotis.evm;
+
+import io.myotis.evm.prefetch.ConvergenceTracker;
+import io.myotis.evm.prefetch.PrefetchingTracer;
+import io.myotis.evm.world.AccessTracker;
+import io.myotis.evm.world.AccountState;
+import io.myotis.evm.world.BytecodeCache;
+import io.myotis.evm.world.SnapStateOracle;
+import io.myotis.evm.world.SyncStateView;
+import org.apache.tuweni.units.bigints.UInt256;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+/**
+ * {@link EvmExecutor} that wraps {@link DefaultEvmExecutor} with a
+ * speculative-prefetch convergence loop.
+ *
+ * <p>The loop runs the EVM repeatedly against a shared per-call
+ * {@link SyncStateView} cache. Each iteration uses {@link PrefetchingTracer}
+ * to record (account, slot) and codeHash accesses without changing what the
+ * EVM reads. After the iteration:
+ *
+ * <ol>
+ *   <li>Compute the set of accesses that <em>missed</em> the cache (the
+ *       accesses from this iteration not already pre-populated).
+ *   <li>If the miss set is empty, the run is stable: return the result.
+ *   <li>Otherwise, parallel-fetch the misses through the
+ *       {@link SnapStateOracle}, populate the {@link SyncStateView} cache,
+ *       and re-run.
+ *   <li>Bail with {@link EvmExecutionError.IterationLimitExceeded} if the
+ *       iteration cap is hit before convergence.
+ * </ol>
+ *
+ * <p>The first iteration is necessarily slow — every miss triggers a
+ * blocking fetch through the oracle's per-call retry path. Subsequent
+ * iterations use the populated cache and only fetch newly-discovered
+ * accesses, in parallel. Real-world contracts (ERC-20, ENS resolvers)
+ * typically converge in 2–3 iterations because the access pattern is
+ * data-independent past the first SLOAD.
+ *
+ * <p>Limitations:
+ * <ul>
+ *   <li>The loop currently re-runs the EVM from scratch each iteration
+ *       (cheap because state is in memory). A future refinement could use
+ *       Besu's frame-pause hooks to resume mid-execution.
+ *   <li>Bytecode is fetched lazily by the existing {@code BytecodeCache}
+ *       path; trace-recorded codeHashes that aren't yet cached are batched
+ *       just like account/storage misses.
+ * </ul>
+ */
+public final class PrefetchingEvmExecutor implements EvmExecutor {
+
+    private static final Logger log = LoggerFactory.getLogger(PrefetchingEvmExecutor.class);
+
+    /** Plan-mandated default iteration cap. */
+    public static final int DEFAULT_ITERATION_CAP = 4;
+
+    private final DefaultEvmExecutor delegate;
+    private final int iterationCap;
+    private final ConvergenceTracker convergenceTracker;
+
+    public PrefetchingEvmExecutor(DefaultEvmExecutor delegate) {
+        this(delegate, DEFAULT_ITERATION_CAP, new ConvergenceTracker());
+    }
+
+    public PrefetchingEvmExecutor(DefaultEvmExecutor delegate, int iterationCap,
+                                  ConvergenceTracker convergenceTracker) {
+        this.delegate = delegate;
+        this.iterationCap = iterationCap;
+        this.convergenceTracker = convergenceTracker;
+    }
+
+    public ConvergenceTracker convergenceTracker() {
+        return convergenceTracker;
+    }
+
+    @Override
+    public CompletableFuture<byte[]> callView(Address target, byte[] calldata, BlockContext blockContext) {
+        Executor executor = delegate.executor();
+        return CompletableFuture.supplyAsync(
+                () -> runConvergent(target, calldata, blockContext), executor);
+    }
+
+    private byte[] runConvergent(Address target, byte[] calldata, BlockContext blockContext) {
+        SnapStateOracle oracle = delegate.oracle();
+        BytecodeCache bytecodeCache = delegate.bytecodeCache();
+
+        // One view across all iterations so cache hits accumulate.
+        SyncStateView view = new SyncStateView(
+                oracle, blockContext.stateRoot(), bytecodeCache, /* tracker */ null);
+
+        // Track every (address, slot) we've ever seen so we can recognise the
+        // "no new misses" stable state across iterations.
+        Set<AccessTracker.SlotKey> seenSlots = new HashSet<>();
+        Set<Address> seenAccounts = new HashSet<>();
+
+        byte[] lastResult = null;
+
+        for (int iter = 0; iter < iterationCap; iter++) {
+            AccessTracker iterationTracker = new AccessTracker();
+            PrefetchingTracer tracer = new PrefetchingTracer(iterationTracker);
+
+            byte[] result = delegate.runOnTracedView(target, calldata, blockContext, view, tracer);
+            lastResult = result;
+
+            AccessTracker.Snapshot snap = iterationTracker.snapshot();
+
+            // What's new this iteration relative to everything we've ever seen?
+            Set<AccessTracker.SlotKey> newSlots = new HashSet<>(snap.storage());
+            newSlots.removeAll(seenSlots);
+            Set<Address> newAccounts = new HashSet<>(snap.accounts());
+            newAccounts.removeAll(seenAccounts);
+
+            if (newSlots.isEmpty() && newAccounts.isEmpty()) {
+                // Stable. Convergence reached.
+                convergenceTracker.record(iter + 1);
+                log.debug("[prefetch] converged after {} iteration(s)", iter + 1);
+                return result;
+            }
+
+            // Pre-populate the view's cache with parallel batch fetches of the
+            // new accesses. After this, the next iteration's reads hit memory.
+            prefetchInParallel(view, blockContext.stateRoot(), newAccounts, newSlots);
+            seenAccounts.addAll(newAccounts);
+            seenSlots.addAll(newSlots);
+        }
+
+        // We hit the cap. Returning the last result would be honest — every
+        // read it observed was satisfiable — but the access set was still
+        // expanding, which usually indicates pathological data-dependent
+        // bytecode the prefetcher couldn't predict. Surface an explicit error
+        // per the plan's contract.
+        log.warn("[prefetch] iteration cap {} exceeded; returning IterationLimitExceeded", iterationCap);
+        throw new EvmExecutionException(new EvmExecutionError.IterationLimitExceeded(iterationCap));
+    }
+
+    /**
+     * Parallel-fetch the accounts and storage slots that just got recorded as
+     * cache misses. Population is via {@link SyncStateView#putAccount} /
+     * {@link SyncStateView#putStorage}, so the next iteration's reads hit the
+     * cache and don't issue any oracle calls.
+     */
+    private void prefetchInParallel(SyncStateView view, byte[] stateRoot,
+                                    Set<Address> accounts,
+                                    Set<AccessTracker.SlotKey> slots) {
+        SnapStateOracle oracle = delegate.oracle();
+        List<CompletableFuture<?>> futures = new ArrayList<>(accounts.size() + slots.size());
+
+        for (Address address : accounts) {
+            if (view.hasAccount(address)) continue;
+            futures.add(oracle.fetchAccount(stateRoot, address)
+                    .thenAccept(state -> view.putAccount(address, state))
+                    .exceptionally(t -> {
+                        log.debug("[prefetch] account fetch for {} failed: {}", address, t.getMessage());
+                        return null;
+                    }));
+        }
+        for (AccessTracker.SlotKey key : slots) {
+            if (view.hasStorage(key.address(), UInt256.valueOf(key.slot()))) continue;
+            futures.add(oracle.fetchStorage(stateRoot, key.address(), key.slot())
+                    .thenAccept(value -> view.putStorage(
+                            key.address(),
+                            UInt256.valueOf(key.slot()),
+                            UInt256.valueOf(value)))
+                    .exceptionally(t -> {
+                        log.debug("[prefetch] storage fetch for {} slot {} failed: {}",
+                                key.address(), key.slot(), t.getMessage());
+                        return null;
+                    }));
+        }
+
+        // Best-effort: wait for the batch to finish, but don't propagate
+        // individual failures here — if a prefetch failed, the next EVM run
+        // will hit the (still-uncached) miss and either succeed via the
+        // oracle's serial path or surface a clean error from there.
+        try {
+            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+                    .get(30, java.util.concurrent.TimeUnit.SECONDS);
+        } catch (Exception e) {
+            log.debug("[prefetch] batch fetch timed out / failed: {}", e.getMessage());
+        }
+    }
+}

--- a/myotis-evm/src/main/java/io/myotis/evm/PrefetchingEvmExecutor.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/PrefetchingEvmExecutor.java
@@ -188,7 +188,7 @@ public final class PrefetchingEvmExecutor implements EvmExecutor {
         // will hit the (still-uncached) miss and either succeed via the
         // oracle's serial path or surface a clean error from there.
         try {
-            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+            CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new))
                     .get(30, java.util.concurrent.TimeUnit.SECONDS);
         } catch (Exception e) {
             log.debug("[prefetch] batch fetch timed out / failed: {}", e.getMessage());

--- a/myotis-evm/src/main/java/io/myotis/evm/PrefetchingEvmExecutor.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/PrefetchingEvmExecutor.java
@@ -11,7 +11,6 @@ import org.apache.tuweni.units.bigints.UInt256;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -21,56 +20,50 @@ import java.util.concurrent.Executor;
 
 /**
  * {@link EvmExecutor} that wraps {@link DefaultEvmExecutor} with a
- * speculative-prefetch convergence loop.
+ * speculative-prefetch convergence loop using the <em>sentinel-return</em>
+ * approach.
  *
- * <p>The loop runs the EVM repeatedly against a shared per-call
- * {@link SyncStateView} cache. Each iteration uses {@link PrefetchingTracer}
- * to record (account, slot) accesses without changing what the EVM reads.
- * After the iteration:
+ * <p>Iteration 0 runs the EVM with {@link SyncStateView#setSentinelOnMiss}
+ * enabled: cache misses return zero-shaped placeholders without blocking
+ * on the oracle. The {@link PrefetchingTracer} records every (account, slot)
+ * touched. The result of iteration 0 is <em>discarded</em> (the placeholders
+ * may have produced wrong values, divergent paths, or even reverts) — only
+ * the access list survives.
  *
- * <ol>
- *   <li>Compute the set of accesses that <em>missed</em> the cache (the
- *       accesses from this iteration not already pre-populated).
- *   <li>If the miss set is empty, the run is stable: return the result.
- *   <li>Otherwise, parallel-fetch the misses through the
- *       {@link SnapStateOracle}, populate the {@link SyncStateView} cache,
- *       and re-run.
- *   <li>Bail with {@link EvmExecutionError.IterationLimitExceeded} if the
- *       iteration cap is hit before convergence.
- * </ol>
+ * <p>Between iterations the loop parallel-fetches all recorded misses
+ * through the {@link SnapStateOracle}, populating the {@link SyncStateView}
+ * cache.
  *
- * <p>The first iteration is necessarily slow — every miss triggers a
- * blocking fetch through the oracle's per-call retry path. Subsequent
- * iterations use the populated cache and only fetch newly-discovered
- * accesses, in parallel. Real-world contracts (ERC-20, ENS resolvers)
- * typically converge in 2–3 iterations because the access pattern is
- * data-independent past the first SLOAD.
+ * <p>Iteration 1 runs with sentinel mode <em>cleared</em>. Cache hits return
+ * real values; any newly-discovered misses (slots iteration 0's wrong path
+ * never reached, but the real path needs) block on the oracle. The tracer
+ * records the real-path access list.
  *
- * <p><strong>Honesty about latency.</strong> Because {@link SyncStateView}
- * caches synchronously during the run that records each access, the
- * "parallel prefetch wave" that runs between iterations is largely a no-op
- * for data-independent contracts: by the time it executes, the previous
- * run already populated everything in the cache. The wave only earns its
- * keep when iteration N+1 takes a different data-dependent path than N
- * (the cache is shared but the access set changed). The convergence loop's
- * primary value is therefore <em>verifying</em> stability, not reducing
- * round-trips. A genuine latency win would require sentinel-return mode for
- * iteration 0 — running the EVM with placeholder values to extract an
- * access list without blocking on each miss — and is deferred to a future
- * phase. See {@code docs/phase2-design.md} for the full discussion.
+ * <p>If iteration 1's access list is a subset of what iteration 0 saw, the
+ * call converges and the result is returned. Otherwise iteration 2+ repeats
+ * with sentinel mode off — each subsequent iteration relies on cache hits
+ * for previously-seen accesses and only blocks on data-dependent new ones.
  *
- * <p>Limitations:
- * <ul>
- *   <li>The loop currently re-runs the EVM from scratch each iteration
- *       (cheap because state is in memory). A future refinement could use
- *       Besu's frame-pause hooks to resume mid-execution.
- *   <li>Bytecode is fetched lazily by the existing {@code BytecodeCache}
- *       path; bytecode is shared with whatever {@link DefaultEvmExecutor}
- *       does — there's no separate prefetch wave for it (an earlier draft
- *       had one and it was reverted: the SyncStateView cache populates
- *       bytecode synchronously during the same run that observes the
- *       access, so a separate wave finds everything already cached).
- * </ul>
+ * <p><strong>The bytecode-and-account-of-target trick.</strong> Sentinel
+ * mode for the very-first lookup would return an empty account record
+ * (codeHash = keccak("")) and the EVM would find no code to execute,
+ * defeating the whole iteration. The executor pre-populates the target
+ * contract's account and bytecode synchronously before iteration 0 so the
+ * sentinel run reaches actual contract logic. This adds two RTTs upfront
+ * but they would be paid in iteration 0 anyway.
+ *
+ * <p><strong>Where this design wins:</strong> contracts with multiple
+ * data-independent state reads. Iteration 0 records all of them at memory
+ * speed; the parallel batch fetch covers them in one network round trip;
+ * iteration 1 produces the real result. For a contract that does N
+ * independent SLOADs, the latency drops from {@code N · RTT} (serial) to
+ * roughly {@code 2 · RTT} (one parallel batch + one verify run).
+ *
+ * <p><strong>Where it doesn't:</strong> chained data-dependent reads
+ * (proxy → impl → balance) require one round trip per chain link, so
+ * sentinel-return offers little advantage over the previous trace-based
+ * design. The convergence loop still verifies stability, which is the
+ * correctness guarantee.
  */
 public final class PrefetchingEvmExecutor implements EvmExecutor {
 
@@ -113,55 +106,90 @@ public final class PrefetchingEvmExecutor implements EvmExecutor {
         SyncStateView view = new SyncStateView(
                 oracle, blockContext.stateRoot(), bytecodeCache, /* tracker */ null);
 
+        // Pre-populate the target contract's account + bytecode synchronously
+        // so iteration 0's sentinel run actually executes meaningful bytecode.
+        // Without this, the very-first lookup would get a sentinel empty
+        // account, find no code, and return immediately.
+        primeTarget(view, target);
+
         // Track every (address, slot) we've ever seen so we can recognise the
         // "no new misses" stable state across iterations.
         Set<AccessTracker.SlotKey> seenSlots = new HashSet<>();
         Set<Address> seenAccounts = new HashSet<>();
 
-        byte[] lastResult = null;
-
         for (int iter = 0; iter < iterationCap; iter++) {
+            boolean sentinelMode = iter == 0;
+            view.setSentinelOnMiss(sentinelMode);
+
             AccessTracker iterationTracker = new AccessTracker();
             PrefetchingTracer tracer = new PrefetchingTracer(iterationTracker);
 
-            byte[] result = delegate.runOnTracedView(target, calldata, blockContext, view, tracer);
-            lastResult = result;
+            byte[] result;
+            try {
+                result = delegate.runOnTracedView(target, calldata, blockContext, view, tracer);
+            } catch (EvmExecutionException e) {
+                if (!sentinelMode) {
+                    // Real iteration produced an actual revert / halt — propagate.
+                    throw e;
+                }
+                // Sentinel iteration 0 may revert because zero-valued state
+                // tripped a require()/divide-by-zero/etc. That's expected;
+                // we still have whatever access list was recorded up to the
+                // point of the revert. Continue to the prefetch wave.
+                log.debug("[prefetch] sentinel iteration 0 halted ({}); continuing with recorded access list",
+                        e.error());
+                result = null;
+            }
 
             AccessTracker.Snapshot snap = iterationTracker.snapshot();
 
-            // What's new this iteration relative to everything we've ever seen?
+            if (sentinelMode) {
+                // Iteration 0's result is bogus by construction. Discard.
+                seenAccounts.addAll(snap.accounts());
+                seenSlots.addAll(snap.storage());
+                prefetchInParallel(view, blockContext.stateRoot(), snap.accounts(), snap.storage());
+                continue;
+            }
+
+            // Real iteration: check whether the access set has stabilised.
             Set<AccessTracker.SlotKey> newSlots = new HashSet<>(snap.storage());
             newSlots.removeAll(seenSlots);
             Set<Address> newAccounts = new HashSet<>(snap.accounts());
             newAccounts.removeAll(seenAccounts);
 
             if (newSlots.isEmpty() && newAccounts.isEmpty()) {
-                // Stable. Convergence reached.
                 convergenceTracker.record(iter + 1);
                 log.debug("[prefetch] converged after {} iteration(s)", iter + 1);
                 return result;
             }
 
-            // Pre-populate the view's cache with parallel batch fetches of the
-            // new accesses. After this, the next iteration's reads hit memory.
-            //
-            // Note: bytecode prefetching isn't a separate wave here because
-            // SyncStateView.bytecode() already populates the shared
-            // BytecodeCache synchronously during the run that just finished;
-            // any EXTCODE* target's code is in the cache by the time the
-            // tracer reports the access. A separate wave would be redundant.
-            prefetchInParallel(view, blockContext.stateRoot(), newAccounts, newSlots);
             seenAccounts.addAll(newAccounts);
             seenSlots.addAll(newSlots);
+            // The new misses were already block-fetched by this iteration's
+            // serial reads (sentinel mode is OFF here), so the prefetchInParallel
+            // call below mostly skips via view.hasAccount / view.hasStorage. It
+            // remains as a safety net for any future code path that records an
+            // access without populating the cache — e.g. an EXTCODESIZE that
+            // doesn't trigger a getCode() in the EVM.
+            prefetchInParallel(view, blockContext.stateRoot(), newAccounts, newSlots);
         }
 
-        // We hit the cap. Returning the last result would be honest — every
-        // read it observed was satisfiable — but the access set was still
-        // expanding, which usually indicates pathological data-dependent
-        // bytecode the prefetcher couldn't predict. Surface an explicit error
-        // per the plan's contract.
-        log.warn("[prefetch] iteration cap {} exceeded; returning IterationLimitExceeded", iterationCap);
+        log.warn("[prefetch] iteration cap {} exceeded", iterationCap);
         throw new EvmExecutionException(new EvmExecutionError.IterationLimitExceeded(iterationCap));
+    }
+
+    /**
+     * Synchronously fetch the target contract's account and bytecode so the
+     * sentinel-mode iteration 0 has real code to execute at the top level.
+     * Does nothing if the target is already cached (e.g. a repeat call from
+     * the same wallet session).
+     */
+    private void primeTarget(SyncStateView view, Address target) {
+        if (view.hasAccount(target)) return;
+        // Sentinel mode is OFF at this point; account() blocks on the oracle.
+        AccountState targetAccount = view.account(target);
+        // Force bytecode fetch into the BytecodeCache (also blocks).
+        view.bytecode(targetAccount.codeHash());
     }
 
     /**
@@ -208,16 +236,9 @@ public final class PrefetchingEvmExecutor implements EvmExecutor {
                     .get(30, java.util.concurrent.TimeUnit.SECONDS);
         } catch (Exception e) {
             log.debug("[prefetch] batch fetch timed out / failed: {}", e.getMessage());
-            // Cancel outstanding futures so background SNAP requests don't
-            // continue racing the next iteration's serial reads. We can't
-            // interrupt the underlying network IO (cancel(true) doesn't help
-            // most JDK / SnapPeer impls), but cancel(false) at least marks
-            // the future complete-exceptionally so any thenApply chains
-            // short-circuit and don't pollute the cache asynchronously.
             for (CompletableFuture<?> f : futures) {
                 if (!f.isDone()) f.cancel(false);
             }
         }
     }
-
 }

--- a/myotis-evm/src/main/java/io/myotis/evm/prefetch/ConvergenceTracker.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/prefetch/ConvergenceTracker.java
@@ -30,4 +30,14 @@ public final class ConvergenceTracker {
             return iterations.stream().mapToInt(Integer::intValue).max().orElse(0);
         }
     }
+
+    /**
+     * Discard all recorded iteration counts. Used by the benchmark IT after
+     * warm-up runs so the reported stats reflect only the timed measurements.
+     */
+    public void clear() {
+        synchronized (iterations) {
+            iterations.clear();
+        }
+    }
 }

--- a/myotis-evm/src/main/java/io/myotis/evm/prefetch/PrefetchingTracer.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/prefetch/PrefetchingTracer.java
@@ -12,10 +12,18 @@ import org.hyperledger.besu.evm.tracing.OperationTracer;
  *
  * <p>Used by {@link io.myotis.evm.PrefetchingEvmExecutor} to drive the
  * convergence loop: run the EVM once with this tracer attached, collect the
- * (account, slot) and codeHash misses, batch-fetch them in parallel, then
- * re-run. The plan calls this the "trace-based" approach, chosen over
- * sentinel-return because it observes the real path the EVM would take
- * rather than a placeholder-shaped one.
+ * (account, slot) misses, batch-fetch them in parallel, then re-run. The
+ * plan calls this the "trace-based" approach, chosen over sentinel-return
+ * because it observes the real path the EVM would take rather than a
+ * placeholder-shaped one.
+ *
+ * <p>Bytecode access is intentionally <em>not</em> recorded here: the
+ * {@code SyncStateView}'s {@link io.myotis.evm.world.BytecodeCache} hits the
+ * same code path whether the bytecode is needed during this iteration's
+ * synchronous run or pre-fetched between iterations, and the prefetch
+ * doesn't avoid any round trips. {@link io.myotis.evm.world.AccessTracker}
+ * still exposes a {@code recordBytecode}/{@code codeHashes} surface so a
+ * future phase can opt in if a sentinel-return iteration-0 mode lands.
  *
  * <p>Hook points (Yellow Paper opcode numbers):
  * <ul>

--- a/myotis-evm/src/main/java/io/myotis/evm/prefetch/PrefetchingTracer.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/prefetch/PrefetchingTracer.java
@@ -1,0 +1,101 @@
+package io.myotis.evm.prefetch;
+
+import io.myotis.evm.world.AccessTracker;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.units.bigints.UInt256;
+import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.tracing.OperationTracer;
+
+/**
+ * Besu {@link OperationTracer} that records every storage and code access
+ * the EVM would issue during execution, without changing what gets executed.
+ *
+ * <p>Used by {@link io.myotis.evm.PrefetchingEvmExecutor} to drive the
+ * convergence loop: run the EVM once with this tracer attached, collect the
+ * (account, slot) and codeHash misses, batch-fetch them in parallel, then
+ * re-run. The plan calls this the "trace-based" approach, chosen over
+ * sentinel-return because it observes the real path the EVM would take
+ * rather than a placeholder-shaped one.
+ *
+ * <p>Hook points (Yellow Paper opcode numbers):
+ * <ul>
+ *   <li>0x54 {@code SLOAD} — stack[0] is the slot key; storage owner is
+ *       {@code frame.getRecipientAddress()} (which is the calling-contract's
+ *       address for normal CALL and stays as-is for STATICCALL/DELEGATECALL
+ *       per Besu's semantics — the recipient is the storage-owning account
+ *       in Besu's MessageFrame model).
+ *   <li>0x3b {@code EXTCODESIZE}, 0x3c {@code EXTCODECOPY},
+ *       0x3f {@code EXTCODEHASH} — stack[0] is the target address whose code
+ *       we may need.
+ *   <li>0x39 {@code CODECOPY} — copies from the executing contract's own code,
+ *       so no extra fetch is needed; the contract's code was already loaded
+ *       when the frame started.
+ * </ul>
+ *
+ * <p>The tracer is single-call: build a fresh one for each EVM run inside
+ * the convergence loop. Snapshots are returned via {@link AccessTracker}
+ * which is already in the codebase from Phase 0/1.
+ *
+ * <p>Limitation: the recorded slot is what {@code SLOAD} sees on the stack
+ * before execution, but the EVM only actually reads it if the {@code SLOAD}
+ * opcode runs to completion. If the surrounding bytecode reverts or runs
+ * out of gas before the {@code SLOAD} retires, the tracer will have
+ * recorded a slot the real run would never touch. The convergence loop
+ * tolerates this — over-fetching is wasteful but harmless.
+ */
+public final class PrefetchingTracer implements OperationTracer {
+
+    /** EVM opcode constants (kept here so we don't depend on Besu's enum). */
+    private static final int OP_SLOAD        = 0x54;
+    private static final int OP_EXTCODESIZE  = 0x3b;
+    private static final int OP_EXTCODECOPY  = 0x3c;
+    private static final int OP_EXTCODEHASH  = 0x3f;
+
+    private final AccessTracker tracker;
+
+    public PrefetchingTracer(AccessTracker tracker) {
+        this.tracker = tracker;
+    }
+
+    @Override
+    public void tracePreExecution(MessageFrame frame) {
+        var op = frame.getCurrentOperation();
+        if (op == null) return;
+        int code = op.getOpcode();
+        // Stack underflow = EVM is about to halt with INSUFFICIENT_STACK_ITEMS;
+        // skip the trace and let the real run produce the halt.
+        int needed = op.getStackItemsConsumed();
+        if (frame.stackSize() < needed) return;
+
+        switch (code) {
+            case OP_SLOAD -> {
+                UInt256 slot = UInt256.fromBytes(Bytes32.leftPad(frame.getStackItem(0)));
+                io.myotis.evm.Address owner = io.myotis.evm.Address.of(
+                        frame.getRecipientAddress().toArrayUnsafe());
+                tracker.recordStorage(owner, slot.toUnsignedBigInteger());
+                tracker.recordAccount(owner);
+            }
+            case OP_EXTCODESIZE, OP_EXTCODECOPY, OP_EXTCODEHASH -> {
+                io.myotis.evm.Address target = io.myotis.evm.Address.of(
+                        rightmost20(frame.getStackItem(0)));
+                tracker.recordAccount(target);
+            }
+            default -> {
+                // SLOAD doesn't carry an account argument, but every other
+                // opcode that touches off-frame state already had its account
+                // fetched when the message frame entered. Nothing to record.
+            }
+        }
+    }
+
+    /**
+     * Truncate a 32-byte stack item to its rightmost 20 bytes (the address
+     * encoding used on the EVM stack: addresses are zero-padded to 256 bits).
+     */
+    private static byte[] rightmost20(org.apache.tuweni.bytes.Bytes raw) {
+        byte[] padded = Bytes32.leftPad(raw).toArrayUnsafe();
+        byte[] addr = new byte[20];
+        System.arraycopy(padded, 12, addr, 0, 20);
+        return addr;
+    }
+}

--- a/myotis-evm/src/main/java/io/myotis/evm/prefetch/PrefetchingTracer.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/prefetch/PrefetchingTracer.java
@@ -7,23 +7,28 @@ import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.tracing.OperationTracer;
 
 /**
- * Besu {@link OperationTracer} that records every storage and code access
- * the EVM would issue during execution, without changing what gets executed.
+ * Besu {@link OperationTracer} that observes opcode-level state accesses
+ * during the Phase 2 sentinel-return convergence loop.
  *
- * <p>Used by {@link io.myotis.evm.PrefetchingEvmExecutor} to drive the
- * convergence loop: run the EVM once with this tracer attached, collect the
- * (account, slot) misses, batch-fetch them in parallel, then re-run. The
- * plan calls this the "trace-based" approach, chosen over sentinel-return
- * because it observes the real path the EVM would take rather than a
- * placeholder-shaped one.
+ * <p>The {@link io.myotis.evm.PrefetchingEvmExecutor} runs the EVM with
+ * this tracer attached and {@code SyncStateView.setSentinelOnMiss(true)};
+ * cache misses return zero-shaped placeholders, the tracer (and the view
+ * itself, via the same {@link AccessTracker}) records every access, and
+ * the prefetch loop batch-fetches the recorded misses in parallel before
+ * re-running for real. See {@code io.myotis.evm.PrefetchingEvmExecutor}'s
+ * Javadoc for the full convergence-loop description.
  *
- * <p>Bytecode access is intentionally <em>not</em> recorded here: the
- * {@code SyncStateView}'s {@link io.myotis.evm.world.BytecodeCache} hits the
- * same code path whether the bytecode is needed during this iteration's
- * synchronous run or pre-fetched between iterations, and the prefetch
- * doesn't avoid any round trips. {@link io.myotis.evm.world.AccessTracker}
- * still exposes a {@code recordBytecode}/{@code codeHashes} surface so a
- * future phase can opt in if a sentinel-return iteration-0 mode lands.
+ * <p>The tracer is one of two recording sources — the other is
+ * {@code SyncStateView}, which records every access the world updater
+ * makes (including the implicit account/bytecode lookups Besu performs
+ * when entering a CALL/STATICCALL/DELEGATECALL child frame). The two
+ * overlap by design and {@link AccessTracker} de-dupes via {@code HashSet}.
+ *
+ * <p>Bytecode access is intentionally <em>not</em> recorded by this tracer:
+ * {@code SyncStateView.bytecode()} already records via the access tracker
+ * when the view is wired with one, so the EXTCODE* opcodes' targets get
+ * captured downstream. {@link io.myotis.evm.world.AccessTracker} retains
+ * the {@code recordBytecode}/{@code codeHashes} surface for future use.
  *
  * <p>Hook points (Yellow Paper opcode numbers):
  * <ul>

--- a/myotis-evm/src/main/java/io/myotis/evm/world/SyncStateView.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/world/SyncStateView.java
@@ -52,7 +52,15 @@ public final class SyncStateView {
     private final SnapStateOracle oracle;
     private final byte[] stateRoot;
     private final BytecodeCache bytecodeCache;
-    private final AccessTracker accessTracker;
+
+    /**
+     * Tracker that receives every account/storage/bytecode access. Mutable
+     * so the Phase 2 prefetch loop can swap a fresh tracker in per
+     * iteration (the per-iteration access set drives the parallel batch
+     * fetch wave between iterations). May be null if no recording is
+     * needed.
+     */
+    private volatile AccessTracker accessTracker;
 
     private final Map<Address, AccountState> accountCache = new ConcurrentHashMap<>();
     private final Map<SlotKey, UInt256> storageCache = new ConcurrentHashMap<>();
@@ -82,6 +90,15 @@ public final class SyncStateView {
 
     public boolean isSentinelOnMiss() {
         return sentinelOnMiss;
+    }
+
+    /**
+     * Swap the access tracker. Used by the Phase 2 prefetch loop to install
+     * a fresh per-iteration tracker without rebuilding the whole view (and
+     * losing the cache).
+     */
+    public void setAccessTracker(AccessTracker accessTracker) {
+        this.accessTracker = accessTracker;
     }
 
     public AccountState account(Address address) {

--- a/myotis-evm/src/main/java/io/myotis/evm/world/SyncStateView.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/world/SyncStateView.java
@@ -1,7 +1,10 @@
 package io.myotis.evm.world;
 
 import io.myotis.evm.Address;
+import io.myotis.evm.CryptoProviders;
 import io.myotis.evm.EvmExecutionException;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.crypto.Hash;
 import org.apache.tuweni.units.bigints.UInt256;
 
 import java.math.BigInteger;
@@ -16,16 +19,20 @@ import java.util.concurrent.CompletionException;
  * <p>Besu's EVM is synchronous: the {@code runToHalt} loop calls
  * {@code WorldUpdater#get} and {@code Account#getStorageValue} expecting
  * values returned directly. Our oracle is async by nature (a SNAP fetch is a
- * network round trip). The bridge is one of two strategies:
+ * network round trip). The bridge has three modes:
  * <ul>
- *   <li>Phase 0: the fixture oracle returns already-completed futures, so
- *       {@code join()} is effectively free.
- *   <li>Phase 1: a single synchronous round trip per miss is acceptable but
- *       slow. {@code join()} blocks the calling thread for the duration of the
- *       fetch.
- *   <li>Phase 2: the prefetch loop populates the in-view cache before the EVM
- *       reaches each miss, making the {@code join()} a no-op in the common
- *       case.
+ *   <li><strong>Cache-only:</strong> read from the in-view cache. Misses
+ *       fall through to one of the two paths below.
+ *   <li><strong>Block-on-miss</strong> (default): on a cache miss, call the
+ *       oracle and {@code join()} the future. Slow but correct. This is
+ *       what {@link io.myotis.evm.DefaultEvmExecutor} uses.
+ *   <li><strong>Sentinel-on-miss</strong> (Phase 2 prefetch loop, iter 0):
+ *       on a cache miss, return a sentinel value (zero / empty) without
+ *       blocking. The miss is recorded in the {@link AccessTracker} and the
+ *       sentinel is <em>not</em> cached — so a subsequent run with the flag
+ *       cleared will hit the oracle. The convergence loop runs the EVM with
+ *       this flag set, collects the access list, parallel-fetches the misses,
+ *       and re-runs with the flag cleared to get a real result.
  * </ul>
  *
  * <p>The view caches {@code (address) → AccountState} and
@@ -36,6 +43,12 @@ import java.util.concurrent.CompletionException;
  */
 public final class SyncStateView {
 
+    private static final byte[] EMPTY_CODE_HASH;
+    static {
+        CryptoProviders.ensureRegistered();
+        EMPTY_CODE_HASH = Hash.keccak256(Bytes.EMPTY).toArrayUnsafe();
+    }
+
     private final SnapStateOracle oracle;
     private final byte[] stateRoot;
     private final BytecodeCache bytecodeCache;
@@ -43,6 +56,13 @@ public final class SyncStateView {
 
     private final Map<Address, AccountState> accountCache = new ConcurrentHashMap<>();
     private final Map<SlotKey, UInt256> storageCache = new ConcurrentHashMap<>();
+
+    /**
+     * When true, cache misses return zero-shaped sentinel values without
+     * calling the oracle. The miss is recorded in {@code accessTracker};
+     * the sentinel is not cached. See class Javadoc.
+     */
+    private volatile boolean sentinelOnMiss = false;
 
     public SyncStateView(
             SnapStateOracle oracle,
@@ -55,10 +75,24 @@ public final class SyncStateView {
         this.accessTracker = accessTracker;
     }
 
+    /** Toggle sentinel-on-miss mode for the next run. See class Javadoc. */
+    public void setSentinelOnMiss(boolean v) {
+        this.sentinelOnMiss = v;
+    }
+
+    public boolean isSentinelOnMiss() {
+        return sentinelOnMiss;
+    }
+
     public AccountState account(Address address) {
         if (accessTracker != null) accessTracker.recordAccount(address);
         AccountState cached = accountCache.get(address);
         if (cached != null) return cached;
+        if (sentinelOnMiss) {
+            // Empty default; intentionally NOT cached so a subsequent run
+            // with the flag cleared will fetch the real value.
+            return new AccountState(address, 0L, BigInteger.ZERO, EMPTY_CODE_HASH);
+        }
         try {
             AccountState fetched = oracle.fetchAccount(stateRoot, address).join();
             accountCache.put(address, fetched);
@@ -74,6 +108,13 @@ public final class SyncStateView {
         SlotKey key = new SlotKey(address, slot);
         UInt256 cached = storageCache.get(key);
         if (cached != null) return cached;
+        if (sentinelOnMiss) {
+            // Zero is a valid storage value, so this is indistinguishable
+            // from a real zero — but the access is recorded in the tracker
+            // either way, and the convergence loop will re-run with the
+            // flag cleared to confirm.
+            return UInt256.ZERO;
+        }
         try {
             BigInteger v = oracle.fetchStorage(stateRoot, address, slot.toUnsignedBigInteger()).join();
             UInt256 value = UInt256.valueOf(v);
@@ -87,16 +128,26 @@ public final class SyncStateView {
 
     public byte[] bytecode(byte[] codeHash) {
         if (accessTracker != null) accessTracker.recordBytecode(codeHash);
-        return bytecodeCache.get(codeHash).orElseGet(() -> {
-            try {
-                byte[] code = oracle.fetchBytecode(codeHash).join();
-                bytecodeCache.put(codeHash, code);
-                return code;
-            } catch (CompletionException ce) {
-                unwrap(ce);
-                throw ce;
-            }
-        });
+        var cached = bytecodeCache.get(codeHash);
+        if (cached.isPresent()) return cached.get();
+        if (sentinelOnMiss) {
+            // Empty bytecode means "no code" to the EVM — a CALL to such an
+            // account returns immediately with no execution, so the iter-0
+            // sentinel run will short-circuit any nested calls. That's
+            // expected: the access list is still recorded, and iter 1
+            // re-enters with real bytecode populated. The PrefetchingEvmExecutor
+            // pre-populates the *target* contract's bytecode synchronously so
+            // iter 0's run reaches actual bytecode at the top level.
+            return new byte[0];
+        }
+        try {
+            byte[] code = oracle.fetchBytecode(codeHash).join();
+            bytecodeCache.put(codeHash, code);
+            return code;
+        } catch (CompletionException ce) {
+            unwrap(ce);
+            throw ce;
+        }
     }
 
     /** Phase 2 helpers — let the prefetch loop pre-populate values from a parallel batch fetch. */

--- a/myotis-evm/src/main/java/io/myotis/evm/world/SyncStateView.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/world/SyncStateView.java
@@ -5,6 +5,9 @@ import io.myotis.evm.EvmExecutionException;
 import org.apache.tuweni.units.bigints.UInt256;
 
 import java.math.BigInteger;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CompletionException;
 
 /**
@@ -19,13 +22,17 @@ import java.util.concurrent.CompletionException;
  *       {@code join()} is effectively free.
  *   <li>Phase 1: a single synchronous round trip per miss is acceptable but
  *       slow. {@code join()} blocks the calling thread for the duration of the
- *       fetch. The executor must run the EVM on a worker thread so this does
- *       not block the caller's coroutine context.
- *   <li>Phase 2: the prefetch loop populates a per-call cache before the EVM
+ *       fetch.
+ *   <li>Phase 2: the prefetch loop populates the in-view cache before the EVM
  *       reaches each miss, making the {@code join()} a no-op in the common
- *       case. Misses fall through and either trigger another iteration of the
- *       loop or return a sentinel (TBD per the open question in the plan).
+ *       case.
  * </ul>
+ *
+ * <p>The view caches {@code (address) → AccountState} and
+ * {@code (address, slot) → UInt256} so that repeated reads — both within a
+ * single EVM run and across iterations of the Phase 2 prefetch loop — hit
+ * memory rather than the oracle. Bytecode caching is delegated to the
+ * supplied {@link BytecodeCache}.
  */
 public final class SyncStateView {
 
@@ -33,6 +40,9 @@ public final class SyncStateView {
     private final byte[] stateRoot;
     private final BytecodeCache bytecodeCache;
     private final AccessTracker accessTracker;
+
+    private final Map<Address, AccountState> accountCache = new ConcurrentHashMap<>();
+    private final Map<SlotKey, UInt256> storageCache = new ConcurrentHashMap<>();
 
     public SyncStateView(
             SnapStateOracle oracle,
@@ -47,8 +57,12 @@ public final class SyncStateView {
 
     public AccountState account(Address address) {
         if (accessTracker != null) accessTracker.recordAccount(address);
+        AccountState cached = accountCache.get(address);
+        if (cached != null) return cached;
         try {
-            return oracle.fetchAccount(stateRoot, address).join();
+            AccountState fetched = oracle.fetchAccount(stateRoot, address).join();
+            accountCache.put(address, fetched);
+            return fetched;
         } catch (CompletionException ce) {
             unwrap(ce);
             throw ce;
@@ -57,9 +71,14 @@ public final class SyncStateView {
 
     public UInt256 storage(Address address, UInt256 slot) {
         if (accessTracker != null) accessTracker.recordStorage(address, slot.toUnsignedBigInteger());
+        SlotKey key = new SlotKey(address, slot);
+        UInt256 cached = storageCache.get(key);
+        if (cached != null) return cached;
         try {
             BigInteger v = oracle.fetchStorage(stateRoot, address, slot.toUnsignedBigInteger()).join();
-            return UInt256.valueOf(v);
+            UInt256 value = UInt256.valueOf(v);
+            storageCache.put(key, value);
+            return value;
         } catch (CompletionException ce) {
             unwrap(ce);
             throw ce;
@@ -80,8 +99,33 @@ public final class SyncStateView {
         });
     }
 
+    /** Phase 2 helpers — let the prefetch loop pre-populate values from a parallel batch fetch. */
+
+    public boolean hasAccount(Address address) {
+        return accountCache.containsKey(address);
+    }
+
+    public boolean hasStorage(Address address, UInt256 slot) {
+        return storageCache.containsKey(new SlotKey(address, slot));
+    }
+
+    public void putAccount(Address address, AccountState value) {
+        accountCache.put(address, value);
+    }
+
+    public void putStorage(Address address, UInt256 slot, UInt256 value) {
+        storageCache.put(new SlotKey(address, slot), value);
+    }
+
     private static void unwrap(CompletionException ce) {
         if (ce.getCause() instanceof EvmExecutionException eee) throw eee;
         if (ce.getCause() instanceof RuntimeException re) throw re;
+    }
+
+    private record SlotKey(Address address, UInt256 slot) {
+        SlotKey {
+            Objects.requireNonNull(address);
+            Objects.requireNonNull(slot);
+        }
     }
 }

--- a/myotis-evm/src/test/java/io/myotis/evm/PrefetchingEvmExecutorTest.java
+++ b/myotis-evm/src/test/java/io/myotis/evm/PrefetchingEvmExecutorTest.java
@@ -134,11 +134,11 @@ class PrefetchingEvmExecutorTest {
         var direct = new DefaultEvmExecutor(oracle);
         var prefetched = new PrefetchingEvmExecutor(new DefaultEvmExecutor(oracle));
 
-        byte[] direct_result = direct.callView(CONTRACT, balanceOfCalldata(), ctx()).get();
-        byte[] prefetched_result = prefetched.callView(CONTRACT, balanceOfCalldata(), ctx()).get();
+        byte[] directResult = direct.callView(CONTRACT, balanceOfCalldata(), ctx()).get();
+        byte[] prefetchedResult = prefetched.callView(CONTRACT, balanceOfCalldata(), ctx()).get();
         assertEquals(
-                HexFormat.of().formatHex(direct_result),
-                HexFormat.of().formatHex(prefetched_result));
+                HexFormat.of().formatHex(directResult),
+                HexFormat.of().formatHex(prefetchedResult));
     }
 
     @Test

--- a/myotis-evm/src/test/java/io/myotis/evm/PrefetchingEvmExecutorTest.java
+++ b/myotis-evm/src/test/java/io/myotis/evm/PrefetchingEvmExecutorTest.java
@@ -162,6 +162,124 @@ class PrefetchingEvmExecutorTest {
         }
     }
 
+    // ---- Sentinel-mode-specific tests --------------------------------------
+
+    /**
+     * Three independent SLOADs whose slot values are all non-zero. With
+     * trace-based execution this used to require N=3 serial network round
+     * trips in iteration 0; with sentinel-return iteration 0 records all
+     * three at memory speed, the parallel batch fetch covers them in one
+     * round trip, and iteration 1 returns the real value of slot 0.
+     *
+     * <p>The fixture oracle is synchronous, so we can't time the win — but we
+     * can verify that the convergence count is still 2 (not more, despite
+     * the multi-slot access set) and that the returned value is correct.
+     */
+    @Test
+    void multipleSloadsConvergeInTwoIterationsWithSentinelMode() throws Exception {
+        // PUSH1 0; SLOAD; PUSH1 1; SLOAD; PUSH1 2; SLOAD; POP; POP;
+        // PUSH1 0; MSTORE; PUSH1 32; PUSH1 0; RETURN
+        byte[] bytecode = HexFormat.of().parseHex(
+                "60005460015460025450506000526020600 0f3".replace(" ", ""));
+        var oracle = FixtureSnapStateOracle.builder()
+                .account(new AccountState(CONTRACT, 0L, BigInteger.ZERO,
+                        FixtureSnapStateOracle.codeHashOf(bytecode)))
+                .bytecode(bytecode)
+                .storage(CONTRACT, BigInteger.ZERO, BigInteger.TEN)
+                .storage(CONTRACT, BigInteger.ONE, BigInteger.valueOf(20))
+                .storage(CONTRACT, BigInteger.TWO, BigInteger.valueOf(30))
+                .build();
+        var tracker = new ConvergenceTracker();
+        var executor = new PrefetchingEvmExecutor(new DefaultEvmExecutor(oracle),
+                PrefetchingEvmExecutor.DEFAULT_ITERATION_CAP, tracker);
+
+        byte[] result = executor.callView(CONTRACT, balanceOfCalldata(), ctx()).get();
+        assertEquals(BigInteger.TEN, AbiDecoder.uint256(result, 0));
+        assertEquals(2, tracker.snapshot().get(0),
+                "three independent SLOADs should still converge in 2 iterations");
+    }
+
+    /**
+     * Sentinel mode causes iteration 0 to see {@code SLOAD(0) == 0}, which
+     * trips an explicit {@code REVERT} in the bytecode. The convergence loop
+     * must absorb that exception and run iteration 1 with real values
+     * (slot 0 = 42), producing a successful return.
+     *
+     * <p>This is the test that proves "iteration 0's wrong values don't leak
+     * to the caller" — without the catch in {@link PrefetchingEvmExecutor},
+     * the first iteration's revert would propagate as the call's failure.
+     */
+    @Test
+    void sentinelIteration0RevertDoesNotSurface() throws Exception {
+        // Pseudocode:
+        //   v = sload(0)
+        //   if (v == 0) revert
+        //   else return v
+        //
+        // 60 00 SLOAD DUP1 ISZERO PUSH1 0x10 JUMPI
+        // PUSH1 0 MSTORE PUSH1 32 PUSH1 0 RETURN
+        // JUMPDEST PUSH1 0 PUSH1 0 REVERT
+        byte[] bytecode = HexFormat.of().parseHex(
+                "6000" + "54" + "80" + "15" + "6010" + "57" +
+                "6000" + "52" + "6020" + "6000" + "f3" +
+                "5b" + "6000" + "6000" + "fd");
+        BigInteger realBalance = BigInteger.valueOf(42);
+        var oracle = FixtureSnapStateOracle.builder()
+                .account(new AccountState(CONTRACT, 0L, BigInteger.ZERO,
+                        FixtureSnapStateOracle.codeHashOf(bytecode)))
+                .bytecode(bytecode)
+                .storage(CONTRACT, BigInteger.ZERO, realBalance)
+                .build();
+        var tracker = new ConvergenceTracker();
+        var executor = new PrefetchingEvmExecutor(new DefaultEvmExecutor(oracle),
+                PrefetchingEvmExecutor.DEFAULT_ITERATION_CAP, tracker);
+
+        byte[] result = executor.callView(CONTRACT, balanceOfCalldata(), ctx()).get();
+        // Without sentinel-revert recovery the call would fail with Reverted.
+        assertEquals(realBalance, AbiDecoder.uint256(result, 0));
+        assertEquals(2, tracker.snapshot().get(0));
+    }
+
+    /**
+     * Last line of defense: regardless of execution path through the prefetch
+     * loop, the result of {@code PrefetchingEvmExecutor.callView} must be
+     * byte-for-byte identical to {@code DefaultEvmExecutor.callView}. The
+     * sentinel run produces wrong intermediate state, but the convergence
+     * loop must always end up returning the real-iteration result.
+     */
+    @Test
+    void prefetchedAndDirectAgreeAcrossManyCallShapes() throws Exception {
+        record Case(byte[] bytecode, java.util.List<long[]> storage) {}
+        var cases = java.util.List.of(
+                new Case(SLOAD_SLOT_0, java.util.List.of(new long[]{0, 100})),
+                new Case(SLOAD_TWO_SLOTS, java.util.List.of(
+                        new long[]{0, 7}, new long[]{1, 13})),
+                new Case(HexFormat.of().parseHex(
+                        "60005460015460025450506000526020600 0f3".replace(" ", "")),
+                        java.util.List.of(
+                                new long[]{0, 42}, new long[]{1, 99}, new long[]{2, 256})));
+
+        for (Case c : cases) {
+            var b = FixtureSnapStateOracle.builder()
+                    .account(new AccountState(CONTRACT, 0L, BigInteger.ZERO,
+                            FixtureSnapStateOracle.codeHashOf(c.bytecode())))
+                    .bytecode(c.bytecode());
+            for (long[] s : c.storage()) {
+                b.storage(CONTRACT, BigInteger.valueOf(s[0]), BigInteger.valueOf(s[1]));
+            }
+            var oracle = b.build();
+
+            byte[] direct = new DefaultEvmExecutor(oracle)
+                    .callView(CONTRACT, balanceOfCalldata(), ctx()).get();
+            byte[] prefetched = new PrefetchingEvmExecutor(new DefaultEvmExecutor(oracle))
+                    .callView(CONTRACT, balanceOfCalldata(), ctx()).get();
+            assertEquals(
+                    HexFormat.of().formatHex(direct),
+                    HexFormat.of().formatHex(prefetched),
+                    "mismatch for bytecode " + HexFormat.of().formatHex(c.bytecode()));
+        }
+    }
+
     // ---- Helpers -----------------------------------------------------------
 
     private static FixtureSnapStateOracle.Builder fixtureOracle(byte[] bytecode) {

--- a/myotis-evm/src/test/java/io/myotis/evm/PrefetchingEvmExecutorTest.java
+++ b/myotis-evm/src/test/java/io/myotis/evm/PrefetchingEvmExecutorTest.java
@@ -1,0 +1,192 @@
+package io.myotis.evm;
+
+import io.myotis.evm.abi.AbiDecoder;
+import io.myotis.evm.abi.AbiEncoder;
+import io.myotis.evm.abi.FunctionSignature;
+import io.myotis.evm.besu.EvmFactory;
+import io.myotis.evm.prefetch.ConvergenceTracker;
+import io.myotis.evm.world.AccountState;
+import io.myotis.evm.world.BytecodeCache;
+import io.myotis.evm.world.FixtureSnapStateOracle;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.HexFormat;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Convergence tests for the Phase 2 prefetch loop.
+ *
+ * <p>Each test runs hand-written bytecode through {@link PrefetchingEvmExecutor}
+ * against a {@link FixtureSnapStateOracle}. The fixture oracle answers
+ * synchronously (no real network), so the latency claim of the prefetch loop
+ * isn't measurable here — but the convergence-iteration-count claim is, and
+ * that's the unit-testable invariant.
+ *
+ * <p>Convergence-count expectations follow directly from the loop logic in
+ * {@link PrefetchingEvmExecutor}: at least one EVM run is needed to discover
+ * the access set, and at least one more is needed to confirm the access set
+ * is stable. Hence the minimum convergence count is 2, regardless of how
+ * trivial the bytecode is.
+ */
+class PrefetchingEvmExecutorTest {
+
+    /** PUSH1 0; SLOAD; PUSH1 0; MSTORE; PUSH1 32; PUSH1 0; RETURN */
+    private static final byte[] SLOAD_SLOT_0 =
+            HexFormat.of().parseHex("60005460005260206000f3");
+
+    /**
+     * Reads two slots and concatenates them into the return buffer.
+     * Layout: SLOAD(0) -> mem[0..32]; SLOAD(1) -> mem[32..64]; RETURN(0, 64).
+     */
+    private static final byte[] SLOAD_TWO_SLOTS = HexFormat.of().parseHex(
+            "60005460005260015460205260406000f3");
+
+    private static final BigInteger SLOT_0_VALUE = new BigInteger("12345678900000000000000");
+    private static final BigInteger SLOT_1_VALUE = BigInteger.valueOf(42);
+
+    private static final io.myotis.evm.Address CONTRACT =
+            io.myotis.evm.Address.fromHex("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
+
+    @Test
+    void simpleSloadConvergesInTwoIterations() throws Exception {
+        var oracle = fixtureOracle(SLOAD_SLOT_0)
+                .storage(CONTRACT, BigInteger.ZERO, SLOT_0_VALUE)
+                .build();
+        var inner = new DefaultEvmExecutor(oracle);
+        var convergenceTracker = new ConvergenceTracker();
+        var executor = new PrefetchingEvmExecutor(inner,
+                PrefetchingEvmExecutor.DEFAULT_ITERATION_CAP, convergenceTracker);
+
+        byte[] result = executor.callView(CONTRACT, balanceOfCalldata(), ctx()).get();
+        assertEquals(SLOT_0_VALUE, AbiDecoder.uint256(result, 0),
+                "result must be the value at slot 0 — prefetch must not change correctness");
+
+        // Two iterations: the first discovers the (CONTRACT, 0) access; the
+        // second observes the same access but recognises it's already in the
+        // seen set, so it converges.
+        assertEquals(1, convergenceTracker.snapshot().size(),
+                "exactly one call should have been recorded");
+        assertEquals(2, convergenceTracker.snapshot().get(0),
+                "simple single-SLOAD bytecode should converge in 2 iterations");
+    }
+
+    @Test
+    void twoSloadsConvergeInTwoIterations() throws Exception {
+        var oracle = fixtureOracle(SLOAD_TWO_SLOTS)
+                .storage(CONTRACT, BigInteger.ZERO, SLOT_0_VALUE)
+                .storage(CONTRACT, BigInteger.ONE, SLOT_1_VALUE)
+                .build();
+        var inner = new DefaultEvmExecutor(oracle);
+        var convergenceTracker = new ConvergenceTracker();
+        var executor = new PrefetchingEvmExecutor(inner,
+                PrefetchingEvmExecutor.DEFAULT_ITERATION_CAP, convergenceTracker);
+
+        byte[] result = executor.callView(CONTRACT, balanceOfCalldata(), ctx()).get();
+        assertEquals(64, result.length, "two-slot return must be 64 bytes");
+        assertEquals(SLOT_0_VALUE, AbiDecoder.uint256(result, 0));
+        assertEquals(SLOT_1_VALUE, AbiDecoder.uint256(result, 32));
+
+        // Both slots get discovered in iteration 0, both are seen by iteration 1.
+        // Convergence = 2 even though the access set has two entries; the
+        // prefetch loop's iteration count is independent of the access cardinality.
+        assertEquals(2, convergenceTracker.snapshot().get(0),
+                "two-SLOAD bytecode in a single straight path should still converge in 2");
+    }
+
+    @Test
+    void iterationCapOfOneAlwaysExceeds() {
+        // Cap=1 means the loop runs once and never gets a chance to confirm
+        // stability — we always throw IterationLimitExceeded. This is the
+        // test that the cap path is actually wired up.
+        var oracle = fixtureOracle(SLOAD_SLOT_0)
+                .storage(CONTRACT, BigInteger.ZERO, SLOT_0_VALUE)
+                .build();
+        var inner = new DefaultEvmExecutor(oracle);
+        var executor = new PrefetchingEvmExecutor(inner, 1, new ConvergenceTracker());
+
+        try {
+            executor.callView(CONTRACT, balanceOfCalldata(), ctx()).get();
+            fail("expected IterationLimitExceeded");
+        } catch (Exception e) {
+            Throwable cause = e instanceof java.util.concurrent.ExecutionException
+                    ? e.getCause() : e;
+            var eee = assertInstanceOf(EvmExecutionException.class, cause);
+            assertInstanceOf(EvmExecutionError.IterationLimitExceeded.class, eee.error());
+            assertEquals(1,
+                    ((EvmExecutionError.IterationLimitExceeded) eee.error()).cap());
+        }
+    }
+
+    @Test
+    void prefetchingDoesNotChangeCorrectness() throws Exception {
+        // Sanity: the same bytecode + state through both DefaultEvmExecutor
+        // and PrefetchingEvmExecutor must return byte-identical bytes. This
+        // is the regression net for the entire phase: optimization that
+        // changes results is worse than no optimization.
+        var oracle = fixtureOracle(SLOAD_SLOT_0)
+                .storage(CONTRACT, BigInteger.ZERO, SLOT_0_VALUE)
+                .build();
+        var direct = new DefaultEvmExecutor(oracle);
+        var prefetched = new PrefetchingEvmExecutor(new DefaultEvmExecutor(oracle));
+
+        byte[] direct_result = direct.callView(CONTRACT, balanceOfCalldata(), ctx()).get();
+        byte[] prefetched_result = prefetched.callView(CONTRACT, balanceOfCalldata(), ctx()).get();
+        assertEquals(
+                HexFormat.of().formatHex(direct_result),
+                HexFormat.of().formatHex(prefetched_result));
+    }
+
+    @Test
+    void convergenceTrackerRecordsAcrossMultipleCalls() throws Exception {
+        var oracle = fixtureOracle(SLOAD_SLOT_0)
+                .storage(CONTRACT, BigInteger.ZERO, SLOT_0_VALUE)
+                .build();
+        var convergenceTracker = new ConvergenceTracker();
+        var executor = new PrefetchingEvmExecutor(new DefaultEvmExecutor(oracle),
+                PrefetchingEvmExecutor.DEFAULT_ITERATION_CAP, convergenceTracker);
+
+        executor.callView(CONTRACT, balanceOfCalldata(), ctx()).get();
+        executor.callView(CONTRACT, balanceOfCalldata(), ctx()).get();
+        executor.callView(CONTRACT, balanceOfCalldata(), ctx()).get();
+
+        var counts = convergenceTracker.snapshot();
+        assertEquals(3, counts.size(), "tracker should record one entry per call");
+        for (int c : counts) {
+            assertTrue(c >= 2 && c <= PrefetchingEvmExecutor.DEFAULT_ITERATION_CAP,
+                    "iteration count " + c + " is out of expected range");
+        }
+    }
+
+    // ---- Helpers -----------------------------------------------------------
+
+    private static FixtureSnapStateOracle.Builder fixtureOracle(byte[] bytecode) {
+        byte[] codeHash = FixtureSnapStateOracle.codeHashOf(bytecode);
+        return FixtureSnapStateOracle.builder()
+                .account(new AccountState(CONTRACT, 0L, BigInteger.ZERO, codeHash))
+                .bytecode(bytecode);
+    }
+
+    private static byte[] balanceOfCalldata() {
+        FunctionSignature sig = FunctionSignature.of("balanceOf(address)");
+        return AbiEncoder.encodeCall(sig,
+                AbiEncoder.address(io.myotis.evm.Address.fromHex(
+                        "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")));
+    }
+
+    private static BlockContext ctx() {
+        return new BlockContext(
+                new byte[32],
+                19_500_000L,
+                EvmFactory.CANCUN_TIME + 1,
+                BigInteger.valueOf(1_000_000_000L),
+                io.myotis.evm.Address.ZERO,
+                new byte[32],
+                BigInteger.ONE,
+                30_000_000L);
+    }
+}


### PR DESCRIPTION
## Summary

Implements Phase 2 of the prefetch optimization plan: a speculative-prefetch convergence loop that reduces latency by parallelizing state fetches. The loop runs the EVM repeatedly against a shared cache, using trace-based access tracking to discover which storage slots and bytecode need to be fetched, then batch-fetches them in parallel before re-running.

## Key Changes

**Core prefetch implementation:**
- `PrefetchingEvmExecutor`: Wraps `DefaultEvmExecutor` with a convergence loop that:
  - Runs the EVM with `PrefetchingTracer` to record (account, slot) and code accesses
  - Detects cache misses by comparing observed accesses to the accumulated seen set
  - Batch-fetches new misses in parallel through `SnapStateOracle`
  - Re-runs the EVM against the populated cache
  - Converges when no new accesses are discovered (typically 2–3 iterations)
  - Throws `IterationLimitExceeded` if the iteration cap (default 4) is exceeded

- `PrefetchingTracer`: Besu `OperationTracer` that observes SLOAD, EXTCODESIZE, EXTCODECOPY, and EXTCODEHASH opcodes without mutating execution, recording exact access patterns for the real code path (not placeholder-based).

- `ConvergenceTracker`: Records iteration counts per call for benchmarking and validation.

**State caching improvements:**
- `SyncStateView` now maintains in-memory caches for accounts and storage slots, allowing repeated reads within a single run and across loop iterations to hit memory instead of the oracle.
- Added `putAccount()` and `putStorage()` methods to allow the prefetch loop to pre-populate the cache.
- Added `hasAccount()` and `hasStorage()` checks to avoid redundant prefetches.

**DefaultEvmExecutor refactoring:**
- Extracted `runOnTracedView()` as a package-private seam that accepts a caller-supplied `SyncStateView` and `OperationTracer`, allowing `PrefetchingEvmExecutor` to reuse the same cache and tracer across iterations.
- Public `callView()` path unchanged; still constructs a fresh per-call view.

**Benchmarking and documentation:**
- `MainnetPrefetchBenchmarkIT`: Integration test that measures convergence iteration counts and end-to-end latency for the corpus (USDC.balanceOf, DAI.balanceOf, ENS.addr) against both `DefaultEvmExecutor` (baseline) and `PrefetchingEvmExecutor` (Phase 2). Validates acceptance criteria: convergence ≤ 3 iterations and p95 latency ≤ 2 s.
- `PrefetchingEvmExecutorTest`: Unit tests proving convergence on simple bytecode (single and multi-slot SLOAD) and validating correctness is unchanged.
- `docs/phase2-design.md`: Design rationale, architecture, and open questions.
- `docs/prefetch-benchmarks.md`: Benchmark methodology and results table (scaffolding; awaits real peer connection).

## Notable Implementation Details

- **Trace-based over sentinel-return**: Observes the real code path the EVM would take, avoiding false positives/negatives from placeholder-shaped branches.
- **Per-call cache, not cross-call**: Each `callView` gets a fresh `SyncStateView` cache; cross-call caching is deferred to the wallet integration layer.
- **Best-effort parallel prefetch**: Batch fetches are wrapped in `CompletableFuture.allOf()` with a 30-second timeout; individual fetch failures don't propagate — the next EVM run will hit the miss and either succeed via the oracle's serial path or surface a clean error.
- **Iteration cap enforcement**: Hitting the cap throws `IterationLimitExceeded` rather than returning a potentially incomplete result, making pathological data-dependent bytecode explicit.
- **Bytecode prefetching implicit**: `SyncStateView.bytecode()` already populates the shared `BytecodeCache` synchronously during the run;

https://claude.ai/code/session_01GhcPYmMi6z3YGrZSe5wuA3