### PR TITLE
cl-cache: persist light_client capability + dial confirmed LC peers first

### DIFF
--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/AndroidCLPeerCache.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/AndroidCLPeerCache.java
@@ -99,6 +99,30 @@ public final class AndroidCLPeerCache {
         if (lcDenied.add(multiaddr)) rewriteFile();
     }
 
+    /** Persist a whole Identify round's verdicts in a single rewrite. Avoids one disk
+     *  write per peer when dozens are identified in parallel at startup. A confirmation
+     *  overrides a prior denial; a denial never demotes a confirmed peer. */
+    public synchronized void markLightClientBatch(java.util.Collection<String> confirmed,
+                                                  java.util.Collection<String> denied) {
+        boolean changed = false;
+        if (confirmed != null) {
+            for (String ma : confirmed) {
+                if (ma == null || ma.isEmpty()) continue;
+                seen.add(ma);
+                changed |= lcConfirmed.add(ma);
+                changed |= lcDenied.remove(ma);
+            }
+        }
+        if (denied != null) {
+            for (String ma : denied) {
+                if (ma == null || ma.isEmpty() || lcConfirmed.contains(ma)) continue;
+                seen.add(ma);
+                changed |= lcDenied.add(ma);
+            }
+        }
+        if (changed) rewriteFile();
+    }
+
     /** Peers whose Identify confirmed light_client support (dial first). */
     public Set<String> lightClientConfirmed() {
         return new java.util.HashSet<>(lcConfirmed);
@@ -109,7 +133,7 @@ public final class AndroidCLPeerCache {
         return new java.util.HashSet<>(lcDenied);
     }
 
-    public void markFailure(String multiaddr) {
+    public synchronized void markFailure(String multiaddr) {
         if (multiaddr == null || multiaddr.isEmpty()) return;
         if (!seen.contains(multiaddr)) return;
         int count = failures.merge(multiaddr, 1, Integer::sum);

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/AndroidCLPeerCache.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/AndroidCLPeerCache.java
@@ -39,6 +39,10 @@ public final class AndroidCLPeerCache {
     private final Map<String, Integer> failures = new ConcurrentHashMap<>();
     /** multiaddr -> lowest sync-committee period it served during catch-up. */
     private final Map<String, Long> servedPeriod = new ConcurrentHashMap<>();
+    /** Peers whose Identify confirmed light_client protocol support — dial these first. */
+    private final Set<String> lcConfirmed = ConcurrentHashMap.newKeySet();
+    /** Peers proven NOT to serve light_client (no LC protocols / negotiation failure) — dial last. */
+    private final Set<String> lcDenied = ConcurrentHashMap.newKeySet();
 
     public AndroidCLPeerCache(Path cacheFile) {
         this.cacheFile = cacheFile;
@@ -75,6 +79,36 @@ public final class AndroidCLPeerCache {
         return new java.util.HashMap<>(servedPeriod);
     }
 
+    /** Record that a peer's Identify confirmed light_client protocol support. Persisted so
+     *  a restart dials known light-client servers first instead of re-Identifying the whole
+     *  fork-matched cache (most of which are full nodes without the light-client server). */
+    public synchronized void markLightClient(String multiaddr) {
+        if (multiaddr == null || multiaddr.isEmpty()) return;
+        seen.add(multiaddr);
+        boolean changed = lcConfirmed.add(multiaddr);
+        changed |= lcDenied.remove(multiaddr);
+        if (changed) rewriteFile();
+    }
+
+    /** Record that a peer is proven NOT to serve light_client (no LC protocols on Identify,
+     *  or a protocol-negotiation failure). Deprioritized on a restart, not evicted. A
+     *  later confirmation (markLightClient) overrides this. */
+    public synchronized void markNoLightClient(String multiaddr) {
+        if (multiaddr == null || multiaddr.isEmpty() || lcConfirmed.contains(multiaddr)) return;
+        seen.add(multiaddr);
+        if (lcDenied.add(multiaddr)) rewriteFile();
+    }
+
+    /** Peers whose Identify confirmed light_client support (dial first). */
+    public Set<String> lightClientConfirmed() {
+        return new java.util.HashSet<>(lcConfirmed);
+    }
+
+    /** Peers proven not to serve light_client (dial last / skip). */
+    public Set<String> lightClientDenied() {
+        return new java.util.HashSet<>(lcDenied);
+    }
+
     public void markFailure(String multiaddr) {
         if (multiaddr == null || multiaddr.isEmpty()) return;
         if (!seen.contains(multiaddr)) return;
@@ -83,6 +117,8 @@ public final class AndroidCLPeerCache {
             if (seen.remove(multiaddr)) {
                 failures.remove(multiaddr);
                 servedPeriod.remove(multiaddr);
+                lcConfirmed.remove(multiaddr);
+                lcDenied.remove(multiaddr);
                 rewriteFile();
                 LogBuffer.i(TAG, "evicted peer after " + count + " failures: " + multiaddr);
             }
@@ -98,20 +134,26 @@ public final class AndroidCLPeerCache {
             while ((line = r.readLine()) != null) {
                 line = line.strip();
                 if (line.isEmpty() || !line.startsWith("/")) continue;
-                String multiaddr = line;
-                int sep = line.indexOf(SEP);
-                if (sep >= 0) {
-                    multiaddr = line.substring(0, sep);
-                    try {
-                        servedPeriod.put(multiaddr, Long.parseLong(line.substring(sep + 1).strip()));
-                    } catch (NumberFormatException ignored) {}
+                // multiaddr [TAB token]...  token = <period int> | "lc" | "nolc"
+                String[] parts = line.split(String.valueOf(SEP));
+                String multiaddr = parts[0].strip();
+                if (multiaddr.isEmpty() || !multiaddr.startsWith("/")) continue;
+                for (int i = 1; i < parts.length; i++) {
+                    String tok = parts[i].strip();
+                    if (tok.equals("lc")) lcConfirmed.add(multiaddr);
+                    else if (tok.equals("nolc")) lcDenied.add(multiaddr);
+                    else {
+                        try { servedPeriod.put(multiaddr, Long.parseLong(tok)); }
+                        catch (NumberFormatException ignored) {}
+                    }
                 }
                 result.add(multiaddr);
                 seen.add(multiaddr);
             }
             if (!result.isEmpty()) {
                 LogBuffer.i(TAG, "loaded " + result.size() + " cached CL peer(s) ("
-                        + servedPeriod.size() + " proven catch-up servers)");
+                        + servedPeriod.size() + " catch-up servers, "
+                        + lcConfirmed.size() + " light-client, " + lcDenied.size() + " non-LC)");
             }
         } catch (IOException e) {
             LogBuffer.w(TAG, "read failed: " + e.getMessage());
@@ -123,6 +165,8 @@ public final class AndroidCLPeerCache {
         seen.clear();
         failures.clear();
         servedPeriod.clear();
+        lcConfirmed.clear();
+        lcDenied.clear();
         if (!cacheFile.toFile().delete() && cacheFile.toFile().exists()) {
             LogBuffer.w(TAG, "failed to delete cache file " + cacheFile);
         }
@@ -137,6 +181,8 @@ public final class AndroidCLPeerCache {
                 w.write(p);
                 Long sp = servedPeriod.get(p);
                 if (sp != null) { w.write(SEP); w.write(Long.toString(sp)); }
+                if (lcConfirmed.contains(p)) { w.write(SEP); w.write("lc"); }
+                else if (lcDenied.contains(p)) { w.write(SEP); w.write("nolc"); }
                 w.write('\n');
             }
         } catch (IOException e) {

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -2050,6 +2050,17 @@ public final class NodeService extends Service {
             // instead of fanning out across discovery peers that don't serve LC.
             localBlc.setProvenCatchUpServers(clCacheRef.servedPeriods());
             localBlc.setOnCatchUpServed(clCacheRef::recordServed);
+            // Seed light_client-capability verdicts from last session and persist new ones,
+            // so a restart dials confirmed light-client servers first and deprioritizes peers
+            // proven not to serve LC — instead of re-Identifying the whole fork-matched cache
+            // (most of which are full nodes without the light-client server). Cuts the
+            // SYNCING->SYNCED churn after a warm restart.
+            localBlc.setProvenLightClient(clCacheRef.lightClientConfirmed());
+            localBlc.setProvenNonLightClient(clCacheRef.lightClientDenied());
+            localBlc.setOnLightClientVerdict((ma, isLc) -> {
+                if (isLc) clCacheRef.markLightClient(ma);
+                else clCacheRef.markNoLightClient(ma);
+            });
             // Persist/resume verified sync-committee state across restarts (day-to-day
             // fast path): next launch resumes from here and only catches up the delta
             // instead of re-bootstrapping from the embedded checkpoint. In getCacheDir()

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -2057,10 +2057,7 @@ public final class NodeService extends Service {
             // SYNCING->SYNCED churn after a warm restart.
             localBlc.setProvenLightClient(clCacheRef.lightClientConfirmed());
             localBlc.setProvenNonLightClient(clCacheRef.lightClientDenied());
-            localBlc.setOnLightClientVerdict((ma, isLc) -> {
-                if (isLc) clCacheRef.markLightClient(ma);
-                else clCacheRef.markNoLightClient(ma);
-            });
+            localBlc.setOnLightClientVerdict(clCacheRef::markLightClientBatch);
             // Persist/resume verified sync-committee state across restarts (day-to-day
             // fast path): next launch resumes from here and only catches up the delta
             // instead of re-bootstrapping from the embedded checkpoint. In getCacheDir()

--- a/app/src/main/java/com/jaeckel/ethp2p/app/CLPeerCache.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/CLPeerCache.java
@@ -75,7 +75,7 @@ public final class CLPeerCache {
      * Record a failed interaction. After {@link #FAILURE_THRESHOLD} consecutive
      * failures, the peer is removed from the cache file.
      */
-    public void markFailure(String multiaddr) {
+    public synchronized void markFailure(String multiaddr) {
         if (multiaddr == null || multiaddr.isEmpty()) return;
         if (!seen.contains(multiaddr)) return; // not a cached peer; ignore
         int count = failures.merge(multiaddr, 1, Integer::sum);
@@ -129,6 +129,30 @@ public final class CLPeerCache {
         if (multiaddr == null || multiaddr.isEmpty() || lcConfirmed.contains(multiaddr)) return;
         seen.add(multiaddr);
         if (lcDenied.add(multiaddr)) rewriteFile();
+    }
+
+    /** Persist a whole Identify round's verdicts in a single rewrite. Avoids one disk
+     *  write per peer when dozens are identified in parallel at startup. A confirmation
+     *  overrides a prior denial; a denial never demotes a confirmed peer. */
+    public synchronized void markLightClientBatch(java.util.Collection<String> confirmed,
+                                                  java.util.Collection<String> denied) {
+        boolean changed = false;
+        if (confirmed != null) {
+            for (String ma : confirmed) {
+                if (ma == null || ma.isEmpty()) continue;
+                seen.add(ma);
+                changed |= lcConfirmed.add(ma);
+                changed |= lcDenied.remove(ma);
+            }
+        }
+        if (denied != null) {
+            for (String ma : denied) {
+                if (ma == null || ma.isEmpty() || lcConfirmed.contains(ma)) continue;
+                seen.add(ma);
+                changed |= lcDenied.add(ma);
+            }
+        }
+        if (changed) rewriteFile();
     }
 
     /** Peers whose Identify confirmed light_client support (dial first). */

--- a/app/src/main/java/com/jaeckel/ethp2p/app/CLPeerCache.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/CLPeerCache.java
@@ -42,6 +42,10 @@ public final class CLPeerCache {
     private final Map<String, Integer> failures = new ConcurrentHashMap<>();
     /** multiaddr -> lowest sync-committee period it served during catch-up. */
     private final Map<String, Long> servedPeriod = new ConcurrentHashMap<>();
+    /** Peers whose Identify confirmed light_client protocol support — dial these first. */
+    private final Set<String> lcConfirmed = ConcurrentHashMap.newKeySet();
+    /** Peers proven NOT to serve light_client (no LC protocols / negotiation failure) — dial last. */
+    private final Set<String> lcDenied = ConcurrentHashMap.newKeySet();
 
     public CLPeerCache(Path cacheFile) {
         this.cacheFile = cacheFile;
@@ -79,6 +83,8 @@ public final class CLPeerCache {
             if (seen.remove(multiaddr)) {
                 failures.remove(multiaddr);
                 servedPeriod.remove(multiaddr);
+                lcConfirmed.remove(multiaddr);
+                lcDenied.remove(multiaddr);
                 rewriteFile();
                 log.info("[cl-cache] Evicted peer after {} consecutive failures: {}", count, multiaddr);
             }
@@ -105,6 +111,36 @@ public final class CLPeerCache {
         return new java.util.HashMap<>(servedPeriod);
     }
 
+    /** Record that a peer's Identify confirmed light_client protocol support. Persisted so
+     *  a restart dials known light-client servers first instead of re-Identifying the whole
+     *  fork-matched cache (most of which are full nodes without the light-client server). */
+    public synchronized void markLightClient(String multiaddr) {
+        if (multiaddr == null || multiaddr.isEmpty()) return;
+        seen.add(multiaddr);
+        boolean changed = lcConfirmed.add(multiaddr);
+        changed |= lcDenied.remove(multiaddr);
+        if (changed) rewriteFile();
+    }
+
+    /** Record that a peer is proven NOT to serve light_client (no LC protocols on Identify,
+     *  or a protocol-negotiation failure). Deprioritized on a restart, not evicted. A
+     *  later confirmation (markLightClient) overrides this. */
+    public synchronized void markNoLightClient(String multiaddr) {
+        if (multiaddr == null || multiaddr.isEmpty() || lcConfirmed.contains(multiaddr)) return;
+        seen.add(multiaddr);
+        if (lcDenied.add(multiaddr)) rewriteFile();
+    }
+
+    /** Peers whose Identify confirmed light_client support (dial first). */
+    public Set<String> lightClientConfirmed() {
+        return new java.util.HashSet<>(lcConfirmed);
+    }
+
+    /** Peers proven not to serve light_client (dial last / skip). */
+    public Set<String> lightClientDenied() {
+        return new java.util.HashSet<>(lcDenied);
+    }
+
     /** Load all cached CL peer multiaddrs. Returns empty list if file doesn't exist. */
     public List<String> load() {
         List<String> result = new ArrayList<>();
@@ -114,20 +150,27 @@ public final class CLPeerCache {
             for (String line : Files.readAllLines(cacheFile)) {
                 line = line.strip();
                 if (line.isEmpty() || !line.startsWith("/")) continue;
-                String multiaddr = line;
-                int sep = line.indexOf(SEP);
-                if (sep >= 0) {
-                    multiaddr = line.substring(0, sep);
-                    try {
-                        servedPeriod.put(multiaddr, Long.parseLong(line.substring(sep + 1).strip()));
-                    } catch (NumberFormatException ignored) {}
+                // multiaddr [TAB token]...  token = <period int> | "lc" | "nolc"
+                String[] parts = line.split(String.valueOf(SEP));
+                String multiaddr = parts[0].strip();
+                if (multiaddr.isEmpty() || !multiaddr.startsWith("/")) continue;
+                for (int i = 1; i < parts.length; i++) {
+                    String tok = parts[i].strip();
+                    if (tok.equals("lc")) lcConfirmed.add(multiaddr);
+                    else if (tok.equals("nolc")) lcDenied.add(multiaddr);
+                    else {
+                        try { servedPeriod.put(multiaddr, Long.parseLong(tok)); }
+                        catch (NumberFormatException ignored) {}
+                    }
                 }
                 result.add(multiaddr);
                 seen.add(multiaddr);
             }
             if (!result.isEmpty()) {
-                log.info("[cl-cache] Loaded {} cached CL peer(s) from {} ({} proven catch-up servers)",
-                        result.size(), cacheFile, servedPeriod.size());
+                log.info("[cl-cache] Loaded {} cached CL peer(s) from {} ({} catch-up servers, "
+                                + "{} light-client, {} non-LC)",
+                        result.size(), cacheFile, servedPeriod.size(),
+                        lcConfirmed.size(), lcDenied.size());
             }
         } catch (Exception e) {
             log.warn("[cl-cache] Failed to read CL peer cache: {}", e.getMessage());
@@ -159,6 +202,8 @@ public final class CLPeerCache {
                 sb.append(p);
                 Long sp = servedPeriod.get(p);
                 if (sp != null) sb.append(SEP).append(sp);
+                if (lcConfirmed.contains(p)) sb.append(SEP).append("lc");
+                else if (lcDenied.contains(p)) sb.append(SEP).append("nolc");
                 sb.append('\n');
             }
             Files.writeString(cacheFile, sb.toString());

--- a/app/src/main/java/com/jaeckel/ethp2p/app/Main.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/Main.java
@@ -506,10 +506,7 @@ public final class Main {
         // not to serve LC — instead of re-Identifying the whole fork-matched cache.
         beaconLightClient.setProvenLightClient(clPeerCache.lightClientConfirmed());
         beaconLightClient.setProvenNonLightClient(clPeerCache.lightClientDenied());
-        beaconLightClient.setOnLightClientVerdict((ma, isLc) -> {
-            if (isLc) clPeerCache.markLightClient(ma);
-            else clPeerCache.markNoLightClient(ma);
-        });
+        beaconLightClient.setOnLightClientVerdict(clPeerCache::markLightClientBatch);
         // Persist/resume verified sync-committee state so restarts resume from the
         // last verified period and only catch up the delta (architecture-doc §
         // "recent sync committee data persisted locally"). purge-cache removes it.

--- a/app/src/main/java/com/jaeckel/ethp2p/app/Main.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/Main.java
@@ -501,6 +501,15 @@ public final class Main {
         // that actually retain the checkpoint period instead of discovery noise.
         beaconLightClient.setProvenCatchUpServers(clPeerCache.servedPeriods());
         beaconLightClient.setOnCatchUpServed(clPeerCache::recordServed);
+        // Seed light_client-capability verdicts from last session and persist new ones, so a
+        // restart dials confirmed light-client servers first and deprioritizes peers proven
+        // not to serve LC — instead of re-Identifying the whole fork-matched cache.
+        beaconLightClient.setProvenLightClient(clPeerCache.lightClientConfirmed());
+        beaconLightClient.setProvenNonLightClient(clPeerCache.lightClientDenied());
+        beaconLightClient.setOnLightClientVerdict((ma, isLc) -> {
+            if (isLc) clPeerCache.markLightClient(ma);
+            else clPeerCache.markNoLightClient(ma);
+        });
         // Persist/resume verified sync-committee state so restarts resume from the
         // last verified period and only catch up the delta (architecture-doc §
         // "recent sync committee data persisted locally"). purge-cache removes it.

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
@@ -114,8 +114,9 @@ public class BeaconLightClient implements AutoCloseable {
     // servers instead of re-Identifying the whole fork-matched set (most of which are
     // full nodes without the light-client server).
     private final Set<String> provenLightClient = java.util.concurrent.ConcurrentHashMap.newKeySet();
-    /** Notified (multiaddr, supportsLightClient) when Identify resolves a peer's LC support. */
-    private volatile java.util.function.BiConsumer<String, Boolean> onLightClientVerdict;
+    /** Notified (confirmedLcMultiaddrs, deniedLcMultiaddrs) once per Identify round, batched so
+     *  the host persists the whole round in a single rewrite rather than once per peer. */
+    private volatile java.util.function.BiConsumer<java.util.Collection<String>, java.util.Collection<String>> onLightClientVerdict;
 
     /** Seed peers confirmed to support light_client (dial first) from a cache. */
     public void setProvenLightClient(java.util.Collection<String> seed) {
@@ -127,8 +128,10 @@ public class BeaconLightClient implements AutoCloseable {
         if (seed != null) peersNoLcUpdates.addAll(seed);
     }
 
-    /** Set the callback persisting a peer's light_client support verdict from Identify. */
-    public void setOnLightClientVerdict(java.util.function.BiConsumer<String, Boolean> cb) {
+    /** Set the callback persisting each Identify round's light_client verdicts
+     *  (confirmed multiaddrs, denied multiaddrs) — invoked once per round, batched. */
+    public void setOnLightClientVerdict(
+            java.util.function.BiConsumer<java.util.Collection<String>, java.util.Collection<String>> cb) {
         this.onLightClientVerdict = cb;
     }
 
@@ -562,14 +565,21 @@ public class BeaconLightClient implements AutoCloseable {
         for (BeaconP2PService.PeerInfo pi : connected) {
             lcByPeerId.put(pi.peerId(), pi.supportsLightClient());
         }
-        java.util.function.BiConsumer<String, Boolean> verdictCb = onLightClientVerdict;
+        List<String> newConfirmed = new ArrayList<>();
+        List<String> newDenied = new ArrayList<>();
         for (String ma : copyPeers(false)) {
             String pid = peerIdOf(ma);
             Boolean lc = pid != null ? lcByPeerId.get(pid) : null;
             if (lc == null) continue; // not Identified this round
-            if (lc) { provenLightClient.add(ma); peersNoLcUpdates.remove(ma); }
-            else { peersNoLcUpdates.add(ma); }
-            if (verdictCb != null) verdictCb.accept(ma, lc);
+            if (lc) { provenLightClient.add(ma); peersNoLcUpdates.remove(ma); newConfirmed.add(ma); }
+            else { peersNoLcUpdates.add(ma); provenLightClient.remove(ma); newDenied.add(ma); }
+        }
+        // Persist the whole round's verdicts in one shot — a per-peer callback would
+        // trigger a disk rewrite for each of dozens of peers identified in parallel.
+        java.util.function.BiConsumer<java.util.Collection<String>, java.util.Collection<String>> verdictCb =
+                onLightClientVerdict;
+        if (verdictCb != null && (!newConfirmed.isEmpty() || !newDenied.isEmpty())) {
+            verdictCb.accept(newConfirmed, newDenied);
         }
     }
 
@@ -1788,10 +1798,15 @@ public class BeaconLightClient implements AutoCloseable {
         return out;
     }
 
-    /** The peerId tail of a {@code .../p2p/<peerId>} multiaddr, or null. */
+    /** The peerId in a {@code .../p2p/<peerId>[/...]} multiaddr, or null. Strips any
+     *  trailing components (e.g. circuit-relay) after the peerId, like
+     *  {@code BeaconP2PService.extractPeerId}. */
     private static String peerIdOf(String multiaddr) {
         int i = multiaddr.lastIndexOf("/p2p/");
-        return i >= 0 ? multiaddr.substring(i + 5) : null;
+        if (i < 0) return null;
+        String pid = multiaddr.substring(i + 5);
+        int slash = pid.indexOf('/');
+        return slash >= 0 ? pid.substring(0, slash) : pid;
     }
 
     /**

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
@@ -109,6 +109,29 @@ public class BeaconLightClient implements AutoCloseable {
         this.onCatchUpServed = cb;
     }
 
+    // Peers whose Identify confirmed light_client protocol support — dialed first by
+    // copyPeers(). Seeded from the CL cache so a restart prioritizes known light-client
+    // servers instead of re-Identifying the whole fork-matched set (most of which are
+    // full nodes without the light-client server).
+    private final Set<String> provenLightClient = java.util.concurrent.ConcurrentHashMap.newKeySet();
+    /** Notified (multiaddr, supportsLightClient) when Identify resolves a peer's LC support. */
+    private volatile java.util.function.BiConsumer<String, Boolean> onLightClientVerdict;
+
+    /** Seed peers confirmed to support light_client (dial first) from a cache. */
+    public void setProvenLightClient(java.util.Collection<String> seed) {
+        if (seed != null) provenLightClient.addAll(seed);
+    }
+
+    /** Seed peers proven NOT to serve light_client (dial last) from a cache. */
+    public void setProvenNonLightClient(java.util.Collection<String> seed) {
+        if (seed != null) peersNoLcUpdates.addAll(seed);
+    }
+
+    /** Set the callback persisting a peer's light_client support verdict from Identify. */
+    public void setOnLightClientVerdict(java.util.function.BiConsumer<String, Boolean> cb) {
+        this.onLightClientVerdict = cb;
+    }
+
     // Persisted verified-store snapshot (day-to-day resume). Null disables persistence.
     private volatile java.nio.file.Path snapshotFile;
     // Period last written, to avoid rewriting the (~50KB) snapshot when nothing advanced.
@@ -530,6 +553,23 @@ public class BeaconLightClient implements AutoCloseable {
             if (pi.supportsLightClient()) {
                 log.info("[beacon]   LC peer: {} agent={}", pi.peerId(), pi.agentVersion());
             }
+        }
+
+        // Record each peer's light_client verdict (keyed by multiaddr) for in-session
+        // prioritization + cache persistence, so a restart dials known light-client
+        // servers first. Identify is per-peerId; map it back to our multiaddrs.
+        java.util.Map<String, Boolean> lcByPeerId = new java.util.HashMap<>();
+        for (BeaconP2PService.PeerInfo pi : connected) {
+            lcByPeerId.put(pi.peerId(), pi.supportsLightClient());
+        }
+        java.util.function.BiConsumer<String, Boolean> verdictCb = onLightClientVerdict;
+        for (String ma : copyPeers(false)) {
+            String pid = peerIdOf(ma);
+            Boolean lc = pid != null ? lcByPeerId.get(pid) : null;
+            if (lc == null) continue; // not Identified this round
+            if (lc) { provenLightClient.add(ma); peersNoLcUpdates.remove(ma); }
+            else { peersNoLcUpdates.add(ma); }
+            if (verdictCb != null) verdictCb.accept(ma, lc);
         }
     }
 
@@ -1715,7 +1755,9 @@ public class BeaconLightClient implements AutoCloseable {
     private List<String> copyPeers(boolean applyAgentFilter) {
         synchronized (clPeerMultiaddrs) {
             List<String> all = List.copyOf(clPeerMultiaddrs);
-            if (!applyAgentFilter || EXCLUDED_AGENT_SUBSTRING == null) return all;
+            if (!applyAgentFilter || EXCLUDED_AGENT_SUBSTRING == null) {
+                return orderByLightClient(all);
+            }
             // Drop peers whose Identify agent matches the exclusion substring.
             // Useful for isolating debugging: pretending Lodestar doesn't exist
             // forces us to actually get Lighthouse/Teku/Nimbus/Prysm working.
@@ -1727,8 +1769,29 @@ public class BeaconLightClient implements AutoCloseable {
                 }
                 filtered.add(p);
             }
-            return filtered;
+            return orderByLightClient(filtered);
         }
+    }
+
+    /** Confirmed light_client servers first, proven non-LC peers last, rest in between —
+     *  so finality polls / bootstrap hit peers that actually serve light-client first. */
+    private List<String> orderByLightClient(List<String> peers) {
+        if (provenLightClient.isEmpty() && peersNoLcUpdates.isEmpty()) return peers;
+        List<String> first = new ArrayList<>(), mid = new ArrayList<>(), last = new ArrayList<>();
+        for (String p : peers) {
+            if (provenLightClient.contains(p)) first.add(p);
+            else if (peersNoLcUpdates.contains(p)) last.add(p);
+            else mid.add(p);
+        }
+        List<String> out = new ArrayList<>(peers.size());
+        out.addAll(first); out.addAll(mid); out.addAll(last);
+        return out;
+    }
+
+    /** The peerId tail of a {@code .../p2p/<peerId>} multiaddr, or null. */
+    private static String peerIdOf(String multiaddr) {
+        int i = multiaddr.lastIndexOf("/p2p/");
+        return i >= 0 ? multiaddr.substring(i + 5) : null;
     }
 
     /**


### PR DESCRIPTION
## Why

The CL peer cache was gated **only** on the eth2 fork digest in the discovered ENR. That digest says nothing about whether the peer actually runs the `light_client_*` req/resp server — light-client support isn't advertised in the ENR at all, it's only known after a libp2p **Identify**.

So on a warm restart we re-dialed the whole fork-matched cache (mostly full nodes without the LC server) and churned through Noise + Identify before stumbling onto peers that serve `light_client_finality_update`. That's a meaningful slice of the **>1 min SYNCING → SYNCED** the user observed on an otherwise-recent sync state — and it's why "there are peers in the cache that don't serve light_client_finality_update."

## What

Persist the Identify verdict per peer and use it to order dials:

- **`AndroidCLPeerCache` / `CLPeerCache`** — add `lcConfirmed` / `lcDenied` sets, `markLightClient` / `markNoLightClient`, and `lightClientConfirmed()` / `lightClientDenied()` accessors. The on-disk format gains `lc` / `nolc` tokens alongside the existing served-period int (`multiaddr[TAB token]...`); older cache files load unchanged. Evict/clear wipe the new sets too.
- **`BeaconLightClient`** — `setProvenLightClient` / `setProvenNonLightClient` seeds + a `setOnLightClientVerdict` callback. After Identify completes, record each connected peer's LC verdict (mapped back to its multiaddr by the `/p2p/<peerId>` tail) and persist it. `copyPeers()` now orders **confirmed-LC first, proven non-LC last**, so finality polls and bootstrap hit LC servers first.
- **`NodeService` / `Main`** — seed the BLC from the cache on boot and wire the verdict callback back to the cache, on both Android and the daemon (parity, so the integration test path benefits too).

Non-LC peers are **deprioritized, not evicted** — a later confirmation overrides the `nolc` mark, and they're still available as a last resort.

## Test

- `./gradlew :consensus:test` green
- `./gradlew :android-app:lintDebug` green
- `:app` / `:android-app` compile clean

Device validation on the Pixel 7 (warm-restart SYNCING → SYNCED timing) to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)