### PR TITLE
Strict permissionless mode: error instead of proxying unverifiable methods

### DIFF
--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -116,6 +116,14 @@ public final class NodeService extends Service {
     // proxy. Bodies within the window are fetched concurrently, so latency ≈ one
     // round-trip regardless of the count.
     private static final int RECEIPT_LOOKBACK_BLOCKS = 8;
+    // Permissionless mode: do NOT fall back to the (permissioned) upstream proxy. A
+    // method we can't answer from cryptographically-verified data ERRORS instead of
+    // silently returning unverified upstream data — that is the whole point of Myotis.
+    // The proxy was only ever a transition aid to learn what MetaMask calls; the
+    // MethodLogger / myotis_rpcCoverage still records every rejected method, so we keep
+    // that discovery signal without serving unverified data. Flip to false only for
+    // local debugging against an injected upstream.
+    private static final boolean STRICT_NO_PROXY = true;
 
     // Static so MainActivity can reflect the correct button state after a
     // configuration change — the activity instance is recreated, but the
@@ -1978,8 +1986,10 @@ public final class NodeService extends Service {
         // Starts immediately — does not wait for beacon sync. Router/proxy land next.
         try {
             // Upstream proxy URL (DEBUG/dev only) comes from BuildConfig.RPC_UPSTREAM
-            // (set in gitignored local.properties); blank → strict (no proxy).
-            String upstream = BuildConfig.RPC_UPSTREAM;
+            // (set in gitignored local.properties); blank → strict (no proxy). In
+            // permissionless mode we force it off regardless, so unverifiable methods
+            // error instead of proxying.
+            String upstream = STRICT_NO_PROXY ? null : BuildConfig.RPC_UPSTREAM;
             // Verified-read backend: delegate to the node's shared connector +
             // beacon state. Phase B serves chain id + verified head; more methods
             // are added here as they're implemented.

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -980,10 +980,13 @@ public final class NodeService extends Service {
                         + h.number + " index " + idx);
                 return buildReceiptJson(receipts, idx, h, blockHash, want);
             }
-            return null; // not found in window → pending / out-of-range → proxy
+            // Verified head + anchored window, but the tx isn't in it → a VERIFIED
+            // "not seen yet": return the JSON-null literal (eth's pending/unknown), NOT
+            // Kotlin null (which means "couldn't verify" → router error).
+            return "null";
         } catch (Exception e) {
             LogBuffer.i(TAG, "[rpc] eth_getTransactionReceipt failed: " + unwrap(e));
-            return null;
+            return null; // couldn't verify → router errors (not a misleading "pending")
         }
     }
 

--- a/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/MyotisRpcBackend.kt
+++ b/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/MyotisRpcBackend.kt
@@ -68,11 +68,14 @@ interface MyotisRpcBackend {
     fun sendRawTransaction(rawTx: ByteArray): ByteArray?
 
     /**
-     * eth_getTransactionReceipt: the receipt for [txHash] as a pre-built JSON object
-     * string, verified against a beacon-anchored header's receiptsRoot, or null when it
-     * can't be answered verified (tx not in the recent verified window / pending / no
-     * peer) so the router falls back to the proxy. Returning a JSON string keeps the
-     * nested receipt+logs shape host-built without a Map→JSON conversion in the router.
+     * eth_getTransactionReceipt for [txHash], verified against a beacon-anchored
+     * header's receiptsRoot. Returns:
+     *  - the receipt as a pre-built JSON object string when found + verified;
+     *  - the literal "null" when VERIFIED-not-found (node synced, tx not in the recent
+     *    verified chain → eth's standard pending/unknown — a valid result);
+     *  - Kotlin null when it CAN'T be answered verified (not synced / no peer), so the
+     *    router errors rather than implying "pending on a healthy chain".
+     * A JSON string keeps the nested receipt+logs host-built (no Map→JSON in the router).
      */
     fun getTransactionReceipt(txHash: ByteArray): String?
 }

--- a/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/RpcRouter.kt
+++ b/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/RpcRouter.kt
@@ -33,6 +33,15 @@ class RpcRouter(
 
     private companion object {
         private val HEX_DIGITS = "0123456789abcdef".toCharArray()
+
+        /** Methods we have a verified implementation for. Used in strict mode to tell
+         *  "supported but can't answer right now" (-32000, retryable) from "we don't
+         *  serve this verified at all" (-32601). Keep in sync with tryVerified's cases. */
+        private val VERIFIED_METHODS = setOf(
+            "eth_chainId", "net_version", "eth_blockNumber", "eth_call", "eth_getBalance",
+            "eth_getTransactionCount", "eth_getCode", "eth_getStorageAt",
+            "eth_sendRawTransaction", "eth_getTransactionReceipt",
+        )
     }
 
     suspend fun handle(body: String): String {
@@ -65,10 +74,20 @@ class RpcRouter(
         }
 
         if (proxy == null) {
-            // Strict mode: nothing to verify yet, no upstream → report unavailable.
+            // Strict (permissionless) mode: no verified answer and no proxy. We refuse
+            // to serve unverified data — error instead. The MethodLogger still records
+            // every rejected method, so myotis_rpcCoverage keeps mapping what the wallet
+            // needs. Distinguish "method we don't implement verified" (-32601, so the
+            // wallet stops asking) from "implemented but can't answer right now — no
+            // peer / not synced" (-32000, retryable).
             methods.forEach { logger.record(it, "ERROR", 0) }
             val id = (root as? JsonObject)?.get("id") ?: JsonNull
-            return errorEnvelope(id, -32000, "no upstream configured (strict mode)")
+            val m = methods.firstOrNull() ?: "request"
+            return if (m in VERIFIED_METHODS) {
+                errorEnvelope(id, -32000, "method '$m' cannot be served verified right now (no peer / not synced)")
+            } else {
+                errorEnvelope(id, -32601, "method '$m' is not supported by this permissionless node")
+            }
         }
 
         val t0 = System.nanoTime()
@@ -153,9 +172,14 @@ class RpcRouter(
             }
             "eth_getTransactionReceipt" -> {
                 val txHash = (root.params()?.getOrNull(0) as? JsonPrimitive)?.asHexBytes() ?: return null
-                // Backend returns a pre-built, verified receipt JSON object, or null (→ proxy).
-                val receiptJson = withContext(Dispatchers.IO) { b.getTransactionReceipt(txHash) } ?: return null
-                resultEnvelope(id, json.parseToJsonElement(receiptJson))
+                // Verified view: the receipt if found+verified, else JSON-null — eth's
+                // standard "unknown/pending" answer. This is itself a valid verified
+                // response (we don't see it confirmed in the recent verified chain), so
+                // it is NOT a proxy/strict fall-through: a wallet polling a just-sent tx
+                // keeps getting null until it's mined, never an error.
+                val receiptJson = withContext(Dispatchers.IO) { b.getTransactionReceipt(txHash) }
+                if (receiptJson != null) resultEnvelope(id, json.parseToJsonElement(receiptJson))
+                else resultEnvelope(id, JsonNull)
             }
             else -> null
         }

--- a/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/RpcRouter.kt
+++ b/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/RpcRouter.kt
@@ -50,59 +50,67 @@ class RpcRouter(
         } catch (e: Exception) {
             return errorEnvelope(JsonNull, -32700, "Parse error")
         }
-
-        // Single request: try local + verified handlers before proxying.
-        if (root is JsonObject) {
-            val method = root["method"]?.jsonPrimitive?.contentOrNull
-            val id = root["id"] ?: JsonNull
-            if (method == "myotis_rpcCoverage") {
-                logger.record(method, "LOCAL", 0)
-                return resultEnvelope(id, logger.coverage())
+        return when (root) {
+            is JsonObject -> handleOne(root, body)
+            is JsonArray -> {
+                // JSON-RPC 2.0 batch: each request gets its own response/error object so
+                // a wallet (MetaMask batches heavily) can match them by id — not a single
+                // error envelope. Elements are handled independently.
+                if (root.isEmpty()) return errorEnvelope(JsonNull, -32600, "Invalid Request")
+                val responses = root.map { el ->
+                    (el as? JsonObject)?.let { handleOne(it, null) }
+                        ?: errorEnvelope(JsonNull, -32600, "Invalid Request")
+                }
+                "[" + responses.joinToString(",") + "]"
             }
-            val t0 = System.nanoTime()
-            val verified = tryVerified(method, id, root)
-            if (verified != null) {
-                logger.record(method!!, "VERIFIED", (System.nanoTime() - t0) / 1_000_000)
-                return verified
-            }
+            else -> errorEnvelope(JsonNull, -32600, "Invalid Request")
         }
+    }
 
-        val methods: List<String> = when (root) {
-            is JsonArray -> root.mapNotNull { (it as? JsonObject)?.method() }
-            is JsonObject -> listOfNotNull(root.method())
-            else -> return errorEnvelope(JsonNull, -32600, "Invalid Request")
+    /**
+     * Handle one request object, returning its complete JSON-RPC response envelope.
+     * [wholeBody] is the original request text used for the single-request proxy path;
+     * null for a batch element (re-serialized and proxied individually).
+     */
+    private suspend fun handleOne(root: JsonObject, wholeBody: String?): String {
+        val method = root["method"]?.jsonPrimitive?.contentOrNull
+        val id = root["id"] ?: JsonNull
+        if (method == "myotis_rpcCoverage") {
+            logger.record(method, "LOCAL", 0)
+            return resultEnvelope(id, logger.coverage())
         }
-
+        val t0 = System.nanoTime()
+        val verified = tryVerified(method, id, root)
+        if (verified != null) {
+            logger.record(method!!, "VERIFIED", (System.nanoTime() - t0) / 1_000_000)
+            return verified
+        }
+        val m = method ?: "request"
         if (proxy == null) {
-            // Strict (permissionless) mode: no verified answer and no proxy. We refuse
-            // to serve unverified data — error instead. The MethodLogger still records
-            // every rejected method, so myotis_rpcCoverage keeps mapping what the wallet
-            // needs. Distinguish "method we don't implement verified" (-32601, so the
-            // wallet stops asking) from "implemented but can't answer right now — no
-            // peer / not synced" (-32000, retryable).
-            methods.forEach { logger.record(it, "ERROR", 0) }
-            val id = (root as? JsonObject)?.get("id") ?: JsonNull
-            val m = methods.firstOrNull() ?: "request"
+            // Strict (permissionless) mode: no verified answer, no proxy → error. We
+            // refuse to serve unverified data. The MethodLogger still records every
+            // rejected method, so myotis_rpcCoverage keeps mapping what the wallet needs.
+            // -32601 = we don't implement it verified (wallet can stop asking); -32000 =
+            // implemented but can't answer right now — no peer / not synced (retryable).
+            logger.record(m, "ERROR", 0)
             return if (m in VERIFIED_METHODS) {
                 errorEnvelope(id, -32000, "method '$m' cannot be served verified right now (no peer / not synced)")
             } else {
                 errorEnvelope(id, -32601, "method '$m' is not supported by this permissionless node")
             }
         }
-
-        val t0 = System.nanoTime()
-        val response = try {
-            proxy.forward(body)
+        // Dev-only proxy fallback (never used in production / strict mode).
+        val pt0 = System.nanoTime()
+        val forwardBody = wholeBody ?: json.encodeToString(JsonObject.serializer(), root)
+        return try {
+            val response = proxy.forward(forwardBody)
+            logger.record(m, "PROXY", (System.nanoTime() - pt0) / 1_000_000)
+            response
         } catch (e: Exception) {
-            // Upstream down/timeout: return a JSON-RPC error, not a raw HTTP 500,
-            // so the wallet can handle it.
-            methods.forEach { logger.record(it, "ERROR", (System.nanoTime() - t0) / 1_000_000) }
-            val id = (root as? JsonObject)?.get("id") ?: JsonNull
-            return errorEnvelope(id, -32603, "upstream proxy error: ${e.message}")
+            // Upstream down/timeout: JSON-RPC error, not a raw HTTP 500, so the wallet copes.
+            logger.record(m, "ERROR", (System.nanoTime() - pt0) / 1_000_000)
+            errorEnvelope(id, -32603, "upstream proxy error: ${e.message}")
         }
-        val latencyMs = (System.nanoTime() - t0) / 1_000_000
-        methods.forEach { logger.record(it, "PROXY", latencyMs) }
-        return response
     }
 
     /**
@@ -172,14 +180,14 @@ class RpcRouter(
             }
             "eth_getTransactionReceipt" -> {
                 val txHash = (root.params()?.getOrNull(0) as? JsonPrimitive)?.asHexBytes() ?: return null
-                // Verified view: the receipt if found+verified, else JSON-null — eth's
-                // standard "unknown/pending" answer. This is itself a valid verified
-                // response (we don't see it confirmed in the recent verified chain), so
-                // it is NOT a proxy/strict fall-through: a wallet polling a just-sent tx
-                // keeps getting null until it's mined, never an error.
-                val receiptJson = withContext(Dispatchers.IO) { b.getTransactionReceipt(txHash) }
-                if (receiptJson != null) resultEnvelope(id, json.parseToJsonElement(receiptJson))
-                else resultEnvelope(id, JsonNull)
+                // Backend contract: a receipt JSON object when found+verified; the literal
+                // "null" for a VERIFIED "not seen yet" (synced, not in the recent chain →
+                // eth's standard pending/unknown, a valid result); or Kotlin-null when it
+                // CAN'T verify (not synced / no peer), which falls through to the strict
+                // error — so we never tell the wallet "pending on a healthy chain" when we
+                // actually couldn't check.
+                val receiptJson = withContext(Dispatchers.IO) { b.getTransactionReceipt(txHash) } ?: return null
+                resultEnvelope(id, json.parseToJsonElement(receiptJson)) // "null" → JsonNull result
             }
             else -> null
         }

--- a/jsonrpc-server/src/test/kotlin/io/myotis/jsonrpc/RpcRouterTest.kt
+++ b/jsonrpc-server/src/test/kotlin/io/myotis/jsonrpc/RpcRouterTest.kt
@@ -2,6 +2,7 @@ package io.myotis.jsonrpc
 
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.junit.jupiter.api.Assertions.assertArrayEquals
@@ -227,13 +228,38 @@ class RpcRouterTest {
         assertEquals(-32000, errorCode(resp))                    // supported, but not verifiable right now
     }
 
-    @Test fun strict_getTransactionReceipt_pending_returnsNullResult_notError() {
-        val resp = route(FakeBackend(),                          // receiptJson null = pending / not found
+    @Test fun strict_getTransactionReceipt_verifiedPending_returnsNullResult_notError() {
+        // "null" = verified "not seen yet" (synced, not in recent chain) → result: null.
+        val resp = route(FakeBackend().apply { receiptJson = "null" },
             """{"jsonrpc":"2.0","id":7,"method":"eth_getTransactionReceipt","params":["0x${"ab".repeat(32)}"]}""")
         assertTrue(!hasError(resp))                              // pending is a valid verified answer, not an error
         val obj = json.parseToJsonElement(resp).jsonObject
         assertTrue(obj.containsKey("result"))
         assertTrue(obj["result"] is kotlinx.serialization.json.JsonNull)
+    }
+
+    @Test fun strict_getTransactionReceipt_cannotVerify_errors() {
+        // Kotlin-null (not synced / no peer) → strict error, NOT a misleading null result.
+        val resp = route(FakeBackend(),                          // receiptJson defaults to null
+            """{"jsonrpc":"2.0","id":7,"method":"eth_getTransactionReceipt","params":["0x${"ab".repeat(32)}"]}""")
+        assertTrue(hasError(resp))
+        assertEquals(-32000, errorCode(resp))                    // implemented but can't answer right now
+    }
+
+    @Test fun strict_batch_returnsPerRequestResponses() {
+        // Batch must yield an array of individual responses (JSON-RPC 2.0), each matchable
+        // by id — not a single error envelope. Mixes a verified hit and an unsupported method.
+        val b = FakeBackend(head = 0x123)
+        val resp = route(b, """[
+            {"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]},
+            {"jsonrpc":"2.0","id":2,"method":"eth_getLogs","params":[{}]}
+        ]""")
+        val arr = json.parseToJsonElement(resp).jsonArray
+        assertEquals(2, arr.size)
+        assertEquals("0x123", arr[0].jsonObject["result"]!!.jsonPrimitive.content)        // verified
+        assertEquals(-32601, arr[1].jsonObject["error"]!!.jsonObject["code"]!!.jsonPrimitive.content.toInt()) // unsupported
+        assertEquals(1, arr[0].jsonObject["id"]!!.jsonPrimitive.content.toInt())          // ids preserved
+        assertEquals(2, arr[1].jsonObject["id"]!!.jsonPrimitive.content.toInt())
     }
 
     @Test fun chainId_and_blockNumber_stillVerified() {

--- a/jsonrpc-server/src/test/kotlin/io/myotis/jsonrpc/RpcRouterTest.kt
+++ b/jsonrpc-server/src/test/kotlin/io/myotis/jsonrpc/RpcRouterTest.kt
@@ -67,6 +67,9 @@ class RpcRouterTest {
     private fun hasError(resp: String): Boolean =
         json.parseToJsonElement(resp).jsonObject["error"] != null
 
+    private fun errorCode(resp: String): Int =
+        json.parseToJsonElement(resp).jsonObject["error"]!!.jsonObject["code"]!!.jsonPrimitive.content.toInt()
+
     @Test fun ethCall_encodesResultAsData_andDecodesToAndData() {
         val b = FakeBackend(callResult = byteArrayOf(0, 6))
         val resp = route(b,
@@ -208,9 +211,29 @@ class RpcRouterTest {
         assertEquals("0x" + "ab".repeat(32), b.lastReceiptTxHash!!.toHex()) // hash decoded + passed in
     }
 
-    @Test fun getTransactionReceipt_notFound_fallsThrough() {     // backend null result -> proxy/strict
-        assertTrue(hasError(route(FakeBackend(),                  // receiptJson defaults to null
-            """{"jsonrpc":"2.0","id":7,"method":"eth_getTransactionReceipt","params":["0x${"ab".repeat(32)}"]}""")))
+    // ---- strict (permissionless, no-proxy) mode -------------------------------------
+
+    @Test fun strict_unimplementedMethod_errorsMethodNotSupported() {
+        val resp = route(FakeBackend(),                          // no proxy → strict
+            """{"jsonrpc":"2.0","id":1,"method":"eth_getLogs","params":[{}]}""")
+        assertTrue(hasError(resp))
+        assertEquals(-32601, errorCode(resp))                    // not served by this permissionless node
+    }
+
+    @Test fun strict_implementedButUnavailable_errorsServerError() {
+        val resp = route(FakeBackend(balance = null),            // eth_getBalance handled, backend can't answer
+            """{"jsonrpc":"2.0","id":1,"method":"eth_getBalance","params":["0x${"11".repeat(20)}","latest"]}""")
+        assertTrue(hasError(resp))
+        assertEquals(-32000, errorCode(resp))                    // supported, but not verifiable right now
+    }
+
+    @Test fun strict_getTransactionReceipt_pending_returnsNullResult_notError() {
+        val resp = route(FakeBackend(),                          // receiptJson null = pending / not found
+            """{"jsonrpc":"2.0","id":7,"method":"eth_getTransactionReceipt","params":["0x${"ab".repeat(32)}"]}""")
+        assertTrue(!hasError(resp))                              // pending is a valid verified answer, not an error
+        val obj = json.parseToJsonElement(resp).jsonObject
+        assertTrue(obj.containsKey("result"))
+        assertTrue(obj["result"] is kotlinx.serialization.json.JsonNull)
     }
 
     @Test fun chainId_and_blockNumber_stillVerified() {


### PR DESCRIPTION
Myotis is permissionless — the upstream proxy was only ever a transition aid to learn what MetaMask calls without breaking it. This switches the production behavior: **a method that can't be answered from cryptographically-verified data ERRORS instead of silently returning unverified upstream data.**

## Changes
- **`NodeService`**: `STRICT_NO_PROXY = true` runs the RPC server with no upstream, so the router's strict path is the production behavior. (Flip to `false` only for local debugging against an injected upstream.)
- **`RpcRouter`** strict path is now **method-aware**:
  - `-32601` *"not supported by this permissionless node"* — methods we don't implement verified (wallet learns to stop asking).
  - `-32000` *"can't answer right now — no peer / not synced"* — methods we *do* implement but can't serve at this moment (retryable).
  - The `MethodLogger` still records every rejected method, so **`myotis_rpcCoverage` keeps mapping MetaMask's needs** — without serving unverified data.
- **`eth_getTransactionReceipt`** returns a JSON-`null` result (eth's standard "unknown/pending") instead of falling through to an error — a wallet polling a just-sent tx keeps getting `null` until it's mined, never a spurious error.

## Why this is the right tool
This makes the node itself the discovery instrument: point MetaMask at it and read `myotis_rpcCoverage` to get the **exact** set of methods MetaMask hits and which we reject — replacing the proxy's "learn what's needed" role with the same signal, permissionlessly.

## Known gaps it will surface (theoretical, to confirm empirically)
For a no-proxy MetaMask send we still need: `eth_getBlockByNumber` (baseFee), `eth_estimateGas` (EVM primitive already exists in `myotis-evm`), a priority-fee source (`eth_maxPriorityFeePerGas`/`eth_gasPrice`, built on the unmerged `feat/verified-fees`), and `eth_getTransactionByHash`. `eth_feeHistory` is the one genuinely hard to verify. All but feeHistory are verifiable with primitives we already have.

Tests: strict unimplemented → -32601; strict implemented-but-unavailable → -32000; pending receipt → null result (not error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)