### PR TITLE
eth_getTransactionReceipt — trustless, verified against receiptsRoot

### DIFF
--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -18,13 +18,17 @@ import com.jaeckel.ethp2p.consensus.BeaconLightClient;
 import com.jaeckel.ethp2p.consensus.BeaconSyncState;
 import com.jaeckel.ethp2p.consensus.libp2p.BeaconP2PService;
 import com.jaeckel.ethp2p.consensus.proof.MerklePatriciaVerifier;
+import com.jaeckel.ethp2p.consensus.proof.OrderedTrieRoot;
 import com.jaeckel.ethp2p.core.crypto.NodeKey;
 import com.jaeckel.ethp2p.core.enr.Enr;
+import com.jaeckel.ethp2p.core.types.BlockHeader;
 import com.jaeckel.ethp2p.networking.NetworkConfig;
 import com.jaeckel.ethp2p.networking.discv4.DiscV4Service;
 import com.jaeckel.ethp2p.networking.discv5.DiscV5Service;
 import com.jaeckel.ethp2p.networking.dns.DnsEnrResolver;
+import com.jaeckel.ethp2p.networking.eth.messages.BlockBodiesMessage;
 import com.jaeckel.ethp2p.networking.eth.messages.BlockHeadersMessage;
+import com.jaeckel.ethp2p.networking.eth.messages.Receipt;
 import com.jaeckel.ethp2p.networking.rlpx.RLPxConnector;
 import com.jaeckel.ethp2p.networking.snap.messages.AccountRangeMessage;
 
@@ -105,6 +109,10 @@ public final class NodeService extends Service {
     // but the bound has to cover catch-up after the phone wakes from doze.
     private static final int MAX_HEADER_CHAIN_GAP = 8192;
     private static final long HEADER_CHAIN_TIMEOUT_SEC = 60;
+    // How many recent blocks below the verified head to scan for a tx in
+    // eth_getTransactionReceipt. ~32 blocks ≈ 6 min — enough for a wallet polling a
+    // just-submitted tx; older txs fall through to the proxy (can't be verified here).
+    private static final int RECEIPT_LOOKBACK_BLOCKS = 32;
 
     // Static so MainActivity can reflect the correct button state after a
     // configuration change — the activity instance is recreated, but the
@@ -878,6 +886,148 @@ public final class NodeService extends Service {
             LogBuffer.i(TAG, "[rpc] eth_sendRawTransaction failed: " + unwrap(e));
             return null;
         }
+    }
+
+    /**
+     * eth_getTransactionReceipt — trustlessly. Scans a bounded window of recent blocks
+     * below the beacon-anchored verified head: for each, fetches the block body and
+     * verifies it against the header's {@code transactionsRoot} (rebuilding the tx trie)
+     * before trusting that the tx is in that block at a given index; then fetches the
+     * block's receipts and verifies them against the header's {@code receiptsRoot} before
+     * returning the matching receipt as JSON. Returns null (→ proxy / pending) if the tx
+     * isn't found verified in the window. Peer data is never trusted unverified.
+     *
+     * <p>Returns the verified core fields (status, gasUsed, logs, block context, type);
+     * from / to / contractAddress / effectiveGasPrice (which need tx decode + sender
+     * recovery) are a follow-up.
+     */
+    private String rpcGetTransactionReceipt(byte[] txHash, String block) {
+        RLPxConnector conn = connector;
+        if (conn == null || txHash == null || txHash.length != 32) return null;
+        try {
+            EnsCall ctx = verifiedHeadCallContext();
+            if (ctx == null || !ctx.beaconVerified()) return null;
+            long headNum = ctx.blockNumber();
+            byte[] headStateRoot = ctx.blockCtx().stateRoot();
+
+            int count = (int) Math.min(RECEIPT_LOOKBACK_BLOCKS, headNum + 1);
+            long start = headNum - count + 1;
+            List<BlockHeadersMessage.VerifiedHeader> window = conn
+                    .requestBlockHeadersBatched(start, count)
+                    .orTimeout(HEADER_CHAIN_TIMEOUT_SEC, TimeUnit.SECONDS)
+                    .get();
+            // Anchor the window: its last header must BE the verified head (stateRoot
+            // match) and every header must hash-link to the next's parentHash.
+            if (!windowAnchoredToHead(window, headStateRoot)) {
+                LogBuffer.i(TAG, "[rpc] eth_getTransactionReceipt: header window failed to anchor");
+                return null;
+            }
+
+            Bytes32 want = Bytes32.wrap(txHash);
+            for (int hi = window.size() - 1; hi >= 0; hi--) {
+                BlockHeader h = window.get(hi).header();
+                Bytes32 blockHash = window.get(hi).hash();
+                List<BlockBodiesMessage.BlockBody> bodies = conn
+                        .requestBlockBodies(blockHash)
+                        .orTimeout(HEADER_CHAIN_TIMEOUT_SEC, TimeUnit.SECONDS)
+                        .get();
+                if (bodies.isEmpty()) continue;
+                List<Bytes> txs = bodies.get(0).transactions();
+                // Verify the body before trusting which txs (and indices) it contains.
+                if (!OrderedTrieRoot.verify(txs, h.transactionsRoot)) {
+                    LogBuffer.i(TAG, "[rpc] block #" + h.number + " body failed transactionsRoot verify");
+                    continue;
+                }
+                int idx = -1;
+                for (int i = 0; i < txs.size(); i++) {
+                    if (Hash.keccak256(txs.get(i)).equals(want)) { idx = i; break; }
+                }
+                if (idx < 0) continue;
+
+                // Found. Fetch + verify the block's receipts against receiptsRoot.
+                List<List<Bytes>> rcptBlocks = conn
+                        .requestReceipts(blockHash)
+                        .orTimeout(HEADER_CHAIN_TIMEOUT_SEC, TimeUnit.SECONDS)
+                        .get();
+                if (rcptBlocks.isEmpty()) return null;
+                List<Bytes> receipts = rcptBlocks.get(0);
+                if (!OrderedTrieRoot.verify(receipts, h.receiptsRoot)) {
+                    LogBuffer.i(TAG, "[rpc] block #" + h.number + " receipts failed receiptsRoot verify");
+                    return null;
+                }
+                if (idx >= receipts.size()) return null;
+                LogBuffer.i(TAG, "[rpc] eth_getTransactionReceipt verified tx in block #"
+                        + h.number + " index " + idx);
+                return buildReceiptJson(receipts, idx, h, blockHash, want);
+            }
+            return null; // not found in window → pending / out-of-range → proxy
+        } catch (Exception e) {
+            LogBuffer.i(TAG, "[rpc] eth_getTransactionReceipt failed: " + unwrap(e));
+            return null;
+        }
+    }
+
+    /** The contiguous header window [start..head] is valid iff its last header is the
+     *  beacon-verified head (stateRoot match) and each header hash-links to the next. */
+    private static boolean windowAnchoredToHead(List<BlockHeadersMessage.VerifiedHeader> window,
+                                                byte[] headStateRoot) {
+        if (window.isEmpty()) return false;
+        BlockHeader last = window.get(window.size() - 1).header();
+        if (!java.util.Arrays.equals(last.stateRoot.toArrayUnsafe(), headStateRoot)) return false;
+        for (int i = 0; i < window.size() - 1; i++) {
+            if (!window.get(i).hash().equals(window.get(i + 1).header().parentHash)) return false;
+        }
+        return true;
+    }
+
+    /** Build the eth_getTransactionReceipt JSON object from VERIFIED receipt bytes.
+     *  {@code txHash} is the body's tx hash (already confirmed == the requested hash). */
+    private static String buildReceiptJson(List<Bytes> receipts, int idx,
+                                           BlockHeader h, Bytes32 blockHash, Bytes32 txHash) {
+        Receipt r = Receipt.decode(receipts.get(idx));
+        long prevCum = idx > 0 ? Receipt.decode(receipts.get(idx - 1)).cumulativeGasUsed() : 0L;
+        long gasUsed = r.cumulativeGasUsed() - prevCum;
+        int logBase = 0;
+        for (int j = 0; j < idx; j++) logBase += Receipt.decode(receipts.get(j)).logs().size();
+
+        String txHashHex = txHash.toHexString();
+        StringBuilder sb = new StringBuilder(256);
+        sb.append("{\"transactionHash\":\"").append(txHashHex).append("\"");
+        sb.append(",\"transactionIndex\":\"").append(hexQuantity(idx)).append("\"");
+        sb.append(",\"blockHash\":\"").append(blockHash.toHexString()).append("\"");
+        sb.append(",\"blockNumber\":\"").append(hexQuantity(h.number)).append("\"");
+        sb.append(",\"cumulativeGasUsed\":\"").append(hexQuantity(r.cumulativeGasUsed())).append("\"");
+        sb.append(",\"gasUsed\":\"").append(hexQuantity(gasUsed)).append("\"");
+        if (r.hasStatus()) {
+            sb.append(",\"status\":\"").append(r.success() ? "0x1" : "0x0").append("\"");
+        }
+        sb.append(",\"type\":\"").append(hexQuantity(r.type())).append("\"");
+        sb.append(",\"logsBloom\":\"").append(r.logsBloom().toHexString()).append("\"");
+        sb.append(",\"logs\":[");
+        for (int k = 0; k < r.logs().size(); k++) {
+            Receipt.Log log = r.logs().get(k);
+            if (k > 0) sb.append(",");
+            sb.append("{\"address\":\"").append(log.address().toHexString()).append("\"");
+            sb.append(",\"topics\":[");
+            for (int t = 0; t < log.topics().size(); t++) {
+                if (t > 0) sb.append(",");
+                sb.append("\"").append(log.topics().get(t).toHexString()).append("\"");
+            }
+            sb.append("],\"data\":\"").append(log.data().toHexString()).append("\"");
+            sb.append(",\"blockNumber\":\"").append(hexQuantity(h.number)).append("\"");
+            sb.append(",\"blockHash\":\"").append(blockHash.toHexString()).append("\"");
+            sb.append(",\"transactionHash\":\"").append(txHashHex).append("\"");
+            sb.append(",\"transactionIndex\":\"").append(hexQuantity(idx)).append("\"");
+            sb.append(",\"logIndex\":\"").append(hexQuantity(logBase + k)).append("\"");
+            sb.append(",\"removed\":false}");
+        }
+        sb.append("]}");
+        return sb.toString();
+    }
+
+    /** Ethereum JSON-RPC QUANTITY: minimal hex, no leading zeros, 0 → "0x0". */
+    private static String hexQuantity(long v) {
+        return "0x" + Long.toHexString(v);
     }
 
     /** Render a storage value as a 32-byte big-endian word (drops BigInteger's
@@ -1846,6 +1996,9 @@ public final class NodeService extends Service {
                 }
                 @Override public byte[] sendRawTransaction(byte[] rawTx) {
                     return rpcSendRawTransaction(rawTx);
+                }
+                @Override public String getTransactionReceipt(byte[] txHash) {
+                    return rpcGetTransactionReceipt(txHash, "latest");
                 }
             };
             io.myotis.jsonrpc.MyotisRpcServer s =

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -917,8 +917,8 @@ public final class NodeService extends Service {
             long start = headNum - count + 1;
             List<BlockHeadersMessage.VerifiedHeader> window = conn
                     .requestBlockHeadersBatched(start, count)
-                    .orTimeout(HEADER_CHAIN_TIMEOUT_SEC, TimeUnit.SECONDS)
-                    .get();
+                    // Future.get(timeout) — NOT CompletableFuture.orTimeout (API 31, minSdk 29).
+                    .get(HEADER_CHAIN_TIMEOUT_SEC, TimeUnit.SECONDS);
             // Anchor the window: its last header must BE the verified head (stateRoot
             // match) and every header must hash-link to the next's parentHash.
             if (!windowAnchoredToHead(window, headStateRoot)) {
@@ -940,10 +940,9 @@ public final class NodeService extends Service {
                 Bytes32 blockHash = window.get(hi).hash();
                 List<BlockBodiesMessage.BlockBody> bodies;
                 try {
-                    bodies = bodyFutures.get(hi)
-                            .orTimeout(HEADER_CHAIN_TIMEOUT_SEC, TimeUnit.SECONDS).get();
+                    bodies = bodyFutures.get(hi).get(HEADER_CHAIN_TIMEOUT_SEC, TimeUnit.SECONDS);
                 } catch (Exception e) {
-                    continue; // body fetch failed for this block — skip it
+                    continue; // body fetch failed/timed out for this block — skip it
                 }
                 if (bodies.isEmpty()) continue;
                 List<Bytes> txs = bodies.get(0).transactions();
@@ -961,8 +960,7 @@ public final class NodeService extends Service {
                 // Found. Fetch + verify the block's receipts against receiptsRoot.
                 List<List<Bytes>> rcptBlocks = conn
                         .requestReceipts(blockHash)
-                        .orTimeout(HEADER_CHAIN_TIMEOUT_SEC, TimeUnit.SECONDS)
-                        .get();
+                        .get(HEADER_CHAIN_TIMEOUT_SEC, TimeUnit.SECONDS);
                 if (rcptBlocks.isEmpty()) return null;
                 List<Bytes> receipts = rcptBlocks.get(0);
                 if (!OrderedTrieRoot.verify(receipts, h.receiptsRoot)) {

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -110,9 +110,12 @@ public final class NodeService extends Service {
     private static final int MAX_HEADER_CHAIN_GAP = 8192;
     private static final long HEADER_CHAIN_TIMEOUT_SEC = 60;
     // How many recent blocks below the verified head to scan for a tx in
-    // eth_getTransactionReceipt. ~32 blocks ≈ 6 min — enough for a wallet polling a
-    // just-submitted tx; older txs fall through to the proxy (can't be verified here).
-    private static final int RECEIPT_LOOKBACK_BLOCKS = 32;
+    // eth_getTransactionReceipt. Kept small to bound the bandwidth/battery cost of the
+    // (trustless) body scan on mobile: ~8 blocks ≈ 1.5 min covers a wallet polling a
+    // just-submitted tx. A pending/older tx isn't found here and falls through to the
+    // proxy. Bodies within the window are fetched concurrently, so latency ≈ one
+    // round-trip regardless of the count.
+    private static final int RECEIPT_LOOKBACK_BLOCKS = 8;
 
     // Static so MainActivity can reflect the correct button state after a
     // configuration change — the activity instance is recreated, but the
@@ -924,13 +927,24 @@ public final class NodeService extends Service {
             }
 
             Bytes32 want = Bytes32.wrap(txHash);
+            // Fire the body fetches concurrently rather than 32 sequential round-trips:
+            // worst case (tx pending / outside the window) is then ~one round-trip of
+            // latency instead of the sum. The window itself is the bandwidth bound.
+            List<CompletableFuture<List<BlockBodiesMessage.BlockBody>>> bodyFutures =
+                    new ArrayList<>(window.size());
+            for (BlockHeadersMessage.VerifiedHeader vh : window) {
+                bodyFutures.add(conn.requestBlockBodies(vh.hash()));
+            }
             for (int hi = window.size() - 1; hi >= 0; hi--) {
                 BlockHeader h = window.get(hi).header();
                 Bytes32 blockHash = window.get(hi).hash();
-                List<BlockBodiesMessage.BlockBody> bodies = conn
-                        .requestBlockBodies(blockHash)
-                        .orTimeout(HEADER_CHAIN_TIMEOUT_SEC, TimeUnit.SECONDS)
-                        .get();
+                List<BlockBodiesMessage.BlockBody> bodies;
+                try {
+                    bodies = bodyFutures.get(hi)
+                            .orTimeout(HEADER_CHAIN_TIMEOUT_SEC, TimeUnit.SECONDS).get();
+                } catch (Exception e) {
+                    continue; // body fetch failed for this block — skip it
+                }
                 if (bodies.isEmpty()) continue;
                 List<Bytes> txs = bodies.get(0).transactions();
                 // Verify the body before trusting which txs (and indices) it contains.
@@ -985,10 +999,16 @@ public final class NodeService extends Service {
     private static String buildReceiptJson(List<Bytes> receipts, int idx,
                                            BlockHeader h, Bytes32 blockHash, Bytes32 txHash) {
         Receipt r = Receipt.decode(receipts.get(idx));
-        long prevCum = idx > 0 ? Receipt.decode(receipts.get(idx - 1)).cumulativeGasUsed() : 0L;
-        long gasUsed = r.cumulativeGasUsed() - prevCum;
+        // Single pass over the preceding receipts: gasUsed needs receipt[idx-1]'s
+        // cumulative, logIndex needs the running log count — decode each only once.
+        long prevCum = 0L;
         int logBase = 0;
-        for (int j = 0; j < idx; j++) logBase += Receipt.decode(receipts.get(j)).logs().size();
+        for (int j = 0; j < idx; j++) {
+            Receipt prev = Receipt.decode(receipts.get(j));
+            logBase += prev.logs().size();
+            if (j == idx - 1) prevCum = prev.cumulativeGasUsed();
+        }
+        long gasUsed = r.cumulativeGasUsed() - prevCum;
 
         String txHashHex = txHash.toHexString();
         StringBuilder sb = new StringBuilder(256);

--- a/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/MyotisRpcBackend.kt
+++ b/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/MyotisRpcBackend.kt
@@ -66,4 +66,13 @@ interface MyotisRpcBackend {
      * Myotis never signs — the wallet user does; this only relays the bytes.
      */
     fun sendRawTransaction(rawTx: ByteArray): ByteArray?
+
+    /**
+     * eth_getTransactionReceipt: the receipt for [txHash] as a pre-built JSON object
+     * string, verified against a beacon-anchored header's receiptsRoot, or null when it
+     * can't be answered verified (tx not in the recent verified window / pending / no
+     * peer) so the router falls back to the proxy. Returning a JSON string keeps the
+     * nested receipt+logs shape host-built without a Map→JSON conversion in the router.
+     */
+    fun getTransactionReceipt(txHash: ByteArray): String?
 }

--- a/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/RpcRouter.kt
+++ b/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/RpcRouter.kt
@@ -151,6 +151,12 @@ class RpcRouter(
                 val hash = withContext(Dispatchers.IO) { b.sendRawTransaction(raw) } ?: return null
                 resultEnvelope(id, JsonPrimitive(hexData(hash)))
             }
+            "eth_getTransactionReceipt" -> {
+                val txHash = (root.params()?.getOrNull(0) as? JsonPrimitive)?.asHexBytes() ?: return null
+                // Backend returns a pre-built, verified receipt JSON object, or null (→ proxy).
+                val receiptJson = withContext(Dispatchers.IO) { b.getTransactionReceipt(txHash) } ?: return null
+                resultEnvelope(id, json.parseToJsonElement(receiptJson))
+            }
             else -> null
         }
     }

--- a/jsonrpc-server/src/test/kotlin/io/myotis/jsonrpc/RpcRouterTest.kt
+++ b/jsonrpc-server/src/test/kotlin/io/myotis/jsonrpc/RpcRouterTest.kt
@@ -51,6 +51,11 @@ class RpcRouterTest {
         override fun sendRawTransaction(rawTx: ByteArray): ByteArray? {
             lastRawTx = rawTx; return txHash
         }
+        var lastReceiptTxHash: ByteArray? = null
+        var receiptJson: String? = null
+        override fun getTransactionReceipt(txHash: ByteArray): String? {
+            lastReceiptTxHash = txHash; return receiptJson
+        }
     }
 
     private fun route(backend: MyotisRpcBackend?, body: String, proxy: UpstreamProxy? = null): String =
@@ -189,6 +194,23 @@ class RpcRouterTest {
     @Test fun sendRawTransaction_noPeer_fallsThrough() {          // backend null -> proxy/strict
         assertTrue(hasError(route(FakeBackend(),                  // txHash defaults to null
             """{"jsonrpc":"2.0","id":1,"method":"eth_sendRawTransaction","params":["0x02aabb"]}""")))
+    }
+
+    @Test fun getTransactionReceipt_verified_embedsReceiptObject() {
+        val b = FakeBackend().apply {
+            receiptJson = """{"status":"0x1","blockNumber":"0x10","transactionHash":"0xab","logs":[]}"""
+        }
+        val resp = route(b, """{"jsonrpc":"2.0","id":7,"method":"eth_getTransactionReceipt",
+            "params":["0x${"ab".repeat(32)}"]}""")
+        val obj = json.parseToJsonElement(resp).jsonObject["result"]!!.jsonObject
+        assertEquals("0x1", obj["status"]!!.jsonPrimitive.content)        // verified object passed through
+        assertEquals("0x10", obj["blockNumber"]!!.jsonPrimitive.content)
+        assertEquals("0x" + "ab".repeat(32), b.lastReceiptTxHash!!.toHex()) // hash decoded + passed in
+    }
+
+    @Test fun getTransactionReceipt_notFound_fallsThrough() {     // backend null result -> proxy/strict
+        assertTrue(hasError(route(FakeBackend(),                  // receiptJson defaults to null
+            """{"jsonrpc":"2.0","id":7,"method":"eth_getTransactionReceipt","params":["0x${"ab".repeat(32)}"]}""")))
     }
 
     @Test fun chainId_and_blockNumber_stillVerified() {

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/messages/Receipt.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/messages/Receipt.java
@@ -33,6 +33,9 @@ public record Receipt(int type,
 
     /** Decode a receipt from its raw consensus bytes (as carried in eth Receipts). */
     public static Receipt decode(Bytes raw) {
+        if (raw == null || raw.isEmpty()) {
+            throw new IllegalArgumentException("receipt bytes are null/empty");
+        }
         int first = raw.get(0) & 0xFF;
         int type;
         Bytes payload;

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/messages/Receipt.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/messages/Receipt.java
@@ -1,0 +1,84 @@
+package com.jaeckel.ethp2p.networking.eth.messages;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.rlp.RLP;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A decoded Ethereum transaction receipt (EIP-2718 typed or legacy).
+ *
+ * <p>Consensus encoding:
+ * <ul>
+ *   <li>legacy: {@code rlp([status|stateRoot, cumulativeGasUsed, logsBloom, logs])}</li>
+ *   <li>typed:  {@code type || rlp([status, cumulativeGasUsed, logsBloom, logs])}</li>
+ * </ul>
+ * where each log is {@code [address, [topic, ...], data]}. Post-Byzantium the first
+ * field is a 0/1 status byte; the rare pre-Byzantium form carries a 32-byte intermediate
+ * stateRoot instead, in which case {@link #hasStatus()} is false.
+ *
+ * <p>This is a pure decoder over bytes the caller has ALREADY verified against a trusted
+ * {@code receiptsRoot} (see OrderedTrieRoot) — it does no verification itself.
+ */
+public record Receipt(int type,
+                      boolean hasStatus,
+                      boolean success,
+                      long cumulativeGasUsed,
+                      Bytes logsBloom,
+                      List<Log> logs) {
+
+    /** A single log entry. */
+    public record Log(Bytes address, List<Bytes> topics, Bytes data) {}
+
+    /** Decode a receipt from its raw consensus bytes (as carried in eth Receipts). */
+    public static Receipt decode(Bytes raw) {
+        int first = raw.get(0) & 0xFF;
+        int type;
+        Bytes payload;
+        if (first >= 0xc0) {            // RLP list → legacy receipt
+            type = 0;
+            payload = raw;
+        } else {                        // EIP-2718 envelope: type byte + RLP payload
+            type = first;
+            payload = raw.slice(1);
+        }
+
+        boolean[] hasStatus = {true};
+        boolean[] success = {false};
+        long[] cumGas = {0};
+        Bytes[] bloom = {Bytes.EMPTY};
+        List<Log> logs = new ArrayList<>();
+
+        RLP.decodeList(payload, reader -> {
+            Bytes statusOrRoot = reader.readValue();
+            if (statusOrRoot.size() <= 1) {
+                hasStatus[0] = true;
+                success[0] = !statusOrRoot.isEmpty() && statusOrRoot.get(statusOrRoot.size() - 1) != 0;
+            } else {
+                hasStatus[0] = false; // pre-Byzantium intermediate stateRoot, not a status
+            }
+            cumGas[0] = reader.readValue().toLong();
+            bloom[0] = reader.readValue();
+            reader.readList(logsReader -> {
+                while (!logsReader.isComplete()) {
+                    logsReader.readList(logReader -> {
+                        Bytes address = logReader.readValue();
+                        List<Bytes> topics = new ArrayList<>();
+                        logReader.readList(topicsReader -> {
+                            while (!topicsReader.isComplete()) topics.add(topicsReader.readValue());
+                            return null;
+                        });
+                        Bytes data = logReader.readValue();
+                        logs.add(new Log(address, topics, data));
+                        return null;
+                    });
+                }
+                return null;
+            });
+            return null;
+        });
+
+        return new Receipt(type, hasStatus[0], success[0], cumGas[0], bloom[0], logs);
+    }
+}

--- a/networking/src/test/java/com/jaeckel/ethp2p/networking/eth/messages/ReceiptTest.java
+++ b/networking/src/test/java/com/jaeckel/ethp2p/networking/eth/messages/ReceiptTest.java
@@ -1,0 +1,60 @@
+package com.jaeckel.ethp2p.networking.eth.messages;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.rlp.RLP;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ReceiptTest {
+
+    @Test
+    void decodesLegacyReceiptWithLog() {
+        Bytes addr = Bytes.repeat((byte) 0xab, 20);
+        Bytes topic = Bytes.repeat((byte) 0xcd, 32);
+        Bytes bloom = Bytes.repeat((byte) 0x00, 256);
+        Bytes raw = RLP.encodeList(r -> {
+            r.writeValue(Bytes.fromHexString("0x01"));   // status = 1 (success)
+            r.writeValue(Bytes.fromHexString("0x5208")); // cumulativeGasUsed = 21000
+            r.writeValue(bloom);
+            r.writeList(logs -> logs.writeList(oneLog -> {
+                oneLog.writeValue(addr);
+                oneLog.writeList(topics -> topics.writeValue(topic));
+                oneLog.writeValue(Bytes.fromHexString("0xdeadbeef"));
+            }));
+        });
+
+        Receipt rcpt = Receipt.decode(raw);
+        assertEquals(0, rcpt.type());
+        assertTrue(rcpt.hasStatus());
+        assertTrue(rcpt.success());
+        assertEquals(21000L, rcpt.cumulativeGasUsed());
+        assertEquals(bloom, rcpt.logsBloom());
+        assertEquals(1, rcpt.logs().size());
+        Receipt.Log log = rcpt.logs().get(0);
+        assertEquals(addr, log.address());
+        assertEquals(1, log.topics().size());
+        assertEquals(topic, log.topics().get(0));
+        assertEquals(Bytes.fromHexString("0xdeadbeef"), log.data());
+    }
+
+    @Test
+    void decodesTypedFailedReceiptNoLogs() {
+        Bytes inner = RLP.encodeList(r -> {
+            r.writeValue(Bytes.EMPTY);                   // status = 0 (failed) → RLP 0x80
+            r.writeValue(Bytes.fromHexString("0x9c40")); // cumulativeGasUsed
+            r.writeValue(Bytes.repeat((byte) 0x00, 256));
+            r.writeList(logs -> { });
+        });
+        Bytes raw = Bytes.concatenate(Bytes.fromHexString("0x02"), inner); // type-2 envelope
+
+        Receipt rcpt = Receipt.decode(raw);
+        assertEquals(2, rcpt.type());
+        assertTrue(rcpt.hasStatus());
+        assertFalse(rcpt.success());
+        assertEquals(40000L, rcpt.cumulativeGasUsed());
+        assertTrue(rcpt.logs().isEmpty());
+    }
+}


### PR DESCRIPTION
Second half of the verified-receipts feature (builds on #30's `OrderedTrieRoot` + `GetReceipts`/`Receipts`). After `eth_sendRawTransaction`, a wallet can now confirm inclusion **without trusting a peer**.

## How it verifies

`NodeService.rpcGetTransactionReceipt` scans a bounded window (32 blocks) below the beacon-anchored verified head:

1. **Anchor a header window** — fetch a contiguous header range and require its last header to *be* the verified head (stateRoot match) with every header hash-linked back to the next's `parentHash`. Now every header's `transactionsRoot`/`receiptsRoot` is trusted.
2. **Verify the body** — for each block from the head down, fetch the body and rebuild the tx trie (`OrderedTrieRoot`), checking it equals `header.transactionsRoot` *before* believing which txs (and indices) the block holds. Then match the requested tx hash.
3. **Verify the receipts** — fetch the block's receipts and check the rebuilt receipts trie equals `header.receiptsRoot` before returning the matching one.

Not found in the window → `null` → proxy (pending / out-of-range stays unverified, consistent with the other verified reads).

## What it returns

The verified core as a JSON object: `transactionHash, transactionIndex, blockHash, blockNumber, cumulativeGasUsed, gasUsed, status, type, logsBloom, logs[]` (each log with full block/tx context + `logIndex`).

`from` / `to` / `contractAddress` / `effectiveGasPrice` need tx decode + sender recovery (ecrecover with per-type signing hashes) and are a deliberate follow-up — kept out to keep this PR focused on the trust-critical verification.

## Pieces
- `Receipt` model — decode EIP-2718 typed/legacy receipts (status/cumGas/bloom/logs). Tested.
- `rpcGetTransactionReceipt` orchestration + `windowAnchoredToHead` + `buildReceiptJson`.
- `getTransactionReceipt` on `MyotisRpcBackend` (returns a host-built JSON string, avoiding a Map→JSON step), `RpcRouter` dispatch, `NodeService` impl, mock + two router tests.

## Validation state (honest)
Unit-tested: `Receipt` decode, `OrderedTrieRoot` (structural + keccak, from #30), router dispatch (verified-object passthrough + null→fallthrough). **Not yet run live**: the real-mainnet path (rebuild a real block's tx/receipt tries; submit a tx and poll the receipt) — that requires the Android app + a submitted tx, and it's also what would validate `OrderedTrieRoot` against real block data. Planned as a manual/integration verification before or right after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)