### PR TITLE
evm: batched snap fetches — coalesce the prefetch wave into few GetTrieNodes

### DIFF
--- a/myotis-evm/src/main/java/io/myotis/evm/PrefetchingEvmExecutor.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/PrefetchingEvmExecutor.java
@@ -291,6 +291,10 @@ public final class PrefetchingEvmExecutor implements EvmExecutor {
             try {
                 oracle.fetchBatch(stateRoot, batch)
                         .get(PREFETCH_WAVE_TIMEOUT_SEC, java.util.concurrent.TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                // Restore the interrupt so the executor/caller sees the cancellation.
+                Thread.currentThread().interrupt();
+                log.debug("[prefetch] batch warm interrupted: {}", e.getMessage());
             } catch (Exception e) {
                 log.debug("[prefetch] batch warm failed/timeout: {}", e.getMessage());
             }

--- a/myotis-evm/src/main/java/io/myotis/evm/PrefetchingEvmExecutor.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/PrefetchingEvmExecutor.java
@@ -275,6 +275,27 @@ public final class PrefetchingEvmExecutor implements EvmExecutor {
                                     Set<Address> accounts,
                                     Set<AccessTracker.SlotKey> slots) {
         SnapStateOracle oracle = delegate.oracle();
+
+        // Coalesce the discovered access list into a few BATCHED GetTrieNodes requests
+        // (one path-set per account, chunked) instead of one round-trip per item — a
+        // 1000-token sweep's ~1000 sequential proofs become ~16. Best-effort warm of the
+        // proof cache; the per-item loop below then reads back from the (now-warm) cache
+        // and re-fetches anything the batch couldn't verify, so this only ever SAVES
+        // round-trips and never changes the result or the verification.
+        java.util.Map<Address, java.util.Set<java.math.BigInteger>> batch = new java.util.HashMap<>();
+        for (Address a : accounts) batch.computeIfAbsent(a, k -> new java.util.HashSet<>());
+        for (AccessTracker.SlotKey key : slots) {
+            batch.computeIfAbsent(key.address(), k -> new java.util.HashSet<>()).add(key.slot());
+        }
+        if (!batch.isEmpty()) {
+            try {
+                oracle.fetchBatch(stateRoot, batch)
+                        .get(PREFETCH_WAVE_TIMEOUT_SEC, java.util.concurrent.TimeUnit.SECONDS);
+            } catch (Exception e) {
+                log.debug("[prefetch] batch warm failed/timeout: {}", e.getMessage());
+            }
+        }
+
         List<java.util.function.Supplier<CompletableFuture<?>>> work =
                 new ArrayList<>(accounts.size() + slots.size());
 

--- a/myotis-evm/src/main/java/io/myotis/evm/world/SnapBackedStateOracle.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/world/SnapBackedStateOracle.java
@@ -161,8 +161,7 @@ public final class SnapBackedStateOracle implements SnapStateOracle {
      *  ({@code slots}) paired index-for-index with their keccak hashes ({@code
      *  slotHashes}, used both for the GetTrieNodes path and the slot-proof verify). */
     private record BatchItem(Address address, byte[] addr, Bytes32 accountHash,
-                             List<BigInteger> slots, List<Bytes32> slotHashes,
-                             boolean accountCached) {}
+                             List<BigInteger> slots, List<Bytes32> slotHashes) {}
 
     @Override
     public CompletableFuture<Void> fetchBatch(
@@ -187,7 +186,7 @@ public final class SnapBackedStateOracle implements SnapStateOracle {
                 slotHashes.add(Bytes32.wrap(Hash.keccak256(paddedSlotKey(slot)).toArrayUnsafe()));
             }
             if (accountCached && slots.isEmpty()) continue;  // fully cached → nothing to do
-            items.add(new BatchItem(address, addr, accountHash, slots, slotHashes, accountCached));
+            items.add(new BatchItem(address, addr, accountHash, slots, slotHashes));
         }
         if (items.isEmpty()) return CompletableFuture.completedFuture(null);
 
@@ -225,9 +224,13 @@ public final class SnapBackedStateOracle implements SnapStateOracle {
     private void verifyAndCacheChunk(byte[] stateRoot, Bytes32 root,
                                      List<BatchItem> chunk, List<Bytes> nodes) {
         for (BatchItem it : chunk) {
+            // Query the cache live (not a static per-build snapshot): on a chunk retry
+            // against a different peer, items the previous attempt already verified are
+            // served from cache, so the new peer's response need not re-prove them. A
+            // static "was it cached when the batch was built?" flag would instead force
+            // re-verification and fail the retry whenever the new peer omits those proofs.
             AccountWithStorageRoot awr;
-            Optional<StateProofCache.AccountEntry> cached =
-                    it.accountCached() ? stateCache.getAccount(stateRoot, it.addr()) : Optional.empty();
+            Optional<StateProofCache.AccountEntry> cached = stateCache.getAccount(stateRoot, it.addr());
             if (cached.isPresent()) {
                 awr = new AccountWithStorageRoot(cached.get().account(),
                         Bytes32.wrap(cached.get().storageRoot()));
@@ -239,9 +242,11 @@ public final class SnapBackedStateOracle implements SnapStateOracle {
             Bytes32 storageRoot = awr.storageRoot();
             boolean emptyStorage = MerklePatriciaProofVerifier.EMPTY_TRIE_ROOT.equals(storageRoot);
             for (int s = 0; s < it.slots().size(); s++) {
+                BigInteger slot = it.slots().get(s);
+                if (stateCache.getStorage(stateRoot, it.addr(), slot).isPresent()) continue;
                 BigInteger value = emptyStorage ? BigInteger.ZERO
                         : verifyAndDecodeStorage(storageRoot, it.slotHashes().get(s), it.address(), nodes);
-                stateCache.putStorage(stateRoot, it.addr(), it.slots().get(s), value);
+                stateCache.putStorage(stateRoot, it.addr(), slot, value);
             }
         }
     }

--- a/myotis-evm/src/main/java/io/myotis/evm/world/SnapBackedStateOracle.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/world/SnapBackedStateOracle.java
@@ -13,10 +13,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.math.BigInteger;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HexFormat;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.function.Supplier;
@@ -146,6 +149,101 @@ public final class SnapBackedStateOracle implements SnapStateOracle {
                         return value;
                     });
         });
+    }
+
+    /** Max path-sets (accounts) per GetTrieNodes request. Bounds the response size a
+     *  peer must assemble (each path-set is ~one account proof + its slot proofs ≈
+     *  several KB), keeping any one request servable while still collapsing a
+     *  1000-account sweep from ~1000 round-trips to ~16. */
+    private static final int BATCH_PATHSET_CHUNK = 64;
+
+    /** Per-account batch work: the address + its hash + the UNCACHED slots wanted
+     *  ({@code slots}) paired index-for-index with their keccak hashes ({@code
+     *  slotHashes}, used both for the GetTrieNodes path and the slot-proof verify). */
+    private record BatchItem(Address address, byte[] addr, Bytes32 accountHash,
+                             List<BigInteger> slots, List<Bytes32> slotHashes,
+                             boolean accountCached) {}
+
+    @Override
+    public CompletableFuture<Void> fetchBatch(
+            byte[] stateRoot, Map<Address, ? extends Set<BigInteger>> request) {
+        if (request == null || request.isEmpty()) {
+            return CompletableFuture.completedFuture(null);
+        }
+        Bytes32 root = Bytes32.wrap(stateRoot.clone());
+        // Build per-account work, skipping anything already in the proof cache so a
+        // partially-warm sweep only fetches the misses.
+        List<BatchItem> items = new ArrayList<>();
+        for (Map.Entry<Address, ? extends Set<BigInteger>> entry : request.entrySet()) {
+            Address address = entry.getKey();
+            byte[] addr = address.toByteArray();
+            Bytes32 accountHash = Bytes32.wrap(Hash.keccak256(Bytes.wrap(addr)).toArrayUnsafe());
+            boolean accountCached = stateCache.getAccount(stateRoot, addr).isPresent();
+            List<BigInteger> slots = new ArrayList<>();
+            List<Bytes32> slotHashes = new ArrayList<>();
+            for (BigInteger slot : entry.getValue()) {
+                if (stateCache.getStorage(stateRoot, addr, slot).isPresent()) continue;
+                slots.add(slot);
+                slotHashes.add(Bytes32.wrap(Hash.keccak256(paddedSlotKey(slot)).toArrayUnsafe()));
+            }
+            if (accountCached && slots.isEmpty()) continue;  // fully cached → nothing to do
+            items.add(new BatchItem(address, addr, accountHash, slots, slotHashes, accountCached));
+        }
+        if (items.isEmpty()) return CompletableFuture.completedFuture(null);
+
+        List<CompletableFuture<Void>> chunkFutures = new ArrayList<>();
+        for (int i = 0; i < items.size(); i += BATCH_PATHSET_CHUNK) {
+            final List<BatchItem> chunk = items.subList(i, Math.min(i + BATCH_PATHSET_CHUNK, items.size()));
+            List<SnapPeer.PathSet> paths = new ArrayList<>(chunk.size());
+            for (BatchItem it : chunk) {
+                List<Bytes> storagePaths = new ArrayList<>(it.slotHashes().size());
+                storagePaths.addAll(it.slotHashes());   // Bytes32 -> Bytes per element
+                paths.add(new SnapPeer.PathSet(it.accountHash(), storagePaths));
+            }
+            // tryWithRetries rotates peers exactly like the per-item path: a peer that
+            // returns an incomplete/forged proof for ANY item in the chunk fails its
+            // verify and the whole chunk retries on the next peer. Best-effort overall —
+            // a chunk that can't be verified after retries is left uncached (the caller's
+            // per-item path re-fetches it), so the batch never weakens correctness.
+            CompletableFuture<Void> cf = tryWithRetries(peer -> peer.getTrieNodes(root, paths)
+                    .thenApply(nodes -> { verifyAndCacheChunk(stateRoot, root, chunk, nodes); return (Void) null; }))
+                    .exceptionally(t -> {
+                        log.debug("[snap-oracle] batch chunk ({} accounts) failed: {}",
+                                chunk.size(), t.getMessage());
+                        return null;
+                    });
+            chunkFutures.add(cf);
+        }
+        return CompletableFuture.allOf(chunkFutures.toArray(CompletableFuture[]::new));
+    }
+
+    /** Verify + cache every account/slot in {@code chunk} from the ONE combined node
+     *  list the peer returned. Each proof is checked with the same verifier the
+     *  per-item path uses (the verifier builds a hash→node map, so a combined node set
+     *  verifies each key independently); a bad proof throws InvalidProof, failing the
+     *  whole chunk so tryWithRetries rotates to another peer. */
+    private void verifyAndCacheChunk(byte[] stateRoot, Bytes32 root,
+                                     List<BatchItem> chunk, List<Bytes> nodes) {
+        for (BatchItem it : chunk) {
+            AccountWithStorageRoot awr;
+            Optional<StateProofCache.AccountEntry> cached =
+                    it.accountCached() ? stateCache.getAccount(stateRoot, it.addr()) : Optional.empty();
+            if (cached.isPresent()) {
+                awr = new AccountWithStorageRoot(cached.get().account(),
+                        Bytes32.wrap(cached.get().storageRoot()));
+            } else {
+                awr = verifyAndDecodeAccount(root, it.accountHash(), it.address(), nodes);
+                stateCache.putAccount(stateRoot, it.addr(),
+                        new StateProofCache.AccountEntry(awr.account(), awr.storageRoot().toArrayUnsafe()));
+            }
+            Bytes32 storageRoot = awr.storageRoot();
+            boolean emptyStorage = MerklePatriciaProofVerifier.EMPTY_TRIE_ROOT.equals(storageRoot);
+            for (int s = 0; s < it.slots().size(); s++) {
+                BigInteger value = emptyStorage ? BigInteger.ZERO
+                        : verifyAndDecodeStorage(storageRoot, it.slotHashes().get(s), it.address(), nodes);
+                stateCache.putStorage(stateRoot, it.addr(), it.slots().get(s), value);
+            }
+        }
     }
 
     @Override

--- a/myotis-evm/src/main/java/io/myotis/evm/world/SnapStateOracle.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/world/SnapStateOracle.java
@@ -36,4 +36,21 @@ public interface SnapStateOracle {
 
     /** Fetch bytecode by its keccak256 hash. */
     CompletableFuture<byte[]> fetchBytecode(byte[] codeHash);
+
+    /**
+     * Best-effort batch WARM of {@code request} (account &rarr; the storage slots
+     * wanted under it) into the oracle's proof cache, coalesced into a few
+     * {@code GetTrieNodes} round-trips (one path-set per account, chunked) instead of
+     * one round-trip per item. Verification is identical to {@link #fetchAccount} /
+     * {@link #fetchStorage} — each account/slot proof is independently checked against
+     * its (state / storage) root; only the REQUESTS coalesce. Callers must treat it as
+     * a pure cache warmer: read the actual values back via fetchAccount/fetchStorage
+     * (which hit the warmed cache), so an item the batch couldn't verify simply
+     * becomes a normal per-item fetch. Default no-op for oracles without a proof cache.
+     */
+    default CompletableFuture<Void> fetchBatch(
+            byte[] stateRoot,
+            java.util.Map<Address, ? extends java.util.Set<BigInteger>> request) {
+        return CompletableFuture.completedFuture(null);
+    }
 }

--- a/myotis-evm/src/test/java/io/myotis/evm/world/SnapBackedStateOracleTest.java
+++ b/myotis-evm/src/test/java/io/myotis/evm/world/SnapBackedStateOracleTest.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -297,6 +298,97 @@ class SnapBackedStateOracleTest {
         BigInteger got = oracle.fetchStorage(
                 trie.root.toArrayUnsafe(), addr, BigInteger.valueOf(42)).get();
         assertEquals(BigInteger.ZERO, got);
+    }
+
+    @Test
+    void fetchBatchVerifiesAndWarmsCacheInOneRequest() throws Exception {
+        // A real peer answers a PathSet(account,[slot]) GetTrieNodes with BOTH the
+        // account-walk and storage-walk nodes COMBINED. fetchBatch must verify each
+        // (account against stateRoot, slot against storageRoot) from that one combined
+        // response and warm the proof cache — so a later fetchAccount/fetchStorage
+        // needs ZERO further round-trips. This is the coalescing that turns a
+        // 1000-token sweep's ~1000 sequential proofs into a handful.
+        Address addr = Address.fromHex("0xabcdef0102030405060708090a0b0c0d0e0f1011");
+        BigInteger slot = BigInteger.valueOf(7);
+        BigInteger value = new BigInteger("1234567890123456789");
+        long nonce = 5L;
+        BigInteger balance = new BigInteger("999000000000000000");
+
+        Bytes32 slotHash = Bytes32.wrap(Hash.keccak256(paddedSlot(slot)).toArrayUnsafe());
+        Bytes valueRlp = RLP.encode(w -> w.writeBigInteger(value));
+        var storageTrie = TrieFixture.singleLeaf(slotHash, valueRlp);
+        Bytes accountValue = encodeAccount(nonce, balance, storageTrie.root,
+                Bytes32.wrap(Hash.keccak256(Bytes.EMPTY).toArrayUnsafe()));
+        var accountTrie = TrieFixture.singleLeaf(keccak(addr.toByteArray()), accountValue);
+
+        List<Bytes> combined = new ArrayList<>();
+        combined.addAll(accountTrie.proof);
+        combined.addAll(storageTrie.proof);
+        AtomicInteger calls = new AtomicInteger();
+        SnapPeer peer = new SnapPeer() {
+            @Override public CompletableFuture<List<Bytes>> getTrieNodes(Bytes32 sr, List<PathSet> p) {
+                calls.incrementAndGet();
+                return CompletableFuture.completedFuture(combined);
+            }
+            @Override public CompletableFuture<List<Bytes>> getByteCodes(List<Bytes32> h) {
+                return CompletableFuture.completedFuture(List.of());
+            }
+            @Override public void reportRootUnavailable() { }
+        };
+        // fetchBatch warms the SHARED proof cache — give the oracle a real one (the
+        // 2-arg ctor uses a noop cache, into which a warm would vanish).
+        var oracle = new SnapBackedStateOracle(
+                () -> peer, BytecodeCache.inMemory(), 8, StateProofCache.inMemory(1024));
+        byte[] root = accountTrie.root.toArrayUnsafe();
+
+        Map<Address, Set<BigInteger>> req = new HashMap<>();
+        req.put(addr, Set.of(slot));
+        oracle.fetchBatch(root, req).get();
+        assertEquals(1, calls.get(), "the batch must issue exactly one GetTrieNodes");
+
+        int before = calls.get();
+        assertEquals(value, oracle.fetchStorage(root, addr, slot).get(),
+                "the verified slot value must be warmed into the cache");
+        assertEquals(balance, oracle.fetchAccount(root, addr).get().balance(),
+                "the verified account must be warmed into the cache");
+        assertEquals(before, calls.get(),
+                "reads after a batch warm must hit the cache, not the peer");
+    }
+
+    @Test
+    void fetchBatchOnForgedProofLeavesCacheCold() throws Exception {
+        // A peer that returns garbage nodes: the batch's verify must REJECT it (the
+        // chunk fails + is left uncached), never poisoning the cache with unverified
+        // state. The follow-up fetchStorage then re-fetches per-item (and here fails
+        // too) — but crucially the batch never weakened the trust path.
+        Address addr = Address.fromHex("0xabcdef0102030405060708090a0b0c0d0e0f1011");
+        BigInteger slot = BigInteger.valueOf(7);
+        Bytes32 root = Bytes32.fromHexString(
+                "0x5555555555555555555555555555555555555555555555555555555555555555");
+        SnapPeer forging = new SnapPeer() {
+            @Override public CompletableFuture<List<Bytes>> getTrieNodes(Bytes32 sr, List<PathSet> p) {
+                return CompletableFuture.completedFuture(List.of(Bytes.fromHexString("0xdeadbeef")));
+            }
+            @Override public CompletableFuture<List<Bytes>> getByteCodes(List<Bytes32> h) {
+                return CompletableFuture.completedFuture(List.of());
+            }
+            @Override public void reportRootUnavailable() { }
+        };
+        var oracle = new SnapBackedStateOracle(() -> forging, BytecodeCache.inMemory(), 2);
+
+        Map<Address, Set<BigInteger>> req = new HashMap<>();
+        req.put(addr, Set.of(slot));
+        // Best-effort: the batch completes (doesn't throw) but caches nothing forged.
+        oracle.fetchBatch(root.toArrayUnsafe(), req).get();
+
+        // The cache stayed cold — a real fetch still has to verify from scratch (and
+        // here fails, because the peer forges). The point: no unverified value was cached.
+        try {
+            oracle.fetchStorage(root.toArrayUnsafe(), addr, slot).get();
+            fail("a forged proof must not yield a value");
+        } catch (ExecutionException expected) {
+            // verifier rejected the garbage — correct.
+        }
     }
 
     @Test

--- a/myotis-evm/src/test/java/io/myotis/evm/world/SnapBackedStateOracleTest.java
+++ b/myotis-evm/src/test/java/io/myotis/evm/world/SnapBackedStateOracleTest.java
@@ -392,6 +392,58 @@ class SnapBackedStateOracleTest {
     }
 
     @Test
+    void fetchBatchRetryServesAlreadyVerifiedItemsFromCache() throws Exception {
+        // Retry robustness across peer rotation. Attempt 1 proves the account but NOT
+        // the slot, so the slot verify fails and the whole chunk retries on the next
+        // peer. Attempt 2 proves the slot but NOT the account. Because verifyAndCacheChunk
+        // queries the cache LIVE, the account verified+cached on attempt 1 is served from
+        // cache on the retry, so the chunk completes even though no single response
+        // carried both proofs. A static "cached when the batch was built?" snapshot would
+        // force re-verifying the account from the retry response (which lacks it) and fail.
+        Address addr = Address.fromHex("0xabcdef0102030405060708090a0b0c0d0e0f1011");
+        BigInteger slot = BigInteger.valueOf(7);
+        BigInteger value = new BigInteger("1234567890123456789");
+        long nonce = 5L;
+        BigInteger balance = new BigInteger("999000000000000000");
+
+        Bytes32 slotHash = Bytes32.wrap(Hash.keccak256(paddedSlot(slot)).toArrayUnsafe());
+        Bytes valueRlp = RLP.encode(w -> w.writeBigInteger(value));
+        var storageTrie = TrieFixture.singleLeaf(slotHash, valueRlp);
+        Bytes accountValue = encodeAccount(nonce, balance, storageTrie.root,
+                Bytes32.wrap(Hash.keccak256(Bytes.EMPTY).toArrayUnsafe()));
+        var accountTrie = TrieFixture.singleLeaf(keccak(addr.toByteArray()), accountValue);
+
+        AtomicInteger attempt = new AtomicInteger();
+        SnapPeer rotating = new SnapPeer() {
+            @Override public CompletableFuture<List<Bytes>> getTrieNodes(Bytes32 sr, List<PathSet> p) {
+                // 1st: account proof only (slot fails → chunk retries).
+                // 2nd+: storage proof only (account must come from the warm cache).
+                int n = attempt.incrementAndGet();
+                return CompletableFuture.completedFuture(n == 1 ? accountTrie.proof : storageTrie.proof);
+            }
+            @Override public CompletableFuture<List<Bytes>> getByteCodes(List<Bytes32> h) {
+                return CompletableFuture.completedFuture(List.of());
+            }
+            @Override public void reportRootUnavailable() { }
+        };
+        var oracle = new SnapBackedStateOracle(
+                () -> rotating, BytecodeCache.inMemory(), 8, StateProofCache.inMemory(1024));
+        byte[] root = accountTrie.root.toArrayUnsafe();
+
+        Map<Address, Set<BigInteger>> req = new HashMap<>();
+        req.put(addr, Set.of(slot));
+        oracle.fetchBatch(root, req).get();
+        assertTrue(attempt.get() >= 2, "the slot miss must have forced at least one retry");
+
+        int after = attempt.get();
+        assertEquals(value, oracle.fetchStorage(root, addr, slot).get(),
+                "slot warmed by the retry that succeeded via the cached account");
+        assertEquals(balance, oracle.fetchAccount(root, addr).get().balance(),
+                "account warmed on the first attempt, retained across the retry");
+        assertEquals(after, attempt.get(), "reads after the batch warm must hit the cache, not the peer");
+    }
+
+    @Test
     void sharedStateCacheServesStorageAcrossOraclesWithoutRefetch() throws Exception {
         // The fix for the confirm-screen retry-storm: a node-level StateProofCache
         // shared across head-context oracle instances. A verified storage value must


### PR DESCRIPTION
## The last wall

Even on a fast device (Pixel 10), the one call that never finished is MetaMask's ~1000-token **BalanceChecker sweep** / the ERC-20 **asset list**. The EVM prefetch issued **one `GetTrieNodes` round-trip per account/slot** (~1000+, 48-wide) — hundreds of sequential proofs that time out on mobile peers and block the asset list. That's why **ETH sends go through** (no token list needed) but **ERC-20 sends stick on the confirm screen**.

## What batched snap fetches are

`snap/1`'s `GetTrieNodes` already takes a **list** of path-sets, and a path-set bundles **an account with its storage slots**. So instead of N requests, send a few requests each carrying many path-sets:

- **`SnapStateOracle.fetchBatch(stateRoot, account→slots)`** — default no-op; the snap oracle overrides it to group the access list (one path-set per account), chunk to **64 accounts per request**, issue each as **one `GetTrieNodes`**, and verify + cache every account/slot from the single combined response. **~1000 round-trips → ~16.**
- **`PrefetchingEvmExecutor`** warms the proof cache via `fetchBatch` before its per-item loop, which then reads back from the warm cache (zero round-trips) and re-fetches only what the batch couldn't verify. Pure round-trip savings — never changes the result.

## Trust is untouched

Each proof is checked with the **same `MerklePatriciaProofVerifier`** the per-item path uses — it builds a hash→node map, so a combined node set verifies each key independently. A forged/incomplete proof fails the chunk's verify and `tryWithRetries` rotates peers exactly as before; a chunk that can't be verified is left **uncached**, never poisoning state.

## Validation
- New tests: one batched `GetTrieNodes` warms the cache for verified reads; a **forged proof leaves the cache cold** (rejected).
- Daemon replay **15/15 gating** (no regression); `:myotis-evm` + `:rpc-backend` tests green.

This is the structural fix for ERC-20 asset lists / heavy sweeps on every device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)