### PR TITLE
android: arm the RPC capture tap in debug builds

### DIFF
--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -1254,6 +1254,16 @@ public final class NodeService extends Service {
             // start() spins up the head warmer (replaces the old startHeadWarmer()).
             backend.start();
             this.rpcBackend = backend;
+            // DEBUG builds: arm MyotisRpcServer's request-capture tap (same JSONL the
+            // daemon records with -Dmyotis.rpc.capture) so a wallet session on-device
+            // can be pulled and diffed against a desktop capture / fed to the replay
+            // harness:  adb pull /sdcard/Android/data/<pkg>/files/rpc-capture.jsonl
+            // app-private external storage, debug-only — release builds never capture.
+            if (BuildConfig.DEBUG && System.getProperty("myotis.rpc.capture") == null) {
+                java.io.File cap = new java.io.File(getExternalFilesDir(null), "rpc-capture.jsonl");
+                System.setProperty("myotis.rpc.capture", cap.getAbsolutePath());
+                LogBuffer.i(TAG, "[rpc] capture tap -> " + cap.getAbsolutePath());
+            }
             // Bind loopback-only: the wallet (MetaMask) runs on the same device and
             // reaches us via localhost. Binding 0.0.0.0 would expose an unauthenticated,
             // TLS-less RPC — incl. eth_sendRawTransaction relay — to the whole LAN.

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -1260,9 +1260,18 @@ public final class NodeService extends Service {
             // harness:  adb pull /sdcard/Android/data/<pkg>/files/rpc-capture.jsonl
             // app-private external storage, debug-only — release builds never capture.
             if (BuildConfig.DEBUG && System.getProperty("myotis.rpc.capture") == null) {
-                java.io.File cap = new java.io.File(getExternalFilesDir(null), "rpc-capture.jsonl");
-                System.setProperty("myotis.rpc.capture", cap.getAbsolutePath());
-                LogBuffer.i(TAG, "[rpc] capture tap -> " + cap.getAbsolutePath());
+                // getExternalFilesDir(null) returns null when external storage is
+                // unavailable (unmounted/emulated-but-not-ready); new File(null, name)
+                // would resolve to a relative path in the process CWD. Skip arming the
+                // tap rather than write somewhere unexpected — it's a debug aid.
+                java.io.File dir = getExternalFilesDir(null);
+                if (dir != null) {
+                    java.io.File cap = new java.io.File(dir, "rpc-capture.jsonl");
+                    System.setProperty("myotis.rpc.capture", cap.getAbsolutePath());
+                    LogBuffer.i(TAG, "[rpc] capture tap -> " + cap.getAbsolutePath());
+                } else {
+                    LogBuffer.w(TAG, "[rpc] capture tap NOT armed: external files dir unavailable");
+                }
             }
             // Bind loopback-only: the wallet (MetaMask) runs on the same device and
             // reaches us via localhost. Binding 0.0.0.0 would expose an unauthenticated,


### PR DESCRIPTION
The shared `MyotisRpcServer` has had a request/response capture tap since #54 (`-Dmyotis.rpc.capture` → JSONL), but Android never set the property, so on-device wallet sessions couldn't be recorded.

Arm it in **DEBUG builds only**, writing to app-private external storage:

```
adb pull /sdcard/Android/data/com.jaeckel.ethp2p.android/files/rpc-capture.jsonl
```

This makes a phone MetaMask session directly comparable to a desktop capture of the same flow (method sets, params, latencies, error rates) and feedable to `tools/mm-replay` — the missing piece for debugging the MM-Android vs MM-desktop behavior differences. Release builds never capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)