### PR TITLE
jsonrpc-server: verified JSON-RPC endpoint for MetaMask (Phase A + B reads) + account-proof hardening

### DIFF
--- a/android-app/build.gradle.kts
+++ b/android-app/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.Properties
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
@@ -73,6 +75,16 @@ configurations.all {
     // Android incompatibilities never trigger.)
 }
 
+// Optional JSON-RPC upstream-proxy URL (DEBUG/dev only) read from local.properties
+// (`rpc.upstream=...`), which is gitignored — the Infura key never enters the repo.
+// Empty when unset → the JSON-RPC server runs in strict (no-proxy) mode.
+val rpcUpstream: String = run {
+    val props = Properties()
+    val lp = rootProject.file("local.properties")
+    if (lp.exists()) lp.inputStream().use { props.load(it) }
+    props.getProperty("rpc.upstream", "")
+}
+
 android {
     namespace = "com.jaeckel.ethp2p.android"
     compileSdk = 34
@@ -83,6 +95,7 @@ android {
         targetSdk = 34
         versionCode = 1
         versionName = "0.1.0"
+        buildConfigField("String", "RPC_UPSTREAM", "\"$rpcUpstream\"")
     }
 
     compileOptions {
@@ -98,6 +111,7 @@ android {
 
     buildFeatures {
         compose = true
+        buildConfig = true
     }
 
     // Pin the debug signing identity to a keystore checked into the repo so
@@ -175,6 +189,10 @@ dependencies {
     // a transitive `implementation` dep from the consumer's compile classpath.
     implementation(project(":myotis-ens"))
     implementation(project(":myotis-evm"))
+
+    // Embedded JSON-RPC HTTP server (Ktor) so wallets like MetaMask can point
+    // at the phone. Hosted by NodeService.
+    implementation(project(":jsonrpc-server"))
 
     // Force the JRE *variant* of Guava. Guava publishes jre and android
     // variants under one module; on an Android project Gradle's

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -619,6 +619,101 @@ public final class NodeService extends Service {
         });
     }
 
+    // -------------------------------------------------------------------------
+    // JSON-RPC verified reads (Phase B). These bridge the Kotlin MyotisRpcBackend
+    // to the same verified machinery the Query tab uses: requestAccount() for
+    // balances/nonces (head-anchored via headerChain) and the prepareEnsCall EVM
+    // stack for eth_call. All blocking — called off the Ktor IO dispatcher.
+    // -------------------------------------------------------------------------
+
+    /** Reuse one anchored head context across a burst of eth_calls (a MetaMask
+     *  page load fires hundreds) instead of re-probing peers + re-anchoring each
+     *  time; short enough that "latest" stays within a few seconds of the head. */
+    private static final long RPC_CALL_TTL_MS = 4_000;
+    /** Per-eth_call EVM budget (CCIP gateways can add a round-trip). */
+    private static final long RPC_CALL_TIMEOUT_SEC = 30;
+    /** Account read budget — includes the headerChain anchoring fetch. */
+    private static final long RPC_ACCOUNT_TIMEOUT_SEC = HEADER_CHAIN_TIMEOUT_SEC + 10;
+
+    private final Object rpcCallCtxLock = new Object();
+    private EnsCall rpcCallCtx;       // cached beacon-anchored head call context
+    private long rpcCallCtxAtMs;
+
+    /** Only fresh-head tags are served verified for now; others → proxy. */
+    private static boolean isLatestTag(String block) {
+        return block == null || block.isEmpty()
+                || block.equals("latest") || block.equals("pending");
+    }
+
+    /** eth_call over a beacon-anchored head. Returns raw ABI bytes, or null to proxy. */
+    private byte[] rpcCall(byte[] to, byte[] data, String block) {
+        if (!isLatestTag(block) || to == null || to.length != 20) return null;
+        try {
+            EnsCall ctx = verifiedHeadCallContext();
+            return ctx.offchainExecutor()
+                    .callView(io.myotis.evm.Address.of(to), data == null ? new byte[0] : data,
+                            ctx.blockCtx())
+                    .get(RPC_CALL_TIMEOUT_SEC, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            LogBuffer.i(TAG, "[rpc] eth_call not verifiable now: " + unwrap(e));
+            return null;
+        }
+    }
+
+    /** Verified account read (balance/nonce). Null unless beacon-anchored → proxy. */
+    private AccountQueryResult rpcAccount(byte[] address, String block) {
+        if (!isLatestTag(block) || address == null || address.length != 20) return null;
+        try {
+            AccountQueryResult r = requestAccount(Bytes.wrap(address).toHexString())
+                    .get(RPC_ACCOUNT_TIMEOUT_SEC, TimeUnit.SECONDS);
+            // Only serve cryptographically-anchored results; otherwise fall to proxy.
+            if (r.failReason() != null || !r.beaconChainVerified()) return null;
+            return r;
+        } catch (Exception e) {
+            LogBuffer.i(TAG, "[rpc] account read not verifiable now: " + unwrap(e));
+            return null;
+        }
+    }
+
+    /** Build (or reuse within {@link #RPC_CALL_TTL_MS}) a snap-peer head context
+     *  whose state root is anchored back to the beacon-finalized root, so the EVM
+     *  call runs against cryptographically-verified state. Blocking. */
+    private EnsCall verifiedHeadCallContext() throws Exception {
+        synchronized (rpcCallCtxLock) {
+            long now = android.os.SystemClock.elapsedRealtime();
+            if (rpcCallCtx != null && now - rpcCallCtxAtMs < RPC_CALL_TTL_MS) {
+                return rpcCallCtx;
+            }
+            EnsCall ctx = prepareEnsCall(io.myotis.ens.EnsResolutionRoot.PEER_HEAD);
+            if (!anchorHeadToBeacon(ctx.blockNumber(), ctx.blockCtx().stateRoot())) {
+                throw new IllegalStateException(
+                        "peer head not beacon-anchored (block #" + ctx.blockNumber() + ")");
+            }
+            rpcCallCtx = ctx;
+            rpcCallCtxAtMs = android.os.SystemClock.elapsedRealtime();
+            return ctx;
+        }
+    }
+
+    /** True iff {@code peerStateRoot} at {@code peerBlock} chains back to the
+     *  beacon-finalized execution root (same headerChain method as get-account). */
+    private boolean anchorHeadToBeacon(long peerBlock, byte[] peerStateRoot) throws Exception {
+        com.jaeckel.ethp2p.consensus.BeaconLightClient blc = beaconLightClient;
+        RLPxConnector conn = connector;
+        if (blc == null || conn == null) return false;
+        com.jaeckel.ethp2p.consensus.types.LightClientHeader fin =
+                blc.getStore().getFinalizedHeader();
+        if (fin == null) return false;
+        com.jaeckel.ethp2p.consensus.types.ExecutionPayloadHeader exec = fin.execution();
+        if (exec.blockNumber() == peerBlock) {
+            // Head is exactly the finalized block — roots must match directly.
+            return java.util.Arrays.equals(exec.stateRoot(), peerStateRoot);
+        }
+        return verifyHeaderChainBatched(conn, exec.blockNumber(), peerBlock,
+                exec.stateRoot(), peerStateRoot)
+                .get(HEADER_CHAIN_TIMEOUT_SEC + 5, TimeUnit.SECONDS);
+    }
+
     private record EnsCall(io.myotis.ens.EnsResolver resolver,
                            io.myotis.evm.BlockContext blockCtx,
                            long blockNumber,
@@ -1110,6 +1205,19 @@ public final class NodeService extends Service {
                 @Override public String syncState() {
                     return backendState.getSyncState(backendGenesis).name();
                 }
+                @Override public byte[] call(byte[] to, byte[] data, String block) {
+                    return rpcCall(to, data, block);
+                }
+                @Override public java.math.BigInteger getBalance(byte[] address, String block) {
+                    AccountQueryResult r = rpcAccount(address, block);
+                    if (r == null) return null;
+                    return r.exists() ? new java.math.BigInteger(r.balanceWei()) : java.math.BigInteger.ZERO;
+                }
+                @Override public Long getTransactionCount(byte[] address, String block) {
+                    AccountQueryResult r = rpcAccount(address, block);
+                    if (r == null) return null;
+                    return r.exists() ? Long.valueOf(r.nonce()) : Long.valueOf(0L);
+                }
             };
             io.myotis.jsonrpc.MyotisRpcServer s =
                     new io.myotis.jsonrpc.MyotisRpcServer(8545, upstream, "0.0.0.0", backend);
@@ -1161,6 +1269,9 @@ public final class NodeService extends Service {
             try { rpcServer.stop(); } catch (Throwable ignored) {}
             rpcServer = null;
         }
+        // Drop the cached eth_call context so a later Start doesn't briefly reuse
+        // a head pinned to a now-dead peer (it would fail safe to proxy anyway).
+        synchronized (rpcCallCtxLock) { rpcCallCtx = null; }
         // Close BLC first: its libp2p host's outbound dials hold references
         // through to the discv5 callback's blcRef, and the sync thread can
         // be in the middle of an addPeer call when shutdown fires.

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -753,8 +753,10 @@ public final class NodeService extends Service {
                     conn.requestStorage(contractAddress, storageKeyHash, snapStateRoot)
                             .get(RPC_ACCOUNT_TIMEOUT_SEC, TimeUnit.SECONDS);
             if (storageResult.proof().isEmpty()) return null;
-            java.util.List<byte[]> proofBytes = storageResult.proof().stream()
-                    .map(Bytes::toArrayUnsafe).toList();
+            // Plain loop (not Stream.toList — that's API 34, minSdk is 29).
+            java.util.List<byte[]> proofBytes =
+                    new java.util.ArrayList<>(storageResult.proof().size());
+            for (Bytes pb : storageResult.proof()) proofBytes.add(pb.toArrayUnsafe());
             byte[] provenLeaf = MerklePatriciaVerifier.verifyStorageProof(
                     storageRoot.toArrayUnsafe(), slot32, proofBytes);
             if (provenLeaf == null) return null;   // absent or invalid → proxy

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -1095,8 +1095,24 @@ public final class NodeService extends Service {
             // Upstream proxy URL (DEBUG/dev only) comes from BuildConfig.RPC_UPSTREAM
             // (set in gitignored local.properties); blank → strict (no proxy).
             String upstream = BuildConfig.RPC_UPSTREAM;
+            // Verified-read backend: delegate to the node's shared connector +
+            // beacon state. Phase B serves chain id + verified head; more methods
+            // are added here as they're implemented.
+            final RLPxConnector backendConn = conn;
+            final BeaconSyncState backendState = beaconState;
+            final long backendGenesis = genesisTime;
+            io.myotis.jsonrpc.MyotisRpcBackend backend = new io.myotis.jsonrpc.MyotisRpcBackend() {
+                @Override public long chainId() { return backendConn.getNetwork().networkId(); }
+                @Override public Long headBlockNumber() {
+                    long n = backendState.getOptimisticBlockNumber();
+                    return n > 0 ? Long.valueOf(n) : null;
+                }
+                @Override public String syncState() {
+                    return backendState.getSyncState(backendGenesis).name();
+                }
+            };
             io.myotis.jsonrpc.MyotisRpcServer s =
-                    new io.myotis.jsonrpc.MyotisRpcServer(8545, upstream, "0.0.0.0");
+                    new io.myotis.jsonrpc.MyotisRpcServer(8545, upstream, "0.0.0.0", backend);
             s.start();
             this.rpcServer = s;
         } catch (Throwable t) {

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -653,7 +653,7 @@ public final class NodeService extends Service {
     private static final long RPC_ACCOUNT_TIMEOUT_SEC = HEADER_CHAIN_TIMEOUT_SEC + 10;
 
     private final Object rpcCallCtxLock = new Object();
-    private EnsCall rpcCallCtx;       // cached beacon-anchored head call context
+    private CompletableFuture<EnsCall> rpcCallCtx;   // cached beacon-anchored head call context
     private long rpcCallCtxAtMs;
 
     /** Only fresh-head tags are served verified for now; others → proxy. */
@@ -799,19 +799,44 @@ public final class NodeService extends Service {
      *  whose state root is anchored back to the beacon-finalized root, so the EVM
      *  call runs against cryptographically-verified state. Blocking. */
     private EnsCall verifiedHeadCallContext() throws Exception {
+        CompletableFuture<EnsCall> future;
+        boolean build = false;
         synchronized (rpcCallCtxLock) {
             long now = android.os.SystemClock.elapsedRealtime();
-            if (rpcCallCtx != null && now - rpcCallCtxAtMs < RPC_CALL_TTL_MS) {
-                return rpcCallCtx;
+            if (rpcCallCtx != null && !rpcCallCtx.isCompletedExceptionally()
+                    && now - rpcCallCtxAtMs < RPC_CALL_TTL_MS) {
+                future = rpcCallCtx;
+            } else {
+                future = new CompletableFuture<>();
+                rpcCallCtx = future;
+                rpcCallCtxAtMs = now;
+                build = true;
             }
-            EnsCall ctx = prepareEnsCall(io.myotis.ens.EnsResolutionRoot.PEER_HEAD);
-            if (!anchorHeadToBeacon(ctx.blockNumber(), ctx.blockCtx().stateRoot())) {
-                throw new IllegalStateException(
-                        "peer head not beacon-anchored (block #" + ctx.blockNumber() + ")");
+        }
+        // Build OUTSIDE the lock so a burst of concurrent eth_calls (a MetaMask
+        // page load fires hundreds) shares the one builder's future instead of
+        // serializing — or starving — on the monitor during the up-to-60s
+        // peer-probe + headerChain anchor.
+        if (build) {
+            try {
+                EnsCall ctx = prepareEnsCall(io.myotis.ens.EnsResolutionRoot.PEER_HEAD);
+                if (!anchorHeadToBeacon(ctx.blockNumber(), ctx.blockCtx().stateRoot())) {
+                    throw new IllegalStateException(
+                            "peer head not beacon-anchored (block #" + ctx.blockNumber() + ")");
+                }
+                future.complete(ctx);
+            } catch (Throwable t) {
+                future.completeExceptionally(t);
+                synchronized (rpcCallCtxLock) {
+                    if (rpcCallCtx == future) rpcCallCtx = null;   // let the next call retry
+                }
             }
-            rpcCallCtx = ctx;
-            rpcCallCtxAtMs = android.os.SystemClock.elapsedRealtime();
-            return ctx;
+        }
+        try {
+            return future.get(RPC_ACCOUNT_TIMEOUT_SEC, TimeUnit.SECONDS);
+        } catch (java.util.concurrent.ExecutionException e) {
+            Throwable cause = e.getCause() != null ? e.getCause() : e;
+            throw (cause instanceof Exception) ? (Exception) cause : new Exception(cause);
         }
     }
 

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -281,15 +281,21 @@ public final class NodeService extends Service {
         String balance = found != null ? found.balance().toString() : null;
 
         boolean peerProofValid = false;
+        MerklePatriciaVerifier.VerifiedAccount verifiedAcct = null;
         if (result.stateRoot() != null && !result.proof().isEmpty()) {
             List<byte[]> proofBytes = new ArrayList<>(result.proof().size());
             for (Bytes b : result.proof()) proofBytes.add(b.toArrayUnsafe());
-            peerProofValid = MerklePatriciaVerifier.verify(
+            // verifyAndExtractAccount returns the storageRoot/codeHash from the
+            // proof-verified leaf — NOT the peer's slim body — so a peer can't
+            // forge those two fields while keeping nonce/balance honest.
+            verifiedAcct = MerklePatriciaVerifier.verifyAndExtractAccount(
                     result.stateRoot().toArrayUnsafe(),
                     address.toArrayUnsafe(),
                     proofBytes, nonce, balance);
+            peerProofValid = (verifiedAcct != null);
         }
         final boolean peerProofValidFinal = peerProofValid;
+        final MerklePatriciaVerifier.VerifiedAccount verifiedAcctFinal = verifiedAcct;
 
         Verification v = new Verification();
 
@@ -305,7 +311,7 @@ public final class NodeService extends Service {
                 v.blsVerified = match.blsVerified();
                 v.verifyMethod = "stateRootMatch";
                 return CompletableFuture.completedFuture(
-                        finalizeResult(addr, foundFinal, result, peerProofValidFinal, v));
+                        finalizeResult(addr, foundFinal, result, peerProofValidFinal, verifiedAcctFinal, v));
             }
         }
 
@@ -358,29 +364,40 @@ public final class NodeService extends Service {
                             } else {
                                 v.failReason = "headerChainInvalid";
                             }
-                            return finalizeResult(addr, foundFinal, result, peerProofValidFinal, v);
+                            return finalizeResult(addr, foundFinal, result, peerProofValidFinal, verifiedAcctFinal, v);
                         });
             }
         }
 
         return CompletableFuture.completedFuture(
-                finalizeResult(addr, foundFinal, result, peerProofValidFinal, v));
+                finalizeResult(addr, foundFinal, result, peerProofValidFinal, verifiedAcctFinal, v));
     }
 
     private static AccountQueryResult finalizeResult(String addr,
                                                       AccountRangeMessage.AccountData found,
                                                       AccountRangeMessage.DecodeResult result,
                                                       boolean peerProofValid,
+                                                      MerklePatriciaVerifier.VerifiedAccount verified,
                                                       Verification v) {
         long nonce = found != null ? found.nonce() : -1;
         String balance = found != null ? found.balance().toString() : null;
+        // storageRoot/codeHash come from the proof-verified leaf when we have it,
+        // so they're cryptographically anchored rather than peer-claimed. Fall
+        // back to the slim body only when the proof didn't verify — in which case
+        // the result is already flagged beaconChainVerified=false.
+        String storageRootHex = verified != null
+                ? Bytes.wrap(verified.storageRoot()).toHexString()
+                : (found != null ? found.storageRoot().toHexString() : null);
+        String codeHashHex = verified != null
+                ? Bytes.wrap(verified.codeHash()).toHexString()
+                : (found != null ? found.codeHash().toHexString() : null);
         return new AccountQueryResult(
                 addr,
                 found != null,
                 nonce,
                 balance,
-                found != null ? found.storageRoot().toHexString() : null,
-                found != null ? found.codeHash().toHexString() : null,
+                storageRootHex,
+                codeHashHex,
                 result.blockNumber(),
                 result.stateRoot() != null ? result.stateRoot().toHexString() : null,
                 peerProofValid,
@@ -673,6 +690,109 @@ public final class NodeService extends Service {
             LogBuffer.i(TAG, "[rpc] account read not verifiable now: " + unwrap(e));
             return null;
         }
+    }
+
+    /** keccak256("") — an account with this codeHash is an EOA (no contract code). */
+    private static final byte[] EMPTY_CODE_HASH = Hash.keccak256(Bytes.EMPTY).toArrayUnsafe();
+
+    /** First ready snap-serving peer, or null. */
+    private com.jaeckel.ethp2p.networking.eth.EthHandler firstReadySnapPeer() {
+        RLPxConnector conn = connector;
+        if (conn == null) return null;
+        for (com.jaeckel.ethp2p.networking.eth.EthHandler p : conn.activeSnapHandlers()) {
+            if (p.isReady() && !p.isSnapServingFailed()) return p;
+        }
+        return null;
+    }
+
+    /** eth_getCode: bytecode verified against the proven codeHash, or null to proxy. */
+    private byte[] rpcCode(byte[] address, String block) {
+        if (!isLatestTag(block) || address == null || address.length != 20) return null;
+        AccountQueryResult r = rpcAccount(address, block);   // codeHashHex is from the proven leaf
+        if (r == null) return null;
+        if (!r.exists()) return new byte[0];                 // no account → no code
+        try {
+            byte[] codeHash = Bytes.fromHexString(r.codeHashHex()).toArrayUnsafe();
+            if (java.util.Arrays.equals(codeHash, EMPTY_CODE_HASH)) return new byte[0];  // EOA
+            com.jaeckel.ethp2p.networking.eth.EthHandler peer = firstReadySnapPeer();
+            if (peer == null) return null;
+            java.util.List<Bytes> codes =
+                    new com.jaeckel.ethp2p.android.snap.EthHandlerSnapPeer(peer)
+                            .getByteCodes(java.util.List.of(Bytes32.wrap(codeHash)))
+                            .get(30, TimeUnit.SECONDS);
+            if (codes.isEmpty()) return null;
+            Bytes code = codes.get(0);
+            // Content-addressed: the bytecode is verified iff keccak256(code)==codeHash.
+            if (!java.util.Arrays.equals(Hash.keccak256(code).toArrayUnsafe(), codeHash)) return null;
+            return code.toArrayUnsafe();
+        } catch (Exception e) {
+            LogBuffer.i(TAG, "[rpc] eth_getCode not verifiable now: " + unwrap(e));
+            return null;
+        }
+    }
+
+    /** eth_getStorageAt: the 32-byte value at {@code slot32}, proven against the
+     *  account's verified storageRoot. Returns null (→ proxy) for absent slots,
+     *  which a single inclusion proof can't positively prove here. */
+    private byte[] rpcStorageAt(byte[] address, byte[] slot32, String block) {
+        if (!isLatestTag(block) || address == null || address.length != 20
+                || slot32 == null || slot32.length != 32) return null;
+        try {
+            // Verified account read → PROVEN storageRoot + the beacon-anchored peer
+            // state root the storage proof must be fetched against.
+            AccountQueryResult r = rpcAccount(address, block);
+            if (r == null || !r.exists()
+                    || r.storageRootHex() == null || r.peerStateRootHex() == null) return null;
+            RLPxConnector conn = connector;
+            if (conn == null) return null;
+            Bytes32 storageRoot = Bytes32.fromHexString(r.storageRootHex());
+            Bytes32 snapStateRoot = Bytes32.fromHexString(r.peerStateRootHex());
+            Bytes contractAddress = Bytes.wrap(address);
+            Bytes32 storageKeyHash = Hash.keccak256(Bytes.wrap(slot32));
+            com.jaeckel.ethp2p.networking.snap.messages.StorageRangesMessage.DecodeResult storageResult =
+                    conn.requestStorage(contractAddress, storageKeyHash, snapStateRoot)
+                            .get(RPC_ACCOUNT_TIMEOUT_SEC, TimeUnit.SECONDS);
+            if (storageResult.proof().isEmpty()) return null;
+            java.util.List<byte[]> proofBytes = storageResult.proof().stream()
+                    .map(Bytes::toArrayUnsafe).toList();
+            byte[] provenLeaf = MerklePatriciaVerifier.verifyStorageProof(
+                    storageRoot.toArrayUnsafe(), slot32, proofBytes);
+            if (provenLeaf == null) return null;   // absent or invalid → proxy
+            // The trie leaf stores RLP(value); cross-check the peer's slim slotValue
+            // against it so a forged slotValue in the slots() list can't slip through.
+            com.jaeckel.ethp2p.networking.snap.messages.StorageRangesMessage.StorageData found =
+                    storageResult.slots().stream()
+                            .filter(s -> s.slotHash().equals(storageKeyHash)).findFirst().orElse(null);
+            byte[] value = (found != null && !found.slotValue().isEmpty())
+                    ? found.slotValue().toArrayUnsafe() : new byte[0];
+            if (!java.util.Arrays.equals(rlpEncodeShort(value), provenLeaf)) {
+                return null;   // slim value inconsistent with the proven leaf
+            }
+            return leftPad32(value);
+        } catch (Exception e) {
+            LogBuffer.i(TAG, "[rpc] eth_getStorageAt not verifiable now: " + unwrap(e));
+            return null;
+        }
+    }
+
+    /** RLP-encode a minimal big-endian value ≤ 32 bytes (a storage slot value):
+     *  a single byte < 0x80 is itself; otherwise a short-string header (0x80+len)
+     *  precedes the bytes. Used to compare the peer's slim slotValue to the
+     *  proof-verified trie leaf (which holds RLP(value)). */
+    private static byte[] rlpEncodeShort(byte[] v) {
+        if (v.length == 1 && (v[0] & 0xFF) < 0x80) return v;
+        byte[] out = new byte[v.length + 1];
+        out[0] = (byte) (0x80 + v.length);   // v.length ≤ 32 < 56, so single-byte header
+        System.arraycopy(v, 0, out, 1, v.length);
+        return out;
+    }
+
+    /** Right-align {@code v} into a 32-byte big-endian word. */
+    private static byte[] leftPad32(byte[] v) {
+        if (v.length >= 32) return java.util.Arrays.copyOfRange(v, v.length - 32, v.length);
+        byte[] out = new byte[32];
+        System.arraycopy(v, 0, out, 32 - v.length, v.length);
+        return out;
     }
 
     /** Build (or reuse within {@link #RPC_CALL_TTL_MS}) a snap-peer head context
@@ -1217,6 +1337,12 @@ public final class NodeService extends Service {
                     AccountQueryResult r = rpcAccount(address, block);
                     if (r == null) return null;
                     return r.exists() ? Long.valueOf(r.nonce()) : Long.valueOf(0L);
+                }
+                @Override public byte[] getCode(byte[] address, String block) {
+                    return rpcCode(address, block);
+                }
+                @Override public byte[] getStorageAt(byte[] address, byte[] slot, String block) {
+                    return rpcStorageAt(address, slot, block);
                 }
             };
             io.myotis.jsonrpc.MyotisRpcServer s =

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -87,6 +87,7 @@ public final class NodeService extends Service {
     private DiscV4Service discV4;
     private DiscV5Service discV5;
     private RLPxConnector connector;
+    private io.myotis.jsonrpc.MyotisRpcServer rpcServer;
     private AndroidPeerCache peerCache;
     private AndroidCLPeerCache clPeerCache;
     private BeaconLightClient beaconLightClient;
@@ -1087,6 +1088,20 @@ public final class NodeService extends Service {
         this.clGenesisTime = genesisTime;
         this.cachedPeerCount = cachedCount;
         this.cachedClPeerCount = cachedClCount;
+        // JSON-RPC server (Phase-A scaffold): start the embedded Ktor endpoint so a
+        // wallet can reach the node (LAN, or host via `adb forward tcp:8545 tcp:8545`).
+        // Starts immediately — does not wait for beacon sync. Router/proxy land next.
+        try {
+            // Upstream proxy URL (DEBUG/dev only) comes from BuildConfig.RPC_UPSTREAM
+            // (set in gitignored local.properties); blank → strict (no proxy).
+            String upstream = BuildConfig.RPC_UPSTREAM;
+            io.myotis.jsonrpc.MyotisRpcServer s =
+                    new io.myotis.jsonrpc.MyotisRpcServer(8545, upstream, "0.0.0.0");
+            s.start();
+            this.rpcServer = s;
+        } catch (Throwable t) {
+            LogBuffer.w(TAG, "[rpc] failed to start JSON-RPC server: " + t);
+        }
         return true;
     }
 
@@ -1125,6 +1140,11 @@ public final class NodeService extends Service {
      * instead of failing with bind-in-use.
      */
     private synchronized void doShutdown() {
+        // Stop the JSON-RPC server first so its port is freed promptly.
+        if (rpcServer != null) {
+            try { rpcServer.stop(); } catch (Throwable ignored) {}
+            rpcServer = null;
+        }
         // Close BLC first: its libp2p host's outbound dials hold references
         // through to the discv5 callback's blcRef, and the sync thread can
         // be in the middle of an addPeer call when shutdown fires.

--- a/app/src/main/java/com/jaeckel/ethp2p/app/CommandHandler.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/CommandHandler.java
@@ -678,6 +678,17 @@ public class CommandHandler {
                     found != null ? found.balance().toString() : null,
                     result.stateRoot(), result.blockNumber());
 
+            // storageRoot/codeHash from the proof-verified leaf, not the peer's
+            // slim body — a peer can forge those two while keeping nonce/balance
+            // honest, and the slim values would otherwise ride along as "verified".
+            MerklePatriciaVerifier.VerifiedAccount verifiedAcct =
+                    (found != null && result.stateRoot() != null && !result.proof().isEmpty())
+                            ? MerklePatriciaVerifier.verifyAndExtractAccount(
+                                    result.stateRoot().toArrayUnsafe(), address.toArrayUnsafe(),
+                                    result.proof().stream().map(Bytes::toArrayUnsafe).toList(),
+                                    found.nonce(), found.balance().toString())
+                            : null;
+
             if (found == null) {
                 return "{\"ok\":true,\"exists\":false"
                     + ",\"address\":\"" + addr + "\""
@@ -690,8 +701,12 @@ public class CommandHandler {
                 + ",\"accountHash\":\"" + found.accountHash().toHexString() + "\""
                 + ",\"nonce\":" + found.nonce()
                 + ",\"balance\":\"" + found.balance() + "\""
-                + ",\"storageRoot\":\"" + found.storageRoot().toHexString() + "\""
-                + ",\"codeHash\":\"" + found.codeHash().toHexString() + "\""
+                + ",\"storageRoot\":\"" + (verifiedAcct != null
+                        ? Bytes.wrap(verifiedAcct.storageRoot()).toHexString()
+                        : found.storageRoot().toHexString()) + "\""
+                + ",\"codeHash\":\"" + (verifiedAcct != null
+                        ? Bytes.wrap(verifiedAcct.codeHash()).toHexString()
+                        : found.codeHash().toHexString()) + "\""
                 + ",\"proof\":" + proofJson
                 + ",\"verification\":" + verificationJson + "}";
         } catch (Exception e) {
@@ -775,10 +790,26 @@ public class CommandHandler {
             if (account == null) {
                 return jsonError("Contract account not found");
             }
-            Bytes32 storageRoot = account.storageRoot();
 
             // Step 2: fetch storage slot using the same peer state root for consistency
             Bytes32 snapStateRoot = accountResult.stateRoot();
+
+            // Take storageRoot from the PROOF-VERIFIED account leaf, not the peer's
+            // slim body. Otherwise a peer could forge storageRoot (keeping nonce/
+            // balance honest) plus a matching storage proof and fabricate a
+            // "verified" slot value. snapStateRoot is anchored to the beacon below.
+            List<byte[]> accountProofBytes = accountResult.proof().stream()
+                    .map(Bytes::toArrayUnsafe).toList();
+            MerklePatriciaVerifier.VerifiedAccount verifiedAccount =
+                    snapStateRoot == null ? null
+                            : MerklePatriciaVerifier.verifyAndExtractAccount(
+                                    snapStateRoot.toArrayUnsafe(),
+                                    contractAddress.toArrayUnsafe(), accountProofBytes,
+                                    account.nonce(), account.balance().toString());
+            if (verifiedAccount == null) {
+                return jsonError("Contract account proof did not verify against peer state root");
+            }
+            Bytes32 storageRoot = Bytes32.wrap(verifiedAccount.storageRoot());
             StorageRangesMessage.DecodeResult storageResult =
                 connector.requestStorage(contractAddress, storageKeyHash, snapStateRoot)
                     .get(30, TimeUnit.SECONDS);

--- a/consensus/build.gradle.kts
+++ b/consensus/build.gradle.kts
@@ -27,6 +27,9 @@ dependencies {
 
     testImplementation(platform(libs.junit.bom))
     testImplementation(libs.junit.jupiter)
+    // Tuweni's Hash.keccak256 resolves "KECCAK-256" via a JCE provider; the trie
+    // proof tests build fixtures with it, so BouncyCastle must be on the test path.
+    testImplementation(libs.bouncycastle)
     testRuntimeOnly(libs.logback.classic)
 }
 

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/proof/MerklePatriciaVerifier.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/proof/MerklePatriciaVerifier.java
@@ -51,15 +51,41 @@ public class MerklePatriciaVerifier {
     public static boolean verify(byte[] stateRoot, byte[] address,
                                   List<byte[]> proofNodes,
                                   long expectedNonce, String expectedBalance) {
+        return verifyAndExtractAccount(stateRoot, address, proofNodes,
+                expectedNonce, expectedBalance) != null;
+    }
 
-        if (proofNodes == null || proofNodes.isEmpty()) return false;
-        if (stateRoot == null || stateRoot.length != 32) return false;
-        if (address == null || address.length != 20) return false;
+    /** The account fields not covered by the nonce/balance check, taken from the
+     *  proof-verified leaf (NOT a peer's slim account body). */
+    public record VerifiedAccount(byte[] storageRoot, byte[] codeHash) {}
+
+    /**
+     * Verify the account proof against {@code stateRoot} and return the leaf's
+     * {@code storageRoot} + {@code codeHash}, or {@code null} if the proof is
+     * invalid or {@code expectedNonce}/{@code expectedBalance} don't match.
+     *
+     * <p>Critically, {@code storageRoot} and {@code codeHash} are read out of the
+     * <em>proof-verified</em> account leaf — the RLP blob whose hash chains to the
+     * trusted {@code stateRoot} — and NOT from the peer's separately-decoded "slim"
+     * account body. A snap peer fully controls both halves of its response, so a
+     * malicious peer can keep nonce+balance honest (which is all the leaf check
+     * compares) while forging the slim body's {@code storageRoot}/{@code codeHash};
+     * callers that then read storage/code against the forged root would verify
+     * bogus values. Returning the leaf's values closes that vector — callers must
+     * use these, not the slim body's.
+     */
+    public static VerifiedAccount verifyAndExtractAccount(
+            byte[] stateRoot, byte[] address, List<byte[]> proofNodes,
+            long expectedNonce, String expectedBalance) {
+
+        if (proofNodes == null || proofNodes.isEmpty()) return null;
+        if (stateRoot == null || stateRoot.length != 32) return null;
+        if (address == null || address.length != 20) return null;
 
         byte[] keyHash = keccak256(address);
         byte[] leafValue = traverseProof(stateRoot, keyHash, proofNodes);
-        if (leafValue == null) return false;
-        return verifyAccountValue(leafValue, expectedNonce, expectedBalance);
+        if (leafValue == null) return null;
+        return decodeAndCheckAccount(leafValue, expectedNonce, expectedBalance);
     }
 
     /**
@@ -233,15 +259,23 @@ public class MerklePatriciaVerifier {
      *
      * Account RLP: [nonce (integer), balance (integer), storageRoot (bytes32), codeHash (bytes32)]
      */
-    private static boolean verifyAccountValue(byte[] accountRlp,
-                                               long expectedNonce,
-                                               String expectedBalance) {
-        if (accountRlp == null || accountRlp.length == 0) return false;
+    /**
+     * Decode a proof-verified account leaf {@code RLP[nonce, balance, storageRoot,
+     * codeHash]}, check nonce/balance against the expected values, and return the
+     * leaf's storageRoot + codeHash. Returns null on a decode failure or a
+     * nonce/balance mismatch.
+     */
+    private static VerifiedAccount decodeAndCheckAccount(byte[] accountRlp,
+                                                         long expectedNonce,
+                                                         String expectedBalance) {
+        if (accountRlp == null || accountRlp.length == 0) return null;
 
         try {
             Bytes rlpBytes = Bytes.wrap(accountRlp);
             long[] nonceHolder = new long[1];
             BigInteger[] balanceHolder = new BigInteger[1];
+            byte[][] storageRootHolder = new byte[1][];
+            byte[][] codeHashHolder = new byte[1][];
 
             RLP.decodeList(rlpBytes, reader -> {
                 // nonce: uint
@@ -256,17 +290,17 @@ public class MerklePatriciaVerifier {
                     balanceHolder[0] = new BigInteger(1, balanceBytes.toArrayUnsafe());
                 }
 
-                // storageRoot and codeHash (32 bytes each) — we skip validation here;
-                // the state root check already validates consistency
-                reader.readValue(); // storageRoot
-                reader.readValue(); // codeHash
+                // storageRoot + codeHash come straight from the proven leaf so
+                // callers get cryptographically-anchored values (see javadoc).
+                storageRootHolder[0] = reader.readValue().toArrayUnsafe();
+                codeHashHolder[0] = reader.readValue().toArrayUnsafe();
 
                 return null;
             });
 
             // Validate expected nonce if requested
             if (expectedNonce >= 0 && nonceHolder[0] != expectedNonce) {
-                return false;
+                return null;
             }
 
             // Validate expected balance if requested
@@ -278,14 +312,14 @@ public class MerklePatriciaVerifier {
                     expected = new BigInteger(expectedBalance, 10);
                 }
                 if (!balanceHolder[0].equals(expected)) {
-                    return false;
+                    return null;
                 }
             }
 
-            return true;
+            return new VerifiedAccount(storageRootHolder[0], codeHashHolder[0]);
 
         } catch (Exception e) {
-            return false;
+            return null;
         }
     }
 

--- a/consensus/src/test/java/com/jaeckel/ethp2p/consensus/proof/MerklePatriciaVerifierAccountTest.java
+++ b/consensus/src/test/java/com/jaeckel/ethp2p/consensus/proof/MerklePatriciaVerifierAccountTest.java
@@ -1,0 +1,126 @@
+package com.jaeckel.ethp2p.consensus.proof;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.crypto.Hash;
+import org.apache.tuweni.rlp.RLP;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.security.Security;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests that {@link MerklePatriciaVerifier#verifyAndExtractAccount} returns the
+ * {@code storageRoot}/{@code codeHash} taken from the <em>proof-verified leaf</em>
+ * (the value whose hash chains to the trusted state root), so callers no longer
+ * have to trust a snap peer's separately-decoded slim account body for those two
+ * fields. Tries are hand-built (RLP + keccak), same approach as the core trie test.
+ */
+class MerklePatriciaVerifierAccountTest {
+
+    @BeforeAll
+    static void registerBouncyCastle() {
+        if (Security.getProvider("BC") == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+    }
+
+    private static final byte[] ADDRESS = repeat((byte) 0x01, 20);
+    private static final long NONCE = 5;
+    private static final BigInteger BALANCE = new BigInteger("1000000000000000000"); // 1 ETH
+    private static final byte[] STORAGE_ROOT = repeat((byte) 0x11, 32);
+    private static final byte[] CODE_HASH = repeat((byte) 0x22, 32);
+
+    /** A single-leaf account trie at keccak256(ADDRESS): returns (root, proof). */
+    private record Trie(byte[] root, List<byte[]> proof) {}
+
+    private static Trie buildAccountTrie(long nonce, BigInteger balance,
+                                         byte[] storageRoot, byte[] codeHash) {
+        byte[] keyHash = Hash.keccak256(Bytes.wrap(ADDRESS)).toArrayUnsafe();
+        // Canonical account leaf value: RLP[nonce, balance, storageRoot, codeHash].
+        Bytes account = RLP.encodeList(w -> {
+            w.writeLong(nonce);
+            w.writeBigInteger(balance);
+            w.writeValue(Bytes.wrap(storageRoot));
+            w.writeValue(Bytes.wrap(codeHash));
+        });
+        // Leaf node: [hexPrefix(64 nibbles, leaf=true) = 0x20||keyHash, account].
+        byte[] leafPath = new byte[33];
+        leafPath[0] = 0x20;
+        System.arraycopy(keyHash, 0, leafPath, 1, 32);
+        Bytes leaf = RLP.encodeList(w -> {
+            w.writeValue(Bytes.wrap(leafPath));
+            w.writeValue(account);
+        });
+        byte[] root = Hash.keccak256(leaf).toArrayUnsafe();
+        return new Trie(root, List.of(leaf.toArrayUnsafe()));
+    }
+
+    @Test
+    void returnsStorageRootAndCodeHashFromProvenLeaf() {
+        Trie t = buildAccountTrie(NONCE, BALANCE, STORAGE_ROOT, CODE_HASH);
+        var v = MerklePatriciaVerifier.verifyAndExtractAccount(
+                t.root, ADDRESS, t.proof, NONCE, BALANCE.toString());
+        assertNotNull(v);
+        assertArrayEquals(STORAGE_ROOT, v.storageRoot());
+        assertArrayEquals(CODE_HASH, v.codeHash());
+    }
+
+    @Test
+    void extractsCanonicalEmptyValuesForEoaLeaf() {
+        // An EOA's leaf carries the canonical empty-trie root + empty-code hash.
+        byte[] emptyTrieRoot = Hash.keccak256(Bytes.of((byte) 0x80)).toArrayUnsafe();
+        byte[] emptyCodeHash = Hash.keccak256(Bytes.EMPTY).toArrayUnsafe();
+        Trie t = buildAccountTrie(0, BigInteger.ZERO, emptyTrieRoot, emptyCodeHash);
+        var v = MerklePatriciaVerifier.verifyAndExtractAccount(
+                t.root, ADDRESS, t.proof, 0, "0");
+        assertNotNull(v);
+        assertArrayEquals(emptyTrieRoot, v.storageRoot());
+        assertArrayEquals(emptyCodeHash, v.codeHash());
+    }
+
+    @Test
+    void nonceMismatchRejected() {
+        Trie t = buildAccountTrie(NONCE, BALANCE, STORAGE_ROOT, CODE_HASH);
+        assertNull(MerklePatriciaVerifier.verifyAndExtractAccount(
+                t.root, ADDRESS, t.proof, NONCE + 1, BALANCE.toString()));
+    }
+
+    @Test
+    void balanceMismatchRejected() {
+        Trie t = buildAccountTrie(NONCE, BALANCE, STORAGE_ROOT, CODE_HASH);
+        assertNull(MerklePatriciaVerifier.verifyAndExtractAccount(
+                t.root, ADDRESS, t.proof, NONCE, BALANCE.add(BigInteger.ONE).toString()));
+    }
+
+    @Test
+    void wrongRootRejected() {
+        Trie t = buildAccountTrie(NONCE, BALANCE, STORAGE_ROOT, CODE_HASH);
+        byte[] wrongRoot = t.root.clone();
+        wrongRoot[0] ^= 0x01;
+        assertNull(MerklePatriciaVerifier.verifyAndExtractAccount(
+                wrongRoot, ADDRESS, t.proof, NONCE, BALANCE.toString()));
+    }
+
+    @Test
+    void verifyDelegatesToExtract() {
+        Trie t = buildAccountTrie(NONCE, BALANCE, STORAGE_ROOT, CODE_HASH);
+        assertTrue(MerklePatriciaVerifier.verify(t.root, ADDRESS, t.proof, NONCE, BALANCE.toString()));
+        assertFalse(MerklePatriciaVerifier.verify(t.root, ADDRESS, t.proof, NONCE + 1, BALANCE.toString()));
+    }
+
+    private static byte[] repeat(byte b, int n) {
+        byte[] out = new byte[n];
+        java.util.Arrays.fill(out, b);
+        return out;
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,10 +21,18 @@ agp = "8.7.3"
 kotlin = "2.0.21"
 compose-bom = "2024.11.00"
 activity-compose = "1.9.3"
+# JSON-RPC server (:jsonrpc-server). Ktor server+client + kotlinx are chosen for
+# Android compatibility (no java.net.http / com.sun.net.httpserver) and to match
+# the project's Ktor/Compose-Multiplatform direction. Aligned with Kotlin 2.0.21.
+ktor = "3.0.3"
+kotlinx-coroutines = "1.9.0"
+kotlinx-serialization = "1.7.3"
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android      = { id = "org.jetbrains.kotlin.android",         version.ref = "kotlin" }
+kotlin-jvm          = { id = "org.jetbrains.kotlin.jvm",             version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 compose-compiler    = { id = "org.jetbrains.kotlin.plugin.compose",  version.ref = "kotlin" }
 
 [libraries]
@@ -68,3 +76,12 @@ androidx-compose-ui-graphics      = { module = "androidx.compose.ui:ui-graphics"
 androidx-compose-ui-tooling       = { module = "androidx.compose.ui:ui-tooling" }
 androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
 androidx-compose-material3        = { module = "androidx.compose.material3:material3" }
+
+# JSON-RPC server (:jsonrpc-server) — all Android-safe (no java.net.http).
+ktor-server-core           = { module = "io.ktor:ktor-server-core",  version.ref = "ktor" }
+ktor-server-cio            = { module = "io.ktor:ktor-server-cio",   version.ref = "ktor" }
+ktor-server-cors           = { module = "io.ktor:ktor-server-cors",  version.ref = "ktor" }
+ktor-client-core           = { module = "io.ktor:ktor-client-core",  version.ref = "ktor" }
+ktor-client-cio            = { module = "io.ktor:ktor-client-cio",   version.ref = "ktor" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
+kotlinx-coroutines-core    = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core",    version.ref = "kotlinx-coroutines" }

--- a/jsonrpc-server/build.gradle.kts
+++ b/jsonrpc-server/build.gradle.kts
@@ -1,0 +1,56 @@
+// :jsonrpc-server — a JSON-RPC HTTP endpoint on top of Myotis, hosted by BOTH
+// the Android app and the CLI daemon. Measurement-driven: starts as a logging
+// proxy and progressively serves verified light-client data (see the plan).
+//
+// MUST run on Android (ART): no java.net.http, no com.sun.net.httpserver. The
+// HTTP server is Ktor CIO and the upstream proxy client is Ktor Client CIO —
+// pure Kotlin, matching the project's Ktor/Compose-Multiplatform direction.
+// Targets JVM 17 bytecode so :android-app can consume + dex it (CLAUDE.md
+// default for new modules), even though the root toolchain runs on JDK 21.
+
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.serialization)
+}
+
+// JVM 21 bytecode: this module depends on :networking (discv5) and :myotis-evm
+// (Besu), both of which publish JVM-21 metadata, so Gradle variant resolution
+// requires a 21 consumer. CLAUDE.md's 17 default explicitly yields when a
+// transitive forces 21 — same situation as those modules — and AGP 8.7's D8
+// dexes 21 class files for :android-app (already proven for :networking).
+// compileJava inherits the root's JDK-21 toolchain; match Kotlin to it.
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21
+    }
+}
+
+dependencies {
+    // Shared verified-read primitives — the same modules :android-app and :app use.
+    implementation(project(":core"))
+    implementation(project(":networking"))
+    implementation(project(":consensus"))
+    implementation(project(":myotis-evm"))
+
+    // HTTP server (endpoint) + client (upstream proxy) — Android-safe.
+    implementation(libs.ktor.server.core)
+    implementation(libs.ktor.server.cio)
+    implementation(libs.ktor.server.cors)
+    implementation(libs.ktor.client.core)
+    implementation(libs.ktor.client.cio)
+
+    implementation(libs.kotlinx.serialization.json)
+    implementation(libs.kotlinx.coroutines.core)
+
+    implementation(libs.tuweni.bytes)
+    implementation(libs.tuweni.crypto)
+    implementation(libs.slf4j.api)
+
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.junit.jupiter)
+    testRuntimeOnly(libs.logback.classic)
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/MethodLogger.kt
+++ b/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/MethodLogger.kt
@@ -1,0 +1,62 @@
+package io.myotis.jsonrpc
+
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.slf4j.LoggerFactory
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Per-request structured logging + an in-memory coverage map. The point of
+ * Phase A: after a MetaMask session, this is the exact "which methods did the
+ * wallet call, and how did we serve each" answer that drives Phases B–D.
+ *
+ * `path` is one of VERIFIED (served by Myotis, cryptographically verified),
+ * PROXY (relayed upstream — unverified), ERROR, or LOCAL (answered here, e.g.
+ * the coverage introspection method).
+ */
+class MethodLogger {
+
+    private val log = LoggerFactory.getLogger("RpcCoverage")
+
+    private class Stat {
+        val count = AtomicLong()
+        val verified = AtomicLong()
+        val proxied = AtomicLong()
+        val error = AtomicLong()
+        val local = AtomicLong()
+    }
+
+    private val byMethod = ConcurrentHashMap<String, Stat>()
+
+    fun record(method: String, path: String, latencyMs: Long) {
+        val s = byMethod.computeIfAbsent(method) { Stat() }
+        s.count.incrementAndGet()
+        when (path) {
+            "VERIFIED" -> s.verified.incrementAndGet()
+            "PROXY" -> s.proxied.incrementAndGet()
+            "LOCAL" -> s.local.incrementAndGet()
+            else -> s.error.incrementAndGet()
+        }
+        log.info("[rpc] method={} path={} latencyMs={}", method, path, latencyMs)
+    }
+
+    /** Coverage map as a JSON object: method -> {count, verified, proxied, error, local}. */
+    fun coverage(): JsonObject = buildJsonObject {
+        byMethod.toSortedMap().forEach { (method, s) ->
+            put(method, buildJsonObject {
+                put("count", s.count.get())
+                put("verified", s.verified.get())
+                put("proxied", s.proxied.get())
+                put("error", s.error.get())
+                put("local", s.local.get())
+            })
+        }
+    }
+
+    /** Dump the coverage summary to the log (call on shutdown). */
+    fun logSummary() {
+        log.info("[rpc] coverage summary: {}", coverage().toString())
+    }
+}

--- a/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/MyotisRpcBackend.kt
+++ b/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/MyotisRpcBackend.kt
@@ -1,0 +1,28 @@
+package io.myotis.jsonrpc
+
+/**
+ * Host-provided access to Myotis's verified light-client state, used by the
+ * verified JSON-RPC handlers. Each host (Android `NodeService`, the CLI daemon)
+ * implements this by delegating to the same shared `RLPxConnector` /
+ * `BeaconSyncState` / EVM primitives it already runs — so the JSON-RPC module
+ * stays host-agnostic.
+ *
+ * Methods return null when the answer isn't available verified (e.g. the beacon
+ * light client isn't synced yet); the router then falls back to the upstream
+ * proxy (or a strict-mode error). Grows phase by phase — Phase B starts with
+ * chain id + verified head.
+ */
+interface MyotisRpcBackend {
+
+    /** EVM chain id (e.g. 1 for mainnet). Always available (from config). */
+    fun chainId(): Long
+
+    /**
+     * Verified head execution block number (the beacon optimistic head), or null
+     * if not synced enough to answer. Returned to wallets as `eth_blockNumber`.
+     */
+    fun headBlockNumber(): Long?
+
+    /** "SYNCING" | "CATCHING_UP" | "SYNCED". */
+    fun syncState(): String
+}

--- a/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/MyotisRpcBackend.kt
+++ b/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/MyotisRpcBackend.kt
@@ -25,4 +25,24 @@ interface MyotisRpcBackend {
 
     /** "SYNCING" | "CATCHING_UP" | "SYNCED". */
     fun syncState(): String
+
+    // --- Phase B verified reads -------------------------------------------
+    // Each takes a JSON-RPC block tag (e.g. "latest"); implementations may
+    // honor only the fresh-head tags ("latest"/"pending") for now and return
+    // null for anything they can't answer verified (unsupported tag, no peer,
+    // head not beacon-anchored), in which case the router proxies. These are
+    // BLOCKING (network + EVM round-trips) — the router calls them off the IO
+    // dispatcher, never on a Java `suspend` boundary, so they stay plain.
+
+    /**
+     * eth_call: run [data] against contract [to] in a local EVM over verified
+     * state, returning the raw ABI return bytes. Null falls through to the proxy.
+     */
+    fun call(to: ByteArray, data: ByteArray, block: String): ByteArray?
+
+    /** eth_getBalance: account balance in wei, or null to proxy. */
+    fun getBalance(address: ByteArray, block: String): java.math.BigInteger?
+
+    /** eth_getTransactionCount: account nonce, or null to proxy. */
+    fun getTransactionCount(address: ByteArray, block: String): Long?
 }

--- a/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/MyotisRpcBackend.kt
+++ b/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/MyotisRpcBackend.kt
@@ -45,4 +45,17 @@ interface MyotisRpcBackend {
 
     /** eth_getTransactionCount: account nonce, or null to proxy. */
     fun getTransactionCount(address: ByteArray, block: String): Long?
+
+    /**
+     * eth_getCode: the account's contract bytecode (empty for an EOA), verified
+     * against the proven codeHash, or null to proxy.
+     */
+    fun getCode(address: ByteArray, block: String): ByteArray?
+
+    /**
+     * eth_getStorageAt: the 32-byte value at storage key [slot] (a 32-byte
+     * big-endian key), proven against the account's verified storageRoot, or null
+     * to proxy (including absent slots, which can't be positively proven here).
+     */
+    fun getStorageAt(address: ByteArray, slot: ByteArray, block: String): ByteArray?
 }

--- a/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/MyotisRpcServer.kt
+++ b/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/MyotisRpcServer.kt
@@ -1,0 +1,77 @@
+package io.myotis.jsonrpc
+
+import io.ktor.server.application.install
+import io.ktor.server.cio.CIO
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.engine.EmbeddedServer
+import io.ktor.server.plugins.cors.routing.CORS
+import io.ktor.server.request.receiveText
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.routing
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import org.slf4j.LoggerFactory
+
+/**
+ * Embedded JSON-RPC HTTP server for Myotis, runnable on both the Android app and
+ * the CLI daemon (Ktor CIO engine — Android-safe).
+ *
+ * Phase A: stands up the endpoint + CORS + a router that relays every method to
+ * the [upstreamUrl] (if set) and logs the coverage map. With no upstream it runs
+ * in strict mode (errors instead of proxying). Verified Myotis handlers are
+ * layered into the router in later phases.
+ *
+ * @param upstreamUrl DEBUG-only upstream RPC to proxy unhandled methods to; null
+ *   = strict mode (no proxy). Never commit this value — inject at runtime.
+ */
+class MyotisRpcServer(
+    private val port: Int,
+    private val upstreamUrl: String? = null,
+    private val host: String = "0.0.0.0",
+) {
+    private val log = LoggerFactory.getLogger(MyotisRpcServer::class.java)
+
+    private val proxy: UpstreamProxy? = upstreamUrl?.takeIf { it.isNotBlank() }?.let { UpstreamProxy(it) }
+    private val logger = MethodLogger()
+    private val router = RpcRouter(proxy, logger)
+
+    @Volatile
+    private var engine: EmbeddedServer<*, *>? = null
+
+    fun start() {
+        if (engine != null) return
+        val server = embeddedServer(CIO, port = port, host = host) {
+            install(CORS) {
+                anyHost()
+                allowHeader(HttpHeaders.ContentType)
+                allowMethod(HttpMethod.Post)
+                allowMethod(HttpMethod.Options)
+            }
+            routing {
+                get("/health") { call.respondText("ok") }
+                post("/") {
+                    val body = call.receiveText()
+                    val response = router.handle(body)
+                    call.respondText(response, ContentType.Application.Json)
+                }
+            }
+        }
+        server.start(wait = false)
+        engine = server
+        log.info(
+            "[rpc] JSON-RPC server listening on http://{}:{} (mode={})",
+            host, port, if (proxy != null) "proxy" else "strict",
+        )
+    }
+
+    fun stop() {
+        engine?.stop(gracePeriodMillis = 200, timeoutMillis = 1000)
+        engine = null
+        proxy?.close()
+        logger.logSummary()
+        log.info("[rpc] JSON-RPC server stopped")
+    }
+}

--- a/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/MyotisRpcServer.kt
+++ b/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/MyotisRpcServer.kt
@@ -31,12 +31,13 @@ class MyotisRpcServer(
     private val port: Int,
     private val upstreamUrl: String? = null,
     private val host: String = "0.0.0.0",
+    private val backend: MyotisRpcBackend? = null,
 ) {
     private val log = LoggerFactory.getLogger(MyotisRpcServer::class.java)
 
     private val proxy: UpstreamProxy? = upstreamUrl?.takeIf { it.isNotBlank() }?.let { UpstreamProxy(it) }
     private val logger = MethodLogger()
-    private val router = RpcRouter(proxy, logger)
+    private val router = RpcRouter(proxy, logger, backend)
 
     @Volatile
     private var engine: EmbeddedServer<*, *>? = null

--- a/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/RpcRouter.kt
+++ b/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/RpcRouter.kt
@@ -31,6 +31,10 @@ class RpcRouter(
 ) {
     private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
 
+    private companion object {
+        private val HEX_DIGITS = "0123456789abcdef".toCharArray()
+    }
+
     suspend fun handle(body: String): String {
         val root = try {
             json.parseToJsonElement(body)
@@ -68,7 +72,15 @@ class RpcRouter(
         }
 
         val t0 = System.nanoTime()
-        val response = proxy.forward(body)
+        val response = try {
+            proxy.forward(body)
+        } catch (e: Exception) {
+            // Upstream down/timeout: return a JSON-RPC error, not a raw HTTP 500,
+            // so the wallet can handle it.
+            methods.forEach { logger.record(it, "ERROR", (System.nanoTime() - t0) / 1_000_000) }
+            val id = (root as? JsonObject)?.get("id") ?: JsonNull
+            return errorEnvelope(id, -32603, "upstream proxy error: ${e.message}")
+        }
         val latencyMs = (System.nanoTime() - t0) / 1_000_000
         methods.forEach { logger.record(it, "PROXY", latencyMs) }
         return response
@@ -97,7 +109,10 @@ class RpcRouter(
                 val p = root.params()
                 val callObj = p?.getOrNull(0) as? JsonObject ?: return null
                 val to = callObj["to"]?.asHexBytes() ?: return null   // contract creation (to=null) -> proxy
-                val data = (callObj["data"] ?: callObj["input"])?.asHexBytes() ?: ByteArray(0)
+                // Absent/null calldata -> empty; present-but-malformed -> proxy
+                // (don't silently run the call with empty calldata).
+                val dataElement = (callObj["data"] ?: callObj["input"])?.takeUnless { it is JsonNull }
+                val data = if (dataElement != null) (dataElement.asHexBytes() ?: return null) else ByteArray(0)
                 val block = p.blockTag(1)
                 val out = withContext(Dispatchers.IO) { b.call(to, data, block) } ?: return null
                 resultEnvelope(id, JsonPrimitive(hexData(out)))
@@ -147,7 +162,8 @@ class RpcRouter(
     private fun JsonElement.asWord32(): ByteArray? {
         val s = (this as? JsonPrimitive)?.takeIf { it.isString }?.contentOrNull ?: return null
         var h = if (s.startsWith("0x") || s.startsWith("0X")) s.substring(2) else s
-        if (h.length % 2 != 0) h = "0$h"           // tolerate odd-length QUANTITY (e.g. "0x0")
+        if (h.isEmpty()) return null                // "0x" is not a valid slot
+        if (h.length % 2 != 0) h = "0$h"            // tolerate odd-length QUANTITY (e.g. "0x0")
         if (h.length > 64) return null
         return try {
             val raw = ByteArray(h.length / 2) {
@@ -175,9 +191,19 @@ class RpcRouter(
     private fun hexQuantity(v: Long): String = "0x" + java.lang.Long.toHexString(v)
     private fun hexQuantity(v: java.math.BigInteger): String = "0x" + v.toString(16)
 
-    /** Ethereum JSON-RPC DATA encoding: 0x-prefixed, every byte rendered (leading zeros kept). */
-    private fun hexData(b: ByteArray): String =
-        b.joinToString(prefix = "0x", separator = "") { "%02x".format(it.toInt() and 0xff) }
+    /** Ethereum JSON-RPC DATA encoding: 0x-prefixed, every byte rendered (leading
+     *  zeros kept). Allocation-free — eth_getCode returns up to ~24KB of bytecode,
+     *  so a String-per-byte encoder would churn the GC hard on Android. */
+    private fun hexData(b: ByteArray): String {
+        val out = CharArray(b.size * 2 + 2)
+        out[0] = '0'; out[1] = 'x'
+        for (i in b.indices) {
+            val v = b[i].toInt() and 0xff
+            out[i * 2 + 2] = HEX_DIGITS[v ushr 4]
+            out[i * 2 + 3] = HEX_DIGITS[v and 0x0f]
+        }
+        return String(out)
+    }
 
     private fun JsonObject.method(): String? = this["method"]?.jsonPrimitive?.contentOrNull
 

--- a/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/RpcRouter.kt
+++ b/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/RpcRouter.kt
@@ -1,0 +1,85 @@
+package io.myotis.jsonrpc
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+
+/**
+ * Routes a JSON-RPC request body. Phase A: every method is relayed to the
+ * upstream (raw passthrough) and logged, except a local introspection method
+ * (`myotis_rpcCoverage`). Verified Myotis handlers replace proxy entries
+ * method-by-method in later phases (see the plan).
+ *
+ * Handles both a single request object and a batch array. For a batch we proxy
+ * the whole body verbatim (Phase A is all-proxy anyway) and log each element's
+ * method; a single local method is answered here.
+ */
+class RpcRouter(
+    private val proxy: UpstreamProxy?,
+    private val logger: MethodLogger,
+) {
+    private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+
+    suspend fun handle(body: String): String {
+        val root = try {
+            json.parseToJsonElement(body)
+        } catch (e: Exception) {
+            return errorEnvelope(JsonNull, -32700, "Parse error")
+        }
+
+        // Single request: may be a local method.
+        if (root is JsonObject) {
+            val method = root["method"]?.jsonPrimitive?.contentOrNull
+            val id = root["id"] ?: JsonNull
+            if (method == "myotis_rpcCoverage") {
+                logger.record(method, "LOCAL", 0)
+                return resultEnvelope(id, logger.coverage())
+            }
+        }
+
+        val methods: List<String> = when (root) {
+            is JsonArray -> root.mapNotNull { (it as? JsonObject)?.method() }
+            is JsonObject -> listOfNotNull(root.method())
+            else -> return errorEnvelope(JsonNull, -32600, "Invalid Request")
+        }
+
+        if (proxy == null) {
+            // Strict mode: nothing to verify yet, no upstream → report unavailable.
+            methods.forEach { logger.record(it, "ERROR", 0) }
+            val id = (root as? JsonObject)?.get("id") ?: JsonNull
+            return errorEnvelope(id, -32000, "no upstream configured (strict mode)")
+        }
+
+        val t0 = System.nanoTime()
+        val response = proxy.forward(body)
+        val latencyMs = (System.nanoTime() - t0) / 1_000_000
+        methods.forEach { logger.record(it, "PROXY", latencyMs) }
+        return response
+    }
+
+    private fun JsonObject.method(): String? = this["method"]?.jsonPrimitive?.contentOrNull
+
+    private fun resultEnvelope(id: JsonElement, result: JsonElement): String =
+        json.encodeToString(JsonObject.serializer(), buildJsonObject {
+            put("jsonrpc", JsonPrimitive("2.0"))
+            put("id", id)
+            put("result", result)
+        })
+
+    private fun errorEnvelope(id: JsonElement, code: Int, message: String): String =
+        json.encodeToString(JsonObject.serializer(), buildJsonObject {
+            put("jsonrpc", JsonPrimitive("2.0"))
+            put("id", id)
+            put("error", buildJsonObject {
+                put("code", JsonPrimitive(code))
+                put("message", JsonPrimitive(message))
+            })
+        })
+}

--- a/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/RpcRouter.kt
+++ b/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/RpcRouter.kt
@@ -116,6 +116,21 @@ class RpcRouter(
                 val nonce = withContext(Dispatchers.IO) { b.getTransactionCount(addr, block) } ?: return null
                 resultEnvelope(id, JsonPrimitive(hexQuantity(nonce)))
             }
+            "eth_getCode" -> {
+                val p = root.params()
+                val addr = (p?.getOrNull(0) as? JsonPrimitive)?.asHexBytes() ?: return null
+                val block = p.blockTag(1)
+                val code = withContext(Dispatchers.IO) { b.getCode(addr, block) } ?: return null
+                resultEnvelope(id, JsonPrimitive(hexData(code)))
+            }
+            "eth_getStorageAt" -> {
+                val p = root.params()
+                val addr = (p?.getOrNull(0) as? JsonPrimitive)?.asHexBytes() ?: return null
+                val slot = (p?.getOrNull(1))?.asWord32() ?: return null
+                val block = p.blockTag(2)
+                val v = withContext(Dispatchers.IO) { b.getStorageAt(addr, slot, block) } ?: return null
+                resultEnvelope(id, JsonPrimitive(hexData(v)))
+            }
             else -> null
         }
     }
@@ -126,6 +141,23 @@ class RpcRouter(
     /** The block tag at [index] (e.g. "latest"), defaulting to "latest" when absent. */
     private fun JsonArray?.blockTag(index: Int): String =
         (this?.getOrNull(index) as? JsonPrimitive)?.contentOrNull ?: "latest"
+
+    /** Decode a storage position (QUANTITY or 32-byte DATA) to a left-padded
+     *  32-byte big-endian key; null if not a hex string or wider than 32 bytes. */
+    private fun JsonElement.asWord32(): ByteArray? {
+        val s = (this as? JsonPrimitive)?.takeIf { it.isString }?.contentOrNull ?: return null
+        var h = if (s.startsWith("0x") || s.startsWith("0X")) s.substring(2) else s
+        if (h.length % 2 != 0) h = "0$h"           // tolerate odd-length QUANTITY (e.g. "0x0")
+        if (h.length > 64) return null
+        return try {
+            val raw = ByteArray(h.length / 2) {
+                ((h[it * 2].digitToInt(16) shl 4) or h[it * 2 + 1].digitToInt(16)).toByte()
+            }
+            ByteArray(32).also { raw.copyInto(it, 32 - raw.size) }
+        } catch (e: IllegalArgumentException) {
+            null
+        }
+    }
 
     /** Decode a `0x…` hex JSON string to bytes; null if not a hex string. */
     private fun JsonElement.asHexBytes(): ByteArray? {

--- a/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/RpcRouter.kt
+++ b/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/RpcRouter.kt
@@ -24,6 +24,7 @@ import kotlinx.serialization.json.put
 class RpcRouter(
     private val proxy: UpstreamProxy?,
     private val logger: MethodLogger,
+    private val backend: MyotisRpcBackend? = null,
 ) {
     private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
 
@@ -34,13 +35,18 @@ class RpcRouter(
             return errorEnvelope(JsonNull, -32700, "Parse error")
         }
 
-        // Single request: may be a local method.
+        // Single request: try local + verified handlers before proxying.
         if (root is JsonObject) {
             val method = root["method"]?.jsonPrimitive?.contentOrNull
             val id = root["id"] ?: JsonNull
             if (method == "myotis_rpcCoverage") {
                 logger.record(method, "LOCAL", 0)
                 return resultEnvelope(id, logger.coverage())
+            }
+            val verified = tryVerified(method, id)
+            if (verified != null) {
+                logger.record(method!!, "VERIFIED", 0)
+                return verified
             }
         }
 
@@ -63,6 +69,26 @@ class RpcRouter(
         methods.forEach { logger.record(it, "PROXY", latencyMs) }
         return response
     }
+
+    /**
+     * Verified handlers (Phase B). Returns a JSON-RPC response string, or null to
+     * fall through to the proxy — either because the method isn't served verified
+     * yet, or because the node can't answer it verified right now (e.g. not synced).
+     */
+    private fun tryVerified(method: String?, id: JsonElement): String? {
+        val b = backend ?: return null
+        return when (method) {
+            // Chain id is config-derived — always answerable, no sync needed.
+            "eth_chainId" -> resultEnvelope(id, JsonPrimitive(hexQuantity(b.chainId())))
+            "net_version" -> resultEnvelope(id, JsonPrimitive(b.chainId().toString()))
+            // Verified beacon head; null (not synced) -> proxy.
+            "eth_blockNumber" -> b.headBlockNumber()?.let { resultEnvelope(id, JsonPrimitive(hexQuantity(it))) }
+            else -> null
+        }
+    }
+
+    /** Ethereum JSON-RPC QUANTITY encoding: minimal hex, no leading zeros, 0 -> "0x0". */
+    private fun hexQuantity(v: Long): String = "0x" + java.lang.Long.toHexString(v)
 
     private fun JsonObject.method(): String? = this["method"]?.jsonPrimitive?.contentOrNull
 

--- a/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/RpcRouter.kt
+++ b/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/RpcRouter.kt
@@ -1,5 +1,7 @@
 package io.myotis.jsonrpc
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -8,6 +10,7 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 
@@ -43,9 +46,10 @@ class RpcRouter(
                 logger.record(method, "LOCAL", 0)
                 return resultEnvelope(id, logger.coverage())
             }
-            val verified = tryVerified(method, id)
+            val t0 = System.nanoTime()
+            val verified = tryVerified(method, id, root)
             if (verified != null) {
-                logger.record(method!!, "VERIFIED", 0)
+                logger.record(method!!, "VERIFIED", (System.nanoTime() - t0) / 1_000_000)
                 return verified
             }
         }
@@ -73,9 +77,14 @@ class RpcRouter(
     /**
      * Verified handlers (Phase B). Returns a JSON-RPC response string, or null to
      * fall through to the proxy — either because the method isn't served verified
-     * yet, or because the node can't answer it verified right now (e.g. not synced).
+     * yet, or because the node can't answer it verified right now (not synced, no
+     * peer, head not beacon-anchored, or an unsupported block tag / malformed
+     * params we'd rather let the upstream handle than reject).
+     *
+     * The state-reading handlers (eth_call / eth_getBalance / …) are BLOCKING, so
+     * they run on the IO dispatcher to keep the Ktor worker thread free.
      */
-    private fun tryVerified(method: String?, id: JsonElement): String? {
+    private suspend fun tryVerified(method: String?, id: JsonElement, root: JsonObject): String? {
         val b = backend ?: return null
         return when (method) {
             // Chain id is config-derived — always answerable, no sync needed.
@@ -83,12 +92,60 @@ class RpcRouter(
             "net_version" -> resultEnvelope(id, JsonPrimitive(b.chainId().toString()))
             // Verified beacon head; null (not synced) -> proxy.
             "eth_blockNumber" -> b.headBlockNumber()?.let { resultEnvelope(id, JsonPrimitive(hexQuantity(it))) }
+
+            "eth_call" -> {
+                val p = root.params()
+                val callObj = p?.getOrNull(0) as? JsonObject ?: return null
+                val to = callObj["to"]?.asHexBytes() ?: return null   // contract creation (to=null) -> proxy
+                val data = (callObj["data"] ?: callObj["input"])?.asHexBytes() ?: ByteArray(0)
+                val block = p.blockTag(1)
+                val out = withContext(Dispatchers.IO) { b.call(to, data, block) } ?: return null
+                resultEnvelope(id, JsonPrimitive(hexData(out)))
+            }
+            "eth_getBalance" -> {
+                val p = root.params()
+                val addr = (p?.getOrNull(0) as? JsonPrimitive)?.asHexBytes() ?: return null
+                val block = p.blockTag(1)
+                val bal = withContext(Dispatchers.IO) { b.getBalance(addr, block) } ?: return null
+                resultEnvelope(id, JsonPrimitive(hexQuantity(bal)))
+            }
+            "eth_getTransactionCount" -> {
+                val p = root.params()
+                val addr = (p?.getOrNull(0) as? JsonPrimitive)?.asHexBytes() ?: return null
+                val block = p.blockTag(1)
+                val nonce = withContext(Dispatchers.IO) { b.getTransactionCount(addr, block) } ?: return null
+                resultEnvelope(id, JsonPrimitive(hexQuantity(nonce)))
+            }
             else -> null
+        }
+    }
+
+    /** This request's `params` array, or null if absent / not an array. */
+    private fun JsonObject.params(): JsonArray? = (this["params"] as? JsonArray)
+
+    /** The block tag at [index] (e.g. "latest"), defaulting to "latest" when absent. */
+    private fun JsonArray?.blockTag(index: Int): String =
+        (this?.getOrNull(index) as? JsonPrimitive)?.contentOrNull ?: "latest"
+
+    /** Decode a `0x…` hex JSON string to bytes; null if not a hex string. */
+    private fun JsonElement.asHexBytes(): ByteArray? {
+        val s = (this as? JsonPrimitive)?.takeIf { it.isString }?.contentOrNull ?: return null
+        val h = if (s.startsWith("0x") || s.startsWith("0X")) s.substring(2) else s
+        if (h.length % 2 != 0) return null
+        return try {
+            ByteArray(h.length / 2) { ((h[it * 2].digitToInt(16) shl 4) or h[it * 2 + 1].digitToInt(16)).toByte() }
+        } catch (e: IllegalArgumentException) {
+            null
         }
     }
 
     /** Ethereum JSON-RPC QUANTITY encoding: minimal hex, no leading zeros, 0 -> "0x0". */
     private fun hexQuantity(v: Long): String = "0x" + java.lang.Long.toHexString(v)
+    private fun hexQuantity(v: java.math.BigInteger): String = "0x" + v.toString(16)
+
+    /** Ethereum JSON-RPC DATA encoding: 0x-prefixed, every byte rendered (leading zeros kept). */
+    private fun hexData(b: ByteArray): String =
+        b.joinToString(prefix = "0x", separator = "") { "%02x".format(it.toInt() and 0xff) }
 
     private fun JsonObject.method(): String? = this["method"]?.jsonPrimitive?.contentOrNull
 

--- a/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/UpstreamProxy.kt
+++ b/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/UpstreamProxy.kt
@@ -1,0 +1,33 @@
+package io.myotis.jsonrpc
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+
+/**
+ * Upstream JSON-RPC relay (DEBUG/development only — see the trust note in the plan).
+ *
+ * Forwards the request body **verbatim** to a configured upstream RPC (e.g. Infura)
+ * and returns its response body unchanged, so Phase A is a faithful mirror that
+ * lets MetaMask work end-to-end while we record which methods it calls. Uses the
+ * Ktor CIO client (Android-safe; NOT java.net.http).
+ */
+class UpstreamProxy(private val url: String) {
+
+    private val client = HttpClient(CIO)
+
+    /** POST the raw JSON-RPC body to the upstream and return the raw response body. */
+    suspend fun forward(rawBody: String): String {
+        val resp = client.post(url) {
+            contentType(ContentType.Application.Json)
+            setBody(rawBody)
+        }
+        return resp.bodyAsText()
+    }
+
+    fun close() = client.close()
+}

--- a/jsonrpc-server/src/test/kotlin/io/myotis/jsonrpc/RpcRouterTest.kt
+++ b/jsonrpc-server/src/test/kotlin/io/myotis/jsonrpc/RpcRouterTest.kt
@@ -84,6 +84,29 @@ class RpcRouterTest {
         assertNull(b.lastTo)                                       // backend never invoked
     }
 
+    @Test fun ethCall_malformedData_fallsThrough() {            // present-but-bad calldata -> proxy, not empty
+        val b = FakeBackend(callResult = byteArrayOf(9))
+        val resp = route(b, """{"jsonrpc":"2.0","id":1,"method":"eth_call",
+               "params":[{"to":"0x00000000219ab540356cBB839Cbe05303d7705Fa","data":"0xZZ"}]}""")
+        assertTrue(hasError(resp))
+        assertNull(b.lastTo)                                       // backend never invoked
+    }
+
+    @Test fun ethCall_nullData_treatedAsEmptyCalldata() {
+        val b = FakeBackend(callResult = byteArrayOf(1))
+        route(b, """{"jsonrpc":"2.0","id":1,"method":"eth_call",
+               "params":[{"to":"0x00000000219ab540356cBB839Cbe05303d7705Fa","data":null}]}""")
+        assertEquals(0, b.lastData!!.size)                         // null calldata -> empty, still served
+    }
+
+    @Test fun getStorageAt_emptyHexSlot_fallsThrough() {          // "0x" is not a valid slot
+        val b = FakeBackend(storage = ByteArray(32))
+        val resp = route(b, """{"jsonrpc":"2.0","id":1,"method":"eth_getStorageAt",
+               "params":["0xabc0000000000000000000000000000000000001","0x"]}""")
+        assertTrue(hasError(resp))
+        assertNull(b.lastSlot)
+    }
+
     @Test fun ethCall_backendNull_fallsThrough() {
         val b = FakeBackend(callResult = null)                     // no verified answer
         val resp = route(b, """{"jsonrpc":"2.0","id":1,"method":"eth_call",

--- a/jsonrpc-server/src/test/kotlin/io/myotis/jsonrpc/RpcRouterTest.kt
+++ b/jsonrpc-server/src/test/kotlin/io/myotis/jsonrpc/RpcRouterTest.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -26,10 +27,13 @@ class RpcRouterTest {
         var balance: BigInteger? = null,
         var nonce: Long? = null,
         var head: Long? = 0x100,
+        var code: ByteArray? = null,
+        var storage: ByteArray? = null,
     ) : MyotisRpcBackend {
         var lastTo: ByteArray? = null
         var lastData: ByteArray? = null
         var lastBlock: String? = null
+        var lastSlot: ByteArray? = null
         override fun chainId() = 1L
         override fun headBlockNumber() = head
         override fun syncState() = "SYNCED"
@@ -38,6 +42,10 @@ class RpcRouterTest {
         }
         override fun getBalance(address: ByteArray, block: String): BigInteger? = balance
         override fun getTransactionCount(address: ByteArray, block: String): Long? = nonce
+        override fun getCode(address: ByteArray, block: String): ByteArray? = code
+        override fun getStorageAt(address: ByteArray, slot: ByteArray, block: String): ByteArray? {
+            lastSlot = slot; return storage
+        }
     }
 
     private fun route(backend: MyotisRpcBackend?, body: String, proxy: UpstreamProxy? = null): String =
@@ -105,6 +113,41 @@ class RpcRouterTest {
     @Test fun getBalance_backendNull_fallsThrough() {
         assertTrue(hasError(route(FakeBackend(balance = null),
             """{"jsonrpc":"2.0","id":1,"method":"eth_getBalance","params":["0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"]}""")))
+    }
+
+    @Test fun getCode_encodesBytecodeAsData() {
+        val b = FakeBackend(code = byteArrayOf(0x60, 0x80.toByte(), 0x60, 0x40))
+        val resp = route(b, """{"jsonrpc":"2.0","id":1,"method":"eth_getCode",
+               "params":["0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48","latest"]}""")
+        assertEquals("0x60806040", result(resp))
+    }
+
+    @Test fun getCode_emptyForEoa() {
+        val resp = route(FakeBackend(code = ByteArray(0)),
+            """{"jsonrpc":"2.0","id":1,"method":"eth_getCode","params":["0xabc0000000000000000000000000000000000001"]}""")
+        assertEquals("0x", result(resp))
+    }
+
+    @Test fun getStorageAt_decodesSlotToWord_andEncodesValueAsData() {
+        val b = FakeBackend(storage = ByteArray(32).also { it[31] = 0x2a }) // value 0x2a
+        val resp = route(b, """{"jsonrpc":"2.0","id":1,"method":"eth_getStorageAt",
+               "params":["0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48","0x0","latest"]}""")
+        // slot "0x0" -> 32-byte zero word
+        assertArrayEquals(ByteArray(32), b.lastSlot)
+        assertEquals("0x000000000000000000000000000000000000000000000000000000000000002a", result(resp))
+    }
+
+    @Test fun getStorageAt_paddsShortSlotKeyTo32Bytes() {
+        val b = FakeBackend(storage = ByteArray(32))
+        route(b, """{"jsonrpc":"2.0","id":1,"method":"eth_getStorageAt",
+               "params":["0xabc0000000000000000000000000000000000001","0x7b","latest"]}""")
+        val expected = ByteArray(32).also { it[31] = 0x7b }   // 0x7b right-aligned
+        assertArrayEquals(expected, b.lastSlot)
+    }
+
+    @Test fun getStorageAt_backendNull_fallsThrough() {
+        assertTrue(hasError(route(FakeBackend(storage = null),
+            """{"jsonrpc":"2.0","id":1,"method":"eth_getStorageAt","params":["0xabc0000000000000000000000000000000000001","0x1"]}""")))
     }
 
     @Test fun chainId_and_blockNumber_stillVerified() {

--- a/jsonrpc-server/src/test/kotlin/io/myotis/jsonrpc/RpcRouterTest.kt
+++ b/jsonrpc-server/src/test/kotlin/io/myotis/jsonrpc/RpcRouterTest.kt
@@ -1,0 +1,122 @@
+package io.myotis.jsonrpc
+
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.math.BigInteger
+
+/**
+ * Router-level tests for the Phase B verified handlers: param decoding, QUANTITY/
+ * DATA result encoding, and the proxy/strict fallthrough when the backend can't
+ * answer. These pin the exact wire encoding the on-device test can't exercise
+ * without a connected snap peer (it correctly degrades to proxy there).
+ */
+class RpcRouterTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    /** Configurable fake; records the last eth_call args so we can assert decoding. */
+    private class FakeBackend(
+        var callResult: ByteArray? = null,
+        var balance: BigInteger? = null,
+        var nonce: Long? = null,
+        var head: Long? = 0x100,
+    ) : MyotisRpcBackend {
+        var lastTo: ByteArray? = null
+        var lastData: ByteArray? = null
+        var lastBlock: String? = null
+        override fun chainId() = 1L
+        override fun headBlockNumber() = head
+        override fun syncState() = "SYNCED"
+        override fun call(to: ByteArray, data: ByteArray, block: String): ByteArray? {
+            lastTo = to; lastData = data; lastBlock = block; return callResult
+        }
+        override fun getBalance(address: ByteArray, block: String): BigInteger? = balance
+        override fun getTransactionCount(address: ByteArray, block: String): Long? = nonce
+    }
+
+    private fun route(backend: MyotisRpcBackend?, body: String, proxy: UpstreamProxy? = null): String =
+        runBlocking { RpcRouter(proxy, MethodLogger(), backend).handle(body) }
+
+    private fun result(resp: String): String? =
+        json.parseToJsonElement(resp).jsonObject["result"]?.jsonPrimitive?.content
+
+    private fun hasError(resp: String): Boolean =
+        json.parseToJsonElement(resp).jsonObject["error"] != null
+
+    @Test fun ethCall_encodesResultAsData_andDecodesToAndData() {
+        val b = FakeBackend(callResult = byteArrayOf(0, 6))
+        val resp = route(b,
+            """{"jsonrpc":"2.0","id":1,"method":"eth_call",
+               "params":[{"to":"0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48","data":"0x313ce567"},"latest"]}""")
+        assertEquals("0x0006", result(resp))                       // DATA: leading zero kept
+        assertEquals(20, b.lastTo!!.size)
+        assertEquals(0xA0.toByte(), b.lastTo!![0])
+        assertEquals("0x313ce567", b.lastData!!.toHex())           // decoded calldata
+        assertEquals("latest", b.lastBlock)
+    }
+
+    @Test fun ethCall_acceptsInputAlias_forData() {
+        val b = FakeBackend(callResult = byteArrayOf(1))
+        route(b, """{"jsonrpc":"2.0","id":1,"method":"eth_call",
+               "params":[{"to":"0x00000000219ab540356cBB839Cbe05303d7705Fa","input":"0xabcd"}]}""")
+        assertEquals("0xabcd", b.lastData!!.toHex())               // "input" honored; block defaults to latest
+        assertEquals("latest", b.lastBlock)
+    }
+
+    @Test fun ethCall_missingTo_fallsThrough() {                   // contract creation -> proxy/strict
+        val b = FakeBackend(callResult = byteArrayOf(9))
+        val resp = route(b, """{"jsonrpc":"2.0","id":1,"method":"eth_call","params":[{"data":"0x00"}]}""")
+        assertTrue(hasError(resp))                                 // strict (no proxy) -> error, not the fake result
+        assertNull(b.lastTo)                                       // backend never invoked
+    }
+
+    @Test fun ethCall_backendNull_fallsThrough() {
+        val b = FakeBackend(callResult = null)                     // no verified answer
+        val resp = route(b, """{"jsonrpc":"2.0","id":1,"method":"eth_call",
+               "params":[{"to":"0x00000000219ab540356cBB839Cbe05303d7705Fa","data":"0x00"}]}""")
+        assertTrue(hasError(resp))
+    }
+
+    @Test fun getBalance_encodesAsQuantity_minimalHex() {
+        val b = FakeBackend(balance = BigInteger("1000000000000000000"))   // 1 ETH
+        val resp = route(b, """{"jsonrpc":"2.0","id":1,"method":"eth_getBalance",
+               "params":["0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045","latest"]}""")
+        assertEquals("0xde0b6b3a7640000", result(resp))            // QUANTITY: no leading zeros
+    }
+
+    @Test fun getBalance_zero_isHex0() {
+        val resp = route(FakeBackend(balance = BigInteger.ZERO),
+            """{"jsonrpc":"2.0","id":1,"method":"eth_getBalance","params":["0xabc0000000000000000000000000000000000001"]}""")
+        assertEquals("0x0", result(resp))
+    }
+
+    @Test fun getTransactionCount_encodesNonceAsQuantity() {
+        val resp = route(FakeBackend(nonce = 0x1708),
+            """{"jsonrpc":"2.0","id":1,"method":"eth_getTransactionCount","params":["0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045","latest"]}""")
+        assertEquals("0x1708", result(resp))
+    }
+
+    @Test fun getBalance_backendNull_fallsThrough() {
+        assertTrue(hasError(route(FakeBackend(balance = null),
+            """{"jsonrpc":"2.0","id":1,"method":"eth_getBalance","params":["0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"]}""")))
+    }
+
+    @Test fun chainId_and_blockNumber_stillVerified() {
+        val b = FakeBackend(head = 0x181af48)
+        assertEquals("0x1", result(route(b, """{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}""")))
+        assertEquals("0x181af48", result(route(b, """{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}""")))
+    }
+
+    @Test fun blockNumber_nullHead_fallsThrough() {
+        assertTrue(hasError(route(FakeBackend(head = null),
+            """{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}""")))
+    }
+
+    private fun ByteArray.toHex() = joinToString(prefix = "0x", separator = "") { "%02x".format(it.toInt() and 0xff) }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -36,4 +36,4 @@ dependencyResolutionManagement {
     }
 }
 
-include("core", "networking", "consensus", "app", "android-app", "myotis-evm", "myotis-ens")
+include("core", "networking", "consensus", "app", "android-app", "myotis-evm", "myotis-ens", "jsonrpc-server")


### PR DESCRIPTION
## What

A **JSON-RPC HTTP endpoint on top of Myotis**, hosted by the Android app, so a wallet (MetaMask) can point at the phone and get answers backed by the light client's **cryptographically verified** state — falling through to a debug-only upstream proxy for anything not yet served verified.

Measurement-driven (Phase A is a logging proxy; Phase B moves methods onto verified paths one at a time). New shared Kotlin module `:jsonrpc-server` (Ktor CIO server + client, kotlinx-serialization) so the CLI daemon can host it later too.

## Phases in this PR

**Phase A** — Ktor CIO endpoint + CORS + JSON-RPC parse/serialize (single + batch) + raw upstream proxy + per-method coverage map (`myotis_rpcCoverage`). The "MetaMask talks to my phone" demo.

**Phase B** — verified read methods, each with graceful proxy fallback when it can't be answered verified (not synced, no snap peer, head not anchored, unsupported block tag):

| Method | How it's verified |
|---|---|
| `eth_chainId`, `net_version` | config-derived |
| `eth_blockNumber` | verified beacon optimistic head |
| `eth_getBalance`, `eth_getTransactionCount` | snap account read, head anchored to the beacon-finalized root via `headerChain` |
| `eth_call` | local Besu EVM over snap-verified, beacon-anchored state (short-TTL context cache for call bursts) |
| `eth_getCode` | proven `codeHash` → bytecode fetched + `keccak256(code)==codeHash` (handles EIP-7702 delegation) |
| `eth_getStorageAt` | proven `storageRoot` → storage proof verified; slim slot value cross-checked against the proof leaf |

## Security fix included (`verify: anchor storageRoot/codeHash to the proof…`)

While building `eth_getStorageAt`/`eth_getCode` I found `MerklePatriciaVerifier.verify()` cross-checked **only nonce+balance** between the proof-verified account leaf and the peer's separately-decoded slim body — it skipped `storageRoot`/`codeHash`. A snap peer controls both halves of its response, so it could keep nonce+balance honest while forging those two fields, letting `get-storage`/`get-code` verify bogus values against a forged root.

Fixed by `verifyAndExtractAccount()`, which returns `storageRoot`/`codeHash` from the **proof-verified leaf**; the daemon's `get-account`/`get-storage` and Android's `get-account` now use the proven values. balance/nonce were already safe.

## Tests

- `MerklePatriciaVerifierAccountTest` (6) — leaf extraction + nonce/balance/root rejection, hand-built tries.
- `RpcRouterTest` (15) — param decode, QUANTITY/DATA encoding, batch, error codes, proxy/strict fallthrough.

## Validation (real device — Pixel 7)

All Phase B methods serve `path=VERIFIED` and match a trusted upstream exactly:
- `eth_getBalance` `0x4ef2d23eda616ea6`, `eth_getTransactionCount` `0x1708`, `eth_call` USDC `decimals()`=6
- `eth_getCode` USDC bytecode matches upstream; vitalik returns its EIP-7702 delegation code
- `eth_getStorageAt` USDC slot 0 matches upstream

The Android **emulator** can't validate the verified state path (its NAT drops discv4/EL responses, so no snap peer — CL/discv5 is fine after the merged discv5 free-port fix); it exercises the CL-derived methods + proxy fallback. Real devices have working discv4.

## Safety / constraints

- Upstream proxy URL is **debug-only**, injected at runtime from gitignored `local.properties` (never a silent production default; absent → strict mode).
- No transaction send path here — `eth_sendRawTransaction` is a later phase and remains user-driven.

## Not in this PR (follow-ups)
- Phase C: `eth_sendRawTransaction` via devp2p `Transactions(0x12)` broadcast.
- Phase D: verified receipts (`GetReceipts`/`Receipts` + receipt-trie verifier) for mined detection.
- Hosting the same server from the CLI daemon (`:app`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
