### PR TITLE
android: readiness traffic-light strip atop the tab bar

### DIFF
--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/MainActivity.kt
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/MainActivity.kt
@@ -17,6 +17,8 @@ import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.background
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -418,11 +420,17 @@ private const val READY_HEAD_WARM_MS = 45_000L
 @Composable
 private fun ReadinessStrip(snapshot: NodeService.Snapshot?) {
     val s = snapshot
-    val target = when {
-        s == null || !s.running -> Color(0xFFD32F2F)                       // red
-        s.beaconState != "SYNCED" -> Color(0xFFD32F2F)                     // red
-        s.verifiedHeadAgeMs <= READY_HEAD_WARM_MS -> Color(0xFF2E7D32)     // green
-        else -> Color(0xFFF9A825)                                         // amber
+    // Color AND a spoken label, derived together so they can never disagree. The
+    // label is exposed via semantics so the readiness state is discoverable by
+    // TalkBack and not conveyed by color alone (red/amber/green is invisible to
+    // color-vision deficiencies). The strip stays a thin non-interactive line by
+    // design; the description is its only a11y surface.
+    val (target, label) = when {
+        s == null || !s.running -> Color(0xFFD32F2F) to "Node readiness: not running"
+        s.beaconState != "SYNCED" -> Color(0xFFD32F2F) to "Node readiness: not synced"
+        s.verifiedHeadAgeMs <= READY_HEAD_WARM_MS ->
+            Color(0xFF2E7D32) to "Node readiness: ready to transact"
+        else -> Color(0xFFF9A825) to "Node readiness: warming up, not ready to transact"
     }
     // Ease between states so a transient amber blip during a rebuild reads as a
     // gentle pulse, not a jarring flash.
@@ -431,7 +439,8 @@ private fun ReadinessStrip(snapshot: NodeService.Snapshot?) {
         Modifier
             .fillMaxWidth()
             .height(3.dp)
-            .background(color),
+            .background(color)
+            .semantics { contentDescription = label },
     )
 }
 

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/MainActivity.kt
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/MainActivity.kt
@@ -15,6 +15,8 @@ import android.os.IBinder
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -295,6 +297,11 @@ private fun NodeScreen(
         // determinate as the light client catches up sync-committee periods, gone
         // once SYNCED.
         SyncProgressBar(snapshot)
+        // Readiness traffic-light: a thin strip atop the tabs. red = consensus not
+        // synced; amber = synced but no warm verified head yet (wallet calls will
+        // error -32000); green = warmed up, safe to transact. The third gate that
+        // nothing else surfaced — turns "is it ready?" from an adb curl into a glance.
+        ReadinessStrip(snapshot)
         TabRow(selectedTabIndex = selectedTab) {
             Tab(
                 selected = selectedTab == 0,
@@ -387,6 +394,45 @@ private fun SyncProgressBar(snapshot: NodeService.Snapshot?) {
             LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
         }
     }
+}
+
+/**
+ * Readiness traffic-light — a thin full-width strip atop the tab bar encoding the
+ * THREE gates a wallet transaction needs, the way nothing else in the UI does:
+ *
+ *  - **red**   — not running, or consensus light client not SYNCED yet. The node
+ *                can't serve anything verified; don't transact.
+ *  - **amber** — beacon SYNCED but no warm verified RPC head (snap peers absent /
+ *                head-build failing). Wallet calls error `-32000 no verified head`,
+ *                so MetaMask's confirm screen stalls. "Almost — wait."
+ *  - **green** — a verified head was built within [READY_HEAD_WARM_MS]. eth_call /
+ *                balances / the confirm-screen simulation will serve. Safe to send.
+ *
+ * The green gate reads [NodeService.Snapshot.verifiedHeadAgeMs] (from the shared
+ * backend's warmer). Threshold is generous vs. the head TTL+build time on mobile
+ * (~12s TTL + 20-26s build) so a healthy node stays green between rebuilds instead
+ * of flickering amber.
+ */
+private const val READY_HEAD_WARM_MS = 45_000L
+
+@Composable
+private fun ReadinessStrip(snapshot: NodeService.Snapshot?) {
+    val s = snapshot
+    val target = when {
+        s == null || !s.running -> Color(0xFFD32F2F)                       // red
+        s.beaconState != "SYNCED" -> Color(0xFFD32F2F)                     // red
+        s.verifiedHeadAgeMs <= READY_HEAD_WARM_MS -> Color(0xFF2E7D32)     // green
+        else -> Color(0xFFF9A825)                                         // amber
+    }
+    // Ease between states so a transient amber blip during a rebuild reads as a
+    // gentle pulse, not a jarring flash.
+    val color by animateColorAsState(targetValue = target, label = "readiness")
+    Box(
+        Modifier
+            .fillMaxWidth()
+            .height(3.dp)
+            .background(color),
+    )
 }
 
 @Composable

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -230,6 +230,10 @@ public final class NodeService extends Service {
             long syncStartPeriod,
             long syncCurrentPeriod,
             long syncTargetPeriod,
+            // Age (ms) of the last verified RPC head, Long.MAX_VALUE if none built yet.
+            // The readiness traffic-light's green gate: a recent head means wallet
+            // calls serve instead of hitting "no verified head".
+            long verifiedHeadAgeMs,
             List<RLPxConnector.PeerInfo> readyPeerList) {}
 
     /** Result of a get-account query. Mirrors the JVM daemon's JSON response shape. */
@@ -1419,7 +1423,7 @@ public final class NodeService extends Service {
                     bs.state, bs.bootstrapped, bs.connected, bs.lc,
                     cachedClPeerCount, bs.finalizedSlot, bs.execBlockNum, bs.execBlockHashHex,
                     bs.syncStartPeriod, bs.syncCurrentPeriod, bs.syncTargetPeriod,
-                    List.of());
+                    Long.MAX_VALUE, List.of());
         }
         List<RLPxConnector.PeerInfo> active = connector.getActivePeers();
         List<RLPxConnector.PeerInfo> ready = new ArrayList<>();
@@ -1435,13 +1439,15 @@ public final class NodeService extends Service {
                 .comparing(RLPxConnector.PeerInfo::snapSupported).reversed()
                 .thenComparing(p -> p.clientId() == null ? "" : p.clientId()));
         int tableSize = discV4 != null ? discV4.table().size() : 0;
+        io.myotis.rpc.VerifiedRpcBackend backend = rpcBackend;
+        long headAge = backend != null ? backend.verifiedHeadAgeMs() : Long.MAX_VALUE;
         return new Snapshot(true, startTimeMs, tableSize, active.size(), ready.size(), snapCount,
                 cachedPeerCount, attempted.size(), countActiveBackoff(),
                 blacklistedNodeIds.size(), discv5Live, clPeersDiscovered.get(),
                 bs.state, bs.bootstrapped, bs.connected, bs.lc,
                 cachedClPeerCount, bs.finalizedSlot, bs.execBlockNum, bs.execBlockHashHex,
                 bs.syncStartPeriod, bs.syncCurrentPeriod, bs.syncTargetPeriod,
-                ready);
+                headAge, ready);
     }
 
     /** Per-snapshot beacon view, computed once so the record fields stay consistent. */

--- a/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
+++ b/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
@@ -838,6 +838,15 @@ public final class VerifiedRpcBackend implements io.myotis.jsonrpc.MyotisRpcBack
         return good == null ? Long.MAX_VALUE : clock.elapsedMillis() - good.builtAtMs();
     }
 
+    /** Public readiness probe: age (ms) of the last verified head, {@code Long.MAX_VALUE}
+     *  if none built yet. A host UI surfaces "warmed up" from this — a recent head means
+     *  wallet reads/calls (eth_call, balances, the confirm-screen simulation) will serve
+     *  rather than hit the "no verified head" path. This is the third readiness gate
+     *  beyond beacon-SYNCED and snap-peers-connected, and the one nothing else exposes. */
+    public long verifiedHeadAgeMs() {
+        return headAgeMs();
+    }
+
     /** True while an anchored-head build is in flight (warmer or a prior read), so a
      *  waiting read can ride it instead of erroring early. */
     private boolean headBuildInFlight() {


### PR DESCRIPTION
## Why

The status screen showed beacon **SYNCED** but nothing about whether the node could actually serve a wallet — and beacon-SYNCED is only the **first of three gates**. The other two (snap peers connected, a verified RPC head built) were invisible, so every MetaMask attempt was a guess.

A capture comparison of an on-device MM send that stalled showed the verified head collapsing for ~2 minutes (every `eth_call` → `-32000 no verified head`) **with zero indication in the UI** — the user couldn't tell "warming up" from "ready."

## What

A thin full-width strip above the tabs encoding all three gates at a glance:

| Color | Meaning |
|---|---|
| 🔴 red | not running, or consensus light client not `SYNCED` |
| 🟡 amber | `SYNCED` but no warm verified head — wallet calls error `-32000`, confirm screen will stall |
| 🟢 green | a verified head was built within 45s — `eth_call`/balances/the confirm-screen simulation serve; safe to transact |

### Plumbing
- `VerifiedRpcBackend.verifiedHeadAgeMs()` — exposes the head warmer's last-build age (the green gate; nothing else surfaced it).
- `NodeService.Snapshot` carries it; `snapshot()` reads it from the shared backend.
- `MainActivity.ReadinessStrip()` renders a 3dp strip with `animateColorAsState` so a transient rebuild blip eases rather than flashes. The 45s threshold is generous vs. mobile head TTL+build (~12s TTL + 20–26s build) so a healthy node stays green between rebuilds instead of flickering amber.

## Validation
On-device: strip went **red** (node stopped) → **green** (SYNCED + warm head), and green coincided with `eth_getBalance` serving a real value (`0x7bc7…`). Builds: `:rpc-backend` tests green, `assembleDebug` green.

> Note: this makes the verified-head collapse *visible*; the underlying head-build/LC-wedge resilience that causes the collapse is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)