### PR TITLE
Fix: eth_getBlockByNumber/getTransactionReceipt use the resilient head path

### DIFF
--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -959,7 +959,10 @@ public final class NodeService extends Service {
         RLPxConnector conn = connector;
         if (conn == null || txHash == null || txHash.length != 32) return null;
         try {
-            EnsCall ctx = verifiedHeadCallContext();
+            // Use the resilient head path (cached good head fallback), not the fresh-head
+            // builder — the chain tip is often not beacon-anchored yet, which made this
+            // fail with -32000 even with healthy snap peers while state reads worked.
+            EnsCall ctx = anchoredHeadOrWait();
             if (ctx == null || !ctx.beaconVerified()) return null;
             long headNum = ctx.blockNumber();
             byte[] headStateRoot = ctx.blockCtx().stateRoot();
@@ -1115,7 +1118,9 @@ public final class NodeService extends Service {
         RLPxConnector conn = connector;
         if (conn == null || fullTx) return null;
         try {
-            EnsCall ctx = verifiedHeadCallContext();
+            // Resilient head path (cached good head), not the fresh-head builder which
+            // fails when the chain tip isn't beacon-anchored yet — see rpcGetTransactionReceipt.
+            EnsCall ctx = anchoredHeadOrWait();
             if (ctx == null || !ctx.beaconVerified()) return null;
             long headNum = ctx.blockNumber();
             byte[] headStateRoot = ctx.blockCtx().stateRoot();

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -1538,7 +1538,14 @@ public final class NodeService extends Service {
         try {
             EnsCall ctx = prepareEnsCall(io.myotis.ens.EnsResolutionRoot.PEER_HEAD);
             if (anchorHeadToBeacon(ctx.blockNumber(), ctx.blockCtx().stateRoot())) {
-                return ctx;
+                // anchorHeadToBeacon ran the full headerChain verify from beacon-finalized
+                // to this head, so it IS cryptographically anchored now — but prepareEnsCall
+                // initialized the PEER_HEAD flag to false. Reflect the verification in the
+                // returned context so beaconVerified() is true (eth_getBlockByNumber /
+                // eth_getTransactionReceipt gate on it; without this they reject the freshly
+                // anchored head and only the finalized fallback ever passed).
+                return new EnsCall(ctx.resolver(), ctx.blockCtx(), ctx.blockNumber(),
+                        true, ctx.offchainExecutor(), ctx.oracle());
             }
             LogBuffer.i(TAG, "[rpc] fresh head not beacon-anchored (block #"
                     + ctx.blockNumber() + "); falling back to finalized");


### PR DESCRIPTION
Found by self-testing #35 on a Pixel 7 with 3 healthy snap peers: `eth_getBalance` worked but `eth_getBlockByNumber` consistently returned `-32000`, with the node logging **"fresh head not beacon-anchored"**.

## Cause
`eth_getBlockByNumber` and `eth_getTransactionReceipt` resolved the head via `verifiedHeadCallContext()` — the **fresh-head builder**, which throws when the chain tip isn't beacon-finality-anchored yet (frequently the case). State reads (`eth_getBalance`/`eth_call`) instead go through `verifiedHeadFor` → `anchoredHeadOrWait()`, which falls back to the recent **cached good head**. So balance worked while block/receipt didn't, despite identical peer state.

## Fix
Both now use `anchoredHeadOrWait()` — the same resilient path as the state reads.

## Verified on device
On a Pixel 7, once a head is available, `eth_getBlockByNumber("latest", false)` now returns the full verified block (`number`, `hash`, `parentHash`, `baseFeePerGas`, tx hashes, …) instead of `-32000`. (`eth_getTransactionReceipt` shares the identical change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)