### PR TITLE
docs: add Portal Network deprecation notice to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,14 @@ Five Gradle modules:
 
 ## Data sources
 - the only sources for data are devp2p and libp2p calling a local client via http may only be used for debugging purposes it is not an option for production
+- **Portal Network is dead.** The EF officially discontinued Portal Network and
+  nobody has picked up its development. Do NOT treat Portal as available
+  infrastructure — anything Portal would have solved (deep historical state/blocks,
+  a distributed state network as a SNAP fallback, etc.) must be solved another way.
+  If you ever come across credible evidence that Portal has been revived or that
+  someone is actively continuing it, FLAG IT TO THE USER IMMEDIATELY and
+  prominently — the user wants to know right away because it would cover a lot of
+  wallet needs.
 
 ## Integration-Test
 - When './gradlew :app:run -Pargs=beacon-status' returns "state":"SYNCED" then './gradlew :app:run -Pargs="get-storage 0x1A5F9352Af8aF974bFC03399e3767DF6370d82e4 1 0x308686553a1EAC2fE721Ac8B814De638975a276e"'  and './gradlew  :app:run -Pargs="get-account 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"' should return "verifyMethod":"headerChain"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,14 +97,17 @@ Five Gradle modules:
 
 ## Data sources
 - the only sources for data are devp2p and libp2p calling a local client via http may only be used for debugging purposes it is not an option for production
-- **Portal Network is dead.** The EF officially discontinued Portal Network and
-  nobody has picked up its development. Do NOT treat Portal as available
-  infrastructure — anything Portal would have solved (deep historical state/blocks,
-  a distributed state network as a SNAP fallback, etc.) must be solved another way.
-  If you ever come across credible evidence that Portal has been revived or that
-  someone is actively continuing it, FLAG IT TO THE USER IMMEDIATELY and
-  prominently — the user wants to know right away because it would cover a lot of
-  wallet needs.
+- **Portal Network is effectively dead.** Its reference clients are abandoned:
+  the EF's own Trin client README states "THIS PROJECT IS NO LONGER ACTIVELY
+  MAINTAINED" (https://github.com/ethereum/trin), and no one is actively
+  continuing the network. (Note: ethereum.org docs may still list Trin/Fluffy as
+  active — that is stale and not reliable.) Do NOT treat Portal as available
+  infrastructure — anything Portal would have solved (deep historical
+  state/blocks, a distributed state network as a SNAP fallback, etc.) must be
+  solved another way. If you ever come across credible evidence that Portal has
+  been revived or that someone is actively continuing it, FLAG IT TO THE USER
+  IMMEDIATELY and prominently — the user wants to know right away because it would
+  cover a lot of wallet needs.
 
 ## Integration-Test
 - When './gradlew :app:run -Pargs=beacon-status' returns "state":"SYNCED" then './gradlew :app:run -Pargs="get-storage 0x1A5F9352Af8aF974bFC03399e3767DF6370d82e4 1 0x308686553a1EAC2fE721Ac8B814De638975a276e"'  and './gradlew  :app:run -Pargs="get-account 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"' should return "verifyMethod":"headerChain"


### PR DESCRIPTION
## Summary
Added a prominent notice to the project conventions documenting that Portal Network has been officially discontinued by the Ethereum Foundation and should not be treated as available infrastructure.

## Changes
- Added a new section under "Data sources" in CLAUDE.md explicitly stating that Portal Network is dead and no longer under active development
- Documented that Portal should not be relied upon for solving historical state/blocks or distributed state network needs
- Included instructions to flag any credible evidence of Portal revival to users immediately, as it would be significant for wallet infrastructure planning

## Rationale
This clarifies project assumptions about available data sources and prevents future contributors from considering Portal Network as a viable option for the architecture. The notice ensures that if Portal is ever revived, the team will be aware and can reassess design decisions accordingly.

https://claude.ai/code/session_01UFWiKHPPpKtAa7fHzvUhSu