### PR TITLE
DNS-ENR EL/snap discovery: a discv4-independent fallback for NAT-restricted nodes

### DIFF
--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -7,6 +7,9 @@ import android.app.NotificationManager;
 import android.app.Service;
 import android.content.Intent;
 import android.content.pm.ServiceInfo;
+import android.net.ConnectivityManager;
+import android.net.LinkProperties;
+import android.net.Network;
 import android.os.Binder;
 import android.os.IBinder;
 import com.jaeckel.ethp2p.android.log.LogBuffer;
@@ -16,9 +19,11 @@ import com.jaeckel.ethp2p.consensus.BeaconSyncState;
 import com.jaeckel.ethp2p.consensus.libp2p.BeaconP2PService;
 import com.jaeckel.ethp2p.consensus.proof.MerklePatriciaVerifier;
 import com.jaeckel.ethp2p.core.crypto.NodeKey;
+import com.jaeckel.ethp2p.core.enr.Enr;
 import com.jaeckel.ethp2p.networking.NetworkConfig;
 import com.jaeckel.ethp2p.networking.discv4.DiscV4Service;
 import com.jaeckel.ethp2p.networking.discv5.DiscV5Service;
+import com.jaeckel.ethp2p.networking.dns.DnsEnrResolver;
 import com.jaeckel.ethp2p.networking.eth.messages.BlockHeadersMessage;
 import com.jaeckel.ethp2p.networking.rlpx.RLPxConnector;
 import com.jaeckel.ethp2p.networking.snap.messages.AccountRangeMessage;
@@ -29,12 +34,17 @@ import org.apache.tuweni.crypto.Hash;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.crypto.SECP256K1;
 
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -60,6 +70,28 @@ public final class NodeService extends Service {
     // abusive on a phone (battery, data, NAT table, file descriptors). attempted
     // is removed only when a peer drops, so this bounds in-flight dial churn.
     private static final int MAX_ATTEMPTED = 200;
+    // How many DNS-resolved (EIP-1459) EL enodes to RLPx-dial directly at startup,
+    // bypassing discv4. This is the EL discovery path that works on the Android
+    // emulator: QEMU/SLIRP user-mode NAT drops the unsolicited inbound discv4 PING
+    // that endpoint-proof needs, but allows the outbound RLPx TCP connection these
+    // direct dials make. Kept small to bound dial churn on a phone.
+    private static final int DNS_DIRECT_DIAL_LIMIT = 30;
+    // Per-maintenance-cycle cap for topping up dials from the DNS ENR pool when below
+    // the snap-peer target. Keeps churning through the pool (like discv4 would) without
+    // a flood; over several 10s cycles it works through the resolved list.
+    private static final int DNS_MAINTAIN_DIAL_BATCH = 15;
+    // Hard ceiling on sustained DNS-pool dials per rolling minute. The maintainer only
+    // tops up while below the snap target, but a NAT-restricted node (mobile CGNAT,
+    // emulator) can sit below target indefinitely — without this cap it would dial
+    // continuously and drain battery/data and pressure the carrier's NAT table (the
+    // very NAT that broke discv4). 60/min keeps progress while staying phone-friendly.
+    private static final int DNS_DIALS_PER_MIN = 60;
+    // Max ENRs retained in the rolling DNS candidate pool (bounds memory; the mainnet
+    // tree has thousands of entries but we only need enough turnover to find open slots).
+    private static final int DNS_POOL_MAX = 600;
+    // Re-walk the ENR tree at most this often (only while below target) to grow and
+    // refresh the candidate pool without hammering DNS.
+    private static final long DNS_REFRESH_INTERVAL_MS = 4 * 60 * 1000L;
     // Keep a working set of snap peers connected so a verified request almost
     // always finds one even as peers churn. Below this we proactively re-dial
     // known snap peers from the cache; 4 leaves headroom so transient churn
@@ -88,6 +120,21 @@ public final class NodeService extends Service {
     private final Set<String> attempted = ConcurrentHashMap.newKeySet();
     private final Map<String, Long> backoff = new ConcurrentHashMap<>();
     private final Set<String> blacklistedNodeIds = ConcurrentHashMap.newKeySet();
+
+    // EIP-1459 DNS-resolved EL enodes — a rolling, fork-filtered candidate pool the
+    // snap-peer maintainer keeps dialing from. This is the discv4 substitute whenever
+    // snap peers run low: on NAT'd hosts (mobile CGNAT, the emulator) discv4 can't
+    // bootstrap, so without a replenishing pool the node would never reach enough
+    // current-fork mainnet snap peers. Refreshed (re-walked + merged) only while below
+    // the snap target, throttled by DNS_REFRESH_INTERVAL_MS, capped at DNS_POOL_MAX.
+    private volatile List<Enr> dnsElEnrs = List.of();
+    private final AtomicBoolean dnsResolving = new AtomicBoolean(false);
+    private volatile long lastDnsResolveMs = 0L;
+    private volatile NetworkConfig dnsNetwork;
+    // Rolling-minute rate limit for DNS-pool dials (see DNS_DIALS_PER_MIN).
+    private volatile long dnsDialWindowStartMs = 0L;
+    private final java.util.concurrent.atomic.AtomicInteger dnsDialsInWindow =
+            new java.util.concurrent.atomic.AtomicInteger(0);
 
     // Service-lifecycle fields: written on the start/shutdown worker, read from
     // the Netty event loop, the Ktor IO dispatcher (JSON-RPC backend), and the UI
@@ -933,21 +980,174 @@ public final class NodeService extends Service {
             AndroidPeerCache pc = peerCache;
             if (conn == null) return;
             int snapPeers = conn.activeSnapHandlers().size();
-            if (snapPeers >= TARGET_SNAP_PEERS || pc == null) return;
-            LogBuffer.i(TAG, "[peers] " + snapPeers + " snap peer(s) < target " + TARGET_SNAP_PEERS
-                    + "; re-dialing cached snap peers");
+            if (snapPeers >= TARGET_SNAP_PEERS) return;
             long now = System.currentTimeMillis();
-            for (AndroidPeerCache.CachedPeer p : pc.load()) {
-                try {
-                    if (!p.snap()) continue;
-                    if (conn.activeSnapHandlers().size() >= TARGET_SNAP_PEERS) break;
-                    dialCachedSnapPeer(conn, p, now);
-                } catch (Exception e) {
-                    LogBuffer.w(TAG, "[peers] skipping cached peer: " + e.getMessage());
+            LogBuffer.i(TAG, "[peers] " + snapPeers + " snap peer(s) < target " + TARGET_SNAP_PEERS
+                    + "; re-dialing cached snap peers + DNS pool");
+            // 1) Re-dial known snap peers from the cache.
+            if (pc != null) {
+                for (AndroidPeerCache.CachedPeer p : pc.load()) {
+                    try {
+                        if (!p.snap()) continue;
+                        if (conn.activeSnapHandlers().size() >= TARGET_SNAP_PEERS) break;
+                        dialCachedSnapPeer(conn, p, now);
+                    } catch (Exception e) {
+                        LogBuffer.w(TAG, "[peers] skipping cached peer: " + e.getMessage());
+                    }
                 }
+            }
+            // 2) Top up from the DNS-resolved ENR pool — the discv4 substitute whenever
+            //    snap peers run low (mobile CGNAT / emulator, where discv4 can't bootstrap
+            //    and the cache is thin). Per-cycle batch + a rolling-minute rate cap keep
+            //    a permanently-starved node from draining battery/data and pressuring the
+            //    carrier NAT; the pool is fork-filtered so dials land on viable peers.
+            List<Enr> pool = dnsElEnrs;
+            if (!pool.isEmpty() && conn.activeSnapHandlers().size() < TARGET_SNAP_PEERS) {
+                int budget = Math.min(DNS_MAINTAIN_DIAL_BATCH, dnsDialBudget());
+                int dialed = 0;
+                for (Enr enr : pool) {
+                    if (dialed >= budget || attempted.size() >= MAX_ATTEMPTED) break;
+                    if (dialEnr(conn, enr, now)) {
+                        dialed++;
+                        dnsDialsInWindow.incrementAndGet();
+                    }
+                }
+                if (dialed > 0) {
+                    LogBuffer.i(TAG, "[peers] topped up " + dialed + " dial(s) from DNS ENR pool ("
+                            + pool.size() + " known)");
+                }
+            }
+            // 3) Grow/refresh the candidate pool by re-walking the tree — only while
+            //    still below target and no more often than DNS_REFRESH_INTERVAL_MS.
+            if (conn.activeSnapHandlers().size() < TARGET_SNAP_PEERS
+                    && !dnsResolving.get()
+                    && System.currentTimeMillis() - lastDnsResolveMs > DNS_REFRESH_INTERVAL_MS) {
+                Thread t = new Thread(this::refreshDnsPool, "dns-el-refresh");
+                t.setDaemon(true);
+                t.start();
             }
         } catch (Throwable t) {
             LogBuffer.e(TAG, "[peers] maintenance loop error", t);
+        }
+    }
+
+    /**
+     * Re-walk the EL ENR trees, fork-filter the result, and merge it into the rolling
+     * candidate pool (dedup by enode address, capped at {@link #DNS_POOL_MAX}). Guarded
+     * so only one walk runs at a time. forkID filtering keeps the limited dial budget
+     * off wrong-chain / stale-fork nodes that would reject us at the eth Status exchange.
+     */
+    private void refreshDnsPool() {
+        NetworkConfig net = dnsNetwork;
+        if (net == null || !dnsResolving.compareAndSet(false, true)) return;
+        try {
+            DnsEnrResolver resolver = new DnsEnrResolver();
+            // dnsjava has no system resolver config on Android, so feed it the active
+            // network's DNS servers; it falls back to public DNS over TCP if those are
+            // dead (the emulator: 10.0.2.3 UDP relay broken, outbound TCP:53 works).
+            resolver.setDnsServerIps(activeNetworkDnsServers());
+            List<Enr> resolved = resolver.resolveAllFromStrings(
+                    net.elEnrTreeUrls(), Duration.ofSeconds(25));
+            lastDnsResolveMs = System.currentTimeMillis();
+
+            byte[] ourFork = net.forkIdHash();
+            // Keep existing pool entries (keyed by enode address), then merge in newly
+            // resolved, fork-compatible ones up to the cap.
+            LinkedHashMap<String, Enr> merged = new LinkedHashMap<>();
+            for (Enr e : dnsElEnrs) {
+                e.tcpAddress().ifPresent(a ->
+                        merged.put(a.getHostString() + ":" + a.getPort(), e));
+            }
+            int added = 0, dropped = 0;
+            for (Enr e : resolved) {
+                if (merged.size() >= DNS_POOL_MAX) break;
+                Optional<InetSocketAddress> tcp = e.tcpAddress();
+                if (tcp.isEmpty() || e.publicKey().isEmpty()) continue;
+                // Keep enodes whose advertised fork matches ours, plus those that don't
+                // advertise one (unknown — worth a try). Drop clearly different forks
+                // (wrong chain or stale): they reject us at the eth Status exchange.
+                Optional<byte[]> fork = e.ethForkIdHash();
+                if (fork.isPresent() && !Arrays.equals(fork.get(), ourFork)) { dropped++; continue; }
+                String key = tcp.get().getHostString() + ":" + tcp.get().getPort();
+                if (merged.putIfAbsent(key, e) == null) added++;
+            }
+            dnsElEnrs = new ArrayList<>(merged.values());
+            LogBuffer.i(TAG, "DNS EL pool: +" + added + " new, " + dropped
+                    + " off-fork dropped, " + dnsElEnrs.size() + " total");
+        } catch (Exception e) {
+            LogBuffer.w(TAG, "DNS EL pool refresh failed: " + e.getMessage());
+        } finally {
+            dnsResolving.set(false);
+        }
+    }
+
+    /** Remaining DNS-pool dials allowed in the current rolling minute (see
+     *  {@link #DNS_DIALS_PER_MIN}). Resets the window lazily. */
+    private int dnsDialBudget() {
+        long now = System.currentTimeMillis();
+        if (now - dnsDialWindowStartMs >= 60_000L) {
+            dnsDialWindowStartMs = now;
+            dnsDialsInWindow.set(0);
+        }
+        return Math.max(0, DNS_DIALS_PER_MIN - dnsDialsInWindow.get());
+    }
+
+    /** DNS server IPs for the active network, for EIP-1459 ENR-tree TXT lookups.
+     *  dnsjava has no system resolver config on Android, so we feed it these
+     *  explicitly. Returns empty (→ resolver uses public-DNS fallback) on any error. */
+    private List<String> activeNetworkDnsServers() {
+        try {
+            ConnectivityManager cm = getSystemService(ConnectivityManager.class);
+            if (cm == null) return List.of();
+            Network active = cm.getActiveNetwork();
+            if (active == null) return List.of();
+            LinkProperties lp = cm.getLinkProperties(active);
+            if (lp == null) return List.of();
+            List<String> ips = new ArrayList<>();
+            for (InetAddress dns : lp.getDnsServers()) {
+                ips.add(dns.getHostAddress());
+            }
+            return ips;
+        } catch (Exception e) {
+            LogBuffer.w(TAG, "could not read active-network DNS servers: " + e.getMessage());
+            return List.of();
+        }
+    }
+
+    /** Dial one DNS-resolved (EIP-1459) EL enode over RLPx — the discv4-independent
+     *  peer source used on NAT'd hosts (the emulator). Same attempted/backoff/blacklist
+     *  bookkeeping as the other dial paths; returns true if a connect was started. */
+    private boolean dialEnr(RLPxConnector conn, Enr enr, long now) {
+        Optional<InetSocketAddress> tcp = enr.tcpAddress();
+        Optional<SECP256K1.PublicKey> pub = enr.publicKey();
+        if (tcp.isEmpty() || pub.isEmpty()) return false;
+        InetSocketAddress peerTcp = tcp.get();
+        String peerKey = peerTcp.getHostString() + ":" + peerTcp.getPort();
+        Long expiry = backoff.get(peerKey);
+        if (expiry != null) {
+            if (now < expiry) return false;
+            backoff.remove(peerKey);
+        }
+        if (attempted.size() >= MAX_ATTEMPTED || !attempted.add(peerKey)) return false;
+        try {
+            conn.connect(peerTcp, pub.get(), (incompatible, idHex) -> {
+                if (incompatible) blacklistedNodeIds.add(idHex);
+                long ms = incompatible ? BACKOFF_INCOMPATIBLE_MS : BACKOFF_TRANSIENT_MS;
+                backoff.putIfAbsent(peerKey, System.currentTimeMillis() + ms);
+                attempted.remove(peerKey);
+            }).addListener(future -> {
+                // TCP-level failure (timeout/refused): free the slot and back off briefly
+                // so a dead enode doesn't pin `attempted` and starve the pool.
+                if (!future.isSuccess()) {
+                    backoff.putIfAbsent(peerKey, System.currentTimeMillis() + BACKOFF_TRANSIENT_MS);
+                    attempted.remove(peerKey);
+                }
+            });
+            return true;
+        } catch (Exception e) {
+            LogBuffer.w(TAG, "DNS EL dial failed: " + e.getMessage());
+            attempted.remove(peerKey);
+            return false;
         }
     }
 
@@ -1378,6 +1578,31 @@ public final class NodeService extends Service {
                     attempted.remove(peerKey);
                 }
             }
+
+            // EIP-1459 DNS discovery + direct RLPx dial — the discv4-independent peer
+            // source used whenever snap peers run low. discv4 can't bootstrap behind a
+            // restrictive NAT (mobile CGNAT, the emulator's QEMU/SLIRP): its endpoint
+            // proof needs the remote to send us an *unsolicited* inbound PING, which
+            // such NATs drop. But the ENR trees give us EL enodes (key + TCP endpoint)
+            // directly, and an RLPx dial is an *outbound* TCP connection the NAT allows.
+            // Runs on its own thread (resolution can take many seconds) so it never
+            // delays discv4/discv5/beacon startup; the maintainer keeps it topped up.
+            this.dnsNetwork = network;
+            final RLPxConnector dnsConnector = connectorRef;
+            Thread dnsDialThread = new Thread(() -> {
+                refreshDnsPool();
+                long now = System.currentTimeMillis();
+                int directDialed = 0;
+                for (Enr enr : dnsElEnrs) {
+                    if (directDialed >= DNS_DIRECT_DIAL_LIMIT
+                            || attempted.size() >= MAX_ATTEMPTED) break;
+                    if (dialEnr(dnsConnector, enr, now)) directDialed++;
+                }
+                LogBuffer.i(TAG, "DNS EL discovery: direct-dialed " + directDialed
+                        + " of " + dnsElEnrs.size() + " pooled enode(s) (discv4-independent path)");
+            }, "dns-el-dial");
+            dnsDialThread.setDaemon(true);
+            dnsDialThread.start();
 
             localDisc = new DiscV4Service(nodeKey, network.bootnodes(), entry -> {
                 // Pause acquiring new peers while an ENS resolution runs: its snap

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -1061,15 +1061,19 @@ public final class NodeService extends Service {
             int added = 0, dropped = 0;
             for (Enr e : resolved) {
                 if (merged.size() >= DNS_POOL_MAX) break;
-                Optional<InetSocketAddress> tcp = e.tcpAddress();
-                if (tcp.isEmpty() || e.publicKey().isEmpty()) continue;
-                // Keep enodes whose advertised fork matches ours, plus those that don't
-                // advertise one (unknown — worth a try). Drop clearly different forks
-                // (wrong chain or stale): they reject us at the eth Status exchange.
-                Optional<byte[]> fork = e.ethForkIdHash();
-                if (fork.isPresent() && !Arrays.equals(fork.get(), ourFork)) { dropped++; continue; }
-                String key = tcp.get().getHostString() + ":" + tcp.get().getPort();
-                if (merged.putIfAbsent(key, e) == null) added++;
+                try {
+                    Optional<InetSocketAddress> tcp = e.tcpAddress();
+                    if (tcp.isEmpty() || e.publicKey().isEmpty()) continue;
+                    // Keep enodes whose advertised fork matches ours, plus those that don't
+                    // advertise one (unknown — worth a try). Drop clearly different forks
+                    // (wrong chain or stale): they reject us at the eth Status exchange.
+                    Optional<byte[]> fork = e.ethForkIdHash();
+                    if (fork.isPresent() && !Arrays.equals(fork.get(), ourFork)) { dropped++; continue; }
+                    String key = tcp.get().getHostString() + ":" + tcp.get().getPort();
+                    if (merged.putIfAbsent(key, e) == null) added++;
+                } catch (Exception ex) {
+                    dropped++; // malformed ENR — skip, don't abort the refresh
+                }
             }
             dnsElEnrs = new ArrayList<>(merged.values());
             LogBuffer.i(TAG, "DNS EL pool: +" + added + " new, " + dropped
@@ -1118,35 +1122,39 @@ public final class NodeService extends Service {
      *  peer source used on NAT'd hosts (the emulator). Same attempted/backoff/blacklist
      *  bookkeeping as the other dial paths; returns true if a connect was started. */
     private boolean dialEnr(RLPxConnector conn, Enr enr, long now) {
-        Optional<InetSocketAddress> tcp = enr.tcpAddress();
-        Optional<SECP256K1.PublicKey> pub = enr.publicKey();
-        if (tcp.isEmpty() || pub.isEmpty()) return false;
-        InetSocketAddress peerTcp = tcp.get();
-        String peerKey = peerTcp.getHostString() + ":" + peerTcp.getPort();
-        Long expiry = backoff.get(peerKey);
-        if (expiry != null) {
-            if (now < expiry) return false;
-            backoff.remove(peerKey);
-        }
-        if (attempted.size() >= MAX_ATTEMPTED || !attempted.add(peerKey)) return false;
+        // Fully guarded (including the ENR accessors below) so a single malformed
+        // entry can never abort a caller's dial loop — callers can ignore exceptions.
+        String peerKey = null;
         try {
+            Optional<InetSocketAddress> tcp = enr.tcpAddress();
+            Optional<SECP256K1.PublicKey> pub = enr.publicKey();
+            if (tcp.isEmpty() || pub.isEmpty()) return false;
+            InetSocketAddress peerTcp = tcp.get();
+            peerKey = peerTcp.getHostString() + ":" + peerTcp.getPort();
+            Long expiry = backoff.get(peerKey);
+            if (expiry != null) {
+                if (now < expiry) return false;
+                backoff.remove(peerKey);
+            }
+            if (attempted.size() >= MAX_ATTEMPTED || !attempted.add(peerKey)) return false;
+            final String key = peerKey;
             conn.connect(peerTcp, pub.get(), (incompatible, idHex) -> {
                 if (incompatible) blacklistedNodeIds.add(idHex);
                 long ms = incompatible ? BACKOFF_INCOMPATIBLE_MS : BACKOFF_TRANSIENT_MS;
-                backoff.putIfAbsent(peerKey, System.currentTimeMillis() + ms);
-                attempted.remove(peerKey);
+                backoff.putIfAbsent(key, System.currentTimeMillis() + ms);
+                attempted.remove(key);
             }).addListener(future -> {
                 // TCP-level failure (timeout/refused): free the slot and back off briefly
                 // so a dead enode doesn't pin `attempted` and starve the pool.
                 if (!future.isSuccess()) {
-                    backoff.putIfAbsent(peerKey, System.currentTimeMillis() + BACKOFF_TRANSIENT_MS);
-                    attempted.remove(peerKey);
+                    backoff.putIfAbsent(key, System.currentTimeMillis() + BACKOFF_TRANSIENT_MS);
+                    attempted.remove(key);
                 }
             });
             return true;
         } catch (Exception e) {
             LogBuffer.w(TAG, "DNS EL dial failed: " + e.getMessage());
-            attempted.remove(peerKey);
+            if (peerKey != null) attempted.remove(peerKey);
             return false;
         }
     }

--- a/app/src/main/java/com/jaeckel/ethp2p/app/Main.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/Main.java
@@ -31,6 +31,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -74,6 +75,10 @@ public final class Main {
     private static final int DEFAULT_PORT = 30303;
     private static final long BACKOFF_INCOMPATIBLE_MS = 10 * 60 * 1000L; // 10 min for wrong-chain peers
     private static final long BACKOFF_TRANSIENT_MS = 30 * 1000L; // 30s for transient failures (too many peers, etc.)
+    // Cap on how many DNS-resolved (EIP-1459) EL enodes we RLPx-dial directly at startup,
+    // bypassing discv4. Enough to land a snap peer on NAT'd hosts (Android emulator) without
+    // a dial storm where discv4 already works.
+    private static final int DNS_DIRECT_DIAL_LIMIT = 50;
 
     /** Socket path; override via {@code ETHP2P_SOCKET} env var. Network-specific suffix for non-mainnet. */
     static Path socketPath(String networkName) {
@@ -294,6 +299,47 @@ public final class Main {
                         peer.address(), e.getMessage());
                 attempted.remove(peerKey);
             }
+        }
+
+        // 5b. Directly RLPx-dial DNS-resolved EL enodes (EIP-1459), bypassing discv4.
+        // discv4's endpoint proof needs the remote to send us an *unsolicited* inbound
+        // PING before it returns NEIGHBORS — which QEMU/SLIRP user-mode NAT (the Android
+        // emulator's default) silently drops, so discv4 never bootstraps there. RLPx is
+        // an *outbound* TCP connection, which SLIRP allows, and the ENR carries the
+        // peer's secp256k1 key + TCP endpoint — everything connect() needs. So we get
+        // EL/snap peers on the emulator with no discv4 and no TAP networking. Harmless
+        // on the daemon (just a faster warm start). Capped so this doesn't become a dial
+        // storm on platforms where discv4 already populates the table.
+        int directDialed = 0;
+        for (Enr enr : dnsElEnrs) {
+            if (directDialed >= DNS_DIRECT_DIAL_LIMIT) break;
+            Optional<InetSocketAddress> tcp = enr.tcpAddress();
+            Optional<SECP256K1.PublicKey> pub = enr.publicKey();
+            if (tcp.isEmpty() || pub.isEmpty()) continue;
+            InetSocketAddress peerTcp = tcp.get();
+            String peerKey = peerTcp.getAddress().getHostAddress() + ":" + peerTcp.getPort();
+            if (!attempted.add(peerKey)) continue;
+            directDialed++;
+            try {
+                log.info("[main] Direct RLPx dial of DNS EL enode {}", peerTcp);
+                connector.connect(peerTcp, pub.get(), (incompatible, nodeIdHex) -> {
+                            if (incompatible) {
+                                blacklistedNodeIds.add(nodeIdHex);
+                            }
+                            long backoffMs = incompatible ? BACKOFF_INCOMPATIBLE_MS : BACKOFF_TRANSIENT_MS;
+                            backoff.putIfAbsent(peerKey, System.currentTimeMillis() + backoffMs);
+                            attempted.remove(peerKey);
+                        })
+                        .addListener(future -> {
+                            if (!future.isSuccess()) attempted.remove(peerKey);
+                        });
+            } catch (Exception e) {
+                log.warn("[main] Failed direct dial of DNS EL enode {}: {}", peerTcp, e.getMessage());
+                attempted.remove(peerKey);
+            }
+        }
+        if (directDialed > 0) {
+            log.info("[main] Direct-dialed {} DNS EL enode(s) (discv4-independent path)", directDialed);
         }
 
         // 6. discv4 discovery

--- a/app/src/main/java/com/jaeckel/ethp2p/app/Main.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/Main.java
@@ -313,29 +313,33 @@ public final class Main {
         int directDialed = 0;
         for (Enr enr : dnsElEnrs) {
             if (directDialed >= DNS_DIRECT_DIAL_LIMIT) break;
-            Optional<InetSocketAddress> tcp = enr.tcpAddress();
-            Optional<SECP256K1.PublicKey> pub = enr.publicKey();
-            if (tcp.isEmpty() || pub.isEmpty()) continue;
-            InetSocketAddress peerTcp = tcp.get();
-            String peerKey = peerTcp.getAddress().getHostAddress() + ":" + peerTcp.getPort();
-            if (!attempted.add(peerKey)) continue;
-            directDialed++;
+            // Whole body guarded so a single malformed ENR can't abort the loop;
+            // getHostString() avoids an NPE if the ENR address is unresolved.
+            String peerKey = null;
             try {
+                Optional<InetSocketAddress> tcp = enr.tcpAddress();
+                Optional<SECP256K1.PublicKey> pub = enr.publicKey();
+                if (tcp.isEmpty() || pub.isEmpty()) continue;
+                InetSocketAddress peerTcp = tcp.get();
+                peerKey = peerTcp.getHostString() + ":" + peerTcp.getPort();
+                if (!attempted.add(peerKey)) continue;
+                directDialed++;
+                final String key = peerKey;
                 log.info("[main] Direct RLPx dial of DNS EL enode {}", peerTcp);
                 connector.connect(peerTcp, pub.get(), (incompatible, nodeIdHex) -> {
                             if (incompatible) {
                                 blacklistedNodeIds.add(nodeIdHex);
                             }
                             long backoffMs = incompatible ? BACKOFF_INCOMPATIBLE_MS : BACKOFF_TRANSIENT_MS;
-                            backoff.putIfAbsent(peerKey, System.currentTimeMillis() + backoffMs);
-                            attempted.remove(peerKey);
+                            backoff.putIfAbsent(key, System.currentTimeMillis() + backoffMs);
+                            attempted.remove(key);
                         })
                         .addListener(future -> {
-                            if (!future.isSuccess()) attempted.remove(peerKey);
+                            if (!future.isSuccess()) attempted.remove(key);
                         });
             } catch (Exception e) {
-                log.warn("[main] Failed direct dial of DNS EL enode {}: {}", peerTcp, e.getMessage());
-                attempted.remove(peerKey);
+                log.warn("[main] Failed direct dial of DNS EL enode: {}", e.getMessage());
+                if (peerKey != null) attempted.remove(peerKey);
             }
         }
         if (directDialed > 0) {

--- a/core/src/main/java/com/jaeckel/ethp2p/core/enr/Enr.java
+++ b/core/src/main/java/com/jaeckel/ethp2p/core/enr/Enr.java
@@ -149,6 +149,54 @@ public final class Enr {
     public record Eth2Field(byte[] forkDigest, byte[] nextForkVersion, long nextForkEpoch) {}
 
     /**
+     * EL "eth" ENR field (EIP-868): the 4-byte EIP-2124 fork hash of the node's
+     * current chain state. Layout is {@code eth = [[fork_hash, fork_next], ...]} — an
+     * RLP list whose first element is the {@code ForkID} tuple.
+     *
+     * <p>{@link #decode} drops list-valued ENR entries, so this re-parses {@link #rawRlp}
+     * in isolation (fully guarded — a malformed entry yields empty, never throws).
+     * Callers use it to filter discovered EL enodes down to peers on the same fork as
+     * us, so dials aren't wasted on wrong-chain or stale-fork nodes that would reject us.
+     */
+    public Optional<byte[]> ethForkIdHash() {
+        try {
+            Bytes[] holder = {null};
+            RLP.decodeList(rawRlp, reader -> {
+                reader.skipNext(); // signature
+                reader.readLong(); // seq
+                while (!reader.isComplete()) {
+                    String key = reader.readString();
+                    boolean isList = reader.nextIsList();
+                    if (key.equals("eth") && isList) {
+                        reader.readList(outer -> {
+                            if (!outer.isComplete() && outer.nextIsList()) {
+                                outer.readList(idReader -> {
+                                    if (!idReader.isComplete() && !idReader.nextIsList()) {
+                                        holder[0] = idReader.readValue(); // fork_hash
+                                    }
+                                    return null;
+                                });
+                            }
+                            return null;
+                        });
+                    } else if (isList) {
+                        reader.skipNext();
+                    } else {
+                        reader.readValue();
+                    }
+                }
+                return null;
+            });
+            if (holder[0] != null && holder[0].size() >= 4) {
+                return Optional.of(holder[0].slice(0, 4).toArrayUnsafe());
+            }
+            return Optional.empty();
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+    }
+
+    /**
      * Derive a libp2p multiaddr string from this ENR.
      * Format: {@code /ip4/<ip>/tcp/<port>/p2p/<peer-id>}
      *

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/discv4/DiscV4Handler.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/discv4/DiscV4Handler.java
@@ -50,17 +50,35 @@ public final class DiscV4Handler extends SimpleChannelInboundHandler<DatagramPac
     @Override
     protected void channelRead0(ChannelHandlerContext ctx, DatagramPacket msg) {
         ByteBuf buf = msg.content();
-        byte[] bytes = new byte[buf.readableBytes()];
+        int size = buf.readableBytes();
+        byte[] bytes = new byte[size];
         buf.readBytes(bytes);
         Bytes raw = Bytes.wrap(bytes);
         InetSocketAddress sender = msg.sender();
 
         try {
             Packet.Parsed parsed = Packet.parse(raw);
+            // Diagnostic: log every inbound datagram's size + type. On the Android
+            // emulator (QEMU/SLIRP user-mode NAT) this tells us whether ANY inbound
+            // discv4 UDP arrives, and crucially whether *unsolicited* PINGs ever do —
+            // discv4's endpoint proof needs the remote to PING us before it returns
+            // NEIGHBORS, and SLIRP drops unsolicited inbound. Replies (PONG/NEIGHBORS)
+            // on flows we initiated traverse the NAT; an unsolicited PING does not.
+            log.debug("[discv4-rx] {} bytes type={} from {}", size, typeName(parsed.type()), sender);
             handlePacket(ctx, parsed, sender);
         } catch (Exception e) {
-            log.debug("Discarding invalid packet from {}: {}", sender, e.getMessage());
+            log.debug("[discv4-rx] {} bytes UNPARSEABLE from {}: {}", size, sender, e.getMessage());
         }
+    }
+
+    private static String typeName(byte type) {
+        return switch (type) {
+            case Packet.TYPE_PING -> "PING";
+            case Packet.TYPE_PONG -> "PONG";
+            case Packet.TYPE_FIND_NODE -> "FINDNODE";
+            case Packet.TYPE_NEIGHBORS -> "NEIGHBORS";
+            default -> "0x" + Integer.toHexString(type & 0xff);
+        };
     }
 
     private void handlePacket(ChannelHandlerContext ctx, Packet.Parsed p, InetSocketAddress sender) {

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/dns/DnsEnrResolver.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/dns/DnsEnrResolver.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 /**
  * EIP-1459 DNS ENR tree resolver.
@@ -50,13 +51,33 @@ public final class DnsEnrResolver {
     static final int DEFAULT_MAX_NODES = 512;
     /** Maximum branch depth to walk. */
     static final int DEFAULT_MAX_DEPTH = 16;
+    /** Grace beyond the deadline to let an in-flight tree walk return its partial
+     *  results before we snapshot them. Covers one last lookup (which may try a few
+     *  servers). Without it, results collected right at the deadline are dropped. */
+    private static final Duration SHUTDOWN_GRACE = Duration.ofSeconds(5);
 
     private final TxtResolver txtResolver;
     private final int maxNodes;
     private final int maxDepth;
 
+    /** Explicit DNS server IPs to query, highest priority first. Empty = use the
+     *  JVM/system resolver config. dnsjava's default {@code SimpleResolver()} relies
+     *  on {@code ResolverConfig} reading /etc/resolv.conf, which is absent on Android
+     *  (the lookup then fails with "network error"), so the Android layer must inject
+     *  the active network's DNS servers here via {@link #setDnsServerIps}. */
+    private volatile List<String> dnsServerIps = List.of();
+
     public DnsEnrResolver() {
-        this(DnsEnrResolver::defaultTxtLookup, DEFAULT_MAX_NODES, DEFAULT_MAX_DEPTH);
+        this.maxNodes = DEFAULT_MAX_NODES;
+        this.maxDepth = DEFAULT_MAX_DEPTH;
+        this.txtResolver = this::instanceTxtLookup;
+    }
+
+    /** Set the DNS server IP(s) used for TXT lookups (e.g. the active network's
+     *  resolvers from Android's ConnectivityManager). Queried before the public-DNS
+     *  fallbacks. Safe to call before {@code resolveAll*}. */
+    public void setDnsServerIps(List<String> ips) {
+        this.dnsServerIps = ips == null ? List.of() : List.copyOf(ips);
     }
 
     /** Package-private for tests. */
@@ -73,10 +94,13 @@ public final class DnsEnrResolver {
         long deadline = start + timeout.toNanos();
         List<Enr> all = java.util.Collections.synchronizedList(new ArrayList<>());
 
-        // Each resolve() call respects the deadline and returns partial results, so
-        // the ExecutorService's close() (which waits on submitted tasks) is bounded
-        // by the per-tree walk rather than the timeout we're trying to enforce here.
-        try (ExecutorService exec = Executors.newVirtualThreadPerTaskExecutor()) {
+        // A plain fixed thread pool — NOT Executors.newVirtualThreadPerTaskExecutor():
+        // virtual threads are a Java 21 API absent on Android/ART (NoSuchMethodError),
+        // and this resolver must run on Android. Likewise we shut down explicitly
+        // instead of try-with-resources, since ExecutorService.close() is a Java 19+
+        // AutoCloseable method that isn't guaranteed on the Android runtime.
+        ExecutorService exec = Executors.newFixedThreadPool(Math.min(urls.size(), 8));
+        try {
             for (EnrTreeUrl url : urls) {
                 exec.submit(() -> {
                     try {
@@ -86,6 +110,20 @@ public final class DnsEnrResolver {
                     }
                 });
             }
+            exec.shutdown();
+            // resolve() self-bounds by `deadline` and returns its PARTIAL list shortly
+            // after the deadline (it checks between lookups). We must wait for that
+            // return so all.addAll() runs — NOT cut off AT the deadline, which would
+            // snapshot an empty `all` and drop everything the walk collected. So wait
+            // the remaining time PLUS a grace window covering one last in-flight lookup.
+            long graceNanos = (deadline - System.nanoTime()) + SHUTDOWN_GRACE.toNanos();
+            if (graceNanos > 0) {
+                exec.awaitTermination(graceNanos, TimeUnit.NANOSECONDS);
+            }
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+        } finally {
+            exec.shutdownNow();
         }
         log.info("[dns] resolved {} ENR(s) from {} tree(s) in {} ms",
                 all.size(), urls.size(), (System.nanoTime() - start) / 1_000_000);
@@ -227,12 +265,59 @@ public final class DnsEnrResolver {
 
     /** Per-DNS-query timeout. Caps blocking on a single unresponsive nameserver so
      *  the overall deadline in {@link #resolveAll} can actually fire. */
-    private static final Duration LOOKUP_TIMEOUT = Duration.ofSeconds(3);
+    private static final Duration LOOKUP_TIMEOUT = Duration.ofSeconds(2);
 
-    private static String defaultTxtLookup(String name) throws Exception {
+    /** A DNS server to try. {@code ip == null} uses dnsjava's system-config resolver
+     *  (works off-Android, no-op on Android). {@code tcp} forces DNS-over-TCP, which
+     *  the Android emulator's SLIRP NAT forwards to public resolvers even when its own
+     *  UDP DNS relay (10.0.2.3) is broken — the failure mode we actually hit. */
+    private record DnsServer(String ip, boolean tcp) {
+        @Override public String toString() {
+            return (ip == null ? "system" : ip) + (tcp ? "/tcp" : "");
+        }
+    }
+
+    /** Public DNS fallbacks, tried after explicit/system servers. Over TCP because
+     *  that's the path proven reachable on the emulator when UDP DNS is dead. */
+    private static final List<DnsServer> PUBLIC_DNS_FALLBACKS =
+            List.of(new DnsServer("1.1.1.1", true), new DnsServer("8.8.8.8", true));
+
+    /** The server that last answered, tried first on subsequent lookups. A tree walk
+     *  is many TXT lookups; without this every one would re-pay the dead-primary tax
+     *  (broken emulator DNS) before failing over. Pin it once, then go straight there. */
+    private volatile DnsServer lastGood;
+
+    /** Try each candidate DNS server until one resolves the TXT record.
+     *  Order: last-good → explicit {@link #dnsServerIps} → system → public DNS. */
+    private String instanceTxtLookup(String name) throws Exception {
+        List<DnsServer> candidates = new ArrayList<>();
+        DnsServer pinned = lastGood;
+        if (pinned != null) candidates.add(pinned);
+        for (String ip : dnsServerIps) candidates.add(new DnsServer(ip, false));
+        if (dnsServerIps.isEmpty()) candidates.add(new DnsServer(null, false));
+        candidates.addAll(PUBLIC_DNS_FALLBACKS);
+        Exception last = null;
+        for (DnsServer cand : candidates) {
+            try {
+                String result = txtLookupVia(name, cand);
+                lastGood = cand;
+                return result;
+            } catch (Exception e) {
+                last = e;
+                log.debug("[dns] TXT {} via {} failed: {}", name, cand, e.getMessage());
+            }
+        }
+        throw last != null ? last
+                : new IllegalStateException("no DNS server resolved " + name);
+    }
+
+    private static String txtLookupVia(String name, DnsServer server) throws Exception {
         Lookup lookup = new Lookup(name, Type.TXT);
-        org.xbill.DNS.SimpleResolver resolver = new org.xbill.DNS.SimpleResolver();
+        org.xbill.DNS.SimpleResolver resolver = (server.ip() == null)
+                ? new org.xbill.DNS.SimpleResolver()
+                : new org.xbill.DNS.SimpleResolver(server.ip());
         resolver.setTimeout(LOOKUP_TIMEOUT);
+        if (server.tcp()) resolver.setTCP(true);
         lookup.setResolver(resolver);
         Record[] records = lookup.run();
         if (lookup.getResult() != Lookup.SUCCESSFUL || records == null || records.length == 0) {


### PR DESCRIPTION
## Why

`discv4` cannot bootstrap behind a restrictive NAT. Its endpoint proof requires the **remote** peer to send us an *unsolicited inbound UDP PING* before it returns `Neighbors` — and **mobile carrier-grade NAT** (symmetric NAT, short UDP timeouts) and the **Android emulator's QEMU/SLIRP** both drop unsolicited inbound. Those nodes get no `Neighbors`, the Kademlia table stays empty, and they never find EL/snap peers. State is still cryptographically verified against the header chain, so the visible symptom is silent fallback to the Infura proxy for `eth_call`/`eth_getBalance`/ENS/etc.

This is **not emulator-only** — it's a real subset of mobile subscribers. The emulator is just a faithful, always-available proxy for that population.

## What

An **EIP-1459 DNS-ENR peer source that needs no inbound UDP**: resolve the EL ENR trees, then RLPx-dial the enodes directly (outbound TCP, which the NAT allows). Wired as a **general snap-peer-starvation fallback** — it tops up whenever `activeSnapHandlers() < TARGET_SNAP_PEERS` on *any* device, not just the emulator. On a healthy node it's a brief startup burst; on a NAT-restricted node it carries the load.

- **`DnsEnrResolver`** — Android-safe + resilient: drop the Java-21 virtual-thread executor (`NoSuchMethodError` on ART), take explicit DNS server IPs (dnsjava has no resolver config on Android) with a sticky last-good server and **public-DNS-over-TCP fallback** (the emulator's `10.0.2.3` UDP relay is dead but outbound TCP:53 works), and wait a grace window past the deadline so a walk finishing *at* the deadline isn't dropped.
- **`Enr.ethForkIdHash()`** — parse the EIP-868 `eth` ENR entry (re-parses `rawRlp` in isolation since `decode()` drops list values). Used to **fork-filter** the pool so dials skip wrong-chain / stale-fork nodes.
- **`NodeService`** — a rolling, fork-filtered candidate pool (capped, periodically re-walked only while below target) feeding the snap-peer maintainer, with a **per-minute dial-rate cap** so a permanently-NAT-starved node doesn't drain battery/data or pressure the carrier NAT (the very NAT that broke discv4).
- **`Main`** (daemon) — direct-dial DNS-resolved EL enodes too (faster warm start).
- **`DiscV4Handler`** — debug-level inbound-packet-type log that diagnoses the NAT case.

## Validation

- Daemon holds peers with this source (and held 196 peers via discv4 with the same static forkID — confirming `07c9462e` is correct, not stale).
- On the emulator: DNS resolves over the TCP fallback (180–220 enodes), the fork filter drops off-fork entries, and the rate cap holds at 15 dials/cycle.

## Honest limitation

A **100%-NAT-blocked** node (the emulator / worst-case CGNAT) still can't reliably *hold* mainnet snap peers: ~90% of dials hit `DiscTooManyPeers` (nodes are full), and catching an open slot needs discv4-firehose dial volume (~thousands/min) that the phone-friendly rate cap deliberately forbids (~60/min). This PR **widens coverage for partially-reachable mobile nodes** — it is **not** a full discv4 replacement. For guaranteed emulator testing, seed the app from a daemon's live peer cache (follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)