### PR TITLE
Verified eth_getBlockByNumber (header-based, no snap state)

### DIFF
--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -1091,6 +1091,7 @@ public final class NodeService extends Service {
                 default:
                     try { target = Long.decode(b); } catch (Exception e) { return null; }
             }
+            if (target < 0) return null;                    // invalid (negative) block number
             if (target > headNum) return "null";            // future/unknown block → eth null
             long back = headNum - target;
             if (back >= BLOCK_LOOKBACK_MAX) return null;     // too far to verify cheaply → error

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -124,6 +124,10 @@ public final class NodeService extends Service {
     // that discovery signal without serving unverified data. Flip to false only for
     // local debugging against an injected upstream.
     private static final boolean STRICT_NO_PROXY = true;
+    // Max blocks below the verified head we'll fetch+verify headers for to answer
+    // eth_getBlockByNumber by number. "latest" is 1 header; older numbers cost a header
+    // range, so bound it (MetaMask asks for "latest" for the fee market anyway).
+    private static final int BLOCK_LOOKBACK_MAX = 256;
 
     // Static so MainActivity can reflect the correct button state after a
     // configuration change — the activity instance is recreated, but the
@@ -1057,6 +1061,103 @@ public final class NodeService extends Service {
     /** Ethereum JSON-RPC QUANTITY: minimal hex, no leading zeros, 0 → "0x0". */
     private static String hexQuantity(long v) {
         return "0x" + Long.toHexString(v);
+    }
+
+    /**
+     * eth_getBlockByNumber, verified. Serves the block header fields from a
+     * beacon-anchored verified header plus the tx hashes from a body checked against
+     * transactionsRoot — no snap state needed (so it works even where eth_call can't).
+     * Returns the block JSON when verified; the literal "null" for a non-existent
+     * (future) block (eth's standard); Kotlin null when it can't verify (not synced)
+     * → router errors. fullTransactions=true (full tx objects, needs tx decode + sender
+     * recovery) is a follow-up — returns Kotlin null for now.
+     */
+    private String rpcGetBlockByNumber(String block, boolean fullTx) {
+        RLPxConnector conn = connector;
+        if (conn == null || fullTx) return null;
+        try {
+            EnsCall ctx = verifiedHeadCallContext();
+            if (ctx == null || !ctx.beaconVerified()) return null;
+            long headNum = ctx.blockNumber();
+            byte[] headStateRoot = ctx.blockCtx().stateRoot();
+
+            long target;
+            String b = (block == null) ? "latest" : block;
+            switch (b) {
+                case "latest": case "pending": case "safe": case "finalized":
+                    target = headNum; break;
+                case "earliest":
+                    return null; // genesis not served verified here (rarely needed)
+                default:
+                    try { target = Long.decode(b); } catch (Exception e) { return null; }
+            }
+            if (target > headNum) return "null";            // future/unknown block → eth null
+            long back = headNum - target;
+            if (back >= BLOCK_LOOKBACK_MAX) return null;     // too far to verify cheaply → error
+
+            List<BlockHeadersMessage.VerifiedHeader> window = conn
+                    .requestBlockHeadersBatched(target, (int) (back + 1))
+                    .get(HEADER_CHAIN_TIMEOUT_SEC, TimeUnit.SECONDS);
+            if (!windowAnchoredToHead(window, headStateRoot)) return null;
+            BlockHeadersMessage.VerifiedHeader vh = window.get(0); // target is first in [target..head]
+
+            List<BlockBodiesMessage.BlockBody> bodies = conn
+                    .requestBlockBodies(vh.hash())
+                    .get(HEADER_CHAIN_TIMEOUT_SEC, TimeUnit.SECONDS);
+            if (bodies.isEmpty()) return null;
+            List<Bytes> txs = bodies.get(0).transactions();
+            if (!OrderedTrieRoot.verify(txs, vh.header().transactionsRoot)) return null;
+
+            return buildBlockJson(vh, txs);
+        } catch (Exception e) {
+            LogBuffer.i(TAG, "[rpc] eth_getBlockByNumber failed: " + unwrap(e));
+            return null;
+        }
+    }
+
+    /** Build the eth_getBlockByNumber JSON from a VERIFIED header + verified tx list
+     *  (transactions as hashes; fullTransactions=true is handled upstream as a follow-up). */
+    private static String buildBlockJson(BlockHeadersMessage.VerifiedHeader vh, List<Bytes> txs) {
+        BlockHeader h = vh.header();
+        StringBuilder sb = new StringBuilder(1024);
+        sb.append("{\"number\":\"").append(hexQuantity(h.number)).append("\"");
+        sb.append(",\"hash\":\"").append(vh.hash().toHexString()).append("\"");
+        sb.append(",\"parentHash\":\"").append(h.parentHash.toHexString()).append("\"");
+        sb.append(",\"nonce\":\"").append(h.nonce.toHexString()).append("\"");
+        sb.append(",\"sha3Uncles\":\"").append(h.ommersHash.toHexString()).append("\"");
+        sb.append(",\"logsBloom\":\"").append(h.logsBloom.toHexString()).append("\"");
+        sb.append(",\"transactionsRoot\":\"").append(h.transactionsRoot.toHexString()).append("\"");
+        sb.append(",\"stateRoot\":\"").append(h.stateRoot.toHexString()).append("\"");
+        sb.append(",\"receiptsRoot\":\"").append(h.receiptsRoot.toHexString()).append("\"");
+        sb.append(",\"miner\":\"").append(h.beneficiary.toHexString()).append("\"");
+        sb.append(",\"difficulty\":\"0x").append(h.difficulty.toString(16)).append("\"");
+        sb.append(",\"extraData\":\"").append(h.extraData.toHexString()).append("\"");
+        sb.append(",\"gasLimit\":\"").append(hexQuantity(h.gasLimit)).append("\"");
+        sb.append(",\"gasUsed\":\"").append(hexQuantity(h.gasUsed)).append("\"");
+        sb.append(",\"timestamp\":\"").append(hexQuantity(h.timestamp)).append("\"");
+        sb.append(",\"mixHash\":\"").append(h.mixHashOrPrevRandao.toHexString()).append("\"");
+        if (h.baseFeePerGas != null) {
+            sb.append(",\"baseFeePerGas\":\"0x").append(h.baseFeePerGas.toString(16)).append("\"");
+        }
+        if (h.withdrawalsRoot != null) {
+            sb.append(",\"withdrawalsRoot\":\"").append(h.withdrawalsRoot.toHexString()).append("\"");
+        }
+        if (h.blobGasUsed >= 0) {
+            sb.append(",\"blobGasUsed\":\"").append(hexQuantity(h.blobGasUsed)).append("\"");
+        }
+        if (h.excessBlobGas >= 0) {
+            sb.append(",\"excessBlobGas\":\"").append(hexQuantity(h.excessBlobGas)).append("\"");
+        }
+        if (h.parentBeaconBlockRoot != null) {
+            sb.append(",\"parentBeaconBlockRoot\":\"").append(h.parentBeaconBlockRoot.toHexString()).append("\"");
+        }
+        sb.append(",\"transactions\":[");
+        for (int i = 0; i < txs.size(); i++) {
+            if (i > 0) sb.append(",");
+            sb.append("\"").append(Hash.keccak256(txs.get(i)).toHexString()).append("\"");
+        }
+        sb.append("],\"uncles\":[]}");
+        return sb.toString();
     }
 
     /** Render a storage value as a 32-byte big-endian word (drops BigInteger's
@@ -2030,6 +2131,9 @@ public final class NodeService extends Service {
                 }
                 @Override public String getTransactionReceipt(byte[] txHash) {
                     return rpcGetTransactionReceipt(txHash, "latest");
+                }
+                @Override public String getBlockByNumber(String block, boolean fullTx) {
+                    return rpcGetBlockByNumber(block, fullTx);
                 }
             };
             io.myotis.jsonrpc.MyotisRpcServer s =

--- a/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/MyotisRpcBackend.kt
+++ b/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/MyotisRpcBackend.kt
@@ -78,4 +78,13 @@ interface MyotisRpcBackend {
      * A JSON string keeps the nested receipt+logs host-built (no Map→JSON in the router).
      */
     fun getTransactionReceipt(txHash: ByteArray): String?
+
+    /**
+     * eth_getBlockByNumber for [block] (a tag like "latest" or a 0x hex number), verified
+     * from a beacon-anchored header (no snap state needed). Returns the block as a JSON
+     * object string (transactions as hashes); the literal "null" for a non-existent
+     * (future) block; or Kotlin null when it can't be answered verified (not synced / too
+     * far back / [fullTransactions]=true, which isn't served verified yet) → router errors.
+     */
+    fun getBlockByNumber(block: String, fullTransactions: Boolean): String?
 }

--- a/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/RpcRouter.kt
+++ b/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/RpcRouter.kt
@@ -9,6 +9,7 @@ import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonPrimitive
@@ -40,7 +41,7 @@ class RpcRouter(
         private val VERIFIED_METHODS = setOf(
             "eth_chainId", "net_version", "eth_blockNumber", "eth_call", "eth_getBalance",
             "eth_getTransactionCount", "eth_getCode", "eth_getStorageAt",
-            "eth_sendRawTransaction", "eth_getTransactionReceipt",
+            "eth_sendRawTransaction", "eth_getTransactionReceipt", "eth_getBlockByNumber",
         )
     }
 
@@ -188,6 +189,15 @@ class RpcRouter(
                 // actually couldn't check.
                 val receiptJson = withContext(Dispatchers.IO) { b.getTransactionReceipt(txHash) } ?: return null
                 resultEnvelope(id, json.parseToJsonElement(receiptJson)) // "null" → JsonNull result
+            }
+            "eth_getBlockByNumber" -> {
+                val p = root.params()
+                val block = p.blockTag(0)                          // tag or 0x hex number
+                val fullTx = (p?.getOrNull(1) as? JsonPrimitive)?.booleanOrNull ?: false
+                // Object string when found; "null" for a future/unknown block; Kotlin null
+                // (can't verify) → fall through to the strict error.
+                val blockJson = withContext(Dispatchers.IO) { b.getBlockByNumber(block, fullTx) } ?: return null
+                resultEnvelope(id, json.parseToJsonElement(blockJson))
             }
             else -> null
         }

--- a/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/RpcRouter.kt
+++ b/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/RpcRouter.kt
@@ -193,7 +193,14 @@ class RpcRouter(
             "eth_getBlockByNumber" -> {
                 val p = root.params()
                 val block = p.blockTag(0)                          // tag or 0x hex number
-                val fullTx = (p?.getOrNull(1) as? JsonPrimitive)?.booleanOrNull ?: false
+                // Default false only when the flag is ABSENT; a present-but-non-boolean
+                // value (number, "yes", object) falls through rather than being silently
+                // coerced to false and returning the wrong shape.
+                val fullParam = p?.getOrNull(1)
+                val fullTx: Boolean = when {
+                    fullParam == null || fullParam is JsonNull -> false
+                    else -> (fullParam as? JsonPrimitive)?.booleanOrNull ?: return null
+                }
                 // Object string when found; "null" for a future/unknown block; Kotlin null
                 // (can't verify) → fall through to the strict error.
                 val blockJson = withContext(Dispatchers.IO) { b.getBlockByNumber(block, fullTx) } ?: return null

--- a/jsonrpc-server/src/test/kotlin/io/myotis/jsonrpc/RpcRouterTest.kt
+++ b/jsonrpc-server/src/test/kotlin/io/myotis/jsonrpc/RpcRouterTest.kt
@@ -271,6 +271,14 @@ class RpcRouterTest {
         assertTrue(json.parseToJsonElement(resp).jsonObject["result"] is kotlinx.serialization.json.JsonNull)
     }
 
+    @Test fun getBlockByNumber_nonBooleanFullTxFlag_fallsThrough() {
+        // present-but-non-boolean flag (1) must not be coerced to false → strict error.
+        val resp = route(FakeBackend().apply { blockJson = """{"number":"0x1"}""" },
+            """{"jsonrpc":"2.0","id":3,"method":"eth_getBlockByNumber","params":["latest",1]}""")
+        assertTrue(hasError(resp))
+        assertEquals(-32000, errorCode(resp))
+    }
+
     @Test fun getBlockByNumber_cannotVerify_errors() {
         val resp = route(FakeBackend(),  // blockJson null → can't verify → strict error
             """{"jsonrpc":"2.0","id":3,"method":"eth_getBlockByNumber","params":["latest",false]}""")

--- a/jsonrpc-server/src/test/kotlin/io/myotis/jsonrpc/RpcRouterTest.kt
+++ b/jsonrpc-server/src/test/kotlin/io/myotis/jsonrpc/RpcRouterTest.kt
@@ -57,6 +57,12 @@ class RpcRouterTest {
         override fun getTransactionReceipt(txHash: ByteArray): String? {
             lastReceiptTxHash = txHash; return receiptJson
         }
+        var lastBlockTag: String? = null
+        var lastFullTx: Boolean? = null
+        var blockJson: String? = null
+        override fun getBlockByNumber(block: String, fullTransactions: Boolean): String? {
+            lastBlockTag = block; lastFullTx = fullTransactions; return blockJson
+        }
     }
 
     private fun route(backend: MyotisRpcBackend?, body: String, proxy: UpstreamProxy? = null): String =
@@ -244,6 +250,32 @@ class RpcRouterTest {
             """{"jsonrpc":"2.0","id":7,"method":"eth_getTransactionReceipt","params":["0x${"ab".repeat(32)}"]}""")
         assertTrue(hasError(resp))
         assertEquals(-32000, errorCode(resp))                    // implemented but can't answer right now
+    }
+
+    @Test fun getBlockByNumber_verified_embedsBlockObject_andPassesTagAndFlag() {
+        val b = FakeBackend().apply { blockJson = """{"number":"0x10","baseFeePerGas":"0x7"}""" }
+        val resp = route(b,
+            """{"jsonrpc":"2.0","id":3,"method":"eth_getBlockByNumber","params":["latest",false]}""")
+        val obj = json.parseToJsonElement(resp).jsonObject["result"]!!.jsonObject
+        assertEquals("0x10", obj["number"]!!.jsonPrimitive.content)
+        assertEquals("0x7", obj["baseFeePerGas"]!!.jsonPrimitive.content)
+        assertEquals("latest", b.lastBlockTag)
+        assertEquals(false, b.lastFullTx)
+    }
+
+    @Test fun getBlockByNumber_futureBlock_returnsNullResult() {
+        // backend returns the literal "null" for a non-existent/future block → result: null.
+        val resp = route(FakeBackend().apply { blockJson = "null" },
+            """{"jsonrpc":"2.0","id":3,"method":"eth_getBlockByNumber","params":["0x7fffffff",false]}""")
+        assertTrue(!hasError(resp))
+        assertTrue(json.parseToJsonElement(resp).jsonObject["result"] is kotlinx.serialization.json.JsonNull)
+    }
+
+    @Test fun getBlockByNumber_cannotVerify_errors() {
+        val resp = route(FakeBackend(),  // blockJson null → can't verify → strict error
+            """{"jsonrpc":"2.0","id":3,"method":"eth_getBlockByNumber","params":["latest",false]}""")
+        assertTrue(hasError(resp))
+        assertEquals(-32000, errorCode(resp))
     }
 
     @Test fun strict_batch_returnsPerRequestResponses() {


### PR DESCRIPTION
First of the MetaMask-tx-flow methods, driven by the strict-mode coverage run: MetaMask hit `eth_getBlockByNumber` and we rejected it (`-32601`). It's needed for the EIP-1559 fee market (the `latest` block's `baseFeePerGas`).

## What
`eth_getBlockByNumber`, **verified from a beacon-anchored header** — so it works even where `eth_call`/`eth_getBalance` can't, because those need a snap peer for verified *state* while this needs only verified *headers*.

`NodeService.rpcGetBlockByNumber`:
1. Resolve the target: `latest`/`pending`/`safe`/`finalized` → the verified head; a `0x` number within a bounded lookback (256).
2. Fetch + **anchor** the header window to the verified head (last header's `stateRoot` matches + `parentHash` links back).
3. Fetch the body and verify it against `transactionsRoot`.
4. Emit the full header fields + transaction **hashes** as JSON.

Returns the block object when verified; the literal `"null"` for a future/unknown block (eth's standard); Kotlin `null` when it can't verify (not synced / too far back) → strict `-32000`. `fullTransactions=true` (full tx objects — needs tx decode + sender recovery) is a follow-up.

Wiring: `getBlockByNumber` on the backend interface, `RpcRouter` dispatch (tag + fullTx flag), `VERIFIED_METHODS`, `NodeService` impl, mock + 3 router tests (object passthrough, future→null, can't-verify→`-32000`).

## Honest scope note
This does **not** fix MetaMask's empty token list. That's `eth_call`/`eth_getBalance` erroring for lack of **verified state** (a snap peer) — a separate availability issue (the emulator's no-snap-peer wall, or a not-yet-synced device), not a missing method. `eth_getBlockByNumber` is a real gap for the fee market and a clean header-only win regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)