### PR TITLE
snap: deny hanging/dropped peers per-head (fix stuck-confirm on flaky peer set)

### DIFF
--- a/myotis-evm/src/main/java/io/myotis/evm/world/SnapBackedStateOracle.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/world/SnapBackedStateOracle.java
@@ -249,8 +249,26 @@ public final class SnapBackedStateOracle implements SnapStateOracle {
         });
     }
 
+    /**
+     * Peel the real cause out of the executor's wrapper exceptions. A single
+     * snap fetch fans out through nested {@code CompletableFuture.allOf(...).join()}
+     * stages, each of which re-wraps a failure in its own
+     * {@link CompletionException} (and {@code ExecutionException} from any
+     * {@code get()}). Unwrapping only one layer would leave the
+     * {@code TimeoutException}/{@code IOException}/{@code InvalidProof} root cause
+     * buried, so the {@code cantServe} routing check would miss it and never
+     * deny the hanging peer. Recurse to the innermost non-wrapper cause, with a
+     * self-cause guard so a malformed cycle can't spin forever.
+     */
     private static Throwable unwrap(Throwable t) {
-        return t instanceof CompletionException && t.getCause() != null ? t.getCause() : t;
+        Throwable cur = t;
+        while ((cur instanceof CompletionException
+                || cur instanceof java.util.concurrent.ExecutionException)
+                && cur.getCause() != null
+                && cur.getCause() != cur) {
+            cur = cur.getCause();
+        }
+        return cur;
     }
 
     private AccountWithStorageRoot verifyAndDecodeAccount(

--- a/myotis-evm/src/main/java/io/myotis/evm/world/SnapBackedStateOracle.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/world/SnapBackedStateOracle.java
@@ -225,14 +225,23 @@ public final class SnapBackedStateOracle implements SnapStateOracle {
                 return;
             }
             Throwable cause = unwrap(error);
-            // A definitive can't-serve failure (empty proof for a non-empty root, or no
-            // state at all) means this peer doesn't retain stateRoot's trie. Tell it so,
-            // so a routing peerSupplier can rotate AWAY from it for this head instead of
-            // re-handing it out every retry — the dominant cost of a heavy multicall
-            // against a fresh head a chunk of the peer set hasn't caught up to.
-            if (cause instanceof EvmExecutionException ee
-                    && (ee.error() instanceof EvmExecutionError.InvalidProof
-                        || ee.error() instanceof EvmExecutionError.StateUnavailable)) {
+            // This peer can't serve stateRoot for this head, via any of:
+            //   - empty proof for a non-empty root / no state at all (InvalidProof /
+            //     StateUnavailable) — it doesn't retain the trie;
+            //   - it accepted the request then HUNG (TimeoutException) or the connection
+            //     dropped (IOException) — equally useless for this short-lived context.
+            // Tell it so, so a routing peerSupplier rotates AWAY from it for this head.
+            // The head context is shared across an eth_call burst (confirm screen fires
+            // many), so denying a hanger once makes the whole burst converge on responsive
+            // peers instead of re-dialing the same hangers and eating the 30s budget on
+            // each call — the cause of the "stuck confirmation" hangs on a flaky peer set.
+            boolean cantServe =
+                    (cause instanceof EvmExecutionException ee
+                        && (ee.error() instanceof EvmExecutionError.InvalidProof
+                            || ee.error() instanceof EvmExecutionError.StateUnavailable))
+                    || cause instanceof java.util.concurrent.TimeoutException
+                    || cause instanceof java.io.IOException;
+            if (cantServe) {
                 try { peer.reportRootUnavailable(); } catch (RuntimeException ignore) {}
             }
             log.warn("[snap-oracle] attempt {} failed: {}", attemptIdx, error.getMessage());

--- a/myotis-evm/src/main/java/io/myotis/evm/world/SnapPeer.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/world/SnapPeer.java
@@ -59,13 +59,21 @@ public interface SnapPeer {
     CompletableFuture<List<Bytes>> getByteCodes(List<Bytes32> hashes);
 
     /**
-     * Signal that this peer could not serve the requested state root — it returned
-     * an empty proof for a non-empty root, or no state at all (it doesn't retain that
-     * stateRoot's trie). The oracle calls this only for definitive can't-serve failures
-     * (InvalidProof / StateUnavailable), NOT transient timeouts, so a peer-routing
-     * implementation can deprioritize this peer for the current head and rotate to one
+     * Signal that this peer could not serve the requested state root for the current
+     * head, so a peer-routing implementation can deprioritize it and rotate to one
      * that actually retains the state — instead of re-dialing it across every retry.
-     * Default no-op for fixture/test implementations.
+     *
+     * <p>The oracle calls this for any failure that makes the peer useless for this
+     * short-lived head context, whether or not the peer is permanently broken:
+     * <ul>
+     *   <li>an empty proof for a non-empty root, or no state at all — it doesn't
+     *       retain that stateRoot's trie ({@code InvalidProof} / {@code StateUnavailable});</li>
+     *   <li>it accepted the request then hung ({@code TimeoutException}) or the
+     *       connection dropped ({@code IOException}) — equally useless here.</li>
+     * </ul>
+     * Because timeouts/drops can be transient, an implementation should treat this as
+     * a per-head deprioritization signal, not a permanent eviction — the same peer may
+     * serve a later head. Default no-op for fixture/test implementations.
      */
     default void reportRootUnavailable() {}
 }

--- a/myotis-evm/src/test/java/io/myotis/evm/world/SnapBackedStateOracleTest.java
+++ b/myotis-evm/src/test/java/io/myotis/evm/world/SnapBackedStateOracleTest.java
@@ -197,6 +197,39 @@ class SnapBackedStateOracleTest {
         assertEquals(2, reported.get());
     }
 
+    @Test
+    void deeplyWrappedTimeoutIsStillReportedRootUnavailable() {
+        // The real fetch path fans out through nested allOf(...).join() stages, each of
+        // which re-wraps the failure in another CompletionException. The root-cause
+        // unwrap must peel ALL of them, not just one — otherwise the TimeoutException
+        // stays buried, cantServe is false, and the hanging peer is never denied.
+        Address addr = Address.fromHex("0xabcdef0102030405060708090a0b0c0d0e0f1011");
+        Bytes32 root = Bytes32.fromHexString(
+                "0x4444444444444444444444444444444444444444444444444444444444444444");
+        AtomicInteger reported = new AtomicInteger();
+        SnapPeer hangingDeep = new SnapPeer() {
+            @Override public CompletableFuture<List<Bytes>> getTrieNodes(Bytes32 sr, List<PathSet> p) {
+                java.util.concurrent.CompletionException nested =
+                        new java.util.concurrent.CompletionException(
+                                new java.util.concurrent.CompletionException(
+                                        new java.util.concurrent.TimeoutException("hung")));
+                return CompletableFuture.failedFuture(nested);
+            }
+            @Override public CompletableFuture<List<Bytes>> getByteCodes(List<Bytes32> h) {
+                return CompletableFuture.failedFuture(new java.util.concurrent.TimeoutException("hung"));
+            }
+            @Override public void reportRootUnavailable() { reported.incrementAndGet(); }
+        };
+
+        var oracle = new SnapBackedStateOracle(() -> hangingDeep, BytecodeCache.inMemory(), 2);
+        try {
+            oracle.fetchAccount(root.toArrayUnsafe(), addr).get();
+            fail("expected fetchAccount to fail");
+        } catch (Exception ignored) { /* expected */ }
+        assertEquals(2, reported.get(),
+                "a multiply-wrapped timeout must still be unwrapped and denied");
+    }
+
     // ---- Storage fetch -----------------------------------------------------
 
     @Test

--- a/myotis-evm/src/test/java/io/myotis/evm/world/SnapBackedStateOracleTest.java
+++ b/myotis-evm/src/test/java/io/myotis/evm/world/SnapBackedStateOracleTest.java
@@ -169,7 +169,13 @@ class SnapBackedStateOracleTest {
         try {
             oracle.fetchAccount(root.toArrayUnsafe(), addr).get();
             fail("expected fetchAccount to fail");
-        } catch (Exception ignored) { /* expected */ }
+        } catch (ExecutionException e) {
+            assertInstanceOf(java.util.concurrent.TimeoutException.class, e.getCause(),
+                    "the surfaced failure must be the timeout, not an unrelated error");
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            fail("interrupted");
+        }
         assertEquals(3, reported.get(), "each timeout must report the peer root-unavailable");
     }
 
@@ -193,7 +199,13 @@ class SnapBackedStateOracleTest {
         try {
             oracle.fetchAccount(root.toArrayUnsafe(), addr).get();
             fail("expected fetchAccount to fail");
-        } catch (Exception ignored) { /* expected */ }
+        } catch (ExecutionException e) {
+            assertInstanceOf(java.io.IOException.class, e.getCause(),
+                    "the surfaced failure must be the channel-closed IOException");
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            fail("interrupted");
+        }
         assertEquals(2, reported.get());
     }
 
@@ -225,7 +237,15 @@ class SnapBackedStateOracleTest {
         try {
             oracle.fetchAccount(root.toArrayUnsafe(), addr).get();
             fail("expected fetchAccount to fail");
-        } catch (Exception ignored) { /* expected */ }
+        } catch (ExecutionException e) {
+            // unwrap() must have peeled every CompletionException layer, so the
+            // surfaced cause is the bare TimeoutException — not a wrapper.
+            assertInstanceOf(java.util.concurrent.TimeoutException.class, e.getCause(),
+                    "the multiply-wrapped timeout must be unwrapped to its root cause");
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            fail("interrupted");
+        }
         assertEquals(2, reported.get(),
                 "a multiply-wrapped timeout must still be unwrapped and denied");
     }

--- a/myotis-evm/src/test/java/io/myotis/evm/world/SnapBackedStateOracleTest.java
+++ b/myotis-evm/src/test/java/io/myotis/evm/world/SnapBackedStateOracleTest.java
@@ -146,6 +146,57 @@ class SnapBackedStateOracleTest {
         assertEquals(0, peer.rootUnavailableCalls.get());
     }
 
+    @Test
+    void hangingPeerIsReportedRootUnavailable() {
+        // A peer that accepts the request then times out (or the connection drops) is as
+        // useless for this head as an empty-proof one — it must be flagged so the routing
+        // supplier rotates away from it, not re-dialed every retry (the confirm-screen hang).
+        Address addr = Address.fromHex("0xabcdef0102030405060708090a0b0c0d0e0f1011");
+        Bytes32 root = Bytes32.fromHexString(
+                "0x2222222222222222222222222222222222222222222222222222222222222222");
+        AtomicInteger reported = new AtomicInteger();
+        SnapPeer hanging = new SnapPeer() {
+            @Override public CompletableFuture<List<Bytes>> getTrieNodes(Bytes32 sr, List<PathSet> p) {
+                return CompletableFuture.failedFuture(new java.util.concurrent.TimeoutException("hung"));
+            }
+            @Override public CompletableFuture<List<Bytes>> getByteCodes(List<Bytes32> h) {
+                return CompletableFuture.failedFuture(new java.util.concurrent.TimeoutException("hung"));
+            }
+            @Override public void reportRootUnavailable() { reported.incrementAndGet(); }
+        };
+
+        var oracle = new SnapBackedStateOracle(() -> hanging, BytecodeCache.inMemory(), 3);
+        try {
+            oracle.fetchAccount(root.toArrayUnsafe(), addr).get();
+            fail("expected fetchAccount to fail");
+        } catch (Exception ignored) { /* expected */ }
+        assertEquals(3, reported.get(), "each timeout must report the peer root-unavailable");
+    }
+
+    @Test
+    void channelClosedIsReportedRootUnavailable() {
+        Address addr = Address.fromHex("0xabcdef0102030405060708090a0b0c0d0e0f1011");
+        Bytes32 root = Bytes32.fromHexString(
+                "0x3333333333333333333333333333333333333333333333333333333333333333");
+        AtomicInteger reported = new AtomicInteger();
+        SnapPeer dropped = new SnapPeer() {
+            @Override public CompletableFuture<List<Bytes>> getTrieNodes(Bytes32 sr, List<PathSet> p) {
+                return CompletableFuture.failedFuture(new java.io.IOException("Channel closed"));
+            }
+            @Override public CompletableFuture<List<Bytes>> getByteCodes(List<Bytes32> h) {
+                return CompletableFuture.failedFuture(new java.io.IOException("Channel closed"));
+            }
+            @Override public void reportRootUnavailable() { reported.incrementAndGet(); }
+        };
+
+        var oracle = new SnapBackedStateOracle(() -> dropped, BytecodeCache.inMemory(), 2);
+        try {
+            oracle.fetchAccount(root.toArrayUnsafe(), addr).get();
+            fail("expected fetchAccount to fail");
+        } catch (Exception ignored) { /* expected */ }
+        assertEquals(2, reported.get());
+    }
+
     // ---- Storage fetch -----------------------------------------------------
 
     @Test


### PR DESCRIPTION
Follow-up to #45. The "stuck confirmation screen" persisted even for a **plain ETH send** with token autodetection off. Root cause, from device logs:

```
[rpc] eth_call 0x00000000000c2e074ec69a0dfb2997ba6c7d2e1e sel=0x0178b8bf ... -> error after 30007ms: TimeoutException
[rpc] eth_call 0xca11bde05977b3631167028862be2a173976ca11 sel=0x82ad56cb ... -> error after 30000ms: TimeoutException
```

These are MetaMask's confirm-screen **enrichment** calls — reverse-resolving the recipient's ENS name (`resolver(bytes32)` on the ENS Registry) and its "estimated changes" Multicall3 simulation — which fire for **ETH and token sends alike**. They need storage proofs, and a chunk of the freshly-acquired snap peer set (thin after a cache wipe) **accepts the request then hangs**. #45 only denied **empty-proof** peers; it didn't catch **hangers** (`TimeoutException`) or dropped connections (`IOException`), so the oracle kept re-dialing them and each storage `eth_call` burned its full 30 s.

### Fix
Extend `reportRootUnavailable` to also fire on `TimeoutException` / `IOException`, not just `InvalidProof` / `StateUnavailable`. The anchored head **context is shared across the confirm screen's eth_call burst** (one per `RPC_HEAD_TTL` window), so denying a hanger once makes the whole burst — and MetaMask's retries — converge on responsive peers instead of re-hitting the same hangers. If every peer is denied, fetches fail fast and the next context rebuild re-probes a serving peer (rather than 30 s/call).

### Why ETH vs ERC-20 didn't matter here
The *transaction* is lighter for ETH (`estimateGas` = flat 21000, validated at 0.36 s), but the *confirm screen's display enrichment* does storage `eth_call`s for both — which is what was hanging.

### Test
`SnapBackedStateOracleTest`: hanging (Timeout) and channel-closed (IOException) peers are reported root-unavailable on every attempt; valid proofs are not (unchanged). `:myotis-evm:test` green.

On-device validation pending (device locked). Independent, EL-snap-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)