### PR TITLE
cl catch-up: bounded, LC-prioritized peer fan-out (fix minutes-long period rotation)

### DIFF
--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
@@ -646,7 +646,12 @@ public class BeaconLightClient implements AutoCloseable {
                 if (knownPeerAddrs.add(multiaddr)) {
                     // Insert after the local peer (index 0) so discovered peers
                     // are tried before unreachable hardcoded bootstrap ENRs.
-                    clPeerMultiaddrs.add(Math.min(1, clPeerMultiaddrs.size()), multiaddr);
+                    // Synchronize on the same monitor as addPeer's eviction loop and
+                    // copyPeers' snapshot so a concurrent add can't interleave with the
+                    // eviction iteration (ConcurrentModificationException).
+                    synchronized (clPeerMultiaddrs) {
+                        clPeerMultiaddrs.add(Math.min(1, clPeerMultiaddrs.size()), multiaddr);
+                    }
                     added++;
                 }
             }
@@ -1304,6 +1309,13 @@ public class BeaconLightClient implements AutoCloseable {
             }
         }
         peers = fanout;
+        if (peers.isEmpty()) {
+            // No peers to ask (e.g. before discovery has populated the pool). Bail now —
+            // otherwise remaining starts at 0, winner never completes, and winner.get(600s)
+            // below blocks the whole sync loop for 10 minutes.
+            log.warn("[beacon] Catch-up: no capable peers for period {} — retry next cycle", bootstrapPeriod);
+            return false;
+        }
         // {@link BeaconP2PService#doReqResp} detects a dying connection and
         // retries with a fresh one, so we no longer pre-emptively disconnect
         // every peer here — that was costing us Lighthouse/Teku connections

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
@@ -497,7 +497,26 @@ public class BeaconLightClient implements AutoCloseable {
     public boolean addPeer(String multiaddr) {
         if (multiaddr == null || multiaddr.isEmpty()) return false;
         if (!knownPeerAddrs.add(multiaddr)) return false;
-        clPeerMultiaddrs.add(Math.min(1, clPeerMultiaddrs.size()), multiaddr);
+        synchronized (clPeerMultiaddrs) {
+            clPeerMultiaddrs.add(Math.min(1, clPeerMultiaddrs.size()), multiaddr);
+            // Bound the discovered pool. discv5 feeds peers continuously, so an
+            // unbounded list grew to thousands — most fork-matched nodes that don't
+            // run a light-client server — making every period-rotation catch-up fan
+            // out across all of them. Over cap, evict from the tail (oldest add) but
+            // never a peer with positive signal (proven catch-up server / LC-confirmed).
+            // Drop it from knownPeerAddrs too so it can be re-discovered later.
+            if (clPeerMultiaddrs.size() > MAX_CL_PEERS) {
+                for (int i = clPeerMultiaddrs.size() - 1; i >= 0; i--) {
+                    String cand = clPeerMultiaddrs.get(i);
+                    if (!provenCatchUpServers.containsKey(cand)
+                            && !provenLightClient.contains(cand)) {
+                        clPeerMultiaddrs.remove(i);
+                        knownPeerAddrs.remove(cand);
+                        break;
+                    }
+                }
+            }
+        }
         return true;
     }
 
@@ -1146,8 +1165,22 @@ public class BeaconLightClient implements AutoCloseable {
      * nextSyncCommittee for each intermediate period and rotate until we reach the
      * current period.
      */
+    /** Cap on the live discovered CL peer pool ({@link #clPeerMultiaddrs}). discv5 feeds
+     *  it continuously; left unbounded it grew to thousands of mostly-dead/non-LC nodes. */
+    private static final int MAX_CL_PEERS = 1024;
     /** Max 128-period batches per catch-up call. Bounds wall-clock on very old checkpoints. */
     private static final int MAX_CATCHUP_BATCHES = 8;
+    /** Max peers dialed per catch-up batch. The discovered CL pool runs to thousands of
+     *  fork-matched nodes, most of which don't run a light-client server — fanning
+     *  updates_by_range at all of them burned minutes of ProtocolNegotiation/Timeout
+     *  churn at every period rotation. We always include the positive-signal peers
+     *  (proven catch-up servers + LC-confirmed) and fill the rest of this budget from a
+     *  rotating window of the unknown pool, so cold pools still get swept across cycles. */
+    private static final int CATCHUP_FANOUT_MAX = 48;
+    /** Rolling offset into the unknown-peer pool so successive catch-up batches sweep
+     *  different peers instead of re-dialing the same dead window every cycle. */
+    private final java.util.concurrent.atomic.AtomicInteger catchUpSweepOffset =
+            new java.util.concurrent.atomic.AtomicInteger();
 
     private void catchUpSyncCommittee() {
         // Estimate current period from wall clock, using the network's CL genesis time.
@@ -1232,35 +1265,53 @@ public class BeaconLightClient implements AutoCloseable {
             }
             capable.add(p);
         }
-        if (!capable.isEmpty()) {
-            peers = capable;
+        if (capable.isEmpty()) capable = peers; // never starve the batch
+
+        // Split the capable pool into positive-signal peers (worth asking) and the
+        // unknown rest. Positive signal = proven (last session) to serve catch-up for
+        // this period, OR Identify-confirmed light-client support / advertises
+        // updates_by_range. These are the peers that actually retained light-client
+        // data; everything else is a fork-matched node that probably doesn't serve it.
+        java.util.LinkedHashSet<String> priority = new java.util.LinkedHashSet<>();
+        for (String p : capable) {
+            Long sp = provenCatchUpServers.get(p);
+            if (sp != null && sp <= bootstrapPeriod) priority.add(p);
         }
-        // Force-include + front-load peers proven (last session) to serve this
-        // period. They actually retained the checkpoint's light-client updates,
-        // the strongest signal we have — stronger than the runtime filters, which
-        // are cold at startup and can wrongly drop a good peer (Identify/Status
-        // not yet exchanged). This is what turns a cold start from "fan out and
-        // hope" into "ask the peers that worked last time".
-        int provenCount = 0;
-        if (!provenCatchUpServers.isEmpty()) {
-            java.util.LinkedHashSet<String> ordered = new java.util.LinkedHashSet<>();
-            for (String p : copyPeers(false)) {
-                Long sp = provenCatchUpServers.get(p);
-                if (sp != null && sp <= bootstrapPeriod && !peersNoLcUpdates.contains(p)) {
-                    ordered.add(p);
-                }
+        for (String p : capable) {
+            if (priority.contains(p)) continue;
+            if (provenLightClient.contains(p)
+                    || Boolean.TRUE.equals(p2pService.servesLightClientUpdates(p))) {
+                priority.add(p);
             }
-            provenCount = ordered.size();
-            ordered.addAll(peers);
-            peers = new ArrayList<>(ordered);
         }
+        int provenCount = priority.size();
+        List<String> rest = new ArrayList<>(capable.size());
+        for (String p : capable) {
+            if (!priority.contains(p)) rest.add(p);
+        }
+
+        // Cap the fan-out: all positive-signal peers, then fill the remaining budget
+        // from a ROTATING window of the unknown pool so each retry cycle tries fresh
+        // peers (a cold pool of thousands still gets swept over a handful of cycles)
+        // instead of re-dialing the same dead window and re-burning minutes.
+        List<String> fanout = new ArrayList<>(priority);
+        int budget = CATCHUP_FANOUT_MAX - fanout.size();
+        if (budget > 0 && !rest.isEmpty()) {
+            int off = Math.floorMod(catchUpSweepOffset.getAndAdd(budget), rest.size());
+            int take = Math.min(budget, rest.size());
+            for (int i = 0; i < take; i++) {
+                fanout.add(rest.get((off + i) % rest.size()));
+            }
+        }
+        peers = fanout;
         // {@link BeaconP2PService#doReqResp} detects a dying connection and
         // retries with a fresh one, so we no longer pre-emptively disconnect
         // every peer here — that was costing us Lighthouse/Teku connections
         // that would otherwise have stayed alive and kept our peer score up.
-        log.info("[beacon] Catch-up: requesting {} update(s) from period {} across {} capable peer(s) "
-                        + "(skipped {} too-shallow, {} no-LC, {} proven)",
-                count, bootstrapPeriod, peers.size(), skippedShallow, skippedNoLc, provenCount);
+        log.info("[beacon] Catch-up: requesting {} update(s) from period {} across {} peer(s) "
+                        + "({} proven/LC, {}/{} unknown pool; skipped {} too-shallow, {} no-LC)",
+                count, bootstrapPeriod, peers.size(), provenCount,
+                peers.size() - provenCount, rest.size(), skippedShallow, skippedNoLc);
 
         CompletableFuture<Boolean> winner = new CompletableFuture<>();
         java.util.concurrent.atomic.AtomicInteger remaining =

--- a/consensus/src/test/java/com/jaeckel/ethp2p/consensus/BeaconLightClientPeerPoolTest.java
+++ b/consensus/src/test/java/com/jaeckel/ethp2p/consensus/BeaconLightClientPeerPoolTest.java
@@ -1,0 +1,93 @@
+package com.jaeckel.ethp2p.consensus;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The discovered CL peer pool ({@code clPeerMultiaddrs}) is fed continuously by discv5
+ * and must stay bounded — an unbounded pool made every sync-committee period rotation
+ * fan {@code updates_by_range} out across thousands of mostly-dead/non-light-client
+ * nodes. {@link BeaconLightClient#addPeer} caps the pool at {@code MAX_CL_PEERS} and
+ * evicts oldest-first, but never a peer with positive signal.
+ */
+class BeaconLightClientPeerPoolTest {
+
+    private static BeaconLightClient newClient() {
+        // Raw valid-length anchors; addPeer touches no network state and the
+        // constructor doesn't start libp2p.
+        byte[] root32 = new byte[32];
+        byte[] fork4 = {0, 0, 0, 1};
+        byte[] gvr32 = new byte[32];
+        return new BeaconLightClient(
+                List.of(), root32, 0L, fork4, gvr32,
+                new BeaconSyncState(), null, null, null, 1_606_824_023L);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<String> pool(BeaconLightClient c) throws Exception {
+        Field f = BeaconLightClient.class.getDeclaredField("clPeerMultiaddrs");
+        f.setAccessible(true);
+        return (List<String>) f.get(c);
+    }
+
+    private static int cap() throws Exception {
+        Field f = BeaconLightClient.class.getDeclaredField("MAX_CL_PEERS");
+        f.setAccessible(true);
+        return (int) f.get(null);
+    }
+
+    private static String addr(int i) {
+        return "/ip4/10.0." + (i / 256) + "." + (i % 256) + "/tcp/9000/p2p/16Uiu2HAm" + i;
+    }
+
+    @Test
+    void poolStaysBoundedUnderFlood() throws Exception {
+        BeaconLightClient c = newClient();
+        int cap = cap();
+        for (int i = 0; i < cap + 500; i++) {
+            c.addPeer(addr(i));
+        }
+        assertTrue(pool(c).size() <= cap,
+                "pool must not exceed MAX_CL_PEERS, was " + pool(c).size());
+    }
+
+    @Test
+    void neverEvictsProvenOrLcConfirmedPeers() throws Exception {
+        BeaconLightClient c = newClient();
+        String proven = addr(1);
+        String lc = addr(2);
+        c.addPeer(proven);
+        c.addPeer(lc);
+        // Mark positive signal (the eviction guard reads these sets).
+        c.setProvenCatchUpServers(Map.of(proven, 1700L));
+        c.setProvenLightClient(List.of(lc));
+
+        for (int i = 1000; i < 1000 + cap() + 500; i++) {
+            c.addPeer(addr(i));
+        }
+        List<String> p = pool(c);
+        assertTrue(p.contains(proven), "proven catch-up server must survive eviction");
+        assertTrue(p.contains(lc), "LC-confirmed peer must survive eviction");
+        assertTrue(p.size() <= cap());
+    }
+
+    @Test
+    void evictedPeerCanBeRediscovered() throws Exception {
+        BeaconLightClient c = newClient();
+        for (int i = 0; i < cap() + 200; i++) {
+            c.addPeer(addr(i));
+        }
+        // New peers insert near the front, so the oldest non-head adds drift to the
+        // tail and evict first. addr(1) (the second add) is the tail-most → evicted;
+        // re-discovery must then succeed (knownPeerAddrs was cleared for it on
+        // eviction), not be silently deduped away forever.
+        assertEquals(false, pool(c).contains(addr(1)), "tail-most old peer should be evicted");
+        assertTrue(c.addPeer(addr(1)), "an evicted peer must be re-addable");
+    }
+}


### PR DESCRIPTION
Sync-committee **period rotation** (e.g. 1772→1773) stalled for **minutes** on a real device. While it churned, new-period finality updates couldn't verify (the store doesn't hold the new committee yet) so the head stalled and verified reads degraded.

### Root cause (from device logs)

```
[beacon] Catch-up batch: no peer advanced store (tried 4719, 4719 failed, 0 returned empty/unusable)
[beacon] Catch-up batch 0 made no progress — will retry on next sync cycle
```

The catch-up fanned `light_client_updates_by_range` at the **entire discovered CL pool — 4,719 peers — every ~12 s cycle**. Failure breakdown: 850+ `TimeoutException` / `ProtocolNegotiationFailed` (fork-matched nodes that don't run a light-client server — the majority of mainnet CL nodes) + dead ENRs (`Connection refused`, junk ports like `13103`/`54873`). It re-dialed the same dead set each cycle until it happened to reach one of the rare serving nodes.

The steady-state finality poll is fast because `copyPeers()` front-loads LC-confirmed peers; the catch-up path didn't get that benefit at the same strength (its filter only prunes peers *already known* bad, so 4,719 never-Identified ENRs all got tried), and the discv5-fed pool grew unbounded.

### Fix — three levers (`attemptCatchUpBatch` + `addPeer`)

1. **Prioritize positive-signal peers** — proven (last session) to serve catch-up for this period, OR Identify-confirmed light-client / advertises `updates_by_range`. Always included.
2. **Cap the fan-out at 48** — positive-signal peers + a fill from a **rotating window** of the unknown pool, so each retry cycle sweeps fresh peers (a cold pool still gets covered over a few cycles) instead of re-burning minutes on the same dead window.
3. **Bound the discovered pool** at `MAX_CL_PEERS=1024`, evicting oldest-first but never a proven/LC-confirmed peer (and clearing the dedup entry so it can be re-discovered).

### Test
`BeaconLightClientPeerPoolTest` — pool stays bounded under flood, never evicts proven/LC-confirmed peers, evicted peers are re-addable. `:consensus:test` green.

Device validation across the next period rotation to follow. No behavior change at steady-state SYNCED (only the catch-up path and the discovery pool size are touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)