### PR TITLE
land PR #38 to main (was merged into its stacked base)

### DIFF
--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -1722,6 +1722,21 @@ public final class NodeService extends Service {
             // get-account gets by retrying across peers. The first peer that passes
             // both is pinned for the whole resolution (one consistent root).
             final long minHead = conn.getNetwork().minSensibleHeadBlock();
+            // Live staleness floor: a peer whose head is BEHIND the beacon-finalized
+            // exec block can never anchor (anchorHeadToBeacon verifies the chain
+            // finalized→head, and finality has already passed it) — yet such a peer
+            // happily snap-serves its frozen root and can win the probe race below,
+            // forcing every build into the finalized fallback while fresh-headed
+            // peers sit connected. Observed on-device: two peers frozen at the same
+            // head for 5+ min starved number-pinned reads.
+            long finalizedFloor = -1;
+            com.jaeckel.ethp2p.consensus.BeaconLightClient blcFloor = beaconLightClient;
+            if (blcFloor != null) {
+                com.jaeckel.ethp2p.consensus.types.LightClientHeader finHdr =
+                        blcFloor.getStore().getFinalizedHeader();
+                if (finHdr != null) finalizedFloor = finHdr.execution().blockNumber();
+            }
+            final long headFloor = Math.max(minHead, finalizedFloor);
             // Probe every ready snap peer CONCURRENTLY — fetch its fresh head, then
             // probe that it snap-serves that head root — and award the FIRST to
             // qualify. The old serial walk paid each unresponsive peer's timeout in
@@ -1734,9 +1749,10 @@ public final class NodeService extends Service {
                         peer.requestFreshHeadHeaderAsync();
                 if (headFut == null) continue;
                 probes.add(headFut.thenCompose(fresh -> {
-                    if (fresh.number < minHead) {
+                    if (fresh.number < headFloor) {
                         throw new java.util.concurrent.CompletionException(
-                                new IllegalStateException("stale head #" + fresh.number));
+                                new IllegalStateException("stale head #" + fresh.number
+                                        + " (< floor #" + headFloor + ")"));
                     }
                     // servesRoot, but async: the peer must return a non-empty proof
                     // for the probe account at its head root.

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -740,9 +740,17 @@ public final class NodeService extends Service {
      *  it bridges transient rebuild gaps (head just advanced, peers' flat state not
      *  yet caught up) instead of proxying. The warmer keeps it fresh (~5-15s). */
     private static final long RPC_HEAD_MAX_STALE_MS = 30_000;
-    /** When there's no usable head at all (cold start / long outage), wait up to
-     *  this long for one to be built before falling back to the proxy. */
+    /** When there's no usable head at all (cold start / long outage) and no build is
+     *  in flight, wait only this long before giving up — a node with no snap peer can't
+     *  build a head, so blocking the caller longer just delays the inevitable error. */
     private static final long RPC_HEAD_WAIT_MS = 5_000;
+    /** When an anchored-head build IS already in flight (warmer or a prior read), ride
+     *  it up to this longer cap instead of erroring at {@link #RPC_HEAD_WAIT_MS}. A cold
+     *  anchored build on a phone (fetch+verify ~30 headers from beacon-finalized to head,
+     *  then the first snap account fetch) routinely takes 10-30s; giving up at 5s makes a
+     *  wallet's first read error even though the verified result is seconds away. Kept
+     *  under typical wallet RPC timeouts so the call returns verified-but-slow, not failed. */
+    private static final long RPC_HEAD_BUILD_WAIT_MS = 25_000;
     /** How far a number-pinned read's block may sit from the verified head and still be
      *  served from the head's state. Wallets pin reads to the just-fetched latest block,
      *  which can be a few blocks off our anchored (snap-servable) head; the head state is
@@ -829,13 +837,18 @@ public final class NodeService extends Service {
                 && android.os.SystemClock.elapsedRealtime() - good.builtAtMs() < RPC_HEAD_MAX_STALE_MS) {
             return good.head();
         }
-        // No usable head (cold start / sustained outage): wait briefly for a build
-        // before giving up — most gaps are short (a peer (re)connecting). The wait
-        // is strictly bounded: each build attempt is capped at the remaining time.
-        long deadline = android.os.SystemClock.elapsedRealtime() + RPC_HEAD_WAIT_MS;
+        // No usable head (cold start / sustained outage): wait for a build before
+        // giving up. The deadline is adaptive — recomputed each iteration: while an
+        // anchored-head build is actually in flight (warmer or a prior read), ride it
+        // up to RPC_HEAD_BUILD_WAIT_MS so a read arriving mid-build returns verified-
+        // but-slow; with no build possible (no snap peer) it falls back at the short
+        // RPC_HEAD_WAIT_MS. Each build attempt is capped at the remaining time.
+        long start = android.os.SystemClock.elapsedRealtime();
         Exception last = null;
-        do {
-            long remainingMs = deadline - android.os.SystemClock.elapsedRealtime();
+        while (true) {
+            long now = android.os.SystemClock.elapsedRealtime();
+            long deadline = start + (headBuildInFlight() ? RPC_HEAD_BUILD_WAIT_MS : RPC_HEAD_WAIT_MS);
+            long remainingMs = deadline - now;
             if (remainingMs <= 0) break;
             try {
                 return verifiedHeadCallContext(remainingMs, TimeUnit.MILLISECONDS);
@@ -850,10 +863,19 @@ public final class NodeService extends Service {
                     break;
                 }
             }
-        } while (android.os.SystemClock.elapsedRealtime() < deadline);
-        LogBuffer.i(TAG, "[rpc] no verified head after " + RPC_HEAD_WAIT_MS + "ms -> proxy: "
+        }
+        LogBuffer.i(TAG, "[rpc] no verified head after "
+                + (android.os.SystemClock.elapsedRealtime() - start) + "ms -> proxy: "
                 + (last != null ? unwrap(last) : "timeout"));
         return null;
+    }
+
+    /** True while an anchored-head build is in flight (warmer or a prior read), so a
+     *  waiting read can ride it instead of erroring early. */
+    private boolean headBuildInFlight() {
+        CompletableFuture<EnsCall> f;
+        synchronized (rpcCallCtxLock) { f = rpcCallCtx; }
+        return f != null && !f.isDone();
     }
 
     /** eth_call over the shared anchored head. Returns raw ABI bytes, or null to proxy. */

--- a/app/src/main/java/com/jaeckel/ethp2p/app/CommandHandler.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/CommandHandler.java
@@ -1190,6 +1190,17 @@ public class CommandHandler {
         // before pinning it. The first peer that passes both is pinned for the
         // whole resolution (all reads anchor to one consistent root).
         long minSensibleHead = connector.getNetwork().minSensibleHeadBlock();
+        // Live staleness floor: a peer whose head is behind the beacon-finalized exec
+        // block can never anchor to the beacon chain (finality already passed it), yet
+        // it still snap-serves its frozen root and would be pinned here — forcing the
+        // finalized fallback while fresh-headed peers sit connected.
+        if (beaconLightClient != null) {
+            com.jaeckel.ethp2p.consensus.types.LightClientHeader finHdr =
+                    beaconLightClient.getStore().getFinalizedHeader();
+            if (finHdr != null) {
+                minSensibleHead = Math.max(minSensibleHead, finHdr.execution().blockNumber());
+            }
+        }
         String lastError = null;
         for (com.jaeckel.ethp2p.networking.eth.EthHandler peer : snapPeers) {
             if (!peer.isReady() || peer.isSnapServingFailed()) {
@@ -1199,7 +1210,8 @@ public class CommandHandler {
                 BlockHeader head = peer.requestFreshHeadHeaderAsync().get(6, TimeUnit.SECONDS);
                 if (head.number < minSensibleHead) {
                     lastError = "peer " + peer.getRemoteAddress()
-                        + " returned stale head #" + head.number;
+                        + " returned stale head #" + head.number
+                        + " (< floor #" + minSensibleHead + ")";
                     continue;
                 }
                 if (!servesRoot(peer, head.stateRoot)) {

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
@@ -13,6 +13,7 @@ import com.jaeckel.ethp2p.consensus.types.LightClientFinalityUpdate;
 import com.jaeckel.ethp2p.consensus.types.LightClientHeader;
 import com.jaeckel.ethp2p.consensus.types.LightClientUpdate;
 import com.jaeckel.ethp2p.consensus.types.StatusMessage;
+import com.jaeckel.ethp2p.consensus.types.SyncCommittee;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -174,6 +175,7 @@ public class BeaconLightClient implements AutoCloseable {
             // (eviction polls the front; export/findStateRoot treat the tail as freshest).
             restoreStateRootsSidecar(file);
             updateSyncState();
+            warmBlsPubkeyCache();
             log.info("[beacon] Resumed from persisted snapshot at period {} (slot {}) — "
                             + "catching up only periods since",
                     snap.currentSyncCommitteePeriod(), snap.finalizedSlot());
@@ -284,6 +286,33 @@ public class BeaconLightClient implements AutoCloseable {
         } catch (Exception e) {
             log.debug("[beacon] roots sidecar restore failed: {}", e.getMessage());
         }
+    }
+
+    /**
+     * Pre-decompress the current (and next, if known) sync committee's pubkeys into
+     * BlsVerifier's cache on a background thread, so the first finality-update verify
+     * after a resume pays only the pairing instead of ~512 G1 square roots (~35-55s
+     * on Android/ART). Safe to call repeatedly — already-cached keys are no-ops.
+     */
+    private void warmBlsPubkeyCache() {
+        Thread t = new Thread(() -> {
+            try {
+                java.util.List<byte[]> keys = new java.util.ArrayList<>();
+                SyncCommittee current = store.getCurrentSyncCommittee();
+                if (current != null) keys.addAll(java.util.Arrays.asList(current.pubkeys()));
+                SyncCommittee next = store.getNextSyncCommittee();
+                if (next != null) keys.addAll(java.util.Arrays.asList(next.pubkeys()));
+                if (keys.isEmpty()) return;
+                long t0 = System.nanoTime();
+                com.jaeckel.ethp2p.consensus.bls.BlsVerifier.warmPubkeyCache(keys);
+                log.info("[beacon] BLS pubkey cache warmed: {} keys in {}ms",
+                        keys.size(), (System.nanoTime() - t0) / 1_000_000);
+            } catch (Exception e) {
+                log.debug("[beacon] BLS cache warm failed: {}", e.getMessage());
+            }
+        }, "bls-cache-warmer");
+        t.setDaemon(true);
+        t.start();
     }
 
     /** Remember a peer that served catch-up from {@code period} (lowest wins) and persist it. */
@@ -486,16 +515,20 @@ public class BeaconLightClient implements AutoCloseable {
         // Phase 0: discover peers from beacon API before attempting connections
         discoverPeersFromBeaconApi();
 
-        // Pre-connect to peers and query Identify to learn protocol support.
-        // This lets bootstrap() prioritize peers advertising light_client protocols.
-        preConnectAndIdentify();
-
         // Phase 1: resume from a persisted snapshot (day-to-day fast path) — if we
         // have verified state newer than the embedded checkpoint from a prior run,
         // pick up there and only catch up the periods since. Falls through to a
         // fresh bootstrap from the embedded checkpoint when there's no usable
         // snapshot (first run, wiped cache, or a corrupt/foreign file).
+        // Runs BEFORE the network pre-connect: it's disk-only, and it kicks off the
+        // background BLS pubkey-cache warm so decompression overlaps the Identify
+        // round instead of stalling the first finality verify after it.
         boolean resumed = tryResumeFromSnapshot();
+
+        // Pre-connect to peers and query Identify to learn protocol support.
+        // This lets bootstrap() prioritize peers advertising light_client protocols.
+        preConnectAndIdentify();
+
         if (!resumed) {
             // Bootstrap with BLS verification from the embedded checkpoint.
             bootstrap();
@@ -600,9 +633,22 @@ public class BeaconLightClient implements AutoCloseable {
      * Waits up to 8 seconds for connections + Identify to complete.
      * This ensures bootstrap() can prioritize light-client-capable peers.
      */
+    /** Boot Identify fan-out cap. The CL cache can hold hundreds of fork-matched peers;
+     *  dialing them all at once cost ~60s of connection churn before the first poll
+     *  could start. copyPeers() orders confirmed-LC peers first, so a bounded slice
+     *  still reaches the peers that matter, and verdict learning for the rest
+     *  continues organically as later polls touch them. */
+    private static final int PRECONNECT_MAX_PEERS = 64;
+    /** Stop waiting on the Identify round once this many LC-capable peers are
+     *  connected — enough to start polling finality updates immediately. */
+    private static final int PRECONNECT_LC_EARLY_EXIT = 3;
+
     private void preConnectAndIdentify() {
         List<String> peers = copyPeers();
         if (peers.isEmpty()) return;
+        if (peers.size() > PRECONNECT_MAX_PEERS) {
+            peers = peers.subList(0, PRECONNECT_MAX_PEERS);
+        }
 
         log.info("[beacon] Pre-connecting to {} peer(s) for Identify...", peers.size());
         List<CompletableFuture<Void>> futures = new ArrayList<>();
@@ -616,11 +662,27 @@ public class BeaconLightClient implements AutoCloseable {
             futures.add(p2pService.queryIdentify(peer).handle((v, ex) -> null));
         }
 
-        try {
-            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
-                    .get(10, TimeUnit.SECONDS);
-        } catch (Exception e) {
-            // Some peers may have timed out — that's fine
+        // Wait up to 10s, but bail as soon as a few LC-capable peers are connected —
+        // that's all the first finality poll needs; stragglers keep Identifying in
+        // the background and get picked up by later polls.
+        CompletableFuture<Void> all =
+                CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+        long identifyDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+        while (System.nanoTime() < identifyDeadline && !all.isDone()) {
+            long lcSoFar = p2pService.getConnectedPeers().stream()
+                    .filter(BeaconP2PService.PeerInfo::supportsLightClient).count();
+            if (lcSoFar >= PRECONNECT_LC_EARLY_EXIT) {
+                log.info("[beacon] {} LC peer(s) identified — starting without waiting for the rest",
+                        lcSoFar);
+                break;
+            }
+            try {
+                all.get(500, TimeUnit.MILLISECONDS);
+            } catch (java.util.concurrent.TimeoutException te) {
+                // keep polling
+            } catch (Exception e) {
+                break; // interrupted or all-failed — proceed with what we have
+            }
         }
 
         List<BeaconP2PService.PeerInfo> connected = p2pService.getConnectedPeers();

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
@@ -170,6 +170,7 @@ public class BeaconLightClient implements AutoCloseable {
             store.restore(snap);
             lastPersistedPeriod = snap.currentSyncCommitteePeriod();
             updateSyncState();
+            restoreStateRootsSidecar(file);
             log.info("[beacon] Resumed from persisted snapshot at period {} (slot {}) — "
                             + "catching up only periods since",
                     snap.currentSyncCommitteePeriod(), snap.finalizedSlot());
@@ -188,6 +189,10 @@ public class BeaconLightClient implements AutoCloseable {
     private void persistSnapshot() {
         java.nio.file.Path file = snapshotFile;
         if (file == null) return;
+        // The known-state-roots window advances on every finality poll, so persist it
+        // each call — independent of the period-change gate below that throttles the
+        // (large) committee snapshot to ~once per period.
+        persistStateRootsSidecar(file);
         LightClientStore.Snapshot snap = store.snapshot();
         if (snap == null) return;
         if (snap.currentSyncCommitteePeriod() == lastPersistedPeriod) return;
@@ -208,6 +213,73 @@ public class BeaconLightClient implements AutoCloseable {
                     snap.currentSyncCommitteePeriod(), data.length);
         } catch (Exception e) {
             log.debug("[beacon] Snapshot persist failed: {}", e.getMessage());
+        }
+    }
+
+    // Sidecar persistence for BeaconSyncState's known-state-roots window. Kept beside the
+    // committee snapshot ("<snapshot>.roots") rather than folded into the SSZ store
+    // snapshot, so the window can be rewritten cheaply every finality poll without
+    // touching the committee format. Compact format: version(1) + count(4) then per
+    // entry slot(8) + root(32) + verified(1). Only the freshest entries are kept.
+    private static final String ROOTS_SIDECAR_SUFFIX = ".roots";
+    private static final int ROOTS_SIDECAR_VERSION = 1;
+    private static final int ROOTS_SIDECAR_MAX = 64;
+
+    private java.nio.file.Path rootsSidecarPath(java.nio.file.Path snapshot) {
+        return snapshot.resolveSibling(snapshot.getFileName() + ROOTS_SIDECAR_SUFFIX);
+    }
+
+    private void persistStateRootsSidecar(java.nio.file.Path snapshot) {
+        try {
+            java.util.List<BeaconSyncState.SlottedStateRoot> all = syncState.exportKnownStateRoots();
+            if (all.isEmpty()) return;
+            // Keep only the freshest ROOTS_SIDECAR_MAX (export is oldest→newest).
+            int from = Math.max(0, all.size() - ROOTS_SIDECAR_MAX);
+            java.util.List<BeaconSyncState.SlottedStateRoot> keep = all.subList(from, all.size());
+            java.nio.ByteBuffer buf = java.nio.ByteBuffer.allocate(1 + 4 + keep.size() * 41);
+            buf.put((byte) ROOTS_SIDECAR_VERSION);
+            buf.putInt(keep.size());
+            for (BeaconSyncState.SlottedStateRoot r : keep) {
+                buf.putLong(r.slot());
+                buf.put(r.stateRoot());                 // exactly 32 bytes (validated on record)
+                buf.put((byte) (r.blsVerified() ? 1 : 0));
+            }
+            java.nio.file.Path file = rootsSidecarPath(snapshot);
+            java.nio.file.Path tmp = file.resolveSibling(file.getFileName() + ".tmp");
+            java.nio.file.Files.write(tmp, buf.array());
+            try {
+                java.nio.file.Files.move(tmp, file,
+                        java.nio.file.StandardCopyOption.REPLACE_EXISTING,
+                        java.nio.file.StandardCopyOption.ATOMIC_MOVE);
+            } catch (java.nio.file.AtomicMoveNotSupportedException amnse) {
+                java.nio.file.Files.move(tmp, file, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+            }
+        } catch (Exception e) {
+            log.debug("[beacon] roots sidecar persist failed: {}", e.getMessage());
+        }
+    }
+
+    private void restoreStateRootsSidecar(java.nio.file.Path snapshot) {
+        try {
+            java.nio.file.Path file = rootsSidecarPath(snapshot);
+            if (!java.nio.file.Files.exists(file)) return;
+            java.nio.ByteBuffer buf = java.nio.ByteBuffer.wrap(java.nio.file.Files.readAllBytes(file));
+            if (buf.remaining() < 5 || buf.get() != ROOTS_SIDECAR_VERSION) return;
+            int count = buf.getInt();
+            if (count < 0 || count > ROOTS_SIDECAR_MAX || buf.remaining() < count * 41) return;
+            java.util.List<BeaconSyncState.SlottedStateRoot> roots = new java.util.ArrayList<>(count);
+            for (int i = 0; i < count; i++) {
+                long slot = buf.getLong();
+                byte[] root = new byte[32];
+                buf.get(root);
+                boolean verified = buf.get() != 0;
+                roots.add(new BeaconSyncState.SlottedStateRoot(slot, root, verified));
+            }
+            syncState.importKnownStateRoots(roots);
+            log.info("[beacon] Restored {} known state root(s) from sidecar — SYNCED needs "
+                    + "one fresh finality poll, not {}", roots.size(), BeaconSyncState.FILL_THRESHOLD);
+        } catch (Exception e) {
+            log.debug("[beacon] roots sidecar restore failed: {}", e.getMessage());
         }
     }
 

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
@@ -229,6 +229,10 @@ public class BeaconLightClient implements AutoCloseable {
     private static final String ROOTS_SIDECAR_SUFFIX = ".roots";
     private static final int ROOTS_SIDECAR_VERSION = 1;
     private static final int ROOTS_SIDECAR_MAX = 64;
+    /** (newestSlot, count) of the last sidecar write — skip the flash write when the
+     *  window hasn't advanced (the 12s poll loop calls persistSnapshot every cycle). */
+    private volatile long rootsSidecarLastNewestSlot = -1;
+    private volatile int rootsSidecarLastCount = -1;
 
     private java.nio.file.Path rootsSidecarPath(java.nio.file.Path snapshot) {
         return snapshot.resolveSibling(snapshot.getFileName() + ROOTS_SIDECAR_SUFFIX);
@@ -241,6 +245,10 @@ public class BeaconLightClient implements AutoCloseable {
             // Keep only the freshest ROOTS_SIDECAR_MAX (export is oldest→newest).
             int from = Math.max(0, all.size() - ROOTS_SIDECAR_MAX);
             java.util.List<BeaconSyncState.SlottedStateRoot> keep = all.subList(from, all.size());
+            long newestSlot = keep.get(keep.size() - 1).slot();
+            if (newestSlot == rootsSidecarLastNewestSlot && keep.size() == rootsSidecarLastCount) {
+                return; // window unchanged since the last write
+            }
             java.nio.ByteBuffer buf = java.nio.ByteBuffer.allocate(1 + 4 + keep.size() * 41);
             buf.put((byte) ROOTS_SIDECAR_VERSION);
             buf.putInt(keep.size());
@@ -259,6 +267,8 @@ public class BeaconLightClient implements AutoCloseable {
             } catch (java.nio.file.AtomicMoveNotSupportedException amnse) {
                 java.nio.file.Files.move(tmp, file, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
             }
+            rootsSidecarLastNewestSlot = newestSlot;
+            rootsSidecarLastCount = keep.size();
         } catch (Exception e) {
             log.debug("[beacon] roots sidecar persist failed: {}", e.getMessage());
         }

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
@@ -169,8 +169,11 @@ public class BeaconLightClient implements AutoCloseable {
             }
             store.restore(snap);
             lastPersistedPeriod = snap.currentSyncCommitteePeriod();
-            updateSyncState();
+            // Sidecar first: its roots predate the snapshot's finalized/optimistic roots
+            // that updateSyncState() records, and the window deque must stay oldest→newest
+            // (eviction polls the front; export/findStateRoot treat the tail as freshest).
             restoreStateRootsSidecar(file);
+            updateSyncState();
             log.info("[beacon] Resumed from persisted snapshot at period {} (slot {}) — "
                             + "catching up only periods since",
                     snap.currentSyncCommitteePeriod(), snap.finalizedSlot());

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
@@ -229,10 +229,12 @@ public class BeaconLightClient implements AutoCloseable {
     private static final String ROOTS_SIDECAR_SUFFIX = ".roots";
     private static final int ROOTS_SIDECAR_VERSION = 1;
     private static final int ROOTS_SIDECAR_MAX = 64;
-    /** (newestSlot, count) of the last sidecar write — skip the flash write when the
-     *  window hasn't advanced (the 12s poll loop calls persistSnapshot every cycle). */
-    private volatile long rootsSidecarLastNewestSlot = -1;
-    private volatile int rootsSidecarLastCount = -1;
+    /** (newestSlot, count) of the last sidecar write, one immutable unit behind a
+     *  single volatile so concurrent persist calls can't pair a new slot with an old
+     *  count (torn read). Used to skip the flash write when the window hasn't
+     *  advanced — the 12s poll loop calls persistSnapshot every cycle. */
+    private record SidecarMark(long newestSlot, int count) {}
+    private volatile SidecarMark rootsSidecarLastWritten;
 
     private java.nio.file.Path rootsSidecarPath(java.nio.file.Path snapshot) {
         return snapshot.resolveSibling(snapshot.getFileName() + ROOTS_SIDECAR_SUFFIX);
@@ -246,7 +248,8 @@ public class BeaconLightClient implements AutoCloseable {
             int from = Math.max(0, all.size() - ROOTS_SIDECAR_MAX);
             java.util.List<BeaconSyncState.SlottedStateRoot> keep = all.subList(from, all.size());
             long newestSlot = keep.get(keep.size() - 1).slot();
-            if (newestSlot == rootsSidecarLastNewestSlot && keep.size() == rootsSidecarLastCount) {
+            SidecarMark last = rootsSidecarLastWritten;
+            if (last != null && newestSlot == last.newestSlot() && keep.size() == last.count()) {
                 return; // window unchanged since the last write
             }
             java.nio.ByteBuffer buf = java.nio.ByteBuffer.allocate(1 + 4 + keep.size() * 41);
@@ -267,8 +270,7 @@ public class BeaconLightClient implements AutoCloseable {
             } catch (java.nio.file.AtomicMoveNotSupportedException amnse) {
                 java.nio.file.Files.move(tmp, file, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
             }
-            rootsSidecarLastNewestSlot = newestSlot;
-            rootsSidecarLastCount = keep.size();
+            rootsSidecarLastWritten = new SidecarMark(newestSlot, keep.size());
         } catch (Exception e) {
             log.debug("[beacon] roots sidecar persist failed: {}", e.getMessage());
         }

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconSyncState.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconSyncState.java
@@ -2,7 +2,10 @@ package com.jaeckel.ethp2p.consensus;
 
 import com.jaeckel.ethp2p.consensus.lightclient.BeaconChainSpec;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -308,6 +311,31 @@ public class BeaconSyncState {
         // Evict oldest entries if window is full
         while (knownStateRoots.size() > MAX_KNOWN_ROOTS) {
             knownStateRoots.pollFirst();
+        }
+    }
+
+    /**
+     * Snapshot the rolling window (oldest→newest) so it can be persisted across
+     * restarts. The entries were validated via finality-update BLS signatures; see
+     * {@link #importKnownStateRoots}.
+     */
+    public List<SlottedStateRoot> exportKnownStateRoots() {
+        return new ArrayList<>(knownStateRoots);
+    }
+
+    /**
+     * Re-import persisted window entries (e.g. from a snapshot sidecar) using the same
+     * dedup/cap path as live recording. Lets a warm restart reach SYNCED without first
+     * re-observing {@link #FILL_THRESHOLD} live finality polls. Soundness: this only
+     * pre-fills the "have we seen enough finality" counter — {@code getSyncState} still
+     * gates SYNCED on {@link #isSynced()} (a fresh post-restart update) and on the sync
+     * committee period being current, so a long-offline restart can't report SYNCED on
+     * stale roots alone.
+     */
+    public void importKnownStateRoots(Collection<SlottedStateRoot> roots) {
+        if (roots == null) return;
+        for (SlottedStateRoot r : roots) {
+            if (r != null) recordStateRoot(r.slot(), r.stateRoot(), r.blsVerified());
         }
     }
 

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/bls/BlsVerifier.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/bls/BlsVerifier.java
@@ -48,6 +48,61 @@ public final class BlsVerifier {
         return halfP;
     }
 
+    // Decompressed-pubkey cache. G1 decompression (a field square root per key) is a
+    // pure function of the 48 key bytes, and sync-committee pubkeys are fixed for a
+    // ~27h period — yet fastAggregateVerify decompressed all ~512 on every update,
+    // which dominates a finality-update verify on Android/ART (~35-55s). Capacity
+    // covers current + next committee (2x512) with slack for rotation overlap; on
+    // overflow the whole map is reset (rotations are rare; no LRU bookkeeping).
+    // Values are master copies: Milagro ECP is mutable (reduce()/affine() normalize
+    // in place), so lookups hand out fresh copies — concurrent verifies must never
+    // share live point objects.
+    private static final int PUBKEY_CACHE_MAX = 4096;
+    private static final java.util.concurrent.ConcurrentHashMap<PubkeyKey, ECP> PUBKEY_CACHE =
+            new java.util.concurrent.ConcurrentHashMap<>();
+
+    /** byte[]-keyed map entry (arrays don't implement value equals/hashCode). */
+    private static final class PubkeyKey {
+        private final byte[] bytes;
+        private final int hash;
+        PubkeyKey(byte[] bytes) {
+            this.bytes = bytes;
+            this.hash = Arrays.hashCode(bytes);
+        }
+        @Override public boolean equals(Object o) {
+            return o instanceof PubkeyKey k && Arrays.equals(bytes, k.bytes);
+        }
+        @Override public int hashCode() { return hash; }
+    }
+
+    /** Decompress a trusted (Merkle-proven, no subgroup check) G1 pubkey through the
+     *  cache. Returns a private copy the caller may freely use; null for invalid keys
+     *  (never cached). */
+    private static ECP cachedTrustedG1(byte[] pubkey) {
+        PubkeyKey key = new PubkeyKey(pubkey.clone());
+        ECP master = PUBKEY_CACHE.get(key);
+        if (master == null) {
+            master = deserializeG1(pubkey, false);
+            if (master == null) return null;
+            if (PUBKEY_CACHE.size() >= PUBKEY_CACHE_MAX) PUBKEY_CACHE.clear();
+            PUBKEY_CACHE.putIfAbsent(key, master);
+        }
+        return new ECP(master);
+    }
+
+    /**
+     * Pre-decompress a set of committee pubkeys into the cache so the next
+     * fastAggregateVerify pays only the pairing, not ~512 square roots. Call off the
+     * hot path (e.g. right after a snapshot resume or committee rotation); decompression
+     * fans out across cores. Invalid keys are skipped — verify rejects them later.
+     */
+    public static void warmPubkeyCache(List<byte[]> pubkeyBytes) {
+        if (pubkeyBytes == null) return;
+        pubkeyBytes.parallelStream().forEach(b -> {
+            if (b != null && b.length == 48) cachedTrustedG1(b);
+        });
+    }
+
     private BlsVerifier() {}
 
     /**
@@ -97,12 +152,13 @@ public final class BlsVerifier {
             // Point decompression (a field square root per key) is independent
             // per pubkey, so we fan it out across cores: on Android/ART the serial
             // 512-key loop took ~30s, dwarfing everything else. parallelStream uses
-            // the common ForkJoinPool (parallelism = cores-1). The aggregation
-            // (ECP.add) is then a cheap sequential reduce — Milagro ECP isn't
-            // safe to mutate from multiple threads, but independent decompression
-            // into fresh ECP objects is.
+            // the common ForkJoinPool (parallelism = cores-1). Decompressed points
+            // are cached across calls (committees are period-stable), so a warm
+            // verify pays only copies + the pairing. The aggregation (ECP.add) is
+            // then a cheap sequential reduce — Milagro ECP isn't safe to mutate
+            // from multiple threads, but each cache lookup returns a private copy.
             List<ECP> points = pubkeyBytes.parallelStream()
-                    .map(b -> deserializeG1(b, false))
+                    .map(BlsVerifier::cachedTrustedG1)
                     .collect(java.util.stream.Collectors.toList());
             ECP aggregated = new ECP(); // point at infinity
             for (ECP pk : points) {

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/bls/BlsVerifier.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/bls/BlsVerifier.java
@@ -77,17 +77,16 @@ public final class BlsVerifier {
 
     /** Decompress a trusted (Merkle-proven, no subgroup check) G1 pubkey through the
      *  cache. Returns a private copy the caller may freely use; null for invalid keys
-     *  (never cached). */
+     *  (never cached). computeIfAbsent guarantees one decompression per key even when
+     *  a warm-up and a verify race on the same committee (the mapping function runs at
+     *  most once; concurrent callers for the same key block briefly and reuse it). The
+     *  overflow reset stays outside the compute — mutating the map from inside its own
+     *  mapping function is forbidden. */
     private static ECP cachedTrustedG1(byte[] pubkey) {
-        PubkeyKey key = new PubkeyKey(pubkey.clone());
-        ECP master = PUBKEY_CACHE.get(key);
-        if (master == null) {
-            master = deserializeG1(pubkey, false);
-            if (master == null) return null;
-            if (PUBKEY_CACHE.size() >= PUBKEY_CACHE_MAX) PUBKEY_CACHE.clear();
-            PUBKEY_CACHE.putIfAbsent(key, master);
-        }
-        return new ECP(master);
+        if (PUBKEY_CACHE.size() >= PUBKEY_CACHE_MAX) PUBKEY_CACHE.clear();
+        ECP master = PUBKEY_CACHE.computeIfAbsent(
+                new PubkeyKey(pubkey.clone()), k -> deserializeG1(k.bytes, false));
+        return master == null ? null : new ECP(master);
     }
 
     /**

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/lightclient/LightClientProcessor.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/lightclient/LightClientProcessor.java
@@ -21,6 +21,15 @@ public class LightClientProcessor {
     private final byte[] forkVersion;
     private final byte[] genesisValidatorsRoot;
 
+    /** Aggregate signature of the last successfully applied finality update. The
+     *  signature commits to the attested header root (whose state root in turn commits
+     *  the finality branch), so a byte-identical signature is the same already-applied
+     *  update: any variant with different contents would fail verification anyway.
+     *  Lets the 12s poll loop skip re-verifying an unchanged head — each BLS verify
+     *  costs ~18s on Android/ART, so without this the steady-state loop burns a full
+     *  core re-proving the same update. */
+    private volatile byte[] lastAppliedFinalitySig;
+
     public LightClientProcessor(LightClientStore store, byte[] forkVersion, byte[] genesisValidatorsRoot) {
         this.store = store;
         this.forkVersion = forkVersion.clone();
@@ -52,6 +61,15 @@ public class LightClientProcessor {
         long attestedSlot = update.attestedHeader().beacon().slot();
         long finalizedSlot = update.finalizedHeader().beacon().slot();
         int participation = update.syncAggregate().countParticipants();
+
+        byte[] sig = update.syncAggregate().syncCommitteeSignature();
+        byte[] lastSig = lastAppliedFinalitySig;
+        if (lastSig != null && java.util.Arrays.equals(lastSig, sig)) {
+            log.debug("[lc-processor] Finality update is a duplicate of the already-applied one "
+                    + "(attestedSlot={}) — skipping re-verify", attestedSlot);
+            return true;
+        }
+
         log.debug("[lc-processor] Processing finality update: attestedSlot={}, finalizedSlot={}, " +
                 "signatureSlot={}, participation={}/512, finalityBranchLen={}",
                 attestedSlot, finalizedSlot, update.signatureSlot(),
@@ -96,6 +114,7 @@ public class LightClientProcessor {
         // (updateFinalized may have already advanced this.finalizedSlot).
         store.applyNextSyncCommitteeWhenPeriodChanges(oldFinalizedSlot, finalizedSlot);
 
+        lastAppliedFinalitySig = sig.clone();
         log.debug("[lc-processor] Finality update applied: finalizedSlot {} → {}", oldFinalizedSlot, finalizedSlot);
         return true;
     }

--- a/consensus/src/test/java/com/jaeckel/ethp2p/consensus/BeaconSyncStateRootsTest.java
+++ b/consensus/src/test/java/com/jaeckel/ethp2p/consensus/BeaconSyncStateRootsTest.java
@@ -1,0 +1,58 @@
+package com.jaeckel.ethp2p.consensus;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Round-trip for the known-state-roots window export/import that backs the snapshot
+ * sidecar — a warm restart restores the window so SYNCED needs one fresh finality poll
+ * instead of {@link BeaconSyncState#FILL_THRESHOLD}.
+ */
+class BeaconSyncStateRootsTest {
+
+    private static byte[] root(int seed) {
+        byte[] r = new byte[32];
+        for (int i = 0; i < 32; i++) r[i] = (byte) (seed + i);
+        return r;
+    }
+
+    @Test
+    void exportImportRoundTripPreservesWindow() {
+        BeaconSyncState a = new BeaconSyncState();
+        for (int i = 0; i < BeaconSyncState.FILL_THRESHOLD; i++) {
+            a.recordStateRoot(1000 + i, root(i), false);
+        }
+        List<BeaconSyncState.SlottedStateRoot> exported = a.exportKnownStateRoots();
+        assertEquals(BeaconSyncState.FILL_THRESHOLD, exported.size());
+
+        BeaconSyncState b = new BeaconSyncState();
+        assertEquals(0, b.getKnownStateRootCount());
+        b.importKnownStateRoots(exported);
+        assertEquals(BeaconSyncState.FILL_THRESHOLD, b.getKnownStateRootCount());
+
+        // Imported roots are individually matchable (findStateRoot) and carry the slot.
+        BeaconSyncState.SlottedStateRoot hit = b.findStateRoot(root(0));
+        assertNotNull(hit);
+        assertEquals(1000, hit.slot());
+    }
+
+    @Test
+    void importIsIdempotentAndNullSafe() {
+        BeaconSyncState a = new BeaconSyncState();
+        a.recordStateRoot(42, root(7), true);
+        List<BeaconSyncState.SlottedStateRoot> exported = a.exportKnownStateRoots();
+
+        BeaconSyncState b = new BeaconSyncState();
+        b.importKnownStateRoots(null);          // tolerated
+        b.importKnownStateRoots(exported);
+        b.importKnownStateRoots(exported);      // dedup, no double count
+        assertEquals(1, b.getKnownStateRootCount());
+        // blsVerified flag survives the round trip.
+        assertTrue(b.findStateRoot(root(7)).blsVerified());
+    }
+}


### PR DESCRIPTION
PR #38 was stacked on \`feat/cl-peer-lightclient-cache\` (PR #37's branch). #37 merged to main at 14:09, #38 merged at 16:09 — but into the already-merged #37 branch, so its commits never reached main. This PR brings them over verbatim (no new changes):

- roots sidecar (persist knownStateRoots) + restore-order fix
- 25s in-flight head-build ride for verified reads
- BLS decompressed-pubkey cache + warm-on-resume
- resume-before-preconnect + bounded LC-aware Identify round (64 peers, early exit)
- finality-update dedup-skip + unchanged-sidecar write skip
- peer-head probe floor at the beacon-finalized exec block

All device-validated on the Pixel 7 today (warm restart ~35s; dedup confirmed live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)