### PR TITLE
verified fees + estimateGas + snap-free blocks (unblocks MetaMask signing screen)

### DIFF
--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -1297,8 +1297,11 @@ public final class NodeService extends Service {
     /** Tip suggestion cache TTL (~one block) — MetaMask polls fees every few seconds,
      *  and each recompute fetches TIP_SUGGEST_BLOCKS bodies. */
     private static final long TIP_CACHE_TTL_MS = 12_000;
-    private volatile java.math.BigInteger cachedSuggestedTip;
-    private volatile long cachedSuggestedTipAtMs;
+    /** Suggested tip + when it was computed, one immutable unit behind a single
+     *  volatile so a reader can't pair a fresh tip with a stale timestamp
+     *  (same pattern as {@link HeadWithTimestamp}). */
+    private record TipWithTimestamp(java.math.BigInteger tip, long atMs) {}
+    private volatile TipWithTimestamp cachedSuggestedTip;
 
     /** Next block's base fee per the EIP-1559 update rule, from the parent header. */
     private static java.math.BigInteger nextBaseFee(BlockHeader h) {
@@ -1393,8 +1396,8 @@ public final class NodeService extends Service {
             TxFeeFields f = TxFeeFields.decode(txs.get(i));
             if (f == null) { // verified body with an unparseable tx — bail
                 LogBuffer.i(TAG, "[rpc] tips: block #" + h.number + " tx " + i
-                        + " undecodable (first byte 0x"
-                        + Integer.toHexString(txs.get(i).get(0) & 0xFF) + ")");
+                        + " undecodable (" + (txs.get(i).isEmpty() ? "empty"
+                        : "first byte 0x" + Integer.toHexString(txs.get(i).get(0) & 0xFF)) + ")");
                 return null;
             }
             out.add(new TxTip(f.effectiveTip(baseFee), gasUsed != null ? gasUsed[i] : 0));
@@ -1406,10 +1409,10 @@ public final class NodeService extends Service {
      *  {@link #TIP_SUGGEST_BLOCKS} verified blocks, floored at
      *  {@link #MIN_SUGGESTED_TIP}. Cached for ~one block. Null → can't verify. */
     private java.math.BigInteger rpcMaxPriorityFeePerGas() {
-        java.math.BigInteger cached = cachedSuggestedTip;
-        if (cached != null && android.os.SystemClock.elapsedRealtime() - cachedSuggestedTipAtMs
-                < TIP_CACHE_TTL_MS) {
-            return cached;
+        TipWithTimestamp cached = cachedSuggestedTip;
+        if (cached != null
+                && android.os.SystemClock.elapsedRealtime() - cached.atMs() < TIP_CACHE_TTL_MS) {
+            return cached.tip();
         }
         try {
             HeaderAnchor anchor = headerAnchor();
@@ -1430,8 +1433,7 @@ public final class NodeService extends Service {
                 java.util.Collections.sort(tips);
                 tip = tips.get(tips.size() / 2).max(MIN_SUGGESTED_TIP);
             }
-            cachedSuggestedTip = tip;
-            cachedSuggestedTipAtMs = android.os.SystemClock.elapsedRealtime();
+            cachedSuggestedTip = new TipWithTimestamp(tip, android.os.SystemClock.elapsedRealtime());
             return tip;
         } catch (Exception e) {
             LogBuffer.i(TAG, "[rpc] eth_maxPriorityFeePerGas failed: " + unwrap(e));

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -29,6 +29,7 @@ import com.jaeckel.ethp2p.networking.dns.DnsEnrResolver;
 import com.jaeckel.ethp2p.networking.eth.messages.BlockBodiesMessage;
 import com.jaeckel.ethp2p.networking.eth.messages.BlockHeadersMessage;
 import com.jaeckel.ethp2p.networking.eth.messages.Receipt;
+import com.jaeckel.ethp2p.networking.eth.messages.TxFeeFields;
 import com.jaeckel.ethp2p.networking.rlpx.RLPxConnector;
 import com.jaeckel.ethp2p.networking.snap.messages.AccountRangeMessage;
 
@@ -981,13 +982,12 @@ public final class NodeService extends Service {
         RLPxConnector conn = connector;
         if (conn == null || txHash == null || txHash.length != 32) return null;
         try {
-            // Use the resilient head path (cached good head fallback), not the fresh-head
-            // builder — the chain tip is often not beacon-anchored yet, which made this
-            // fail with -32000 even with healthy snap peers while state reads worked.
-            EnsCall ctx = anchoredHeadOrWait();
-            if (ctx == null || !ctx.beaconVerified()) return null;
-            long headNum = ctx.blockNumber();
-            byte[] headStateRoot = ctx.blockCtx().stateRoot();
+            // Headers-only anchor (snap head preferred, beacon optimistic fallback):
+            // receipts need verified headers + bodies, not snap state, so this path
+            // keeps working through snap-peer outages — see headerAnchor().
+            HeaderAnchor anchor = headerAnchor();
+            if (anchor == null) return null;
+            long headNum = anchor.number();
 
             int count = (int) Math.min(RECEIPT_LOOKBACK_BLOCKS, headNum + 1);
             long start = headNum - count + 1;
@@ -995,9 +995,9 @@ public final class NodeService extends Service {
                     .requestBlockHeadersBatched(start, count)
                     // Future.get(timeout) — NOT CompletableFuture.orTimeout (API 31, minSdk 29).
                     .get(HEADER_CHAIN_TIMEOUT_SEC, TimeUnit.SECONDS);
-            // Anchor the window: its last header must BE the verified head (stateRoot
-            // match) and every header must hash-link to the next's parentHash.
-            if (!windowAnchoredToHead(window, headStateRoot)) {
+            // Anchor the window: its last header must BE the verified head and every
+            // header must hash-link to the next's parentHash.
+            if (!anchor.anchors(window)) {
                 LogBuffer.i(TAG, "[rpc] eth_getTransactionReceipt: header window failed to anchor");
                 return null;
             }
@@ -1065,10 +1065,61 @@ public final class NodeService extends Service {
         if (window.isEmpty()) return false;
         BlockHeader last = window.get(window.size() - 1).header();
         if (!java.util.Arrays.equals(last.stateRoot.toArrayUnsafe(), headStateRoot)) return false;
+        return windowHashLinked(window);
+    }
+
+    /** Like {@link #windowAnchoredToHead} but anchored by the head's block HASH —
+     *  used with the beacon optimistic anchor, whose exec blockHash is what the
+     *  light client verified. */
+    private static boolean windowAnchoredToHash(List<BlockHeadersMessage.VerifiedHeader> window,
+                                                byte[] headBlockHash) {
+        if (window.isEmpty()) return false;
+        if (!java.util.Arrays.equals(
+                window.get(window.size() - 1).hash().toArrayUnsafe(), headBlockHash)) return false;
+        return windowHashLinked(window);
+    }
+
+    private static boolean windowHashLinked(List<BlockHeadersMessage.VerifiedHeader> window) {
         for (int i = 0; i < window.size() - 1; i++) {
             if (!window.get(i).hash().equals(window.get(i + 1).header().parentHash)) return false;
         }
         return true;
+    }
+
+    /** A beacon-verified header anchor: block {@code number} plus either the head's
+     *  {@code stateRoot} (snap-built head) or its block {@code hash} (beacon optimistic
+     *  exec payload) — exactly one is non-null. */
+    private record HeaderAnchor(long number, byte[] stateRoot, byte[] blockHash) {
+        boolean anchors(List<BlockHeadersMessage.VerifiedHeader> window) {
+            return stateRoot != null ? windowAnchoredToHead(window, stateRoot)
+                                     : windowAnchoredToHash(window, blockHash);
+        }
+    }
+
+    /**
+     * Resolve a beacon-verified header anchor for block/receipt serving — paths that
+     * need verified HEADERS but no snap state. Prefers the snap-built anchored head
+     * (freshest, the chain tip); falls back to the beacon optimistic execution payload
+     * (light-client-verified blockHash, at worst ~1 epoch stale) when no snap peer is
+     * available — so eth_getBlockByNumber / eth_getTransactionReceipt keep working
+     * through snap-peer outages (e.g. a cold start before discovery finds snap peers,
+     * where MetaMask's block tracker previously died and hung the UI).
+     */
+    private HeaderAnchor headerAnchor() {
+        RLPxConnector c = connector;
+        // Only pay the anchored-head wait when a snap peer exists to build from.
+        if (c != null && !c.activeSnapHandlers().isEmpty()) {
+            EnsCall ctx = anchoredHeadOrWait();
+            if (ctx != null && ctx.beaconVerified()) {
+                return new HeaderAnchor(ctx.blockNumber(), ctx.blockCtx().stateRoot(), null);
+            }
+        }
+        BeaconSyncState bss = beaconSyncState;
+        if (bss == null) return null;
+        long n = bss.getOptimisticBlockNumber();
+        byte[] h = bss.getOptimisticBlockHash();
+        if (n <= 0 || h == null) return null;
+        return new HeaderAnchor(n, null, h);
     }
 
     /** Build the eth_getTransactionReceipt JSON object from VERIFIED receipt bytes.
@@ -1140,12 +1191,12 @@ public final class NodeService extends Service {
         RLPxConnector conn = connector;
         if (conn == null || fullTx) return null;
         try {
-            // Resilient head path (cached good head), not the fresh-head builder which
-            // fails when the chain tip isn't beacon-anchored yet — see rpcGetTransactionReceipt.
-            EnsCall ctx = anchoredHeadOrWait();
-            if (ctx == null || !ctx.beaconVerified()) return null;
-            long headNum = ctx.blockNumber();
-            byte[] headStateRoot = ctx.blockCtx().stateRoot();
+            // Headers-only anchor: snap-built head when available, beacon optimistic
+            // exec payload otherwise — block serving must survive snap-peer outages
+            // (MetaMask's block tracker polls this and hangs the UI without it).
+            HeaderAnchor anchor = headerAnchor();
+            if (anchor == null) return null;
+            long headNum = anchor.number();
 
             long target;
             String b = (block == null) ? "latest" : block;
@@ -1165,7 +1216,7 @@ public final class NodeService extends Service {
             List<BlockHeadersMessage.VerifiedHeader> window = conn
                     .requestBlockHeadersBatched(target, (int) (back + 1))
                     .get(HEADER_CHAIN_TIMEOUT_SEC, TimeUnit.SECONDS);
-            if (!windowAnchoredToHead(window, headStateRoot)) return null;
+            if (!anchor.anchors(window)) return null;
             BlockHeadersMessage.VerifiedHeader vh = window.get(0); // target is first in [target..head]
 
             List<BlockBodiesMessage.BlockBody> bodies = conn
@@ -1225,6 +1276,304 @@ public final class NodeService extends Service {
         }
         sb.append("],\"uncles\":[]}");
         return sb.toString();
+    }
+
+    // ---- Fee suggestion (verified) ----------------------------------------
+    // MetaMask's signing screen blocks on fee data (eth_feeHistory / eth_gasPrice /
+    // eth_maxPriorityFeePerGas) — without it the confirm UI sits in skeleton-loading
+    // forever. All fee data here is derived from VERIFIED sources only: baseFee /
+    // gasUsed / gasLimit from beacon-anchored headers, priority-fee tips from block
+    // bodies verified against transactionsRoot (+ receipts verified against
+    // receiptsRoot for gas-used percentile weighting).
+
+    /** Max blocks served per eth_feeHistory call (clamped per EIP-1559; MetaMask asks 5-10). */
+    private static final int FEE_HISTORY_MAX_BLOCKS = 10;
+    /** Blocks scanned for the priority-fee suggestion. */
+    private static final int TIP_SUGGEST_BLOCKS = 3;
+    /** Floor for the suggested tip: 0.1 gwei — keeps suggestions inclusive-but-sane
+     *  when recent blocks are empty or full of zero-tip txs. */
+    private static final java.math.BigInteger MIN_SUGGESTED_TIP =
+            java.math.BigInteger.valueOf(100_000_000L);
+    /** Tip suggestion cache TTL (~one block) — MetaMask polls fees every few seconds,
+     *  and each recompute fetches TIP_SUGGEST_BLOCKS bodies. */
+    private static final long TIP_CACHE_TTL_MS = 12_000;
+    private volatile java.math.BigInteger cachedSuggestedTip;
+    private volatile long cachedSuggestedTipAtMs;
+
+    /** Next block's base fee per the EIP-1559 update rule, from the parent header. */
+    private static java.math.BigInteger nextBaseFee(BlockHeader h) {
+        java.math.BigInteger base = h.baseFeePerGas;
+        if (base == null) return java.math.BigInteger.ZERO; // pre-London (not mainnet today)
+        long gasTarget = h.gasLimit / 2;
+        if (gasTarget <= 0 || h.gasUsed == gasTarget) return base;
+        java.math.BigInteger target = java.math.BigInteger.valueOf(gasTarget);
+        if (h.gasUsed > gasTarget) {
+            java.math.BigInteger delta = base
+                    .multiply(java.math.BigInteger.valueOf(h.gasUsed - gasTarget))
+                    .divide(target)
+                    .divide(java.math.BigInteger.valueOf(8))
+                    .max(java.math.BigInteger.ONE);
+            return base.add(delta);
+        }
+        java.math.BigInteger delta = base
+                .multiply(java.math.BigInteger.valueOf(gasTarget - h.gasUsed))
+                .divide(target)
+                .divide(java.math.BigInteger.valueOf(8));
+        return base.subtract(delta);
+    }
+
+    /** Fetch the beacon-anchored header window [head-count+1 .. head]; null if it
+     *  can't be fetched or doesn't anchor. */
+    private List<BlockHeadersMessage.VerifiedHeader> anchoredHeaderWindow(
+            HeaderAnchor anchor, int count) throws Exception {
+        RLPxConnector conn = connector;
+        if (conn == null) return null;
+        long start = Math.max(0, anchor.number() - count + 1);
+        List<BlockHeadersMessage.VerifiedHeader> window = conn
+                .requestBlockHeadersBatched(start, (int) (anchor.number() - start + 1))
+                .get(HEADER_CHAIN_TIMEOUT_SEC, TimeUnit.SECONDS);
+        return anchor.anchors(window) ? window : null;
+    }
+
+    /** A tx's effective priority fee plus the gas it used (receipt cumulative diff). */
+    private record TxTip(java.math.BigInteger tip, long gasUsed) {}
+
+    /** Per-tx (effectiveTip, gasUsed) of a block, from a body verified against
+     *  transactionsRoot (+ receipts verified against receiptsRoot when
+     *  {@code needGasWeights}). Null when the block can't be verified; empty for
+     *  an empty block. */
+    private List<TxTip> verifiedBlockTips(BlockHeadersMessage.VerifiedHeader vh,
+                                          boolean needGasWeights) throws Exception {
+        RLPxConnector conn = connector;
+        if (conn == null) return null;
+        BlockHeader h = vh.header();
+        List<BlockBodiesMessage.BlockBody> bodies = conn
+                .requestBlockBodies(vh.hash())
+                .get(HEADER_CHAIN_TIMEOUT_SEC, TimeUnit.SECONDS);
+        if (bodies.isEmpty()) return null;
+        List<Bytes> txs = bodies.get(0).transactions();
+        if (!OrderedTrieRoot.verify(txs, h.transactionsRoot)) return null;
+        if (txs.isEmpty()) return java.util.Collections.emptyList();
+
+        long[] gasUsed = null;
+        if (needGasWeights) {
+            List<List<Bytes>> rcptBlocks = conn
+                    .requestReceipts(vh.hash())
+                    .get(HEADER_CHAIN_TIMEOUT_SEC, TimeUnit.SECONDS);
+            if (rcptBlocks.isEmpty()) return null;
+            List<Bytes> receipts = rcptBlocks.get(0);
+            if (receipts.size() != txs.size()
+                    || !OrderedTrieRoot.verify(receipts, h.receiptsRoot)) return null;
+            gasUsed = new long[txs.size()];
+            long prevCum = 0;
+            for (int i = 0; i < receipts.size(); i++) {
+                long cum = Receipt.decode(receipts.get(i)).cumulativeGasUsed();
+                gasUsed[i] = cum - prevCum;
+                prevCum = cum;
+            }
+        }
+
+        java.math.BigInteger baseFee =
+                h.baseFeePerGas != null ? h.baseFeePerGas : java.math.BigInteger.ZERO;
+        List<TxTip> out = new ArrayList<>(txs.size());
+        for (int i = 0; i < txs.size(); i++) {
+            TxFeeFields f = TxFeeFields.decode(txs.get(i));
+            if (f == null) return null; // verified body with an unparseable tx — bail
+            out.add(new TxTip(f.effectiveTip(baseFee), gasUsed != null ? gasUsed[i] : 0));
+        }
+        return out;
+    }
+
+    /** Suggested priority fee: median effective tip over the last
+     *  {@link #TIP_SUGGEST_BLOCKS} verified blocks, floored at
+     *  {@link #MIN_SUGGESTED_TIP}. Cached for ~one block. Null → can't verify. */
+    private java.math.BigInteger rpcMaxPriorityFeePerGas() {
+        java.math.BigInteger cached = cachedSuggestedTip;
+        if (cached != null && android.os.SystemClock.elapsedRealtime() - cachedSuggestedTipAtMs
+                < TIP_CACHE_TTL_MS) {
+            return cached;
+        }
+        try {
+            HeaderAnchor anchor = headerAnchor();
+            if (anchor == null) return null;
+            List<BlockHeadersMessage.VerifiedHeader> window =
+                    anchoredHeaderWindow(anchor, TIP_SUGGEST_BLOCKS);
+            if (window == null) return null;
+            List<java.math.BigInteger> tips = new ArrayList<>();
+            for (BlockHeadersMessage.VerifiedHeader vh : window) {
+                List<TxTip> blockTips = verifiedBlockTips(vh, false);
+                if (blockTips == null) continue; // one unverifiable block doesn't kill the suggestion
+                for (TxTip t : blockTips) tips.add(t.tip());
+            }
+            java.math.BigInteger tip;
+            if (tips.isEmpty()) {
+                tip = MIN_SUGGESTED_TIP;
+            } else {
+                java.util.Collections.sort(tips);
+                tip = tips.get(tips.size() / 2).max(MIN_SUGGESTED_TIP);
+            }
+            cachedSuggestedTip = tip;
+            cachedSuggestedTipAtMs = android.os.SystemClock.elapsedRealtime();
+            return tip;
+        } catch (Exception e) {
+            LogBuffer.i(TAG, "[rpc] eth_maxPriorityFeePerGas failed: " + unwrap(e));
+            return null;
+        }
+    }
+
+    /** Legacy-style total gas price: next block's base fee + the suggested tip. */
+    private java.math.BigInteger rpcGasPrice() {
+        try {
+            HeaderAnchor anchor = headerAnchor();
+            if (anchor == null) return null;
+            List<BlockHeadersMessage.VerifiedHeader> window = anchoredHeaderWindow(anchor, 1);
+            if (window == null || window.isEmpty()) return null;
+            java.math.BigInteger tip = rpcMaxPriorityFeePerGas();
+            if (tip == null) return null;
+            return nextBaseFee(window.get(window.size() - 1).header()).add(tip);
+        } catch (Exception e) {
+            LogBuffer.i(TAG, "[rpc] eth_gasPrice failed: " + unwrap(e));
+            return null;
+        }
+    }
+
+    /**
+     * eth_feeHistory from verified data. baseFeePerGas / gasUsedRatio come from the
+     * beacon-anchored header window; reward percentiles (when requested) from bodies
+     * verified against transactionsRoot + receipts verified against receiptsRoot,
+     * using geth's gas-used-weighted percentile walk. blockCount is clamped to
+     * {@link #FEE_HISTORY_MAX_BLOCKS}; the result reflects what was served.
+     */
+    private String rpcFeeHistory(long blockCount, String newestBlock, double[] percentiles) {
+        try {
+            HeaderAnchor anchor = headerAnchor();
+            if (anchor == null) return null;
+            long headNum = anchor.number();
+
+            long newest;
+            String nb = (newestBlock == null) ? "latest" : newestBlock;
+            switch (nb) {
+                case "latest": case "pending": case "safe": case "finalized":
+                    newest = headNum; break;
+                case "earliest":
+                    return null;
+                default:
+                    try { newest = Long.decode(nb); } catch (Exception e) { return null; }
+            }
+            if (newest < 0 || newest > headNum) return null;
+
+            int count = (int) Math.min(Math.min(blockCount, FEE_HISTORY_MAX_BLOCKS), newest + 1);
+            long oldest = newest - count + 1;
+            if (headNum - oldest >= BLOCK_LOOKBACK_MAX) return null; // too far back to verify cheaply
+
+            // One anchored window [oldest..head]; the requested span is its first
+            // `count` entries (the window may extend past `newest` up to the head —
+            // that's what anchors it, and it gives the ACTUAL next-block baseFee).
+            List<BlockHeadersMessage.VerifiedHeader> window =
+                    anchoredHeaderWindow(anchor, (int) (headNum - oldest + 1));
+            if (window == null || window.size() < count) return null;
+
+            StringBuilder sb = new StringBuilder(256);
+            sb.append("{\"oldestBlock\":\"").append(hexQuantity(oldest)).append("\"");
+
+            sb.append(",\"baseFeePerGas\":[");
+            for (int i = 0; i < count; i++) {
+                if (i > 0) sb.append(",");
+                java.math.BigInteger bf = window.get(i).header().baseFeePerGas;
+                sb.append("\"0x").append((bf != null ? bf : java.math.BigInteger.ZERO).toString(16)).append("\"");
+            }
+            // Entry count+1: the next block after `newest` — its actual baseFee when the
+            // window extends past newest, else the EIP-1559 prediction from `newest`.
+            java.math.BigInteger nextBf = (count < window.size())
+                    ? (window.get(count).header().baseFeePerGas != null
+                        ? window.get(count).header().baseFeePerGas : java.math.BigInteger.ZERO)
+                    : nextBaseFee(window.get(count - 1).header());
+            sb.append(",\"0x").append(nextBf.toString(16)).append("\"]");
+
+            sb.append(",\"gasUsedRatio\":[");
+            for (int i = 0; i < count; i++) {
+                if (i > 0) sb.append(",");
+                BlockHeader h = window.get(i).header();
+                double ratio = h.gasLimit > 0 ? (double) h.gasUsed / (double) h.gasLimit : 0.0;
+                sb.append(ratio);
+            }
+            sb.append("]");
+
+            if (percentiles != null) {
+                sb.append(",\"reward\":[");
+                for (int i = 0; i < count; i++) {
+                    if (i > 0) sb.append(",");
+                    List<TxTip> tips = verifiedBlockTips(window.get(i), true);
+                    if (tips == null) return null; // strict: no unverified rewards
+                    sb.append(rewardJson(tips, percentiles));
+                }
+                sb.append("]");
+            }
+            sb.append("}");
+            return sb.toString();
+        } catch (Exception e) {
+            LogBuffer.i(TAG, "[rpc] eth_feeHistory failed: " + unwrap(e));
+            return null;
+        }
+    }
+
+    /** Gas-used-weighted percentile rewards for one block (geth's algorithm): sort txs
+     *  by tip, walk percentile thresholds over cumulative gasUsed. Empty block → zeros. */
+    private static String rewardJson(List<TxTip> tips, double[] percentiles) {
+        StringBuilder sb = new StringBuilder(percentiles.length * 12 + 2);
+        sb.append("[");
+        if (tips.isEmpty()) {
+            for (int p = 0; p < percentiles.length; p++) {
+                if (p > 0) sb.append(",");
+                sb.append("\"0x0\"");
+            }
+            return sb.append("]").toString();
+        }
+        List<TxTip> sorted = new ArrayList<>(tips);
+        sorted.sort(java.util.Comparator.comparing(TxTip::tip));
+        long totalGas = 0;
+        for (TxTip t : sorted) totalGas += t.gasUsed();
+        int idx = 0;
+        long cumGas = sorted.get(0).gasUsed();
+        for (int p = 0; p < percentiles.length; p++) {
+            if (p > 0) sb.append(",");
+            double threshold = totalGas * percentiles[p] / 100.0;
+            while (cumGas < threshold && idx < sorted.size() - 1) {
+                idx++;
+                cumGas += sorted.get(idx).gasUsed();
+            }
+            sb.append("\"0x").append(sorted.get(idx).tip().toString(16)).append("\"");
+        }
+        return sb.append("]").toString();
+    }
+
+    /**
+     * eth_estimateGas over the shared anchored head: runs the call in the local EVM
+     * against snap-verified state with full gas accounting (intrinsic + execution +
+     * 15% headroom — see {@code DefaultEvmExecutor.estimateGas}). A reverting tx gets
+     * an error, not a number — the wallet must not broadcast it. Contract creation
+     * (to=null) isn't served verified yet → null → router errors.
+     */
+    private java.math.BigInteger rpcEstimateGas(byte[] from, byte[] to, byte[] data,
+                                                java.math.BigInteger value) {
+        if (to == null || to.length != 20) return null;
+        if (from != null && from.length != 20) return null;
+        EnsCall h = anchoredHeadOrWait();
+        if (h == null) return null;
+        try {
+            io.myotis.evm.UnsignedTransaction tx = new io.myotis.evm.UnsignedTransaction(
+                    io.myotis.evm.Address.of(from != null ? from : new byte[20]),
+                    io.myotis.evm.Address.of(to),
+                    value != null ? value : java.math.BigInteger.ZERO,
+                    data != null ? data : new byte[0],
+                    null);
+            Long gas = h.offchainExecutor().estimateGas(tx, h.blockCtx())
+                    .get(RPC_CALL_TIMEOUT_SEC, TimeUnit.SECONDS);
+            return gas == null ? null : java.math.BigInteger.valueOf(gas);
+        } catch (Exception e) {
+            LogBuffer.i(TAG, "[rpc] eth_estimateGas -> error: " + unwrap(e));
+            return null;
+        }
     }
 
     /** Render a storage value as a 32-byte big-endian word (drops BigInteger's
@@ -2232,6 +2581,20 @@ public final class NodeService extends Service {
                 }
                 @Override public String getBlockByNumber(String block, boolean fullTx) {
                     return rpcGetBlockByNumber(block, fullTx);
+                }
+                @Override public java.math.BigInteger gasPrice() {
+                    return rpcGasPrice();
+                }
+                @Override public java.math.BigInteger maxPriorityFeePerGas() {
+                    return rpcMaxPriorityFeePerGas();
+                }
+                @Override public String feeHistory(long blockCount, String newestBlock,
+                                                   double[] rewardPercentiles) {
+                    return rpcFeeHistory(blockCount, newestBlock, rewardPercentiles);
+                }
+                @Override public java.math.BigInteger estimateGas(byte[] from, byte[] to,
+                                                                  byte[] data, java.math.BigInteger value) {
+                    return rpcEstimateGas(from, to, data, value);
                 }
             };
             io.myotis.jsonrpc.MyotisRpcServer s =

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -1350,9 +1350,15 @@ public final class NodeService extends Service {
         List<BlockBodiesMessage.BlockBody> bodies = conn
                 .requestBlockBodies(vh.hash())
                 .get(HEADER_CHAIN_TIMEOUT_SEC, TimeUnit.SECONDS);
-        if (bodies.isEmpty()) return null;
+        if (bodies.isEmpty()) {
+            LogBuffer.i(TAG, "[rpc] tips: no body for block #" + h.number);
+            return null;
+        }
         List<Bytes> txs = bodies.get(0).transactions();
-        if (!OrderedTrieRoot.verify(txs, h.transactionsRoot)) return null;
+        if (!OrderedTrieRoot.verify(txs, h.transactionsRoot)) {
+            LogBuffer.i(TAG, "[rpc] tips: block #" + h.number + " body failed transactionsRoot verify");
+            return null;
+        }
         if (txs.isEmpty()) return java.util.Collections.emptyList();
 
         long[] gasUsed = null;
@@ -1360,10 +1366,17 @@ public final class NodeService extends Service {
             List<List<Bytes>> rcptBlocks = conn
                     .requestReceipts(vh.hash())
                     .get(HEADER_CHAIN_TIMEOUT_SEC, TimeUnit.SECONDS);
-            if (rcptBlocks.isEmpty()) return null;
+            if (rcptBlocks.isEmpty()) {
+                LogBuffer.i(TAG, "[rpc] tips: no receipts for block #" + h.number);
+                return null;
+            }
             List<Bytes> receipts = rcptBlocks.get(0);
             if (receipts.size() != txs.size()
-                    || !OrderedTrieRoot.verify(receipts, h.receiptsRoot)) return null;
+                    || !OrderedTrieRoot.verify(receipts, h.receiptsRoot)) {
+                LogBuffer.i(TAG, "[rpc] tips: block #" + h.number + " receipts mismatch (got "
+                        + receipts.size() + " for " + txs.size() + " txs) or root verify failed");
+                return null;
+            }
             gasUsed = new long[txs.size()];
             long prevCum = 0;
             for (int i = 0; i < receipts.size(); i++) {
@@ -1378,7 +1391,12 @@ public final class NodeService extends Service {
         List<TxTip> out = new ArrayList<>(txs.size());
         for (int i = 0; i < txs.size(); i++) {
             TxFeeFields f = TxFeeFields.decode(txs.get(i));
-            if (f == null) return null; // verified body with an unparseable tx — bail
+            if (f == null) { // verified body with an unparseable tx — bail
+                LogBuffer.i(TAG, "[rpc] tips: block #" + h.number + " tx " + i
+                        + " undecodable (first byte 0x"
+                        + Integer.toHexString(txs.get(i).get(0) & 0xFF) + ")");
+                return null;
+            }
             out.add(new TxTip(f.effectiveTip(baseFee), gasUsed != null ? gasUsed[i] : 0));
         }
         return out;
@@ -1571,9 +1589,29 @@ public final class NodeService extends Service {
                     .get(RPC_CALL_TIMEOUT_SEC, TimeUnit.SECONDS);
             return gas == null ? null : java.math.BigInteger.valueOf(gas);
         } catch (Exception e) {
-            LogBuffer.i(TAG, "[rpc] eth_estimateGas -> error: " + unwrap(e));
+            LogBuffer.i(TAG, "[rpc] eth_estimateGas -> error: " + describeEvmError(e));
             return null;
         }
+    }
+
+    /** Render an estimate/call failure, decoding EvmExecutionException revert data —
+     *  the estimator packs halt diagnostics ("halt=... state=...") into Reverted bytes,
+     *  which the default toString prints as an opaque [B@hash. */
+    private static String describeEvmError(Throwable e) {
+        for (Throwable t = e; t != null; t = t.getCause()) {
+            if (t instanceof io.myotis.evm.EvmExecutionException ee
+                    && ee.error() instanceof io.myotis.evm.EvmExecutionError.Reverted rev) {
+                byte[] d = rev.data();
+                boolean printable = d.length > 0;
+                for (byte b : d) {
+                    if (b < 0x20 || b > 0x7e) { printable = false; break; }
+                }
+                return "Reverted: " + (printable
+                        ? new String(d, java.nio.charset.StandardCharsets.US_ASCII)
+                        : Bytes.wrap(d).toHexString());
+            }
+        }
+        return unwrap(e);
     }
 
     /** Render a storage value as a 32-byte big-endian word (drops BigInteger's

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -1722,6 +1722,21 @@ public final class NodeService extends Service {
             // get-account gets by retrying across peers. The first peer that passes
             // both is pinned for the whole resolution (one consistent root).
             final long minHead = conn.getNetwork().minSensibleHeadBlock();
+            // Live staleness floor: a peer whose head is BEHIND the beacon-finalized
+            // exec block can never anchor (anchorHeadToBeacon verifies the chain
+            // finalized→head, and finality has already passed it) — yet such a peer
+            // happily snap-serves its frozen root and can win the probe race below,
+            // forcing every build into the finalized fallback while fresh-headed
+            // peers sit connected. Observed on-device: two peers frozen at the same
+            // head for 5+ min starved number-pinned reads.
+            long finalizedFloor = -1;
+            com.jaeckel.ethp2p.consensus.BeaconLightClient blcFloor = beaconLightClient;
+            if (blcFloor != null) {
+                com.jaeckel.ethp2p.consensus.types.LightClientHeader finHdr =
+                        blcFloor.getStore().getFinalizedHeader();
+                if (finHdr != null) finalizedFloor = finHdr.execution().blockNumber();
+            }
+            final long headFloor = Math.max(minHead, finalizedFloor);
             // Probe every ready snap peer CONCURRENTLY — fetch its fresh head, then
             // probe that it snap-serves that head root — and award the FIRST to
             // qualify. The old serial walk paid each unresponsive peer's timeout in
@@ -1734,9 +1749,10 @@ public final class NodeService extends Service {
                         peer.requestFreshHeadHeaderAsync();
                 if (headFut == null) continue;
                 probes.add(headFut.thenCompose(fresh -> {
-                    if (fresh.number < minHead) {
+                    if (fresh.number < headFloor) {
                         throw new java.util.concurrent.CompletionException(
-                                new IllegalStateException("stale head #" + fresh.number));
+                                new IllegalStateException("stale head #" + fresh.number
+                                        + " (< floor #" + headFloor + ")"));
                     }
                     // servesRoot, but async: the peer must return a non-empty proof
                     // for the probe account at its head root.

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -740,9 +740,17 @@ public final class NodeService extends Service {
      *  it bridges transient rebuild gaps (head just advanced, peers' flat state not
      *  yet caught up) instead of proxying. The warmer keeps it fresh (~5-15s). */
     private static final long RPC_HEAD_MAX_STALE_MS = 30_000;
-    /** When there's no usable head at all (cold start / long outage), wait up to
-     *  this long for one to be built before falling back to the proxy. */
+    /** When there's no usable head at all (cold start / long outage) and no build is
+     *  in flight, wait only this long before giving up — a node with no snap peer can't
+     *  build a head, so blocking the caller longer just delays the inevitable error. */
     private static final long RPC_HEAD_WAIT_MS = 5_000;
+    /** When an anchored-head build IS already in flight (warmer or a prior read), ride
+     *  it up to this longer cap instead of erroring at {@link #RPC_HEAD_WAIT_MS}. A cold
+     *  anchored build on a phone (fetch+verify ~30 headers from beacon-finalized to head,
+     *  then the first snap account fetch) routinely takes 10-30s; giving up at 5s makes a
+     *  wallet's first read error even though the verified result is seconds away. Kept
+     *  under typical wallet RPC timeouts so the call returns verified-but-slow, not failed. */
+    private static final long RPC_HEAD_BUILD_WAIT_MS = 25_000;
     /** How far a number-pinned read's block may sit from the verified head and still be
      *  served from the head's state. Wallets pin reads to the just-fetched latest block,
      *  which can be a few blocks off our anchored (snap-servable) head; the head state is
@@ -829,13 +837,18 @@ public final class NodeService extends Service {
                 && android.os.SystemClock.elapsedRealtime() - good.builtAtMs() < RPC_HEAD_MAX_STALE_MS) {
             return good.head();
         }
-        // No usable head (cold start / sustained outage): wait briefly for a build
-        // before giving up — most gaps are short (a peer (re)connecting). The wait
-        // is strictly bounded: each build attempt is capped at the remaining time.
-        long deadline = android.os.SystemClock.elapsedRealtime() + RPC_HEAD_WAIT_MS;
+        // No usable head (cold start / sustained outage): wait for a build before
+        // giving up. The deadline is adaptive — recomputed each iteration: while an
+        // anchored-head build is actually in flight (warmer or a prior read), ride it
+        // up to RPC_HEAD_BUILD_WAIT_MS so a read arriving mid-build returns verified-
+        // but-slow; with no build possible (no snap peer) it falls back at the short
+        // RPC_HEAD_WAIT_MS. Each build attempt is capped at the remaining time.
+        long start = android.os.SystemClock.elapsedRealtime();
         Exception last = null;
-        do {
-            long remainingMs = deadline - android.os.SystemClock.elapsedRealtime();
+        while (true) {
+            long now = android.os.SystemClock.elapsedRealtime();
+            long deadline = start + (headBuildInFlight() ? RPC_HEAD_BUILD_WAIT_MS : RPC_HEAD_WAIT_MS);
+            long remainingMs = deadline - now;
             if (remainingMs <= 0) break;
             try {
                 return verifiedHeadCallContext(remainingMs, TimeUnit.MILLISECONDS);
@@ -850,10 +863,19 @@ public final class NodeService extends Service {
                     break;
                 }
             }
-        } while (android.os.SystemClock.elapsedRealtime() < deadline);
-        LogBuffer.i(TAG, "[rpc] no verified head after " + RPC_HEAD_WAIT_MS + "ms -> proxy: "
+        }
+        LogBuffer.i(TAG, "[rpc] no verified head after "
+                + (android.os.SystemClock.elapsedRealtime() - start) + "ms -> proxy: "
                 + (last != null ? unwrap(last) : "timeout"));
         return null;
+    }
+
+    /** True while an anchored-head build is in flight (warmer or a prior read), so a
+     *  waiting read can ride it instead of erroring early. */
+    private boolean headBuildInFlight() {
+        CompletableFuture<EnsCall> f;
+        synchronized (rpcCallCtxLock) { f = rpcCallCtx; }
+        return f != null && !f.isDone();
     }
 
     /** eth_call over the shared anchored head. Returns raw ABI bytes, or null to proxy. */

--- a/app/src/main/java/com/jaeckel/ethp2p/app/CommandHandler.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/CommandHandler.java
@@ -1190,6 +1190,17 @@ public class CommandHandler {
         // before pinning it. The first peer that passes both is pinned for the
         // whole resolution (all reads anchor to one consistent root).
         long minSensibleHead = connector.getNetwork().minSensibleHeadBlock();
+        // Live staleness floor: a peer whose head is behind the beacon-finalized exec
+        // block can never anchor to the beacon chain (finality already passed it), yet
+        // it still snap-serves its frozen root and would be pinned here — forcing the
+        // finalized fallback while fresh-headed peers sit connected.
+        if (beaconLightClient != null) {
+            com.jaeckel.ethp2p.consensus.types.LightClientHeader finHdr =
+                    beaconLightClient.getStore().getFinalizedHeader();
+            if (finHdr != null) {
+                minSensibleHead = Math.max(minSensibleHead, finHdr.execution().blockNumber());
+            }
+        }
         String lastError = null;
         for (com.jaeckel.ethp2p.networking.eth.EthHandler peer : snapPeers) {
             if (!peer.isReady() || peer.isSnapServingFailed()) {
@@ -1199,7 +1210,8 @@ public class CommandHandler {
                 BlockHeader head = peer.requestFreshHeadHeaderAsync().get(6, TimeUnit.SECONDS);
                 if (head.number < minSensibleHead) {
                     lastError = "peer " + peer.getRemoteAddress()
-                        + " returned stale head #" + head.number;
+                        + " returned stale head #" + head.number
+                        + " (< floor #" + minSensibleHead + ")";
                     continue;
                 }
                 if (!servesRoot(peer, head.stateRoot)) {

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
@@ -13,6 +13,7 @@ import com.jaeckel.ethp2p.consensus.types.LightClientFinalityUpdate;
 import com.jaeckel.ethp2p.consensus.types.LightClientHeader;
 import com.jaeckel.ethp2p.consensus.types.LightClientUpdate;
 import com.jaeckel.ethp2p.consensus.types.StatusMessage;
+import com.jaeckel.ethp2p.consensus.types.SyncCommittee;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -174,6 +175,7 @@ public class BeaconLightClient implements AutoCloseable {
             // (eviction polls the front; export/findStateRoot treat the tail as freshest).
             restoreStateRootsSidecar(file);
             updateSyncState();
+            warmBlsPubkeyCache();
             log.info("[beacon] Resumed from persisted snapshot at period {} (slot {}) — "
                             + "catching up only periods since",
                     snap.currentSyncCommitteePeriod(), snap.finalizedSlot());
@@ -284,6 +286,33 @@ public class BeaconLightClient implements AutoCloseable {
         } catch (Exception e) {
             log.debug("[beacon] roots sidecar restore failed: {}", e.getMessage());
         }
+    }
+
+    /**
+     * Pre-decompress the current (and next, if known) sync committee's pubkeys into
+     * BlsVerifier's cache on a background thread, so the first finality-update verify
+     * after a resume pays only the pairing instead of ~512 G1 square roots (~35-55s
+     * on Android/ART). Safe to call repeatedly — already-cached keys are no-ops.
+     */
+    private void warmBlsPubkeyCache() {
+        Thread t = new Thread(() -> {
+            try {
+                java.util.List<byte[]> keys = new java.util.ArrayList<>();
+                SyncCommittee current = store.getCurrentSyncCommittee();
+                if (current != null) keys.addAll(java.util.Arrays.asList(current.pubkeys()));
+                SyncCommittee next = store.getNextSyncCommittee();
+                if (next != null) keys.addAll(java.util.Arrays.asList(next.pubkeys()));
+                if (keys.isEmpty()) return;
+                long t0 = System.nanoTime();
+                com.jaeckel.ethp2p.consensus.bls.BlsVerifier.warmPubkeyCache(keys);
+                log.info("[beacon] BLS pubkey cache warmed: {} keys in {}ms",
+                        keys.size(), (System.nanoTime() - t0) / 1_000_000);
+            } catch (Exception e) {
+                log.debug("[beacon] BLS cache warm failed: {}", e.getMessage());
+            }
+        }, "bls-cache-warmer");
+        t.setDaemon(true);
+        t.start();
     }
 
     /** Remember a peer that served catch-up from {@code period} (lowest wins) and persist it. */
@@ -486,16 +515,20 @@ public class BeaconLightClient implements AutoCloseable {
         // Phase 0: discover peers from beacon API before attempting connections
         discoverPeersFromBeaconApi();
 
-        // Pre-connect to peers and query Identify to learn protocol support.
-        // This lets bootstrap() prioritize peers advertising light_client protocols.
-        preConnectAndIdentify();
-
         // Phase 1: resume from a persisted snapshot (day-to-day fast path) — if we
         // have verified state newer than the embedded checkpoint from a prior run,
         // pick up there and only catch up the periods since. Falls through to a
         // fresh bootstrap from the embedded checkpoint when there's no usable
         // snapshot (first run, wiped cache, or a corrupt/foreign file).
+        // Runs BEFORE the network pre-connect: it's disk-only, and it kicks off the
+        // background BLS pubkey-cache warm so decompression overlaps the Identify
+        // round instead of stalling the first finality verify after it.
         boolean resumed = tryResumeFromSnapshot();
+
+        // Pre-connect to peers and query Identify to learn protocol support.
+        // This lets bootstrap() prioritize peers advertising light_client protocols.
+        preConnectAndIdentify();
+
         if (!resumed) {
             // Bootstrap with BLS verification from the embedded checkpoint.
             bootstrap();
@@ -600,9 +633,22 @@ public class BeaconLightClient implements AutoCloseable {
      * Waits up to 8 seconds for connections + Identify to complete.
      * This ensures bootstrap() can prioritize light-client-capable peers.
      */
+    /** Boot Identify fan-out cap. The CL cache can hold hundreds of fork-matched peers;
+     *  dialing them all at once cost ~60s of connection churn before the first poll
+     *  could start. copyPeers() orders confirmed-LC peers first, so a bounded slice
+     *  still reaches the peers that matter, and verdict learning for the rest
+     *  continues organically as later polls touch them. */
+    private static final int PRECONNECT_MAX_PEERS = 64;
+    /** Stop waiting on the Identify round once this many LC-capable peers are
+     *  connected — enough to start polling finality updates immediately. */
+    private static final int PRECONNECT_LC_EARLY_EXIT = 3;
+
     private void preConnectAndIdentify() {
         List<String> peers = copyPeers();
         if (peers.isEmpty()) return;
+        if (peers.size() > PRECONNECT_MAX_PEERS) {
+            peers = peers.subList(0, PRECONNECT_MAX_PEERS);
+        }
 
         log.info("[beacon] Pre-connecting to {} peer(s) for Identify...", peers.size());
         List<CompletableFuture<Void>> futures = new ArrayList<>();
@@ -616,11 +662,27 @@ public class BeaconLightClient implements AutoCloseable {
             futures.add(p2pService.queryIdentify(peer).handle((v, ex) -> null));
         }
 
-        try {
-            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
-                    .get(10, TimeUnit.SECONDS);
-        } catch (Exception e) {
-            // Some peers may have timed out — that's fine
+        // Wait up to 10s, but bail as soon as a few LC-capable peers are connected —
+        // that's all the first finality poll needs; stragglers keep Identifying in
+        // the background and get picked up by later polls.
+        CompletableFuture<Void> all =
+                CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+        long identifyDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+        while (System.nanoTime() < identifyDeadline && !all.isDone()) {
+            long lcSoFar = p2pService.getConnectedPeers().stream()
+                    .filter(BeaconP2PService.PeerInfo::supportsLightClient).count();
+            if (lcSoFar >= PRECONNECT_LC_EARLY_EXIT) {
+                log.info("[beacon] {} LC peer(s) identified — starting without waiting for the rest",
+                        lcSoFar);
+                break;
+            }
+            try {
+                all.get(500, TimeUnit.MILLISECONDS);
+            } catch (java.util.concurrent.TimeoutException te) {
+                // keep polling
+            } catch (Exception e) {
+                break; // interrupted or all-failed — proceed with what we have
+            }
         }
 
         List<BeaconP2PService.PeerInfo> connected = p2pService.getConnectedPeers();

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
@@ -170,6 +170,7 @@ public class BeaconLightClient implements AutoCloseable {
             store.restore(snap);
             lastPersistedPeriod = snap.currentSyncCommitteePeriod();
             updateSyncState();
+            restoreStateRootsSidecar(file);
             log.info("[beacon] Resumed from persisted snapshot at period {} (slot {}) — "
                             + "catching up only periods since",
                     snap.currentSyncCommitteePeriod(), snap.finalizedSlot());
@@ -188,6 +189,10 @@ public class BeaconLightClient implements AutoCloseable {
     private void persistSnapshot() {
         java.nio.file.Path file = snapshotFile;
         if (file == null) return;
+        // The known-state-roots window advances on every finality poll, so persist it
+        // each call — independent of the period-change gate below that throttles the
+        // (large) committee snapshot to ~once per period.
+        persistStateRootsSidecar(file);
         LightClientStore.Snapshot snap = store.snapshot();
         if (snap == null) return;
         if (snap.currentSyncCommitteePeriod() == lastPersistedPeriod) return;
@@ -208,6 +213,73 @@ public class BeaconLightClient implements AutoCloseable {
                     snap.currentSyncCommitteePeriod(), data.length);
         } catch (Exception e) {
             log.debug("[beacon] Snapshot persist failed: {}", e.getMessage());
+        }
+    }
+
+    // Sidecar persistence for BeaconSyncState's known-state-roots window. Kept beside the
+    // committee snapshot ("<snapshot>.roots") rather than folded into the SSZ store
+    // snapshot, so the window can be rewritten cheaply every finality poll without
+    // touching the committee format. Compact format: version(1) + count(4) then per
+    // entry slot(8) + root(32) + verified(1). Only the freshest entries are kept.
+    private static final String ROOTS_SIDECAR_SUFFIX = ".roots";
+    private static final int ROOTS_SIDECAR_VERSION = 1;
+    private static final int ROOTS_SIDECAR_MAX = 64;
+
+    private java.nio.file.Path rootsSidecarPath(java.nio.file.Path snapshot) {
+        return snapshot.resolveSibling(snapshot.getFileName() + ROOTS_SIDECAR_SUFFIX);
+    }
+
+    private void persistStateRootsSidecar(java.nio.file.Path snapshot) {
+        try {
+            java.util.List<BeaconSyncState.SlottedStateRoot> all = syncState.exportKnownStateRoots();
+            if (all.isEmpty()) return;
+            // Keep only the freshest ROOTS_SIDECAR_MAX (export is oldest→newest).
+            int from = Math.max(0, all.size() - ROOTS_SIDECAR_MAX);
+            java.util.List<BeaconSyncState.SlottedStateRoot> keep = all.subList(from, all.size());
+            java.nio.ByteBuffer buf = java.nio.ByteBuffer.allocate(1 + 4 + keep.size() * 41);
+            buf.put((byte) ROOTS_SIDECAR_VERSION);
+            buf.putInt(keep.size());
+            for (BeaconSyncState.SlottedStateRoot r : keep) {
+                buf.putLong(r.slot());
+                buf.put(r.stateRoot());                 // exactly 32 bytes (validated on record)
+                buf.put((byte) (r.blsVerified() ? 1 : 0));
+            }
+            java.nio.file.Path file = rootsSidecarPath(snapshot);
+            java.nio.file.Path tmp = file.resolveSibling(file.getFileName() + ".tmp");
+            java.nio.file.Files.write(tmp, buf.array());
+            try {
+                java.nio.file.Files.move(tmp, file,
+                        java.nio.file.StandardCopyOption.REPLACE_EXISTING,
+                        java.nio.file.StandardCopyOption.ATOMIC_MOVE);
+            } catch (java.nio.file.AtomicMoveNotSupportedException amnse) {
+                java.nio.file.Files.move(tmp, file, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+            }
+        } catch (Exception e) {
+            log.debug("[beacon] roots sidecar persist failed: {}", e.getMessage());
+        }
+    }
+
+    private void restoreStateRootsSidecar(java.nio.file.Path snapshot) {
+        try {
+            java.nio.file.Path file = rootsSidecarPath(snapshot);
+            if (!java.nio.file.Files.exists(file)) return;
+            java.nio.ByteBuffer buf = java.nio.ByteBuffer.wrap(java.nio.file.Files.readAllBytes(file));
+            if (buf.remaining() < 5 || buf.get() != ROOTS_SIDECAR_VERSION) return;
+            int count = buf.getInt();
+            if (count < 0 || count > ROOTS_SIDECAR_MAX || buf.remaining() < count * 41) return;
+            java.util.List<BeaconSyncState.SlottedStateRoot> roots = new java.util.ArrayList<>(count);
+            for (int i = 0; i < count; i++) {
+                long slot = buf.getLong();
+                byte[] root = new byte[32];
+                buf.get(root);
+                boolean verified = buf.get() != 0;
+                roots.add(new BeaconSyncState.SlottedStateRoot(slot, root, verified));
+            }
+            syncState.importKnownStateRoots(roots);
+            log.info("[beacon] Restored {} known state root(s) from sidecar — SYNCED needs "
+                    + "one fresh finality poll, not {}", roots.size(), BeaconSyncState.FILL_THRESHOLD);
+        } catch (Exception e) {
+            log.debug("[beacon] roots sidecar restore failed: {}", e.getMessage());
         }
     }
 

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
@@ -229,6 +229,10 @@ public class BeaconLightClient implements AutoCloseable {
     private static final String ROOTS_SIDECAR_SUFFIX = ".roots";
     private static final int ROOTS_SIDECAR_VERSION = 1;
     private static final int ROOTS_SIDECAR_MAX = 64;
+    /** (newestSlot, count) of the last sidecar write — skip the flash write when the
+     *  window hasn't advanced (the 12s poll loop calls persistSnapshot every cycle). */
+    private volatile long rootsSidecarLastNewestSlot = -1;
+    private volatile int rootsSidecarLastCount = -1;
 
     private java.nio.file.Path rootsSidecarPath(java.nio.file.Path snapshot) {
         return snapshot.resolveSibling(snapshot.getFileName() + ROOTS_SIDECAR_SUFFIX);
@@ -241,6 +245,10 @@ public class BeaconLightClient implements AutoCloseable {
             // Keep only the freshest ROOTS_SIDECAR_MAX (export is oldest→newest).
             int from = Math.max(0, all.size() - ROOTS_SIDECAR_MAX);
             java.util.List<BeaconSyncState.SlottedStateRoot> keep = all.subList(from, all.size());
+            long newestSlot = keep.get(keep.size() - 1).slot();
+            if (newestSlot == rootsSidecarLastNewestSlot && keep.size() == rootsSidecarLastCount) {
+                return; // window unchanged since the last write
+            }
             java.nio.ByteBuffer buf = java.nio.ByteBuffer.allocate(1 + 4 + keep.size() * 41);
             buf.put((byte) ROOTS_SIDECAR_VERSION);
             buf.putInt(keep.size());
@@ -259,6 +267,8 @@ public class BeaconLightClient implements AutoCloseable {
             } catch (java.nio.file.AtomicMoveNotSupportedException amnse) {
                 java.nio.file.Files.move(tmp, file, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
             }
+            rootsSidecarLastNewestSlot = newestSlot;
+            rootsSidecarLastCount = keep.size();
         } catch (Exception e) {
             log.debug("[beacon] roots sidecar persist failed: {}", e.getMessage());
         }

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
@@ -169,8 +169,11 @@ public class BeaconLightClient implements AutoCloseable {
             }
             store.restore(snap);
             lastPersistedPeriod = snap.currentSyncCommitteePeriod();
-            updateSyncState();
+            // Sidecar first: its roots predate the snapshot's finalized/optimistic roots
+            // that updateSyncState() records, and the window deque must stay oldest→newest
+            // (eviction polls the front; export/findStateRoot treat the tail as freshest).
             restoreStateRootsSidecar(file);
+            updateSyncState();
             log.info("[beacon] Resumed from persisted snapshot at period {} (slot {}) — "
                             + "catching up only periods since",
                     snap.currentSyncCommitteePeriod(), snap.finalizedSlot());

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
@@ -229,10 +229,12 @@ public class BeaconLightClient implements AutoCloseable {
     private static final String ROOTS_SIDECAR_SUFFIX = ".roots";
     private static final int ROOTS_SIDECAR_VERSION = 1;
     private static final int ROOTS_SIDECAR_MAX = 64;
-    /** (newestSlot, count) of the last sidecar write — skip the flash write when the
-     *  window hasn't advanced (the 12s poll loop calls persistSnapshot every cycle). */
-    private volatile long rootsSidecarLastNewestSlot = -1;
-    private volatile int rootsSidecarLastCount = -1;
+    /** (newestSlot, count) of the last sidecar write, one immutable unit behind a
+     *  single volatile so concurrent persist calls can't pair a new slot with an old
+     *  count (torn read). Used to skip the flash write when the window hasn't
+     *  advanced — the 12s poll loop calls persistSnapshot every cycle. */
+    private record SidecarMark(long newestSlot, int count) {}
+    private volatile SidecarMark rootsSidecarLastWritten;
 
     private java.nio.file.Path rootsSidecarPath(java.nio.file.Path snapshot) {
         return snapshot.resolveSibling(snapshot.getFileName() + ROOTS_SIDECAR_SUFFIX);
@@ -246,7 +248,8 @@ public class BeaconLightClient implements AutoCloseable {
             int from = Math.max(0, all.size() - ROOTS_SIDECAR_MAX);
             java.util.List<BeaconSyncState.SlottedStateRoot> keep = all.subList(from, all.size());
             long newestSlot = keep.get(keep.size() - 1).slot();
-            if (newestSlot == rootsSidecarLastNewestSlot && keep.size() == rootsSidecarLastCount) {
+            SidecarMark last = rootsSidecarLastWritten;
+            if (last != null && newestSlot == last.newestSlot() && keep.size() == last.count()) {
                 return; // window unchanged since the last write
             }
             java.nio.ByteBuffer buf = java.nio.ByteBuffer.allocate(1 + 4 + keep.size() * 41);
@@ -267,8 +270,7 @@ public class BeaconLightClient implements AutoCloseable {
             } catch (java.nio.file.AtomicMoveNotSupportedException amnse) {
                 java.nio.file.Files.move(tmp, file, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
             }
-            rootsSidecarLastNewestSlot = newestSlot;
-            rootsSidecarLastCount = keep.size();
+            rootsSidecarLastWritten = new SidecarMark(newestSlot, keep.size());
         } catch (Exception e) {
             log.debug("[beacon] roots sidecar persist failed: {}", e.getMessage());
         }

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconSyncState.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconSyncState.java
@@ -2,7 +2,10 @@ package com.jaeckel.ethp2p.consensus;
 
 import com.jaeckel.ethp2p.consensus.lightclient.BeaconChainSpec;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -308,6 +311,31 @@ public class BeaconSyncState {
         // Evict oldest entries if window is full
         while (knownStateRoots.size() > MAX_KNOWN_ROOTS) {
             knownStateRoots.pollFirst();
+        }
+    }
+
+    /**
+     * Snapshot the rolling window (oldest→newest) so it can be persisted across
+     * restarts. The entries were validated via finality-update BLS signatures; see
+     * {@link #importKnownStateRoots}.
+     */
+    public List<SlottedStateRoot> exportKnownStateRoots() {
+        return new ArrayList<>(knownStateRoots);
+    }
+
+    /**
+     * Re-import persisted window entries (e.g. from a snapshot sidecar) using the same
+     * dedup/cap path as live recording. Lets a warm restart reach SYNCED without first
+     * re-observing {@link #FILL_THRESHOLD} live finality polls. Soundness: this only
+     * pre-fills the "have we seen enough finality" counter — {@code getSyncState} still
+     * gates SYNCED on {@link #isSynced()} (a fresh post-restart update) and on the sync
+     * committee period being current, so a long-offline restart can't report SYNCED on
+     * stale roots alone.
+     */
+    public void importKnownStateRoots(Collection<SlottedStateRoot> roots) {
+        if (roots == null) return;
+        for (SlottedStateRoot r : roots) {
+            if (r != null) recordStateRoot(r.slot(), r.stateRoot(), r.blsVerified());
         }
     }
 

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/bls/BlsVerifier.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/bls/BlsVerifier.java
@@ -48,6 +48,61 @@ public final class BlsVerifier {
         return halfP;
     }
 
+    // Decompressed-pubkey cache. G1 decompression (a field square root per key) is a
+    // pure function of the 48 key bytes, and sync-committee pubkeys are fixed for a
+    // ~27h period — yet fastAggregateVerify decompressed all ~512 on every update,
+    // which dominates a finality-update verify on Android/ART (~35-55s). Capacity
+    // covers current + next committee (2x512) with slack for rotation overlap; on
+    // overflow the whole map is reset (rotations are rare; no LRU bookkeeping).
+    // Values are master copies: Milagro ECP is mutable (reduce()/affine() normalize
+    // in place), so lookups hand out fresh copies — concurrent verifies must never
+    // share live point objects.
+    private static final int PUBKEY_CACHE_MAX = 4096;
+    private static final java.util.concurrent.ConcurrentHashMap<PubkeyKey, ECP> PUBKEY_CACHE =
+            new java.util.concurrent.ConcurrentHashMap<>();
+
+    /** byte[]-keyed map entry (arrays don't implement value equals/hashCode). */
+    private static final class PubkeyKey {
+        private final byte[] bytes;
+        private final int hash;
+        PubkeyKey(byte[] bytes) {
+            this.bytes = bytes;
+            this.hash = Arrays.hashCode(bytes);
+        }
+        @Override public boolean equals(Object o) {
+            return o instanceof PubkeyKey k && Arrays.equals(bytes, k.bytes);
+        }
+        @Override public int hashCode() { return hash; }
+    }
+
+    /** Decompress a trusted (Merkle-proven, no subgroup check) G1 pubkey through the
+     *  cache. Returns a private copy the caller may freely use; null for invalid keys
+     *  (never cached). */
+    private static ECP cachedTrustedG1(byte[] pubkey) {
+        PubkeyKey key = new PubkeyKey(pubkey.clone());
+        ECP master = PUBKEY_CACHE.get(key);
+        if (master == null) {
+            master = deserializeG1(pubkey, false);
+            if (master == null) return null;
+            if (PUBKEY_CACHE.size() >= PUBKEY_CACHE_MAX) PUBKEY_CACHE.clear();
+            PUBKEY_CACHE.putIfAbsent(key, master);
+        }
+        return new ECP(master);
+    }
+
+    /**
+     * Pre-decompress a set of committee pubkeys into the cache so the next
+     * fastAggregateVerify pays only the pairing, not ~512 square roots. Call off the
+     * hot path (e.g. right after a snapshot resume or committee rotation); decompression
+     * fans out across cores. Invalid keys are skipped — verify rejects them later.
+     */
+    public static void warmPubkeyCache(List<byte[]> pubkeyBytes) {
+        if (pubkeyBytes == null) return;
+        pubkeyBytes.parallelStream().forEach(b -> {
+            if (b != null && b.length == 48) cachedTrustedG1(b);
+        });
+    }
+
     private BlsVerifier() {}
 
     /**
@@ -97,12 +152,13 @@ public final class BlsVerifier {
             // Point decompression (a field square root per key) is independent
             // per pubkey, so we fan it out across cores: on Android/ART the serial
             // 512-key loop took ~30s, dwarfing everything else. parallelStream uses
-            // the common ForkJoinPool (parallelism = cores-1). The aggregation
-            // (ECP.add) is then a cheap sequential reduce — Milagro ECP isn't
-            // safe to mutate from multiple threads, but independent decompression
-            // into fresh ECP objects is.
+            // the common ForkJoinPool (parallelism = cores-1). Decompressed points
+            // are cached across calls (committees are period-stable), so a warm
+            // verify pays only copies + the pairing. The aggregation (ECP.add) is
+            // then a cheap sequential reduce — Milagro ECP isn't safe to mutate
+            // from multiple threads, but each cache lookup returns a private copy.
             List<ECP> points = pubkeyBytes.parallelStream()
-                    .map(b -> deserializeG1(b, false))
+                    .map(BlsVerifier::cachedTrustedG1)
                     .collect(java.util.stream.Collectors.toList());
             ECP aggregated = new ECP(); // point at infinity
             for (ECP pk : points) {

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/bls/BlsVerifier.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/bls/BlsVerifier.java
@@ -77,17 +77,16 @@ public final class BlsVerifier {
 
     /** Decompress a trusted (Merkle-proven, no subgroup check) G1 pubkey through the
      *  cache. Returns a private copy the caller may freely use; null for invalid keys
-     *  (never cached). */
+     *  (never cached). computeIfAbsent guarantees one decompression per key even when
+     *  a warm-up and a verify race on the same committee (the mapping function runs at
+     *  most once; concurrent callers for the same key block briefly and reuse it). The
+     *  overflow reset stays outside the compute — mutating the map from inside its own
+     *  mapping function is forbidden. */
     private static ECP cachedTrustedG1(byte[] pubkey) {
-        PubkeyKey key = new PubkeyKey(pubkey.clone());
-        ECP master = PUBKEY_CACHE.get(key);
-        if (master == null) {
-            master = deserializeG1(pubkey, false);
-            if (master == null) return null;
-            if (PUBKEY_CACHE.size() >= PUBKEY_CACHE_MAX) PUBKEY_CACHE.clear();
-            PUBKEY_CACHE.putIfAbsent(key, master);
-        }
-        return new ECP(master);
+        if (PUBKEY_CACHE.size() >= PUBKEY_CACHE_MAX) PUBKEY_CACHE.clear();
+        ECP master = PUBKEY_CACHE.computeIfAbsent(
+                new PubkeyKey(pubkey.clone()), k -> deserializeG1(k.bytes, false));
+        return master == null ? null : new ECP(master);
     }
 
     /**

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/lightclient/LightClientProcessor.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/lightclient/LightClientProcessor.java
@@ -21,6 +21,15 @@ public class LightClientProcessor {
     private final byte[] forkVersion;
     private final byte[] genesisValidatorsRoot;
 
+    /** Aggregate signature of the last successfully applied finality update. The
+     *  signature commits to the attested header root (whose state root in turn commits
+     *  the finality branch), so a byte-identical signature is the same already-applied
+     *  update: any variant with different contents would fail verification anyway.
+     *  Lets the 12s poll loop skip re-verifying an unchanged head — each BLS verify
+     *  costs ~18s on Android/ART, so without this the steady-state loop burns a full
+     *  core re-proving the same update. */
+    private volatile byte[] lastAppliedFinalitySig;
+
     public LightClientProcessor(LightClientStore store, byte[] forkVersion, byte[] genesisValidatorsRoot) {
         this.store = store;
         this.forkVersion = forkVersion.clone();
@@ -52,6 +61,15 @@ public class LightClientProcessor {
         long attestedSlot = update.attestedHeader().beacon().slot();
         long finalizedSlot = update.finalizedHeader().beacon().slot();
         int participation = update.syncAggregate().countParticipants();
+
+        byte[] sig = update.syncAggregate().syncCommitteeSignature();
+        byte[] lastSig = lastAppliedFinalitySig;
+        if (lastSig != null && java.util.Arrays.equals(lastSig, sig)) {
+            log.debug("[lc-processor] Finality update is a duplicate of the already-applied one "
+                    + "(attestedSlot={}) — skipping re-verify", attestedSlot);
+            return true;
+        }
+
         log.debug("[lc-processor] Processing finality update: attestedSlot={}, finalizedSlot={}, " +
                 "signatureSlot={}, participation={}/512, finalityBranchLen={}",
                 attestedSlot, finalizedSlot, update.signatureSlot(),
@@ -96,6 +114,7 @@ public class LightClientProcessor {
         // (updateFinalized may have already advanced this.finalizedSlot).
         store.applyNextSyncCommitteeWhenPeriodChanges(oldFinalizedSlot, finalizedSlot);
 
+        lastAppliedFinalitySig = sig.clone();
         log.debug("[lc-processor] Finality update applied: finalizedSlot {} → {}", oldFinalizedSlot, finalizedSlot);
         return true;
     }

--- a/consensus/src/test/java/com/jaeckel/ethp2p/consensus/BeaconSyncStateRootsTest.java
+++ b/consensus/src/test/java/com/jaeckel/ethp2p/consensus/BeaconSyncStateRootsTest.java
@@ -1,0 +1,58 @@
+package com.jaeckel.ethp2p.consensus;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Round-trip for the known-state-roots window export/import that backs the snapshot
+ * sidecar — a warm restart restores the window so SYNCED needs one fresh finality poll
+ * instead of {@link BeaconSyncState#FILL_THRESHOLD}.
+ */
+class BeaconSyncStateRootsTest {
+
+    private static byte[] root(int seed) {
+        byte[] r = new byte[32];
+        for (int i = 0; i < 32; i++) r[i] = (byte) (seed + i);
+        return r;
+    }
+
+    @Test
+    void exportImportRoundTripPreservesWindow() {
+        BeaconSyncState a = new BeaconSyncState();
+        for (int i = 0; i < BeaconSyncState.FILL_THRESHOLD; i++) {
+            a.recordStateRoot(1000 + i, root(i), false);
+        }
+        List<BeaconSyncState.SlottedStateRoot> exported = a.exportKnownStateRoots();
+        assertEquals(BeaconSyncState.FILL_THRESHOLD, exported.size());
+
+        BeaconSyncState b = new BeaconSyncState();
+        assertEquals(0, b.getKnownStateRootCount());
+        b.importKnownStateRoots(exported);
+        assertEquals(BeaconSyncState.FILL_THRESHOLD, b.getKnownStateRootCount());
+
+        // Imported roots are individually matchable (findStateRoot) and carry the slot.
+        BeaconSyncState.SlottedStateRoot hit = b.findStateRoot(root(0));
+        assertNotNull(hit);
+        assertEquals(1000, hit.slot());
+    }
+
+    @Test
+    void importIsIdempotentAndNullSafe() {
+        BeaconSyncState a = new BeaconSyncState();
+        a.recordStateRoot(42, root(7), true);
+        List<BeaconSyncState.SlottedStateRoot> exported = a.exportKnownStateRoots();
+
+        BeaconSyncState b = new BeaconSyncState();
+        b.importKnownStateRoots(null);          // tolerated
+        b.importKnownStateRoots(exported);
+        b.importKnownStateRoots(exported);      // dedup, no double count
+        assertEquals(1, b.getKnownStateRootCount());
+        // blsVerified flag survives the round trip.
+        assertTrue(b.findStateRoot(root(7)).blsVerified());
+    }
+}

--- a/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/MyotisRpcBackend.kt
+++ b/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/MyotisRpcBackend.kt
@@ -87,4 +87,36 @@ interface MyotisRpcBackend {
      * far back / [fullTransactions]=true, which isn't served verified yet) → router errors.
      */
     fun getBlockByNumber(block: String, fullTransactions: Boolean): String?
+
+    // --- Fee suggestion (MetaMask's signing screen blocks on these) -----------
+    // Defaults return null (→ router errors) so hosts can adopt incrementally.
+
+    /**
+     * eth_gasPrice: a legacy-style total gas price suggestion (next baseFee + suggested
+     * tip), derived from beacon-verified headers + body-verified tips. Null to error.
+     */
+    fun gasPrice(): java.math.BigInteger? = null
+
+    /**
+     * eth_maxPriorityFeePerGas: suggested priority fee from recent blocks' verified
+     * transactions (effective tips, verified against transactionsRoot). Null to error.
+     */
+    fun maxPriorityFeePerGas(): java.math.BigInteger? = null
+
+    /**
+     * eth_feeHistory: the EIP-1559 fee history result as a pre-built JSON object string
+     * ({oldestBlock, baseFeePerGas[], gasUsedRatio[], reward[][]?}), computed from
+     * beacon-verified headers (+ verified bodies/receipts when [rewardPercentiles] is
+     * non-empty). [blockCount] may be clamped by the host (the result reflects what was
+     * served, per EIP-1559). Kotlin null when it can't be answered verified → router errors.
+     */
+    fun feeHistory(blockCount: Long, newestBlock: String, rewardPercentiles: DoubleArray?): String? = null
+
+    /**
+     * eth_estimateGas: gas estimate for executing the call/tx against verified state at
+     * the head. [value] is the wei value (null = 0). Null when it can't be answered
+     * verified (not synced / no snap peer / execution failure) → router errors.
+     */
+    fun estimateGas(from: ByteArray?, to: ByteArray?, data: ByteArray?,
+                    value: java.math.BigInteger?): java.math.BigInteger? = null
 }

--- a/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/RpcRouter.kt
+++ b/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/RpcRouter.kt
@@ -11,6 +11,7 @@ import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.doubleOrNull
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
@@ -42,6 +43,7 @@ class RpcRouter(
             "eth_chainId", "net_version", "eth_blockNumber", "eth_call", "eth_getBalance",
             "eth_getTransactionCount", "eth_getCode", "eth_getStorageAt",
             "eth_sendRawTransaction", "eth_getTransactionReceipt", "eth_getBlockByNumber",
+            "eth_gasPrice", "eth_maxPriorityFeePerGas", "eth_feeHistory", "eth_estimateGas",
         )
     }
 
@@ -205,6 +207,65 @@ class RpcRouter(
                 // (can't verify) → fall through to the strict error.
                 val blockJson = withContext(Dispatchers.IO) { b.getBlockByNumber(block, fullTx) } ?: return null
                 resultEnvelope(id, json.parseToJsonElement(blockJson))
+            }
+            "eth_gasPrice" -> {
+                val price = withContext(Dispatchers.IO) { b.gasPrice() } ?: return null
+                resultEnvelope(id, JsonPrimitive(hexQuantity(price)))
+            }
+            "eth_maxPriorityFeePerGas" -> {
+                val tip = withContext(Dispatchers.IO) { b.maxPriorityFeePerGas() } ?: return null
+                resultEnvelope(id, JsonPrimitive(hexQuantity(tip)))
+            }
+            "eth_feeHistory" -> {
+                val p = root.params()
+                // blockCount is a QUANTITY (hex) per spec, but some clients send a JSON
+                // number — accept both.
+                val countPrim = p?.getOrNull(0) as? JsonPrimitive ?: return null
+                val blockCount = countPrim.contentOrNull?.let { s ->
+                    if (s.startsWith("0x") || s.startsWith("0X")) s.substring(2).toLongOrNull(16)
+                    else s.toLongOrNull()
+                } ?: return null
+                if (blockCount <= 0) return null
+                val newest = p.blockTag(1)
+                // Percentiles must be monotonically non-decreasing in [0,100]; a request
+                // without them gets baseFee/gasUsedRatio only (no reward array).
+                val pctArr: DoubleArray? = when (val pe = p.getOrNull(2)) {
+                    null, is JsonNull -> null
+                    is JsonArray -> {
+                        val vals = DoubleArray(pe.size)
+                        for (i in pe.indices) {
+                            val d = (pe[i] as? JsonPrimitive)?.doubleOrNull ?: return null
+                            if (d < 0.0 || d > 100.0) return null
+                            if (i > 0 && vals[i - 1] > d) return null
+                            vals[i] = d
+                        }
+                        vals
+                    }
+                    else -> return null
+                }
+                val historyJson = withContext(Dispatchers.IO) { b.feeHistory(blockCount, newest, pctArr) }
+                    ?: return null
+                resultEnvelope(id, json.parseToJsonElement(historyJson))
+            }
+            "eth_estimateGas" -> {
+                val p = root.params()
+                val callObj = p?.getOrNull(0) as? JsonObject ?: return null
+                val from = (callObj["from"]?.takeUnless { it is JsonNull })?.let { it.asHexBytes() ?: return null }
+                // to=null is contract creation — supported (estimates the deploy).
+                val to = (callObj["to"]?.takeUnless { it is JsonNull })?.let { it.asHexBytes() ?: return null }
+                val dataElement = (callObj["data"] ?: callObj["input"])?.takeUnless { it is JsonNull }
+                val data = if (dataElement != null) (dataElement.asHexBytes() ?: return null) else null
+                val valueElement = callObj["value"]?.takeUnless { it is JsonNull }
+                val value = if (valueElement != null) {
+                    val s = (valueElement as? JsonPrimitive)?.contentOrNull ?: return null
+                    try {
+                        if (s.startsWith("0x") || s.startsWith("0X"))
+                            java.math.BigInteger(s.substring(2).ifEmpty { "0" }, 16)
+                        else java.math.BigInteger(s)
+                    } catch (e: NumberFormatException) { return null }
+                } else null
+                val gas = withContext(Dispatchers.IO) { b.estimateGas(from, to, data, value) } ?: return null
+                resultEnvelope(id, JsonPrimitive(hexQuantity(gas)))
             }
             else -> null
         }

--- a/jsonrpc-server/src/test/kotlin/io/myotis/jsonrpc/RpcRouterTest.kt
+++ b/jsonrpc-server/src/test/kotlin/io/myotis/jsonrpc/RpcRouterTest.kt
@@ -63,6 +63,30 @@ class RpcRouterTest {
         override fun getBlockByNumber(block: String, fullTransactions: Boolean): String? {
             lastBlockTag = block; lastFullTx = fullTransactions; return blockJson
         }
+        var gasPriceWei: BigInteger? = null
+        override fun gasPrice(): BigInteger? = gasPriceWei
+        var tipWei: BigInteger? = null
+        override fun maxPriorityFeePerGas(): BigInteger? = tipWei
+        var lastFeeBlockCount: Long? = null
+        var lastFeeNewest: String? = null
+        var lastFeePercentiles: DoubleArray? = null
+        var feeHistoryJson: String? = null
+        override fun feeHistory(blockCount: Long, newestBlock: String,
+                                rewardPercentiles: DoubleArray?): String? {
+            lastFeeBlockCount = blockCount; lastFeeNewest = newestBlock
+            lastFeePercentiles = rewardPercentiles
+            return feeHistoryJson
+        }
+        var lastEstFrom: ByteArray? = null
+        var lastEstTo: ByteArray? = null
+        var lastEstData: ByteArray? = null
+        var lastEstValue: BigInteger? = null
+        var estimateResult: BigInteger? = null
+        override fun estimateGas(from: ByteArray?, to: ByteArray?, data: ByteArray?,
+                                 value: BigInteger?): BigInteger? {
+            lastEstFrom = from; lastEstTo = to; lastEstData = data; lastEstValue = value
+            return estimateResult
+        }
     }
 
     private fun route(backend: MyotisRpcBackend?, body: String, proxy: UpstreamProxy? = null): String =
@@ -282,6 +306,94 @@ class RpcRouterTest {
     @Test fun getBlockByNumber_cannotVerify_errors() {
         val resp = route(FakeBackend(),  // blockJson null → can't verify → strict error
             """{"jsonrpc":"2.0","id":3,"method":"eth_getBlockByNumber","params":["latest",false]}""")
+        assertTrue(hasError(resp))
+        assertEquals(-32000, errorCode(resp))
+    }
+
+    @Test fun gasPrice_verified_encodesQuantity() {
+        val b = FakeBackend().apply { gasPriceWei = BigInteger.valueOf(0x9184e72a000L) } // 10 gwei
+        val resp = route(b, """{"jsonrpc":"2.0","id":1,"method":"eth_gasPrice","params":[]}""")
+        assertEquals("0x9184e72a000", result(resp))
+    }
+
+    @Test fun gasPrice_cannotVerify_errorsRetryable() {
+        val resp = route(FakeBackend(), """{"jsonrpc":"2.0","id":1,"method":"eth_gasPrice","params":[]}""")
+        assertTrue(hasError(resp))
+        assertEquals(-32000, errorCode(resp))                    // implemented, retryable — not -32601
+    }
+
+    @Test fun maxPriorityFeePerGas_verified_encodesQuantity() {
+        val b = FakeBackend().apply { tipWei = BigInteger.valueOf(100_000_000L) } // 0.1 gwei
+        val resp = route(b, """{"jsonrpc":"2.0","id":1,"method":"eth_maxPriorityFeePerGas","params":[]}""")
+        assertEquals("0x5f5e100", result(resp))
+    }
+
+    @Test fun feeHistory_decodesHexCount_tagAndPercentiles_embedsResult() {
+        val b = FakeBackend().apply {
+            feeHistoryJson = """{"oldestBlock":"0xfc","baseFeePerGas":["0x7","0x8"],"gasUsedRatio":[0.5]}"""
+        }
+        val resp = route(b,
+            """{"jsonrpc":"2.0","id":1,"method":"eth_feeHistory","params":["0x5","latest",[10,20.5,30]]}""")
+        val obj = json.parseToJsonElement(resp).jsonObject["result"]!!.jsonObject
+        assertEquals("0xfc", obj["oldestBlock"]!!.jsonPrimitive.content)
+        assertEquals(5L, b.lastFeeBlockCount)
+        assertEquals("latest", b.lastFeeNewest)
+        assertArrayEquals(doubleArrayOf(10.0, 20.5, 30.0), b.lastFeePercentiles!!, 0.0)
+    }
+
+    @Test fun feeHistory_acceptsPlainNumberCount_andNoPercentiles() {
+        val b = FakeBackend().apply { feeHistoryJson = """{"oldestBlock":"0x1"}""" }
+        val resp = route(b, """{"jsonrpc":"2.0","id":1,"method":"eth_feeHistory","params":[5,"0x100"]}""")
+        assertTrue(!hasError(resp))
+        assertEquals(5L, b.lastFeeBlockCount)
+        assertEquals("0x100", b.lastFeeNewest)
+        assertNull(b.lastFeePercentiles)
+    }
+
+    @Test fun feeHistory_rejectsBadPercentiles() {
+        val b = FakeBackend().apply { feeHistoryJson = """{"oldestBlock":"0x1"}""" }
+        // descending percentiles → invalid per EIP-1559 → strict error, backend not invoked
+        val resp = route(b,
+            """{"jsonrpc":"2.0","id":1,"method":"eth_feeHistory","params":["0x5","latest",[30,10]]}""")
+        assertTrue(hasError(resp))
+        assertNull(b.lastFeeBlockCount)
+        // out-of-range percentile
+        val resp2 = route(b,
+            """{"jsonrpc":"2.0","id":1,"method":"eth_feeHistory","params":["0x5","latest",[101]]}""")
+        assertTrue(hasError(resp2))
+        assertNull(b.lastFeeBlockCount)
+    }
+
+    @Test fun estimateGas_decodesCallObject_encodesQuantity() {
+        val b = FakeBackend().apply { estimateResult = BigInteger.valueOf(21000) }
+        val resp = route(b,
+            """{"jsonrpc":"2.0","id":1,"method":"eth_estimateGas",
+               "params":[{"from":"0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+                          "to":"0x00000000219ab540356cBB839Cbe05303d7705Fa",
+                          "value":"0xde0b6b3a7640000","data":"0xab"}]}""")
+        assertEquals("0x5208", result(resp))
+        assertEquals(0xd8.toByte(), b.lastEstFrom!![0])
+        assertEquals(20, b.lastEstTo!!.size)
+        assertEquals(BigInteger("de0b6b3a7640000", 16), b.lastEstValue)  // 1 ETH
+        assertEquals("0xab", b.lastEstData!!.toHex())
+    }
+
+    @Test fun estimateGas_minimalParams_passesNulls() {
+        val b = FakeBackend().apply { estimateResult = BigInteger.valueOf(53000) }
+        val resp = route(b,
+            """{"jsonrpc":"2.0","id":1,"method":"eth_estimateGas",
+               "params":[{"to":"0x00000000219ab540356cBB839Cbe05303d7705Fa"}]}""")
+        assertEquals("0xcf08", result(resp))
+        assertNull(b.lastEstFrom)
+        assertNull(b.lastEstData)
+        assertNull(b.lastEstValue)
+    }
+
+    @Test fun estimateGas_revertingTx_errors() {
+        // Backend null (reverting tx / can't verify) → strict -32000, never a number.
+        val resp = route(FakeBackend(),
+            """{"jsonrpc":"2.0","id":1,"method":"eth_estimateGas",
+               "params":[{"to":"0x00000000219ab540356cBB839Cbe05303d7705Fa"}]}""")
         assertTrue(hasError(resp))
         assertEquals(-32000, errorCode(resp))
     }

--- a/myotis-evm/src/main/java/io/myotis/evm/CcipReadEvmExecutor.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/CcipReadEvmExecutor.java
@@ -75,6 +75,14 @@ public final class CcipReadEvmExecutor implements EvmExecutor {
         return tryWithCcipRead(target, calldata, blockContext, 0);
     }
 
+    /** Estimation passes straight through — CCIP-Read (ERC-3668) only applies to
+     *  OffchainLookup reverts during view reads, not to gas metering of a
+     *  to-be-broadcast transaction (a tx that reverts must NOT get an estimate). */
+    @Override
+    public CompletableFuture<Long> estimateGas(UnsignedTransaction tx, BlockContext blockContext) {
+        return delegate.estimateGas(tx, blockContext);
+    }
+
     private CompletableFuture<byte[]> tryWithCcipRead(
             Address target, byte[] calldata, BlockContext ctx, int depth) {
         return delegate.callView(target, calldata, ctx)

--- a/myotis-evm/src/main/java/io/myotis/evm/DefaultEvmExecutor.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/DefaultEvmExecutor.java
@@ -123,9 +123,7 @@ public final class DefaultEvmExecutor implements EvmExecutor {
                 org.hyperledger.besu.datatypes.Address.wrap(Bytes.wrap(blockContext.coinbase().toByteArray()));
 
         var targetAccount = scope.get(besuTarget);
-        Bytes contractCode = targetAccount == null ? Bytes.EMPTY : targetAccount.getCode();
-        Hash contractCodeHash = targetAccount == null ? Hash.EMPTY : targetAccount.getCodeHash();
-        Code code = evm.getCode(contractCodeHash, contractCode);
+        Code code = resolveCode(evm, scope, targetAccount);
 
         Wei value = Wei.of(tx.value());
 
@@ -181,6 +179,33 @@ public final class DefaultEvmExecutor implements EvmExecutor {
                 new EvmExecutionError.Reverted(detail.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
     }
 
+    /** EIP-7702 delegation designator prefix: an EOA whose code is
+     *  {@code 0xef0100 || address} executes the delegate's code in its own context. */
+    private static final Bytes DELEGATION_PREFIX = Bytes.fromHexString("0xef0100");
+
+    /**
+     * The code to execute for a call target, resolving an EIP-7702 delegation
+     * designator one hop (the spec forbids chains — a delegate that itself holds
+     * a designator is NOT followed; executing those raw bytes then correctly
+     * yields an invalid-opcode halt). Without this, a plain call/estimate against
+     * a delegated EOA (increasingly common post-Pectra) executed the raw
+     * {@code 0xEF...} designator and died with INVALID_OPERATION.
+     */
+    private static Code resolveCode(EVM evm,
+            org.hyperledger.besu.evm.worldstate.WorldUpdater scope,
+            org.hyperledger.besu.evm.account.Account targetAccount) {
+        Bytes contractCode = targetAccount == null ? Bytes.EMPTY : targetAccount.getCode();
+        Hash contractCodeHash = targetAccount == null ? Hash.EMPTY : targetAccount.getCodeHash();
+        if (contractCode.size() == 23 && contractCode.slice(0, 3).equals(DELEGATION_PREFIX)) {
+            org.hyperledger.besu.datatypes.Address delegate =
+                    org.hyperledger.besu.datatypes.Address.wrap(contractCode.slice(3, 20));
+            var delegateAccount = scope.get(delegate);
+            contractCode = delegateAccount == null ? Bytes.EMPTY : delegateAccount.getCode();
+            contractCodeHash = delegateAccount == null ? Hash.EMPTY : delegateAccount.getCodeHash();
+        }
+        return evm.getCode(contractCodeHash, contractCode);
+    }
+
     /**
      * Yellow-Paper-Appendix-G intrinsic gas cost for a transaction:
      * 21000 base, 4 per zero byte of calldata, 16 per non-zero byte
@@ -229,9 +254,7 @@ public final class DefaultEvmExecutor implements EvmExecutor {
                 org.hyperledger.besu.datatypes.Address.wrap(Bytes.wrap(blockContext.coinbase().toByteArray()));
 
         var targetAccount = scope.get(besuTarget);
-        Bytes contractCode = targetAccount == null ? Bytes.EMPTY : targetAccount.getCode();
-        Hash contractCodeHash = targetAccount == null ? Hash.EMPTY : targetAccount.getCodeHash();
-        Code code = evm.getCode(contractCodeHash, contractCode);
+        Code code = resolveCode(evm, scope, targetAccount);
 
         MessageFrame frame = MessageFrame.builder()
                 .type(MessageFrame.Type.MESSAGE_CALL)

--- a/myotis-evm/src/main/java/io/myotis/evm/PrefetchingEvmExecutor.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/PrefetchingEvmExecutor.java
@@ -98,6 +98,14 @@ public final class PrefetchingEvmExecutor implements EvmExecutor {
                 () -> runConvergent(target, calldata, blockContext), executor);
     }
 
+    /** Estimation delegates directly: the prefetch/convergence loop exists to batch
+     *  oracle round-trips for reads; the estimator already runs against the same
+     *  snap-backed view and its gas accounting must not be re-run to convergence. */
+    @Override
+    public CompletableFuture<Long> estimateGas(UnsignedTransaction tx, BlockContext blockContext) {
+        return delegate.estimateGas(tx, blockContext);
+    }
+
     private byte[] runConvergent(Address target, byte[] calldata, BlockContext blockContext) {
         SnapStateOracle oracle = delegate.oracle();
         BytecodeCache bytecodeCache = delegate.bytecodeCache();

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/EthHandler.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/EthHandler.java
@@ -477,7 +477,12 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
             case ETH_RECEIPTS -> {
                 long reqId = peekRequestId(msg.payload());
                 try {
-                    ReceiptsMessage.DecodeResult decoded = ReceiptsMessage.decode(msg.payload());
+                    // eth/69 (EIP-7642) receipts arrive bloomless + envelope-flattened;
+                    // decode69 recomputes the bloom and re-canonicalizes so downstream
+                    // receiptsRoot verification is identical across versions.
+                    ReceiptsMessage.DecodeResult decoded = negotiatedEthVersion >= 69
+                            ? ReceiptsMessage.decode69(msg.payload())
+                            : ReceiptsMessage.decode(msg.payload());
                     log.info("[eth] Received receipts for {} block(s) (reqId={})",
                             decoded.perBlockReceipts().size(), decoded.requestId());
                     CompletableFuture<List<List<org.apache.tuweni.bytes.Bytes>>> future =

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/messages/ReceiptsMessage.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/messages/ReceiptsMessage.java
@@ -64,6 +64,95 @@ public final class ReceiptsMessage {
     }
 
     /**
+     * Decode an eth/69 (EIP-7642) Receipts message into CANONICAL consensus receipt
+     * bytes. eth/69 strips the logsBloom from each wire receipt and flattens the
+     * typed envelope: every receipt arrives as the 4-item list
+     * {@code [txType, postStateOrStatus, cumulativeGas, logs]}. The bloom is a pure
+     * function of the logs, so we recompute it and re-encode the canonical form
+     * (legacy: {@code rlp([status, cumGas, bloom, logs])}; typed: {@code type || rlp(...)})
+     * — the caller's receipts-trie verification against {@code header.receiptsRoot}
+     * then works exactly as for eth/66-68. A peer that lies about the logs still
+     * fails that root check; recomputing the bloom adds no trust.
+     */
+    public static DecodeResult decode69(byte[] rlp) {
+        List<List<Bytes>> blocks = new ArrayList<>();
+        long[] reqId = {0};
+        RLP.decodeList(Bytes.wrap(rlp), reader -> {
+            reqId[0] = reader.readLong();
+            reader.readList(blocksReader -> {
+                while (!blocksReader.isComplete()) {
+                    List<Bytes> receipts = new ArrayList<>();
+                    blocksReader.readList(receiptListReader -> {
+                        while (!receiptListReader.isComplete()) {
+                            receipts.add(canonicalizeEth69Receipt(receiptListReader));
+                        }
+                        return null;
+                    });
+                    blocks.add(receipts);
+                }
+                return null;
+            });
+            return null;
+        });
+        return new DecodeResult(reqId[0], blocks);
+    }
+
+    /** Read one eth/69 wire receipt and return its canonical consensus encoding. */
+    private static Bytes canonicalizeEth69Receipt(RLPReader outer) {
+        return outer.readList(r -> {
+            Bytes typeBytes = r.readValue();
+            int type = typeBytes.isEmpty() ? 0 : typeBytes.get(typeBytes.size() - 1) & 0xFF;
+            Bytes statusOrState = r.readValue();
+            Bytes cumGas = r.readValue();
+            byte[] bloom = new byte[256];
+            List<Bytes> rawLogs = new ArrayList<>();
+            r.readList(logsReader -> {
+                while (!logsReader.isComplete()) {
+                    logsReader.readList(logReader -> {
+                        Bytes address = logReader.readValue();
+                        List<Bytes> topics = new ArrayList<>();
+                        logReader.readList(tr -> {
+                            while (!tr.isComplete()) topics.add(tr.readValue());
+                            return null;
+                        });
+                        Bytes data = logReader.readValue();
+                        bloomAccrue(bloom, address);
+                        for (Bytes t : topics) bloomAccrue(bloom, t);
+                        rawLogs.add(RLP.encodeList(w -> {
+                            w.writeValue(address);
+                            w.writeList(tw -> topics.forEach(tw::writeValue));
+                            w.writeValue(data);
+                        }));
+                        return null;
+                    });
+                }
+                return null;
+            });
+            Bytes payload = RLP.encodeList(w -> {
+                w.writeValue(statusOrState);
+                w.writeValue(cumGas);
+                w.writeValue(Bytes.wrap(bloom));
+                w.writeList(lw -> rawLogs.forEach(lw::writeRLP));
+            });
+            return type == 0 ? payload : Bytes.concatenate(Bytes.of((byte) type), payload);
+        });
+    }
+
+    /**
+     * Accrue one bloom item (log address or topic) into a 2048-bit logs bloom
+     * (Yellow Paper M3:2048): three bits indexed by the low 11 bits of the first
+     * three byte-PAIRS of keccak256(item); bit i sets byte {@code 255 - i/8},
+     * bit {@code i % 8}.
+     */
+    private static void bloomAccrue(byte[] bloom, Bytes item) {
+        byte[] h = org.apache.tuweni.crypto.Hash.keccak256(item).toArrayUnsafe();
+        for (int i = 0; i < 6; i += 2) {
+            int bit = (((h[i] & 0xFF) << 8) | (h[i + 1] & 0xFF)) & 0x7FF;
+            bloom[255 - bit / 8] |= (byte) (1 << (bit % 8));
+        }
+    }
+
+    /**
      * Reconstruct the canonical raw RLP of the list the reader is positioned on, recursing
      * into nested lists (e.g. a receipt's logs). RLP is canonical, so re-encoding a decoded
      * structure reproduces the original bytes that the receipts trie was built over.

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/messages/TxFeeFields.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/messages/TxFeeFields.java
@@ -1,0 +1,86 @@
+package com.jaeckel.ethp2p.networking.eth.messages;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.rlp.RLP;
+
+import java.math.BigInteger;
+
+/**
+ * The fee-relevant fields of an Ethereum transaction (EIP-2718 typed or legacy),
+ * decoded from the raw tx bytes carried in an eth BlockBodies response.
+ *
+ * <p>Wire layouts (only the prefix up to the fee fields matters here):
+ * <ul>
+ *   <li>legacy:   {@code rlp([nonce, gasPrice, gasLimit, to, value, data, v, r, s])}</li>
+ *   <li>type 1 (EIP-2930): {@code 0x01 || rlp([chainId, nonce, gasPrice, gasLimit, ...])}</li>
+ *   <li>type 2 (EIP-1559): {@code 0x02 || rlp([chainId, nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit, ...])}</li>
+ *   <li>type 3 (EIP-4844): same fee prefix as type 2</li>
+ *   <li>type 4 (EIP-7702): same fee prefix as type 2</li>
+ * </ul>
+ *
+ * <p>Pure decoder over bytes the caller has ALREADY verified against a trusted
+ * {@code transactionsRoot} (see OrderedTrieRoot) — it does no verification itself.
+ */
+public record TxFeeFields(int type,
+                          BigInteger gasPrice,             // legacy / type-1, else null
+                          BigInteger maxPriorityFeePerGas, // type >= 2, else null
+                          BigInteger maxFeePerGas) {       // type >= 2, else null
+
+    /**
+     * The priority fee per gas this tx actually pays on a block with {@code baseFee}:
+     * {@code min(maxPriorityFeePerGas, maxFeePerGas - baseFee)} for 1559-style txs,
+     * {@code gasPrice - baseFee} for legacy/2930. Floored at zero (a legacy tx whose
+     * gasPrice sits below baseFee can't be included, but guard against bad data).
+     */
+    public BigInteger effectiveTip(BigInteger baseFee) {
+        BigInteger tip;
+        if (type >= 2) {
+            tip = maxFeePerGas.subtract(baseFee).min(maxPriorityFeePerGas);
+        } else {
+            tip = gasPrice.subtract(baseFee);
+        }
+        return tip.max(BigInteger.ZERO);
+    }
+
+    /** Decode the fee fields from raw tx bytes, or null if the tx can't be parsed. */
+    public static TxFeeFields decode(Bytes raw) {
+        if (raw == null || raw.isEmpty()) return null;
+        try {
+            int first = raw.get(0) & 0xFF;
+            if (first >= 0xc0) {                       // RLP list → legacy tx
+                return RLP.decodeList(raw, r -> {
+                    r.readValue();                     // nonce
+                    BigInteger gasPrice = toBigInt(r.readValue());
+                    return new TxFeeFields(0, gasPrice, null, null);
+                });
+            }
+            int type = first;
+            Bytes payload = raw.slice(1);
+            if (type == 1) {                           // EIP-2930: gasPrice model
+                return RLP.decodeList(payload, r -> {
+                    r.readValue();                     // chainId
+                    r.readValue();                     // nonce
+                    BigInteger gasPrice = toBigInt(r.readValue());
+                    return new TxFeeFields(1, gasPrice, null, null);
+                });
+            }
+            if (type >= 2 && type <= 4) {              // 1559 / 4844 / 7702: same prefix
+                final int t = type;
+                return RLP.decodeList(payload, r -> {
+                    r.readValue();                     // chainId
+                    r.readValue();                     // nonce
+                    BigInteger maxPriority = toBigInt(r.readValue());
+                    BigInteger maxFee = toBigInt(r.readValue());
+                    return new TxFeeFields(t, null, maxPriority, maxFee);
+                });
+            }
+            return null;                               // unknown future type
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static BigInteger toBigInt(Bytes b) {
+        return b.isEmpty() ? BigInteger.ZERO : b.toUnsignedBigInteger();
+    }
+}

--- a/networking/src/test/java/com/jaeckel/ethp2p/networking/eth/messages/ReceiptsMessage69Test.java
+++ b/networking/src/test/java/com/jaeckel/ethp2p/networking/eth/messages/ReceiptsMessage69Test.java
@@ -1,0 +1,114 @@
+package com.jaeckel.ethp2p.networking.eth.messages;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.crypto.Hash;
+import org.apache.tuweni.rlp.RLP;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * eth/69 (EIP-7642) Receipts decoding: the wire form is bloomless and
+ * envelope-flattened ({@code [txType, status, cumGas, logs]}); decode69 must
+ * recompute the logs bloom and reproduce the exact canonical consensus bytes
+ * (what the receipts trie commits to).
+ */
+class ReceiptsMessage69Test {
+
+    static {
+        java.security.Security.addProvider(
+                new org.bouncycastle.jce.provider.BouncyCastleProvider());
+    }
+
+    private static final Bytes ADDRESS = Bytes.fromHexString("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
+    private static final Bytes TOPIC = Bytes.fromHexString(
+            "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef");
+
+    /** Independent M3:2048 bloom (BigInteger bit-twiddling, different code path than impl). */
+    private static Bytes referenceBloom(List<Bytes> items) {
+        BigInteger acc = BigInteger.ZERO;
+        for (Bytes item : items) {
+            byte[] h = Hash.keccak256(item).toArray();
+            for (int i = 0; i < 6; i += 2) {
+                int bit = (((h[i] & 0xFF) << 8) | (h[i + 1] & 0xFF)) % 2048;
+                acc = acc.setBit(bit);
+            }
+        }
+        byte[] out = new byte[256];
+        byte[] mag = acc.toByteArray();
+        int len = Math.min(mag.length, 256);
+        System.arraycopy(mag, mag.length - len, out, 256 - len, len);
+        return Bytes.wrap(out);
+    }
+
+    /** eth/69 wire message with one block holding one receipt. */
+    private static byte[] wire69(int txType, Bytes status, Bytes cumGas, boolean withLog) {
+        return RLP.encodeList(w -> {
+            w.writeLong(99);                                  // requestId
+            w.writeList(blocks -> blocks.writeList(receipts -> receipts.writeList(r -> {
+                r.writeInt(txType);
+                r.writeValue(status);
+                r.writeValue(cumGas);
+                r.writeList(logs -> {
+                    if (withLog) {
+                        logs.writeList(log -> {
+                            log.writeValue(ADDRESS);
+                            log.writeList(t -> t.writeValue(TOPIC));
+                            log.writeValue(Bytes.fromHexString("0xdeadbeef"));
+                        });
+                    }
+                });
+            })));
+        }).toArray();
+    }
+
+    /** Canonical consensus receipt: rlp([status, cumGas, bloom, logs]), typed → prefixed. */
+    private static Bytes canonical(int txType, Bytes status, Bytes cumGas, Bytes bloom, boolean withLog) {
+        Bytes payload = RLP.encodeList(w -> {
+            w.writeValue(status);
+            w.writeValue(cumGas);
+            w.writeValue(bloom);
+            w.writeList(logs -> {
+                if (withLog) {
+                    logs.writeList(log -> {
+                        log.writeValue(ADDRESS);
+                        log.writeList(t -> t.writeValue(TOPIC));
+                        log.writeValue(Bytes.fromHexString("0xdeadbeef"));
+                    });
+                }
+            });
+        });
+        return txType == 0 ? payload : Bytes.concatenate(Bytes.of((byte) txType), payload);
+    }
+
+    @Test
+    void typedReceiptWithLog_recanonicalizedWithRecomputedBloom() {
+        Bytes status = Bytes.fromHexString("0x01");
+        Bytes cumGas = Bytes.fromHexString("0x5208");
+        ReceiptsMessage.DecodeResult res = ReceiptsMessage.decode69(wire69(2, status, cumGas, true));
+        assertEquals(99, res.requestId());
+        Bytes expectBloom = referenceBloom(List.of(ADDRESS, TOPIC));
+        assertEquals(canonical(2, status, cumGas, expectBloom, true),
+                res.perBlockReceipts().get(0).get(0));
+        // The canonicalized receipt also decodes through the standard Receipt decoder.
+        Receipt rcpt = Receipt.decode(res.perBlockReceipts().get(0).get(0));
+        assertEquals(2, rcpt.type());
+        assertEquals(0x5208, rcpt.cumulativeGasUsed());
+        assertEquals(expectBloom, rcpt.logsBloom());
+        assertEquals(1, rcpt.logs().size());
+    }
+
+    @Test
+    void legacyReceiptNoLogs_zeroBloom_noEnvelope() {
+        Bytes status = Bytes.fromHexString("0x01");
+        Bytes cumGas = Bytes.fromHexString("0x9c40");
+        ReceiptsMessage.DecodeResult res = ReceiptsMessage.decode69(wire69(0, status, cumGas, false));
+        Bytes zeroBloom = Bytes.repeat((byte) 0, 256);
+        assertEquals(canonical(0, status, cumGas, zeroBloom, false),
+                res.perBlockReceipts().get(0).get(0));
+        assertEquals(0, Receipt.decode(res.perBlockReceipts().get(0).get(0)).type());
+    }
+}

--- a/networking/src/test/java/com/jaeckel/ethp2p/networking/eth/messages/TxFeeFieldsTest.java
+++ b/networking/src/test/java/com/jaeckel/ethp2p/networking/eth/messages/TxFeeFieldsTest.java
@@ -1,0 +1,84 @@
+package com.jaeckel.ethp2p.networking.eth.messages;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.rlp.RLP;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/** Fee-field decoding for legacy and typed transactions, plus effectiveTip math. */
+class TxFeeFieldsTest {
+
+    private static final BigInteger GWEI = BigInteger.valueOf(1_000_000_000L);
+
+    /** Legacy tx: rlp([nonce, gasPrice, gasLimit, to, value, data, v, r, s]) */
+    private static Bytes legacyTx(BigInteger gasPrice) {
+        return RLP.encodeList(w -> {
+            w.writeLong(7);                              // nonce
+            w.writeBigInteger(gasPrice);
+            w.writeLong(21000);                          // gasLimit
+            w.writeByteArray(new byte[20]);              // to
+            w.writeBigInteger(BigInteger.ONE);           // value
+            w.writeByteArray(new byte[0]);               // data
+            w.writeLong(27); w.writeLong(1); w.writeLong(1); // v, r, s
+        });
+    }
+
+    /** EIP-1559 tx: 0x02 || rlp([chainId, nonce, maxPriority, maxFee, gasLimit, to, value, data, accessList, yParity, r, s]) */
+    private static Bytes eip1559Tx(BigInteger maxPriority, BigInteger maxFee) {
+        Bytes payload = RLP.encodeList(w -> {
+            w.writeLong(1);                              // chainId
+            w.writeLong(7);                              // nonce
+            w.writeBigInteger(maxPriority);
+            w.writeBigInteger(maxFee);
+            w.writeLong(21000);
+            w.writeByteArray(new byte[20]);
+            w.writeBigInteger(BigInteger.ONE);
+            w.writeByteArray(new byte[0]);
+            w.writeList(lw -> {});                       // accessList
+            w.writeLong(0); w.writeLong(1); w.writeLong(1);
+        });
+        return Bytes.concatenate(Bytes.of(0x02), payload);
+    }
+
+    @Test
+    void decodesLegacyGasPrice() {
+        TxFeeFields f = TxFeeFields.decode(legacyTx(GWEI.multiply(BigInteger.valueOf(20))));
+        assertEquals(0, f.type());
+        assertEquals(GWEI.multiply(BigInteger.valueOf(20)), f.gasPrice());
+        // effective tip = gasPrice - baseFee
+        assertEquals(GWEI.multiply(BigInteger.valueOf(5)),
+                f.effectiveTip(GWEI.multiply(BigInteger.valueOf(15))));
+    }
+
+    @Test
+    void decodes1559FeeCaps() {
+        TxFeeFields f = TxFeeFields.decode(eip1559Tx(GWEI, GWEI.multiply(BigInteger.valueOf(30))));
+        assertEquals(2, f.type());
+        assertEquals(GWEI, f.maxPriorityFeePerGas());
+        assertEquals(GWEI.multiply(BigInteger.valueOf(30)), f.maxFeePerGas());
+        // baseFee leaves more headroom than the tip cap → tip cap wins
+        assertEquals(GWEI, f.effectiveTip(GWEI.multiply(BigInteger.valueOf(10))));
+        // baseFee squeezes headroom below the tip cap → maxFee - baseFee wins
+        assertEquals(GWEI.divide(BigInteger.TWO),
+                f.effectiveTip(GWEI.multiply(BigInteger.valueOf(30)).subtract(GWEI.divide(BigInteger.TWO))));
+    }
+
+    @Test
+    void effectiveTipFlooredAtZero() {
+        // legacy gasPrice below baseFee (can't actually be included) → 0, never negative
+        TxFeeFields f = TxFeeFields.decode(legacyTx(GWEI));
+        assertEquals(BigInteger.ZERO, f.effectiveTip(GWEI.multiply(BigInteger.TEN)));
+    }
+
+    @Test
+    void unknownTypeAndGarbageReturnNull() {
+        assertNull(TxFeeFields.decode(Bytes.concatenate(Bytes.of(0x7f), Bytes.of(1, 2, 3))));
+        assertNull(TxFeeFields.decode(Bytes.of(0x01, 0x02)));   // truncated typed payload
+        assertNull(TxFeeFields.decode(Bytes.EMPTY));
+        assertNull(TxFeeFields.decode(null));
+    }
+}


### PR DESCRIPTION
MetaMask's signing screen sits in skeleton-loading forever because it polls `eth_feeHistory` / `eth_gasPrice` / `eth_getBlockByNumber` / `eth_estimateGas` and renders nothing until they answer. This implements all of them, verified-only (no proxy, per the permissionless rule).

**Note:** merge #39 first — this branch builds on it; the diff then shrinks to just these commits.

## What

1. **Snap-free `eth_getBlockByNumber` / `eth_getTransactionReceipt`** — new `HeaderAnchor`: prefer the snap-built anchored head, fall back to the beacon optimistic execution payload (light-client-verified blockHash) and anchor the header window by hash. Blocks/receipts need verified headers+bodies, not snap state — the block tracker now survives snap-peer outages (validated on-device with zero snap peers).

2. **Verified fee methods** — `TxFeeFields` decodes fee fields of legacy/2930/1559/4844/7702 txs from verified bodies.
   - `eth_maxPriorityFeePerGas`: median effective tip over the last 3 verified blocks, 0.1 gwei floor, ~one-block cache.
   - `eth_gasPrice`: EIP-1559 next-block baseFee + suggested tip.
   - `eth_feeHistory`: baseFee/gasUsedRatio from the anchored header window; reward percentiles via geth's gas-used-weighted walk over verified bodies + receipts. blockCount clamped to 10.

3. **`eth_estimateGas`** — wires the existing `DefaultEvmExecutor.estimateGas` (local Besu EVM against snap-verified state; reverting tx → error, never a number) through the head context; CCIP/Prefetching wrappers now delegate.

## Bugs found & fixed during device validation

- **eth/69 receipts broke every receiptsRoot verify.** We negotiate eth/69 (Geth 1.16+ default), but EIP-7642 strips logsBloom from wire receipts. `decode69` recomputes the bloom from logs (pure function — no trust added; lying peers still fail the root check) and re-canonicalizes. This was also silently breaking `eth_getTransactionReceipt` against eth/69 peers.
- **EIP-7702 delegated EOAs killed eth_call/estimateGas** with INVALID_OPERATION (the EVM executed the raw `0xef0100||addr` designator). `resolveCode()` resolves one hop per the EIP. Found via a live mainnet delegation.

## Device validation (Pixel 7, strict mode)
- `eth_getBlockByNumber` verified with **zero** snap peers ✓
- `eth_gasPrice` → 0.57 gwei, `eth_maxPriorityFeePerGas` → 0.19 gwei ✓
- `eth_estimateGas` plain transfer → `0x5e56` (21000 × 1.15) ✓; reverting tx → error ✓
- `eth_feeHistory` headers-only ✓; percentile-rewards + 7702-target estimate validation in progress (needs the eth/69 + resolveCode build that just deployed)

Daemon keeps compiling via interface defaults; daemon-side fee parity is follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)