### PR TITLE
el-cache: persist snap-serving quality so good snap peers are dialed first

### DIFF
--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/AndroidPeerCache.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/AndroidPeerCache.java
@@ -7,11 +7,15 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -20,24 +24,64 @@ import java.util.concurrent.ConcurrentHashMap;
  * uses {@code android.util.Log} and the app's filesDir-rooted path supplied by
  * the caller, so we don't pull in slf4j-android or hardcode {@code /tmp}.
  *
- * <p>Record format: {@code ip\tport\tpublicKeyHex[\tsnap]\n} (tab-separated,
- * UTF-8). Tabs can't appear in {@link java.net.InetAddress#getHostAddress()}
- * output, so the format stays unambiguous for IPv6 literals. The trailing
- * {@code snap} flag ("1"/"0") records snap/1 capability and is optional, so
- * pre-existing cache files load unchanged (missing flag → not snap-capable).
+ * <p>Record format: {@code ip\tport\tpublicKeyHex[\tsnap][\tsnapok|\tsnapbad]\n}
+ * (tab-separated, UTF-8). Tabs can't appear in
+ * {@link java.net.InetAddress#getHostAddress()} output, so the format stays
+ * unambiguous for IPv6 literals. The trailing {@code snap} flag ("1"/"0")
+ * records snap/1 <em>capability</em> and is optional, so pre-existing cache
+ * files load unchanged (missing flag → not snap-capable). An optional
+ * {@code snapok}/{@code snapbad} token after it records snap-serving
+ * <em>quality</em> — whether the peer actually returned usable proofs
+ * ({@link SnapQuality}).
+ *
+ * <p><b>Capability vs quality.</b> The {@code snap} flag means the peer
+ * negotiated snap/1 during Hello; it says nothing about whether the peer
+ * actually serves the state trie for a given root. Many advertised snap peers
+ * hang or return empty proofs. {@link #recordSnapServed} /
+ * {@link #recordSnapFailure} layer a learned quality verdict on top — analogous
+ * to the CL cache's light-client confirmed/denied — so a restart can dial peers
+ * proven to serve proofs first and deprioritize known hangers, instead of
+ * re-discovering the bad ones one timeout at a time. A peer needs
+ * {@link #SNAP_FAILURE_THRESHOLD} consecutive failures (no intervening serve)
+ * to be marked {@code DENIED}; any successful serve re-confirms it. Denied peers
+ * are deprioritized, never evicted — state roots change, and a peer that
+ * couldn't serve an old pivot may serve the current one (and is still a fine
+ * plain-eth peer for headers/blocks).
  */
 public final class AndroidPeerCache {
 
     private static final String TAG = "ethp2p.cache";
     private static final char SEP = '\t';
 
-    public record CachedPeer(InetSocketAddress address, String publicKeyHex, boolean snap) {}
+    /** Consecutive snap-serve failures before a peer is marked {@code DENIED}. */
+    public static final int SNAP_FAILURE_THRESHOLD = 3;
+
+    /** Learned snap-serving verdict, persisted across restarts. */
+    public enum SnapQuality { CONFIRMED, UNKNOWN, DENIED }
+
+    public record CachedPeer(InetSocketAddress address, String publicKeyHex,
+                             boolean snap, SnapQuality snapQuality) {}
+
+    /** In-memory record of a known peer, enough to rewrite its line. */
+    private record PeerRec(String publicKeyHex, boolean snap) {}
 
     private final Path cacheFile;
-    private final Set<String> seen = ConcurrentHashMap.newKeySet();
+    /** key ("ip\tport") -> identity (pubkey + snap capability). Insertion-ordered
+     *  so a rewrite preserves discovery order among same-quality peers. */
+    private final Map<String, PeerRec> entries = new LinkedHashMap<>();
+    private final Set<String> snapConfirmed = ConcurrentHashMap.newKeySet();
+    private final Set<String> snapDenied = ConcurrentHashMap.newKeySet();
+    private final Map<String, Integer> snapFailures = new ConcurrentHashMap<>();
 
     public AndroidPeerCache(Path cacheFile) {
         this.cacheFile = cacheFile;
+    }
+
+    private static String keyOf(InetSocketAddress address) {
+        // getHostString() over getAddress().getHostAddress() — the latter NPEs
+        // if the address is unresolved. getHostString() returns the literal ip
+        // string directly and skips the defensive branch.
+        return address.getHostString() + SEP + address.getPort();
     }
 
     /**
@@ -45,12 +89,11 @@ public final class AndroidPeerCache {
      * without it two simultaneous writes can interleave and corrupt a line.
      */
     public synchronized void add(InetSocketAddress address, String publicKeyHex, boolean snap) {
-        // getHostString() over getAddress().getHostAddress() — the latter NPEs
-        // if the address is unresolved. RLPxConnector hands us resolved
-        // addresses, but getHostString() returns the literal ip string
-        // directly and skips the defensive branch.
-        String key = address.getHostString() + SEP + address.getPort();
-        if (!seen.add(key)) return;
+        String key = keyOf(address);
+        if (entries.containsKey(key)) return;
+        entries.put(key, new PeerRec(publicKeyHex, snap));
+        // Fast path: append the new line (UNKNOWN quality) rather than rewriting
+        // the whole file on every newly-handshaked peer.
         String line = key + SEP + publicKeyHex + SEP + (snap ? "1" : "0") + "\n";
         try (FileOutputStream out = new FileOutputStream(cacheFile.toFile(), true)) {
             out.write(line.getBytes(StandardCharsets.UTF_8));
@@ -60,17 +103,55 @@ public final class AndroidPeerCache {
     }
 
     /**
+     * Record that a peer returned a usable snap proof for some state root —
+     * promote it to {@code CONFIRMED} so a restart dials it first. Resets the
+     * failure counter and clears any prior denial. Idempotent: once confirmed,
+     * repeat serves are in-memory no-ops (no disk rewrite).
+     */
+    public synchronized void recordSnapServed(InetSocketAddress address) {
+        String key = keyOf(address);
+        snapFailures.remove(key);
+        boolean changed = snapConfirmed.add(key);
+        changed |= snapDenied.remove(key);
+        if (changed) rewriteFile();
+    }
+
+    /**
+     * Record that a peer failed to serve the current state root (empty/invalid
+     * proof, timeout, or IO error — the same signals {@code SnapBackedStateOracle}
+     * uses to rotate). After {@link #SNAP_FAILURE_THRESHOLD} consecutive failures
+     * the peer is marked {@code DENIED} (deprioritized on restart, not evicted).
+     * A later {@link #recordSnapServed} re-confirms it.
+     */
+    public synchronized void recordSnapFailure(InetSocketAddress address) {
+        String key = keyOf(address);
+        if (!entries.containsKey(key)) return; // never seen → nothing to demote
+        int count = snapFailures.merge(key, 1, Integer::sum);
+        if (count >= SNAP_FAILURE_THRESHOLD) {
+            boolean changed = snapDenied.add(key);
+            changed |= snapConfirmed.remove(key);
+            if (changed) {
+                rewriteFile();
+                LogBuffer.i(TAG, "snap peer denied after " + count + " failures: " + key);
+            }
+        }
+    }
+
+    /**
      * Delete the cache file and forget every peer we've written. Next call
      * to {@link #add} will recreate the file.
      */
     public synchronized void clear() {
-        seen.clear();
+        entries.clear();
+        snapConfirmed.clear();
+        snapDenied.clear();
+        snapFailures.clear();
         if (!cacheFile.toFile().delete() && cacheFile.toFile().exists()) {
             LogBuffer.w(TAG, "failed to delete cache file " + cacheFile);
         }
     }
 
-    public List<CachedPeer> load() {
+    public synchronized List<CachedPeer> load() {
         List<CachedPeer> result = new ArrayList<>();
         if (!cacheFile.toFile().exists()) return result;
         try (BufferedReader r = new BufferedReader(new InputStreamReader(
@@ -80,34 +161,59 @@ public final class AndroidPeerCache {
                 line = line.strip();
                 if (line.isEmpty()) continue;
                 try {
-                    int firstSep = line.indexOf(SEP);
-                    int secondSep = line.indexOf(SEP, firstSep + 1);
-                    if (firstSep < 0 || secondSep < 0) {
+                    String[] parts = line.split(String.valueOf(SEP), -1);
+                    if (parts.length < 3) {
                         LogBuffer.w(TAG, "skipping malformed peer line");
                         continue;
                     }
-                    String ip = line.substring(0, firstSep);
-                    int port = Integer.parseInt(line.substring(firstSep + 1, secondSep));
-                    // Optional trailing snap flag (3rd separator). Older lines
-                    // without it parse as pubKeyHex with snap=false.
-                    String pubKeyHex;
-                    boolean snap = false;
-                    int thirdSep = line.indexOf(SEP, secondSep + 1);
-                    if (thirdSep >= 0) {
-                        pubKeyHex = line.substring(secondSep + 1, thirdSep);
-                        snap = "1".equals(line.substring(thirdSep + 1));
-                    } else {
-                        pubKeyHex = line.substring(secondSep + 1);
+                    String ip = parts[0];
+                    int port = Integer.parseInt(parts[1]);
+                    String pubKeyHex = parts[2];
+                    // Optional trailing tokens: snap flag ("1"/"0"), then a
+                    // quality token ("snapok"/"snapbad"). Older lines without
+                    // them parse as snap=false / UNKNOWN.
+                    boolean snap = parts.length > 3 && "1".equals(parts[3]);
+                    SnapQuality quality = SnapQuality.UNKNOWN;
+                    for (int i = 4; i < parts.length; i++) {
+                        if ("snapok".equals(parts[i])) quality = SnapQuality.CONFIRMED;
+                        else if ("snapbad".equals(parts[i])) quality = SnapQuality.DENIED;
                     }
-                    result.add(new CachedPeer(new InetSocketAddress(ip, port), pubKeyHex, snap));
-                    seen.add(ip + SEP + port);
+                    String key = ip + SEP + port;
+                    entries.put(key, new PeerRec(pubKeyHex, snap));
+                    if (quality == SnapQuality.CONFIRMED) snapConfirmed.add(key);
+                    else if (quality == SnapQuality.DENIED) snapDenied.add(key);
+                    result.add(new CachedPeer(
+                            new InetSocketAddress(ip, port), pubKeyHex, snap, quality));
                 } catch (Exception e) {
                     LogBuffer.w(TAG, "skipping malformed peer line: " + e.getMessage());
                 }
+            }
+            int conf = snapConfirmed.size(), den = snapDenied.size();
+            if (!result.isEmpty() && (conf > 0 || den > 0)) {
+                LogBuffer.i(TAG, "loaded " + result.size() + " cached peer(s) ("
+                        + conf + " snap-confirmed, " + den + " snap-denied)");
             }
         } catch (IOException e) {
             LogBuffer.w(TAG, "read failed: " + e.getMessage());
         }
         return result;
+    }
+
+    private synchronized void rewriteFile() {
+        try (Writer w = new OutputStreamWriter(
+                new FileOutputStream(cacheFile.toFile(), false), StandardCharsets.UTF_8)) {
+            for (Map.Entry<String, PeerRec> e : entries.entrySet()) {
+                String key = e.getKey();
+                PeerRec rec = e.getValue();
+                w.write(key);                       // ip\tport
+                w.write(SEP); w.write(rec.publicKeyHex());
+                w.write(SEP); w.write(rec.snap() ? "1" : "0");
+                if (snapConfirmed.contains(key)) { w.write(SEP); w.write("snapok"); }
+                else if (snapDenied.contains(key)) { w.write(SEP); w.write("snapbad"); }
+                w.write('\n');
+            }
+        } catch (IOException e) {
+            LogBuffer.w(TAG, "rewrite failed: " + e.getMessage());
+        }
     }
 }

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/AndroidPeerCache.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/AndroidPeerCache.java
@@ -3,12 +3,11 @@ package com.jaeckel.ethp2p.android;
 import com.jaeckel.ethp2p.android.log.LogBuffer;
 
 import java.io.BufferedReader;
+import java.io.Closeable;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
-import java.io.Writer;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -18,6 +17,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Android-native peer cache. Mirrors {@code PeerCache} in the :app module but
@@ -47,8 +49,19 @@ import java.util.concurrent.ConcurrentHashMap;
  * are deprioritized, never evicted — state roots change, and a peer that
  * couldn't serve an old pivot may serve the current one (and is still a fine
  * plain-eth peer for headers/blocks).
+ *
+ * <p><b>Threading.</b> The in-memory maps are the authoritative copy and are
+ * mutated only under {@code synchronized(this)}. Disk writes are offloaded to a
+ * single daemon thread ({@link #diskWriter}) so the snap response callbacks
+ * (which run on the Netty event loop) and the RLPx worker threads never block on
+ * file I/O. Each write task is submitted <em>while holding the monitor</em>, so
+ * submission order matches the in-memory state-capture order and the
+ * single-threaded executor applies them in that order — the file converges to
+ * the in-memory state. Persistence is best-effort: a process kill can drop a
+ * queued write, which is fine because the cache is reconstructible (peers are
+ * re-discovered) and was never fsync'd even when writes were synchronous.
  */
-public final class AndroidPeerCache {
+public final class AndroidPeerCache implements Closeable {
 
     private static final String TAG = "ethp2p.cache";
     private static final char SEP = '\t';
@@ -72,6 +85,17 @@ public final class AndroidPeerCache {
     private final Set<String> snapConfirmed = ConcurrentHashMap.newKeySet();
     private final Set<String> snapDenied = ConcurrentHashMap.newKeySet();
     private final Map<String, Integer> snapFailures = new ConcurrentHashMap<>();
+    /** True once the on-disk file has been read into {@link #entries} (or shown
+     *  absent), after which {@link #load()} serves from memory without disk I/O. */
+    private boolean loaded = false;
+
+    /** Serializes all file writes off the caller's (Netty) thread. Single-threaded
+     *  so submission order == apply order; daemon so it never blocks JVM exit. */
+    private final ExecutorService diskWriter = Executors.newSingleThreadExecutor(r -> {
+        Thread t = new Thread(r, "peer-cache-writer");
+        t.setDaemon(true);
+        return t;
+    });
 
     public AndroidPeerCache(Path cacheFile) {
         this.cacheFile = cacheFile;
@@ -85,21 +109,18 @@ public final class AndroidPeerCache {
     }
 
     /**
-     * Synchronized because RLPxConnector calls this from Netty worker threads;
-     * without it two simultaneous writes can interleave and corrupt a line.
+     * Record a newly-handshaked peer. Updates the in-memory map and appends its
+     * line to disk (asynchronously). No-op if already known.
      */
     public synchronized void add(InetSocketAddress address, String publicKeyHex, boolean snap) {
         String key = keyOf(address);
         if (entries.containsKey(key)) return;
         entries.put(key, new PeerRec(publicKeyHex, snap));
-        // Fast path: append the new line (UNKNOWN quality) rather than rewriting
-        // the whole file on every newly-handshaked peer.
-        String line = key + SEP + publicKeyHex + SEP + (snap ? "1" : "0") + "\n";
-        try (FileOutputStream out = new FileOutputStream(cacheFile.toFile(), true)) {
-            out.write(line.getBytes(StandardCharsets.UTF_8));
-        } catch (IOException e) {
-            LogBuffer.w(TAG, "write failed: " + e.getMessage());
-        }
+        // Append fast path: a single new line (UNKNOWN quality) rather than
+        // rewriting the whole file on every newly-handshaked peer.
+        byte[] line = (key + SEP + publicKeyHex + SEP + (snap ? "1" : "0") + "\n")
+                .getBytes(StandardCharsets.UTF_8);
+        submitWrite(() -> writeBytes(line, true));
     }
 
     /**
@@ -113,7 +134,7 @@ public final class AndroidPeerCache {
         snapFailures.remove(key);
         boolean changed = snapConfirmed.add(key);
         changed |= snapDenied.remove(key);
-        if (changed) rewriteFile();
+        if (changed) rewriteAsync();
     }
 
     /**
@@ -131,29 +152,67 @@ public final class AndroidPeerCache {
             boolean changed = snapDenied.add(key);
             changed |= snapConfirmed.remove(key);
             if (changed) {
-                rewriteFile();
+                rewriteAsync();
                 LogBuffer.i(TAG, "snap peer denied after " + count + " failures: " + key);
             }
         }
     }
 
     /**
-     * Delete the cache file and forget every peer we've written. Next call
-     * to {@link #add} will recreate the file.
+     * Forget every peer and delete the cache file. Memory is the authoritative
+     * copy, so it's cleared synchronously and {@link #loaded} stays true (an
+     * immediately-following {@link #load()} correctly returns the now-empty set
+     * without racing the asynchronous file delete).
      */
     public synchronized void clear() {
         entries.clear();
         snapConfirmed.clear();
         snapDenied.clear();
         snapFailures.clear();
-        if (!cacheFile.toFile().delete() && cacheFile.toFile().exists()) {
-            LogBuffer.w(TAG, "failed to delete cache file " + cacheFile);
-        }
+        loaded = true;
+        submitWrite(() -> {
+            if (!cacheFile.toFile().delete() && cacheFile.toFile().exists()) {
+                LogBuffer.w(TAG, "failed to delete cache file " + cacheFile);
+            }
+        });
     }
 
+    /**
+     * Return all cached peers. Reads and parses the file on the first call, then
+     * serves from the in-memory copy — so the periodic peer-maintenance loop
+     * doesn't re-read/parse the file every few seconds.
+     */
     public synchronized List<CachedPeer> load() {
-        List<CachedPeer> result = new ArrayList<>();
-        if (!cacheFile.toFile().exists()) return result;
+        if (!loaded) loadFromDisk();
+        List<CachedPeer> result = new ArrayList<>(entries.size());
+        for (Map.Entry<String, PeerRec> e : entries.entrySet()) {
+            String key = e.getKey();
+            int tab = key.indexOf(SEP);
+            if (tab < 0) continue;
+            String ip = key.substring(0, tab);
+            int port;
+            try {
+                port = Integer.parseInt(key.substring(tab + 1));
+            } catch (NumberFormatException ex) {
+                continue;
+            }
+            PeerRec rec = e.getValue();
+            SnapQuality quality = snapConfirmed.contains(key) ? SnapQuality.CONFIRMED
+                    : snapDenied.contains(key) ? SnapQuality.DENIED
+                    : SnapQuality.UNKNOWN;
+            result.add(new CachedPeer(
+                    new InetSocketAddress(ip, port), rec.publicKeyHex(), rec.snap(), quality));
+        }
+        return result;
+    }
+
+    /** Read the file into the in-memory maps. Runs at most once (guarded by
+     *  {@link #loaded}); each line parses independently so a malformed entry is
+     *  skipped without aborting the rest. */
+    private void loadFromDisk() {
+        loaded = true;
+        if (!cacheFile.toFile().exists()) return;
+        int conf = 0, den = 0, count = 0;
         try (BufferedReader r = new BufferedReader(new InputStreamReader(
                 new FileInputStream(cacheFile.toFile()), StandardCharsets.UTF_8))) {
             String line;
@@ -180,40 +239,70 @@ public final class AndroidPeerCache {
                     }
                     String key = ip + SEP + port;
                     entries.put(key, new PeerRec(pubKeyHex, snap));
-                    if (quality == SnapQuality.CONFIRMED) snapConfirmed.add(key);
-                    else if (quality == SnapQuality.DENIED) snapDenied.add(key);
-                    result.add(new CachedPeer(
-                            new InetSocketAddress(ip, port), pubKeyHex, snap, quality));
+                    if (quality == SnapQuality.CONFIRMED) { snapConfirmed.add(key); conf++; }
+                    else if (quality == SnapQuality.DENIED) { snapDenied.add(key); den++; }
+                    count++;
                 } catch (Exception e) {
                     LogBuffer.w(TAG, "skipping malformed peer line: " + e.getMessage());
                 }
             }
-            int conf = snapConfirmed.size(), den = snapDenied.size();
-            if (!result.isEmpty() && (conf > 0 || den > 0)) {
-                LogBuffer.i(TAG, "loaded " + result.size() + " cached peer(s) ("
+            if (count > 0 && (conf > 0 || den > 0)) {
+                LogBuffer.i(TAG, "loaded " + count + " cached peer(s) ("
                         + conf + " snap-confirmed, " + den + " snap-denied)");
             }
         } catch (IOException e) {
             LogBuffer.w(TAG, "read failed: " + e.getMessage());
         }
-        return result;
     }
 
-    private synchronized void rewriteFile() {
-        try (Writer w = new OutputStreamWriter(
-                new FileOutputStream(cacheFile.toFile(), false), StandardCharsets.UTF_8)) {
-            for (Map.Entry<String, PeerRec> e : entries.entrySet()) {
-                String key = e.getKey();
-                PeerRec rec = e.getValue();
-                w.write(key);                       // ip\tport
-                w.write(SEP); w.write(rec.publicKeyHex());
-                w.write(SEP); w.write(rec.snap() ? "1" : "0");
-                if (snapConfirmed.contains(key)) { w.write(SEP); w.write("snapok"); }
-                else if (snapDenied.contains(key)) { w.write(SEP); w.write("snapbad"); }
-                w.write('\n');
-            }
+    /** Render the full file content from the in-memory state (called under the
+     *  monitor) and submit it as a truncating rewrite. */
+    private void rewriteAsync() {
+        StringBuilder sb = new StringBuilder(entries.size() * 96);
+        for (Map.Entry<String, PeerRec> e : entries.entrySet()) {
+            String key = e.getKey();
+            PeerRec rec = e.getValue();
+            sb.append(key)                                  // ip\tport
+              .append(SEP).append(rec.publicKeyHex())
+              .append(SEP).append(rec.snap() ? "1" : "0");
+            if (snapConfirmed.contains(key)) sb.append(SEP).append("snapok");
+            else if (snapDenied.contains(key)) sb.append(SEP).append("snapbad");
+            sb.append('\n');
+        }
+        byte[] data = sb.toString().getBytes(StandardCharsets.UTF_8);
+        submitWrite(() -> writeBytes(data, false));
+    }
+
+    /** Submit a file op to the writer thread; tolerate a shutdown executor. */
+    private void submitWrite(Runnable task) {
+        try {
+            diskWriter.execute(task);
+        } catch (java.util.concurrent.RejectedExecutionException ignore) {
+            // Cache already closed (node stopping) — drop the write; memory is
+            // authoritative and the next start re-reads whatever did land.
+        }
+    }
+
+    /** Write {@code data} to the cache file on the writer thread. */
+    private void writeBytes(byte[] data, boolean append) {
+        try (FileOutputStream out = new FileOutputStream(cacheFile.toFile(), append)) {
+            out.write(data);
         } catch (IOException e) {
-            LogBuffer.w(TAG, "rewrite failed: " + e.getMessage());
+            LogBuffer.w(TAG, "write failed: " + e.getMessage());
+        }
+    }
+
+    /** Stop the writer thread, draining any queued writes first. */
+    @Override
+    public void close() {
+        diskWriter.shutdown();
+        try {
+            if (!diskWriter.awaitTermination(2, TimeUnit.SECONDS)) {
+                diskWriter.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            diskWriter.shutdownNow();
         }
     }
 }

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -1899,11 +1899,17 @@ public final class NodeService extends Service {
             long now = System.currentTimeMillis();
             LogBuffer.i(TAG, "[peers] " + snapPeers + " snap peer(s) < target " + TARGET_SNAP_PEERS
                     + "; re-dialing cached snap peers + DNS pool");
-            // 1) Re-dial known snap peers from the cache.
+            // 1) Re-dial known snap peers from the cache, proven snap-servers first
+            //    (same ordering as cold start) so a starved node reconnects a
+            //    working snap peer before retrying known hangers.
             if (pc != null) {
+                List<AndroidPeerCache.CachedPeer> snapCached = new ArrayList<>();
                 for (AndroidPeerCache.CachedPeer p : pc.load()) {
+                    if (p.snap()) snapCached.add(p);
+                }
+                snapCached.sort(java.util.Comparator.comparingInt(NodeService::snapDialRank));
+                for (AndroidPeerCache.CachedPeer p : snapCached) {
                     try {
-                        if (!p.snap()) continue;
                         if (conn.activeSnapHandlers().size() >= TARGET_SNAP_PEERS) break;
                         dialCachedSnapPeer(conn, p, now);
                     } catch (Exception e) {
@@ -2097,6 +2103,66 @@ public final class NodeService extends Service {
         } catch (Exception e) {
             attempted.remove(peerKey);
         }
+    }
+
+    /**
+     * Feed a snap-serving verdict for {@code peer} into the EL peer cache so good
+     * snap peers are remembered across restarts (dialed first) and repeat hangers
+     * deprioritized. {@code served=true} on a usable proof, {@code false} on a
+     * root-unavailable (empty/invalid proof, timeout, IO). No-op if the cache is
+     * absent or the handler's remote address can't be parsed.
+     */
+    private static void recordSnapQuality(AndroidPeerCache cache,
+            com.jaeckel.ethp2p.networking.eth.EthHandler peer, boolean served) {
+        if (cache == null || peer == null) return;
+        InetSocketAddress addr = remoteAddressOf(peer);
+        if (addr == null) return;
+        try {
+            if (served) cache.recordSnapServed(addr);
+            else cache.recordSnapFailure(addr);
+        } catch (RuntimeException ignore) {
+            // Never let cache bookkeeping disrupt an in-flight RPC.
+        }
+    }
+
+    /**
+     * Parse {@link com.jaeckel.ethp2p.networking.eth.EthHandler#getRemoteAddress()}
+     * ("ip:port", or "[v6]:port") into an unresolved {@link InetSocketAddress} whose
+     * {@code getHostString()} matches the key {@link AndroidPeerCache} stored at dial
+     * time. Returns {@code null} on a missing/malformed address.
+     */
+    private static InetSocketAddress remoteAddressOf(
+            com.jaeckel.ethp2p.networking.eth.EthHandler peer) {
+        String ra = peer.getRemoteAddress();
+        if (ra == null || ra.isEmpty()) return null;
+        int colon = ra.lastIndexOf(':');
+        if (colon <= 0 || colon == ra.length() - 1) return null;
+        String host = ra.substring(0, colon);
+        if (host.startsWith("[") && host.endsWith("]")) {
+            host = host.substring(1, host.length() - 1);
+        }
+        try {
+            int port = Integer.parseInt(ra.substring(colon + 1));
+            return InetSocketAddress.createUnresolved(host, port);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Dial-priority rank for a cached peer (lower = dialed first): proven
+     * snap-servers, then snap-capable-but-unproven, then known snap hangers, then
+     * plain-eth peers. Denied snap peers still outrank non-snap peers — state
+     * roots change, so a peer that couldn't serve an old pivot may serve the
+     * current head, and it's still snap-capable.
+     */
+    private static int snapDialRank(AndroidPeerCache.CachedPeer p) {
+        if (!p.snap()) return 3;
+        return switch (p.snapQuality()) {
+            case CONFIRMED -> 0;
+            case UNKNOWN -> 1;
+            case DENIED -> 2;
+        };
     }
 
     private void startHeadWarmer() {
@@ -2378,6 +2444,11 @@ public final class NodeService extends Service {
         // cause of heavy-multicall eth_call 30s failures). Per-context; cleared next build.
         final java.util.Set<com.jaeckel.ethp2p.networking.eth.EthHandler> rootDenied =
                 java.util.concurrent.ConcurrentHashMap.newKeySet();
+        // Persisted EL-cache quality signal: a non-empty proof confirms the peer
+        // as snap-serving (dialed first on restart); the same root-unavailable
+        // event that deprioritizes it for this head also feeds a failure verdict
+        // so repeat hangers are deprioritized across restarts.
+        final AndroidPeerCache snapQualityCache = peerCache;
         io.myotis.evm.world.SnapBackedStateOracle oracle =
                 new io.myotis.evm.world.SnapBackedStateOracle(
                         () -> {
@@ -2386,7 +2457,9 @@ public final class NodeService extends Service {
                                     && !rootDenied.contains(probedPeer)) {
                                 final com.jaeckel.ethp2p.networking.eth.EthHandler pp = probedPeer;
                                 return new com.jaeckel.ethp2p.android.snap.EthHandlerSnapPeer(
-                                        pp, () -> rootDenied.add(pp));
+                                        pp,
+                                        () -> { rootDenied.add(pp); recordSnapQuality(snapQualityCache, pp, false); },
+                                        () -> recordSnapQuality(snapQualityCache, pp, true));
                             }
                             // activeSnapHandlers() already returns only ready, snap-negotiated,
                             // non-failed peers; drop the ones denied for this root.
@@ -2399,7 +2472,9 @@ public final class NodeService extends Service {
                             final com.jaeckel.ethp2p.networking.eth.EthHandler chosen =
                                     ready.get(Math.floorMod(n, ready.size()));
                             return new com.jaeckel.ethp2p.android.snap.EthHandlerSnapPeer(
-                                    chosen, () -> rootDenied.add(chosen));
+                                    chosen,
+                                    () -> { rootDenied.add(chosen); recordSnapQuality(snapQualityCache, chosen, false); },
+                                    () -> recordSnapQuality(snapQualityCache, chosen, true));
                         },
                         ensBytecodeCache,
                         SNAP_ORACLE_MAX_ATTEMPTS);
@@ -2529,8 +2604,11 @@ public final class NodeService extends Service {
             // Reconnect snap/1-capable peers first: state queries (get-account /
             // ENS) need a snap peer, and snap peers are a minority of eth peers,
             // so dialing them ahead of plain-eth peers makes queries work sooner
-            // after a restart instead of waiting for re-discovery.
-            cached.sort((a, b) -> Boolean.compare(b.snap(), a.snap()));
+            // after a restart instead of waiting for re-discovery. Within the snap
+            // set, peers proven to serve proofs (CONFIRMED) come ahead of unproven
+            // ones, and known hangers (DENIED) come last — so a restart converges
+            // on a working snap peer instead of re-timing-out the bad ones first.
+            cached.sort(java.util.Comparator.comparingInt(NodeService::snapDialRank));
 
             final AndroidPeerCache cacheRef = localCache;
             localConnector = new RLPxConnector(nodeKey, DEFAULT_PORT, network,

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -3013,7 +3013,11 @@ public final class NodeService extends Service {
         discV5 = null;
         closeQuietly(discV4);
         discV4 = null;
-        peerCache = null;
+        // Flush + stop the peer cache's async writer before dropping the reference.
+        if (peerCache != null) {
+            try { peerCache.close(); } catch (Exception ignored) {}
+            peerCache = null;
+        }
         clPeerCache = null;
         attempted.clear();
         backoff.clear();

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/snap/EthHandlerSnapPeer.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/snap/EthHandlerSnapPeer.java
@@ -31,16 +31,31 @@ public final class EthHandlerSnapPeer implements SnapPeer {
 
     private final EthHandler handler;
     private final Runnable onRootUnavailable;
+    private final Runnable onRootServed;
 
     public EthHandlerSnapPeer(EthHandler handler) {
-        this(handler, null);
+        this(handler, null, null);
     }
 
     /** @param onRootUnavailable run when the oracle reports this peer can't serve the
      *  current state root, so the routing supplier can deprioritize it for this head. */
     public EthHandlerSnapPeer(EthHandler handler, Runnable onRootUnavailable) {
+        this(handler, onRootUnavailable, null);
+    }
+
+    /**
+     * @param onRootUnavailable run when the oracle reports this peer can't serve the
+     *  current state root (deprioritize it for this head).
+     * @param onRootServed run when this peer returns a usable (non-empty) proof, so
+     *  the EL peer cache can record it as a proven snap-serving peer to dial first
+     *  on a restart. The two callbacks are mutually exclusive per fetch: a non-empty
+     *  proof fires {@code onRootServed}; an empty one is treated by the oracle as
+     *  no-state and ultimately fires {@code onRootUnavailable}.
+     */
+    public EthHandlerSnapPeer(EthHandler handler, Runnable onRootUnavailable, Runnable onRootServed) {
         this.handler = handler;
         this.onRootUnavailable = onRootUnavailable;
+        this.onRootServed = onRootServed;
     }
 
     @Override
@@ -81,6 +96,13 @@ public final class EthHandlerSnapPeer implements SnapPeer {
                 List<Bytes> all = new ArrayList<>();
                 for (CompletableFuture<List<Bytes>> f : perSet) {
                     all.addAll(f.join());
+                }
+                // A non-empty proof means this peer actually retains the trie for
+                // this root — the durable "snap-serving" signal the EL cache wants.
+                // Empty proofs fall through to the oracle's no-state path, which
+                // calls reportRootUnavailable instead.
+                if (!all.isEmpty() && onRootServed != null) {
+                    try { onRootServed.run(); } catch (RuntimeException ignore) {}
                 }
                 return all;
             });


### PR DESCRIPTION
## Why

You asked: *does the peer cache store only good peers, for both networks, automatically?* The honest answer was **no for EL**: the EL peer cache (`AndroidPeerCache`) was **append-only** and recorded only snap **capability** (the negotiated snap/1 flag), not whether a peer actually serves the state trie. The per-context `rootDenied` set that deprioritizes hangers (PR #45/#46) was **ephemeral** — never persisted. So every restart (or `pm clear`) re-loaded a pile of capability-flagged peers, many of which hang, and the oracle re-discovered the bad ones one timeout at a time.

The CL cache (`AndroidCLPeerCache`) already learns light-client confirmed/denied verdicts and evicts after repeated failures — surviving restarts. This PR brings the same idea to the EL side for **snap-serving quality**.

## What

- **`AndroidPeerCache`** gains a `SnapQuality` verdict (`CONFIRMED` / `UNKNOWN` / `DENIED`), persisted as a `snapok`/`snapbad` token appended to each line. Backward compatible: old files and the append fast-path load as `UNKNOWN`.
  - `recordSnapServed(addr)` → confirm on a usable proof; resets the failure counter, clears any denial. Idempotent (no disk write once confirmed).
  - `recordSnapFailure(addr)` → after `SNAP_FAILURE_THRESHOLD` (3) **consecutive** failures, mark `DENIED`. **Deprioritized, never evicted** — state roots change, so a peer that missed an old pivot may serve the current head, and it's still a fine plain-eth peer.
- **`EthHandlerSnapPeer`** gains a symmetric `onRootServed` callback, fired when a proof fetch returns **non-empty** nodes (the wire-level "this peer retains the trie" signal). Empty proofs stay on the existing `reportRootUnavailable` path.
- **`NodeService`** wires both signals from the oracle's routing supplier into the cache, and orders cached dials (cold start **and** the snap-peer maintainer loop) by `snapDialRank`: proven snap-servers → snap-capable-unknown → known hangers → plain-eth. So a restart converges on a working snap peer instead of re-timing-out the bad ones first.

## Quality vs capability

The `snap` flag means snap/1 was negotiated during Hello — it says nothing about serving. This PR layers a *learned* verdict on top, exactly analogous to the CL cache's light-client confirmed/denied.

## Testing

`./gradlew :android-app:compileDebugJavaWithJavac` passes. No unit test added: `android-app` has no test sourceset and `LogBuffer` hard-depends on `android.util.Log` (same situation as the sibling `AndroidCLPeerCache`, which is also untested). On-device validation pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)