### PR TITLE
bls: bound + deprioritize G1 decompression to stop UI-starvation ANRs

### DIFF
--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/bls/BlsVerifier.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/bls/BlsVerifier.java
@@ -84,9 +84,15 @@ public final class BlsVerifier {
                         java.util.concurrent.ForkJoinWorkerThread t =
                                 java.util.concurrent.ForkJoinPool
                                         .defaultForkJoinWorkerThreadFactory.newThread(pool);
-                        t.setName("bls-decompress-" + t.getPoolIndex());
-                        t.setPriority(Thread.MIN_PRIORITY);
-                        t.setDaemon(true);
+                        // The default factory can return null if a worker can't be
+                        // created (resource limits / security restrictions); the pool
+                        // treats null as "no thread now" and retries later. Guard so we
+                        // don't NPE configuring it.
+                        if (t != null) {
+                            t.setName("bls-decompress-" + t.getPoolIndex());
+                            t.setPriority(Thread.MIN_PRIORITY);
+                            t.setDaemon(true);
+                        }
                         return t;
                     },
                     null, false);

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/bls/BlsVerifier.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/bls/BlsVerifier.java
@@ -61,6 +61,51 @@ public final class BlsVerifier {
     private static final java.util.concurrent.ConcurrentHashMap<PubkeyKey, ECP> PUBKEY_CACHE =
             new java.util.concurrent.ConcurrentHashMap<>();
 
+    // Dedicated pool for the parallel G1 decompression below — NOT the common
+    // ForkJoinPool. parallelStream() defaults to the common pool (parallelism =
+    // cores-1), so a committee warm-up or a burst of catch-up verifies pegged
+    // every core at normal priority. On a foreground Android app that starved the
+    // UI thread for >5s and triggered input-dispatch ANRs (the Compose hit-test /
+    // frame work simply couldn't get scheduled). Two levers fix that without
+    // meaningfully slowing sync:
+    //   1) bound parallelism to leave cores free for rendering/input — half the
+    //      cores (min 1), so a hot decompress can never occupy the whole CPU;
+    //   2) run the workers at MIN_PRIORITY so the scheduler always prefers the
+    //      foreground UI thread when they do compete.
+    // The decompression is embarrassingly parallel and cache-backed, so even at
+    // half width a cold committee warm-up still finishes in a few seconds, and a
+    // warm verify pays only copies + the pairing.
+    private static final int BLS_PARALLELISM =
+            Math.max(1, Runtime.getRuntime().availableProcessors() / 2);
+    private static final java.util.concurrent.ForkJoinPool BLS_DECOMPRESS_POOL =
+            new java.util.concurrent.ForkJoinPool(
+                    BLS_PARALLELISM,
+                    pool -> {
+                        java.util.concurrent.ForkJoinWorkerThread t =
+                                java.util.concurrent.ForkJoinPool
+                                        .defaultForkJoinWorkerThreadFactory.newThread(pool);
+                        t.setName("bls-decompress-" + t.getPoolIndex());
+                        t.setPriority(Thread.MIN_PRIORITY);
+                        t.setDaemon(true);
+                        return t;
+                    },
+                    null, false);
+
+    /**
+     * Run a parallel-stream pipeline on {@link #BLS_DECOMPRESS_POOL} instead of the
+     * common ForkJoinPool. Submitting the task to a specific pool makes the parallel
+     * stream's fork/join work execute on that pool's (bounded, low-priority) workers.
+     * If the pool rejects the task (e.g. during shutdown), fall back to running it
+     * directly on the calling thread so verification never silently fails.
+     */
+    private static <T> T onDecompressPool(java.util.function.Supplier<T> task) {
+        try {
+            return BLS_DECOMPRESS_POOL.submit(task::get).join();
+        } catch (java.util.concurrent.RejectedExecutionException e) {
+            return task.get();
+        }
+    }
+
     /** byte[]-keyed map entry (arrays don't implement value equals/hashCode). */
     private static final class PubkeyKey {
         private final byte[] bytes;
@@ -97,8 +142,11 @@ public final class BlsVerifier {
      */
     public static void warmPubkeyCache(List<byte[]> pubkeyBytes) {
         if (pubkeyBytes == null) return;
-        pubkeyBytes.parallelStream().forEach(b -> {
-            if (b != null && b.length == 48) cachedTrustedG1(b);
+        onDecompressPool(() -> {
+            pubkeyBytes.parallelStream().forEach(b -> {
+                if (b != null && b.length == 48) cachedTrustedG1(b);
+            });
+            return null;
         });
     }
 
@@ -150,15 +198,17 @@ public final class BlsVerifier {
             //
             // Point decompression (a field square root per key) is independent
             // per pubkey, so we fan it out across cores: on Android/ART the serial
-            // 512-key loop took ~30s, dwarfing everything else. parallelStream uses
-            // the common ForkJoinPool (parallelism = cores-1). Decompressed points
-            // are cached across calls (committees are period-stable), so a warm
-            // verify pays only copies + the pairing. The aggregation (ECP.add) is
-            // then a cheap sequential reduce — Milagro ECP isn't safe to mutate
-            // from multiple threads, but each cache lookup returns a private copy.
-            List<ECP> points = pubkeyBytes.parallelStream()
+            // 512-key loop took ~30s, dwarfing everything else. We use a dedicated
+            // bounded, low-priority pool (BLS_DECOMPRESS_POOL) rather than the common
+            // ForkJoinPool so a verify burst can't saturate every core and starve the
+            // foreground UI thread (input-dispatch ANRs). Decompressed points are
+            // cached across calls (committees are period-stable), so a warm verify
+            // pays only copies + the pairing. The aggregation (ECP.add) is then a
+            // cheap sequential reduce — Milagro ECP isn't safe to mutate from
+            // multiple threads, but each cache lookup returns a private copy.
+            List<ECP> points = onDecompressPool(() -> pubkeyBytes.parallelStream()
                     .map(BlsVerifier::cachedTrustedG1)
-                    .collect(java.util.stream.Collectors.toList());
+                    .collect(java.util.stream.Collectors.toList()));
             ECP aggregated = new ECP(); // point at infinity
             for (ECP pk : points) {
                 if (pk == null || pk.is_infinity()) return false;


### PR DESCRIPTION
## Symptom

Frequent `Input dispatching timed out … MainActivity is not responding. Waited 5001ms for MotionEvent` ANRs on a Pixel 7.

## Root cause (from the ANR trace)

The captured `main` thread was ordinary Compose hit-testing (`MatrixKt.dot` → `GraphicsLayerOwnerLayer.updateMatrix`) — a red herring. The real signal:

- Process header: **309% CPU, 288% user** — multiple cores pegged.
- **All 7 `ForkJoinPool.commonPool` workers** + `bls-cache-warmer` + `beacon-sync` were `Runnable` inside `BlsVerifier.deserializeG1` → Milagro `FP.sqrt` (a BLS12-381 field square root per pubkey, ~brutal on ART).

So it's a **CPU-starvation ANR**: BLS G1 decompression saturated every core at normal priority, and the foreground Compose UI thread couldn't be scheduled within the 5s input deadline.

Both `parallelStream()` sites — `warmPubkeyCache` (committee warm-up) and the per-verify decompression in `fastAggregateVerify` — defaulted to the **common** ForkJoinPool (parallelism = cores−1), with no priority throttling.

## Fix

Route both through a dedicated `ForkJoinPool` (`BLS_DECOMPRESS_POOL`) that:
1. **bounds parallelism to `cores/2` (min 1)** — leaves cores free for rendering/input so a hot decompress can't own the whole CPU;
2. **runs workers at `Thread.MIN_PRIORITY`** — the scheduler prefers the foreground UI thread when they compete.

Submitting the parallel-stream task to a specific pool makes its fork/join work run on that pool's workers. Falls back to the calling thread on `RejectedExecutionException` (pool shutdown) so verification never silently fails.

Decompression is embarrassingly parallel and cache-backed (committees are period-stable), so half-width still warms a cold committee in a few seconds and a warm verify pays only copies + the pairing — no meaningful sync slowdown.

## Testing

`:consensus:test` BLS suite (`BlsVerifierTest`, `BlsFixtureTest`) green — `fastAggregateVerify` behavior unchanged. On-device ANR validation pending (needs a foreground catch-up/period-rotation on the Pixel 7).

## Scope

Independent of #47 (EL snap-quality cache); this is a `:consensus` threading fix on its own branch off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)