### PR TITLE
Verified receipts foundation: ordered-trie root builder + GetReceipts/Receipts devp2p path

### DIFF
--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/proof/OrderedTrieRoot.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/proof/OrderedTrieRoot.java
@@ -1,0 +1,165 @@
+package com.jaeckel.ethp2p.consensus.proof;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.crypto.Hash;
+import org.apache.tuweni.rlp.RLP;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Computes the root of an Ethereum "ordered" Merkle-Patricia trie — the construction
+ * used for a block's {@code transactionsRoot} and {@code receiptsRoot}, where the trie
+ * maps {@code key = RLP(index)} to {@code value = consensus-encoding of the item}.
+ *
+ * <p>Unlike {@link MerklePatriciaVerifier} (which only walks an existing proof downward,
+ * root → leaf), this builds the trie bottom-up to <em>derive</em> the root, so a caller
+ * can verify a full transaction or receipt list against a trusted header without trusting
+ * the peer that supplied it: rebuild the trie from the received items and compare the
+ * computed root to {@code header.transactionsRoot} / {@code header.receiptsRoot}.
+ *
+ * <p>Trie encoding follows the Yellow Paper: hex-prefix (compact) node keys, 17-item
+ * branch nodes, 2-item leaf/extension nodes, child references inlined when their RLP is
+ * &lt; 32 bytes and keccak256-hashed otherwise, and the root always hashed.
+ */
+public final class OrderedTrieRoot {
+
+    /** keccak256(RLP("")) — the root of an empty trie. */
+    public static final Bytes32 EMPTY_ROOT =
+            Hash.keccak256(RLP.encodeValue(Bytes.EMPTY));
+
+    private OrderedTrieRoot() {}
+
+    /** True iff the ordered trie over {@code items} (index → item) roots to {@code expectedRoot}. */
+    public static boolean verify(List<Bytes> items, Bytes32 expectedRoot) {
+        return expectedRoot != null && expectedRoot.equals(ofList(items));
+    }
+
+    /** Root of the ordered trie mapping {@code RLP(i) -> items.get(i)}. */
+    public static Bytes32 ofList(List<Bytes> items) {
+        if (items == null || items.isEmpty()) return EMPTY_ROOT;
+        List<Bytes> keys = new ArrayList<>(items.size());
+        for (int i = 0; i < items.size(); i++) {
+            keys.add(RLP.encodeValue(minimalBytes(i)));
+        }
+        return rootOf(keys, items);
+    }
+
+    /** Root of an arbitrary-keyed Merkle-Patricia trie (keys used directly as the path,
+     *  not hashed — the tx/receipt-trie convention). Package-private: lets tests drive
+     *  the branch/extension/leaf machinery with crafted keys. */
+    static Bytes32 rootOf(List<Bytes> keys, List<Bytes> values) {
+        if (keys.isEmpty()) return EMPTY_ROOT;
+        List<Entry> entries = new ArrayList<>(keys.size());
+        for (int i = 0; i < keys.size(); i++) {
+            entries.add(new Entry(nibbles(keys.get(i)), values.get(i)));
+        }
+        // The trie shape is determined by key-nibble order, not insertion order,
+        // so sort lexicographically before building.
+        entries.sort(Comparator.comparing(e -> e.path, OrderedTrieRoot::compareNibbles));
+        return Hash.keccak256(buildNode(entries, 0));
+    }
+
+    /** RLP bytes of the trie node covering {@code entries}, which all share nibbles [0, depth). */
+    private static Bytes buildNode(List<Entry> entries, int depth) {
+        if (entries.size() == 1) {
+            Entry e = entries.get(0);
+            int[] rest = java.util.Arrays.copyOfRange(e.path, depth, e.path.length);
+            return RLP.encodeList(w -> {
+                w.writeValue(hexPrefix(rest, true));
+                w.writeValue(e.value);
+            });
+        }
+        int common = commonPrefixEnd(entries, depth);
+        if (common > depth) {
+            int[] shared = java.util.Arrays.copyOfRange(entries.get(0).path, depth, common);
+            Bytes child = buildNode(entries, common);
+            return RLP.encodeList(w -> {
+                w.writeValue(hexPrefix(shared, false));
+                writeRef(w, child);
+            });
+        }
+        // Branch node: 16 child slots + a value slot (for a key ending exactly here).
+        List<List<Entry>> groups = new ArrayList<>(16);
+        for (int i = 0; i < 16; i++) groups.add(new ArrayList<>());
+        Bytes branchValue = Bytes.EMPTY;
+        for (Entry e : entries) {
+            if (e.path.length == depth) branchValue = e.value;
+            else groups.get(e.path[depth]).add(e);
+        }
+        Bytes finalBranchValue = branchValue;
+        return RLP.encodeList(w -> {
+            for (int n = 0; n < 16; n++) {
+                List<Entry> g = groups.get(n);
+                if (g.isEmpty()) w.writeValue(Bytes.EMPTY);
+                else writeRef(w, buildNode(g, depth + 1));
+            }
+            w.writeValue(finalBranchValue);
+        });
+    }
+
+    /** Embed a child reference: inline the node RLP if < 32 bytes, else its keccak256 hash. */
+    private static void writeRef(org.apache.tuweni.rlp.RLPWriter w, Bytes childRlp) {
+        if (childRlp.size() < 32) {
+            w.writeRLP(childRlp); // inline the node's RLP directly
+        } else {
+            w.writeValue(Hash.keccak256(childRlp)); // 32-byte hash reference
+        }
+    }
+
+    /** Largest nibble index c (>= depth) such that every entry shares nibbles [depth, c). */
+    private static int commonPrefixEnd(List<Entry> entries, int depth) {
+        int[] first = entries.get(0).path;
+        int[] last = entries.get(entries.size() - 1).path; // sorted, so these bound the set
+        int c = depth;
+        while (c < first.length && c < last.length && first[c] == last[c]) c++;
+        return c;
+    }
+
+    /** Hex-prefix (compact) encoding of a nibble path with the leaf/extension flag. */
+    private static Bytes hexPrefix(int[] path, boolean leaf) {
+        boolean odd = (path.length & 1) == 1;
+        int flag = (leaf ? 2 : 0) | (odd ? 1 : 0);
+        int[] nibs = new int[(odd ? 1 : 2) + path.length];
+        int idx = 0;
+        nibs[idx++] = flag;
+        if (!odd) nibs[idx++] = 0; // even path: pad first byte's low nibble
+        for (int p : path) nibs[idx++] = p;
+        byte[] out = new byte[nibs.length / 2];
+        for (int i = 0; i < out.length; i++) {
+            out[i] = (byte) ((nibs[2 * i] << 4) | nibs[2 * i + 1]);
+        }
+        return Bytes.wrap(out);
+    }
+
+    private static int[] nibbles(Bytes key) {
+        int[] out = new int[key.size() * 2];
+        for (int i = 0; i < key.size(); i++) {
+            int b = key.get(i) & 0xFF;
+            out[2 * i] = b >>> 4;
+            out[2 * i + 1] = b & 0x0F;
+        }
+        return out;
+    }
+
+    /** Minimal big-endian byte representation of a non-negative long (empty for 0). */
+    private static Bytes minimalBytes(long v) {
+        if (v == 0) return Bytes.EMPTY;
+        byte[] tmp = new byte[8];
+        int i = 8;
+        while (v != 0) { tmp[--i] = (byte) (v & 0xFF); v >>>= 8; }
+        return Bytes.wrap(java.util.Arrays.copyOfRange(tmp, i, 8));
+    }
+
+    private static int compareNibbles(int[] a, int[] b) {
+        int n = Math.min(a.length, b.length);
+        for (int i = 0; i < n; i++) {
+            if (a[i] != b[i]) return Integer.compare(a[i], b[i]);
+        }
+        return Integer.compare(a.length, b.length);
+    }
+
+    private record Entry(int[] path, Bytes value) {}
+}

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/proof/OrderedTrieRoot.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/proof/OrderedTrieRoot.java
@@ -51,6 +51,10 @@ public final class OrderedTrieRoot {
      *  not hashed — the tx/receipt-trie convention). Package-private: lets tests drive
      *  the branch/extension/leaf machinery with crafted keys. */
     static Bytes32 rootOf(List<Bytes> keys, List<Bytes> values) {
+        if (keys.size() != values.size()) {
+            throw new IllegalArgumentException(
+                    "keys/values size mismatch: " + keys.size() + " != " + values.size());
+        }
         if (keys.isEmpty()) return EMPTY_ROOT;
         List<Entry> entries = new ArrayList<>(keys.size());
         for (int i = 0; i < keys.size(); i++) {

--- a/consensus/src/test/java/com/jaeckel/ethp2p/consensus/proof/OrderedTrieRootTest.java
+++ b/consensus/src/test/java/com/jaeckel/ethp2p/consensus/proof/OrderedTrieRootTest.java
@@ -1,0 +1,133 @@
+package com.jaeckel.ethp2p.consensus.proof;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.crypto.Hash;
+import org.apache.tuweni.rlp.RLP;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.security.Security;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OrderedTrieRootTest {
+
+    // Static block: runs before the static field initializers below, which call
+    // keccak256 (needs the BC provider). @BeforeAll would be too late for those.
+    static {
+        if (Security.getProvider("BC") == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+    }
+
+    /** The empty-trie root is keccak256(RLP("")) = keccak256(0x80). Derived here from
+     *  the proven-correct primitives (keccak256 is validated against the "abc" vector in
+     *  {@link #keccakIsRealEthereumKeccak256()}) rather than a hand-copied constant. */
+    private static final Bytes32 KNOWN_EMPTY_ROOT =
+            Hash.keccak256(Bytes.fromHexString("0x80"));
+
+    @Test
+    void keccakIsRealEthereumKeccak256() {
+        // keccak256("abc") — the canonical NIST-Keccak (not SHA3) test vector.
+        assertEquals(
+                Bytes32.fromHexString("0x4e03657aea45a94fc7d47ba826c8d667c0d1e6e33a64a036ec44f58fa12d6c45"),
+                Hash.keccak256(Bytes.wrap("abc".getBytes(java.nio.charset.StandardCharsets.US_ASCII))));
+    }
+
+    @Test
+    void emptyListRootIsTheCanonicalEmptyTrieRoot() {
+        assertEquals(KNOWN_EMPTY_ROOT, OrderedTrieRoot.ofList(List.of()));
+        assertEquals(KNOWN_EMPTY_ROOT, OrderedTrieRoot.EMPTY_ROOT);
+    }
+
+    /** Single item → single leaf at key RLP(0)=0x80 (nibbles [8,0], even). Root is the
+     *  hash of leaf [HP(even-leaf [8,0])=0x2080, value], built independently here. */
+    @Test
+    void singleItemMatchesIndependentlyBuiltLeaf() {
+        Bytes v = Bytes.fromHexString("0x01020304");
+        Bytes leafRlp = RLP.encodeList(w -> {
+            w.writeValue(Bytes.fromHexString("0x2080")); // HP(leaf, [8,0])
+            w.writeValue(v);
+        });
+        assertEquals(Hash.keccak256(leafRlp), OrderedTrieRoot.ofList(List.of(v)));
+    }
+
+    /** Two items diverging at nibble 0 → a branch node with inlined small leaves at
+     *  slots 0 (RLP(1)=0x01 → [0,1]) and 8 (RLP(0)=0x80 → [8,0]). Built independently. */
+    @Test
+    void twoSmallItemsMatchIndependentlyBuiltBranchWithInlineLeaves() {
+        Bytes v0 = Bytes.fromHexString("0xaa"); // index 0, path [8,0]
+        Bytes v1 = Bytes.fromHexString("0xbb"); // index 1, path [0,1]
+        Bytes leaf0 = RLP.encodeList(w -> { w.writeValue(Bytes.fromHexString("0x30")); w.writeValue(v0); }); // odd leaf [0]
+        Bytes leaf1 = RLP.encodeList(w -> { w.writeValue(Bytes.fromHexString("0x31")); w.writeValue(v1); }); // odd leaf [1]
+        assertTrue(leaf0.size() < 32 && leaf1.size() < 32, "leaves should inline");
+        Bytes branch = RLP.encodeList(w -> {
+            for (int n = 0; n < 16; n++) {
+                if (n == 0) w.writeRLP(leaf1);
+                else if (n == 8) w.writeRLP(leaf0);
+                else w.writeValue(Bytes.EMPTY);
+            }
+            w.writeValue(Bytes.EMPTY); // branch value
+        });
+        assertEquals(Hash.keccak256(branch), OrderedTrieRoot.ofList(List.of(v0, v1)));
+    }
+
+    /** Same shape but a large value at index 0 forces a hashed (not inlined) child ref. */
+    @Test
+    void largeLeafForcesHashedChildReference() {
+        Bytes v0 = Bytes.repeat((byte) 0x11, 40); // >32 once wrapped in a leaf → hashed ref
+        Bytes v1 = Bytes.fromHexString("0xbb");
+        Bytes leaf0 = RLP.encodeList(w -> { w.writeValue(Bytes.fromHexString("0x30")); w.writeValue(v0); });
+        Bytes leaf1 = RLP.encodeList(w -> { w.writeValue(Bytes.fromHexString("0x31")); w.writeValue(v1); });
+        assertTrue(leaf0.size() >= 32, "leaf0 should be hashed");
+        Bytes branch = RLP.encodeList(w -> {
+            for (int n = 0; n < 16; n++) {
+                if (n == 0) w.writeRLP(leaf1);
+                else if (n == 8) w.writeValue(Hash.keccak256(leaf0));
+                else w.writeValue(Bytes.EMPTY);
+            }
+            w.writeValue(Bytes.EMPTY);
+        });
+        assertEquals(Hash.keccak256(branch), OrderedTrieRoot.ofList(List.of(v0, v1)));
+    }
+
+    /** Two keys sharing a 2-nibble prefix [1,2] force an EXTENSION node above a branch.
+     *  Built independently: ext[HP(ext,[1,2])=0x0012, branch{slot3=leaf[4], slot5=leaf[6]}]. */
+    @Test
+    void sharedPrefixKeysProduceExtensionNode() {
+        Bytes kA = Bytes.fromHexString("0x1234"); // nibbles [1,2,3,4]
+        Bytes kB = Bytes.fromHexString("0x1256"); // nibbles [1,2,5,6]
+        Bytes vA = Bytes.fromHexString("0xaa");
+        Bytes vB = Bytes.fromHexString("0xbb");
+        Bytes leafA = RLP.encodeList(w -> { w.writeValue(Bytes.fromHexString("0x34")); w.writeValue(vA); }); // odd leaf [4]
+        Bytes leafB = RLP.encodeList(w -> { w.writeValue(Bytes.fromHexString("0x36")); w.writeValue(vB); }); // odd leaf [6]
+        Bytes branch = RLP.encodeList(w -> {
+            for (int n = 0; n < 16; n++) {
+                if (n == 3) w.writeRLP(leafA);
+                else if (n == 5) w.writeRLP(leafB);
+                else w.writeValue(Bytes.EMPTY);
+            }
+            w.writeValue(Bytes.EMPTY);
+        });
+        assertTrue(branch.size() < 32, "branch should inline into the extension");
+        Bytes ext = RLP.encodeList(w -> {
+            w.writeValue(Bytes.fromHexString("0x0012")); // HP(extension, [1,2])
+            w.writeRLP(branch);
+        });
+        assertEquals(Hash.keccak256(ext),
+                OrderedTrieRoot.rootOf(List.of(kA, kB), List.of(vA, vB)));
+    }
+
+    @Test
+    void verifyHelperMatchesAndRejects() {
+        Bytes v = Bytes.fromHexString("0x01020304");
+        Bytes32 root = OrderedTrieRoot.ofList(List.of(v));
+        assertTrue(OrderedTrieRoot.verify(List.of(v), root));
+        assertFalse(OrderedTrieRoot.verify(List.of(v), KNOWN_EMPTY_ROOT));
+    }
+}

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/EthHandler.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/EthHandler.java
@@ -58,6 +58,8 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
     private static final int ETH_BLOCK_HEADERS = 0x14;
     private static final int ETH_GET_BLOCK_BODIES = 0x15;
     private static final int ETH_BLOCK_BODIES = 0x16;
+    private static final int ETH_GET_RECEIPTS = 0x1f; // eth msg 0x0f + base 0x10
+    private static final int ETH_RECEIPTS = 0x20;     // eth msg 0x10 + base 0x10
 
     // snap/1 message codes depend on negotiated eth version:
     //   eth/67-68: protocol length 17, snap base = 0x10 + 17 = 0x21
@@ -101,6 +103,8 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
             pendingRequests = new ConcurrentHashMap<>();
     private final ConcurrentMap<Long, CompletableFuture<List<BlockBodiesMessage.BlockBody>>>
             pendingBodyRequests = new ConcurrentHashMap<>();
+    private final ConcurrentMap<Long, CompletableFuture<List<List<org.apache.tuweni.bytes.Bytes>>>>
+            pendingReceiptRequests = new ConcurrentHashMap<>();
     private final ConcurrentMap<Long, CompletableFuture<AccountRangeMessage.DecodeResult>>
             pendingSnapRequests = new ConcurrentHashMap<>();
     private final ConcurrentMap<Long, CompletableFuture<StorageRangesMessage.DecodeResult>>
@@ -466,6 +470,18 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
                     log.error("[eth] Failed to decode BlockBodies", e);
                 }
             }
+            case ETH_RECEIPTS -> {
+                try {
+                    ReceiptsMessage.DecodeResult decoded = ReceiptsMessage.decode(msg.payload());
+                    log.info("[eth] Received receipts for {} block(s) (reqId={})",
+                            decoded.perBlockReceipts().size(), decoded.requestId());
+                    CompletableFuture<List<List<org.apache.tuweni.bytes.Bytes>>> future =
+                            pendingReceiptRequests.remove(decoded.requestId());
+                    if (future != null) future.complete(decoded.perBlockReceipts());
+                } catch (Exception e) {
+                    log.error("[eth] Failed to decode Receipts", e);
+                }
+            }
             case P2P_PING -> sendPong(ctx);
             case P2P_DISCONNECT -> {
                 int reason = decodeDisconnectReason(msg.payload());
@@ -807,6 +823,26 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
         log.debug("[eth] GetBlockBodies (async) hashes={} reqId={}", hashes.length, reqId);
         byte[] payload = GetBlockBodiesMessage.encode(reqId, hashes);
         rlpxHandler.sendMessage(ctx, ETH_GET_BLOCK_BODIES, payload);
+        return future;
+    }
+
+    /**
+     * Request consensus-encoded receipts for the given block hashes; the future completes
+     * with one receipt list per block (request order). Null if not in READY state. The
+     * caller verifies the receipts by rebuilding the receipts trie and comparing its root
+     * to the beacon-anchored header's {@code receiptsRoot} (peer data is never trusted).
+     */
+    public CompletableFuture<List<List<org.apache.tuweni.bytes.Bytes>>> requestReceiptsAsync(
+            org.apache.tuweni.bytes.Bytes32... hashes) {
+        ChannelHandlerContext ctx = readyCtx;
+        if (ctx == null || state != State.READY) return null;
+
+        CompletableFuture<List<List<org.apache.tuweni.bytes.Bytes>>> future = new CompletableFuture<>();
+        long reqId = requestId.getAndIncrement();
+        pendingReceiptRequests.put(reqId, future);
+        log.debug("[eth] GetReceipts (async) hashes={} reqId={}", hashes.length, reqId);
+        byte[] payload = GetReceiptsMessage.encode(reqId, hashes);
+        rlpxHandler.sendMessage(ctx, ETH_GET_RECEIPTS, payload);
         return future;
     }
 

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/EthHandler.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/EthHandler.java
@@ -216,6 +216,10 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
             pendingStorageRequests.values().forEach(f -> f.completeExceptionally(cause));
             pendingStorageRequests.clear();
         }
+        if (!pendingReceiptRequests.isEmpty()) {
+            pendingReceiptRequests.values().forEach(f -> f.completeExceptionally(cause));
+            pendingReceiptRequests.clear();
+        }
         super.channelInactive(ctx);
     }
 
@@ -471,6 +475,7 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
                 }
             }
             case ETH_RECEIPTS -> {
+                long reqId = peekRequestId(msg.payload());
                 try {
                     ReceiptsMessage.DecodeResult decoded = ReceiptsMessage.decode(msg.payload());
                     log.info("[eth] Received receipts for {} block(s) (reqId={})",
@@ -480,6 +485,12 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
                     if (future != null) future.complete(decoded.perBlockReceipts());
                 } catch (Exception e) {
                     log.error("[eth] Failed to decode Receipts", e);
+                    // Don't leave the requester hanging on a malformed response.
+                    if (reqId >= 0) {
+                        CompletableFuture<List<List<org.apache.tuweni.bytes.Bytes>>> future =
+                                pendingReceiptRequests.remove(reqId);
+                        if (future != null) future.completeExceptionally(e);
+                    }
                 }
             }
             case P2P_PING -> sendPong(ctx);
@@ -528,6 +539,19 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
      * (which every full node broadcasts unsolicited) has no use here and is
      * dropped on purpose. Codes are absolute wire ids (eth base 0x10).
      */
+    /** Read just the leading requestId of a {@code [requestId, ...]} payload; -1 if
+     *  unreadable. Lets the ETH_RECEIPTS handler fail the right pending future when the
+     *  full decode throws, instead of leaving the requester hung. */
+    private static long peekRequestId(byte[] payload) {
+        try {
+            return org.apache.tuweni.rlp.RLP.decodeList(
+                    org.apache.tuweni.bytes.Bytes.wrap(payload),
+                    reader -> reader.readLong());
+        } catch (Exception e) {
+            return -1;
+        }
+    }
+
     private static String ignoredEthMessageReason(int code) {
         return switch (code) {
             case 0x11 -> "NewBlockHashes — pre-Merge block gossip, obsolete; light wallet tracks heads via the beacon chain";

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/messages/GetReceiptsMessage.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/messages/GetReceiptsMessage.java
@@ -1,0 +1,33 @@
+package com.jaeckel.ethp2p.networking.eth.messages;
+
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.rlp.RLP;
+
+/**
+ * eth/GetReceipts (wire code 0x1f = eth message 0x0f + base offset 0x10).
+ *
+ * eth/66-68 format:
+ *   RLP: [requestId, [blockHash1, blockHash2, ...]]
+ *
+ * The response ({@link ReceiptsMessage}, 0x20) carries the full consensus-encoded
+ * receipts per block, which the caller verifies by rebuilding the receipts trie and
+ * comparing its root to the (beacon-anchored) header's {@code receiptsRoot}.
+ */
+public final class GetReceiptsMessage {
+
+    public static final int CODE = 0x1f;
+
+    private GetReceiptsMessage() {}
+
+    /** Request receipts for the given block hashes. */
+    public static byte[] encode(long requestId, Bytes32... blockHashes) {
+        return RLP.encodeList(writer -> {
+            writer.writeLong(requestId);
+            writer.writeList(hashWriter -> {
+                for (Bytes32 hash : blockHashes) {
+                    hashWriter.writeValue(hash);
+                }
+            });
+        }).toArrayUnsafe();
+    }
+}

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/messages/ReceiptsMessage.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/messages/ReceiptsMessage.java
@@ -1,0 +1,85 @@
+package com.jaeckel.ethp2p.networking.eth.messages;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.rlp.RLP;
+import org.apache.tuweni.rlp.RLPReader;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * eth/Receipts (wire code 0x20 = eth message 0x10 + base offset 0x10).
+ *
+ * eth/66-68 format:
+ *   RLP: [requestId, [ [receipt, receipt, ...] , ... ]]
+ *
+ * The outer list has one entry per requested block; each inner list holds that block's
+ * receipts in order. Each receipt is its consensus encoding: a legacy receipt is an RLP
+ * list {@code [status, cumulativeGasUsed, logsBloom, logs]}; a typed (EIP-2718) receipt
+ * is the envelope {@code type || rlp(...)} sent as an RLP byte-string. We capture each
+ * receipt's RAW consensus bytes — that is exactly the value stored in the receipts trie,
+ * so the caller can rebuild the trie and check its root against {@code header.receiptsRoot}.
+ *
+ * <p>(eth/69 omits the bloom from the wire receipt; this decoder targets eth/66-68, where
+ * the receipt is the full canonical encoding. Request receipts from an eth/&le;68 peer.)
+ */
+public final class ReceiptsMessage {
+
+    public static final int CODE = 0x20;
+
+    private ReceiptsMessage() {}
+
+    /** Raw consensus-encoded receipts, grouped per requested block (request order). */
+    public record DecodeResult(long requestId, List<List<Bytes>> perBlockReceipts) {}
+
+    public static DecodeResult decode(byte[] rlp) {
+        List<List<Bytes>> blocks = new ArrayList<>();
+        long[] reqId = {0};
+        RLP.decodeList(Bytes.wrap(rlp), reader -> {
+            reqId[0] = reader.readLong();
+            reader.readList(blocksReader -> {
+                while (!blocksReader.isComplete()) {
+                    List<Bytes> receipts = new ArrayList<>();
+                    blocksReader.readList(receiptListReader -> {
+                        while (!receiptListReader.isComplete()) {
+                            if (receiptListReader.nextIsList()) {
+                                // Legacy receipt: an RLP list (with nested logs). Reconstruct
+                                // its raw RLP bytes — that's the trie value.
+                                receipts.add(reconstructRlpList(receiptListReader));
+                            } else {
+                                // Typed receipt: the byte-string content IS type||rlp(...),
+                                // which is the trie value as-is (not re-wrapped).
+                                receipts.add(receiptListReader.readValue());
+                            }
+                        }
+                        return null;
+                    });
+                    blocks.add(receipts);
+                }
+                return null;
+            });
+            return null;
+        });
+        return new DecodeResult(reqId[0], blocks);
+    }
+
+    /**
+     * Reconstruct the canonical raw RLP of the list the reader is positioned on, recursing
+     * into nested lists (e.g. a receipt's logs). RLP is canonical, so re-encoding a decoded
+     * structure reproduces the original bytes that the receipts trie was built over.
+     */
+    private static Bytes reconstructRlpList(RLPReader reader) {
+        List<Bytes> rawChildren = new ArrayList<>();
+        reader.readList(inner -> {
+            while (!inner.isComplete()) {
+                if (inner.nextIsList()) {
+                    rawChildren.add(reconstructRlpList(inner));
+                } else {
+                    rawChildren.add(RLP.encodeValue(inner.readValue()));
+                }
+            }
+            return null;
+        });
+        return RLP.encodeList(w -> rawChildren.forEach(w::writeRLP));
+    }
+}

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/rlpx/RLPxConnector.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/rlpx/RLPxConnector.java
@@ -270,6 +270,29 @@ public final class RLPxConnector implements AutoCloseable {
     }
 
     /**
+     * Request consensus-encoded receipts for the given block hashes from any active READY
+     * peer. The future completes with one receipt list per block (request order). Callers
+     * MUST verify the result against a trusted {@code header.receiptsRoot} before use.
+     *
+     * @return a future, or a failed future if no peer is available
+     */
+    public CompletableFuture<List<List<Bytes>>> requestReceipts(Bytes32... hashes) {
+        Iterator<EthHandler> it = activeHandlers.iterator();
+        while (it.hasNext()) {
+            EthHandler handler = it.next();
+            if (!handler.isReady()) continue;
+            CompletableFuture<List<List<Bytes>>> future = handler.requestReceiptsAsync(hashes);
+            if (future != null) {
+                log.info("[rlpx] Routed GetReceipts({} hashes) to active peer", hashes.length);
+                return future;
+            }
+            it.remove();
+        }
+        return CompletableFuture.failedFuture(
+                new IllegalStateException("No active peer with completed eth handshake"));
+    }
+
+    /**
      * Gossip a raw signed transaction to <em>every</em> READY eth peer (eth
      * Transactions 0x12). A light client doesn't relay the mempool, so peers may
      * not re-propagate our gossip — broadcasting widely maximizes the chance the

--- a/networking/src/test/java/com/jaeckel/ethp2p/networking/eth/messages/ReceiptsMessageTest.java
+++ b/networking/src/test/java/com/jaeckel/ethp2p/networking/eth/messages/ReceiptsMessageTest.java
@@ -1,0 +1,66 @@
+package com.jaeckel.ethp2p.networking.eth.messages;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.rlp.RLP;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ReceiptsMessageTest {
+
+    /** A legacy receipt RLP list [status, cumGas, bloom, [ [addr, [topic], data] ]] —
+     *  with the nested logs that make receipt re-encoding harder than transactions. */
+    private static Bytes legacyReceipt() {
+        Bytes addr = Bytes.repeat((byte) 0xab, 20);
+        Bytes topic = Bytes.repeat((byte) 0xcd, 32);
+        Bytes bloom = Bytes.repeat((byte) 0x00, 256);
+        return RLP.encodeList(r -> {
+            r.writeValue(Bytes.fromHexString("0x01")); // status = 1
+            r.writeValue(Bytes.fromHexString("0x5208")); // cumulativeGasUsed
+            r.writeValue(bloom);
+            r.writeList(logs -> logs.writeList(oneLog -> {       // logs: [ [addr,[topic],data] ]
+                oneLog.writeValue(addr);
+                oneLog.writeList(topics -> topics.writeValue(topic));
+                oneLog.writeValue(Bytes.fromHexString("0xdeadbeef")); // data
+            }));
+        });
+    }
+
+    /** A typed (EIP-2718) receipt envelope: type(0x02) || rlp([...]) as raw bytes. */
+    private static Bytes typedReceipt() {
+        Bytes inner = RLP.encodeList(r -> {
+            r.writeValue(Bytes.fromHexString("0x01"));
+            r.writeValue(Bytes.fromHexString("0x9c40"));
+            r.writeValue(Bytes.repeat((byte) 0x00, 256));
+            r.writeList(logs -> { /* no logs */ });
+        });
+        return Bytes.concatenate(Bytes.fromHexString("0x02"), inner);
+    }
+
+    @Test
+    void decodesRawReceiptBytesForTypedAndLegacy() {
+        Bytes typed = typedReceipt();
+        Bytes legacy = legacyReceipt();
+
+        // Receipts payload: [requestId, [ [typed, legacy] ]]  (one block, two receipts)
+        byte[] payload = RLP.encodeList(w -> {
+            w.writeLong(42L);
+            w.writeList(blocks -> blocks.writeList(receipts -> {
+                receipts.writeValue(typed);  // typed → byte-string envelope
+                receipts.writeRLP(legacy);   // legacy → RLP list, inlined raw
+            }));
+        }).toArrayUnsafe();
+
+        ReceiptsMessage.DecodeResult result = ReceiptsMessage.decode(payload);
+
+        assertEquals(42L, result.requestId());
+        assertEquals(1, result.perBlockReceipts().size());
+        List<Bytes> block0 = result.perBlockReceipts().get(0);
+        assertEquals(2, block0.size());
+        // Raw consensus bytes must round-trip exactly — these are the receipts-trie values.
+        assertEquals(typed, block0.get(0));
+        assertEquals(legacy, block0.get(1));
+    }
+}


### PR DESCRIPTION
Foundation for trustless `eth_getTransactionReceipt`. This is the first half (the two verifiable primitives); the RPC method + orchestration follow in a second PR so each stays reviewable.

## Why

After `eth_sendRawTransaction` (already in `main`) a wallet has no trustless way to confirm inclusion. A receipt can't be taken on a peer's word — it must be proven against the `receiptsRoot` of a **verified** header. The client had neither a way to *derive* a trie root (the existing `MerklePatriciaVerifier` only walks proofs downward) nor a way to *fetch* receipts over devp2p. This PR adds both.

## What

**1. `OrderedTrieRoot` (consensus)** — derives the root of an Ethereum "ordered" trie (`key = RLP(index) → value`), i.e. a block's `transactionsRoot` / `receiptsRoot`. Lets a caller rebuild the trie from received transactions/receipts and compare the root to a trusted header — so peer data is verified, not trusted. Hand-rolled (the Tuweni fork doesn't publish `tuweni-merkle-trie`; Besu's trie isn't Android-friendly and this runs on-device). Standard Yellow-Paper encoding: hex-prefix keys, 17-item branch / 2-item leaf+extension nodes, child refs inlined <32B else keccak256-hashed, root always hashed.

Tests: empty / single-leaf / branch (inline + hashed child refs) / extension node, each checked against an independently hand-built node structure; keccak256 validated against the canonical `"abc"` vector.

**2. `GetReceipts`/`Receipts` (0x1f/0x20) (networking)** — the receipt-fetch path the light client previously skipped. Message classes + async `EthHandler.requestReceiptsAsync` (request-id correlated, mirroring block bodies) + `RLPxConnector.requestReceipts`. `decode` captures each receipt's **raw consensus bytes** (typed EIP-2718 envelopes as-is; legacy receipts reconstructed via a recursive raw-RLP copy that handles the nested logs list) — exactly the receipts-trie values, ready to feed `OrderedTrieRoot`. Round-trip tested for typed + legacy(with logs).

Wire codes corrected: `GetReceipts`/`Receipts` are `0x1f/0x20` (eth `0x0f/0x10` + base `0x10`); the old `0x1d/0x1e` comment referenced the removed GetNodeData/NodeData slots. Targets eth/66–68 (full receipt encoding with bloom); eth/69's bloom-less variant is a follow-up.

## Not yet (next PR)
- Receipt model (decode → status/gasUsed/logs/JSON)
- `NodeService.rpcGetTransactionReceipt`: scan recent verified-head bodies for the tx (verify body vs `transactionsRoot`), fetch+verify receipts vs `receiptsRoot`, return the matching receipt
- `eth_getTransactionReceipt` RPC plumbing. Its end-to-end test will validate `OrderedTrieRoot` against real mainnet block data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)