### PR TITLE
snap: deny empty-proof peers per-head (fix heavy eth_call multicall 30s timeouts)

### DIFF
--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -735,7 +735,7 @@ public final class NodeService extends Service {
     /** Snap-oracle per-fetch retry budget. Each attempt rotates to a different ready
      *  snap peer (the probed peer first), so a slow/dead peer fails over instead of
      *  burning the whole RPC_CALL_TIMEOUT on one peer. */
-    private static final int SNAP_ORACLE_MAX_ATTEMPTS = 4;
+    private static final int SNAP_ORACLE_MAX_ATTEMPTS = 8;
     /** Head-build budget — includes the headerChain anchoring fetch. */
     private static final long RPC_ACCOUNT_TIMEOUT_SEC = HEADER_CHAIN_TIMEOUT_SEC + 10;
     /** Overall budget for the (parallel) snap-peer head probe. */
@@ -2371,23 +2371,35 @@ public final class NodeService extends Service {
         final RLPxConnector oracleConn = conn;
         final java.util.concurrent.atomic.AtomicInteger rotation =
                 new java.util.concurrent.atomic.AtomicInteger();
+        // Peers that returned an empty proof / no-state for THIS head's stateRoot — they
+        // don't retain its trie (a chunk of the pool lags the head). Deny them for this
+        // context so the rotation converges on peers that actually serve the root instead
+        // of re-handing out empty-proof peers and exhausting every fetch's retries (the
+        // cause of heavy-multicall eth_call 30s failures). Per-context; cleared next build.
+        final java.util.Set<com.jaeckel.ethp2p.networking.eth.EthHandler> rootDenied =
+                java.util.concurrent.ConcurrentHashMap.newKeySet();
         io.myotis.evm.world.SnapBackedStateOracle oracle =
                 new io.myotis.evm.world.SnapBackedStateOracle(
                         () -> {
                             int n = rotation.getAndIncrement();
-                            if (n == 0 && probedPeer.isReady() && !probedPeer.isSnapServingFailed()) {
-                                return new com.jaeckel.ethp2p.android.snap.EthHandlerSnapPeer(probedPeer);
+                            if (n == 0 && probedPeer.isReady() && !probedPeer.isSnapServingFailed()
+                                    && !rootDenied.contains(probedPeer)) {
+                                final com.jaeckel.ethp2p.networking.eth.EthHandler pp = probedPeer;
+                                return new com.jaeckel.ethp2p.android.snap.EthHandlerSnapPeer(
+                                        pp, () -> rootDenied.add(pp));
                             }
                             // activeSnapHandlers() already returns only ready, snap-negotiated,
-                            // non-failed peers — no need to re-check here. probedPeer is in that
-                            // list too (if still healthy), so it stays in the rotation as a
-                            // fallback without a separate add.
+                            // non-failed peers; drop the ones denied for this root.
                             java.util.List<com.jaeckel.ethp2p.networking.eth.EthHandler> ready =
-                                    oracleConn.activeSnapHandlers();
+                                    new java.util.ArrayList<>();
+                            for (com.jaeckel.ethp2p.networking.eth.EthHandler p : oracleConn.activeSnapHandlers()) {
+                                if (!rootDenied.contains(p)) ready.add(p);
+                            }
                             if (ready.isEmpty()) return null;
-                            com.jaeckel.ethp2p.networking.eth.EthHandler chosen =
+                            final com.jaeckel.ethp2p.networking.eth.EthHandler chosen =
                                     ready.get(Math.floorMod(n, ready.size()));
-                            return new com.jaeckel.ethp2p.android.snap.EthHandlerSnapPeer(chosen);
+                            return new com.jaeckel.ethp2p.android.snap.EthHandlerSnapPeer(
+                                    chosen, () -> rootDenied.add(chosen));
                         },
                         ensBytecodeCache,
                         SNAP_ORACLE_MAX_ATTEMPTS);

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/snap/EthHandlerSnapPeer.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/snap/EthHandlerSnapPeer.java
@@ -30,9 +30,22 @@ import java.util.concurrent.CompletableFuture;
 public final class EthHandlerSnapPeer implements SnapPeer {
 
     private final EthHandler handler;
+    private final Runnable onRootUnavailable;
 
     public EthHandlerSnapPeer(EthHandler handler) {
+        this(handler, null);
+    }
+
+    /** @param onRootUnavailable run when the oracle reports this peer can't serve the
+     *  current state root, so the routing supplier can deprioritize it for this head. */
+    public EthHandlerSnapPeer(EthHandler handler, Runnable onRootUnavailable) {
         this.handler = handler;
+        this.onRootUnavailable = onRootUnavailable;
+    }
+
+    @Override
+    public void reportRootUnavailable() {
+        if (onRootUnavailable != null) onRootUnavailable.run();
     }
 
     @Override

--- a/app/src/main/java/com/jaeckel/ethp2p/app/CommandHandler.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/CommandHandler.java
@@ -1283,7 +1283,7 @@ public class CommandHandler {
      */
     /** Snap-oracle per-fetch retry budget; each attempt rotates to a different ready
      *  snap peer so a slow/dead peer fails over instead of eating the whole budget. */
-    private static final int SNAP_ORACLE_MAX_ATTEMPTS = 4;
+    private static final int SNAP_ORACLE_MAX_ATTEMPTS = 8;
 
     private io.myotis.evm.CcipReadEvmExecutor buildEnsResolver(
             com.jaeckel.ethp2p.networking.eth.EthHandler pinnedPeer,
@@ -1297,20 +1297,33 @@ public class CommandHandler {
         final com.jaeckel.ethp2p.networking.eth.EthHandler probedPeer = pinnedPeer;
         final java.util.concurrent.atomic.AtomicInteger rotation =
             new java.util.concurrent.atomic.AtomicInteger();
+        // Peers that returned an empty proof / no-state for this head's stateRoot — deny
+        // them for this context so the rotation converges on peers that actually serve
+        // the root (see NodeService for the rationale). Per-context.
+        final java.util.Set<com.jaeckel.ethp2p.networking.eth.EthHandler> rootDenied =
+            java.util.concurrent.ConcurrentHashMap.newKeySet();
         io.myotis.evm.world.SnapBackedStateOracle oracle =
             new io.myotis.evm.world.SnapBackedStateOracle(
                 () -> {
                     int n = rotation.getAndIncrement();
-                    if (n == 0 && probedPeer.isReady() && !probedPeer.isSnapServingFailed()) {
-                        return new com.jaeckel.ethp2p.app.snap.EthHandlerSnapPeer(probedPeer);
+                    if (n == 0 && probedPeer.isReady() && !probedPeer.isSnapServingFailed()
+                            && !rootDenied.contains(probedPeer)) {
+                        final com.jaeckel.ethp2p.networking.eth.EthHandler pp = probedPeer;
+                        return new com.jaeckel.ethp2p.app.snap.EthHandlerSnapPeer(
+                            pp, () -> rootDenied.add(pp));
                     }
                     // activeSnapHandlers() already filters to ready, snap-negotiated,
-                    // non-failed peers (probedPeer included if still healthy) — no re-check.
+                    // non-failed peers; drop the ones denied for this root.
                     java.util.List<com.jaeckel.ethp2p.networking.eth.EthHandler> ready =
-                        connector.activeSnapHandlers();
+                        new java.util.ArrayList<>();
+                    for (com.jaeckel.ethp2p.networking.eth.EthHandler p : connector.activeSnapHandlers()) {
+                        if (!rootDenied.contains(p)) ready.add(p);
+                    }
                     if (ready.isEmpty()) return null;
+                    final com.jaeckel.ethp2p.networking.eth.EthHandler chosen =
+                        ready.get(Math.floorMod(n, ready.size()));
                     return new com.jaeckel.ethp2p.app.snap.EthHandlerSnapPeer(
-                        ready.get(Math.floorMod(n, ready.size())));
+                        chosen, () -> rootDenied.add(chosen));
                 },
                 ensBytecodeCache,
                 SNAP_ORACLE_MAX_ATTEMPTS);

--- a/app/src/main/java/com/jaeckel/ethp2p/app/snap/EthHandlerSnapPeer.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/snap/EthHandlerSnapPeer.java
@@ -41,9 +41,22 @@ import java.util.concurrent.CompletableFuture;
 public final class EthHandlerSnapPeer implements SnapPeer {
 
     private final EthHandler handler;
+    private final Runnable onRootUnavailable;
 
     public EthHandlerSnapPeer(EthHandler handler) {
+        this(handler, null);
+    }
+
+    /** @param onRootUnavailable run when the oracle reports this peer can't serve the
+     *  current state root, so the routing supplier can deprioritize it for this head. */
+    public EthHandlerSnapPeer(EthHandler handler, Runnable onRootUnavailable) {
         this.handler = handler;
+        this.onRootUnavailable = onRootUnavailable;
+    }
+
+    @Override
+    public void reportRootUnavailable() {
+        if (onRootUnavailable != null) onRootUnavailable.run();
     }
 
     @Override

--- a/myotis-evm/src/main/java/io/myotis/evm/world/SnapBackedStateOracle.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/world/SnapBackedStateOracle.java
@@ -224,8 +224,19 @@ public final class SnapBackedStateOracle implements SnapStateOracle {
                 sink.complete(value);
                 return;
             }
+            Throwable cause = unwrap(error);
+            // A definitive can't-serve failure (empty proof for a non-empty root, or no
+            // state at all) means this peer doesn't retain stateRoot's trie. Tell it so,
+            // so a routing peerSupplier can rotate AWAY from it for this head instead of
+            // re-handing it out every retry — the dominant cost of a heavy multicall
+            // against a fresh head a chunk of the peer set hasn't caught up to.
+            if (cause instanceof EvmExecutionException ee
+                    && (ee.error() instanceof EvmExecutionError.InvalidProof
+                        || ee.error() instanceof EvmExecutionError.StateUnavailable)) {
+                try { peer.reportRootUnavailable(); } catch (RuntimeException ignore) {}
+            }
             log.warn("[snap-oracle] attempt {} failed: {}", attemptIdx, error.getMessage());
-            attempt(op, attemptIdx + 1, unwrap(error), sink);
+            attempt(op, attemptIdx + 1, cause, sink);
         });
     }
 

--- a/myotis-evm/src/main/java/io/myotis/evm/world/SnapPeer.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/world/SnapPeer.java
@@ -57,4 +57,15 @@ public interface SnapPeer {
      * keccak256 matches the requested hash.
      */
     CompletableFuture<List<Bytes>> getByteCodes(List<Bytes32> hashes);
+
+    /**
+     * Signal that this peer could not serve the requested state root — it returned
+     * an empty proof for a non-empty root, or no state at all (it doesn't retain that
+     * stateRoot's trie). The oracle calls this only for definitive can't-serve failures
+     * (InvalidProof / StateUnavailable), NOT transient timeouts, so a peer-routing
+     * implementation can deprioritize this peer for the current head and rotate to one
+     * that actually retains the state — instead of re-dialing it across every retry.
+     * Default no-op for fixture/test implementations.
+     */
+    default void reportRootUnavailable() {}
 }

--- a/myotis-evm/src/test/java/io/myotis/evm/world/SnapBackedStateOracleTest.java
+++ b/myotis-evm/src/test/java/io/myotis/evm/world/SnapBackedStateOracleTest.java
@@ -124,6 +124,26 @@ class SnapBackedStateOracleTest {
         }
         // Supplier was consulted once per attempt.
         assertEquals(3, attempts.get());
+        // Each InvalidProof tells the peer it can't serve this root, so a routing
+        // supplier can rotate away from it (the fix for empty-proof churn).
+        assertEquals(3, peer.rootUnavailableCalls.get());
+    }
+
+    @Test
+    void successDoesNotReportRootUnavailable() throws Exception {
+        // A peer that serves a valid account proof must NOT be flagged root-unavailable.
+        Address addr = Address.fromHex("0xabcdef0102030405060708090a0b0c0d0e0f1011");
+        Bytes accountValue = encodeAccount(42L, new BigInteger("1000000000000000000"),
+                TrieFixture.EMPTY_TRIE_ROOT,
+                Bytes32.wrap(Hash.keccak256(Bytes.EMPTY).toArrayUnsafe()));
+        var trie = TrieFixture.singleLeaf(keccak(addr.toByteArray()), accountValue);
+
+        FixturePeer peer = new FixturePeer();
+        peer.addTrieNodes(trie.root, trie.proof);
+
+        var oracle = new SnapBackedStateOracle(() -> peer, BytecodeCache.inMemory());
+        oracle.fetchAccount(trie.root.toArrayUnsafe(), addr).get();
+        assertEquals(0, peer.rootUnavailableCalls.get());
     }
 
     // ---- Storage fetch -----------------------------------------------------
@@ -327,6 +347,13 @@ class SnapBackedStateOracleTest {
                 if (code != null) result.add(code);
             }
             return CompletableFuture.completedFuture(result);
+        }
+
+        final AtomicInteger rootUnavailableCalls = new AtomicInteger();
+
+        @Override
+        public void reportRootUnavailable() {
+            rootUnavailableCalls.incrementAndGet();
         }
     }
 }


### PR DESCRIPTION
MetaMask's confirm screen hung after a cold start. The node is SYNCED and simple reads (`getBalance`, `estimateGas`, fees) are fast, but its **heavy multicall `eth_call`s time out at 30 s** — `SingleCallBalances` over ~1000 tokens (32 KB calldata) and a Multicall3 — and even a plain `balanceOf` `eth_call` fails.

### Root cause (device logs)

```
StorageRanges: 0 slots (reqId=289)
[snap-oracle] attempt 0 failed: InvalidProof[... empty proof for non-empty root]
```

Account proofs work, but a chunk of the freshly-acquired snap peer set **doesn't retain the current head's stateRoot**, so `GetStorageRanges` comes back empty. The PR #41 round-robin rotation (great for *stalls*) kept re-handing out those empty-proof peers; when no rotated peer serves a required slot, the fetch exhausts its retries and the whole `eth_call` fails — and a multicall touching many slots almost always hits one such slot.

### Fix — per-head "this peer can't serve the root" feedback

- `SnapPeer.reportRootUnavailable()` (default no-op). The oracle calls it **only** on definitive can't-serve failures (`InvalidProof` / `StateUnavailable`), never on transient timeouts.
- `EthHandlerSnapPeer` (Android + daemon): optional `onRootUnavailable` callback.
- `NodeService` / `CommandHandler` supplier: a per-context `rootDenied` set. A peer reported root-unavailable is dropped from the rotation **for this head**, so later fetches skip it instead of re-dialing it. The probed peer (verified to serve the root at build time) stays primary. If every peer is denied, the supplier returns null → fetch fails fast (→ finalized-fallback rebuild) instead of churning 30 s.
- `SNAP_ORACLE_MAX_ATTEMPTS` 4 → 8: with denial, attempts hit *distinct* peers, so one fetch tries enough to find a server.

This keeps PR #41's stall-failover (rotation on timeout) while fixing the empty-proof churn — the two failure modes want opposite responses, and this distinguishes them.

### Test
`SnapBackedStateOracleTest` — `reportRootUnavailable` fires once per `InvalidProof` attempt and not on success. `:myotis-evm:test` green; all modules compile.

On-device validation pending (device locked overnight). Independent of PR #44 (catch-up); touches only the EL snap/eth_call path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)