### PR TITLE
jsonrpc: eth_sendRawTransaction via devp2p broadcast (Phase C step 1)

### DIFF
--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -84,15 +84,18 @@ public final class NodeService extends Service {
     private final Map<String, Long> backoff = new ConcurrentHashMap<>();
     private final Set<String> blacklistedNodeIds = ConcurrentHashMap.newKeySet();
 
-    private DiscV4Service discV4;
-    private DiscV5Service discV5;
-    private RLPxConnector connector;
+    // Service-lifecycle fields: written on the start/shutdown worker, read from
+    // the Netty event loop, the Ktor IO dispatcher (JSON-RPC backend), and the UI
+    // thread (snapshot()). volatile so readers never see a stale/null reference.
+    private volatile DiscV4Service discV4;
+    private volatile DiscV5Service discV5;
+    private volatile RLPxConnector connector;
     private io.myotis.jsonrpc.MyotisRpcServer rpcServer;
     private AndroidPeerCache peerCache;
     private AndroidCLPeerCache clPeerCache;
-    private BeaconLightClient beaconLightClient;
-    private BeaconSyncState beaconSyncState;
-    private long clGenesisTime;
+    private volatile BeaconLightClient beaconLightClient;
+    private volatile BeaconSyncState beaconSyncState;
+    private volatile long clGenesisTime;
     private volatile int cachedPeerCount;
     private volatile int cachedClPeerCount;
     private volatile long startTimeMs;

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -695,6 +695,25 @@ public final class NodeService extends Service {
     /** keccak256("") — an account with this codeHash is an EOA (no contract code). */
     private static final byte[] EMPTY_CODE_HASH = Hash.keccak256(Bytes.EMPTY).toArrayUnsafe();
 
+    /** eth_sendRawTransaction: gossip the user-signed tx to peers; return its hash
+     *  (keccak256 of the raw bytes), or null (→ proxy) if no peer took it. Myotis
+     *  never signs or originates a tx — this only relays bytes the user submitted. */
+    private byte[] rpcSendRawTransaction(byte[] rawTx) {
+        RLPxConnector conn = connector;
+        if (conn == null || rawTx == null || rawTx.length == 0) return null;
+        try {
+            int sent = conn.broadcastTransaction(rawTx);
+            if (sent == 0) return null;   // no peer reached → let the proxy relay it
+            byte[] txHash = Hash.keccak256(Bytes.wrap(rawTx)).toArrayUnsafe();
+            LogBuffer.i(TAG, "[rpc] eth_sendRawTransaction broadcast to " + sent
+                    + " peer(s), hash=" + Bytes.wrap(txHash).toHexString());
+            return txHash;
+        } catch (Exception e) {
+            LogBuffer.i(TAG, "[rpc] eth_sendRawTransaction failed: " + unwrap(e));
+            return null;
+        }
+    }
+
     /** First ready snap-serving peer, or null. */
     private com.jaeckel.ethp2p.networking.eth.EthHandler firstReadySnapPeer() {
         RLPxConnector conn = connector;
@@ -1370,6 +1389,9 @@ public final class NodeService extends Service {
                 }
                 @Override public byte[] getStorageAt(byte[] address, byte[] slot, String block) {
                     return rpcStorageAt(address, slot, block);
+                }
+                @Override public byte[] sendRawTransaction(byte[] rawTx) {
+                    return rpcSendRawTransaction(rawTx);
                 }
             };
             io.myotis.jsonrpc.MyotisRpcServer s =

--- a/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/MyotisRpcBackend.kt
+++ b/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/MyotisRpcBackend.kt
@@ -58,4 +58,12 @@ interface MyotisRpcBackend {
      * to proxy (including absent slots, which can't be positively proven here).
      */
     fun getStorageAt(address: ByteArray, slot: ByteArray, block: String): ByteArray?
+
+    /**
+     * eth_sendRawTransaction: gossip an already-signed [rawTx] to the devp2p
+     * network and return its hash (keccak256 of the raw bytes), or null if it
+     * couldn't be broadcast (no peer) so the router can fall back to the proxy.
+     * Myotis never signs — the wallet user does; this only relays the bytes.
+     */
+    fun sendRawTransaction(rawTx: ByteArray): ByteArray?
 }

--- a/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/RpcRouter.kt
+++ b/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/RpcRouter.kt
@@ -146,6 +146,11 @@ class RpcRouter(
                 val v = withContext(Dispatchers.IO) { b.getStorageAt(addr, slot, block) } ?: return null
                 resultEnvelope(id, JsonPrimitive(hexData(v)))
             }
+            "eth_sendRawTransaction" -> {
+                val raw = (root.params()?.getOrNull(0) as? JsonPrimitive)?.asHexBytes() ?: return null
+                val hash = withContext(Dispatchers.IO) { b.sendRawTransaction(raw) } ?: return null
+                resultEnvelope(id, JsonPrimitive(hexData(hash)))
+            }
             else -> null
         }
     }

--- a/jsonrpc-server/src/test/kotlin/io/myotis/jsonrpc/RpcRouterTest.kt
+++ b/jsonrpc-server/src/test/kotlin/io/myotis/jsonrpc/RpcRouterTest.kt
@@ -46,6 +46,11 @@ class RpcRouterTest {
         override fun getStorageAt(address: ByteArray, slot: ByteArray, block: String): ByteArray? {
             lastSlot = slot; return storage
         }
+        var lastRawTx: ByteArray? = null
+        var txHash: ByteArray? = null
+        override fun sendRawTransaction(rawTx: ByteArray): ByteArray? {
+            lastRawTx = rawTx; return txHash
+        }
     }
 
     private fun route(backend: MyotisRpcBackend?, body: String, proxy: UpstreamProxy? = null): String =
@@ -171,6 +176,19 @@ class RpcRouterTest {
     @Test fun getStorageAt_backendNull_fallsThrough() {
         assertTrue(hasError(route(FakeBackend(storage = null),
             """{"jsonrpc":"2.0","id":1,"method":"eth_getStorageAt","params":["0xabc0000000000000000000000000000000000001","0x1"]}""")))
+    }
+
+    @Test fun sendRawTransaction_decodesRaw_andReturnsHashAsData() {
+        val b = FakeBackend().apply { txHash = ByteArray(32).also { it[31] = 0xfe.toByte() } }
+        val resp = route(b, """{"jsonrpc":"2.0","id":1,"method":"eth_sendRawTransaction",
+               "params":["0x02f8650182..."]}""".replace("...", "aabb"))
+        assertEquals("0x" + "00".repeat(31) + "fe", result(resp))
+        assertEquals("0x02f8650182aabb", b.lastRawTx!!.toHex())   // raw bytes passed through verbatim
+    }
+
+    @Test fun sendRawTransaction_noPeer_fallsThrough() {          // backend null -> proxy/strict
+        assertTrue(hasError(route(FakeBackend(),                  // txHash defaults to null
+            """{"jsonrpc":"2.0","id":1,"method":"eth_sendRawTransaction","params":["0x02aabb"]}""")))
     }
 
     @Test fun chainId_and_blockNumber_stillVerified() {

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/EthHandler.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/EthHandler.java
@@ -782,7 +782,7 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
      */
     public boolean sendTransactions(byte[]... rawTxs) {
         ChannelHandlerContext ctx = readyCtx;
-        if (ctx == null || state != State.READY) return false;
+        if (ctx == null || state != State.READY || rawTxs == null || rawTxs.length == 0) return false;
         byte[] payload = com.jaeckel.ethp2p.networking.eth.messages.TransactionsMessage.encode(rawTxs);
         rlpxHandler.sendMessage(ctx, ETH_TRANSACTIONS, payload);
         return true;

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/EthHandler.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/EthHandler.java
@@ -53,6 +53,7 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
 
     // eth/68 offsets from capability base (0x10)
     private static final int ETH_STATUS = 0x10;
+    private static final int ETH_TRANSACTIONS = 0x12;
     private static final int ETH_GET_BLOCK_HEADERS = 0x13;
     private static final int ETH_BLOCK_HEADERS = 0x14;
     private static final int ETH_GET_BLOCK_BODIES = 0x15;
@@ -770,6 +771,21 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
                 }
                 return headers.get(0).header();
             });
+    }
+
+    /**
+     * Broadcast one or more raw signed transactions to this peer (eth Transactions
+     * 0x12). Fire-and-forget — Transactions has no response. The wallet user signs
+     * and submits the tx; we only gossip the bytes so they reach a block producer.
+     *
+     * @return false if this handler is not in READY state (nothing sent)
+     */
+    public boolean sendTransactions(byte[]... rawTxs) {
+        ChannelHandlerContext ctx = readyCtx;
+        if (ctx == null || state != State.READY) return false;
+        byte[] payload = com.jaeckel.ethp2p.networking.eth.messages.TransactionsMessage.encode(rawTxs);
+        rlpxHandler.sendMessage(ctx, ETH_TRANSACTIONS, payload);
+        return true;
     }
 
     /**

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/messages/TransactionsMessage.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/messages/TransactionsMessage.java
@@ -27,10 +27,13 @@ public final class TransactionsMessage {
 
     private TransactionsMessage() {}
 
-    /** Encode one or more raw signed transactions into a Transactions message. */
+    /** Encode one or more raw signed transactions into a Transactions message.
+     *  Null/empty elements (and a null vararg) are skipped, yielding an empty list. */
     public static byte[] encode(byte[]... rawTxs) {
         return RLP.encodeList(writer -> {
+            if (rawTxs == null) return;
             for (byte[] rawTx : rawTxs) {
+                if (rawTx == null || rawTx.length == 0) continue;
                 Bytes tx = Bytes.wrap(rawTx);
                 if (isTyped(rawTx)) {
                     // EIP-2718 typed tx: carried as an RLP byte string.
@@ -50,6 +53,6 @@ public final class TransactionsMessage {
      * valid first byte of a transaction.)
      */
     private static boolean isTyped(byte[] rawTx) {
-        return rawTx.length > 0 && (rawTx[0] & 0xff) <= 0x7f;
+        return rawTx != null && rawTx.length > 0 && (rawTx[0] & 0xff) <= 0x7f;
     }
 }

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/messages/TransactionsMessage.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/messages/TransactionsMessage.java
@@ -1,0 +1,55 @@
+package com.jaeckel.ethp2p.networking.eth.messages;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.rlp.RLP;
+
+/**
+ * eth/Transactions (message code 0x12) — mempool broadcast.
+ *
+ * <p>Wire format (eth/66–69): {@code [tx_1, tx_2, ...]}. Each {@code tx_i} is a
+ * <em>complete signed transaction</em> exactly as a wallet hands it to
+ * {@code eth_sendRawTransaction}:
+ * <ul>
+ *   <li><b>legacy</b> — the raw bytes are already an RLP list
+ *       {@code [nonce, gasPrice, ...]}; they nest into the outer list verbatim
+ *       (inserted as pre-encoded RLP, not re-wrapped).</li>
+ *   <li><b>typed (EIP-2718)</b> — the raw bytes are {@code type || payload}
+ *       (first byte ≤ 0x7f); per EIP-2718 they ride inside the outer list as an
+ *       RLP <em>byte string</em>.</li>
+ * </ul>
+ *
+ * <p>We only ever <em>send</em> this (to gossip a user's signed tx); inbound
+ * Transactions from peers are mempool noise we ignore.
+ */
+public final class TransactionsMessage {
+
+    public static final int CODE = 0x12;
+
+    private TransactionsMessage() {}
+
+    /** Encode one or more raw signed transactions into a Transactions message. */
+    public static byte[] encode(byte[]... rawTxs) {
+        return RLP.encodeList(writer -> {
+            for (byte[] rawTx : rawTxs) {
+                Bytes tx = Bytes.wrap(rawTx);
+                if (isTyped(rawTx)) {
+                    // EIP-2718 typed tx: carried as an RLP byte string.
+                    writer.writeValue(tx);
+                } else {
+                    // Legacy tx: already an RLP list — embed its bytes directly.
+                    writer.writeRLP(tx);
+                }
+            }
+        }).toArrayUnsafe();
+    }
+
+    /**
+     * A transaction is EIP-2718 "typed" when its first byte is a transaction-type
+     * id in {@code [0x00, 0x7f]}; a legacy transaction starts with an RLP list
+     * header ({@code >= 0xc0}). (0x80–0xbf — an RLP string header — is never a
+     * valid first byte of a transaction.)
+     */
+    private static boolean isTyped(byte[] rawTx) {
+        return rawTx.length > 0 && (rawTx[0] & 0xff) <= 0x7f;
+    }
+}

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/rlpx/RLPxConnector.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/rlpx/RLPxConnector.java
@@ -270,6 +270,23 @@ public final class RLPxConnector implements AutoCloseable {
     }
 
     /**
+     * Gossip a raw signed transaction to <em>every</em> READY eth peer (eth
+     * Transactions 0x12). A light client doesn't relay the mempool, so peers may
+     * not re-propagate our gossip — broadcasting widely maximizes the chance the
+     * tx reaches a block producer.
+     *
+     * @return the number of peers the tx was sent to
+     */
+    public int broadcastTransaction(byte[] rawTx) {
+        int sent = 0;
+        for (EthHandler handler : activeHandlers) {
+            if (handler.isReady() && handler.sendTransactions(rawTx)) sent++;
+        }
+        log.info("[rlpx] Broadcast transaction to {} peer(s)", sent);
+        return sent;
+    }
+
+    /**
      * Fetch a single account from the snap/1 state trie via any active READY + snap peer.
      * Automatically retries with the next snap peer if the first one fails.
      *

--- a/networking/src/test/java/com/jaeckel/ethp2p/networking/eth/messages/TransactionsMessageTest.java
+++ b/networking/src/test/java/com/jaeckel/ethp2p/networking/eth/messages/TransactionsMessageTest.java
@@ -41,6 +41,18 @@ class TransactionsMessageTest {
     }
 
     @Test
+    void skipsNullAndEmptyElementsAndNullVararg() {
+        byte[] emptyList = {(byte) 0xc0};   // RLP encoding of an empty list
+        assertArrayEquals(emptyList, TransactionsMessage.encode());                 // no args
+        assertArrayEquals(emptyList, TransactionsMessage.encode((byte[][]) null));   // null vararg
+        assertArrayEquals(emptyList, TransactionsMessage.encode(null, new byte[0])); // null + empty skipped
+        // A null/empty element next to a real one is dropped, leaving just the real one.
+        byte[] legacy = {(byte) 0xc2, 0x01, 0x02};
+        assertArrayEquals(TransactionsMessage.encode(legacy),
+                TransactionsMessage.encode(null, legacy, new byte[0]));
+    }
+
+    @Test
     void multipleTxsKeepOrderAndPerTxForm() {
         byte[] legacy = {(byte) 0xc2, 0x01, 0x02};   // nested list
         byte[] typed = {0x02, 0x7f};                 // typed -> 2-byte string 0x82 02 7f

--- a/networking/src/test/java/com/jaeckel/ethp2p/networking/eth/messages/TransactionsMessageTest.java
+++ b/networking/src/test/java/com/jaeckel/ethp2p/networking/eth/messages/TransactionsMessageTest.java
@@ -1,0 +1,52 @@
+package com.jaeckel.ethp2p.networking.eth.messages;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Wire-format tests for the eth Transactions (0x12) encoder. Assertions are
+ * against the raw RLP bytes so they pin the legacy-vs-typed distinction the
+ * codec hinges on, independent of any decoder.
+ */
+class TransactionsMessageTest {
+
+    @Test
+    void legacyTxEmbeddedVerbatimAsNestedList() {
+        // A legacy tx is itself an RLP list (here a 2-element fake [1, 2] = 0xc2 01 02);
+        // it must nest into the outer list unchanged, not be re-wrapped as a string.
+        byte[] legacy = {(byte) 0xc2, 0x01, 0x02};
+        byte[] msg = TransactionsMessage.encode(legacy);
+        // outer list of 3 payload bytes: 0xc3 || c2 01 02
+        assertArrayEquals(new byte[]{(byte) 0xc3, (byte) 0xc2, 0x01, 0x02}, msg);
+    }
+
+    @Test
+    void typedTxWrappedAsRlpByteString() {
+        // EIP-2718 typed tx: 0x02 || 100 bytes (101 total, first byte <= 0x7f).
+        byte[] typed = new byte[101];
+        typed[0] = 0x02;
+        Arrays.fill(typed, 1, 101, (byte) 0xAB);
+        byte[] msg = TransactionsMessage.encode(typed);
+        // outer list (0xf8, len=103) -> RLP string (0xb8, len=101) -> 0x02 ...
+        assertEquals((byte) 0xf8, msg[0]);
+        assertEquals((byte) 0x67, msg[1]);   // list payload length = 103
+        assertEquals((byte) 0xb8, msg[2]);   // string, 1 length byte
+        assertEquals((byte) 0x65, msg[3]);   // string length = 101
+        assertEquals((byte) 0x02, msg[4]);   // tx type byte
+        assertEquals(105, msg.length);
+    }
+
+    @Test
+    void multipleTxsKeepOrderAndPerTxForm() {
+        byte[] legacy = {(byte) 0xc2, 0x01, 0x02};   // nested list
+        byte[] typed = {0x02, 0x7f};                 // typed -> 2-byte string 0x82 02 7f
+        byte[] msg = TransactionsMessage.encode(legacy, typed);
+        // outer list of 6 payload bytes: 0xc6 || (c2 01 02) || (82 02 7f)
+        assertArrayEquals(
+                new byte[]{(byte) 0xc6, (byte) 0xc2, 0x01, 0x02, (byte) 0x82, 0x02, 0x7f}, msg);
+    }
+}


### PR DESCRIPTION
## What

Adds **`eth_sendRawTransaction`** so a wallet can submit a signed transaction through Myotis over **devp2p** instead of a trusted RPC. This is the "submit" half of the send flow (Phase C step 1); verified confirmation (pending visibility + receipts) is the follow-up.

**Safety:** Myotis never signs or originates a transaction — it only gossips bytes the user signed in their wallet. Nothing is auto-broadcast; the actual send stays user-driven.

## Changes

- **`TransactionsMessage`** (eth `0x12`) encoder — nests **legacy** txs (already an RLP list) verbatim and wraps **EIP-2718 typed** txs as RLP byte strings, per the wire format. `0x12` was previously in `EthHandler`'s ignore branch.
- **`EthHandler.sendTransactions`** — fire-and-forget `0x12` to a READY peer (Transactions has no response).
- **`RLPxConnector.broadcastTransaction`** — gossip to **every** READY eth peer and return the peer count. A light client's tx isn't re-propagated by peers, so broadcasting widely maximizes the chance it reaches a block producer.
- **`eth_sendRawTransaction`** handler — broadcast, return `keccak256(rawTx)` as the tx hash. If no peer took it, fall through to the proxy so the tx still goes out (a signed tx is self-authenticating, so proxy relay carries no trust cost). **No double-send:** a successful devp2p broadcast does not also proxy.

## Flow today

A MetaMask send now goes out over devp2p and returns the hash. MetaMask's follow-up `eth_getTransactionByHash`/`Receipt` polling still **proxies**, so it sees pending→mined via the upstream — i.e. **verified submission, proxied confirmation**. Making confirmation trust-minimized is the next phase.

## Tests

- `TransactionsMessageTest` (3) — pins the legacy/typed wire format from the raw RLP bytes.
- `RpcRouterTest` +2 (now 20) — raw-tx passthrough + hash return, and no-peer fallthrough.

The send path is **not** auto-exercised end to end (no agent-originated broadcast); the codec + wiring are covered by unit tests, and a real send is validated by the user via the wallet.

## Follow-ups (not in this PR)
- **Phase C step 2** — `PendingTxStore` + verified `eth_getTransactionByHash` (pending) + `eth_getTransactionCount("pending")` (needs a signed-tx RLP decoder + ECDSA `from`-recovery).
- **Phase D** — `GetReceipts`/`Receipts` wire + a receipt-trie verifier (rebuild to the beacon-anchored `receiptsRoot`) for verified mined-detection + `eth_getTransactionReceipt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
