### PR TITLE
rpc+android: fast-fail unservable state reads + deepen the mobile snap pool

### DIFF
--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -99,9 +99,20 @@ public final class NodeService extends Service {
     private static final long DNS_REFRESH_INTERVAL_MS = 4 * 60 * 1000L;
     // Keep a working set of snap peers connected so a verified request almost
     // always finds one even as peers churn. Below this we proactively re-dial
-    // known snap peers from the cache; 4 leaves headroom so transient churn
-    // doesn't drop us below the ~2 a request realistically needs.
-    private static final int TARGET_SNAP_PEERS = 4;
+    // known snap peers from the cache (CONFIRMED-quality first, via snapDialRank).
+    //
+    // 12, not 4: being a snap peer is NOT the same as retaining the state at the
+    // head root we anchor. Geth prunes trie state beyond ~128 blocks and snap-serves
+    // from a flat layer that lags the head, so at any moment only SOME connected snap
+    // peers can serve the current root — the rest fail with StateUnavailable. On-device
+    // captures showed eth_call/the confirm-screen Multicall3 sim failing for minutes
+    // with several snap peers connected: 4 wasn't a deep enough pool to reliably hold
+    // one peer whose retained state covers the head. A deeper pool makes the
+    // probe-and-pin build (firstPeerServing / the PEER_HEAD race) far likelier to find
+    // a state-servable peer. The daemon holds ~36 organically with no ill effect;
+    // 12 lightweight eth/snap connections is a fine bound for a phone actively serving
+    // a wallet in the foreground.
+    private static final int TARGET_SNAP_PEERS = 12;
     // Same bound the JVM daemon uses (CommandHandler.MAX_HEADER_CHAIN_GAP).
     // Caps how many headers we'll fetch to bridge from the beacon-finalized
     // block to the peer's head — i.e. the maximum gap the headerChain

--- a/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
+++ b/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
@@ -1282,25 +1282,25 @@ public final class VerifiedRpcBackend implements io.myotis.jsonrpc.MyotisRpcBack
      *  STALE head to a state callView so a doomed read fails fast instead of timing out.
      *  Verdict cached for {@link #STALE_PROBE_CACHE_MS} keyed by root so a confirm-screen
      *  burst on one root shares a single probe rather than hammering every peer N times. */
-    private volatile byte[] probedRoot;
-    private volatile boolean probedRootServable;
-    private volatile long probedRootAtMs;
+    private record ProbeVerdict(byte[] root, boolean servable, long atMs) {}
+    /** One immutable unit behind a single volatile so root, verdict and timestamp are
+     *  read/written atomically together — a reader can't pair a fresh root with a stale
+     *  timestamp/verdict (same pattern as {@link HeadWithTimestamp} / {@code FeeSnapshot}). */
+    private volatile ProbeVerdict lastRootProbe;
 
     private boolean anyPeerServesRoot(byte[] stateRoot) {
         if (stateRoot == null) return false;
         long now = clock.elapsedMillis();
-        byte[] cachedRoot = probedRoot;
-        if (cachedRoot != null && java.util.Arrays.equals(cachedRoot, stateRoot)
-                && now - probedRootAtMs < STALE_PROBE_CACHE_MS) {
-            return probedRootServable;
+        ProbeVerdict v = lastRootProbe;
+        if (v != null && java.util.Arrays.equals(v.root(), stateRoot)
+                && now - v.atMs() < STALE_PROBE_CACHE_MS) {
+            return v.servable();
         }
         RLPxConnector c = connector;
         List<EthHandler> peers = (c == null) ? List.of() : c.activeSnapHandlers();
         boolean ok = !peers.isEmpty()
                 && firstPeerServing(peers, Bytes32.wrap(stateRoot), RPC_STALE_PROBE_TIMEOUT_SEC) != null;
-        probedRoot = stateRoot.clone();
-        probedRootServable = ok;
-        probedRootAtMs = now;
+        lastRootProbe = new ProbeVerdict(stateRoot.clone(), ok, now);
         return ok;
     }
 

--- a/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
+++ b/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
@@ -88,6 +88,14 @@ public final class VerifiedRpcBackend implements io.myotis.jsonrpc.MyotisRpcBack
     private static final long RPC_ACCOUNT_TIMEOUT_SEC = HEADER_CHAIN_TIMEOUT_SEC + 10;
     /** Overall budget for the (parallel) snap-peer head probe. */
     private static final long PEER_PROBE_TIMEOUT_SEC = 15;
+    /** Tight timeout for the pre-stale-serve servability probe: we're already in the
+     *  degraded last-resort path, so a doomed read should fail in a few seconds, not
+     *  rotate the peer set for the full 30s callView. */
+    private static final long RPC_STALE_PROBE_TIMEOUT_SEC = 3;
+    /** A stale-head servability verdict is cached this long (keyed by root) so a burst
+     *  of confirm-screen calls on one root shares a single probe. Short — a peer can
+     *  drop the root between bursts, but within a couple seconds the verdict holds. */
+    private static final long STALE_PROBE_CACHE_MS = 2_000;
     /** Keep serving the last successfully-built head up to this age while a refresh
      *  is in flight. It's still beacon-anchored, just a few blocks stale — serving
      *  it bridges transient rebuild gaps (head just advanced, peers' flat state not
@@ -762,7 +770,7 @@ public final class VerifiedRpcBackend implements io.myotis.jsonrpc.MyotisRpcBack
                 return frozen.head();
             }
         }
-        RpcCallContext ctx = anchoredHeadOrWait(RPC_STATE_HEAD_MAX_STALE_MS);
+        RpcCallContext ctx = anchoredHeadOrWait(RPC_STATE_HEAD_MAX_STALE_MS, true);
         if (ctx == null) return null;
         if (requestedNum >= 0) {
             // A pinned number means "the latest block I saw" — wallets fetch
@@ -806,8 +814,11 @@ public final class VerifiedRpcBackend implements io.myotis.jsonrpc.MyotisRpcBack
      *  {@code maxStaleMs} caps how old a last-resort stale head may be: STATE-execution
      *  callers pass the tight {@link #RPC_STATE_HEAD_MAX_STALE_MS} (the root must still
      *  be snap-servable); header-only callers pass the long {@link
-     *  #RPC_HEAD_SERVE_STALE_MAX_MS}. */
-    private RpcCallContext anchoredHeadOrWait(long maxStaleMs) {
+     *  #RPC_HEAD_SERVE_STALE_MAX_MS}. {@code probeStaleServe} (state reads only) probes
+     *  that a connected peer actually serves the stale head's root before returning it
+     *  — so a doomed read fast-errors in ~{@link #RPC_STALE_PROBE_TIMEOUT_SEC}s instead
+     *  of handing the dead root to a 30s callView that StateUnavailable-times-out. */
+    private RpcCallContext anchoredHeadOrWait(long maxStaleMs, boolean probeStaleServe) {
         // Fast path: serve the last good head if it's recent enough. It stays
         // beacon-anchored; a few seconds stale beats erroring, and it bridges the
         // brief windows where a TTL-expiry rebuild can't yet anchor the just-
@@ -850,6 +861,18 @@ public final class VerifiedRpcBackend implements io.myotis.jsonrpc.MyotisRpcBack
         // warmer keeps retrying fresh builds in the background regardless.
         HeadWithTimestamp stale = lastGoodHead.get();
         if (stale != null && clock.elapsedMillis() - stale.builtAtMs() < maxStaleMs) {
+            // Probe-before-serve for STATE reads: the rebuild just failed, so this aged
+            // root may no longer be snap-servable. A quick probe (~RPC_STALE_PROBE_TIMEOUT
+            // s) that some peer still serves it turns the common "serve dead root → 30s
+            // StateUnavailable timeout, ×20 across a confirm-screen burst" into a fast
+            // clean error the wallet can retry. Header-only callers skip the probe (they
+            // anchor headers, not state). Cached briefly so a burst shares one probe.
+            if (probeStaleServe && !anyPeerServesRoot(stale.head().blockCtx().stateRoot())) {
+                log.info("[rpc] STALE head #" + stale.head().blockNumber() + " ("
+                        + (clock.elapsedMillis() - stale.builtAtMs()) / 1000
+                        + "s old) not snap-servable by any peer -> fast-error (skip 30s callView)");
+                return null;
+            }
             log.info("[rpc] serving STALE anchored head (block #"
                     + stale.head().blockNumber() + ", "
                     + (clock.elapsedMillis() - stale.builtAtMs()) / 1000
@@ -1231,6 +1254,10 @@ public final class VerifiedRpcBackend implements io.myotis.jsonrpc.MyotisRpcBack
      *  or null. Probes all peers CONCURRENTLY (same rationale as the PEER_HEAD probe)
      *  and awards the first to serve the root. */
     private EthHandler firstPeerServing(List<EthHandler> peers, Bytes32 root) {
+        return firstPeerServing(peers, root, PEER_PROBE_TIMEOUT_SEC);
+    }
+
+    private EthHandler firstPeerServing(List<EthHandler> peers, Bytes32 root, long timeoutSec) {
         List<CompletableFuture<EthHandler>> probes = new ArrayList<>();
         for (EthHandler peer : peers) {
             if (!peer.isReady() || peer.isSnapServingFailed()) continue;
@@ -1244,10 +1271,37 @@ public final class VerifiedRpcBackend implements io.myotis.jsonrpc.MyotisRpcBack
                     }));
         }
         try {
-            return firstSuccess(probes, PEER_PROBE_TIMEOUT_SEC);
+            return firstSuccess(probes, timeoutSec);
         } catch (Exception e) {
             return null;
         }
+    }
+
+    /** Quick liveness probe (≤{@link #RPC_STALE_PROBE_TIMEOUT_SEC}s) that at least one
+     *  connected snap peer serves {@code stateRoot} right now — used before handing a
+     *  STALE head to a state callView so a doomed read fails fast instead of timing out.
+     *  Verdict cached for {@link #STALE_PROBE_CACHE_MS} keyed by root so a confirm-screen
+     *  burst on one root shares a single probe rather than hammering every peer N times. */
+    private volatile byte[] probedRoot;
+    private volatile boolean probedRootServable;
+    private volatile long probedRootAtMs;
+
+    private boolean anyPeerServesRoot(byte[] stateRoot) {
+        if (stateRoot == null) return false;
+        long now = clock.elapsedMillis();
+        byte[] cachedRoot = probedRoot;
+        if (cachedRoot != null && java.util.Arrays.equals(cachedRoot, stateRoot)
+                && now - probedRootAtMs < STALE_PROBE_CACHE_MS) {
+            return probedRootServable;
+        }
+        RLPxConnector c = connector;
+        List<EthHandler> peers = (c == null) ? List.of() : c.activeSnapHandlers();
+        boolean ok = !peers.isEmpty()
+                && firstPeerServing(peers, Bytes32.wrap(stateRoot), RPC_STALE_PROBE_TIMEOUT_SEC) != null;
+        probedRoot = stateRoot.clone();
+        probedRootServable = ok;
+        probedRootAtMs = now;
+        return ok;
     }
 
     /**
@@ -1910,7 +1964,7 @@ public final class VerifiedRpcBackend implements io.myotis.jsonrpc.MyotisRpcBack
         // Header anchoring needs verified headers, not snap STATE — so it keeps the
         // long stale window (a stale head still anchors a fetched header window).
         if (c != null && !c.activeSnapHandlers().isEmpty()) {
-            RpcCallContext ctx = anchoredHeadOrWait(RPC_HEAD_SERVE_STALE_MAX_MS);
+            RpcCallContext ctx = anchoredHeadOrWait(RPC_HEAD_SERVE_STALE_MAX_MS, false);
             if (ctx != null && ctx.beaconVerified()) {
                 return new HeaderAnchor(ctx.blockNumber(), ctx.blockCtx().stateRoot(), null);
             }
@@ -2395,7 +2449,7 @@ public final class VerifiedRpcBackend implements io.myotis.jsonrpc.MyotisRpcBack
                                                 java.math.BigInteger value) {
         if (to == null || to.length != 20) return null;
         if (from != null && from.length != 20) return null;
-        RpcCallContext h = anchoredHeadOrWait(RPC_STATE_HEAD_MAX_STALE_MS);
+        RpcCallContext h = anchoredHeadOrWait(RPC_STATE_HEAD_MAX_STALE_MS, true);
         if (h == null) return null;
         try {
             // Fast path: a value transfer with no calldata to a plain account costs


### PR DESCRIPTION
Follow-up to #59 (stacked on it). #59 stopped *re-serving* a pruned root; this makes the residual failures **fast** and makes a state-servable peer far more **likely** on mobile — the two things still blocking MetaMask's fee from rendering on-device.

> Live evidence (current #59 build on the phone): the confirm-screen Multicall3 sim (`0xca11bde0`) failed with `StateUnavailable` after **20–30s**, repeatedly, because a burst of ~20 `eth_call`s all grabbed the same stale-but-unservable head before the first one's timeout fired #59's eviction — and "no snap peer retains the beacon-finalized state" with only ~8 peers connected.

## 1. Probe-before-serve → fast-fail (`:rpc-backend`)
`#59`'s eviction only helps the *next* read; a concurrent burst still all times out 30s first. Now, before the last-resort **stale-serve** for a state read, a tight probe (`RPC_STALE_PROBE_TIMEOUT_SEC` = 3s, verdict cached `STALE_PROBE_CACHE_MS` per root so a burst shares one probe) checks that some connected snap peer actually serves the aged root. If none do → **fast-error in ~3s** instead of handing the dead root to a 30s `callView`. Header-only callers skip the probe (they anchor headers, not state). Trust untouched — the probe is a liveness check, never a verification relaxation.

## 2. Deepen the snap pool (`:android-app`)
`TARGET_SNAP_PEERS` **4 → 12**. Being a snap peer ≠ retaining the head root's state (Geth prunes beyond ~128 blocks; snap serves a flat layer that lags head). 4 was too thin a pool to reliably hold one peer whose retained state covers the head, so the probe-and-pin build kept falling back to the unservable finalized root. The maintainer already dials CONFIRMED-quality peers first (`snapDialRank`), so a deeper pool **composes** with quality preference and makes the PEER_HEAD probe race far likelier to find a state-servable peer. The daemon holds ~36 organically; 12 is a fine bound for a foreground wallet.

## Validation
- `:rpc-backend` tests green; `assembleDebug` green; daemon replay 15/15 (no happy-path regression — the probe only fires on the degraded last-resort path a healthy node doesn't hit).
- The on-device win (fast amber instead of 30s hangs; deeper pool finding a servable peer) is best watched live via the readiness strip during a confirm-screen attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)