### PR TITLE
phase4: CCIP-Read (ERC-3668) — handler refactor + executor decorator

### DIFF
--- a/docs/phase4-design.md
+++ b/docs/phase4-design.md
@@ -52,20 +52,43 @@ This mirrors the `SnapPeer` decoupling pattern in `:myotis-evm`:
 `:myotis-evm` doesn't depend on `:networking`; the wallet integration
 provides the bridge.
 
-### Wiring into `DefaultEvmExecutor.callView`
+### Wiring into the EVM call path
+
+CCIP-Read is wired in via a decorator, **not** baked into
+`DefaultEvmExecutor`. `CcipReadEvmExecutor` wraps any `EvmExecutor`
+(Default, Prefetching, etc.) and intercepts `OffchainLookup` reverts at
+the call boundary. Wallet stack:
+
+```java
+new CcipReadEvmExecutor(
+    new PrefetchingEvmExecutor(
+        new DefaultEvmExecutor(oracle)),
+    new CcipReadHandler(gateway))
+```
+
+The handler chain is fully async — no `.join()` anywhere — so the
+gateway transport's network IO never blocks the EVM executor's thread
+pool.
 
 ```
-DefaultEvmExecutor.callView(target, calldata, ctx)
-  result = runOnTracedView(...)         // existing path
-  catch EvmExecutionException(Reverted(data)):
-    parsed = OffchainLookupRevert.tryParse(data)
-    if parsed.isEmpty(): rethrow         // not CCIP-Read; bubble up
-    if depth >= MAX_RECURSION_DEPTH: rethrow CcipGatewayFailed
-    response = ccipGateway.request(...)  // (parsed.urls, parsed.callData, parsed.sender)
-    callback = parsed.callbackSelector || abi.encode(response, parsed.extraData)
-    // Re-enter against the original sender, depth+1
-    return callView(parsed.sender, callback, ctx, depth+1)
+CcipReadEvmExecutor.tryWithCcipRead(target, calldata, ctx, depth):
+  delegate.callView(target, calldata, ctx)
+    .exceptionallyCompose(error ->
+      lookup = OffchainLookupRevert.tryParse(reverteddata(error))
+      if lookup absent:    return failedFuture(error)        // not CCIP-Read
+      if depth >= MAX_RECURSION_DEPTH:
+                           return failedFuture(CcipGatewayFailed(...))
+      handler.handle(lookup)                                  // async
+        .thenCompose(response ->
+          callback = lookup.callbackSelector
+                  || abi.encode(response, lookup.extraData)
+          tryWithCcipRead(lookup.sender, callback, ctx, depth+1)))
 ```
+
+URLs are tried serially inside `handler.handle` (composed via
+`thenCompose` recursion), not in parallel — ERC-3668 wants the first
+listed URL to win when it can, and parallel fan-out would mask
+diagnostic information about specific gateway problems.
 
 The depth cap is plan-mandated at 1 — the spec allows nested
 OffchainLookup reverts, but no real resolver does it, and capping is a

--- a/docs/phase4-design.md
+++ b/docs/phase4-design.md
@@ -1,0 +1,125 @@
+# Phase 4 — CCIP-Read (ERC-3668)
+
+Phase 3 ships forward + reverse ENS resolution for classic on-chain
+names. Phase 4 makes modern ENS work — Coinbase IDs (`*.cb.id`),
+Uniswap names (`*.uni.eth`), Base subnames (`*.base.eth`), and
+generally any name whose resolver delegates lookups off-chain via
+ERC-3668.
+
+> **Scope:** make `EnsResolver.resolveAddress("someone.cb.id")` work.
+> Generic `eth_call` exposing CCIP-Read at the public API surface is
+> deliberately out of scope (the plan calls for a narrow surface — only
+> `callView` and `estimateGas`).
+
+## Acceptance criteria (from the original plan)
+
+- CCIP-Read handler with URL template substitution and GET/POST routing.
+- Universal Resolver path enabled in `EnsResolver`.
+- Modern ENS test corpus passes:
+  - A `.cb.id` name resolves
+  - A `.uni.eth` name resolves
+  - A Base subdomain resolves
+
+## What's already in place from earlier phases
+
+`OffchainLookupRevert` (parser for the ERC-3668 revert payload) and a
+`CcipReadHandler` skeleton already shipped in Phase 0. The handler
+currently uses `java.net.http.HttpClient`, which is documented in
+`CLAUDE.md` as not Android-safe. Phase 4 refactors it.
+
+## Design
+
+### HTTP client decoupling
+
+`CcipReadHandler` currently embeds `java.net.http.HttpClient`. Two
+problems:
+
+- That package is API 33+ on Android and not in the desugar set, so the
+  handler crashes at runtime on `minSdk = 29` devices.
+- `CLAUDE.md` mandates Ktor for HTTP, since Ktor is Multiplatform-ready.
+
+Pulling Ktor into `:myotis-evm` is a substantial dep-graph addition
+(Kotlin runtime + coroutines). **Phase 4 sidesteps the question**: the
+handler is refactored to take a `CcipGateway` interface — a small SAM-
+shape `(method, url, body) → CompletableFuture<String>`. The handler
+does URL template substitution, body construction, and JSON parsing;
+the actual HTTP transport is supplied by the caller. Tests use an
+in-memory implementation that returns hardcoded responses; the
+production implementation lives in `:app` (or wherever the Android
+wiring sits) and uses Ktor.
+
+This mirrors the `SnapPeer` decoupling pattern in `:myotis-evm`:
+`:myotis-evm` doesn't depend on `:networking`; the wallet integration
+provides the bridge.
+
+### Wiring into `DefaultEvmExecutor.callView`
+
+```
+DefaultEvmExecutor.callView(target, calldata, ctx)
+  result = runOnTracedView(...)         // existing path
+  catch EvmExecutionException(Reverted(data)):
+    parsed = OffchainLookupRevert.tryParse(data)
+    if parsed.isEmpty(): rethrow         // not CCIP-Read; bubble up
+    if depth >= MAX_RECURSION_DEPTH: rethrow CcipGatewayFailed
+    response = ccipGateway.request(...)  // (parsed.urls, parsed.callData, parsed.sender)
+    callback = parsed.callbackSelector || abi.encode(response, parsed.extraData)
+    // Re-enter against the original sender, depth+1
+    return callView(parsed.sender, callback, ctx, depth+1)
+```
+
+The depth cap is plan-mandated at 1 — the spec allows nested
+OffchainLookup reverts, but no real resolver does it, and capping is a
+defensive property against gateway loops.
+
+### Universal Resolver path
+
+The plan says "switch `EnsResolver` to use the Universal Resolver path
+now that CCIP-Read is supported." The UR's `resolve(name, data)` method
+takes a DNS-encoded name and ABI-encoded inner-call data, and handles
+wildcard resolution + CCIP-Read in one place. `EnsResolver` becomes:
+
+```
+ur.resolve(dnsEncode("vitalik.eth"),
+           abi.encode(addr.selector, namehash("vitalik.eth")))
+```
+
+One callView instead of two. CCIP-Read happens transparently inside the
+UR's bytecode, surfacing as the normal `OffchainLookup` revert that the
+Phase 4 executor handles.
+
+A new `DnsEncoder` helper produces the DNS wire format
+(length-prefixed labels + null terminator). Reusable; small (~30 lines).
+
+### What this branch will ship
+
+This is a multi-commit phase:
+
+- **Commit 1** (this commit): refactor `CcipReadHandler` around a
+  `CcipGateway` interface, wire CCIP-Read into `DefaultEvmExecutor`
+  with the 1-hop cap, end-to-end tests using bytecode that reverts
+  with the `OffchainLookup` selector.
+- **Commit 2**: `DnsEncoder`, `EnsResolver` UR path, mainnet IT corpus
+  expansion to include `.cb.id`/`.uni.eth`/`.base.eth`.
+- **Commit 3 (optional)**: Ktor `CcipGateway` implementation in a
+  separate module (probably `:myotis-ens-impl` or in `:app`'s wiring).
+
+## Out of scope
+
+- Generic `eth_call` exposed via the public API. The narrow surface is
+  intentional.
+- Tor routing for CCIP-Read gateways (privacy concern documented in
+  `CcipReadHandler`'s Javadoc; future phase).
+- Caching gateway responses across calls. Each `callView` re-fetches
+  unless the wallet integration adds a layer.
+
+## Privacy note
+
+CCIP-Read gateways necessarily learn:
+- The user's IP address.
+- The queried name (because the request includes its callData).
+- Approximate request timing.
+
+Documenting this on `EvmExecutor.callView` and on `CcipReadHandler` so
+consumers understand the trade-off before turning on resolution for
+gateway-based names. Tor routing is a separate piece of work tracked
+in the wallet's privacy roadmap.

--- a/myotis-ens/src/integrationTest/java/io/myotis/ens/integration/MainnetEnsResolutionIT.java
+++ b/myotis-ens/src/integrationTest/java/io/myotis/ens/integration/MainnetEnsResolutionIT.java
@@ -3,8 +3,11 @@ package io.myotis.ens.integration;
 import io.myotis.ens.EnsResolver;
 import io.myotis.evm.Address;
 import io.myotis.evm.BlockContext;
+import io.myotis.evm.CcipReadEvmExecutor;
 import io.myotis.evm.DefaultEvmExecutor;
 import io.myotis.evm.PrefetchingEvmExecutor;
+import io.myotis.evm.ccipread.CcipGateway;
+import io.myotis.evm.ccipread.CcipReadHandler;
 import io.myotis.evm.world.BytecodeCache;
 import io.myotis.evm.world.SnapBackedStateOracle;
 import io.myotis.evm.world.SnapPeer;
@@ -12,9 +15,17 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 import java.math.BigInteger;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.HexFormat;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -84,6 +95,41 @@ class MainnetEnsResolutionIT {
         assertEquals("vitalik.eth", name.get());
     }
 
+    /**
+     * CCIP-Read corpus: names whose resolvers delegate to off-chain
+     * gateways via ERC-3668. These work only when the executor is
+     * wrapped in {@link CcipReadEvmExecutor} and a working
+     * {@link CcipGateway} is plumbed in.
+     *
+     * <p>Specific addresses aren't pinned because gateway-served records
+     * can change without an on-chain transaction. The smoke test just
+     * verifies the names resolve to <em>some</em> non-empty address
+     * within the timeout.
+     */
+    private static final List<String> CCIP_READ_CORPUS = List.of(
+            // Coinbase IDs (resolver delegates to a Coinbase gateway).
+            "ens.cb.id",
+            // Uniswap names (resolver uses Uniswap's CCIP-Read gateway).
+            "ens.uni.eth",
+            // Base subnames (resolver uses Base's gateway).
+            "ens.base.eth");
+
+    @Test
+    void ccipReadNamesResolve() throws Exception {
+        EnsResolver resolver = mainnetResolver();
+        BlockContext ctx = mainnetBlockContext();
+
+        for (String name : CCIP_READ_CORPUS) {
+            Optional<Address> resolved = resolver.resolveAddress(name, ctx)
+                    .get(120, TimeUnit.SECONDS);
+            assertTrue(resolved.isPresent(),
+                    "CCIP-Read resolution returned empty for " + name
+                            + " — gateway may have rotated, name unregistered, "
+                            + "or CCIP-Read flow is broken");
+            System.out.printf("[ens-it] %-24s -> %s%n", name, resolved.get().toHex());
+        }
+    }
+
     @Test
     void absentNameReturnsEmpty() throws Exception {
         EnsResolver resolver = mainnetResolver();
@@ -109,9 +155,47 @@ class MainnetEnsResolutionIT {
                     t.setDaemon(true);
                     return t;
                 }));
-        // Use the prefetcher — Phase 3 is a Phase-2 consumer.
-        var executor = new PrefetchingEvmExecutor(inner);
-        return new EnsResolver(executor);
+        // Stack: prefetch on the inside, CCIP-Read on the outside. Order
+        // matters — CCIP-Read needs to observe OffchainLookup reverts at
+        // the call boundary, which only the outer wrapper sees.
+        var prefetched = new PrefetchingEvmExecutor(inner);
+        var ccipReady = new CcipReadEvmExecutor(prefetched,
+                new CcipReadHandler(new JavaHttpCcipGateway()));
+        return new EnsResolver(ccipReady);
+    }
+
+    /**
+     * IT-only {@link CcipGateway} backed by {@code java.net.http.HttpClient}.
+     * The wallet's Android-side implementation will use Ktor per
+     * {@code CLAUDE.md}'s platform direction; this one is fine for the
+     * JVM integration test which only runs on developer/CI machines, not
+     * on Android.
+     */
+    private static final class JavaHttpCcipGateway implements CcipGateway {
+        private final HttpClient client = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(10))
+                .build();
+
+        @Override
+        public CompletableFuture<String> request(Method method, String url, String body) {
+            HttpRequest.Builder builder = HttpRequest.newBuilder(URI.create(url))
+                    .timeout(Duration.ofSeconds(15))
+                    .header("Accept", "application/json");
+            HttpRequest request = (method == Method.POST)
+                    ? builder.header("Content-Type", "application/json")
+                            .POST(HttpRequest.BodyPublishers.ofString(
+                                    body == null ? "" : body, StandardCharsets.UTF_8))
+                            .build()
+                    : builder.GET().build();
+            return client.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+                    .thenApply(response -> {
+                        if (response.statusCode() / 100 != 2) {
+                            throw new RuntimeException("gateway " + url
+                                    + " returned status " + response.statusCode());
+                        }
+                        return response.body();
+                    });
+        }
     }
 
     private static SnapPeer connectToMainnetPeer() {

--- a/myotis-ens/src/main/java/io/myotis/ens/DnsEncoder.java
+++ b/myotis-ens/src/main/java/io/myotis/ens/DnsEncoder.java
@@ -31,7 +31,13 @@ public final class DnsEncoder {
      * Encode {@code name} into DNS wire format. Returns a single null byte
      * for the empty string (the root domain).
      *
-     * @throws IllegalArgumentException if any label exceeds 63 bytes.
+     * <p>Rejects names with empty labels — {@code "a..b"}, {@code "..eth"},
+     * etc. The trailing-dot form {@code "vitalik.eth."} (FQDN-style) is
+     * accepted by stripping the trailing dot, since it's a common convention
+     * and unambiguously equivalent to the bare form.
+     *
+     * @throws IllegalArgumentException if any label is empty (other than the
+     *         implicit root) or exceeds 63 bytes.
      */
     public static byte[] encode(String name) {
         if (name == null || name.isEmpty()) {
@@ -40,6 +46,16 @@ public final class DnsEncoder {
         // Lower-case for consistency with Namehash; ENSIP-1 normalisation
         // is a separate concern (UTS-46 / IDNA) tracked elsewhere.
         String lower = name.toLowerCase(java.util.Locale.ROOT);
+        // FQDN form ("vitalik.eth.") is accepted by stripping the trailing
+        // dot — semantically equivalent to the bare form, but the split
+        // would otherwise produce a spurious empty label and an invalid
+        // double-zero terminator on the wire.
+        if (lower.endsWith(".")) {
+            lower = lower.substring(0, lower.length() - 1);
+        }
+        if (lower.isEmpty()) {
+            return new byte[]{0x00};
+        }
         String[] labels = lower.split("\\.", -1);
 
         // Compute total size: each label is 1 byte length + N bytes of UTF-8,
@@ -47,10 +63,18 @@ public final class DnsEncoder {
         int total = 1; // terminator
         byte[][] encodedLabels = new byte[labels.length][];
         for (int i = 0; i < labels.length; i++) {
-            byte[] labelBytes = labels[i].getBytes(StandardCharsets.UTF_8);
+            String label = labels[i];
+            if (label.isEmpty()) {
+                // Per RFC 1035, only the final root label may be zero-length.
+                // Empty labels in the middle / start come from inputs like
+                // "a..b" or ".eth"; both are not valid DNS names.
+                throw new IllegalArgumentException(
+                        "DNS name contains an empty label: " + name);
+            }
+            byte[] labelBytes = label.getBytes(StandardCharsets.UTF_8);
             if (labelBytes.length > MAX_LABEL_LENGTH) {
                 throw new IllegalArgumentException(
-                        "DNS label exceeds " + MAX_LABEL_LENGTH + " bytes: " + labels[i]);
+                        "DNS label exceeds " + MAX_LABEL_LENGTH + " bytes: " + label);
             }
             encodedLabels[i] = labelBytes;
             total += 1 + labelBytes.length;

--- a/myotis-ens/src/main/java/io/myotis/ens/DnsEncoder.java
+++ b/myotis-ens/src/main/java/io/myotis/ens/DnsEncoder.java
@@ -1,0 +1,69 @@
+package io.myotis.ens;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * DNS wire-format encoder for ENS names per ENSIP-10.
+ *
+ * <p>The Universal Resolver and ENSIP-10 wildcard resolvers consume names
+ * in the canonical DNS wire format: each label is preceded by its
+ * one-byte length, terminated by a zero-length root label. Labels
+ * themselves must be ≤ 63 bytes (DNS label limit).
+ *
+ * <p>Examples:
+ * <ul>
+ *   <li>{@code "vitalik.eth"} → {@code 07 76 69 74 61 6c 69 6b 03 65 74 68 00}
+ *   <li>{@code ""} → {@code 00}
+ *   <li>{@code "a.b.c"} → {@code 01 61 01 62 01 63 00}
+ * </ul>
+ *
+ * <p>Per ENSIP-10, dots in a label (escaped via the encoded form
+ * {@code "..."}) are out of scope for now — the encoder splits on
+ * literal dots and assumes labels contain none.
+ */
+public final class DnsEncoder {
+
+    private static final int MAX_LABEL_LENGTH = 63;
+
+    private DnsEncoder() {}
+
+    /**
+     * Encode {@code name} into DNS wire format. Returns a single null byte
+     * for the empty string (the root domain).
+     *
+     * @throws IllegalArgumentException if any label exceeds 63 bytes.
+     */
+    public static byte[] encode(String name) {
+        if (name == null || name.isEmpty()) {
+            return new byte[]{0x00};
+        }
+        // Lower-case for consistency with Namehash; ENSIP-1 normalisation
+        // is a separate concern (UTS-46 / IDNA) tracked elsewhere.
+        String lower = name.toLowerCase(java.util.Locale.ROOT);
+        String[] labels = lower.split("\\.", -1);
+
+        // Compute total size: each label is 1 byte length + N bytes of UTF-8,
+        // plus the final zero terminator.
+        int total = 1; // terminator
+        byte[][] encodedLabels = new byte[labels.length][];
+        for (int i = 0; i < labels.length; i++) {
+            byte[] labelBytes = labels[i].getBytes(StandardCharsets.UTF_8);
+            if (labelBytes.length > MAX_LABEL_LENGTH) {
+                throw new IllegalArgumentException(
+                        "DNS label exceeds " + MAX_LABEL_LENGTH + " bytes: " + labels[i]);
+            }
+            encodedLabels[i] = labelBytes;
+            total += 1 + labelBytes.length;
+        }
+
+        byte[] out = new byte[total];
+        int p = 0;
+        for (byte[] labelBytes : encodedLabels) {
+            out[p++] = (byte) labelBytes.length;
+            System.arraycopy(labelBytes, 0, out, p, labelBytes.length);
+            p += labelBytes.length;
+        }
+        out[p] = 0x00;
+        return out;
+    }
+}

--- a/myotis-ens/src/main/java/io/myotis/ens/EnsAddresses.java
+++ b/myotis-ens/src/main/java/io/myotis/ens/EnsAddresses.java
@@ -20,4 +20,23 @@ public final class EnsAddresses {
      */
     public static final Address MAINNET_REGISTRY =
             Address.fromHex("0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e");
+
+    /**
+     * Mainnet ENS Universal Resolver (ENSIP-10 + CCIP-Read aware). The UR
+     * walks the registry/resolver chain in a single call and supports
+     * wildcard resolution, which is what most modern ENS surfaces (Coinbase
+     * names, Uniswap names, Base subnames) rely on. Without it,
+     * step-by-step calls to {@code resolver.addr(node)} return zero for
+     * wildcard names because the wildcard resolver only implements
+     * {@code resolve(bytes name, bytes data)}, not the per-name accessors.
+     *
+     * <p>The address pinned here is the ENS Labs deployment current at the
+     * time of writing. The UR is occasionally redeployed when new ENSIPs
+     * land; consumers can pass a different address via
+     * {@link EnsResolver#EnsResolver(io.myotis.evm.EvmExecutor,
+     * io.myotis.evm.Address, io.myotis.evm.Address) the three-arg
+     * constructor}.
+     */
+    public static final Address MAINNET_UNIVERSAL_RESOLVER =
+            Address.fromHex("0xce01f8eee7E479C928F8919abD53E553a36CeF67");
 }

--- a/myotis-ens/src/main/java/io/myotis/ens/EnsResolver.java
+++ b/myotis-ens/src/main/java/io/myotis/ens/EnsResolver.java
@@ -2,6 +2,8 @@ package io.myotis.ens;
 
 import io.myotis.evm.Address;
 import io.myotis.evm.BlockContext;
+import io.myotis.evm.EvmExecutionError;
+import io.myotis.evm.EvmExecutionException;
 import io.myotis.evm.EvmExecutor;
 import io.myotis.evm.abi.AbiDecoder;
 import io.myotis.evm.abi.AbiEncoder;
@@ -10,49 +12,57 @@ import io.myotis.evm.ens.Namehash;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 /**
- * Forward + reverse resolver for classic on-chain ENS names.
+ * Forward + reverse resolver for ENS names.
  *
- * <p>Forward (`name → address`) chains two {@link EvmExecutor#callView}
- * invocations: first the Registry to find the name's resolver, then the
- * resolver itself for the {@code addr(bytes32)} record. Reverse
- * (`address → name`) does the same for the {@code .addr.reverse} subdomain
- * plus a mandatory ENSIP-3 verification round-trip — the resolver's claim
- * is only accepted if a forward lookup of the claimed name returns the
- * original address.
+ * <p>Forward resolution ({@code name → address}) goes through the
+ * Universal Resolver: a single {@code resolve(bytes name, bytes data)}
+ * call that walks the registry/resolver chain, handles wildcard names
+ * (ENSIP-10), and surfaces ERC-3668 OffchainLookup reverts at the call
+ * boundary so a {@code CcipReadEvmExecutor} wrapping the supplied
+ * executor can fetch the off-chain response transparently.
  *
- * <p>CCIP-Read (ERC-3668) is <strong>not</strong> handled here. Names that
- * resolve via off-chain gateways (Coinbase IDs, Base subnames, etc.) will
- * cause the underlying {@code callView} to revert with the
- * {@code OffchainLookup} selector; the caller will see a
- * {@code Reverted} error. Phase 4 wires CCIP-Read into the executor and
- * makes those calls work transparently.
+ * <p>Reverse resolution ({@code address → name}) uses the step-by-step
+ * Registry → reverse-resolver path with a mandatory ENSIP-3 forward
+ * verification round-trip — the resolver's claim is only accepted if a
+ * forward lookup of the claimed name returns the original address.
+ *
+ * <p>For modern ENS surfaces (Coinbase IDs, Uniswap names, Base
+ * subdomains, etc.) to work, callers must wrap the executor in
+ * {@code io.myotis.evm.CcipReadEvmExecutor}. Without that, those names
+ * surface as {@code Reverted} errors when the wildcard resolver issues
+ * its OffchainLookup revert.
  */
 public final class EnsResolver {
 
-    private static final FunctionSignature RESOLVER =
-            FunctionSignature.of("resolver(bytes32)");
+    private static final FunctionSignature RESOLVE =
+            FunctionSignature.of("resolve(bytes,bytes)");
     private static final FunctionSignature ADDR =
             FunctionSignature.of("addr(bytes32)");
+    private static final FunctionSignature RESOLVER =
+            FunctionSignature.of("resolver(bytes32)");
     private static final FunctionSignature NAME =
             FunctionSignature.of("name(bytes32)");
 
     private final EvmExecutor executor;
     private final Address registry;
+    private final Address universalResolver;
 
-    /** Default constructor: mainnet Registry at the canonical address. */
+    /** Default constructor: mainnet Registry + Universal Resolver. */
     public EnsResolver(EvmExecutor executor) {
-        this(executor, EnsAddresses.MAINNET_REGISTRY);
+        this(executor, EnsAddresses.MAINNET_REGISTRY, EnsAddresses.MAINNET_UNIVERSAL_RESOLVER);
     }
 
     /**
-     * Construct against a non-default Registry. Useful for testnets and for
-     * unit tests that mock a custom registry address.
+     * Construct against non-default contract addresses. Useful for
+     * testnets and for unit tests that mock the resolver chain.
      */
-    public EnsResolver(EvmExecutor executor, Address registry) {
+    public EnsResolver(EvmExecutor executor, Address registry, Address universalResolver) {
         this.executor = executor;
         this.registry = registry;
+        this.universalResolver = universalResolver;
     }
 
     /**
@@ -60,37 +70,75 @@ public final class EnsResolver {
      *
      * <p>Returns {@link Optional#empty()} when:
      * <ul>
-     *   <li>The Registry has no resolver for the name (returns the zero address).
-     *   <li>The resolver returns the zero address for the name's
-     *       {@code addr} record.
+     *   <li>The Universal Resolver returns empty / zero bytes for the
+     *       inner call (no record set).
+     *   <li>The UR reverts with a known "not found" condition. Most UR
+     *       implementations revert with {@code ResolverNotFound} or
+     *       similar custom errors when the name has no resolver; we
+     *       map any revert from the UR to {@code Optional.empty()}
+     *       rather than propagate it as a call failure, since the
+     *       wallet's intent is "look up this name" and the reasonable
+     *       answer for an unregistered name is "no result."
      * </ul>
+     *
+     * <p>OffchainLookup reverts from the UR's nested resolver call are
+     * <em>not</em> surfaced here — they're caught one layer up by the
+     * {@code CcipReadEvmExecutor} wrapping {@code executor}. If the
+     * caller hasn't wrapped, those reverts propagate as
+     * {@code Reverted} errors.
      */
     public CompletableFuture<Optional<Address>> resolveAddress(String name, BlockContext blockContext) {
+        byte[] dnsName = DnsEncoder.encode(name);
         byte[] node = Namehash.of(name);
-        return getResolver(node, blockContext)
-                .thenCompose(resolver -> {
-                    if (resolver.isEmpty()) return CompletableFuture.completedFuture(Optional.empty());
-                    return getAddress(resolver.get(), node, blockContext);
+        // Inner call: addr(bytes32) with the namehash. The UR will dispatch
+        // this against the right resolver internally.
+        byte[] innerCall = AbiEncoder.encodeCall(ADDR, AbiEncoder.bytes32(node));
+        // Outer call: resolve(bytes name, bytes data) on the UR.
+        byte[] resolveCalldata = AbiEncoder.encodeCall(
+                RESOLVE,
+                AbiEncoder.bytes(dnsName),
+                AbiEncoder.bytes(innerCall));
+
+        return executor.callView(universalResolver, resolveCalldata, blockContext)
+                .handle((result, error) -> {
+                    if (error != null) {
+                        // The UR may revert with custom errors for unregistered
+                        // names. Treat all reverts the same for the wallet: no
+                        // answer. CCIP-Read reverts are caught upstream by the
+                        // CcipReadEvmExecutor decorator before they reach here,
+                        // so anything that escapes is a genuine "not resolvable."
+                        Throwable cause = unwrap(error);
+                        if (cause instanceof EvmExecutionException eee
+                                && eee.error() instanceof EvmExecutionError.Reverted) {
+                            return Optional.<Address>empty();
+                        }
+                        // Not a revert: bubble the real failure (oracle issue,
+                        // network problem, etc.). Wrap in a CompletionException
+                        // so the caller sees the original cause.
+                        if (cause instanceof RuntimeException re) throw re;
+                        throw new CompletionException(cause);
+                    }
+                    return decodeUrAddrResult(result);
                 });
     }
 
     /**
      * Reverse resolution: {@code address → name}, with ENSIP-3 verification.
      *
-     * <p>Returns {@link Optional#empty()} when:
-     * <ul>
-     *   <li>The address has no reverse record (no resolver, or resolver
-     *       returns the empty string).
-     *   <li>The resolver claims a name but a forward lookup of that name
-     *       does <em>not</em> point back at the original address — the
-     *       claim is unverifiable and rejected (defends against
-     *       impersonation, since anyone can write any string into their
-     *       reverse record).
-     * </ul>
+     * <p>Step-by-step path against the Registry. The plan calls out
+     * switching to the UR's {@code reverse()} method as a future
+     * refinement; the step-by-step path is correct for classic on-chain
+     * reverse records and the verification round-trip uses the new UR-
+     * based forward path under the hood.
+     *
+     * <p>Returns {@link Optional#empty()} when the address has no reverse
+     * record OR when the resolver's claim fails ENSIP-3 verification (a
+     * forward lookup of the claimed name doesn't point back at the
+     * original address).
      */
     public CompletableFuture<Optional<String>> resolveName(Address address, BlockContext blockContext) {
         byte[] reverseNode = Namehash.of(ReverseLookup.nameFor(address));
-        return getResolver(reverseNode, blockContext)
+        return getReverseResolver(reverseNode, blockContext)
                 .thenCompose(resolver -> {
                     if (resolver.isEmpty()) return CompletableFuture.completedFuture(Optional.<String>empty());
                     return getName(resolver.get(), reverseNode, blockContext)
@@ -98,17 +146,12 @@ public final class EnsResolver {
                 });
     }
 
-    /** Registry call: {@code resolver(bytes32) → address}. */
-    private CompletableFuture<Optional<Address>> getResolver(byte[] node, BlockContext ctx) {
+    // ---- Reverse-path step-by-step calls ----------------------------------
+
+    /** Registry call: {@code resolver(bytes32) → address}. Used only for the reverse path. */
+    private CompletableFuture<Optional<Address>> getReverseResolver(byte[] node, BlockContext ctx) {
         byte[] calldata = AbiEncoder.encodeCall(RESOLVER, AbiEncoder.bytes32(node));
         return executor.callView(registry, calldata, ctx)
-                .thenApply(EnsResolver::decodeAddressOrEmpty);
-    }
-
-    /** Resolver call: {@code addr(bytes32) → address}. */
-    private CompletableFuture<Optional<Address>> getAddress(Address resolver, byte[] node, BlockContext ctx) {
-        byte[] calldata = AbiEncoder.encodeCall(ADDR, AbiEncoder.bytes32(node));
-        return executor.callView(resolver, calldata, ctx)
                 .thenApply(EnsResolver::decodeAddressOrEmpty);
     }
 
@@ -119,39 +162,41 @@ public final class EnsResolver {
                 .thenApply(EnsResolver::decodeStringOrEmpty);
     }
 
+    // ---- Decoders ---------------------------------------------------------
+
     /**
-     * Decode a single address from a {@code callView} return, returning
-     * {@link Optional#empty()} for any of:
-     * <ul>
-     *   <li>An empty result. The EVM returns zero bytes when a CALL targets
-     *       an EOA (address with no code) or a contract that doesn't
-     *       implement the queried function — both are "no answer" for ENS.
-     *   <li>A short result (&lt; 32 bytes). Indicates a non-conforming
-     *       contract; treat as "no answer" rather than crash the call.
-     *   <li>The zero address.
-     * </ul>
+     * Decode the Universal Resolver's {@code resolve(...)} return.
+     *
+     * <p>Wire shape: {@code (bytes result, address resolver)}. For an
+     * {@code addr(bytes32)} inner call, {@code result} is the 32-byte
+     * ABI-encoded address (or empty if no record).
      */
+    private static Optional<Address> decodeUrAddrResult(byte[] urReturn) {
+        if (urReturn == null || urReturn.length < 64) return Optional.empty();
+        try {
+            byte[] resultBytes = AbiDecoder.dynamicBytes(urReturn, 0);
+            if (resultBytes.length < 32) return Optional.empty();
+            Address addr = AbiDecoder.address(resultBytes, 0);
+            return addr.equals(Address.ZERO) ? Optional.<Address>empty() : Optional.of(addr);
+        } catch (RuntimeException e) {
+            return Optional.empty();
+        }
+    }
+
+    /** Decode a single 32-byte address with empty/short fallback. */
     private static Optional<Address> decodeAddressOrEmpty(byte[] result) {
         if (result == null || result.length < 32) return Optional.empty();
         Address addr = AbiDecoder.address(result, 0);
         return addr.equals(Address.ZERO) ? Optional.<Address>empty() : Optional.of(addr);
     }
 
-    /**
-     * Decode a single dynamic string from a {@code callView} return, with
-     * the same robustness contract as {@link #decodeAddressOrEmpty}: empty,
-     * short, or malformed responses surface as {@link Optional#empty()}
-     * rather than throwing.
-     */
+    /** Decode a single dynamic string with empty/short/malformed fallback. */
     private static Optional<String> decodeStringOrEmpty(byte[] result) {
         if (result == null || result.length < 64) return Optional.empty();
         try {
             String s = AbiDecoder.string(result, 0);
             return s.isEmpty() ? Optional.<String>empty() : Optional.of(s);
         } catch (RuntimeException e) {
-            // Malformed dynamic encoding (offset/length out of range) —
-            // a non-conforming resolver. Treat as "no name" rather than
-            // propagate the decode failure to the wallet.
             return Optional.empty();
         }
     }
@@ -159,12 +204,18 @@ public final class EnsResolver {
     /**
      * ENSIP-3 verification: confirm the resolver's name claim by resolving
      * it forward and checking it points back at the original address.
-     * Returns {@code Optional.of(name)} only if the round-trip succeeds.
      */
     private CompletableFuture<Optional<String>> verifyForward(
             Optional<String> claimed, Address address, BlockContext ctx) {
         if (claimed.isEmpty()) return CompletableFuture.completedFuture(Optional.empty());
         return resolveAddress(claimed.get(), ctx).thenApply(forward ->
                 forward.filter(a -> a.equals(address)).map(a -> claimed.get()));
+    }
+
+    private static Throwable unwrap(Throwable t) {
+        while (t instanceof CompletionException && t.getCause() != null) {
+            t = t.getCause();
+        }
+        return t;
     }
 }

--- a/myotis-ens/src/main/java/io/myotis/ens/EnsResolver.java
+++ b/myotis-ens/src/main/java/io/myotis/ens/EnsResolver.java
@@ -8,6 +8,7 @@ import io.myotis.evm.EvmExecutor;
 import io.myotis.evm.abi.AbiDecoder;
 import io.myotis.evm.abi.AbiEncoder;
 import io.myotis.evm.abi.FunctionSignature;
+import io.myotis.evm.ccipread.OffchainLookupRevert;
 import io.myotis.evm.ens.Namehash;
 
 import java.util.Optional;
@@ -32,8 +33,11 @@ import java.util.concurrent.CompletionException;
  * <p>For modern ENS surfaces (Coinbase IDs, Uniswap names, Base
  * subdomains, etc.) to work, callers must wrap the executor in
  * {@code io.myotis.evm.CcipReadEvmExecutor}. Without that, those names
- * surface as {@code Reverted} errors when the wildcard resolver issues
- * its OffchainLookup revert.
+ * surface as {@code Reverted} errors carrying the {@code OffchainLookup}
+ * selector — distinct from "name not found", so callers can tell whether
+ * they forgot to wrap vs. whether the name is genuinely unregistered.
+ * Generic UR reverts (ResolverNotFound and friends) still map to
+ * {@link Optional#empty()}.
  */
 public final class EnsResolver {
 
@@ -102,20 +106,27 @@ public final class EnsResolver {
         return executor.callView(universalResolver, resolveCalldata, blockContext)
                 .handle((result, error) -> {
                     if (error != null) {
-                        // The UR may revert with custom errors for unregistered
-                        // names. Treat all reverts the same for the wallet: no
-                        // answer. CCIP-Read reverts are caught upstream by the
-                        // CcipReadEvmExecutor decorator before they reach here,
-                        // so anything that escapes is a genuine "not resolvable."
                         Throwable cause = unwrap(error);
+                        // OffchainLookup reverts are rethrown so the caller's
+                        // CcipReadEvmExecutor wrapper can handle them. If the
+                        // caller forgot to wrap, the OffchainLookup surfaces
+                        // as a Reverted error rather than being silently
+                        // swallowed as "name not found."
+                        if (cause instanceof EvmExecutionException eee
+                                && eee.error() instanceof EvmExecutionError.Reverted r
+                                && OffchainLookupRevert.tryParse(r.data()).isPresent()) {
+                            throw new CompletionException(cause);
+                        }
+                        // Other reverts (UR's ResolverNotFound and friends) =
+                        // "no result." The wallet's intent is "look up this
+                        // name" and the reasonable answer for an unregistered
+                        // name is empty.
                         if (cause instanceof EvmExecutionException eee
                                 && eee.error() instanceof EvmExecutionError.Reverted) {
                             return Optional.<Address>empty();
                         }
-                        // Not a revert: bubble the real failure (oracle issue,
-                        // network problem, etc.). Wrap in a CompletionException
-                        // so the caller sees the original cause.
-                        if (cause instanceof RuntimeException re) throw re;
+                        // Not a revert at all: bubble the real failure
+                        // (oracle issue, network problem, etc.).
                         throw new CompletionException(cause);
                     }
                     return decodeUrAddrResult(result);

--- a/myotis-ens/src/test/java/io/myotis/ens/DnsEncoderTest.java
+++ b/myotis-ens/src/test/java/io/myotis/ens/DnsEncoderTest.java
@@ -1,0 +1,62 @@
+package io.myotis.ens;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HexFormat;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Test vectors for the DNS wire-format encoder.
+ *
+ * <p>Examples per ENSIP-10 / DNS RFC 1035: each label is preceded by a
+ * one-byte length, followed by the label bytes, terminated by a zero
+ * byte for the root.
+ */
+class DnsEncoderTest {
+
+    @Test
+    void encodeVitalikEth() {
+        // "vitalik" = 0x76 69 74 61 6c 69 6b (7 bytes), "eth" = 0x65 74 68 (3 bytes).
+        // Wire: 07 vitalik 03 eth 00
+        assertEquals(
+                "0776697461 6c696b03657468 00".replace(" ", ""),
+                HexFormat.of().formatHex(DnsEncoder.encode("vitalik.eth")));
+    }
+
+    @Test
+    void encodeRootIsSingleZeroByte() {
+        assertEquals("00", HexFormat.of().formatHex(DnsEncoder.encode("")));
+        assertEquals("00", HexFormat.of().formatHex(DnsEncoder.encode(null)));
+    }
+
+    @Test
+    void encodeSingleLabel() {
+        // "eth" alone — label of 3 bytes, then root terminator.
+        assertEquals("0365746800",
+                HexFormat.of().formatHex(DnsEncoder.encode("eth")));
+    }
+
+    @Test
+    void encodeMultiLevelSubdomain() {
+        // "a.b.c.eth" — four labels.
+        assertEquals(
+                "01 61 01 62 01 63 03 65 74 68 00".replace(" ", ""),
+                HexFormat.of().formatHex(DnsEncoder.encode("a.b.c.eth")));
+    }
+
+    @Test
+    void encodeLowercasesInput() {
+        assertEquals(
+                HexFormat.of().formatHex(DnsEncoder.encode("vitalik.eth")),
+                HexFormat.of().formatHex(DnsEncoder.encode("VITALIK.ETH")));
+    }
+
+    @Test
+    void encodeRejectsLabelsLongerThan63Bytes() {
+        String tooLong = "a".repeat(64);
+        assertThrows(IllegalArgumentException.class,
+                () -> DnsEncoder.encode(tooLong + ".eth"));
+    }
+}

--- a/myotis-ens/src/test/java/io/myotis/ens/DnsEncoderTest.java
+++ b/myotis-ens/src/test/java/io/myotis/ens/DnsEncoderTest.java
@@ -59,4 +59,28 @@ class DnsEncoderTest {
         assertThrows(IllegalArgumentException.class,
                 () -> DnsEncoder.encode(tooLong + ".eth"));
     }
+
+    @Test
+    void encodeAcceptsTrailingDotAsFqdnForm() {
+        // FQDN form ("vitalik.eth.") is equivalent to the bare form;
+        // the encoder strips the trailing dot before splitting.
+        assertEquals(
+                HexFormat.of().formatHex(DnsEncoder.encode("vitalik.eth")),
+                HexFormat.of().formatHex(DnsEncoder.encode("vitalik.eth.")));
+    }
+
+    @Test
+    void encodeRejectsEmptyMiddleLabel() {
+        // "a..b" would otherwise produce 01 61 00 01 62 00 — invalid because
+        // only the final root label may be zero-length.
+        assertThrows(IllegalArgumentException.class,
+                () -> DnsEncoder.encode("a..b"));
+    }
+
+    @Test
+    void encodeRejectsEmptyLeadingLabel() {
+        // ".eth" leads with an empty label, also invalid.
+        assertThrows(IllegalArgumentException.class,
+                () -> DnsEncoder.encode(".eth"));
+    }
 }

--- a/myotis-ens/src/test/java/io/myotis/ens/EnsResolverTest.java
+++ b/myotis-ens/src/test/java/io/myotis/ens/EnsResolverTest.java
@@ -88,6 +88,49 @@ class EnsResolverTest {
     }
 
     @Test
+    void resolveAddressOffchainLookupRevertIsRethrown() {
+        // The Universal Resolver's wildcard resolver may revert with an
+        // ERC-3668 OffchainLookup. When the caller hasn't wrapped the
+        // executor in CcipReadEvmExecutor, that revert must surface as a
+        // distinct error — not be swallowed as "name not found." This
+        // distinguishes "you forgot CCIP-Read wiring" from "the name
+        // genuinely doesn't resolve."
+        var mock = new MockExecutor();
+        // Build a minimal, valid OffchainLookup payload so
+        // OffchainLookupRevert.tryParse() recognises it.
+        byte[] offchainLookupPayload = io.myotis.evm.ccipread.OffchainLookupRevert.SELECTOR;
+        // The selector alone isn't a valid full payload, but we need a
+        // representative payload that the parser recognises. Build one via
+        // AbiEncoder so it round-trips:
+        byte[] body = AbiEncoder.encodeRaw(
+                AbiEncoder.address(io.myotis.evm.Address.ZERO),                  // sender
+                AbiEncoder.stringArray(java.util.List.of("test://gateway")),     // urls
+                AbiEncoder.bytes(new byte[0]),                                   // callData
+                new io.myotis.evm.abi.AbiValue(false, new byte[32]),             // callbackFunction
+                AbiEncoder.bytes(new byte[0]));                                  // extraData
+        byte[] full = new byte[4 + body.length];
+        System.arraycopy(offchainLookupPayload, 0, full, 0, 4);
+        System.arraycopy(body, 0, full, 4, body.length);
+
+        mock.revertOn(UR, callUrResolveAddr("ccip-read.eth"), full);
+
+        var resolver = new EnsResolver(mock, REGISTRY, UR);
+        try {
+            resolver.resolveAddress("ccip-read.eth", ctx()).get();
+            org.junit.jupiter.api.Assertions.fail(
+                    "OffchainLookup reverts must propagate so the caller learns "
+                            + "they need CcipReadEvmExecutor — not be swallowed as empty");
+        } catch (Exception e) {
+            Throwable cause = e instanceof java.util.concurrent.ExecutionException
+                    ? e.getCause() : e;
+            var eee = org.junit.jupiter.api.Assertions.assertInstanceOf(
+                    EvmExecutionException.class, cause);
+            org.junit.jupiter.api.Assertions.assertInstanceOf(
+                    EvmExecutionError.Reverted.class, eee.error());
+        }
+    }
+
+    @Test
     void resolveAddressShortResponseReturnsEmpty() throws Exception {
         // UR returned non-conforming bytes (less than the 64 head bytes
         // a (bytes, address) tuple needs). Treat as no answer.

--- a/myotis-ens/src/test/java/io/myotis/ens/EnsResolverTest.java
+++ b/myotis-ens/src/test/java/io/myotis/ens/EnsResolverTest.java
@@ -2,15 +2,15 @@ package io.myotis.ens;
 
 import io.myotis.evm.Address;
 import io.myotis.evm.BlockContext;
+import io.myotis.evm.EvmExecutionError;
+import io.myotis.evm.EvmExecutionException;
 import io.myotis.evm.EvmExecutor;
-import io.myotis.evm.abi.AbiDecoder;
 import io.myotis.evm.abi.AbiEncoder;
 import io.myotis.evm.abi.FunctionSignature;
 import io.myotis.evm.ens.Namehash;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigInteger;
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.HexFormat;
 import java.util.Map;
@@ -24,76 +24,83 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Unit tests for {@link EnsResolver}.
  *
- * <p>The tests substitute a {@link MockExecutor} for the real
- * {@link EvmExecutor}, programming it with the exact (target, calldata)
- * → return-bytes mappings the resolver should issue. This proves:
- * <ul>
- *   <li>The Registry call uses the right selector and namehash.
- *   <li>The Resolver call uses the right selector and namehash.
- *   <li>Forward + reverse resolution chain correctly.
- *   <li>ENSIP-3 verification round-trip rejects unverifiable claims.
- * </ul>
+ * <p>Forward tests mock the Universal Resolver's
+ * {@code resolve(bytes name, bytes data)} call. Reverse tests still mock
+ * the step-by-step Registry → reverse-resolver path (the resolver's
+ * reverse path stayed step-by-step in Phase 4).
  *
- * <p>Concrete EVM execution against fixture state is exercised by Phase 0's
- * {@code EvmFactoryTest}; the resolver is just orchestration on top, so
- * mocking the executor is the right level of test isolation.
+ * <p>The {@link MockExecutor} maps {@code (target, calldata) → response}
+ * deterministically, with a separate channel for "this call should fail
+ * with EvmExecutionException(Reverted)" to test the UR-revert-as-empty
+ * pathway.
  */
 class EnsResolverTest {
 
     private static final Address REGISTRY = Address.fromHex(
             "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e");
+    private static final Address UR = Address.fromHex(
+            "0xce01f8eee7E479C928F8919abD53E553a36CeF67");
     private static final Address PUBLIC_RESOLVER = Address.fromHex(
             "0x231b0Ee14048e9dCcD1d247744d114a4EB5E8E63");
     private static final Address VITALIK = Address.fromHex(
             "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
 
+    // ---- Forward resolution (UR path) -------------------------------------
+
     @Test
     void resolveAddressVitalikEth() throws Exception {
         var mock = new MockExecutor();
-        // Registry.resolver(namehash("vitalik.eth")) → PUBLIC_RESOLVER
-        mock.respond(REGISTRY,
-                callRegistryResolver("vitalik.eth"),
-                encodeAddress(PUBLIC_RESOLVER));
-        // PublicResolver.addr(namehash("vitalik.eth")) → VITALIK
-        mock.respond(PUBLIC_RESOLVER,
-                callResolverAddr("vitalik.eth"),
-                encodeAddress(VITALIK));
+        mock.respond(UR, callUrResolveAddr("vitalik.eth"),
+                encodeUrAddrResponse(VITALIK, PUBLIC_RESOLVER));
 
-        var resolver = new EnsResolver(mock, REGISTRY);
+        var resolver = new EnsResolver(mock, REGISTRY, UR);
         Optional<Address> result = resolver.resolveAddress("vitalik.eth", ctx()).get();
         assertEquals(Optional.of(VITALIK), result);
+        assertEquals(1, mock.callCount(),
+                "UR-based forward resolution issues exactly one callView");
     }
 
     @Test
-    void resolveAddressMissingResolverReturnsEmpty() throws Exception {
+    void resolveAddressUrRevertReturnsEmpty() throws Exception {
+        // The Universal Resolver may revert with a custom error
+        // (ResolverNotFound, etc.) for unregistered names. Treat as
+        // "no answer" rather than propagate the revert.
         var mock = new MockExecutor();
-        // Registry returns address(0) — no resolver registered for the name.
-        mock.respond(REGISTRY,
-                callRegistryResolver("not-registered.eth"),
-                encodeAddress(Address.ZERO));
+        mock.revertOn(UR, callUrResolveAddr("not-registered.eth"),
+                /* revert data = empty */ new byte[0]);
 
-        var resolver = new EnsResolver(mock, REGISTRY);
+        var resolver = new EnsResolver(mock, REGISTRY, UR);
         Optional<Address> result = resolver.resolveAddress("not-registered.eth", ctx()).get();
         assertTrue(result.isEmpty());
-        // Resolver wasn't called — only the Registry.
-        assertEquals(1, mock.callCount());
     }
 
     @Test
-    void resolveAddressEmptyAddrRecordReturnsEmpty() throws Exception {
+    void resolveAddressEmptyResultBytesReturnsEmpty() throws Exception {
+        // The UR returns successfully but with an empty inner-call result
+        // (resolver returned no addr record).
         var mock = new MockExecutor();
-        mock.respond(REGISTRY,
-                callRegistryResolver("ghost.eth"),
-                encodeAddress(PUBLIC_RESOLVER));
-        // Resolver knows the name but has no addr record for it.
-        mock.respond(PUBLIC_RESOLVER,
-                callResolverAddr("ghost.eth"),
-                encodeAddress(Address.ZERO));
+        mock.respond(UR, callUrResolveAddr("ghost.eth"),
+                encodeUrAddrResponse(Address.ZERO, PUBLIC_RESOLVER));
 
-        var resolver = new EnsResolver(mock, REGISTRY);
+        var resolver = new EnsResolver(mock, REGISTRY, UR);
         Optional<Address> result = resolver.resolveAddress("ghost.eth", ctx()).get();
         assertTrue(result.isEmpty());
     }
+
+    @Test
+    void resolveAddressShortResponseReturnsEmpty() throws Exception {
+        // UR returned non-conforming bytes (less than the 64 head bytes
+        // a (bytes, address) tuple needs). Treat as no answer.
+        var mock = new MockExecutor();
+        mock.respond(UR, callUrResolveAddr("weird.eth"),
+                new byte[]{1, 2, 3, 4, 5, 6, 7, 8});
+
+        var resolver = new EnsResolver(mock, REGISTRY, UR);
+        Optional<Address> result = resolver.resolveAddress("weird.eth", ctx()).get();
+        assertTrue(result.isEmpty());
+    }
+
+    // ---- Reverse resolution (step-by-step path) ---------------------------
 
     @Test
     void resolveNameVerifiesForwardRoundTrip() throws Exception {
@@ -101,53 +108,39 @@ class EnsResolverTest {
         String reverseName = ReverseLookup.nameFor(VITALIK);
 
         // Reverse path: Registry.resolver(reverseNode) → PUBLIC_RESOLVER
-        mock.respond(REGISTRY,
-                callRegistryResolver(reverseName),
+        mock.respond(REGISTRY, callRegistryResolver(reverseName),
                 encodeAddress(PUBLIC_RESOLVER));
         // Resolver.name(reverseNode) → "vitalik.eth"
-        mock.respond(PUBLIC_RESOLVER,
-                callResolverName(reverseName),
+        mock.respond(PUBLIC_RESOLVER, callResolverName(reverseName),
                 encodeString("vitalik.eth"));
+        // Forward verification: now via UR
+        mock.respond(UR, callUrResolveAddr("vitalik.eth"),
+                encodeUrAddrResponse(VITALIK, PUBLIC_RESOLVER));
 
-        // Forward verification path: same as resolveAddress test.
-        mock.respond(REGISTRY,
-                callRegistryResolver("vitalik.eth"),
-                encodeAddress(PUBLIC_RESOLVER));
-        mock.respond(PUBLIC_RESOLVER,
-                callResolverAddr("vitalik.eth"),
-                encodeAddress(VITALIK));
-
-        var resolver = new EnsResolver(mock, REGISTRY);
+        var resolver = new EnsResolver(mock, REGISTRY, UR);
         Optional<String> result = resolver.resolveName(VITALIK, ctx()).get();
         assertEquals(Optional.of("vitalik.eth"), result);
     }
 
     @Test
     void resolveNameRejectsImpersonationAttempt() throws Exception {
-        // The reverse resolver claims vitalik owns "vitalik.eth", but the
-        // forward lookup of "vitalik.eth" returns a DIFFERENT address — so
-        // someone has tampered with the reverse record. ENSIP-3 says reject.
+        // Reverse resolver claims someone else's address resolves to
+        // vitalik.eth, but a forward UR call for vitalik.eth returns
+        // VITALIK's address — not the impersonator. ENSIP-3 says reject.
         var mock = new MockExecutor();
         Address impersonator = Address.fromHex(
                 "0x9999999999999999999999999999999999999999");
         String reverseName = ReverseLookup.nameFor(impersonator);
 
-        mock.respond(REGISTRY,
-                callRegistryResolver(reverseName),
+        mock.respond(REGISTRY, callRegistryResolver(reverseName),
                 encodeAddress(PUBLIC_RESOLVER));
-        mock.respond(PUBLIC_RESOLVER,
-                callResolverName(reverseName),
+        mock.respond(PUBLIC_RESOLVER, callResolverName(reverseName),
                 encodeString("vitalik.eth"));
-        // Forward verification: vitalik.eth resolves to vitalik's real
-        // address, NOT the impersonator. Mismatch → reject the claim.
-        mock.respond(REGISTRY,
-                callRegistryResolver("vitalik.eth"),
-                encodeAddress(PUBLIC_RESOLVER));
-        mock.respond(PUBLIC_RESOLVER,
-                callResolverAddr("vitalik.eth"),
-                encodeAddress(VITALIK));
+        // Forward verification: vitalik.eth → VITALIK (NOT impersonator)
+        mock.respond(UR, callUrResolveAddr("vitalik.eth"),
+                encodeUrAddrResponse(VITALIK, PUBLIC_RESOLVER));
 
-        var resolver = new EnsResolver(mock, REGISTRY);
+        var resolver = new EnsResolver(mock, REGISTRY, UR);
         Optional<String> result = resolver.resolveName(impersonator, ctx()).get();
         assertTrue(result.isEmpty(),
                 "ENSIP-3 verification must reject claims that don't round-trip");
@@ -157,86 +150,47 @@ class EnsResolverTest {
     void resolveNameMissingReverseRecordReturnsEmpty() throws Exception {
         var mock = new MockExecutor();
         String reverseName = ReverseLookup.nameFor(VITALIK);
-        // No resolver registered for the reverse subdomain.
-        mock.respond(REGISTRY,
-                callRegistryResolver(reverseName),
+        mock.respond(REGISTRY, callRegistryResolver(reverseName),
                 encodeAddress(Address.ZERO));
 
-        var resolver = new EnsResolver(mock, REGISTRY);
+        var resolver = new EnsResolver(mock, REGISTRY, UR);
         Optional<String> result = resolver.resolveName(VITALIK, ctx()).get();
         assertTrue(result.isEmpty());
-        // Did not consult the resolver or attempt forward verification.
-        assertEquals(1, mock.callCount());
+        assertEquals(1, mock.callCount(),
+                "absence of reverse resolver short-circuits before any other call");
     }
 
-    /**
-     * The Registry address in an offline / misconfigured wallet might point
-     * at an EOA (no code). The EVM returns empty bytes for a successful
-     * call against a code-less account. The resolver must surface this as
-     * {@code Optional.empty()} rather than throwing in the ABI decoder.
-     */
-    @Test
-    void emptyResponseFromRegistryReturnsEmpty() throws Exception {
-        var mock = new MockExecutor();
-        mock.respond(REGISTRY,
-                callRegistryResolver("anything.eth"),
-                new byte[0]);
-
-        var resolver = new EnsResolver(mock, REGISTRY);
-        Optional<Address> result = resolver.resolveAddress("anything.eth", ctx()).get();
-        assertTrue(result.isEmpty());
-    }
-
-    /**
-     * A non-conforming resolver might return short or malformed data instead
-     * of a 32-byte address. The resolver must treat this as "no answer"
-     * rather than crash the call.
-     */
-    @Test
-    void shortResponseFromResolverReturnsEmpty() throws Exception {
-        var mock = new MockExecutor();
-        mock.respond(REGISTRY,
-                callRegistryResolver("weird.eth"),
-                encodeAddress(PUBLIC_RESOLVER));
-        // Resolver returns 16 bytes — not a valid uint256/address encoding.
-        mock.respond(PUBLIC_RESOLVER,
-                callResolverAddr("weird.eth"),
-                new byte[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16});
-
-        var resolver = new EnsResolver(mock, REGISTRY);
-        Optional<Address> result = resolver.resolveAddress("weird.eth", ctx()).get();
-        assertTrue(result.isEmpty());
-    }
-
-    /** Symmetric short/empty handling for the reverse-name decoder. */
     @Test
     void emptyResponseFromReverseResolverReturnsEmpty() throws Exception {
         var mock = new MockExecutor();
         String reverseName = ReverseLookup.nameFor(VITALIK);
-        mock.respond(REGISTRY,
-                callRegistryResolver(reverseName),
+        mock.respond(REGISTRY, callRegistryResolver(reverseName),
                 encodeAddress(PUBLIC_RESOLVER));
-        // Resolver returns nothing for the name(bytes32) call.
-        mock.respond(PUBLIC_RESOLVER,
-                callResolverName(reverseName),
-                new byte[0]);
+        // Resolver returns empty data for name(bytes32).
+        mock.respond(PUBLIC_RESOLVER, callResolverName(reverseName), new byte[0]);
 
-        var resolver = new EnsResolver(mock, REGISTRY);
+        var resolver = new EnsResolver(mock, REGISTRY, UR);
         Optional<String> result = resolver.resolveName(VITALIK, ctx()).get();
         assertTrue(result.isEmpty());
     }
 
-    // ---- Calldata builders mirroring what EnsResolver should issue --------
+    // ---- Calldata builders ------------------------------------------------
+
+    private static byte[] callUrResolveAddr(String name) {
+        byte[] dnsName = DnsEncoder.encode(name);
+        byte[] node = Namehash.of(name);
+        byte[] innerCall = AbiEncoder.encodeCall(
+                FunctionSignature.of("addr(bytes32)"),
+                AbiEncoder.bytes32(node));
+        return AbiEncoder.encodeCall(
+                FunctionSignature.of("resolve(bytes,bytes)"),
+                AbiEncoder.bytes(dnsName),
+                AbiEncoder.bytes(innerCall));
+    }
 
     private static byte[] callRegistryResolver(String name) {
         return AbiEncoder.encodeCall(
                 FunctionSignature.of("resolver(bytes32)"),
-                AbiEncoder.bytes32(Namehash.of(name)));
-    }
-
-    private static byte[] callResolverAddr(String name) {
-        return AbiEncoder.encodeCall(
-                FunctionSignature.of("addr(bytes32)"),
                 AbiEncoder.bytes32(Namehash.of(name)));
     }
 
@@ -256,6 +210,19 @@ class EnsResolverTest {
         return AbiEncoder.encodeRaw(AbiEncoder.string(s));
     }
 
+    /**
+     * Encode the Universal Resolver's {@code resolve()} return for an
+     * {@code addr(bytes32)} inner call: {@code (bytes result, address resolver)}.
+     * The {@code result} bytes are themselves the 32-byte ABI encoding of
+     * the resolved address.
+     */
+    private static byte[] encodeUrAddrResponse(Address resolved, Address resolver) {
+        byte[] innerReturn = encodeAddress(resolved);
+        return AbiEncoder.encodeRaw(
+                AbiEncoder.bytes(innerReturn),
+                AbiEncoder.address(resolver));
+    }
+
     private static BlockContext ctx() {
         return new BlockContext(
                 new byte[32],
@@ -271,15 +238,20 @@ class EnsResolverTest {
     /**
      * Programmable {@link EvmExecutor}: callers register
      * {@code (target, calldata) → returnBytes} mappings, and {@code callView}
-     * looks them up. Unmatched calls fail loudly so the test catches any
-     * unexpected calldata shape.
+     * looks them up. Also supports {@code revertOn(...)} to fail a specific
+     * call with {@link EvmExecutionException}.
      */
     private static final class MockExecutor implements EvmExecutor {
         private final Map<Key, byte[]> responses = new HashMap<>();
+        private final Map<Key, byte[]> reverts = new HashMap<>();
         private int callCount = 0;
 
         void respond(Address target, byte[] calldata, byte[] returnBytes) {
             responses.put(new Key(target, HexFormat.of().formatHex(calldata)), returnBytes);
+        }
+
+        void revertOn(Address target, byte[] calldata, byte[] revertData) {
+            reverts.put(new Key(target, HexFormat.of().formatHex(calldata)), revertData);
         }
 
         int callCount() { return callCount; }
@@ -287,8 +259,13 @@ class EnsResolverTest {
         @Override
         public CompletableFuture<byte[]> callView(Address target, byte[] calldata, BlockContext blockContext) {
             callCount++;
-            byte[] response = responses.get(
-                    new Key(target, HexFormat.of().formatHex(calldata)));
+            Key key = new Key(target, HexFormat.of().formatHex(calldata));
+            byte[] revertData = reverts.get(key);
+            if (revertData != null) {
+                return CompletableFuture.failedFuture(new EvmExecutionException(
+                        new EvmExecutionError.Reverted(revertData)));
+            }
+            byte[] response = responses.get(key);
             if (response == null) {
                 return CompletableFuture.failedFuture(new AssertionError(
                         "MockExecutor: no response programmed for callView(target="

--- a/myotis-evm/src/main/java/io/myotis/evm/CcipReadEvmExecutor.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/CcipReadEvmExecutor.java
@@ -1,0 +1,123 @@
+package io.myotis.evm;
+
+import io.myotis.evm.abi.AbiEncoder;
+import io.myotis.evm.ccipread.CcipReadHandler;
+import io.myotis.evm.ccipread.OffchainLookupRevert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+/**
+ * {@link EvmExecutor} decorator that handles ERC-3668 CCIP-Read transparently.
+ *
+ * <p>When a wrapped {@code callView} reverts with the {@code OffchainLookup}
+ * selector, this executor:
+ * <ol>
+ *   <li>Parses the revert payload into an {@link OffchainLookupRevert}.
+ *   <li>Asks the {@link CcipReadHandler} to fetch from the listed gateways
+ *       (URL template substitution + GET/POST routing per spec).
+ *   <li>Re-enters the EVM with
+ *       {@code callbackFunction(response, extraData)} targeted at the
+ *       original {@code sender}, recursing through this decorator so a
+ *       chained CCIP-Read on the callback is also handled — up to
+ *       {@link CcipReadHandler#MAX_RECURSION_DEPTH} (1, plan-mandated).
+ * </ol>
+ *
+ * <p>Composes with any other {@link EvmExecutor}: in production the wallet
+ * builds {@code new CcipReadEvmExecutor(new PrefetchingEvmExecutor(...))}
+ * so prefetching and CCIP-Read both work, with CCIP-Read on the outside
+ * because the OffchainLookup revert can only be observed at the call
+ * boundary.
+ *
+ * <p>If a non-CCIP-Read revert escapes the wrapped executor, this class
+ * passes it through unchanged.
+ */
+public final class CcipReadEvmExecutor implements EvmExecutor {
+
+    private static final Logger log = LoggerFactory.getLogger(CcipReadEvmExecutor.class);
+
+    private final EvmExecutor delegate;
+    private final CcipReadHandler handler;
+
+    public CcipReadEvmExecutor(EvmExecutor delegate, CcipReadHandler handler) {
+        this.delegate = delegate;
+        this.handler = handler;
+    }
+
+    @Override
+    public CompletableFuture<byte[]> callView(Address target, byte[] calldata, BlockContext blockContext) {
+        return tryWithCcipRead(target, calldata, blockContext, 0);
+    }
+
+    private CompletableFuture<byte[]> tryWithCcipRead(
+            Address target, byte[] calldata, BlockContext ctx, int depth) {
+        return delegate.callView(target, calldata, ctx)
+                .exceptionallyCompose(t -> handleException(t, ctx, depth));
+    }
+
+    private CompletableFuture<byte[]> handleException(Throwable t, BlockContext ctx, int depth) {
+        Throwable cause = unwrap(t);
+        Optional<OffchainLookupRevert> lookup = extractLookup(cause);
+        if (lookup.isEmpty()) {
+            // Not a CCIP-Read revert; rethrow whatever the delegate produced.
+            return CompletableFuture.failedFuture(cause);
+        }
+
+        if (depth >= CcipReadHandler.MAX_RECURSION_DEPTH) {
+            log.warn("[ccip] recursion depth {} exceeds cap {}; failing",
+                    depth, CcipReadHandler.MAX_RECURSION_DEPTH);
+            return CompletableFuture.failedFuture(new EvmExecutionException(
+                    new EvmExecutionError.CcipGatewayFailed(
+                            List.copyOf(lookup.get().urls()),
+                            List.of("CCIP-Read recursion depth " + depth
+                                    + " exceeds cap " + CcipReadHandler.MAX_RECURSION_DEPTH))));
+        }
+
+        byte[] gatewayResponse;
+        try {
+            gatewayResponse = handler.handle(lookup.get());
+        } catch (EvmExecutionException eee) {
+            return CompletableFuture.failedFuture(eee);
+        } catch (Exception e) {
+            return CompletableFuture.failedFuture(e);
+        }
+
+        byte[] callbackCalldata = encodeCallback(lookup.get(), gatewayResponse);
+        log.debug("[ccip] re-entering EVM (sender={}, depth={})",
+                lookup.get().sender(), depth + 1);
+        return tryWithCcipRead(lookup.get().sender(), callbackCalldata, ctx, depth + 1);
+    }
+
+    /**
+     * Build the calldata for the resolver's callback: a 4-byte selector
+     * followed by ABI-encoded {@code (bytes response, bytes extraData)}
+     * per ERC-3668 §6.
+     */
+    private static byte[] encodeCallback(OffchainLookupRevert lookup, byte[] response) {
+        byte[] selector = lookup.callbackSelector();
+        byte[] body = AbiEncoder.encodeRaw(
+                AbiEncoder.bytes(response),
+                AbiEncoder.bytes(lookup.extraData()));
+        byte[] out = new byte[selector.length + body.length];
+        System.arraycopy(selector, 0, out, 0, selector.length);
+        System.arraycopy(body, 0, out, selector.length, body.length);
+        return out;
+    }
+
+    private static Optional<OffchainLookupRevert> extractLookup(Throwable t) {
+        if (!(t instanceof EvmExecutionException eee)) return Optional.empty();
+        if (!(eee.error() instanceof EvmExecutionError.Reverted r)) return Optional.empty();
+        return OffchainLookupRevert.tryParse(r.data());
+    }
+
+    private static Throwable unwrap(Throwable t) {
+        while (t instanceof CompletionException && t.getCause() != null) {
+            t = t.getCause();
+        }
+        return t;
+    }
+}

--- a/myotis-evm/src/main/java/io/myotis/evm/CcipReadEvmExecutor.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/CcipReadEvmExecutor.java
@@ -35,6 +35,11 @@ import java.util.concurrent.CompletionException;
  *
  * <p>If a non-CCIP-Read revert escapes the wrapped executor, this class
  * passes it through unchanged.
+ *
+ * <p><strong>Async-by-contract.</strong> The handler chain is composed via
+ * {@link CompletableFuture#thenCompose} all the way down — no
+ * {@code join()}, no blocking on the EVM executor's thread pool. The
+ * gateway transport is free to use whatever async HTTP client it likes.
  */
 public final class CcipReadEvmExecutor implements EvmExecutor {
 
@@ -77,19 +82,15 @@ public final class CcipReadEvmExecutor implements EvmExecutor {
                                     + " exceeds cap " + CcipReadHandler.MAX_RECURSION_DEPTH))));
         }
 
-        byte[] gatewayResponse;
-        try {
-            gatewayResponse = handler.handle(lookup.get());
-        } catch (EvmExecutionException eee) {
-            return CompletableFuture.failedFuture(eee);
-        } catch (Exception e) {
-            return CompletableFuture.failedFuture(e);
-        }
-
-        byte[] callbackCalldata = encodeCallback(lookup.get(), gatewayResponse);
-        log.debug("[ccip] re-entering EVM (sender={}, depth={})",
-                lookup.get().sender(), depth + 1);
-        return tryWithCcipRead(lookup.get().sender(), callbackCalldata, ctx, depth + 1);
+        log.debug("[ccip] caught OffchainLookup; fetching from {} gateway(s)",
+                lookup.get().urls().size());
+        return handler.handle(lookup.get())
+                .thenCompose(gatewayResponse -> {
+                    byte[] callbackCalldata = encodeCallback(lookup.get(), gatewayResponse);
+                    log.debug("[ccip] re-entering EVM (sender={}, depth={})",
+                            lookup.get().sender(), depth + 1);
+                    return tryWithCcipRead(lookup.get().sender(), callbackCalldata, ctx, depth + 1);
+                });
     }
 
     /**

--- a/myotis-evm/src/main/java/io/myotis/evm/ccipread/CcipGateway.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/ccipread/CcipGateway.java
@@ -26,10 +26,11 @@ public interface CcipGateway {
      * Send a request to {@code url} and return the raw response body as a
      * UTF-8 string.
      *
-     * @param method  GET or POST. ERC-3668 says GET when the URL template
-     *                contains both {@code {sender}} and {@code {data}}
-     *                placeholders (so the request can fit in the URL),
-     *                POST otherwise.
+     * @param method  GET or POST. ERC-3668 §6.1: the wallet uses GET when
+     *                the URL template contains a {@code {data}} placeholder
+     *                (so the entire request fits in the URL), POST otherwise.
+     *                The {@code {sender}} placeholder is independent of the
+     *                routing decision — it can appear in either method's URL.
      * @param url     URL with {@code {sender}}/{@code {data}} placeholders
      *                already substituted.
      * @param body    For POST requests: the JSON body

--- a/myotis-evm/src/main/java/io/myotis/evm/ccipread/CcipGateway.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/ccipread/CcipGateway.java
@@ -1,0 +1,40 @@
+package io.myotis.evm.ccipread;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Pluggable HTTP transport for CCIP-Read gateway requests.
+ *
+ * <p>{@code :myotis-evm} stays decoupled from any specific HTTP client.
+ * The handler does URL template substitution, body construction, and
+ * response parsing; the wallet integration supplies the transport via
+ * this interface — typically a Ktor-backed implementation per the
+ * {@code CLAUDE.md} platform direction.
+ *
+ * <p>Tests substitute an in-memory implementation that returns hardcoded
+ * responses for specific URL/body combinations.
+ *
+ * <p>Same decoupling pattern as {@code SnapPeer} for the SNAP wire layer:
+ * the EVM module owns the protocol logic; the wallet owns the network.
+ */
+public interface CcipGateway {
+
+    /** HTTP method to use for the gateway request, per ERC-3668 §6.1. */
+    enum Method { GET, POST }
+
+    /**
+     * Send a request to {@code url} and return the raw response body as a
+     * UTF-8 string.
+     *
+     * @param method  GET or POST. ERC-3668 says GET when the URL template
+     *                contains both {@code {sender}} and {@code {data}}
+     *                placeholders (so the request can fit in the URL),
+     *                POST otherwise.
+     * @param url     URL with {@code {sender}}/{@code {data}} placeholders
+     *                already substituted.
+     * @param body    For POST requests: the JSON body
+     *                {@code {"sender": "0x...", "data": "0x..."}}. Null
+     *                or empty for GET requests.
+     */
+    CompletableFuture<String> request(Method method, String url, String body);
+}

--- a/myotis-evm/src/main/java/io/myotis/evm/ccipread/CcipReadHandler.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/ccipread/CcipReadHandler.java
@@ -3,78 +3,63 @@ package io.myotis.evm.ccipread;
 import io.myotis.evm.EvmExecutionError;
 import io.myotis.evm.EvmExecutionException;
 
-import java.io.IOException;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HexFormat;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
  * ERC-3668 (CCIP-Read) gateway handler.
  *
- * <p><strong>Phase 4 deliverable.</strong> The class is implemented as a
- * standalone unit so the OffchainLookup parser is exercised under tests; the
- * wiring into {@link io.myotis.evm.DefaultEvmExecutor#callView} happens in
- * Phase 4 once the recursion and re-entry semantics are settled.
+ * <p>When the EVM reverts with the {@code OffchainLookup} selector, the
+ * executor calls {@link #handle} with the parsed revert; this class
+ * iterates the listed URLs, performs the gateway request via the supplied
+ * {@link CcipGateway} transport (URL template substitution, GET/POST
+ * routing per spec), and returns the response bytes for the executor to
+ * pass into the contract's callback function.
  *
- * <p><strong>HTTP client TODO (Android compat).</strong> This class currently
- * uses {@code java.net.http.HttpClient} for the JVM Phase-4 prototype. That
- * package is API 33+ on Android and is <em>not</em> in the
- * {@code coreLibraryDesugaring} set, so it would crash at runtime on
- * {@code minSdk = 29} devices. Per {@code CLAUDE.md}'s "Platform & language
- * direction" section, the production HTTP client must be Ktor (works on
- * Android and is Compose-Multiplatform-ready). Swap before Phase 4 lands or
- * before this module is wired into {@code :android-app}.
- *
- * <p>Execution path per spec:
+ * <p>Execution path per ERC-3668 §6:
  * <ol>
  *   <li>EVM reverts with {@link OffchainLookupRevert#SELECTOR}.
  *   <li>For each URL in {@code urls}, attempt the gateway request:
- *       GET if the URL contains a {@code {data}} placeholder body, POST otherwise.
+ *       GET if the URL contains both {@code {sender}} and {@code {data}}
+ *       placeholders, POST otherwise.
  *   <li>Parse the JSON {@code {"data": "0x..."}} response.
- *   <li>The first URL that returns 200 wins; on all-failure, propagate
- *       {@link EvmExecutionError.CcipGatewayFailed}.
- *   <li>Re-enter the EVM with {@code callbackFunction(response, extraData)}
- *       targeted at {@code sender}. Recursion is capped at depth 1 (plan-mandated).
+ *   <li>The first URL that returns a parseable body wins; on all-failure,
+ *       throw {@link EvmExecutionError.CcipGatewayFailed}.
+ *   <li>The executor re-enters the EVM with
+ *       {@code callbackFunction(response, extraData)} targeted at
+ *       {@code sender}. Recursion is capped at depth 1 (plan-mandated).
  * </ol>
  *
- * <p>Privacy note: gateway calls leak the user's IP and the queried name to
- * the gateway operator. Tor routing is a future TODO.
+ * <p><strong>Privacy note.</strong> Gateway calls necessarily reveal:
+ * the user's IP address, the queried name (encoded in {@code callData}),
+ * and approximate request timing. Tor or Mixnet routing of these requests
+ * is a future privacy improvement tracked separately.
  */
 public final class CcipReadHandler {
 
-    /** Plan-mandated cap. Spec allows nesting; real resolvers don't need it. */
+    /** Plan-mandated cap. The spec allows nesting; real resolvers don't need it. */
     public static final int MAX_RECURSION_DEPTH = 1;
 
     private static final Pattern SENDER_PLACEHOLDER = Pattern.compile("\\{sender\\}");
     private static final Pattern DATA_PLACEHOLDER   = Pattern.compile("\\{data\\}");
     private static final Pattern DATA_FIELD_RE      = Pattern.compile("\"data\"\\s*:\\s*\"(0x[0-9a-fA-F]*)\"");
 
-    private final HttpClient client;
-    private final Duration perGatewayTimeout;
+    private final CcipGateway gateway;
 
-    public CcipReadHandler(HttpClient client, Duration perGatewayTimeout) {
-        this.client = client;
-        this.perGatewayTimeout = perGatewayTimeout;
-    }
-
-    public CcipReadHandler() {
-        this(HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build(),
-                Duration.ofSeconds(10));
+    public CcipReadHandler(CcipGateway gateway) {
+        this.gateway = gateway;
     }
 
     /**
      * Try each URL in order. Returns the {@code data} bytes from the first
-     * gateway that responds with a 200 and a parseable body. Throws
-     * {@link EvmExecutionException} wrapping {@link EvmExecutionError.CcipGatewayFailed}
-     * if every URL fails.
+     * gateway that responds with a parseable body. Throws
+     * {@link EvmExecutionException} wrapping
+     * {@link EvmExecutionError.CcipGatewayFailed} if every URL fails.
      */
     public byte[] handle(OffchainLookupRevert lookup) {
         List<String> reasons = new ArrayList<>(lookup.urls().size());
@@ -84,45 +69,46 @@ public final class CcipReadHandler {
                 if (response != null) return response;
                 reasons.add("non-200 or unparseable response from " + urlTemplate);
             } catch (Exception e) {
-                reasons.add(urlTemplate + ": " + e.getClass().getSimpleName() + ": " + e.getMessage());
+                Throwable cause = e instanceof CompletionException && e.getCause() != null
+                        ? e.getCause() : e;
+                reasons.add(urlTemplate + ": " + cause.getClass().getSimpleName()
+                        + ": " + cause.getMessage());
             }
         }
         throw new EvmExecutionException(
-                new EvmExecutionError.CcipGatewayFailed(List.copyOf(lookup.urls()), List.copyOf(reasons)));
+                new EvmExecutionError.CcipGatewayFailed(
+                        List.copyOf(lookup.urls()), List.copyOf(reasons)));
     }
 
-    private byte[] tryUrl(String urlTemplate, OffchainLookupRevert lookup) throws IOException, InterruptedException {
+    private byte[] tryUrl(String urlTemplate, OffchainLookupRevert lookup) {
         String senderHex = lookup.sender().toHex();
         String dataHex = "0x" + HexFormat.of().formatHex(lookup.callData());
-        String substituted = SENDER_PLACEHOLDER.matcher(urlTemplate).replaceAll(Matcher.quoteReplacement(senderHex));
-        boolean hasDataPlaceholder = DATA_PLACEHOLDER.matcher(substituted).find();
-        substituted = DATA_PLACEHOLDER.matcher(substituted).replaceAll(Matcher.quoteReplacement(dataHex));
 
-        HttpRequest request;
-        if (hasDataPlaceholder) {
-            // GET — both placeholders were embedded directly in the URL.
-            request = HttpRequest.newBuilder(URI.create(substituted))
-                    .timeout(perGatewayTimeout)
-                    .header("Accept", "application/json")
-                    .GET().build();
-        } else {
-            // POST — the gateway expects a JSON body with sender/data.
-            String body = "{\"sender\":\"" + senderHex + "\",\"data\":\"" + dataHex + "\"}";
-            request = HttpRequest.newBuilder(URI.create(substituted))
-                    .timeout(perGatewayTimeout)
-                    .header("Accept", "application/json")
-                    .header("Content-Type", "application/json")
-                    .POST(HttpRequest.BodyPublishers.ofString(body, StandardCharsets.UTF_8))
-                    .build();
-        }
+        // ERC-3668 §6.1: route is GET if the URL template contains {data}
+        // (so the entire request fits in the path/query), POST otherwise.
+        // Detection happens BEFORE substitution because once substituted
+        // the placeholder is gone.
+        boolean hasDataPlaceholder = DATA_PLACEHOLDER.matcher(urlTemplate).find();
 
-        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
-        if (response.statusCode() / 100 != 2) return null;
-        return parseDataField(response.body());
+        String substituted = SENDER_PLACEHOLDER.matcher(urlTemplate)
+                .replaceAll(Matcher.quoteReplacement(senderHex));
+        substituted = DATA_PLACEHOLDER.matcher(substituted)
+                .replaceAll(Matcher.quoteReplacement(dataHex));
+
+        CcipGateway.Method method = hasDataPlaceholder
+                ? CcipGateway.Method.GET : CcipGateway.Method.POST;
+        String body = method == CcipGateway.Method.POST
+                ? "{\"sender\":\"" + senderHex + "\",\"data\":\"" + dataHex + "\"}"
+                : null;
+
+        String responseBody = gateway.request(method, substituted, body).join();
+        if (responseBody == null) return null;
+        return parseDataField(responseBody);
     }
 
     /** Returns the bytes hex-encoded under {@code data}, or null if absent. */
     static byte[] parseDataField(String json) {
+        if (json == null) return null;
         Matcher m = DATA_FIELD_RE.matcher(json);
         if (!m.find()) return null;
         String hex = m.group(1);

--- a/myotis-evm/src/main/java/io/myotis/evm/ccipread/CcipReadHandler.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/ccipread/CcipReadHandler.java
@@ -16,24 +16,37 @@ import java.util.regex.Pattern;
  *
  * <p>When the EVM reverts with the {@code OffchainLookup} selector, the
  * executor calls {@link #handle} with the parsed revert; this class
- * iterates the listed URLs, performs the gateway request via the supplied
- * {@link CcipGateway} transport (URL template substitution, GET/POST
- * routing per spec), and returns the response bytes for the executor to
- * pass into the contract's callback function.
+ * iterates the listed URLs <strong>serially</strong> and asynchronously,
+ * performing each gateway request via the supplied {@link CcipGateway}
+ * transport (URL template substitution, GET/POST routing per spec) until
+ * one succeeds, then completes the returned future with the response
+ * bytes for the executor to pass into the contract's callback function.
  *
  * <p>Execution path per ERC-3668 §6:
  * <ol>
  *   <li>EVM reverts with {@link OffchainLookupRevert#SELECTOR}.
  *   <li>For each URL in {@code urls}, attempt the gateway request:
- *       GET if the URL contains both {@code {sender}} and {@code {data}}
- *       placeholders, POST otherwise.
+ *       GET if the URL template contains a {@code {data}} placeholder
+ *       (so the call fits in the URL), POST otherwise. Per ERC-3668 §6.1.
  *   <li>Parse the JSON {@code {"data": "0x..."}} response.
  *   <li>The first URL that returns a parseable body wins; on all-failure,
- *       throw {@link EvmExecutionError.CcipGatewayFailed}.
+ *       the future fails with {@link EvmExecutionError.CcipGatewayFailed}.
  *   <li>The executor re-enters the EVM with
  *       {@code callbackFunction(response, extraData)} targeted at
  *       {@code sender}. Recursion is capped at depth 1 (plan-mandated).
  * </ol>
+ *
+ * <p><strong>Async by contract.</strong> {@link #handle} returns a
+ * {@link CompletableFuture} so the caller (the {@code CcipReadEvmExecutor}
+ * decorator) can chain via {@code thenCompose} without blocking the EVM
+ * thread on network IO. Earlier drafts used {@code .join()} which tied up
+ * the executor thread pool and risked deadlock if the gateway impl
+ * completed on the same pool.
+ *
+ * <p>URLs are tried <strong>serially</strong>, not in parallel, because the
+ * spec wants the first listed URL to win when it can — failing over only
+ * if it actually fails. Parallel fan-out would mask diagnostic information
+ * about specific gateway problems and increase peer load.
  *
  * <p><strong>Privacy note.</strong> Gateway calls necessarily reveal:
  * the user's IP address, the queried name (encoded in {@code callData}),
@@ -56,38 +69,47 @@ public final class CcipReadHandler {
     }
 
     /**
-     * Try each URL in order. Returns the {@code data} bytes from the first
-     * gateway that responds with a parseable body. Throws
-     * {@link EvmExecutionException} wrapping
+     * Try each URL serially until one returns a parseable body. The
+     * returned future completes with that body's {@code data} bytes, or
+     * fails with {@link EvmExecutionException} wrapping
      * {@link EvmExecutionError.CcipGatewayFailed} if every URL fails.
      */
-    public byte[] handle(OffchainLookupRevert lookup) {
-        List<String> reasons = new ArrayList<>(lookup.urls().size());
-        for (String urlTemplate : lookup.urls()) {
-            try {
-                byte[] response = tryUrl(urlTemplate, lookup);
-                if (response != null) return response;
-                reasons.add("non-200 or unparseable response from " + urlTemplate);
-            } catch (Exception e) {
-                Throwable cause = e instanceof CompletionException && e.getCause() != null
-                        ? e.getCause() : e;
-                reasons.add(urlTemplate + ": " + cause.getClass().getSimpleName()
-                        + ": " + cause.getMessage());
-            }
-        }
-        throw new EvmExecutionException(
-                new EvmExecutionError.CcipGatewayFailed(
-                        List.copyOf(lookup.urls()), List.copyOf(reasons)));
+    public CompletableFuture<byte[]> handle(OffchainLookupRevert lookup) {
+        return tryUrlsSerially(lookup, 0, new ArrayList<>(lookup.urls().size()));
     }
 
-    private byte[] tryUrl(String urlTemplate, OffchainLookupRevert lookup) {
+    private CompletableFuture<byte[]> tryUrlsSerially(
+            OffchainLookupRevert lookup, int idx, List<String> reasons) {
+        if (idx >= lookup.urls().size()) {
+            return CompletableFuture.failedFuture(new EvmExecutionException(
+                    new EvmExecutionError.CcipGatewayFailed(
+                            List.copyOf(lookup.urls()), List.copyOf(reasons))));
+        }
+        String urlTemplate = lookup.urls().get(idx);
+        return tryUrlAsync(urlTemplate, lookup)
+                .thenCompose(response -> {
+                    if (response != null) {
+                        return CompletableFuture.completedFuture(response);
+                    }
+                    reasons.add("non-200 or unparseable response from " + urlTemplate);
+                    return tryUrlsSerially(lookup, idx + 1, reasons);
+                })
+                .exceptionallyCompose(t -> {
+                    Throwable cause = unwrap(t);
+                    reasons.add(urlTemplate + ": " + cause.getClass().getSimpleName()
+                            + ": " + cause.getMessage());
+                    return tryUrlsSerially(lookup, idx + 1, reasons);
+                });
+    }
+
+    private CompletableFuture<byte[]> tryUrlAsync(String urlTemplate, OffchainLookupRevert lookup) {
         String senderHex = lookup.sender().toHex();
         String dataHex = "0x" + HexFormat.of().formatHex(lookup.callData());
 
         // ERC-3668 §6.1: route is GET if the URL template contains {data}
         // (so the entire request fits in the path/query), POST otherwise.
-        // Detection happens BEFORE substitution because once substituted
-        // the placeholder is gone.
+        // Detection happens BEFORE substitution because once substituted the
+        // placeholder is gone.
         boolean hasDataPlaceholder = DATA_PLACEHOLDER.matcher(urlTemplate).find();
 
         String substituted = SENDER_PLACEHOLDER.matcher(urlTemplate)
@@ -101,9 +123,8 @@ public final class CcipReadHandler {
                 ? "{\"sender\":\"" + senderHex + "\",\"data\":\"" + dataHex + "\"}"
                 : null;
 
-        String responseBody = gateway.request(method, substituted, body).join();
-        if (responseBody == null) return null;
-        return parseDataField(responseBody);
+        return gateway.request(method, substituted, body)
+                .thenApply(CcipReadHandler::parseDataField);
     }
 
     /** Returns the bytes hex-encoded under {@code data}, or null if absent. */
@@ -115,5 +136,12 @@ public final class CcipReadHandler {
         if (hex.startsWith("0x") || hex.startsWith("0X")) hex = hex.substring(2);
         if (hex.isEmpty()) return new byte[0];
         return HexFormat.of().parseHex(hex);
+    }
+
+    private static Throwable unwrap(Throwable t) {
+        while (t instanceof CompletionException && t.getCause() != null) {
+            t = t.getCause();
+        }
+        return t;
     }
 }

--- a/myotis-evm/src/test/java/io/myotis/evm/CcipReadEvmExecutorTest.java
+++ b/myotis-evm/src/test/java/io/myotis/evm/CcipReadEvmExecutorTest.java
@@ -1,0 +1,338 @@
+package io.myotis.evm;
+
+import io.myotis.evm.abi.AbiDecoder;
+import io.myotis.evm.abi.AbiEncoder;
+import io.myotis.evm.abi.AbiValue;
+import io.myotis.evm.abi.FunctionSignature;
+import io.myotis.evm.besu.EvmFactory;
+import io.myotis.evm.ccipread.CcipGateway;
+import io.myotis.evm.ccipread.CcipReadHandler;
+import io.myotis.evm.ccipread.OffchainLookupRevert;
+import io.myotis.evm.world.AccountState;
+import io.myotis.evm.world.BytecodeCache;
+import io.myotis.evm.world.FixtureSnapStateOracle;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.HashMap;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * End-to-end tests for {@link CcipReadEvmExecutor}.
+ *
+ * <p>The tests build hand-crafted bytecode that reverts with the
+ * {@code OffchainLookup} payload, then verify the executor catches the
+ * revert, calls the {@link MockGateway} to fetch the response, and
+ * re-enters the EVM against the resolver-supplied {@code sender} address
+ * with the proper callback calldata.
+ */
+class CcipReadEvmExecutorTest {
+
+    private static final Address RESOLVER_CONTRACT = Address.fromHex(
+            "0x1111111111111111111111111111111111111111");
+    /** Where the OffchainLookup directs the wallet to call back. */
+    private static final Address CALLBACK_CONTRACT = Address.fromHex(
+            "0x2222222222222222222222222222222222222222");
+    /** Selector the resolver will ask the wallet to invoke on the callback contract. */
+    private static final byte[] CALLBACK_SELECTOR = hex("aabbccdd");
+    /** Arbitrary opaque blob the resolver puts in {@code extraData}. */
+    private static final byte[] EXTRA_DATA = hex("c0ffee");
+
+    /** Returns 32 bytes ending in 0xff regardless of calldata. */
+    private static final byte[] RETURN_FF_BYTECODE = hex("60ff60005260206000f3");
+
+    /** A contract that reverts with empty data — used for the passthrough test. */
+    private static final byte[] EMPTY_REVERT_BYTECODE = hex("60006000fd");
+
+    @Test
+    void offchainLookupRevertTriggersGatewayCallAndCallback() throws Exception {
+        // Resolver bytecode reverts with OffchainLookup pointing at CALLBACK_CONTRACT.
+        // Callback bytecode returns 32 bytes ending in 0xff.
+        byte[] resolverCode = revertWithOffchainLookup(
+                CALLBACK_CONTRACT,
+                List.of("test://gateway/{sender}/{data}"),
+                hex("01020304"),  // callData
+                CALLBACK_SELECTOR,
+                EXTRA_DATA);
+
+        var oracle = oracleWithContracts(
+                Map.of(
+                        RESOLVER_CONTRACT, resolverCode,
+                        CALLBACK_CONTRACT, RETURN_FF_BYTECODE));
+
+        // Gateway returns a hardcoded JSON {"data":"0xdeadbeef"} for any URL/body.
+        // The bytes here become the `response` argument to the callback.
+        MockGateway gateway = new MockGateway();
+        gateway.respondWith("{\"data\":\"0xdeadbeef\"}");
+
+        var handler = new CcipReadHandler(gateway);
+        var executor = new CcipReadEvmExecutor(new DefaultEvmExecutor(oracle), handler);
+
+        byte[] result = executor.callView(RESOLVER_CONTRACT, hex("12345678"), ctx()).get();
+        // The callback contract returned 0xff in slot 0 of a 32-byte uint.
+        assertEquals(BigInteger.valueOf(255), AbiDecoder.uint256(result, 0));
+
+        // Gateway was called exactly once.
+        assertEquals(1, gateway.callCount());
+        // Substituted URL contained both placeholders' values.
+        assertEquals("test://gateway/" + CALLBACK_CONTRACT.toHex() + "/0x01020304",
+                gateway.lastUrl());
+        // It was a GET (because the URL template had {data}).
+        assertEquals(CcipGateway.Method.GET, gateway.lastMethod());
+    }
+
+    @Test
+    void postRoutedWhenUrlOmitsDataPlaceholder() throws Exception {
+        // URL has only {sender}; per ERC-3668 §6.1 this means POST with the
+        // (sender, data) JSON body.
+        byte[] resolverCode = revertWithOffchainLookup(
+                CALLBACK_CONTRACT,
+                List.of("https://example/{sender}"),
+                hex("99"),
+                CALLBACK_SELECTOR,
+                hex(""));
+
+        var oracle = oracleWithContracts(
+                Map.of(
+                        RESOLVER_CONTRACT, resolverCode,
+                        CALLBACK_CONTRACT, RETURN_FF_BYTECODE));
+
+        MockGateway gateway = new MockGateway();
+        gateway.respondWith("{\"data\":\"0x00\"}");
+
+        var handler = new CcipReadHandler(gateway);
+        var executor = new CcipReadEvmExecutor(new DefaultEvmExecutor(oracle), handler);
+
+        executor.callView(RESOLVER_CONTRACT, hex(""), ctx()).get();
+        assertEquals(CcipGateway.Method.POST, gateway.lastMethod());
+        // POST body carries (sender, data) JSON.
+        assertEquals(
+                "{\"sender\":\"" + CALLBACK_CONTRACT.toHex() + "\",\"data\":\"0x99\"}",
+                gateway.lastBody());
+    }
+
+    @Test
+    void allGatewaysFailingPropagatesCcipGatewayFailed() {
+        byte[] resolverCode = revertWithOffchainLookup(
+                CALLBACK_CONTRACT,
+                List.of("test://gateway-1/{sender}/{data}", "test://gateway-2/{sender}/{data}"),
+                hex(""),
+                CALLBACK_SELECTOR,
+                hex(""));
+
+        var oracle = oracleWithContracts(
+                Map.of(
+                        RESOLVER_CONTRACT, resolverCode,
+                        CALLBACK_CONTRACT, RETURN_FF_BYTECODE));
+
+        // Gateway throws on every request — every URL in the list fails.
+        MockGateway gateway = new MockGateway();
+        gateway.respondWithFailure(new RuntimeException("gateway unreachable"));
+
+        var handler = new CcipReadHandler(gateway);
+        var executor = new CcipReadEvmExecutor(new DefaultEvmExecutor(oracle), handler);
+
+        try {
+            executor.callView(RESOLVER_CONTRACT, hex(""), ctx()).get();
+            fail("expected CcipGatewayFailed");
+        } catch (Exception e) {
+            Throwable cause = e instanceof ExecutionException ? e.getCause() : e;
+            var eee = assertInstanceOf(EvmExecutionException.class, cause);
+            var failed = assertInstanceOf(EvmExecutionError.CcipGatewayFailed.class, eee.error());
+            assertEquals(2, failed.urls().size(),
+                    "both URLs must be reported in the failure");
+        }
+    }
+
+    @Test
+    void nonCcipReadRevertPassesThrough() {
+        // A regular revert (no OffchainLookup selector) must reach the
+        // caller unchanged — the CCIP-Read decorator only intercepts
+        // OffchainLookup-shaped payloads.
+        var oracle = oracleWithContracts(
+                Map.of(RESOLVER_CONTRACT, EMPTY_REVERT_BYTECODE));
+
+        MockGateway gateway = new MockGateway(); // never called
+        var executor = new CcipReadEvmExecutor(
+                new DefaultEvmExecutor(oracle),
+                new CcipReadHandler(gateway));
+
+        try {
+            executor.callView(RESOLVER_CONTRACT, hex(""), ctx()).get();
+            fail("expected the underlying revert to surface");
+        } catch (Exception e) {
+            Throwable cause = e instanceof ExecutionException ? e.getCause() : e;
+            var eee = assertInstanceOf(EvmExecutionException.class, cause);
+            assertInstanceOf(EvmExecutionError.Reverted.class, eee.error());
+        }
+        assertEquals(0, gateway.callCount(),
+                "non-CCIP-Read revert must not invoke the gateway");
+    }
+
+    @Test
+    void recursiveCcipReadCappedAtOneHop() {
+        // Resolver A reverts with OffchainLookup pointing at Resolver A's
+        // own address. The callback re-enters A, which reverts again. The
+        // second OffchainLookup exceeds the depth cap (1) and surfaces as
+        // CcipGatewayFailed.
+        byte[] selfReferentialRevert = revertWithOffchainLookup(
+                RESOLVER_CONTRACT,  // sender = self
+                List.of("test://gateway/{sender}/{data}"),
+                hex(""),
+                CALLBACK_SELECTOR,
+                hex(""));
+
+        var oracle = oracleWithContracts(Map.of(RESOLVER_CONTRACT, selfReferentialRevert));
+
+        MockGateway gateway = new MockGateway();
+        gateway.respondWith("{\"data\":\"0x\"}");
+
+        var handler = new CcipReadHandler(gateway);
+        var executor = new CcipReadEvmExecutor(new DefaultEvmExecutor(oracle), handler);
+
+        try {
+            executor.callView(RESOLVER_CONTRACT, hex(""), ctx()).get();
+            fail("expected CcipGatewayFailed for recursion-cap breach");
+        } catch (Exception e) {
+            Throwable cause = e instanceof ExecutionException ? e.getCause() : e;
+            var eee = assertInstanceOf(EvmExecutionException.class, cause);
+            assertInstanceOf(EvmExecutionError.CcipGatewayFailed.class, eee.error());
+        }
+        // First call hit the gateway, second call (after depth cap) should not.
+        assertEquals(1, gateway.callCount());
+    }
+
+    // ---- Bytecode helpers --------------------------------------------------
+
+    /**
+     * Build bytecode that reverts with an ERC-3668 {@code OffchainLookup}
+     * payload. The strategy: pre-compute the entire revert payload as a
+     * static byte array, append it to the code section, and prepend a
+     * tiny stub that {@code CODECOPY}s the payload into memory and
+     * {@code REVERT}s with it.
+     */
+    private static byte[] revertWithOffchainLookup(
+            Address sender, List<String> urls, byte[] callData,
+            byte[] callbackSelector4, byte[] extraData) {
+        if (callbackSelector4.length != 4) {
+            throw new IllegalArgumentException("callbackSelector must be 4 bytes");
+        }
+        // ABI-encode the body: (address sender, string[] urls, bytes callData,
+        // bytes4 callbackFunction, bytes extraData). bytes4 is left-aligned
+        // in its 32-byte slot.
+        byte[] callbackPadded = new byte[32];
+        System.arraycopy(callbackSelector4, 0, callbackPadded, 0, 4);
+        byte[] body = AbiEncoder.encodeRaw(
+                AbiEncoder.address(sender),
+                AbiEncoder.stringArray(urls),
+                AbiEncoder.bytes(callData),
+                new AbiValue(false, callbackPadded),
+                AbiEncoder.bytes(extraData));
+        byte[] selector = OffchainLookupRevert.SELECTOR;
+        byte[] payload = new byte[selector.length + body.length];
+        System.arraycopy(selector, 0, payload, 0, selector.length);
+        System.arraycopy(body, 0, payload, selector.length, body.length);
+
+        // Stub: CODECOPY payload from offset 15 (== prefix length) into
+        // memory[0..len], then REVERT memory[0..len].
+        //   PUSH2 length    (0x61 LL HH)        3 bytes
+        //   PUSH2 offset    (0x61 LL HH)        3 bytes
+        //   PUSH1 0         (0x60 0x00)         2 bytes
+        //   CODECOPY        (0x39)              1 byte
+        //   PUSH2 length    (0x61 LL HH)        3 bytes
+        //   PUSH1 0         (0x60 0x00)         2 bytes
+        //   REVERT          (0xfd)              1 byte
+        // Total = 15 bytes.
+        int len = payload.length;
+        int codeOffset = 15;
+        byte[] prefix = {
+                0x61, hi(len), lo(len),
+                0x61, hi(codeOffset), lo(codeOffset),
+                0x60, 0x00,
+                0x39,
+                0x61, hi(len), lo(len),
+                0x60, 0x00,
+                (byte) 0xfd,
+        };
+        byte[] result = new byte[prefix.length + payload.length];
+        System.arraycopy(prefix, 0, result, 0, prefix.length);
+        System.arraycopy(payload, 0, result, prefix.length, payload.length);
+        return result;
+    }
+
+    private static byte hi(int n) { return (byte) ((n >>> 8) & 0xff); }
+    private static byte lo(int n) { return (byte) (n & 0xff); }
+
+    private static FixtureSnapStateOracle oracleWithContracts(Map<Address, byte[]> contracts) {
+        var b = FixtureSnapStateOracle.builder();
+        for (var entry : contracts.entrySet()) {
+            byte[] codeHash = FixtureSnapStateOracle.codeHashOf(entry.getValue());
+            b.account(new AccountState(entry.getKey(), 0L, BigInteger.ZERO, codeHash));
+            b.bytecode(entry.getValue());
+        }
+        return b.build();
+    }
+
+    private static byte[] hex(String s) {
+        return HexFormat.of().parseHex(s);
+    }
+
+    private static BlockContext ctx() {
+        return new BlockContext(
+                new byte[32],
+                19_500_000L,
+                EvmFactory.CANCUN_TIME + 1,
+                BigInteger.valueOf(1_000_000_000L),
+                Address.ZERO,
+                new byte[32],
+                BigInteger.ONE,
+                30_000_000L);
+    }
+
+    /** Programmable {@link CcipGateway} for tests. */
+    private static final class MockGateway implements CcipGateway {
+        private String responseBody;
+        private RuntimeException failure;
+        private int callCount;
+        private String lastUrl;
+        private String lastBody;
+        private Method lastMethod;
+
+        void respondWith(String body) {
+            this.responseBody = body;
+            this.failure = null;
+        }
+
+        void respondWithFailure(RuntimeException e) {
+            this.failure = e;
+            this.responseBody = null;
+        }
+
+        int callCount() { return callCount; }
+        String lastUrl() { return lastUrl; }
+        String lastBody() { return lastBody; }
+        Method lastMethod() { return lastMethod; }
+
+        @Override
+        public CompletableFuture<String> request(Method method, String url, String body) {
+            callCount++;
+            lastMethod = method;
+            lastUrl = url;
+            lastBody = body;
+            if (failure != null) {
+                return CompletableFuture.failedFuture(failure);
+            }
+            return CompletableFuture.completedFuture(Objects.requireNonNull(responseBody));
+        }
+    }
+}


### PR DESCRIPTION
Wires ERC-3668 CCIP-Read into the EVM execution path. When a wrapped
callView reverts with the OffchainLookup selector, the new
CcipReadEvmExecutor catches it, fetches from the listed gateways via a
pluggable transport, and re-enters the EVM against the resolver-supplied
sender with the proper callback calldata. Recursion is capped at 1 hop
per the plan.

Key design choices

- Decorator over delegate. CcipReadEvmExecutor wraps any EvmExecutor
  (Default, Prefetching, etc.) instead of being baked into
  DefaultEvmExecutor. Wallet stack:
    new CcipReadEvmExecutor(new PrefetchingEvmExecutor(new DefaultEvmExecutor(oracle)), handler)
  CCIP-Read on the outside because OffchainLookup reverts can only be
  observed at the call boundary; prefetch on the inside because each
  re-entered call still benefits from the convergence loop.
- Pluggable HTTP. CcipReadHandler used to embed java.net.http.HttpClient,
  which crashes on Android < API 33 (not in coreLibraryDesugaring) and
  contradicts CLAUDE.md's "use Ktor" directive. Refactored to take a
  CcipGateway interface — a small SAM-shape (method, url, body) ->
  CompletableFuture<String>. The handler does URL substitution + GET/POST
  routing + response parsing; the wallet supplies the transport. Same
  decoupling pattern as SnapPeer for the SNAP wire layer.

Files
- ccipread/CcipGateway.java: new interface.
- ccipread/CcipReadHandler.java: rewritten around CcipGateway. URL
  template substitution (regex-based, kept intact). GET/POST route
  detection now happens BEFORE substitution (so {data}'s presence as a
  template literal triggers GET, not the substituted value).
- CcipReadEvmExecutor.java: new public decorator.
  - exceptionallyCompose() catches CompletionException-wrapped reverts
    and routes them through extractLookup -> handler -> re-entry.
  - encodeCallback() builds the callback calldata: 4-byte selector +
    abi.encode(bytes response, bytes extraData) per ERC-3668 §6.
  - 1-hop recursion cap raises CcipGatewayFailed if breached.
  - Non-CCIP-Read reverts pass through unchanged.

Tests (5 new in CcipReadEvmExecutorTest)
- offchainLookupRevertTriggersGatewayCallAndCallback: full flow with
  hand-crafted bytecode that reverts with a real OffchainLookup payload
  (constructed via AbiEncoder + CODECOPY/REVERT stub) and a callback
  contract that returns 0xff. Verifies URL substitution and GET routing.
- postRoutedWhenUrlOmitsDataPlaceholder: URL with only {sender} -> POST
  with the (sender, data) JSON body. ERC-3668 §6.1 routing.
- allGatewaysFailingPropagatesCcipGatewayFailed: every gateway throws ->
  the call's failure mode lists all attempted URLs.
- nonCcipReadRevertPassesThrough: empty REVERT (non-CCIP-Read) reaches
  the caller unchanged; gateway never consulted.
- recursiveCcipReadCappedAtOneHop: self-referential resolver hits the
  depth-1 cap and surfaces CcipGatewayFailed.

42/42 :myotis-evm unit tests pass (37 prior + 5 new).
12/12 :myotis-ens still pass — Phase 3 unaffected.

Out of scope for this commit (phase 4 follow-ups)
- DnsEncoder + EnsResolver Universal Resolver path. Step-by-step still
  works for classic names; UR's win is unifying CCIP-Read flows, which
  this commit makes possible at the executor level. EnsResolver switch
  is mechanical follow-up.
- Ktor implementation of CcipGateway. The handler contract is now
  decoupled; wallet integration provides the impl in :app or a sibling
  module.
- Mainnet IT corpus expansion (.cb.id, .uni.eth, .base.eth). Requires
  the bootstrap helper that gates Phases 1-3 mainnet ITs.

https://claude.ai/code/session_01GhcPYmMi6z3YGrZSe5wuA3