### PR TITLE
Fix MetaMask confirm-screen hang: state cache, EVM lanes, fee snapshot, frozen per-block context

### DIFF
--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -2003,6 +2003,10 @@ public final class NodeService extends Service {
                         EnsCall ctx = buildAnchoredHead();
                         lastGoodHead = new HeadWithTimestamp(ctx, android.os.SystemClock.elapsedRealtime());
                         f.complete(ctx);
+                        // After the future is completed (readers unblocked), prime the
+                        // confirm-critical contracts at this root so a wallet's first
+                        // confirm-screen calls start from warm state — see the method doc.
+                        primeConfirmContracts(ctx);
                     } catch (Throwable t) {
                         f.completeExceptionally(t);
                         synchronized (rpcCallCtxLock) {
@@ -2381,6 +2385,46 @@ public final class NodeService extends Service {
         // Fallback: the beacon-finalized execution root, verified directly by the
         // light client (no headerChain needed). Throws if no peer retains it.
         return prepareEnsCall(io.myotis.ens.EnsResolutionRoot.FINALIZED);
+    }
+
+    /** Contracts every MetaMask confirm flow hits: the ENS Registry (recipient
+     *  reverse-resolution), Multicall3 (the confirm screen's transaction
+     *  simulation) and the BalanceChecker (token sweep). */
+    private static final String[] CONFIRM_WARM_CONTRACTS = {
+            "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e",
+            "0xcA11bde05977b3631167028862bE2a173976CA11",
+            "0xb1F8e55c7f64D203C1400B9D8555d050F94aDF39",
+    };
+
+    /**
+     * Prime the confirm-critical contracts at a freshly-built head: fetch each
+     * account record (banked per-root in the {@link #stateProofCache}) and its
+     * bytecode (banked forever in the {@link #ensBytecodeCache} — code is keyed by
+     * hash, so this is one fetch per contract per process lifetime). Without this,
+     * the FIRST confirm after a node restart paid the cold fetch waves inside the
+     * wallet's own 30s call deadline and timed out (observed live: the Multicall3
+     * simulation and ENS resolver probes erroring at 30s on a cold root while warm
+     * runs take 1-3s). Runs on the head-build thread after the context future has
+     * completed, so readers are never delayed by it. Best-effort: failures just
+     * mean the next real call pays the (retryable) cold cost as before.
+     */
+    private void primeConfirmContracts(EnsCall ctx) {
+        try {
+            byte[] root = ctx.blockCtx().stateRoot();
+            java.util.List<CompletableFuture<?>> warms = new java.util.ArrayList<>();
+            for (String hex : CONFIRM_WARM_CONTRACTS) {
+                io.myotis.evm.Address addr = io.myotis.evm.Address.fromHex(hex);
+                warms.add(ctx.oracle().fetchAccount(root, addr)
+                        .thenCompose(acct -> ctx.oracle().fetchBytecode(acct.codeHash()))
+                        .exceptionally(t -> null));   // best-effort per contract
+            }
+            CompletableFuture.allOf(warms.toArray(new CompletableFuture<?>[0]))
+                    .get(20, TimeUnit.SECONDS);
+            LogBuffer.i(TAG, "[rpc] primed " + CONFIRM_WARM_CONTRACTS.length
+                    + " confirm-critical contract(s) at block #" + ctx.blockNumber());
+        } catch (Throwable t) {
+            LogBuffer.i(TAG, "[rpc] confirm-contract prime skipped: " + unwrap(t));
+        }
     }
 
     /** True iff {@code peerStateRoot} at {@code peerBlock} chains back to the

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -189,6 +189,15 @@ public final class NodeService extends Service {
     // survive Stop/Start; shut down in onDestroy.
     private final io.myotis.evm.world.BytecodeCache ensBytecodeCache =
             io.myotis.evm.world.BytecodeCache.inMemory();
+    // Cross-call cache of proof-verified account/storage state, keyed by stateRoot.
+    // Shared across every head-context oracle so a wallet's repeated retries of a
+    // heavy eth_call (MetaMask's ~1000-token BalanceChecker sweep / Multicall3
+    // simulation) reuse already-fetched slots instead of re-proving hundreds each
+    // time — turning a 30s-timeout retry-storm into a couple of converging attempts.
+    // Bounded LRU per kind; ~64k storage slots ≈ a few MB.
+    private static final int STATE_PROOF_CACHE_MAX = 65_536;
+    private final io.myotis.evm.world.StateProofCache stateProofCache =
+            io.myotis.evm.world.StateProofCache.inMemory(STATE_PROOF_CACHE_MAX);
     // Single thread: Besu EVM execution is CPU-bound and the oracle is pinned
     // to one peer, so serializing avoids contention. Daemon thread so it never
     // blocks process exit.
@@ -2477,7 +2486,8 @@ public final class NodeService extends Service {
                                     () -> recordSnapQuality(snapQualityCache, chosen, true));
                         },
                         ensBytecodeCache,
-                        SNAP_ORACLE_MAX_ATTEMPTS);
+                        SNAP_ORACLE_MAX_ATTEMPTS,
+                        stateProofCache);
         io.myotis.evm.DefaultEvmExecutor base =
                 new io.myotis.evm.DefaultEvmExecutor(oracle, ensBytecodeCache, evmPool);
         io.myotis.evm.PrefetchingEvmExecutor prefetching =

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -847,6 +847,26 @@ public final class NodeService extends Service {
     // record behind a single volatile ref so head and timestamp are read/written
     // atomically together (no torn read of new head with old timestamp).
     private volatile HeadWithTimestamp lastGoodHead;
+    /**
+     * Frozen anchored context per pinned block NUMBER. A wallet (MetaMask) pins a
+     * confirm to one block and retries the same heavy calls against it for minutes.
+     * Serving each retry against the <em>current</em> head — which the warmer rebuilds
+     * to a new stateRoot every ~12-15s — reset the stateRoot-keyed StateProofCache on
+     * every rebuild, so a 1000-slot BalanceChecker / Multicall3 simulation re-fetched
+     * from scratch each retry and never converged (the persistent confirm-screen hang,
+     * uptime-independent). Freezing the context — and thus its stateRoot — per pinned
+     * number makes all retries hit one stable root, so the cache accumulates and the
+     * call converges in a couple of tries. Bounded LRU (wallets pin a few recent
+     * blocks); each entry ages out at {@link #RPC_HEAD_SERVE_STALE_MAX_MS}.
+     */
+    private final java.util.Map<Long, HeadWithTimestamp> pinnedHeadByNumber =
+            java.util.Collections.synchronizedMap(
+                    new java.util.LinkedHashMap<>(16, 0.75f, true) {
+                        @Override protected boolean removeEldestEntry(
+                                java.util.Map.Entry<Long, HeadWithTimestamp> e) {
+                            return size() > 16;
+                        }
+                    });
     /** Runs the blocking, network-bound head build off the caller's thread so a
      *  request blocks only up to its own timeout. Single-thread: the future
      *  dedup means at most one build runs at a time. */
@@ -894,6 +914,16 @@ public final class NodeService extends Service {
                 if (requestedNum < 0) return null;
             }
         }
+        // Pinned-number fast path: reuse the context already frozen to this number so
+        // its (fixed) stateRoot lets the StateProofCache accumulate across the wallet's
+        // minutes-long retries instead of resetting every time the head rebuilds.
+        if (requestedNum >= 0) {
+            HeadWithTimestamp frozen = pinnedHeadByNumber.get(requestedNum);
+            if (frozen != null && android.os.SystemClock.elapsedRealtime() - frozen.builtAtMs()
+                    < RPC_HEAD_SERVE_STALE_MAX_MS) {
+                return frozen.head();
+            }
+        }
         EnsCall ctx = anchoredHeadOrWait();
         if (ctx == null) return null;
         if (requestedNum >= 0) {
@@ -918,6 +948,10 @@ public final class NodeService extends Service {
                         + ", optimistic=" + optimistic + ") -> not served");
                 return null;
             }
+            // Freeze this context for the number so every subsequent retry pinned to it
+            // resolves the SAME root (cache accumulation). First pin wins; it ages out.
+            pinnedHeadByNumber.putIfAbsent(requestedNum,
+                    new HeadWithTimestamp(ctx, android.os.SystemClock.elapsedRealtime()));
         }
         return ctx;
     }
@@ -3215,6 +3249,7 @@ public final class NodeService extends Service {
         // briefly reuse one pinned to a now-dead peer (fails safe to proxy anyway).
         synchronized (rpcCallCtxLock) { rpcCallCtx = null; }
         lastGoodHead = null;
+        pinnedHeadByNumber.clear();
         // Close BLC first: its libp2p host's outbound dials hold references
         // through to the discv5 callback's blcRef, and the sync thread can
         // be in the middle of an addPeer call when shutdown fires.

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -1500,6 +1500,43 @@ public final class NodeService extends Service {
      *  (same pattern as {@link HeadWithTimestamp}). */
     private record TipWithTimestamp(java.math.BigInteger tip, long atMs) {}
     private volatile TipWithTimestamp cachedSuggestedTip;
+    /** Pre-computed (gasPrice, tip) snapshot, refreshed by the head warmer.
+     *  eth_gasPrice / eth_maxPriorityFeePerGas serve from this in microseconds
+     *  instead of paying the cold path (header anchor + header window + 3 block
+     *  bodies over devp2p, observed 6-18s on-device) on the wallet's poll.
+     *  MetaMask's confirm screen sits in skeleton until a fee poll returns and
+     *  only re-polls every few minutes, so one slow answer stalls the screen for
+     *  minutes. The snapshot is derived from the same verified data as the cold
+     *  path — precomputing changes freshness, not trust. Serving a snapshot a
+     *  minute or two old is fine: it's a fee suggestion, and the wallet re-polls. */
+    private record FeeSnapshot(java.math.BigInteger gasPrice, java.math.BigInteger tip, long atMs) {}
+    private volatile FeeSnapshot feeSnapshot;
+    /** Refresh the snapshot when older than this (head warmer cadence is 5s). */
+    private static final long FEE_SNAPSHOT_REFRESH_MS = 12_000;
+    /** Don't serve a snapshot older than this — fall through to the cold path. */
+    private static final long FEE_SNAPSHOT_MAX_SERVE_MS = 10 * 60_000;
+    private final java.util.concurrent.atomic.AtomicBoolean feeRefreshing =
+            new java.util.concurrent.atomic.AtomicBoolean();
+
+    /** Recompute the fee snapshot if stale; called from the head-warmer tick (and
+     *  as a side effect of a cold-path fee RPC). Single-flight; never throws. */
+    private void refreshFeeSnapshotIfStale() {
+        FeeSnapshot snap = feeSnapshot;
+        long now = android.os.SystemClock.elapsedRealtime();
+        if (snap != null && now - snap.atMs() < FEE_SNAPSHOT_REFRESH_MS) return;
+        if (!feeRefreshing.compareAndSet(false, true)) return;
+        try {
+            java.math.BigInteger price = computeGasPriceCold();
+            java.math.BigInteger tip = cachedSuggestedTip != null ? cachedSuggestedTip.tip() : null;
+            if (price != null && tip != null) {
+                feeSnapshot = new FeeSnapshot(price, tip, android.os.SystemClock.elapsedRealtime());
+            }
+        } catch (Throwable t) {
+            LogBuffer.i(TAG, "[rpc] fee snapshot refresh failed: " + unwrap(t));
+        } finally {
+            feeRefreshing.set(false);
+        }
+    }
 
     /** Next block's base fee per the EIP-1559 update rule, from the parent header. */
     private static java.math.BigInteger nextBaseFee(BlockHeader h) {
@@ -1607,6 +1644,17 @@ public final class NodeService extends Service {
      *  {@link #TIP_SUGGEST_BLOCKS} verified blocks, floored at
      *  {@link #MIN_SUGGESTED_TIP}. Cached for ~one block. Null → can't verify. */
     private java.math.BigInteger rpcMaxPriorityFeePerGas() {
+        // Serve the pre-computed snapshot first — same freshness contract as
+        // eth_gasPrice (the head warmer refreshes it; the wallet re-polls).
+        FeeSnapshot snap = feeSnapshot;
+        if (snap != null && android.os.SystemClock.elapsedRealtime() - snap.atMs()
+                < FEE_SNAPSHOT_MAX_SERVE_MS) {
+            return snap.tip();
+        }
+        return computeMaxPriorityFeeCold();
+    }
+
+    private java.math.BigInteger computeMaxPriorityFeeCold() {
         TipWithTimestamp cached = cachedSuggestedTip;
         if (cached != null
                 && android.os.SystemClock.elapsedRealtime() - cached.atMs() < TIP_CACHE_TTL_MS) {
@@ -1639,14 +1687,35 @@ public final class NodeService extends Service {
         }
     }
 
-    /** Legacy-style total gas price: next block's base fee + the suggested tip. */
+    /** Legacy-style total gas price: next block's base fee + the suggested tip.
+     *  Served from the pre-computed {@link #feeSnapshot} when available (the head
+     *  warmer keeps it fresh) so the wallet's fee poll returns in microseconds;
+     *  falls back to the cold path only before the first snapshot exists. */
     private java.math.BigInteger rpcGasPrice() {
+        FeeSnapshot snap = feeSnapshot;
+        if (snap != null && android.os.SystemClock.elapsedRealtime() - snap.atMs()
+                < FEE_SNAPSHOT_MAX_SERVE_MS) {
+            return snap.gasPrice();
+        }
+        java.math.BigInteger price = computeGasPriceCold();
+        if (price != null) {
+            java.math.BigInteger tip = cachedSuggestedTip != null ? cachedSuggestedTip.tip() : null;
+            if (tip != null) {
+                feeSnapshot = new FeeSnapshot(price, tip, android.os.SystemClock.elapsedRealtime());
+            }
+        }
+        return price;
+    }
+
+    /** The cold gas-price computation (header anchor + window + tip from verified
+     *  bodies). Seconds-slow on-device; callers should prefer {@link #feeSnapshot}. */
+    private java.math.BigInteger computeGasPriceCold() {
         try {
             HeaderAnchor anchor = headerAnchor();
             if (anchor == null) return null;
             List<BlockHeadersMessage.VerifiedHeader> window = anchoredHeaderWindow(anchor, 1);
             if (window == null || window.isEmpty()) return null;
-            java.math.BigInteger tip = rpcMaxPriorityFeePerGas();
+            java.math.BigInteger tip = computeMaxPriorityFeeCold();
             if (tip == null) return null;
             return nextBaseFee(window.get(window.size() - 1).header()).add(tip);
         } catch (Exception e) {
@@ -2214,6 +2283,14 @@ public final class NodeService extends Service {
                 verifiedHeadCallContext();
             } catch (Exception ignored) {
                 // No usable snap peer / anchorable head yet — retry next tick.
+            }
+            // Keep the fee snapshot warm too: the wallet's confirm screen blocks on
+            // its fee poll, and the cold computation takes seconds — paying it here
+            // (off the RPC path) makes eth_gasPrice effectively instant.
+            try {
+                refreshFeeSnapshotIfStale();
+            } catch (Throwable ignored) {
+                // never kill the warmer tick
             }
         }, 3, 5, TimeUnit.SECONDS);
     }

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -804,6 +804,17 @@ public final class NodeService extends Service {
      *  instant error that emptied MetaMask's asset list. Beyond this (~13 min) the pin is
      *  genuinely historical and we can't represent it, so reject. */
     private static final long RPC_BLOCK_NUM_LAG_TOLERANCE = 64;
+    /** Last-resort stale-serve horizon: when rebuilds keep failing (a heavy token
+     *  sweep starving the snap peers, a peer-set outage), serve the last anchored
+     *  head up to the SAME horizon the pinned-number check accepts —
+     *  {@link #RPC_BLOCK_NUM_LAG_TOLERANCE} blocks (~13min at 12s slots). The
+     *  context's verification never expires (it's beacon-anchored); only its
+     *  freshness ages, and a wallet read against ~minutes-old verified state is
+     *  strictly better than an instant error: MetaMask pins reads to a recent
+     *  block number and re-polls anyway. Without this, every read during a
+     *  sustained rebuild outage died with "no verified head" (the confirm-screen
+     *  instant-ERROR storm) even though a perfectly servable context existed. */
+    private static final long RPC_HEAD_SERVE_STALE_MAX_MS = RPC_BLOCK_NUM_LAG_TOLERANCE * 12_000;
 
     private final Object rpcCallCtxLock = new Object();
     private CompletableFuture<EnsCall> rpcCallCtx;   // in-flight/fresh build (dedup)
@@ -925,6 +936,19 @@ public final class NodeService extends Service {
                     break;
                 }
             }
+        }
+        // Last resort: a stale-but-anchored head beats erroring. Its verification
+        // hasn't expired — it's just old — and verifiedHeadFor's pinned-number
+        // bounds still reject pins this context genuinely can't represent. The
+        // warmer keeps retrying fresh builds in the background regardless.
+        HeadWithTimestamp stale = lastGoodHead;
+        if (stale != null && android.os.SystemClock.elapsedRealtime() - stale.builtAtMs()
+                < RPC_HEAD_SERVE_STALE_MAX_MS) {
+            LogBuffer.i(TAG, "[rpc] serving STALE anchored head (block #"
+                    + stale.head().blockNumber() + ", "
+                    + (android.os.SystemClock.elapsedRealtime() - stale.builtAtMs()) / 1000
+                    + "s old) — rebuild failing: " + (last != null ? unwrap(last) : "timeout"));
+            return stale.head();
         }
         LogBuffer.i(TAG, "[rpc] no verified head after "
                 + (android.os.SystemClock.elapsedRealtime() - start) + "ms -> proxy: "

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -198,15 +198,42 @@ public final class NodeService extends Service {
     private static final int STATE_PROOF_CACHE_MAX = 65_536;
     private final io.myotis.evm.world.StateProofCache stateProofCache =
             io.myotis.evm.world.StateProofCache.inMemory(STATE_PROOF_CACHE_MAX);
-    // Single thread: Besu EVM execution is CPU-bound and the oracle is pinned
-    // to one peer, so serializing avoids contention. Daemon thread so it never
-    // blocks process exit.
-    private final java.util.concurrent.ExecutorService evmPool =
-            java.util.concurrent.Executors.newSingleThreadExecutor(r -> {
+    // EVM pool. Was a single thread ("EVM is CPU-bound, oracle pinned to one
+    // peer") — but the oracle rotates across peers now, and an EVM task spends
+    // most of its wall-clock BLOCKED on snap fetch waves, not executing. A wallet
+    // confirm screen fires ~20 eth_calls at once; serialized behind one thread
+    // they queue for minutes and every one of them blows the 30s RPC deadline
+    // (observed on-device). A small pool lets calls overlap their fetch waits.
+    // Kept modest (3) so Besu interpretation can't peg the CPU alongside BLS.
+    private static final int EVM_POOL_THREADS = 3;
+    private final java.util.concurrent.ExecutorService evmPoolDelegate =
+            java.util.concurrent.Executors.newFixedThreadPool(EVM_POOL_THREADS, r -> {
                 Thread t = new Thread(r, "android-evm");
                 t.setDaemon(true);
                 return t;
             });
+    /** Tasks older than this when dequeued are skipped: their RPC caller (30s
+     *  deadline) has long since given up, so running them would burn EVM-thread
+     *  time for nobody — observed as a queue of dead confirm-screen calls
+     *  starving the live retries that followed them. Slightly above the longest
+     *  RPC wait so a still-awaited task is never dropped early. */
+    private static final long EVM_TASK_MAX_QUEUE_AGE_MS = 35_000;
+    /** Executor handed to the EVM stack: delegates to {@link #evmPoolDelegate}
+     *  but drops tasks that sat queued past {@link #EVM_TASK_MAX_QUEUE_AGE_MS}.
+     *  A skipped task leaves its CompletableFuture incomplete — safe, because
+     *  the only waiter timed out and abandoned it long before. */
+    private final java.util.concurrent.Executor evmPool = task -> {
+        final long enqueuedAtMs = android.os.SystemClock.elapsedRealtime();
+        evmPoolDelegate.execute(() -> {
+            long ageMs = android.os.SystemClock.elapsedRealtime() - enqueuedAtMs;
+            if (ageMs > EVM_TASK_MAX_QUEUE_AGE_MS) {
+                LogBuffer.i(TAG, "[evm] skipping task queued " + ageMs
+                        + "ms (caller deadline long past)");
+                return;
+            }
+            task.run();
+        });
+    };
     // CCIP-Read gateway HTTP is blocking; keep it off the single EVM thread.
     private final java.util.concurrent.ExecutorService ccipPool =
             java.util.concurrent.Executors.newCachedThreadPool(r -> {
@@ -3208,7 +3235,7 @@ public final class NodeService extends Service {
         // worker holds the same lock as startAndPublish, so a subsequent
         // service start can't race with a half-finished close.
         RUNNING.set(false);
-        evmPool.shutdownNow();
+        evmPoolDelegate.shutdownNow();
         ccipPool.shutdownNow();
         headBuildPool.shutdownNow();
         new Thread(this::doShutdown, "ethp2p-shutdown").start();

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -206,9 +206,28 @@ public final class NodeService extends Service {
     // (observed on-device). A small pool lets calls overlap their fetch waits.
     // Kept modest (3) so Besu interpretation can't peg the CPU alongside BLS.
     private static final int EVM_POOL_THREADS = 3;
-    private final java.util.concurrent.ExecutorService evmPoolDelegate =
-            java.util.concurrent.Executors.newFixedThreadPool(EVM_POOL_THREADS, r -> {
-                Thread t = new Thread(r, "android-evm");
+    /** Calldata size at/below which an eth_call rides the reserved small lane. A
+     *  wallet confirm screen's calls are tiny (36-byte balanceOf probes, ~516-byte
+     *  Multicall3 simulations) while the background token sweep is ~32KB; without a
+     *  reserved lane the sweep's 30s+ executions occupy every EVM thread and the
+     *  confirm screen's calls queue to death behind them (observed live: the
+     *  simulation timing out at 30s four times in a row during a sweep storm). */
+    private static final int EVM_SMALL_CALLDATA_MAX = 4_096;
+    /** Set by the RPC handler around callView/estimateGas invocations; read by the
+     *  routing {@link #evmPool} when supplyAsync submits on the same thread. */
+    private static final ThreadLocal<Boolean> EVM_SMALL_LANE = new ThreadLocal<>();
+    /** Heavy lane: the token sweeps and other large calls (2 threads). */
+    private final java.util.concurrent.ExecutorService evmPoolHeavy =
+            java.util.concurrent.Executors.newFixedThreadPool(EVM_POOL_THREADS - 1, r -> {
+                Thread t = new Thread(r, "android-evm-heavy");
+                t.setDaemon(true);
+                return t;
+            });
+    /** Small lane: one thread reserved for small-calldata calls so interactive
+     *  reads never queue behind a sweep. */
+    private final java.util.concurrent.ExecutorService evmPoolSmall =
+            java.util.concurrent.Executors.newSingleThreadExecutor(r -> {
+                Thread t = new Thread(r, "android-evm-small");
                 t.setDaemon(true);
                 return t;
             });
@@ -218,13 +237,18 @@ public final class NodeService extends Service {
      *  starving the live retries that followed them. Slightly above the longest
      *  RPC wait so a still-awaited task is never dropped early. */
     private static final long EVM_TASK_MAX_QUEUE_AGE_MS = 35_000;
-    /** Executor handed to the EVM stack: delegates to {@link #evmPoolDelegate}
-     *  but drops tasks that sat queued past {@link #EVM_TASK_MAX_QUEUE_AGE_MS}.
-     *  A skipped task leaves its CompletableFuture incomplete — safe, because
-     *  the only waiter timed out and abandoned it long before. */
+    /** Executor handed to the EVM stack: routes to the small or heavy lane (via the
+     *  {@link #EVM_SMALL_LANE} hint the RPC handler sets on its own thread before
+     *  invoking callView — supplyAsync calls execute() synchronously on that thread,
+     *  so the hint is visible here; continuations submitted from other threads
+     *  default to the heavy lane). Both lanes drop tasks that sat queued past
+     *  {@link #EVM_TASK_MAX_QUEUE_AGE_MS}: a skipped task leaves its
+     *  CompletableFuture incomplete — safe, because the only waiter timed out and
+     *  abandoned it long before. */
     private final java.util.concurrent.Executor evmPool = task -> {
         final long enqueuedAtMs = android.os.SystemClock.elapsedRealtime();
-        evmPoolDelegate.execute(() -> {
+        boolean small = Boolean.TRUE.equals(EVM_SMALL_LANE.get());
+        (small ? evmPoolSmall : evmPoolHeavy).execute(() -> {
             long ageMs = android.os.SystemClock.elapsedRealtime() - enqueuedAtMs;
             if (ageMs > EVM_TASK_MAX_QUEUE_AGE_MS) {
                 LogBuffer.i(TAG, "[evm] skipping task queued " + ageMs
@@ -981,6 +1005,12 @@ public final class NodeService extends Service {
             return null;
         }
         long t0 = android.os.SystemClock.elapsedRealtime();
+        // Route small calls onto the reserved EVM lane so a confirm screen's tiny
+        // probes/simulations never queue behind a ~32KB token-sweep storm. The hint
+        // is read synchronously by evmPool when callView's supplyAsync submits on
+        // this thread; cleared in finally so the handler thread doesn't leak it.
+        boolean smallLane = (data == null || data.length <= EVM_SMALL_CALLDATA_MAX);
+        if (smallLane) EVM_SMALL_LANE.set(Boolean.TRUE);
         try {
             byte[] out = h.offchainExecutor()
                     .callView(io.myotis.evm.Address.of(to), data == null ? new byte[0] : data,
@@ -994,6 +1024,8 @@ public final class NodeService extends Service {
                     + (android.os.SystemClock.elapsedRealtime() - t0) + "ms: "
                     + describeEvmError(e));
             return null;
+        } finally {
+            if (smallLane) EVM_SMALL_LANE.remove();
         }
     }
 
@@ -3336,7 +3368,8 @@ public final class NodeService extends Service {
         // worker holds the same lock as startAndPublish, so a subsequent
         // service start can't race with a half-finished close.
         RUNNING.set(false);
-        evmPoolDelegate.shutdownNow();
+        evmPoolHeavy.shutdownNow();
+        evmPoolSmall.shutdownNow();
         ccipPool.shutdownNow();
         headBuildPool.shutdownNow();
         new Thread(this::doShutdown, "ethp2p-shutdown").start();

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -950,8 +950,15 @@ public final class NodeService extends Service {
             }
             // Freeze this context for the number so every subsequent retry pinned to it
             // resolves the SAME root (cache accumulation). First pin wins; it ages out.
-            pinnedHeadByNumber.putIfAbsent(requestedNum,
+            // On a concurrent first-read race the putIfAbsent loser must serve the
+            // WINNER's context, not its own — otherwise two contexts with different
+            // stateRoots briefly serve the same pinned number, splitting the
+            // StateProofCache across roots for that block.
+            HeadWithTimestamp existing = pinnedHeadByNumber.putIfAbsent(requestedNum,
                     new HeadWithTimestamp(ctx, android.os.SystemClock.elapsedRealtime()));
+            if (existing != null) {
+                return existing.head();
+            }
         }
         return ctx;
     }

--- a/myotis-evm/src/main/java/io/myotis/evm/PrefetchingEvmExecutor.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/PrefetchingEvmExecutor.java
@@ -255,12 +255,19 @@ public final class PrefetchingEvmExecutor implements EvmExecutor {
      * cache and don't issue any oracle calls.
      */
     /** Max prefetch requests in flight at once. A wallet balance sweep can record
-     *  ~1000 misses in one wave; firing them all concurrently floods the single
-     *  pinned snap peer (request-queue overflow / disconnects). A semaphore caps
-     *  concurrency without an artificial per-chunk barrier — as each request
-     *  completes its permit frees and the next starts, so one slow request only
-     *  occupies its own slot, not the whole next batch. */
-    private static final int PREFETCH_MAX_IN_FLIGHT = 128;
+     *  ~1000 misses in one wave; firing them all concurrently floods the handful of
+     *  snap peers (request-queue overflow / disconnects) AND monopolizes them so that
+     *  cheap interactive reads issued concurrently — eth_getBalance, nonce,
+     *  eth_getBlockByNumber, and the head-context probe — queue behind hundreds of
+     *  prefetch requests and balloon to tens of seconds (observed 9-28s on a wallet
+     *  confirm screen). The bound is deliberately well below the per-peer request
+     *  ceiling so a single heavy call leaves peer capacity for those interactive
+     *  reads; the cross-call StateProofCache makes the resulting extra retry waves
+     *  cheap (cache hits), so capping concurrency costs little throughput. A semaphore
+     *  caps it without an artificial per-chunk barrier — as each request completes its
+     *  permit frees and the next starts, so one slow request only occupies its own
+     *  slot, not the whole next batch. */
+    private static final int PREFETCH_MAX_IN_FLIGHT = 48;
     /** Overall best-effort budget for one prefetch wave. */
     private static final long PREFETCH_WAVE_TIMEOUT_SEC = 30;
 

--- a/myotis-evm/src/main/java/io/myotis/evm/world/SnapBackedStateOracle.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/world/SnapBackedStateOracle.java
@@ -16,6 +16,7 @@ import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.HexFormat;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.function.Supplier;
@@ -61,6 +62,10 @@ public final class SnapBackedStateOracle implements SnapStateOracle {
     private final Supplier<SnapPeer> peerSupplier;
     private final BytecodeCache bytecodeCache;
     private final int maxAttempts;
+    /** Cross-call, node-level cache of verified account/storage state keyed by
+     *  stateRoot — survives head-context rebuilds so a wallet's repeated retries of
+     *  the same heavy call reuse fetched slots instead of re-proving them. */
+    private final StateProofCache stateCache;
 
     /**
      * Per-oracle (i.e. per-resolution) memoization of account-record fetches,
@@ -79,16 +84,25 @@ public final class SnapBackedStateOracle implements SnapStateOracle {
             accountCache = new java.util.concurrent.ConcurrentHashMap<>();
 
     public SnapBackedStateOracle(Supplier<SnapPeer> peerSupplier, BytecodeCache bytecodeCache) {
-        this(peerSupplier, bytecodeCache, DEFAULT_MAX_ATTEMPTS);
+        this(peerSupplier, bytecodeCache, DEFAULT_MAX_ATTEMPTS, StateProofCache.noop());
     }
 
     public SnapBackedStateOracle(
             Supplier<SnapPeer> peerSupplier,
             BytecodeCache bytecodeCache,
             int maxAttempts) {
+        this(peerSupplier, bytecodeCache, maxAttempts, StateProofCache.noop());
+    }
+
+    public SnapBackedStateOracle(
+            Supplier<SnapPeer> peerSupplier,
+            BytecodeCache bytecodeCache,
+            int maxAttempts,
+            StateProofCache stateCache) {
         this.peerSupplier = peerSupplier;
         this.bytecodeCache = bytecodeCache;
         this.maxAttempts = maxAttempts;
+        this.stateCache = stateCache == null ? StateProofCache.noop() : stateCache;
     }
 
     @Override
@@ -99,8 +113,16 @@ public final class SnapBackedStateOracle implements SnapStateOracle {
 
     @Override
     public CompletableFuture<BigInteger> fetchStorage(byte[] stateRoot, Address address, BigInteger slot) {
+        byte[] addr = address.toByteArray();
+        // Cross-call cache hit: the verified value at this (stateRoot, addr, slot)
+        // is returned with zero round-trips. This is what lets a wallet's repeated
+        // retries of a 1000-slot balance sweep converge instead of re-proving every
+        // slot each time.
+        Optional<BigInteger> cached = stateCache.getStorage(stateRoot, addr, slot);
+        if (cached.isPresent()) return CompletableFuture.completedFuture(cached.get());
+
         Bytes32 root = Bytes32.wrap(stateRoot.clone());
-        Bytes addressBytes = Bytes.wrap(address.toByteArray());
+        Bytes addressBytes = Bytes.wrap(addr);
         Bytes32 accountHash = Bytes32.wrap(Hash.keccak256(addressBytes).toArrayUnsafe());
         Bytes32 slotKey = paddedSlotKey(slot);
         Bytes32 slotHash = Bytes32.wrap(Hash.keccak256(slotKey).toArrayUnsafe());
@@ -113,11 +135,16 @@ public final class SnapBackedStateOracle implements SnapStateOracle {
             Bytes32 storageRoot = awr.storageRoot();
             if (MerklePatriciaProofVerifier.EMPTY_TRIE_ROOT.equals(storageRoot)) {
                 // Account has no storage at all; every slot is zero.
+                stateCache.putStorage(stateRoot, addr, slot, BigInteger.ZERO);
                 return CompletableFuture.completedFuture(BigInteger.ZERO);
             }
             return tryWithRetries(peer -> peer
                     .getTrieNodes(root, List.of(SnapPeer.PathSet.storageSlot(accountHash, slotHash)))
-                    .thenApply(nodes -> verifyAndDecodeStorage(storageRoot, slotHash, address, nodes)));
+                    .thenApply(nodes -> verifyAndDecodeStorage(storageRoot, slotHash, address, nodes)))
+                    .thenApply(value -> {
+                        stateCache.putStorage(stateRoot, addr, slot, value);
+                        return value;
+                    });
         });
     }
 
@@ -160,8 +187,19 @@ public final class SnapBackedStateOracle implements SnapStateOracle {
      * mismatched proof is rotated out of consideration immediately.
      */
     private CompletableFuture<AccountWithStorageRoot> fetchAccountWithRoot(byte[] stateRoot, Address address) {
+        byte[] addr = address.toByteArray();
+        // Cross-call L2: a verified account record at this stateRoot, reused across
+        // head-context rebuilds and calls (the per-oracle accountCache below is only
+        // an in-flight dedup for one resolution).
+        Optional<StateProofCache.AccountEntry> cachedAccount = stateCache.getAccount(stateRoot, addr);
+        if (cachedAccount.isPresent()) {
+            StateProofCache.AccountEntry e = cachedAccount.get();
+            return CompletableFuture.completedFuture(
+                    new AccountWithStorageRoot(e.account(), Bytes32.wrap(e.storageRoot())));
+        }
+
         Bytes32 root = Bytes32.wrap(stateRoot.clone());
-        Bytes addressBytes = Bytes.wrap(address.toByteArray());
+        Bytes addressBytes = Bytes.wrap(addr);
         Bytes32 accountHash = Bytes32.wrap(Hash.keccak256(addressBytes).toArrayUnsafe());
 
         String key = root.toHexString() + ':' + addressBytes.toHexString();
@@ -169,12 +207,17 @@ public final class SnapBackedStateOracle implements SnapStateOracle {
             CompletableFuture<AccountWithStorageRoot> f = tryWithRetries(peer -> peer
                     .getTrieNodes(root, List.of(SnapPeer.PathSet.account(accountHash)))
                     .thenApply(nodes -> verifyAndDecodeAccount(root, accountHash, address, nodes)));
-            // Evict failed fetches so a later read can retry across peers. Use
-            // *Async so the removal never runs synchronously inside
-            // computeIfAbsent (which would be a reentrant map mutation); the
-            // value-conditional remove keeps a racing re-fetch intact.
+            // Evict failed fetches so a later read can retry across peers; on success
+            // promote the verified record to the cross-call cache. Use *Async so
+            // neither runs synchronously inside computeIfAbsent (a reentrant map
+            // mutation); the value-conditional remove keeps a racing re-fetch intact.
             f.whenCompleteAsync((v, e) -> {
-                if (e != null) accountCache.remove(k, f);
+                if (e != null) {
+                    accountCache.remove(k, f);
+                } else if (v != null) {
+                    stateCache.putAccount(stateRoot, addr,
+                            new StateProofCache.AccountEntry(v.account(), v.storageRoot().toArrayUnsafe()));
+                }
             }, java.util.concurrent.ForkJoinPool.commonPool());
             return f;
         });

--- a/myotis-evm/src/main/java/io/myotis/evm/world/StateProofCache.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/world/StateProofCache.java
@@ -1,0 +1,121 @@
+package io.myotis.evm.world;
+
+import java.math.BigInteger;
+import java.util.Collections;
+import java.util.HexFormat;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Cross-call cache of proof-<em>verified</em> state, keyed by world {@code stateRoot}.
+ *
+ * <p><b>Why this exists.</b> A wallet confirm screen fires huge {@code eth_call}s —
+ * a ~1000-token balance sweep (MetaMask's BalanceChecker) and Multicall3
+ * simulations — and, when they exceed the per-call timeout, MetaMask <em>retries
+ * the identical call</em> many times. {@link SnapBackedStateOracle}'s account
+ * memo is per-instance (rebuilt with each head context) and storage slots were
+ * not cached across calls at all, so every retry re-fetched hundreds of storage
+ * proofs from scratch — a retry-storm that saturated the few snap peers, starved
+ * cheap reads, and never converged. Caching the verified results at the node
+ * level lets each retry reuse what the last one fetched, so the call converges in
+ * a couple of attempts instead of looping forever.
+ *
+ * <p><b>Why it's safe.</b> Entries are keyed by {@code stateRoot} and stored only
+ * after the MPT proof has been verified against that root (see
+ * {@code verifyAndDecode*} in {@link SnapBackedStateOracle}). State at a fixed
+ * {@code stateRoot} is immutable, so a cached {@code (stateRoot, address, slot) ->
+ * value} mapping is a cryptographic fact, not peer-trusted data — reusing it
+ * across any call pinned to that root is sound. MetaMask number-pins its confirm
+ * reads to a block, so the retries share a {@code stateRoot} and hit the cache.
+ *
+ * <p>Bounded (LRU, per kind) so a long-lived node doesn't grow without limit as
+ * the head advances and old roots fall out of use.
+ */
+public interface StateProofCache {
+
+    /** Verified value of {@code slot} for {@code address} at {@code stateRoot}, if cached. */
+    Optional<BigInteger> getStorage(byte[] stateRoot, byte[] address, BigInteger slot);
+
+    /** Cache a verified storage value. */
+    void putStorage(byte[] stateRoot, byte[] address, BigInteger slot, BigInteger value);
+
+    /** Verified account record (+ storage root) for {@code address} at {@code stateRoot}, if cached. */
+    Optional<AccountEntry> getAccount(byte[] stateRoot, byte[] address);
+
+    /** Cache a verified account record. */
+    void putAccount(byte[] stateRoot, byte[] address, AccountEntry entry);
+
+    /** A verified account record plus its storage trie root (the latter is needed to
+     *  anchor subsequent storage-slot proofs and isn't exposed on {@link AccountState}). */
+    record AccountEntry(AccountState account, byte[] storageRoot) {
+        public AccountEntry(AccountState account, byte[] storageRoot) {
+            this.account = account;
+            this.storageRoot = storageRoot.clone();
+        }
+        @Override public byte[] storageRoot() { return storageRoot.clone(); }
+    }
+
+    /** No-op cache; the default so existing callers/tests are unaffected. */
+    static StateProofCache noop() {
+        return Noop.INSTANCE;
+    }
+
+    /** Bounded in-memory cache; {@code maxEntriesPerKind} caps storage and account
+     *  entries separately (LRU eviction). */
+    static StateProofCache inMemory(int maxEntriesPerKind) {
+        return new InMemory(maxEntriesPerKind);
+    }
+
+    enum Noop implements StateProofCache {
+        INSTANCE;
+        @Override public Optional<BigInteger> getStorage(byte[] r, byte[] a, BigInteger s) { return Optional.empty(); }
+        @Override public void putStorage(byte[] r, byte[] a, BigInteger s, BigInteger v) {}
+        @Override public Optional<AccountEntry> getAccount(byte[] r, byte[] a) { return Optional.empty(); }
+        @Override public void putAccount(byte[] r, byte[] a, AccountEntry e) {}
+    }
+
+    final class InMemory implements StateProofCache {
+        private final Map<String, BigInteger> storage;
+        private final Map<String, AccountEntry> accounts;
+
+        InMemory(int maxEntriesPerKind) {
+            this.storage = boundedLru(maxEntriesPerKind);
+            this.accounts = boundedLru(maxEntriesPerKind);
+        }
+
+        private static <V> Map<String, V> boundedLru(int cap) {
+            return Collections.synchronizedMap(new LinkedHashMap<>(16, 0.75f, true) {
+                @Override protected boolean removeEldestEntry(Map.Entry<String, V> eldest) {
+                    return size() > cap;
+                }
+            });
+        }
+
+        private static String hex(byte[] b) { return HexFormat.of().formatHex(b); }
+
+        private static String accountKey(byte[] root, byte[] addr) {
+            return hex(root) + ':' + hex(addr);
+        }
+
+        private static String storageKey(byte[] root, byte[] addr, BigInteger slot) {
+            return hex(root) + ':' + hex(addr) + ':' + slot.toString(16);
+        }
+
+        @Override public Optional<BigInteger> getStorage(byte[] root, byte[] addr, BigInteger slot) {
+            return Optional.ofNullable(storage.get(storageKey(root, addr, slot)));
+        }
+
+        @Override public void putStorage(byte[] root, byte[] addr, BigInteger slot, BigInteger value) {
+            storage.put(storageKey(root, addr, slot), value);   // BigInteger is immutable
+        }
+
+        @Override public Optional<AccountEntry> getAccount(byte[] root, byte[] addr) {
+            return Optional.ofNullable(accounts.get(accountKey(root, addr)));
+        }
+
+        @Override public void putAccount(byte[] root, byte[] addr, AccountEntry entry) {
+            accounts.put(accountKey(root, addr), entry);
+        }
+    }
+}

--- a/myotis-evm/src/test/java/io/myotis/evm/world/SnapBackedStateOracleTest.java
+++ b/myotis-evm/src/test/java/io/myotis/evm/world/SnapBackedStateOracleTest.java
@@ -299,6 +299,86 @@ class SnapBackedStateOracleTest {
         assertEquals(BigInteger.ZERO, got);
     }
 
+    @Test
+    void sharedStateCacheServesStorageAcrossOraclesWithoutRefetch() throws Exception {
+        // The fix for the confirm-screen retry-storm: a node-level StateProofCache
+        // shared across head-context oracle instances. A verified storage value must
+        // survive an oracle rebuild so a wallet's repeated retries reuse it instead of
+        // re-proving every slot. Prove it: oracle 1 populates the shared cache; oracle 2
+        // (a "later head-context", given a peer that serves NOTHING) must still answer
+        // from cache with zero round-trips.
+        Address addr = Address.fromHex("0xabcdef0102030405060708090a0b0c0d0e0f1011");
+        BigInteger slot = BigInteger.valueOf(7);
+        BigInteger value = new BigInteger("1234567890123456789");
+
+        Bytes32 slotHash = Bytes32.wrap(Hash.keccak256(paddedSlot(slot)).toArrayUnsafe());
+        Bytes valueRlp = RLP.encode(w -> w.writeBigInteger(value));
+        var storageTrie = TrieFixture.singleLeaf(slotHash, valueRlp);
+        Bytes accountValue = encodeAccount(0L, BigInteger.ZERO, storageTrie.root,
+                Bytes32.wrap(Hash.keccak256(Bytes.EMPTY).toArrayUnsafe()));
+        var accountTrie = TrieFixture.singleLeaf(keccak(addr.toByteArray()), accountValue);
+
+        FixturePeer peer = new FixturePeer();
+        peer.addAccountProof(accountTrie.root, accountTrie.proof);
+        peer.addStorageProof(accountTrie.root, storageTrie.proof);
+
+        StateProofCache shared = StateProofCache.inMemory(1024);
+        var oracle1 = new SnapBackedStateOracle(() -> peer, BytecodeCache.inMemory(),
+                SnapBackedStateOracle.DEFAULT_MAX_ATTEMPTS, shared);
+        assertEquals(value, oracle1.fetchStorage(accountTrie.root.toArrayUnsafe(), addr, slot).get());
+
+        SnapPeer deadPeer = new SnapPeer() {
+            @Override public CompletableFuture<List<Bytes>> getTrieNodes(Bytes32 r, List<PathSet> p) {
+                return CompletableFuture.failedFuture(new java.io.IOException("no peer available"));
+            }
+            @Override public CompletableFuture<List<Bytes>> getByteCodes(List<Bytes32> h) {
+                return CompletableFuture.failedFuture(new java.io.IOException("no peer available"));
+            }
+        };
+        var oracle2 = new SnapBackedStateOracle(() -> deadPeer, BytecodeCache.inMemory(),
+                SnapBackedStateOracle.DEFAULT_MAX_ATTEMPTS, shared);
+        assertEquals(value, oracle2.fetchStorage(accountTrie.root.toArrayUnsafe(), addr, slot).get(),
+                "second oracle must serve the slot from the shared cache, no peer round-trip");
+    }
+
+    @Test
+    void noopStateCacheStillRefetchesAcrossOracles() throws Exception {
+        // Control for the test above: with the default noop cache, a fresh oracle has
+        // no memory, so a dead peer DOES fail — confirming the pass above is the cache
+        // working, not the fixture being lenient.
+        Address addr = Address.fromHex("0xabcdef0102030405060708090a0b0c0d0e0f1011");
+        BigInteger slot = BigInteger.valueOf(7);
+        BigInteger value = new BigInteger("1234567890123456789");
+        Bytes32 slotHash = Bytes32.wrap(Hash.keccak256(paddedSlot(slot)).toArrayUnsafe());
+        Bytes valueRlp = RLP.encode(w -> w.writeBigInteger(value));
+        var storageTrie = TrieFixture.singleLeaf(slotHash, valueRlp);
+        Bytes accountValue = encodeAccount(0L, BigInteger.ZERO, storageTrie.root,
+                Bytes32.wrap(Hash.keccak256(Bytes.EMPTY).toArrayUnsafe()));
+        var accountTrie = TrieFixture.singleLeaf(keccak(addr.toByteArray()), accountValue);
+        FixturePeer peer = new FixturePeer();
+        peer.addAccountProof(accountTrie.root, accountTrie.proof);
+        peer.addStorageProof(accountTrie.root, storageTrie.proof);
+
+        var oracle1 = new SnapBackedStateOracle(() -> peer, BytecodeCache.inMemory()); // noop cache
+        assertEquals(value, oracle1.fetchStorage(accountTrie.root.toArrayUnsafe(), addr, slot).get());
+
+        SnapPeer deadPeer = new SnapPeer() {
+            @Override public CompletableFuture<List<Bytes>> getTrieNodes(Bytes32 r, List<PathSet> p) {
+                return CompletableFuture.failedFuture(new java.io.IOException("no peer available"));
+            }
+            @Override public CompletableFuture<List<Bytes>> getByteCodes(List<Bytes32> h) {
+                return CompletableFuture.failedFuture(new java.io.IOException("no peer available"));
+            }
+        };
+        var oracle2 = new SnapBackedStateOracle(() -> deadPeer, BytecodeCache.inMemory());
+        try {
+            oracle2.fetchStorage(accountTrie.root.toArrayUnsafe(), addr, slot).get();
+            fail("without a shared cache, a dead peer must fail");
+        } catch (ExecutionException expected) {
+            // expected — no cache, no peer, no value
+        }
+    }
+
     // ---- Bytecode fetch ----------------------------------------------------
 
     @Test


### PR DESCRIPTION
## Problem

MetaMask's confirm screen hung in skeleton for minutes (often appearing permanent), on both fresh and long-running (3h+) nodes. Diagnosed live on a Pixel 7 by capturing the full RPC wire during real send flows.

## Root causes (in discovery order)

1. **No cross-call state caching.** MetaMask retries identical heavy `eth_call`s (~1000-token BalanceChecker sweep `0xb1f8e55c`, Multicall3 `aggregate3` simulation) every ~30s for minutes; each retry re-fetched hundreds of storage proofs from scratch.
2. **Single-threaded EVM pool + dead work.** ~20 concurrent confirm-screen calls serialized behind one thread; abandoned (timed-out) tasks kept draining the queue, starving live retries (observed: a call completing VERIFIED at 32.6s — queue death, not execution cost).
3. **`eth_gasPrice` recomputed cold on every poll** (header anchor + verified bodies over devp2p: 6.6–17.9s observed). MetaMask's fee poller blocks the confirm render on it and re-polls only every ~5min — matching the observed "renders eventually".
4. **Instant `no verified head` error storms**: when rebuilds failed under load, `lastGoodHead` aged past 30s and every read died — though a cryptographically anchored context minutes old was servable within the existing 64-block pinned-read tolerance.
5. **Small calls starved by sweeps**: the 516B Multicall3 simulation and 36B probes queued to death behind 32KB sweep retries occupying all EVM threads.
6. **THE root cause (uptime-independent): head-root churn defeats the cache.** MetaMask pins a confirm to ONE block number; our head context rebuilds to a new `stateRoot` every ~12–15s; the stateRoot-keyed cache reset on every rebuild, so the heavy calls **never converged** — explaining why a 3-hour-old node hung identically.

## Fixes (one commit each)

1. `StateProofCache` — node-level cache of **proof-verified** account/storage state keyed by stateRoot, shared across head-context oracles. Safe: entries stored only after MPT verification — a cached `(root,addr,slot)→value` is a cryptographic fact. Bounded LRU.
2. Prefetch fairness: `PREFETCH_MAX_IN_FLIGHT` 128→48.
3. EVM pool 1→3 threads + stale-task skip (queued >35s = caller long gone → dropped).
4. `FeeSnapshot` precomputed by the head warmer — `eth_gasPrice` **17.9s → 2ms** on-device.
5. Serve stale-but-anchored head up to the 64-block pinned-read horizon (verification never expires; only freshness ages).
6. Two-lane EVM pool: 1 thread reserved for calldata ≤4KB so confirm calls jump past sweep storms.
7. Prime confirm-critical contracts (ENS Registry, Multicall3, BalanceChecker) after each head build.
8. **Frozen per-block context**: first read pinned to block N freezes the anchored context; all retries at N reuse the same stateRoot so the cache accumulates. Bounded LRU(16), aged at the stale horizon, cleared on shutdown.

## Validation (on-device, Pixel 7)

- Synthetic confirm burst (20 concurrent token calls + cheap reads, pinned block): before — retry **0/20 ok forever**; after — retry1 16/20, retry2 **20/20 ok in 5.5s wall-clock**, cheap reads 260ms (were 9–28s).
- Frozen-context (rounds spaced 40s, each spanning a head rebuild): **1/20 → 5/20 → 6/20 ok monotonic** — the cache now survives head rebuilds (pre-fix each round reset to ~1/20).
- Live MetaMask confirm wire: `eth_gasPrice` 2–5ms, `getCode` 248ms, simulation calls VERIFIED, zero instant-error storms.
- All `myotis-evm` tests green incl. new shared-cache-across-oracles test + noop control.

Remaining on-device limits are environmental (mobile snap throughput; stale post-restart peer batches), which the planned daemon JSON-RPC (#stacked PR) sidesteps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)