### PR TITLE
eth_call: snap-peer rotation + multi-hop prefetch + number-pin tolerance (unstick MetaMask confirm)

### DIFF
--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -756,11 +756,18 @@ public final class NodeService extends Service {
      *  wallet's first read error even though the verified result is seconds away. Kept
      *  under typical wallet RPC timeouts so the call returns verified-but-slow, not failed. */
     private static final long RPC_HEAD_BUILD_WAIT_MS = 25_000;
-    /** How far a number-pinned read's block may sit from the verified head and still be
-     *  served from the head's state. Wallets pin reads to the just-fetched latest block,
-     *  which can be a few blocks off our anchored (snap-servable) head; the head state is
-     *  the same for the queried account across such a small gap. Larger gaps → not served. */
+    /** How far ABOVE the verified head a number-pinned read may sit and still be served
+     *  (a wallet that just saw a newer block than our context). Small: a pin far above
+     *  head is a genuinely future/unknown block. */
     private static final long RPC_BLOCK_NUM_TOLERANCE = 16;
+    /** How far BELOW the context a number-pinned read may sit and still be served from
+     *  the context's (newer) state. Wallets pin "latest"-intent reads to the last block
+     *  they saw; when our calls are slow the chain advances past that pin before the read
+     *  lands, leaving it tens of blocks behind. Serving the context's state for such a
+     *  recent pin gives current-ish data (what the wallet wants) — far better than the
+     *  instant error that emptied MetaMask's asset list. Beyond this (~13 min) the pin is
+     *  genuinely historical and we can't represent it, so reject. */
+    private static final long RPC_BLOCK_NUM_LAG_TOLERANCE = 64;
 
     private final Object rpcCallCtxLock = new Object();
     private CompletableFuture<EnsCall> rpcCallCtx;   // in-flight/fresh build (dedup)
@@ -833,7 +840,7 @@ public final class NodeService extends Service {
             BeaconSyncState bss = beaconSyncState;
             long optimistic = bss != null ? bss.getOptimisticBlockNumber() : 0;
             long upperBound = Math.max(ctx.blockNumber(), optimistic) + RPC_BLOCK_NUM_TOLERANCE;
-            long lowerBound = ctx.blockNumber() - RPC_BLOCK_NUM_TOLERANCE;
+            long lowerBound = ctx.blockNumber() - RPC_BLOCK_NUM_LAG_TOLERANCE;
             if (requestedNum < lowerBound || requestedNum > upperBound) {
                 LogBuffer.i(TAG, "[rpc] requested block " + requestedNum + " outside servable ["
                         + lowerBound + ".." + upperBound + "] (ctx=" + ctx.blockNumber()
@@ -985,6 +992,17 @@ public final class NodeService extends Service {
     /** eth_sendRawTransaction: gossip the user-signed tx to peers; return its hash
      *  (keccak256 of the raw bytes), or null (→ proxy) if no peer took it. Myotis
      *  never signs or originates a tx — this only relays bytes the user submitted. */
+    /** Raw bytes of transactions this node broadcast, keyed by lowercase 0x tx hash, so
+     *  eth_getTransactionByHash can answer a just-sent tx as "pending" before it's mined
+     *  (we hold the signed bytes — serving them is not a trust assumption). Bounded LRU;
+     *  entries fall out as they age (they're served from verified blocks once mined). */
+    private final Map<String, byte[]> sentTxCache = java.util.Collections.synchronizedMap(
+            new java.util.LinkedHashMap<>(64, 0.75f, true) {
+                @Override protected boolean removeEldestEntry(Map.Entry<String, byte[]> e) {
+                    return size() > 256;
+                }
+            });
+
     private byte[] rpcSendRawTransaction(byte[] rawTx) {
         RLPxConnector conn = connector;
         if (conn == null || rawTx == null || rawTx.length == 0) return null;
@@ -992,6 +1010,7 @@ public final class NodeService extends Service {
             int sent = conn.broadcastTransaction(rawTx);
             if (sent == 0) return null;   // no peer reached → let the proxy relay it
             byte[] txHash = Hash.keccak256(Bytes.wrap(rawTx)).toArrayUnsafe();
+            sentTxCache.put(Bytes.wrap(txHash).toHexString(), rawTx.clone());
             LogBuffer.i(TAG, "[rpc] eth_sendRawTransaction broadcast to " + sent
                     + " peer(s), hash=" + Bytes.wrap(txHash).toHexString());
             return txHash;
@@ -999,6 +1018,104 @@ public final class NodeService extends Service {
             LogBuffer.i(TAG, "[rpc] eth_sendRawTransaction failed: " + unwrap(e));
             return null;
         }
+    }
+
+    /**
+     * eth_getTransactionByHash. Scans the recent beacon-verified block window for the tx
+     * (body verified vs transactionsRoot); if found, returns it with block context. If not
+     * yet mined but this node broadcast it, returns it as pending (blockNumber null) from
+     * the sent-tx cache. "null" for a verified-unknown tx; Kotlin null when not verifiable.
+     */
+    private String rpcGetTransactionByHash(byte[] txHash) {
+        RLPxConnector conn = connector;
+        if (conn == null || txHash == null || txHash.length != 32) return null;
+        Bytes32 want = Bytes32.wrap(txHash);
+        try {
+            HeaderAnchor anchor = headerAnchor();
+            if (anchor == null) {
+                // Can't verify chain inclusion right now — but if it's our own just-sent tx
+                // we can still honestly answer "pending" from the signed bytes we hold.
+                byte[] ourRaw = sentTxCache.get(want.toHexString());
+                return ourRaw != null ? buildTxJson(ourRaw, want, null, -1, -1) : null;
+            }
+            long headNum = anchor.number();
+            int count = (int) Math.min(RECEIPT_LOOKBACK_BLOCKS, headNum + 1);
+            long start = headNum - count + 1;
+            List<BlockHeadersMessage.VerifiedHeader> window = conn
+                    .requestBlockHeadersBatched(start, count)
+                    .get(HEADER_CHAIN_TIMEOUT_SEC, TimeUnit.SECONDS);
+            if (!anchor.anchors(window)) return null;
+
+            List<CompletableFuture<List<BlockBodiesMessage.BlockBody>>> bodyFutures =
+                    new ArrayList<>(window.size());
+            for (BlockHeadersMessage.VerifiedHeader vh : window) {
+                bodyFutures.add(conn.requestBlockBodies(vh.hash()));
+            }
+            for (int hi = window.size() - 1; hi >= 0; hi--) {
+                BlockHeader h = window.get(hi).header();
+                Bytes32 blockHash = window.get(hi).hash();
+                List<BlockBodiesMessage.BlockBody> bodies;
+                try {
+                    bodies = bodyFutures.get(hi).get(HEADER_CHAIN_TIMEOUT_SEC, TimeUnit.SECONDS);
+                } catch (Exception e) { continue; }
+                if (bodies.isEmpty()) continue;
+                List<Bytes> txs = bodies.get(0).transactions();
+                if (!OrderedTrieRoot.verify(txs, h.transactionsRoot)) continue;
+                for (int i = 0; i < txs.size(); i++) {
+                    if (Hash.keccak256(txs.get(i)).equals(want)) {
+                        LogBuffer.i(TAG, "[rpc] eth_getTransactionByHash found in block #"
+                                + h.number + " index " + i);
+                        return buildTxJson(txs.get(i).toArrayUnsafe(), want, blockHash, h.number, i);
+                    }
+                }
+            }
+            // Verified head + anchored window, not in it. If it's our own broadcast, it's
+            // pending; otherwise a verified "unknown tx".
+            byte[] ourRaw = sentTxCache.get(want.toHexString());
+            return ourRaw != null ? buildTxJson(ourRaw, want, null, -1, -1) : "null";
+        } catch (Exception e) {
+            LogBuffer.i(TAG, "[rpc] eth_getTransactionByHash failed: " + unwrap(e));
+            return null;
+        }
+    }
+
+    /** Build the eth_getTransactionByHash JSON. blockHash null + blockNum/index < 0 = pending. */
+    private static String buildTxJson(byte[] rawTx, Bytes32 txHash,
+                                      Bytes32 blockHash, long blockNum, int index) {
+        com.jaeckel.ethp2p.networking.eth.messages.EthTxDecoder.DecodedTx t =
+                com.jaeckel.ethp2p.networking.eth.messages.EthTxDecoder.decode(Bytes.wrap(rawTx));
+        if (t == null) return "null"; // unknown tx type — can't render
+        StringBuilder sb = new StringBuilder(512);
+        sb.append("{\"hash\":\"").append(txHash.toHexString()).append("\"");
+        if (blockHash != null) {
+            sb.append(",\"blockHash\":\"").append(blockHash.toHexString()).append("\"");
+            sb.append(",\"blockNumber\":\"").append(hexQuantity(blockNum)).append("\"");
+            sb.append(",\"transactionIndex\":\"").append(hexQuantity(index)).append("\"");
+        } else {
+            sb.append(",\"blockHash\":null,\"blockNumber\":null,\"transactionIndex\":null");
+        }
+        sb.append(",\"type\":\"").append(hexQuantity(t.type())).append("\"");
+        if (t.chainId() != null) sb.append(",\"chainId\":\"").append(hexQuantity(t.chainId())).append("\"");
+        sb.append(",\"nonce\":\"").append(hexQuantity(t.nonce())).append("\"");
+        if (t.from() != null) sb.append(",\"from\":\"").append(t.from().toHexString()).append("\"");
+        if (!t.to().isEmpty()) sb.append(",\"to\":\"").append(t.to().toHexString()).append("\"");
+        else sb.append(",\"to\":null");
+        sb.append(",\"value\":\"0x").append(t.value().toString(16)).append("\"");
+        sb.append(",\"gas\":\"").append(hexQuantity(t.gas())).append("\"");
+        if (t.gasPrice() != null) {
+            sb.append(",\"gasPrice\":\"0x").append(t.gasPrice().toString(16)).append("\"");
+        }
+        if (t.maxFeePerGas() != null) {
+            sb.append(",\"maxFeePerGas\":\"0x").append(t.maxFeePerGas().toString(16)).append("\"");
+            sb.append(",\"maxPriorityFeePerGas\":\"0x")
+              .append(t.maxPriorityFeePerGas().toString(16)).append("\"");
+        }
+        sb.append(",\"input\":\"").append(t.input().isEmpty() ? "0x" : t.input().toHexString()).append("\"");
+        sb.append(",\"v\":\"0x").append(t.v().toString(16)).append("\"");
+        sb.append(",\"r\":\"0x").append(t.r().toString(16)).append("\"");
+        sb.append(",\"s\":\"0x").append(t.s().toString(16)).append("\"");
+        sb.append("}");
+        return sb.toString();
     }
 
     /**
@@ -1617,6 +1734,23 @@ public final class NodeService extends Service {
         EnsCall h = anchoredHeadOrWait();
         if (h == null) return null;
         try {
+            // Fast path: a value transfer with no calldata to a plain account costs
+            // exactly 21000 — no EVM execution, no 15% headroom (it's exact). This is
+            // MetaMask's send-ETH flow. We still fetch the recipient ONCE to confirm
+            // it has no code (a contract receive()/fallback, or a 7702 delegation,
+            // would execute and cost more) — but skip building+running the EVM, the
+            // bulk of the per-estimate work on ART.
+            boolean noData = data == null || data.length == 0;
+            if (noData) {
+                io.myotis.evm.world.AccountState acct = h.oracle()
+                        .fetchAccount(h.blockCtx().stateRoot(), io.myotis.evm.Address.of(to))
+                        .get(RPC_CALL_TIMEOUT_SEC, TimeUnit.SECONDS);
+                byte[] codeHash = acct == null ? null : acct.codeHash();
+                if (codeHash != null && java.util.Arrays.equals(codeHash, EMPTY_CODE_HASH)) {
+                    return java.math.BigInteger.valueOf(21_000);
+                }
+                // Has code (contract / 7702 EOA) → fall through to the full EVM estimate.
+            }
             io.myotis.evm.UnsignedTransaction tx = new io.myotis.evm.UnsignedTransaction(
                     io.myotis.evm.Address.of(from != null ? from : new byte[20]),
                     io.myotis.evm.Address.of(to),
@@ -2683,6 +2817,9 @@ public final class NodeService extends Service {
                 }
                 @Override public String getTransactionReceipt(byte[] txHash) {
                     return rpcGetTransactionReceipt(txHash, "latest");
+                }
+                @Override public String getTransactionByHash(byte[] txHash) {
+                    return rpcGetTransactionByHash(txHash);
                 }
                 @Override public String getBlockByNumber(String block, boolean fullTx) {
                     return rpcGetBlockByNumber(block, fullTx);

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -732,6 +732,10 @@ public final class NodeService extends Service {
     private static final long RPC_HEAD_TTL_MS = 12_000;
     /** Per-read/-call budget (snap round-trips; CCIP can add one for eth_call). */
     private static final long RPC_CALL_TIMEOUT_SEC = 30;
+    /** Snap-oracle per-fetch retry budget. Each attempt rotates to a different ready
+     *  snap peer (the probed peer first), so a slow/dead peer fails over instead of
+     *  burning the whole RPC_CALL_TIMEOUT on one peer. */
+    private static final int SNAP_ORACLE_MAX_ATTEMPTS = 4;
     /** Head-build budget — includes the headerChain anchoring fetch. */
     private static final long RPC_ACCOUNT_TIMEOUT_SEC = HEADER_CHAIN_TIMEOUT_SEC + 10;
     /** Overall budget for the (parallel) snap-peer head probe. */
@@ -2212,14 +2216,43 @@ public final class NodeService extends Service {
             pinned = headPeer;
         }
 
-        // Pin every SNAP request to the chosen peer (serves blockCtx's stateRoot).
-        final com.jaeckel.ethp2p.networking.eth.EthHandler finalPeer = pinned;
+        // Snap requests carry the stateRoot explicitly, so ANY connected snap peer
+        // that retains blockCtx's trie can serve them — not just the one we probed.
+        // The oracle retries across peers (peerSupplier.get() per attempt); rotate the
+        // supplier so a peer that times out fails over to others instead of funnelling
+        // all retries into one dead peer (every eth_call against that context then hit
+        // the 30s timeout while OTHER peers held the same state). The probed peer is
+        // tried first (known to serve this root); subsequent attempts round-robin the
+        // rest of the ready snap set.
+        final com.jaeckel.ethp2p.networking.eth.EthHandler probedPeer = pinned;
+        final RLPxConnector oracleConn = conn;
+        final java.util.concurrent.atomic.AtomicInteger rotation =
+                new java.util.concurrent.atomic.AtomicInteger();
         io.myotis.evm.world.SnapBackedStateOracle oracle =
                 new io.myotis.evm.world.SnapBackedStateOracle(
-                        () -> finalPeer.isReady() && !finalPeer.isSnapServingFailed()
-                                ? new com.jaeckel.ethp2p.android.snap.EthHandlerSnapPeer(finalPeer)
-                                : null,
-                        ensBytecodeCache);
+                        () -> {
+                            int n = rotation.getAndIncrement();
+                            if (n == 0 && probedPeer.isReady() && !probedPeer.isSnapServingFailed()) {
+                                return new com.jaeckel.ethp2p.android.snap.EthHandlerSnapPeer(probedPeer);
+                            }
+                            java.util.List<com.jaeckel.ethp2p.networking.eth.EthHandler> ready =
+                                    new java.util.ArrayList<>();
+                            for (com.jaeckel.ethp2p.networking.eth.EthHandler p :
+                                    oracleConn.activeSnapHandlers()) {
+                                if (p.isReady() && !p.isSnapServingFailed() && p != probedPeer) {
+                                    ready.add(p);
+                                }
+                            }
+                            if (probedPeer.isReady() && !probedPeer.isSnapServingFailed()) {
+                                ready.add(probedPeer); // keep it in rotation as a fallback too
+                            }
+                            if (ready.isEmpty()) return null;
+                            com.jaeckel.ethp2p.networking.eth.EthHandler chosen =
+                                    ready.get(Math.floorMod(n, ready.size()));
+                            return new com.jaeckel.ethp2p.android.snap.EthHandlerSnapPeer(chosen);
+                        },
+                        ensBytecodeCache,
+                        SNAP_ORACLE_MAX_ATTEMPTS);
         io.myotis.evm.DefaultEvmExecutor base =
                 new io.myotis.evm.DefaultEvmExecutor(oracle, ensBytecodeCache, evmPool);
         io.myotis.evm.PrefetchingEvmExecutor prefetching =

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -2369,17 +2369,12 @@ public final class NodeService extends Service {
                             if (n == 0 && probedPeer.isReady() && !probedPeer.isSnapServingFailed()) {
                                 return new com.jaeckel.ethp2p.android.snap.EthHandlerSnapPeer(probedPeer);
                             }
+                            // activeSnapHandlers() already returns only ready, snap-negotiated,
+                            // non-failed peers — no need to re-check here. probedPeer is in that
+                            // list too (if still healthy), so it stays in the rotation as a
+                            // fallback without a separate add.
                             java.util.List<com.jaeckel.ethp2p.networking.eth.EthHandler> ready =
-                                    new java.util.ArrayList<>();
-                            for (com.jaeckel.ethp2p.networking.eth.EthHandler p :
-                                    oracleConn.activeSnapHandlers()) {
-                                if (p.isReady() && !p.isSnapServingFailed() && p != probedPeer) {
-                                    ready.add(p);
-                                }
-                            }
-                            if (probedPeer.isReady() && !probedPeer.isSnapServingFailed()) {
-                                ready.add(probedPeer); // keep it in rotation as a fallback too
-                            }
+                                    oracleConn.activeSnapHandlers();
                             if (ready.isEmpty()) return null;
                             com.jaeckel.ethp2p.networking.eth.EthHandler chosen =
                                     ready.get(Math.floorMod(n, ready.size()));

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -1079,12 +1079,15 @@ public final class NodeService extends Service {
         }
     }
 
-    /** Build the eth_getTransactionByHash JSON. blockHash null + blockNum/index < 0 = pending. */
+    /** Build the eth_getTransactionByHash JSON. blockHash null + blockNum/index < 0 = pending.
+     *  Returns Java null (NOT the literal "null") when the tx can't be decoded: the tx WAS
+     *  found/held, so this is "can't render it verified" → the caller errors, never a
+     *  misleading "tx not found". */
     private static String buildTxJson(byte[] rawTx, Bytes32 txHash,
                                       Bytes32 blockHash, long blockNum, int index) {
         com.jaeckel.ethp2p.networking.eth.messages.EthTxDecoder.DecodedTx t =
                 com.jaeckel.ethp2p.networking.eth.messages.EthTxDecoder.decode(Bytes.wrap(rawTx));
-        if (t == null) return "null"; // unknown tx type — can't render
+        if (t == null) return null; // unrenderable tx type — can't-serve, not unknown-tx
         StringBuilder sb = new StringBuilder(512);
         sb.append("{\"hash\":\"").append(txHash.toHexString()).append("\"");
         if (blockHash != null) {
@@ -1111,9 +1114,15 @@ public final class NodeService extends Service {
               .append(t.maxPriorityFeePerGas().toString(16)).append("\"");
         }
         sb.append(",\"input\":\"").append(t.input().isEmpty() ? "0x" : t.input().toHexString()).append("\"");
+        // v is a QUANTITY (recovery id / EIP-155 v); typed txs also carry yParity (0/1).
         sb.append(",\"v\":\"0x").append(t.v().toString(16)).append("\"");
-        sb.append(",\"r\":\"0x").append(t.r().toString(16)).append("\"");
-        sb.append(",\"s\":\"0x").append(t.s().toString(16)).append("\"");
+        if (t.type() >= 1) {
+            sb.append(",\"yParity\":\"0x").append(t.v().toString(16)).append("\"");
+        }
+        // r and s are 32-byte DATA — left-pad, never QUANTITY (odd-length / unpadded
+        // breaks clients expecting exactly 32 bytes).
+        sb.append(",\"r\":\"").append(Bytes.wrap(word32(t.r())).toHexString()).append("\"");
+        sb.append(",\"s\":\"").append(Bytes.wrap(word32(t.s())).toHexString()).append("\"");
         sb.append("}");
         return sb.toString();
     }

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -815,11 +815,25 @@ public final class NodeService extends Service {
         EnsCall ctx = anchoredHeadOrWait();
         if (ctx == null) return null;
         if (requestedNum >= 0) {
-            long delta = Math.abs(requestedNum - ctx.blockNumber());
-            if (delta > RPC_BLOCK_NUM_TOLERANCE) {
-                LogBuffer.i(TAG, "[rpc] requested block " + requestedNum + " is " + delta
-                        + " from verified head " + ctx.blockNumber()
-                        + " (> " + RPC_BLOCK_NUM_TOLERANCE + ") -> not served");
+            // A pinned number means "the latest block I saw" — wallets fetch
+            // eth_blockNumber (our beacon OPTIMISTIC head) and pin the very next reads
+            // to it. The serving context can legitimately sit behind that number: the
+            // finalized fallback is ~2 epochs older, a snap peer's head a few blocks.
+            // So accept anything between the context and the optimistic head (+slack):
+            // those reads get the same verified state a "latest" call would get from
+            // this context — rejecting them just because the context lags the chain
+            // turned every number-pinned call into an instant error whenever snap fell
+            // back to finalized (MetaMask: empty asset list, stuck confirm screen).
+            // Numbers BELOW the context keep the strict tolerance: the caller asked
+            // for genuinely older state, which this context cannot represent.
+            BeaconSyncState bss = beaconSyncState;
+            long optimistic = bss != null ? bss.getOptimisticBlockNumber() : 0;
+            long upperBound = Math.max(ctx.blockNumber(), optimistic) + RPC_BLOCK_NUM_TOLERANCE;
+            long lowerBound = ctx.blockNumber() - RPC_BLOCK_NUM_TOLERANCE;
+            if (requestedNum < lowerBound || requestedNum > upperBound) {
+                LogBuffer.i(TAG, "[rpc] requested block " + requestedNum + " outside servable ["
+                        + lowerBound + ".." + upperBound + "] (ctx=" + ctx.blockNumber()
+                        + ", optimistic=" + optimistic + ") -> not served");
                 return null;
             }
         }
@@ -881,15 +895,33 @@ public final class NodeService extends Service {
 
     /** eth_call over the shared anchored head. Returns raw ABI bytes, or null to proxy. */
     private byte[] rpcCall(byte[] to, byte[] data, String block) {
+        // Identify the call up front: target + 4-byte selector + calldata size + block
+        // tag. eth_call failures were undiagnosable as "eth_call -> proxy: Timeout" —
+        // with hundreds of MetaMask poll variants we need to know WHICH contract/method
+        // is being asked for (e.g. its confirm-screen simulation multicall).
+        String desc = (to != null && to.length == 20 ? Bytes.wrap(to).toHexString() : "?")
+                + " sel=" + (data != null && data.length >= 4
+                        ? Bytes.wrap(data, 0, 4).toHexString() : "0x")
+                + " dataLen=" + (data == null ? 0 : data.length)
+                + " block=" + block;
         EnsCall h = verifiedHeadFor(block);
-        if (h == null || to == null || to.length != 20) return null;
+        if (h == null || to == null || to.length != 20) {
+            LogBuffer.i(TAG, "[rpc] eth_call " + desc + " -> no verified head for block tag");
+            return null;
+        }
+        long t0 = android.os.SystemClock.elapsedRealtime();
         try {
-            return h.offchainExecutor()
+            byte[] out = h.offchainExecutor()
                     .callView(io.myotis.evm.Address.of(to), data == null ? new byte[0] : data,
                             h.blockCtx())
                     .get(RPC_CALL_TIMEOUT_SEC, TimeUnit.SECONDS);
+            LogBuffer.i(TAG, "[rpc] eth_call " + desc + " ok in "
+                    + (android.os.SystemClock.elapsedRealtime() - t0) + "ms");
+            return out;
         } catch (Exception e) {
-            LogBuffer.i(TAG, "[rpc] eth_call -> proxy: " + unwrap(e));
+            LogBuffer.i(TAG, "[rpc] eth_call " + desc + " -> error after "
+                    + (android.os.SystemClock.elapsedRealtime() - t0) + "ms: "
+                    + describeEvmError(e));
             return null;
         }
     }

--- a/app/src/main/java/com/jaeckel/ethp2p/app/CommandHandler.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/CommandHandler.java
@@ -1281,16 +1281,41 @@ public class CommandHandler {
      * channel close), but every retry targets this one peer — the one expected to
      * have {@code blockCtx}'s stateRoot in its snapshot.
      */
+    /** Snap-oracle per-fetch retry budget; each attempt rotates to a different ready
+     *  snap peer so a slow/dead peer fails over instead of eating the whole budget. */
+    private static final int SNAP_ORACLE_MAX_ATTEMPTS = 4;
+
     private io.myotis.evm.CcipReadEvmExecutor buildEnsResolver(
             com.jaeckel.ethp2p.networking.eth.EthHandler pinnedPeer,
             io.myotis.evm.BlockContext blockCtx) {
-        final com.jaeckel.ethp2p.networking.eth.EthHandler finalPeer = pinnedPeer;
+        // Snap requests carry the stateRoot explicitly, so ANY connected snap peer that
+        // retains blockCtx's trie can serve them. Rotate the oracle's supplier (probed
+        // peer first, then round-robin the ready set) so a peer that stalls on
+        // GetAccountRange fails over instead of funnelling every retry into one dead
+        // peer — the single-peer pin made each eth_call against a stalled peer eat the
+        // full timeout while other peers held the same state.
+        final com.jaeckel.ethp2p.networking.eth.EthHandler probedPeer = pinnedPeer;
+        final java.util.concurrent.atomic.AtomicInteger rotation =
+            new java.util.concurrent.atomic.AtomicInteger();
         io.myotis.evm.world.SnapBackedStateOracle oracle =
             new io.myotis.evm.world.SnapBackedStateOracle(
-                () -> finalPeer.isReady() && !finalPeer.isSnapServingFailed()
-                    ? new com.jaeckel.ethp2p.app.snap.EthHandlerSnapPeer(finalPeer)
-                    : null,
-                ensBytecodeCache);
+                () -> {
+                    int n = rotation.getAndIncrement();
+                    if (n == 0 && probedPeer.isReady() && !probedPeer.isSnapServingFailed()) {
+                        return new com.jaeckel.ethp2p.app.snap.EthHandlerSnapPeer(probedPeer);
+                    }
+                    java.util.List<com.jaeckel.ethp2p.networking.eth.EthHandler> ready =
+                        new java.util.ArrayList<>();
+                    for (com.jaeckel.ethp2p.networking.eth.EthHandler p : connector.activeSnapHandlers()) {
+                        if (p.isReady() && !p.isSnapServingFailed() && p != probedPeer) ready.add(p);
+                    }
+                    if (probedPeer.isReady() && !probedPeer.isSnapServingFailed()) ready.add(probedPeer);
+                    if (ready.isEmpty()) return null;
+                    return new com.jaeckel.ethp2p.app.snap.EthHandlerSnapPeer(
+                        ready.get(Math.floorMod(n, ready.size())));
+                },
+                ensBytecodeCache,
+                SNAP_ORACLE_MAX_ATTEMPTS);
         io.myotis.evm.DefaultEvmExecutor base = new io.myotis.evm.DefaultEvmExecutor(
             oracle, ensBytecodeCache, EVM_POOL);
         io.myotis.evm.PrefetchingEvmExecutor prefetching =

--- a/app/src/main/java/com/jaeckel/ethp2p/app/CommandHandler.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/CommandHandler.java
@@ -1304,12 +1304,10 @@ public class CommandHandler {
                     if (n == 0 && probedPeer.isReady() && !probedPeer.isSnapServingFailed()) {
                         return new com.jaeckel.ethp2p.app.snap.EthHandlerSnapPeer(probedPeer);
                     }
+                    // activeSnapHandlers() already filters to ready, snap-negotiated,
+                    // non-failed peers (probedPeer included if still healthy) — no re-check.
                     java.util.List<com.jaeckel.ethp2p.networking.eth.EthHandler> ready =
-                        new java.util.ArrayList<>();
-                    for (com.jaeckel.ethp2p.networking.eth.EthHandler p : connector.activeSnapHandlers()) {
-                        if (p.isReady() && !p.isSnapServingFailed() && p != probedPeer) ready.add(p);
-                    }
-                    if (probedPeer.isReady() && !probedPeer.isSnapServingFailed()) ready.add(probedPeer);
+                        connector.activeSnapHandlers();
                     if (ready.isEmpty()) return null;
                     return new com.jaeckel.ethp2p.app.snap.EthHandlerSnapPeer(
                         ready.get(Math.floorMod(n, ready.size())));

--- a/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/MyotisRpcBackend.kt
+++ b/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/MyotisRpcBackend.kt
@@ -80,6 +80,18 @@ interface MyotisRpcBackend {
     fun getTransactionReceipt(txHash: ByteArray): String?
 
     /**
+     * eth_getTransactionByHash for [txHash]. Returns:
+     *  - the tx as a pre-built JSON object string when found — either in a recent
+     *    beacon-verified block (blockHash/blockNumber/transactionIndex set) or, for a tx
+     *    this node itself broadcast and not yet mined, from the local sent-tx cache
+     *    (blockNumber null = pending; the node holds the signed bytes, so no trust);
+     *  - the literal "null" for a VERIFIED "unknown tx" (synced, not in the recent chain
+     *    and not one we sent — eth's standard);
+     *  - Kotlin null when it CAN'T be answered verified (not synced / no peer) → router errors.
+     */
+    fun getTransactionByHash(txHash: ByteArray): String? = null
+
+    /**
      * eth_getBlockByNumber for [block] (a tag like "latest" or a 0x hex number), verified
      * from a beacon-anchored header (no snap state needed). Returns the block as a JSON
      * object string (transactions as hashes); the literal "null" for a non-existent

--- a/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/RpcRouter.kt
+++ b/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/RpcRouter.kt
@@ -44,6 +44,7 @@ class RpcRouter(
             "eth_getTransactionCount", "eth_getCode", "eth_getStorageAt",
             "eth_sendRawTransaction", "eth_getTransactionReceipt", "eth_getBlockByNumber",
             "eth_gasPrice", "eth_maxPriorityFeePerGas", "eth_feeHistory", "eth_estimateGas",
+            "eth_getTransactionByHash",
         )
     }
 
@@ -191,6 +192,13 @@ class RpcRouter(
                 // actually couldn't check.
                 val receiptJson = withContext(Dispatchers.IO) { b.getTransactionReceipt(txHash) } ?: return null
                 resultEnvelope(id, json.parseToJsonElement(receiptJson)) // "null" → JsonNull result
+            }
+            "eth_getTransactionByHash" -> {
+                val txHash = (root.params()?.getOrNull(0) as? JsonPrimitive)?.asHexBytes() ?: return null
+                // Object string when found (mined or pending-from-our-cache); "null" for a
+                // verified-unknown tx; Kotlin null (can't verify) → strict error.
+                val txJson = withContext(Dispatchers.IO) { b.getTransactionByHash(txHash) } ?: return null
+                resultEnvelope(id, json.parseToJsonElement(txJson))
             }
             "eth_getBlockByNumber" -> {
                 val p = root.params()

--- a/myotis-evm/src/main/java/io/myotis/evm/PrefetchingEvmExecutor.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/PrefetchingEvmExecutor.java
@@ -256,9 +256,13 @@ public final class PrefetchingEvmExecutor implements EvmExecutor {
      */
     /** Max prefetch requests in flight at once. A wallet balance sweep can record
      *  ~1000 misses in one wave; firing them all concurrently floods the single
-     *  pinned snap peer (request-queue overflow / disconnects). Chunking keeps the
-     *  peer responsive while still collapsing a wave to ~(N/chunk) round trips. */
-    private static final int PREFETCH_CHUNK = 128;
+     *  pinned snap peer (request-queue overflow / disconnects). A semaphore caps
+     *  concurrency without an artificial per-chunk barrier — as each request
+     *  completes its permit frees and the next starts, so one slow request only
+     *  occupies its own slot, not the whole next batch. */
+    private static final int PREFETCH_MAX_IN_FLIGHT = 128;
+    /** Overall best-effort budget for one prefetch wave. */
+    private static final long PREFETCH_WAVE_TIMEOUT_SEC = 30;
 
     private void prefetchInParallel(SyncStateView view, byte[] stateRoot,
                                     Set<Address> accounts,
@@ -289,24 +293,36 @@ public final class PrefetchingEvmExecutor implements EvmExecutor {
                         return null;
                     }));
         }
+        if (work.isEmpty()) return;
 
-        // Best-effort, chunked: wait for each chunk before firing the next, but don't
-        // propagate individual failures — if a prefetch failed, the next EVM run will
-        // hit the (still-uncached) miss and either succeed via the oracle's serial
-        // path or surface a clean error from there.
-        for (int from = 0; from < work.size(); from += PREFETCH_CHUNK) {
-            List<CompletableFuture<?>> chunk = new ArrayList<>(PREFETCH_CHUNK);
-            for (int i = from; i < Math.min(from + PREFETCH_CHUNK, work.size()); i++) {
-                chunk.add(work.get(i).get());
-            }
+        // Semaphore-bounded: keep up to PREFETCH_MAX_IN_FLIGHT requests running, the
+        // calling worker thread blocking on acquire to pace submission. Each fetch
+        // self-times-out (per-request timeout in the wire layer) and releases its
+        // permit, so a slow request frees its slot without stalling the others — no
+        // head-of-line blocking across batches. Best-effort: a failed/cancelled
+        // prefetch just becomes a cache miss the real EVM run block-fetches.
+        java.util.concurrent.Semaphore permits =
+                new java.util.concurrent.Semaphore(PREFETCH_MAX_IN_FLIGHT);
+        List<CompletableFuture<?>> futures = new ArrayList<>(work.size());
+        for (java.util.function.Supplier<CompletableFuture<?>> w : work) {
+            permits.acquireUninterruptibly();
+            CompletableFuture<?> f;
             try {
-                CompletableFuture.allOf(chunk.toArray(CompletableFuture[]::new))
-                        .get(30, java.util.concurrent.TimeUnit.SECONDS);
-            } catch (Exception e) {
-                log.debug("[prefetch] chunk fetch timed out / failed: {}", e.getMessage());
-                for (CompletableFuture<?> f : chunk) {
-                    if (!f.isDone()) f.cancel(false);
-                }
+                f = w.get();
+            } catch (RuntimeException ex) {        // synchronous failure: don't leak the permit
+                permits.release();
+                log.debug("[prefetch] submit failed: {}", ex.getMessage());
+                continue;
+            }
+            futures.add(f.whenComplete((v, e) -> permits.release()));
+        }
+        try {
+            CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new))
+                    .get(PREFETCH_WAVE_TIMEOUT_SEC, java.util.concurrent.TimeUnit.SECONDS);
+        } catch (Exception e) {
+            log.debug("[prefetch] wave timed out / failed: {}", e.getMessage());
+            for (CompletableFuture<?> f : futures) {
+                if (!f.isDone()) f.cancel(false);
             }
         }
     }

--- a/myotis-evm/src/main/java/io/myotis/evm/PrefetchingEvmExecutor.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/PrefetchingEvmExecutor.java
@@ -129,8 +129,22 @@ public final class PrefetchingEvmExecutor implements EvmExecutor {
         Set<AccessTracker.SlotKey> seenSlots = new HashSet<>();
         Set<Address> seenAccounts = new HashSet<>();
 
+        // Sentinel mode stays ON while each iteration still DISCOVERS new accesses,
+        // so multi-hop access patterns get one parallel prefetch wave per hop instead
+        // of falling into serial blocking reads. The motivating case is MetaMask's
+        // SingleCallBalances sweep — balances(users[], tokens[]) over ~1000 tokens:
+        // iteration 0 (sentinel) discovers the 1000 token ACCOUNTS (their code isn't
+        // loaded yet, so no balanceOf executes); with iteration 1 forced real, the
+        // 1000 balance SLOTS were then fetched one blocking read at a time (~minutes,
+        // i.e. a guaranteed 30s RPC timeout — the wallet showed no balances at all).
+        // Sentinel iteration 1 instead RECORDS all 1000 slots and batch-fetches them
+        // in one wave; the real run then executes against a fully-warm cache.
+        // The last two iterations are always real, preserving the old convergence
+        // budget for paths the sentinel zeros diverged away from; results returned to
+        // the caller still come only from a real, fully-converged run.
+        boolean discovering = true;
         for (int iter = 0; iter < iterationCap; iter++) {
-            boolean sentinelMode = iter == 0;
+            boolean sentinelMode = discovering && iter < iterationCap - 2;
             view.setSentinelOnMiss(sentinelMode);
 
             // Per-iteration tracker, wired into both the tracer (records SLOAD
@@ -144,6 +158,7 @@ public final class PrefetchingEvmExecutor implements EvmExecutor {
             view.setAccessTracker(iterationTracker);
             PrefetchingTracer tracer = new PrefetchingTracer(iterationTracker);
 
+            long missesBefore = view.sentinelMissCount();
             byte[] result;
             try {
                 result = delegate.runOnTracedView(target, calldata, blockContext, view, tracer);
@@ -152,22 +167,43 @@ public final class PrefetchingEvmExecutor implements EvmExecutor {
                     // Real iteration produced an actual revert / halt — propagate.
                     throw e;
                 }
-                // Sentinel iteration 0 may revert because zero-valued state
+                // A sentinel iteration may revert because zero-valued state
                 // tripped a require()/divide-by-zero/etc. That's expected;
                 // we still have whatever access list was recorded up to the
                 // point of the revert. Continue to the prefetch wave.
-                log.debug("[prefetch] sentinel iteration 0 halted ({}); continuing with recorded access list",
-                        e.error());
+                log.debug("[prefetch] sentinel iteration {} halted ({}); continuing with recorded access list",
+                        iter, e.error());
                 result = null;
             }
 
             AccessTracker.Snapshot snap = iterationTracker.snapshot();
 
             if (sentinelMode) {
-                // Iteration 0's result is bogus by construction. Discard.
-                seenAccounts.addAll(snap.accounts());
-                seenSlots.addAll(snap.storage());
-                prefetchInParallel(view, blockContext.stateRoot(), snap.accounts(), snap.storage());
+                Set<AccessTracker.SlotKey> sentinelNewSlots = new HashSet<>(snap.storage());
+                sentinelNewSlots.removeAll(seenSlots);
+                Set<Address> sentinelNewAccounts = new HashSet<>(snap.accounts());
+                sentinelNewAccounts.removeAll(seenAccounts);
+                if (sentinelNewAccounts.isEmpty() && sentinelNewSlots.isEmpty()) {
+                    if (result != null && view.sentinelMissCount() == missesBefore) {
+                        // No new accesses AND no sentinel value was handed out: every
+                        // read hit the (verified) cache, so this run is byte-identical
+                        // to a real run — converged, no extra iteration needed.
+                        convergenceTracker.record(iter + 1);
+                        log.debug("[prefetch] converged after {} iteration(s) (hit-only sentinel run)",
+                                iter + 1);
+                        return result;
+                    }
+                    // Nothing new to prefetch, but a sentinel placeholder leaked into
+                    // (or reverted) this run — e.g. a prior wave's fetch failed. Run
+                    // real next so misses block-fetch serially and the result is true.
+                    discovering = false;
+                    continue;
+                }
+                // A sentinel iteration's result may be bogus by construction. Discard;
+                // batch-prefetch what it newly discovered and go discover the next hop.
+                seenAccounts.addAll(sentinelNewAccounts);
+                seenSlots.addAll(sentinelNewSlots);
+                prefetchInParallel(view, blockContext.stateRoot(), sentinelNewAccounts, sentinelNewSlots);
                 continue;
             }
 
@@ -218,15 +254,22 @@ public final class PrefetchingEvmExecutor implements EvmExecutor {
      * {@link SyncStateView#putStorage}, so the next iteration's reads hit the
      * cache and don't issue any oracle calls.
      */
+    /** Max prefetch requests in flight at once. A wallet balance sweep can record
+     *  ~1000 misses in one wave; firing them all concurrently floods the single
+     *  pinned snap peer (request-queue overflow / disconnects). Chunking keeps the
+     *  peer responsive while still collapsing a wave to ~(N/chunk) round trips. */
+    private static final int PREFETCH_CHUNK = 128;
+
     private void prefetchInParallel(SyncStateView view, byte[] stateRoot,
                                     Set<Address> accounts,
                                     Set<AccessTracker.SlotKey> slots) {
         SnapStateOracle oracle = delegate.oracle();
-        List<CompletableFuture<?>> futures = new ArrayList<>(accounts.size() + slots.size());
+        List<java.util.function.Supplier<CompletableFuture<?>>> work =
+                new ArrayList<>(accounts.size() + slots.size());
 
         for (Address address : accounts) {
             if (view.hasAccount(address)) continue;
-            futures.add(oracle.fetchAccount(stateRoot, address)
+            work.add(() -> oracle.fetchAccount(stateRoot, address)
                     .thenAccept(state -> view.putAccount(address, state))
                     .exceptionally(t -> {
                         log.debug("[prefetch] account fetch for {} failed: {}", address, t.getMessage());
@@ -235,7 +278,7 @@ public final class PrefetchingEvmExecutor implements EvmExecutor {
         }
         for (AccessTracker.SlotKey key : slots) {
             if (view.hasStorage(key.address(), UInt256.valueOf(key.slot()))) continue;
-            futures.add(oracle.fetchStorage(stateRoot, key.address(), key.slot())
+            work.add(() -> oracle.fetchStorage(stateRoot, key.address(), key.slot())
                     .thenAccept(value -> view.putStorage(
                             key.address(),
                             UInt256.valueOf(key.slot()),
@@ -247,17 +290,23 @@ public final class PrefetchingEvmExecutor implements EvmExecutor {
                     }));
         }
 
-        // Best-effort: wait for the batch to finish, but don't propagate
-        // individual failures here — if a prefetch failed, the next EVM run
-        // will hit the (still-uncached) miss and either succeed via the
-        // oracle's serial path or surface a clean error from there.
-        try {
-            CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new))
-                    .get(30, java.util.concurrent.TimeUnit.SECONDS);
-        } catch (Exception e) {
-            log.debug("[prefetch] batch fetch timed out / failed: {}", e.getMessage());
-            for (CompletableFuture<?> f : futures) {
-                if (!f.isDone()) f.cancel(false);
+        // Best-effort, chunked: wait for each chunk before firing the next, but don't
+        // propagate individual failures — if a prefetch failed, the next EVM run will
+        // hit the (still-uncached) miss and either succeed via the oracle's serial
+        // path or surface a clean error from there.
+        for (int from = 0; from < work.size(); from += PREFETCH_CHUNK) {
+            List<CompletableFuture<?>> chunk = new ArrayList<>(PREFETCH_CHUNK);
+            for (int i = from; i < Math.min(from + PREFETCH_CHUNK, work.size()); i++) {
+                chunk.add(work.get(i).get());
+            }
+            try {
+                CompletableFuture.allOf(chunk.toArray(CompletableFuture[]::new))
+                        .get(30, java.util.concurrent.TimeUnit.SECONDS);
+            } catch (Exception e) {
+                log.debug("[prefetch] chunk fetch timed out / failed: {}", e.getMessage());
+                for (CompletableFuture<?> f : chunk) {
+                    if (!f.isDone()) f.cancel(false);
+                }
             }
         }
     }

--- a/myotis-evm/src/main/java/io/myotis/evm/world/SyncStateView.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/world/SyncStateView.java
@@ -72,6 +72,18 @@ public final class SyncStateView {
      */
     private volatile boolean sentinelOnMiss = false;
 
+    /** Count of sentinel values handed out (cache misses while {@link #sentinelOnMiss}
+     *  is on). Lets the convergence loop tell a sentinel run that was ALL cache hits
+     *  (its result is real — every read returned verified data) from one that may
+     *  have computed on placeholders. */
+    private final java.util.concurrent.atomic.AtomicLong sentinelMisses =
+            new java.util.concurrent.atomic.AtomicLong();
+
+    /** Total sentinel values handed out so far; diff across a run to detect misses. */
+    public long sentinelMissCount() {
+        return sentinelMisses.get();
+    }
+
     public SyncStateView(
             SnapStateOracle oracle,
             byte[] stateRoot,
@@ -108,6 +120,7 @@ public final class SyncStateView {
         if (sentinelOnMiss) {
             // Empty default; intentionally NOT cached so a subsequent run
             // with the flag cleared will fetch the real value.
+            sentinelMisses.incrementAndGet();
             return new AccountState(address, 0L, BigInteger.ZERO, EMPTY_CODE_HASH);
         }
         try {
@@ -130,6 +143,7 @@ public final class SyncStateView {
             // from a real zero — but the access is recorded in the tracker
             // either way, and the convergence loop will re-run with the
             // flag cleared to confirm.
+            sentinelMisses.incrementAndGet();
             return UInt256.ZERO;
         }
         try {
@@ -155,6 +169,7 @@ public final class SyncStateView {
             // re-enters with real bytecode populated. The PrefetchingEvmExecutor
             // pre-populates the *target* contract's bytecode synchronously so
             // iter 0's run reaches actual bytecode at the top level.
+            sentinelMisses.incrementAndGet();
             return new byte[0];
         }
         try {

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/messages/EthTxDecoder.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/messages/EthTxDecoder.java
@@ -1,0 +1,215 @@
+package com.jaeckel.ethp2p.networking.eth.messages;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.crypto.Hash;
+import org.apache.tuweni.crypto.SECP256K1;
+import org.apache.tuweni.rlp.RLP;
+
+import java.math.BigInteger;
+
+/**
+ * Decodes a raw Ethereum transaction (EIP-2718 typed or legacy) into the fields an
+ * {@code eth_getTransactionByHash} JSON response needs, including the sender address
+ * recovered from the signature. Pure decoder over bytes the caller has either signed-
+ * and-broadcast itself or verified against a block's {@code transactionsRoot}; it does
+ * no verification of its own (the sender recovery is just ECDSA over the signing hash —
+ * a malformed signature yields a null {@code from}, not a trust hole).
+ *
+ * <p>Supports legacy (incl. EIP-155), EIP-2930 (type 1), EIP-1559 (type 2), and
+ * EIP-4844 (type 3). Unknown types decode to null.
+ */
+public final class EthTxDecoder {
+
+    private EthTxDecoder() {}
+
+    public record DecodedTx(
+            int type,                       // 0 legacy, 1 2930, 2 1559, 3 4844
+            Long chainId,                   // null for pre-155 legacy
+            long nonce,
+            BigInteger gasPrice,            // legacy / 2930; null for 1559+
+            BigInteger maxPriorityFeePerGas,// 1559+; null otherwise
+            BigInteger maxFeePerGas,        // 1559+; null otherwise
+            long gas,
+            Bytes to,                       // 20 bytes, or empty for contract creation
+            BigInteger value,
+            Bytes input,
+            BigInteger v, BigInteger r, BigInteger s,
+            Bytes from) {                   // recovered sender (20 bytes), or null
+    }
+
+    /** Decode raw tx bytes; null if the type is unknown or decoding fails. */
+    public static DecodedTx decode(Bytes raw) {
+        if (raw == null || raw.isEmpty()) return null;
+        try {
+            int first = raw.get(0) & 0xFF;
+            if (first >= 0xc0) return decodeLegacy(raw);
+            return switch (first) {
+                case 1 -> decode2930(raw);
+                case 2 -> decode1559(raw);
+                case 3 -> decode4844(raw);
+                default -> null;
+            };
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    // legacy: rlp([nonce, gasPrice, gasLimit, to, value, data, v, r, s])
+    private static DecodedTx decodeLegacy(Bytes raw) {
+        return RLP.decodeList(raw, r -> {
+            long nonce = toLong(r.readValue());
+            BigInteger gasPrice = toBig(r.readValue());
+            long gas = toLong(r.readValue());
+            Bytes to = r.readValue();
+            BigInteger value = toBig(r.readValue());
+            Bytes input = r.readValue();
+            BigInteger v = toBig(r.readValue());
+            BigInteger sigR = toBig(r.readValue());
+            BigInteger sigS = toBig(r.readValue());
+
+            Long chainId = null;
+            int recId;
+            Bytes signing;
+            int vi = v.intValueExact();
+            if (vi == 27 || vi == 28) {
+                recId = vi - 27;
+                signing = RLP.encodeList(w -> {
+                    w.writeLong(nonce); w.writeBigInteger(gasPrice); w.writeLong(gas);
+                    w.writeValue(to); w.writeBigInteger(value); w.writeValue(input);
+                });
+            } else {
+                long cid = (vi - 35) / 2;       // EIP-155
+                chainId = cid;
+                recId = (vi - 35) % 2;
+                final long fcid = cid;
+                signing = RLP.encodeList(w -> {
+                    w.writeLong(nonce); w.writeBigInteger(gasPrice); w.writeLong(gas);
+                    w.writeValue(to); w.writeBigInteger(value); w.writeValue(input);
+                    w.writeLong(fcid); w.writeInt(0); w.writeInt(0);
+                });
+            }
+            Bytes from = recover(Hash.keccak256(signing), sigR, sigS, recId);
+            return new DecodedTx(0, chainId, nonce, gasPrice, null, null, gas, to, value,
+                    input, v, sigR, sigS, from);
+        });
+    }
+
+    // 0x01 || rlp([chainId, nonce, gasPrice, gas, to, value, data, accessList, yParity, r, s])
+    private static DecodedTx decode2930(Bytes raw) {
+        Bytes body = raw.slice(1);
+        return RLP.decodeList(body, r -> {
+            long chainId = toLong(r.readValue());
+            long nonce = toLong(r.readValue());
+            BigInteger gasPrice = toBig(r.readValue());
+            long gas = toLong(r.readValue());
+            Bytes to = r.readValue();
+            BigInteger value = toBig(r.readValue());
+            Bytes input = r.readValue();
+            Bytes accessList = rawList(r);
+            BigInteger yParity = toBig(r.readValue());
+            BigInteger sigR = toBig(r.readValue());
+            BigInteger sigS = toBig(r.readValue());
+            Bytes signing = Bytes.concatenate(Bytes.of(1), RLP.encodeList(w -> {
+                w.writeLong(chainId); w.writeLong(nonce); w.writeBigInteger(gasPrice);
+                w.writeLong(gas); w.writeValue(to); w.writeBigInteger(value);
+                w.writeValue(input); w.writeRLP(accessList);
+            }));
+            Bytes from = recover(Hash.keccak256(signing), sigR, sigS, yParity.intValueExact());
+            return new DecodedTx(1, chainId, nonce, gasPrice, null, null, gas, to, value,
+                    input, yParity, sigR, sigS, from);
+        });
+    }
+
+    // 0x02 || rlp([chainId, nonce, maxPriority, maxFee, gas, to, value, data, accessList, yParity, r, s])
+    private static DecodedTx decode1559(Bytes raw) {
+        Bytes body = raw.slice(1);
+        return RLP.decodeList(body, r -> {
+            long chainId = toLong(r.readValue());
+            long nonce = toLong(r.readValue());
+            BigInteger maxPriority = toBig(r.readValue());
+            BigInteger maxFee = toBig(r.readValue());
+            long gas = toLong(r.readValue());
+            Bytes to = r.readValue();
+            BigInteger value = toBig(r.readValue());
+            Bytes input = r.readValue();
+            Bytes accessList = rawList(r);
+            BigInteger yParity = toBig(r.readValue());
+            BigInteger sigR = toBig(r.readValue());
+            BigInteger sigS = toBig(r.readValue());
+            Bytes signing = Bytes.concatenate(Bytes.of(2), RLP.encodeList(w -> {
+                w.writeLong(chainId); w.writeLong(nonce); w.writeBigInteger(maxPriority);
+                w.writeBigInteger(maxFee); w.writeLong(gas); w.writeValue(to);
+                w.writeBigInteger(value); w.writeValue(input); w.writeRLP(accessList);
+            }));
+            Bytes from = recover(Hash.keccak256(signing), sigR, sigS, yParity.intValueExact());
+            return new DecodedTx(2, chainId, nonce, null, maxPriority, maxFee, gas, to, value,
+                    input, yParity, sigR, sigS, from);
+        });
+    }
+
+    // 0x03 || rlp([chainId, nonce, maxPriority, maxFee, gas, to, value, data, accessList,
+    //              maxFeePerBlobGas, blobVersionedHashes, yParity, r, s])
+    private static DecodedTx decode4844(Bytes raw) {
+        Bytes body = raw.slice(1);
+        return RLP.decodeList(body, r -> {
+            long chainId = toLong(r.readValue());
+            long nonce = toLong(r.readValue());
+            BigInteger maxPriority = toBig(r.readValue());
+            BigInteger maxFee = toBig(r.readValue());
+            long gas = toLong(r.readValue());
+            Bytes to = r.readValue();
+            BigInteger value = toBig(r.readValue());
+            Bytes input = r.readValue();
+            Bytes accessList = rawList(r);
+            BigInteger maxFeePerBlobGas = toBig(r.readValue());
+            Bytes blobHashes = rawList(r);
+            BigInteger yParity = toBig(r.readValue());
+            BigInteger sigR = toBig(r.readValue());
+            BigInteger sigS = toBig(r.readValue());
+            Bytes signing = Bytes.concatenate(Bytes.of(3), RLP.encodeList(w -> {
+                w.writeLong(chainId); w.writeLong(nonce); w.writeBigInteger(maxPriority);
+                w.writeBigInteger(maxFee); w.writeLong(gas); w.writeValue(to);
+                w.writeBigInteger(value); w.writeValue(input); w.writeRLP(accessList);
+                w.writeBigInteger(maxFeePerBlobGas); w.writeRLP(blobHashes);
+            }));
+            Bytes from = recover(Hash.keccak256(signing), sigR, sigS, yParity.intValueExact());
+            return new DecodedTx(3, chainId, nonce, null, maxPriority, maxFee, gas, to, value,
+                    input, yParity, sigR, sigS, from);
+        });
+    }
+
+    /** Capture the raw canonical RLP of the (possibly nested) list at the reader head. */
+    private static Bytes rawList(org.apache.tuweni.rlp.RLPReader reader) {
+        java.util.List<Bytes> children = new java.util.ArrayList<>();
+        reader.readList(inner -> {
+            while (!inner.isComplete()) {
+                if (inner.nextIsList()) children.add(rawList(inner));
+                else children.add(RLP.encodeValue(inner.readValue()));
+            }
+            return null;
+        });
+        return RLP.encodeList(w -> children.forEach(w::writeRLP));
+    }
+
+    /** Recover the 20-byte sender address, or null if the signature is unrecoverable. */
+    private static Bytes recover(Bytes32 signingHash, BigInteger r, BigInteger s, int recId) {
+        try {
+            SECP256K1.Signature sig = SECP256K1.Signature.create((byte) recId, r, s);
+            SECP256K1.PublicKey pub = SECP256K1.PublicKey.recoverFromHashAndSignature(signingHash, sig);
+            if (pub == null) return null;
+            // address = last 20 bytes of keccak256(uncompressed pubkey, 64 bytes x||y)
+            return Hash.keccak256(pub.bytes()).slice(12, 20);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static long toLong(Bytes b) {
+        return b.isEmpty() ? 0L : b.toLong();
+    }
+
+    private static BigInteger toBig(Bytes b) {
+        return b.isEmpty() ? BigInteger.ZERO : b.toUnsignedBigInteger();
+    }
+}

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/messages/EthTxDecoder.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/messages/EthTxDecoder.java
@@ -16,15 +16,15 @@ import java.math.BigInteger;
  * no verification of its own (the sender recovery is just ECDSA over the signing hash —
  * a malformed signature yields a null {@code from}, not a trust hole).
  *
- * <p>Supports legacy (incl. EIP-155), EIP-2930 (type 1), EIP-1559 (type 2), and
- * EIP-4844 (type 3). Unknown types decode to null.
+ * <p>Supports legacy (incl. EIP-155), EIP-2930 (type 1), EIP-1559 (type 2),
+ * EIP-4844 (type 3), and EIP-7702 (type 4). Unknown types decode to null.
  */
 public final class EthTxDecoder {
 
     private EthTxDecoder() {}
 
     public record DecodedTx(
-            int type,                       // 0 legacy, 1 2930, 2 1559, 3 4844
+            int type,                       // 0 legacy, 1 2930, 2 1559, 3 4844, 4 7702
             Long chainId,                   // null for pre-155 legacy
             long nonce,
             BigInteger gasPrice,            // legacy / 2930; null for 1559+
@@ -48,6 +48,7 @@ public final class EthTxDecoder {
                 case 1 -> decode2930(raw);
                 case 2 -> decode1559(raw);
                 case 3 -> decode4844(raw);
+                case 4 -> decode7702(raw);
                 default -> null;
             };
         } catch (Exception e) {
@@ -175,6 +176,37 @@ public final class EthTxDecoder {
             }));
             Bytes from = recover(Hash.keccak256(signing), sigR, sigS, yParity.intValueExact());
             return new DecodedTx(3, chainId, nonce, null, maxPriority, maxFee, gas, to, value,
+                    input, yParity, sigR, sigS, from);
+        });
+    }
+
+    // 0x04 || rlp([chainId, nonce, maxPriority, maxFee, gas, to, value, data, accessList,
+    //              authorizationList, yParity, r, s]) — EIP-7702. Same fee model as 1559,
+    //              with an authorizationList (signed delegation tuples) before the sig.
+    private static DecodedTx decode7702(Bytes raw) {
+        Bytes body = raw.slice(1);
+        return RLP.decodeList(body, r -> {
+            long chainId = toLong(r.readValue());
+            long nonce = toLong(r.readValue());
+            BigInteger maxPriority = toBig(r.readValue());
+            BigInteger maxFee = toBig(r.readValue());
+            long gas = toLong(r.readValue());
+            Bytes to = r.readValue();
+            BigInteger value = toBig(r.readValue());
+            Bytes input = r.readValue();
+            Bytes accessList = rawList(r);
+            Bytes authList = rawList(r);
+            BigInteger yParity = toBig(r.readValue());
+            BigInteger sigR = toBig(r.readValue());
+            BigInteger sigS = toBig(r.readValue());
+            Bytes signing = Bytes.concatenate(Bytes.of(4), RLP.encodeList(w -> {
+                w.writeLong(chainId); w.writeLong(nonce); w.writeBigInteger(maxPriority);
+                w.writeBigInteger(maxFee); w.writeLong(gas); w.writeValue(to);
+                w.writeBigInteger(value); w.writeValue(input); w.writeRLP(accessList);
+                w.writeRLP(authList);
+            }));
+            Bytes from = recover(Hash.keccak256(signing), sigR, sigS, yParity.intValueExact());
+            return new DecodedTx(4, chainId, nonce, null, maxPriority, maxFee, gas, to, value,
                     input, yParity, sigR, sigS, from);
         });
     }

--- a/networking/src/test/java/com/jaeckel/ethp2p/networking/eth/messages/EthTxDecoderTest.java
+++ b/networking/src/test/java/com/jaeckel/ethp2p/networking/eth/messages/EthTxDecoderTest.java
@@ -97,6 +97,50 @@ class EthTxDecoderTest {
         assertArrayEquals(EXPECTED_FROM.toArray(), t.from().toArray());
     }
 
+    /** 0x04 || rlp([chainId, nonce, maxPriority, maxFee, gas, to, value, data, accessList,
+     *               authorizationList, yParity, r, s]) — EIP-7702. */
+    @Test
+    void recoversSenderFrom7702() {
+        // One authorization tuple [chainId, address, nonce, yParity, r, s].
+        java.util.function.Consumer<org.apache.tuweni.rlp.RLPWriter> writeAuthList = w ->
+                w.writeList(al -> al.writeList(tuple -> {
+                    tuple.writeLong(1);
+                    tuple.writeValue(TO);
+                    tuple.writeLong(0);
+                    tuple.writeInt(0);
+                    tuple.writeBigInteger(BigInteger.ONE);
+                    tuple.writeBigInteger(BigInteger.ONE);
+                }));
+        Bytes signing = Bytes.concatenate(Bytes.of(4), RLP.encodeList(w -> {
+            w.writeLong(1); w.writeLong(9);
+            w.writeBigInteger(BigInteger.valueOf(2_000_000_000L));
+            w.writeBigInteger(BigInteger.valueOf(40_000_000_000L));
+            w.writeLong(50000); w.writeValue(TO);
+            w.writeBigInteger(BigInteger.ZERO); w.writeValue(Bytes.fromHexString("0x1234"));
+            w.writeList(al -> {});             // accessList
+            writeAuthList.accept(w);           // authorizationList
+        }));
+        SECP256K1.Signature sig = SECP256K1.signHashed(Hash.keccak256(signing), KP);
+
+        Bytes raw = Bytes.concatenate(Bytes.of(4), RLP.encodeList(w -> {
+            w.writeLong(1); w.writeLong(9);
+            w.writeBigInteger(BigInteger.valueOf(2_000_000_000L));
+            w.writeBigInteger(BigInteger.valueOf(40_000_000_000L));
+            w.writeLong(50000); w.writeValue(TO);
+            w.writeBigInteger(BigInteger.ZERO); w.writeValue(Bytes.fromHexString("0x1234"));
+            w.writeList(al -> {});
+            writeAuthList.accept(w);
+            w.writeInt(sig.v()); w.writeBigInteger(sig.r()); w.writeBigInteger(sig.s());
+        }));
+
+        EthTxDecoder.DecodedTx t = EthTxDecoder.decode(raw);
+        assertNotNull(t);
+        assertEquals(4, t.type());
+        assertEquals(BigInteger.valueOf(40_000_000_000L), t.maxFeePerGas());
+        assertArrayEquals(Bytes.fromHexString("0x1234").toArray(), t.input().toArray());
+        assertArrayEquals(EXPECTED_FROM.toArray(), t.from().toArray());
+    }
+
     @Test
     void unknownTypeReturnsNull() {
         assertNull(EthTxDecoder.decode(Bytes.fromHexString("0x7fabcdef")));

--- a/networking/src/test/java/com/jaeckel/ethp2p/networking/eth/messages/EthTxDecoderTest.java
+++ b/networking/src/test/java/com/jaeckel/ethp2p/networking/eth/messages/EthTxDecoderTest.java
@@ -1,0 +1,106 @@
+package com.jaeckel.ethp2p.networking.eth.messages;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.crypto.Hash;
+import org.apache.tuweni.crypto.SECP256K1;
+import org.apache.tuweni.rlp.RLP;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Round-trips a tx through sign → decode and asserts the recovered sender matches the
+ * signing key's address — the load-bearing part (per-type signing-hash reconstruction).
+ */
+class EthTxDecoderTest {
+
+    static {
+        java.security.Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
+    }
+
+    private static final SECP256K1.KeyPair KP = SECP256K1.KeyPair.random();
+    private static final Bytes EXPECTED_FROM = Hash.keccak256(KP.publicKey().bytes()).slice(12, 20);
+    private static final Bytes TO = Bytes.fromHexString("0x00000000219ab540356cBB839Cbe05303d7705Fa");
+
+    /** 0x02 || rlp([chainId, nonce, maxPriority, maxFee, gas, to, value, data, accessList, yParity, r, s]) */
+    @Test
+    void recoversSenderFrom1559() {
+        Bytes signing = Bytes.concatenate(Bytes.of(2), RLP.encodeList(w -> {
+            w.writeLong(1);                                   // chainId
+            w.writeLong(42);                                  // nonce
+            w.writeBigInteger(BigInteger.valueOf(1_000_000_000L));     // maxPriority
+            w.writeBigInteger(BigInteger.valueOf(30_000_000_000L));    // maxFee
+            w.writeLong(21000);                               // gas
+            w.writeValue(TO);
+            w.writeBigInteger(BigInteger.valueOf(1_000_000));  // value
+            w.writeValue(Bytes.EMPTY);                         // data
+            w.writeList(al -> {});                             // accessList
+        }));
+        SECP256K1.Signature sig = SECP256K1.signHashed(Hash.keccak256(signing), KP);
+
+        Bytes raw = Bytes.concatenate(Bytes.of(2), RLP.encodeList(w -> {
+            w.writeLong(1); w.writeLong(42);
+            w.writeBigInteger(BigInteger.valueOf(1_000_000_000L));
+            w.writeBigInteger(BigInteger.valueOf(30_000_000_000L));
+            w.writeLong(21000); w.writeValue(TO);
+            w.writeBigInteger(BigInteger.valueOf(1_000_000)); w.writeValue(Bytes.EMPTY);
+            w.writeList(al -> {});
+            w.writeInt(sig.v());
+            w.writeBigInteger(sig.r()); w.writeBigInteger(sig.s());
+        }));
+
+        EthTxDecoder.DecodedTx t = EthTxDecoder.decode(raw);
+        assertNotNull(t);
+        assertEquals(2, t.type());
+        assertEquals(42, t.nonce());
+        assertEquals(1L, t.chainId());
+        assertEquals(BigInteger.valueOf(30_000_000_000L), t.maxFeePerGas());
+        assertArrayEquals(TO.toArray(), t.to().toArray());
+        assertNotNull(t.from(), "sender must be recovered");
+        assertArrayEquals(EXPECTED_FROM.toArray(), t.from().toArray());
+    }
+
+    /** legacy EIP-155: rlp([nonce, gasPrice, gas, to, value, data, v, r, s]), v = chainId*2+35+yParity */
+    @Test
+    void recoversSenderFromLegacyEip155() {
+        long chainId = 1;
+        Bytes signing = RLP.encodeList(w -> {
+            w.writeLong(7);                                    // nonce
+            w.writeBigInteger(BigInteger.valueOf(20_000_000_000L));  // gasPrice
+            w.writeLong(21000);                                // gas
+            w.writeValue(TO);
+            w.writeBigInteger(BigInteger.valueOf(5_000_000));   // value
+            w.writeValue(Bytes.EMPTY);                          // data
+            w.writeLong(chainId); w.writeInt(0); w.writeInt(0); // EIP-155 trailer
+        });
+        SECP256K1.Signature sig = SECP256K1.signHashed(Hash.keccak256(signing), KP);
+        long v = chainId * 2 + 35 + sig.v();
+
+        Bytes raw = RLP.encodeList(w -> {
+            w.writeLong(7); w.writeBigInteger(BigInteger.valueOf(20_000_000_000L));
+            w.writeLong(21000); w.writeValue(TO);
+            w.writeBigInteger(BigInteger.valueOf(5_000_000)); w.writeValue(Bytes.EMPTY);
+            w.writeLong(v); w.writeBigInteger(sig.r()); w.writeBigInteger(sig.s());
+        });
+
+        EthTxDecoder.DecodedTx t = EthTxDecoder.decode(raw);
+        assertNotNull(t);
+        assertEquals(0, t.type());
+        assertEquals(1L, t.chainId());
+        assertEquals(BigInteger.valueOf(20_000_000_000L), t.gasPrice());
+        assertArrayEquals(EXPECTED_FROM.toArray(), t.from().toArray());
+    }
+
+    @Test
+    void unknownTypeReturnsNull() {
+        assertNull(EthTxDecoder.decode(Bytes.fromHexString("0x7fabcdef")));
+        assertNull(EthTxDecoder.decode(Bytes.EMPTY));
+        assertNull(EthTxDecoder.decode(null));
+    }
+}


### PR DESCRIPTION
MetaMask's confirm screen (and the asset list — Ether wasn't even offered to send) sat in skeleton-loading because every `eth_call` returned ERROR. Three distinct bugs, peeled one at a time on the Pixel 7:

## 1. Number-pin rejection against a lagging context
Wallets fetch the latest block (our beacon **optimistic** head) and pin every read to it, but the serving context is often the finalized fallback (~2 epochs back) or a snap peer's slightly-older head. `verifiedHeadFor` rejected any pinned number more than `RPC_BLOCK_NUM_TOLERANCE` from the **context** — so a pin at the chain tip failed instantly whenever snap fell back to finalized. Window is now `[context−tol … max(context, optimisticHead)+tol]`; only genuinely-older pins keep the strict floor.

## 2. Single-peer pinning — the real eth_call blocker
`getBalance` (account-only) returned in 0.5 s, but every `eth_call` (needs contract **code + storage**) timed out at 30 s. The head context pinned **one** snap peer for all of a call's fetches, and `SnapBackedStateOracle`'s retry-across-peers was defeated — the supplier returned the *same* peer every attempt. When that peer stalled on `GetAccountRange` for the head's stateRoot, all retries hit it and the call ate the full timeout, while other connected peers held the same state. Snap requests carry the stateRoot explicitly, so the supplier now **rotates** (probed peer first, then round-robin the ready set); a stalled peer fails over.

## 3. Balance-sweep multicall timed out
MetaMask's `SingleCallBalances` over ~1000 tokens made the convergence loop discover 1000 accounts in sentinel iter 0, then fetch 1000 balance slots one blocking read at a time. The loop now stays in record-don't-block mode while each iteration discovers new state (one parallel prefetch wave per access-graph hop), then a real run on a warm cache. **Correctness unchanged**: a result is only returned from a run where every read hit the verified cache — a new `sentinelMissCount` proves a hit-only run is byte-identical to a real run; otherwise a real confirming run still executes. Waves are chunked at 128 in-flight so they can't flood one peer.

Plus: `rpcCall` now logs target + selector + calldata size + block tag + duration (the diagnosis was impossible without it).

## Device validation (Pixel 7, strict mode)
- `eth_call balanceOf(USDC)` 30 s timeout → **~1 s warm** (cold first call ~14 s, one peer-warmup failover); `decimals()` 2.2 s; values correct (31.19 USDC, 290 USDT)
- block-tracker pins advanced from a 27 h-stale block to the chain tip once `getBlockByNumber` started answering (that fix shipped in #40)

Daemon `CommandHandler` has the same single-peer pinning; parity fix is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)