### PR TITLE
rpc-backend: scaffold shared verified-RPC module (daemon JSON-RPC for rotki)

### DIFF
--- a/rpc-backend/build.gradle.kts
+++ b/rpc-backend/build.gradle.kts
@@ -1,0 +1,50 @@
+// :rpc-backend — the shared, verified JSON-RPC backend.
+//
+// Hosts the verified-read machinery (head-context anchoring, the snap-backed
+// state oracle wiring, the cross-call StateProofCache, fee derivation, the
+// per-pinned-block frozen context) behind the `MyotisRpcBackend` interface from
+// :jsonrpc-server, plus the shared `EthHandlerSnapPeer` adapter that bridges
+// :networking's EthHandler to :myotis-evm's SnapPeer.
+//
+// This is the single implementation that BOTH :android-app (NodeService) and the
+// :app CLI daemon construct, so the verified-RPC logic — and the confirm-screen
+// fixes — live once. Before this module, that logic was Android-only in
+// NodeService and the adapter was copy-pasted into :app and :android-app (no
+// common module saw both :networking and :myotis-evm). This module does.
+//
+// Java 21 source/target: it depends on :networking (discv5) and :myotis-evm
+// (Besu), both of which publish JVM-21 Gradle metadata, so a 21 consumer is
+// required (same rationale as those modules; CLAUDE.md's 17 default yields when
+// a transitive forces 21). AGP 8.7's D8 dexes 21 class files for :android-app.
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
+
+dependencies {
+    // The MyotisRpcBackend interface + RpcRouter/MyotisRpcServer this implements.
+    implementation(project(":jsonrpc-server"))
+
+    // Verified-read primitives, shared with both hosts.
+    implementation(project(":core"))
+    implementation(project(":networking"))
+    implementation(project(":consensus"))
+    implementation(project(":myotis-evm"))
+    implementation(project(":myotis-ens"))
+
+    implementation(libs.tuweni.bytes)
+    implementation(libs.tuweni.units)
+    implementation(libs.tuweni.crypto)
+    implementation(libs.tuweni.rlp)
+
+    implementation(libs.slf4j.api)
+
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.junit.jupiter)
+    testRuntimeOnly(libs.logback.classic)
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/rpc-backend/src/main/java/io/myotis/rpc/RpcClock.java
+++ b/rpc-backend/src/main/java/io/myotis/rpc/RpcClock.java
@@ -1,0 +1,21 @@
+package io.myotis.rpc;
+
+/**
+ * Monotonic millisecond clock seam. The backend's TTLs and staleness windows
+ * (head-context freshness, fee-snapshot age, frozen-pin age) need a monotonic
+ * source unaffected by wall-clock jumps. {@code :android-app} backs this with
+ * {@code android.os.SystemClock.elapsedRealtime()}; the daemon with
+ * {@link System#nanoTime()}. Kept as a seam so the shared module pulls in no
+ * Android API.
+ */
+@FunctionalInterface
+public interface RpcClock {
+
+    /** A monotonically non-decreasing time in milliseconds (arbitrary epoch). */
+    long elapsedMillis();
+
+    /** Default monotonic clock from {@link System#nanoTime()} (daemon/tests). */
+    static RpcClock monotonic() {
+        return () -> System.nanoTime() / 1_000_000L;
+    }
+}

--- a/rpc-backend/src/main/java/io/myotis/rpc/RpcLogger.java
+++ b/rpc-backend/src/main/java/io/myotis/rpc/RpcLogger.java
@@ -1,0 +1,26 @@
+package io.myotis.rpc;
+
+/**
+ * Logging seam for the shared RPC backend. Each host routes it to its own sink:
+ * {@code :android-app} to its in-app {@code LogBuffer} (so RPC lines show in the
+ * Logs tab), the {@code :app} daemon to slf4j. Keeps the shared backend free of
+ * any Android ({@code android.util.Log}) or daemon-specific logging dependency.
+ *
+ * <p>Methods take a tag + message (and optional throwable) mirroring the common
+ * subset of both sinks; levels below info are folded into {@link #info} by
+ * default-method, since the backend only emits info/warn in practice.
+ */
+public interface RpcLogger {
+
+    void info(String message);
+
+    void warn(String message);
+
+    /** Default: route to a no-tag slf4j-style logger that prints nothing. */
+    static RpcLogger noop() {
+        return new RpcLogger() {
+            @Override public void info(String message) { }
+            @Override public void warn(String message) { }
+        };
+    }
+}

--- a/rpc-backend/src/main/java/io/myotis/rpc/SnapQualitySink.java
+++ b/rpc-backend/src/main/java/io/myotis/rpc/SnapQualitySink.java
@@ -1,0 +1,31 @@
+package io.myotis.rpc;
+
+import java.net.InetSocketAddress;
+
+/**
+ * Sink for per-peer snap-serving quality verdicts produced by the oracle path,
+ * so good snap peers are remembered across restarts and repeat hangers are
+ * deprioritized. The shared backend calls these from the snap routing supplier's
+ * served/denied callbacks (via {@link io.myotis.rpc.snap.EthHandlerSnapPeer}); each
+ * host implements persistence its own way — {@code :android-app} into its
+ * filesDir peer cache, the {@code :app} daemon into its on-disk peer cache — so
+ * both get the EL peer-quality optimization without the backend knowing how the
+ * cache is stored.
+ */
+public interface SnapQualitySink {
+
+    /** The peer at {@code address} returned a usable proof — mark it snap-confirmed. */
+    void recordSnapServed(InetSocketAddress address);
+
+    /** The peer at {@code address} failed to serve the current root (empty/invalid
+     *  proof, timeout, IO) — count toward denial. */
+    void recordSnapFailure(InetSocketAddress address);
+
+    /** No-op sink for hosts/tests that don't persist peer quality. */
+    static SnapQualitySink noop() {
+        return new SnapQualitySink() {
+            @Override public void recordSnapServed(InetSocketAddress address) { }
+            @Override public void recordSnapFailure(InetSocketAddress address) { }
+        };
+    }
+}

--- a/rpc-backend/src/main/java/io/myotis/rpc/snap/EthHandlerSnapPeer.java
+++ b/rpc-backend/src/main/java/io/myotis/rpc/snap/EthHandlerSnapPeer.java
@@ -1,0 +1,116 @@
+package io.myotis.rpc.snap;
+
+import com.jaeckel.ethp2p.networking.eth.EthHandler;
+import com.jaeckel.ethp2p.networking.snap.messages.AccountRangeMessage;
+import com.jaeckel.ethp2p.networking.snap.messages.ByteCodesMessage;
+import com.jaeckel.ethp2p.networking.snap.messages.StorageRangesMessage;
+import io.myotis.evm.world.SnapPeer;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * {@link SnapPeer} adapter over a single {@link EthHandler}.
+ *
+ * <p>Port of {@code com.jaeckel.ethp2p.app.snap.EthHandlerSnapPeer}. The bridge
+ * has to live in a module that sees both {@code :networking} (the wire layer)
+ * and {@code :myotis-evm} (the EVM's {@code SnapPeer}); {@code :app} can't be a
+ * dependency of {@code :android-app}, so the adapter is duplicated here. If a
+ * third consumer appears, extract it into a shared {@code :snap-evm-bridge}
+ * module instead of copying a third time.
+ *
+ * <p>Routes through {@code GetAccountRange} (account-only path sets) and
+ * {@code GetStorageRanges} (path sets carrying a storage slot) rather than
+ * {@code GetTrieNodes}, because only those return the full root-to-leaf Merkle
+ * proof {@code SnapBackedStateOracle} needs to descend from a stateRoot.
+ */
+public final class EthHandlerSnapPeer implements SnapPeer {
+
+    private final EthHandler handler;
+    private final Runnable onRootUnavailable;
+    private final Runnable onRootServed;
+
+    public EthHandlerSnapPeer(EthHandler handler) {
+        this(handler, null, null);
+    }
+
+    /** @param onRootUnavailable run when the oracle reports this peer can't serve the
+     *  current state root, so the routing supplier can deprioritize it for this head. */
+    public EthHandlerSnapPeer(EthHandler handler, Runnable onRootUnavailable) {
+        this(handler, onRootUnavailable, null);
+    }
+
+    /**
+     * @param onRootUnavailable run when the oracle reports this peer can't serve the
+     *  current state root (deprioritize it for this head).
+     * @param onRootServed run when this peer returns a usable (non-empty) proof, so
+     *  the EL peer cache can record it as a proven snap-serving peer to dial first
+     *  on a restart. The two callbacks are mutually exclusive per fetch: a non-empty
+     *  proof fires {@code onRootServed}; an empty one is treated by the oracle as
+     *  no-state and ultimately fires {@code onRootUnavailable}.
+     */
+    public EthHandlerSnapPeer(EthHandler handler, Runnable onRootUnavailable, Runnable onRootServed) {
+        this.handler = handler;
+        this.onRootUnavailable = onRootUnavailable;
+        this.onRootServed = onRootServed;
+    }
+
+    @Override
+    public void reportRootUnavailable() {
+        if (onRootUnavailable != null) onRootUnavailable.run();
+    }
+
+    @Override
+    public CompletableFuture<List<Bytes>> getTrieNodes(Bytes32 stateRoot, List<PathSet> paths) {
+        List<CompletableFuture<List<Bytes>>> perSet = new ArrayList<>(paths.size());
+        for (PathSet p : paths) {
+            Bytes32 accountHash = Bytes32.wrap(p.accountPath());
+            if (p.storagePaths().isEmpty()) {
+                perSet.add(handler.requestAccountByHashAsync(accountHash, stateRoot)
+                    .thenApply(AccountRangeMessage.DecodeResult::proof));
+            } else {
+                List<CompletableFuture<List<Bytes>>> storageFuts =
+                    new ArrayList<>(p.storagePaths().size());
+                for (Bytes sp : p.storagePaths()) {
+                    Bytes32 slotHash = Bytes32.wrap(sp);
+                    storageFuts.add(handler
+                        .requestStorageByHashAsync(accountHash, slotHash, stateRoot)
+                        .thenApply(StorageRangesMessage.DecodeResult::proof));
+                }
+                perSet.add(CompletableFuture
+                    .allOf(storageFuts.toArray(new CompletableFuture<?>[0]))
+                    .thenApply(v -> {
+                        List<Bytes> merged = new ArrayList<>();
+                        for (CompletableFuture<List<Bytes>> f : storageFuts) {
+                            merged.addAll(f.join());
+                        }
+                        return merged;
+                    }));
+            }
+        }
+        return CompletableFuture.allOf(perSet.toArray(new CompletableFuture<?>[0]))
+            .thenApply(v -> {
+                List<Bytes> all = new ArrayList<>();
+                for (CompletableFuture<List<Bytes>> f : perSet) {
+                    all.addAll(f.join());
+                }
+                // A non-empty proof means this peer actually retains the trie for
+                // this root — the durable "snap-serving" signal the EL cache wants.
+                // Empty proofs fall through to the oracle's no-state path, which
+                // calls reportRootUnavailable instead.
+                if (!all.isEmpty() && onRootServed != null) {
+                    try { onRootServed.run(); } catch (RuntimeException ignore) {}
+                }
+                return all;
+            });
+    }
+
+    @Override
+    public CompletableFuture<List<Bytes>> getByteCodes(List<Bytes32> hashes) {
+        return handler.requestByteCodesAsync(hashes)
+                .thenApply(ByteCodesMessage.DecodeResult::codes);
+    }
+}

--- a/rpc-backend/src/main/java/io/myotis/rpc/snap/EthHandlerSnapPeer.java
+++ b/rpc-backend/src/main/java/io/myotis/rpc/snap/EthHandlerSnapPeer.java
@@ -100,9 +100,14 @@ public final class EthHandlerSnapPeer implements SnapPeer {
                 // A non-empty proof means this peer actually retains the trie for
                 // this root — the durable "snap-serving" signal the EL cache wants.
                 // Empty proofs fall through to the oracle's no-state path, which
-                // calls reportRootUnavailable instead.
+                // calls reportRootUnavailable instead. Offloaded: this completion
+                // chain runs on the Netty event loop, and a host's quality sink may
+                // block (lock contention, sync persistence) — a shared adapter must
+                // not let a host callback stall network processing.
                 if (!all.isEmpty() && onRootServed != null) {
-                    try { onRootServed.run(); } catch (RuntimeException ignore) {}
+                    CompletableFuture.runAsync(() -> {
+                        try { onRootServed.run(); } catch (RuntimeException ignore) {}
+                    });
                 }
                 return all;
             });

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -36,4 +36,4 @@ dependencyResolutionManagement {
     }
 }
 
-include("core", "networking", "consensus", "app", "android-app", "myotis-evm", "myotis-ens", "jsonrpc-server")
+include("core", "networking", "consensus", "app", "android-app", "myotis-evm", "myotis-ens", "jsonrpc-server", "rpc-backend")


### PR DESCRIPTION
## What

First increment of extracting the verified JSON-RPC backend out of `NodeService` into a module **both** `:android-app` and the `:app` CLI daemon consume — so the daemon serves JSON-RPC on `127.0.0.1:8545` (for rotki) from the *same* implementation as Android, instead of a second copy.

**Stacked on #49** (extracts that branch's logic, so it must land first).

- New `:rpc-backend` Java 21 module: depends on `:jsonrpc-server` (the `MyotisRpcBackend` interface) + `core`/`networking`/`consensus`/`myotis-evm`/`myotis-ens`.
- Moves `EthHandlerSnapPeer` (the complete android-app copy with the `onRootServed` quality hook) to `io.myotis.rpc.snap` — the first module that sees both `:networking` and `:myotis-evm`, giving the previously copy-pasted adapter one home.
- Host-seam interfaces keeping the shared backend free of Android/daemon specifics:
  - `RpcLogger` (LogBuffer vs slf4j)
  - `RpcClock` (SystemClock.elapsedRealtime vs System.nanoTime)
  - `SnapQualitySink` (each host persists snap peer-quality verdicts its own way — the daemon gets the #47 peer-caching optimizations through this seam)

## Not yet in this PR (next increments)

- Port of NodeService's head-context + `rpc*` methods into `VerifiedRpcBackend implements MyotisRpcBackend`
- NodeService rewired onto the shared backend
- Daemon wiring: `MyotisRpcServer` on loopback 8545 + quality-aware daemon peer cache

The old `:app`/`:android-app` adapter copies are intentionally left in place until the hosts are rewired (next increment), so this PR is purely additive and both hosts build unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)