### PR TITLE
rpc: pending-nonce overlay + gossip-confirmed mini-mempool (no-mempool sends)

### DIFF
--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/EthHandler.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/EthHandler.java
@@ -136,6 +136,22 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
     private volatile long readyTimestamp; // when we entered READY state
     private int negotiatedEthVersion = 68; // default, updated during Hello negotiation
 
+    /** Optional sink for mempool-gossip tx hashes, set by the connector. When present
+     *  AND {@link TxGossipObserver#watchingAny()} is true, inbound Transactions (0x12)
+     *  and NewPooledTransactionHashes (0x18) are decoded and their hashes reported so a
+     *  node can watch its own just-broadcast tx propagate. Null / not-watching = the
+     *  firehose stays dropped untouched (its normal cheap path). */
+    private volatile TxGossipObserver txGossipObserver;
+
+    /** Hard cap on hashes decoded per gossip message — bounds event-loop work even if a
+     *  peer announces a huge batch while we happen to be watching. */
+    private static final int MAX_GOSSIP_HASHES_PER_MSG = 256;
+
+    /** Set the gossip observer (idempotent; the connector calls this on every handler). */
+    public void setTxGossipObserver(TxGossipObserver observer) {
+        this.txGossipObserver = observer;
+    }
+
     public EthHandler(NodeKey nodeKey, int tcpPort, NetworkConfig network,
                       ChainHead chainHead,
                       Consumer<List<BlockHeadersMessage.VerifiedHeader>> onHeaders,
@@ -523,6 +539,13 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
                     handleSnapTrieNodes(msg);
                 } else if (msg.code() == snapGetTrieNodes) {
                     handleSnapGetTrieNodes(ctx, msg);
+                } else if ((msg.code() == ETH_TRANSACTIONS || msg.code() == NewPooledTransactionHashesMessage.CODE)
+                        && isWatchingGossip()) {
+                    // Mempool gossip we'd normally drop — but a watcher (a node with an
+                    // unconfirmed broadcast of its own) wants to see that hash come back.
+                    // Only reached while watchingAny() is true, so the firehose stays
+                    // free the rest of the time.
+                    matchOwnTxGossip(msg);
                 } else {
                     // TRACE, not DEBUG: the ignored codes are dominated by
                     // high-frequency mempool gossip (0x12 / 0x18) every full-node
@@ -834,6 +857,32 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
         byte[] payload = com.jaeckel.ethp2p.networking.eth.messages.TransactionsMessage.encode(rawTxs);
         rlpxHandler.sendMessage(ctx, ETH_TRANSACTIONS, payload);
         return true;
+    }
+
+    /** Cheap event-loop guard: is an observer present and actively watching for hashes?
+     *  Read once into a local so a concurrent clear can't NPE between check and use. */
+    private boolean isWatchingGossip() {
+        TxGossipObserver o = txGossipObserver;
+        return o != null && o.watchingAny();
+    }
+
+    /**
+     * Decode the tx hashes from an inbound Transactions (0x12) / NewPooledTransactionHashes
+     * (0x18) gossip message and report each to the observer, which matches them against the
+     * node's own broadcast txs. Only invoked while {@link #isWatchingGossip()} holds, so the
+     * decode cost is paid only during the short window a send of ours is unconfirmed.
+     * Best-effort throughout: the decoders never throw on malformed peer input, and a null
+     * observer race is a no-op.
+     */
+    private void matchOwnTxGossip(RLPxHandler.RLPxMessage msg) {
+        TxGossipObserver observer = txGossipObserver;
+        if (observer == null) return;
+        List<org.apache.tuweni.bytes.Bytes32> hashes = msg.code() == ETH_TRANSACTIONS
+                ? com.jaeckel.ethp2p.networking.eth.messages.TransactionsMessage
+                        .hashes(msg.payload(), MAX_GOSSIP_HASHES_PER_MSG)
+                : com.jaeckel.ethp2p.networking.eth.messages.NewPooledTransactionHashesMessage
+                        .hashes(msg.payload(), negotiatedEthVersion, MAX_GOSSIP_HASHES_PER_MSG);
+        for (org.apache.tuweni.bytes.Bytes32 h : hashes) observer.onTxHashSeen(h);
     }
 
     /**

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/TxGossipObserver.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/TxGossipObserver.java
@@ -1,0 +1,29 @@
+package com.jaeckel.ethp2p.networking.eth;
+
+import org.apache.tuweni.bytes.Bytes32;
+
+/**
+ * Sink for transaction hashes observed in mempool gossip — Transactions (0x12) and
+ * NewPooledTransactionHashes (0x18).
+ *
+ * <p>A light wallet ignores the mempool firehose for state verification. But a node
+ * that has just broadcast its <em>own</em> signed tx can watch for that exact hash
+ * coming back over gossip to confirm the tx is propagating (a "mini-mempool" of only
+ * our own sends) — and, by its continued absence, that it may have been dropped.
+ *
+ * <p>{@link EthHandler} consults {@link #watchingAny()} before decoding any gossip
+ * message, so when nothing of ours is in flight the firehose is dropped untouched on
+ * the event loop (its normal, cheap path). Only while we hold an unconfirmed broadcast
+ * does the handler decode announcements/bodies and report their hashes here, where a
+ * cheap membership check matches them against what we sent.
+ */
+public interface TxGossipObserver {
+
+    /** True while the node holds at least one broadcast-but-unconfirmed tx worth
+     *  watching for. Called on the event loop for every gossip message, so it must be
+     *  O(1) and allocation-free; when false the handler skips gossip decoding entirely. */
+    boolean watchingAny();
+
+    /** Report one tx hash seen on the network. Cheap no-op for hashes that aren't ours. */
+    void onTxHashSeen(Bytes32 txHash);
+}

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/messages/NewPooledTransactionHashesMessage.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/messages/NewPooledTransactionHashesMessage.java
@@ -1,0 +1,71 @@
+package com.jaeckel.ethp2p.networking.eth.messages;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.rlp.RLP;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * eth/NewPooledTransactionHashes (message code 0x18) — a peer announcing tx hashes it
+ * has in its pool, so we can request the bodies we don't yet hold.
+ *
+ * <p>We never request bodies (a light wallet keeps no mempool). We decode this only to
+ * match the announced hashes against our <em>own</em> just-broadcast transactions — to
+ * see them propagating back across the network.
+ *
+ * <p>The wire format changed at eth/68 (EIP-5793):
+ * <ul>
+ *   <li><b>eth/66, eth/67</b> — a flat list {@code [hash_0, hash_1, ...]}.</li>
+ *   <li><b>eth/68+</b> — {@code [types, sizes, hashes]}: a byte string of one type
+ *       per tx, a list of sizes, then the list of 32-byte hashes.</li>
+ * </ul>
+ */
+public final class NewPooledTransactionHashesMessage {
+
+    public static final int CODE = 0x18;
+
+    private NewPooledTransactionHashesMessage() {}
+
+    /**
+     * Decode the announced 32-byte tx hashes, picking the wire layout from {@code
+     * ethVersion}. Caps at {@code max} hashes and returns whatever decoded before any
+     * malformed element — gossip is best-effort and must never throw on the event loop.
+     */
+    public static List<Bytes32> hashes(byte[] payload, int ethVersion, int max) {
+        List<Bytes32> out = new ArrayList<>();
+        if (payload == null || payload.length == 0 || max <= 0) return out;
+        try {
+            Bytes b = Bytes.wrap(payload);
+            if (ethVersion >= 68) {
+                RLP.decodeList(b, reader -> {
+                    reader.readValue();                 // types — one byte per tx, skip
+                    reader.readList(sz -> {             // sizes — skip
+                        while (!sz.isComplete()) sz.readValue();
+                        return null;
+                    });
+                    reader.readList(hr -> {             // hashes
+                        while (!hr.isComplete()) {
+                            Bytes h = hr.readValue();
+                            if (out.size() < max && h.size() == 32) out.add(Bytes32.wrap(h));
+                        }
+                        return null;
+                    });
+                    return null;
+                });
+            } else {
+                RLP.decodeList(b, reader -> {           // flat [hash, ...]
+                    while (!reader.isComplete()) {
+                        Bytes h = reader.readValue();
+                        if (out.size() < max && h.size() == 32) out.add(Bytes32.wrap(h));
+                    }
+                    return null;
+                });
+            }
+        } catch (Exception e) {
+            // Best-effort: return whatever decoded before the malformed element.
+        }
+        return out;
+    }
+}

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/messages/TransactionsMessage.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/messages/TransactionsMessage.java
@@ -1,7 +1,13 @@
 package com.jaeckel.ethp2p.networking.eth.messages;
 
 import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.crypto.Hash;
 import org.apache.tuweni.rlp.RLP;
+import org.apache.tuweni.rlp.RLPReader;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * eth/Transactions (message code 0x12) — mempool broadcast.
@@ -54,5 +60,50 @@ public final class TransactionsMessage {
      */
     private static boolean isTyped(byte[] rawTx) {
         return rawTx != null && rawTx.length > 0 && (rawTx[0] & 0xff) <= 0x7f;
+    }
+
+    /**
+     * Decode the {@code keccak256} hash of each transaction in an inbound Transactions
+     * message, without fully decoding the tx fields. A tx's hash is keccak over its
+     * <em>canonical</em> bytes: for a legacy tx that's the RLP list itself; for a typed
+     * (EIP-2718) tx it's the {@code type || payload} byte string carried inside the
+     * outer list. Used only to match the firehose against our own broadcast hashes, so
+     * it caps at {@code max} hashes and treats any malformed input as "no hashes"
+     * (gossip is best-effort — a bad peer message must never throw on the event loop).
+     */
+    public static List<Bytes32> hashes(byte[] payload, int max) {
+        List<Bytes32> out = new ArrayList<>();
+        if (payload == null || payload.length == 0 || max <= 0) return out;
+        try {
+            RLP.decodeList(Bytes.wrap(payload), reader -> {
+                while (!reader.isComplete() && out.size() < max) {
+                    if (reader.nextIsList()) {
+                        // legacy tx: hash its canonical RLP-list encoding
+                        out.add(Bytes32.wrap(Hash.keccak256(rawList(reader)).toArrayUnsafe()));
+                    } else {
+                        // typed tx: byte string of type||payload — hash the inner bytes
+                        out.add(Bytes32.wrap(Hash.keccak256(reader.readValue()).toArrayUnsafe()));
+                    }
+                }
+                return null;
+            });
+        } catch (Exception e) {
+            // Best-effort: return whatever we decoded before the malformed element.
+        }
+        return out;
+    }
+
+    /** Re-encode the canonical RLP of the (possibly nested) list at the reader head so
+     *  it can be hashed. Mirrors the helper in {@code EthTxDecoder}. */
+    private static Bytes rawList(RLPReader reader) {
+        List<Bytes> children = new ArrayList<>();
+        reader.readList(inner -> {
+            while (!inner.isComplete()) {
+                if (inner.nextIsList()) children.add(rawList(inner));
+                else children.add(RLP.encodeValue(inner.readValue()));
+            }
+            return null;
+        });
+        return RLP.encodeList(w -> children.forEach(w::writeRLP));
     }
 }

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/messages/TransactionsMessage.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/messages/TransactionsMessage.java
@@ -79,10 +79,10 @@ public final class TransactionsMessage {
                 while (!reader.isComplete() && out.size() < max) {
                     if (reader.nextIsList()) {
                         // legacy tx: hash its canonical RLP-list encoding
-                        out.add(Bytes32.wrap(Hash.keccak256(rawList(reader)).toArrayUnsafe()));
+                        out.add(Hash.keccak256(rawList(reader)));
                     } else {
                         // typed tx: byte string of type||payload — hash the inner bytes
-                        out.add(Bytes32.wrap(Hash.keccak256(reader.readValue()).toArrayUnsafe()));
+                        out.add(Hash.keccak256(reader.readValue()));
                     }
                 }
                 return null;

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/rlpx/RLPxConnector.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/rlpx/RLPxConnector.java
@@ -4,6 +4,7 @@ import com.jaeckel.ethp2p.core.crypto.NodeKey;
 import com.jaeckel.ethp2p.networking.ChainHead;
 import com.jaeckel.ethp2p.networking.NetworkConfig;
 import com.jaeckel.ethp2p.networking.eth.EthHandler;
+import com.jaeckel.ethp2p.networking.eth.TxGossipObserver;
 import com.jaeckel.ethp2p.networking.eth.messages.BlockBodiesMessage;
 import com.jaeckel.ethp2p.networking.eth.messages.BlockHeadersMessage;
 import com.jaeckel.ethp2p.networking.snap.messages.AccountRangeMessage;
@@ -65,6 +66,9 @@ public final class RLPxConnector implements AutoCloseable {
     private final Consumer<List<BlockHeadersMessage.VerifiedHeader>> onHeaders;
     private final PeerReadyCallback peerReadyCallback;
     private final Set<EthHandler> activeHandlers = ConcurrentHashMap.newKeySet();
+    /** Optional mempool-gossip sink, applied to every handler so a node can watch its
+     *  own broadcast txs propagate. Null until a consumer (the RPC backend) registers. */
+    private volatile TxGossipObserver txGossipObserver;
 
     /**
      * Re-entrant counter of in-progress snap-heavy operations (ENS resolution).
@@ -127,6 +131,7 @@ public final class RLPxConnector implements AutoCloseable {
         EthHandler ethHandler = new EthHandler(localKey, tcpPort, network, chainHead, onHeaders, onReady);
         handlerRef[0] = ethHandler;
         ethHandler.setRemoteAddress(peerAddr.getAddress().getHostAddress() + ":" + peerAddr.getPort());
+        ethHandler.setTxGossipObserver(txGossipObserver);   // null until a consumer registers
 
         Bootstrap bootstrap = new Bootstrap()
             .group(group)
@@ -307,6 +312,19 @@ public final class RLPxConnector implements AutoCloseable {
         }
         log.info("[rlpx] Broadcast transaction to {} peer(s)", sent);
         return sent;
+    }
+
+    /**
+     * Register (or clear, with null) the mempool-gossip observer. Stored for handlers
+     * created later and pushed to every currently-active handler, so a node that just
+     * broadcast a tx can watch for that hash returning over Transactions (0x12) /
+     * NewPooledTransactionHashes (0x18) gossip. Idempotent.
+     */
+    public void setTxGossipObserver(TxGossipObserver observer) {
+        this.txGossipObserver = observer;
+        for (EthHandler handler : activeHandlers) {
+            handler.setTxGossipObserver(observer);
+        }
     }
 
     /**

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/rlpx/RLPxConnector.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/rlpx/RLPxConnector.java
@@ -131,7 +131,6 @@ public final class RLPxConnector implements AutoCloseable {
         EthHandler ethHandler = new EthHandler(localKey, tcpPort, network, chainHead, onHeaders, onReady);
         handlerRef[0] = ethHandler;
         ethHandler.setRemoteAddress(peerAddr.getAddress().getHostAddress() + ":" + peerAddr.getPort());
-        ethHandler.setTxGossipObserver(txGossipObserver);   // null until a consumer registers
 
         Bootstrap bootstrap = new Bootstrap()
             .group(group)
@@ -161,6 +160,12 @@ public final class RLPxConnector implements AutoCloseable {
         connectFuture.addListener((ChannelFuture f) -> {
             if (f.isSuccess()) {
                 activeHandlers.add(ethHandler);
+                // Apply the gossip observer AFTER joining activeHandlers, closing the
+                // race with setTxGossipObserver: that setter writes the (volatile) field
+                // then iterates active handlers, so ordering it "add then read field"
+                // here guarantees delivery on every interleaving — either the setter's
+                // iteration sees this handler, or this read sees the setter's write.
+                ethHandler.setTxGossipObserver(txGossipObserver);
             } else {
                 log.debug("[rlpx] Connection to {} failed: {}", peerAddr, f.cause().getMessage());
             }

--- a/networking/src/test/java/com/jaeckel/ethp2p/networking/eth/messages/NewPooledTransactionHashesMessageTest.java
+++ b/networking/src/test/java/com/jaeckel/ethp2p/networking/eth/messages/NewPooledTransactionHashesMessageTest.java
@@ -1,0 +1,75 @@
+package com.jaeckel.ethp2p.networking.eth.messages;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.rlp.RLP;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Decodes NewPooledTransactionHashes (0x18) in both wire layouts: the flat
+ * {@code [hash, ...]} of eth/66–67 and the {@code [types, sizes, hashes]} of eth/68+
+ * (EIP-5793). We only ever decode this to match our own broadcast hashes, so the
+ * decoder must be version-correct, capped, and unfazed by malformed peer input.
+ */
+class NewPooledTransactionHashesMessageTest {
+
+    private static final Bytes32 H1 = Bytes32.fromHexString(
+            "0x1111111111111111111111111111111111111111111111111111111111111111");
+    private static final Bytes32 H2 = Bytes32.fromHexString(
+            "0x2222222222222222222222222222222222222222222222222222222222222222");
+
+    private static byte[] flat(Bytes32... hashes) {
+        return RLP.encodeList(w -> {
+            for (Bytes32 h : hashes) w.writeValue(h);
+        }).toArrayUnsafe();
+    }
+
+    private static byte[] eth68(Bytes types, List<Integer> sizes, Bytes32... hashes) {
+        Bytes sizeList = RLP.encodeList(w -> sizes.forEach(w::writeInt));
+        Bytes hashList = RLP.encodeList(w -> {
+            for (Bytes32 h : hashes) w.writeValue(h);
+        });
+        return RLP.encodeList(w -> {
+            w.writeValue(types);
+            w.writeRLP(sizeList);
+            w.writeRLP(hashList);
+        }).toArrayUnsafe();
+    }
+
+    @Test
+    void decodesFlatListForEth66And67() {
+        byte[] msg = flat(H1, H2);
+        assertEquals(List.of(H1, H2), NewPooledTransactionHashesMessage.hashes(msg, 66, 256));
+        assertEquals(List.of(H1, H2), NewPooledTransactionHashesMessage.hashes(msg, 67, 256));
+    }
+
+    @Test
+    void decodesTypesSizesHashesForEth68Plus() {
+        byte[] msg = eth68(Bytes.of(0x00, 0x02), List.of(100, 120), H1, H2);
+        assertEquals(List.of(H1, H2), NewPooledTransactionHashesMessage.hashes(msg, 68, 256));
+        assertEquals(List.of(H1, H2), NewPooledTransactionHashesMessage.hashes(msg, 69, 256));
+    }
+
+    @Test
+    void capsAtMax() {
+        assertEquals(1, NewPooledTransactionHashesMessage.hashes(flat(H1, H2), 66, 1).size());
+        byte[] v68 = eth68(Bytes.of(0x02, 0x02), List.of(1, 1), H1, H2);
+        assertEquals(1, NewPooledTransactionHashesMessage.hashes(v68, 68, 1).size());
+    }
+
+    @Test
+    void toleratesGarbageAndWrongSizedHashes() {
+        assertTrue(NewPooledTransactionHashesMessage.hashes(null, 68, 256).isEmpty());
+        assertTrue(NewPooledTransactionHashesMessage.hashes(new byte[0], 68, 256).isEmpty());
+        // a non-list payload must not throw.
+        assertTrue(NewPooledTransactionHashesMessage.hashes(new byte[]{0x01, 0x02}, 66, 256).isEmpty());
+        // a 31-byte "hash" in the flat list is skipped, not accepted.
+        byte[] shortHash = RLP.encodeList(w -> w.writeValue(Bytes.repeat((byte) 0xAB, 31))).toArrayUnsafe();
+        assertTrue(NewPooledTransactionHashesMessage.hashes(shortHash, 66, 256).isEmpty());
+    }
+}

--- a/networking/src/test/java/com/jaeckel/ethp2p/networking/eth/messages/TransactionsMessageTest.java
+++ b/networking/src/test/java/com/jaeckel/ethp2p/networking/eth/messages/TransactionsMessageTest.java
@@ -1,11 +1,16 @@
 package com.jaeckel.ethp2p.networking.eth.messages;
 
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.crypto.Hash;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Wire-format tests for the eth Transactions (0x12) encoder. Assertions are
@@ -13,6 +18,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * codec hinges on, independent of any decoder.
  */
 class TransactionsMessageTest {
+
+    static {
+        java.security.Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
+    }
 
     @Test
     void legacyTxEmbeddedVerbatimAsNestedList() {
@@ -60,5 +69,30 @@ class TransactionsMessageTest {
         // outer list of 6 payload bytes: 0xc6 || (c2 01 02) || (82 02 7f)
         assertArrayEquals(
                 new byte[]{(byte) 0xc6, (byte) 0xc2, 0x01, 0x02, (byte) 0x82, 0x02, 0x7f}, msg);
+    }
+
+    @Test
+    void hashesAreKeccakOfEachTxsCanonicalBytes() {
+        // legacy tx = its own RLP list; typed tx = type||payload byte string. The hash
+        // is keccak over those canonical bytes — exactly what eth_sendRawTransaction
+        // returns and what a block's transactionsRoot is built from.
+        byte[] legacy = {(byte) 0xc2, 0x01, 0x02};
+        byte[] typed = {0x02, 0x7f};
+        byte[] msg = TransactionsMessage.encode(legacy, typed);
+        List<Bytes32> hashes = TransactionsMessage.hashes(msg, 256);
+        assertEquals(2, hashes.size());
+        assertEquals(Bytes32.wrap(Hash.keccak256(Bytes.wrap(legacy))), hashes.get(0));
+        assertEquals(Bytes32.wrap(Hash.keccak256(Bytes.wrap(typed))), hashes.get(1));
+    }
+
+    @Test
+    void hashesCapsAtMaxAndToleratesGarbage() {
+        // null / not-a-list / empty all yield no hashes — never throw on the event loop.
+        assertTrue(TransactionsMessage.hashes(null, 256).isEmpty());
+        assertTrue(TransactionsMessage.hashes(new byte[0], 256).isEmpty());
+        assertTrue(TransactionsMessage.hashes(new byte[]{0x01, 0x02, 0x03}, 256).isEmpty());
+        // the cap bounds event-loop work even for a large batch.
+        byte[] two = TransactionsMessage.encode(new byte[]{0x02, 0x7f}, new byte[]{0x02, 0x7e});
+        assertEquals(1, TransactionsMessage.hashes(two, 1).size());
     }
 }

--- a/rpc-backend/src/main/java/io/myotis/rpc/PendingNonceTracker.java
+++ b/rpc-backend/src/main/java/io/myotis/rpc/PendingNonceTracker.java
@@ -22,6 +22,14 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  * <p>Time is supplied by the caller (a monotonic {@link RpcClock} millis) so the tracker
  * stays a pure, deterministically-testable unit with no clock dependency of its own.
+ *
+ * <p><strong>Trust:</strong> the nonce this produces is NOT proof-backed against chain
+ * state — unlike the mined count it overlays. That is intentional and bounded: "pending"
+ * is un-provable, the increment derives from our own ECDSA-authenticated broadcast, it
+ * only ever raises above the verified mined floor, and a wrong view self-heals via TTL
+ * (worst case a delayed tx, never forged state). The full rationale lives at the call
+ * site in {@code VerifiedRpcBackend.getTransactionCount}; do not reuse this for any tag
+ * a caller treats as settled ("latest"/numbered).
  */
 final class PendingNonceTracker {
 

--- a/rpc-backend/src/main/java/io/myotis/rpc/PendingNonceTracker.java
+++ b/rpc-backend/src/main/java/io/myotis/rpc/PendingNonceTracker.java
@@ -1,0 +1,72 @@
+package io.myotis.rpc;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Tracks the highest nonce this node has broadcast for a sender but not yet seen
+ * mined, so eth_getTransactionCount("pending") can report next = nonce + 1 instead
+ * of reusing a still-pending nonce.
+ *
+ * <p>A light node has no mempool. Without this, two back-to-back sends from one
+ * account collide on a single nonce: the second reads the not-yet-incremented mined
+ * count while the first is still pending and reuses its nonce (MetaMask's "second
+ * send hangs on the confirm screen" symptom). The txs are ones we relayed ourselves
+ * and hold the signed bytes for, so reporting their nonce as pending is our own honest
+ * knowledge of the mempool we fed — not a trust assumption.
+ *
+ * <p>An entry expires when the chain's mined count passes it ({@link #overlay} sees the
+ * tx mined) or after {@code ttlMs} (tx dropped/replaced — never wedge the account at a
+ * nonce the chain will never reach). The overlay only ever RAISES the nonce; it never
+ * returns a value below the supplied verified mined count.
+ *
+ * <p>Time is supplied by the caller (a monotonic {@link RpcClock} millis) so the tracker
+ * stays a pure, deterministically-testable unit with no clock dependency of its own.
+ */
+final class PendingNonceTracker {
+
+    private record Entry(long nonce, long atMs) {}
+
+    private final Map<String, Entry> bySender = new ConcurrentHashMap<>();
+    private final long ttlMs;
+
+    PendingNonceTracker(long ttlMs) {
+        this.ttlMs = ttlMs;
+    }
+
+    /** Record that {@code senderHex} broadcast a tx with {@code nonce} at {@code nowMs}.
+     *  Keeps only the highest nonce seen for the sender. {@code senderHex} should be the
+     *  lowercase 0x address. */
+    void record(String senderHex, long nonce, long nowMs) {
+        bySender.merge(senderHex, new Entry(nonce, nowMs),
+                (cur, next) -> next.nonce() >= cur.nonce() ? next : cur);
+    }
+
+    /** Overlay our pending nonce onto a freshly-read mined count for {@code senderHex}.
+     *  Returns {@code max(minedCount, pendingNonce + 1)} while our send hasn't landed,
+     *  else the plain {@code minedCount}. Expires the entry when mined catches up or the
+     *  TTL elapses. */
+    long overlay(String senderHex, long minedCount, long nowMs) {
+        Entry e = bySender.get(senderHex);
+        if (e == null) return minedCount;
+        // mined count becomes nonce + 1 once our tx lands; until then it's <= nonce.
+        boolean mined = minedCount > e.nonce();
+        boolean expired = nowMs - e.atMs() > ttlMs;
+        if (mined || expired) {
+            bySender.remove(senderHex, e);
+            return minedCount;
+        }
+        return Math.max(minedCount, e.nonce() + 1);
+    }
+
+    /** True iff we hold an unexpired-by-mining pending nonce for the sender (for logging). */
+    boolean has(String senderHex) {
+        return bySender.containsKey(senderHex);
+    }
+
+    /** The tracked pending nonce for the sender, or -1 if none (for logging). */
+    long pendingNonce(String senderHex) {
+        Entry e = bySender.get(senderHex);
+        return e == null ? -1L : e.nonce();
+    }
+}

--- a/rpc-backend/src/main/java/io/myotis/rpc/SentTxTracker.java
+++ b/rpc-backend/src/main/java/io/myotis/rpc/SentTxTracker.java
@@ -1,0 +1,90 @@
+package io.myotis.rpc;
+
+import org.apache.tuweni.bytes.Bytes32;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * A "mini-mempool" of only this node's OWN broadcast transactions, used to watch them
+ * propagate back across devp2p gossip.
+ *
+ * <p>A light wallet keeps no mempool and ignores the gossip firehose. But after it
+ * broadcasts a signed tx it can watch for that exact hash returning over Transactions
+ * (0x12) / NewPooledTransactionHashes (0x18) — positive confirmation the tx reached the
+ * network (and, by its continued absence, a hint it may have been dropped). This holds
+ * the watch set and stamps the first sighting of each.
+ *
+ * <p>Keyed by {@link Bytes32} (not hex) because {@link #markSeen} is called on the Netty
+ * event loop for every gossip hash while watching — value-typed keys avoid per-hash hex
+ * allocation. {@link #watchingAny} is the O(1) guard the handler checks before decoding
+ * any gossip at all, so the firehose stays free whenever nothing of ours is in flight.
+ *
+ * <p>Time is supplied by the caller (monotonic {@link RpcClock} millis), keeping this a
+ * pure, deterministically-testable unit.
+ */
+final class SentTxTracker {
+
+    /** When we broadcast it, and when we first saw it on gossip ({@code -1} until seen). */
+    private record Watch(long broadcastAtMs, long seenAtMs) {}
+
+    private final Map<Bytes32, Watch> watched = new ConcurrentHashMap<>();
+    private final long ttlMs;
+
+    SentTxTracker(long ttlMs) {
+        this.ttlMs = ttlMs;
+    }
+
+    /** Start watching a tx we just broadcast. */
+    void watch(Bytes32 hash, long nowMs) {
+        watched.put(hash, new Watch(nowMs, -1L));
+    }
+
+    /** O(1) hot-path guard: do we currently care about any gossip hash at all? */
+    boolean watchingAny() {
+        return !watched.isEmpty();
+    }
+
+    /**
+     * Record that {@code hash} was seen on gossip.
+     *
+     * @return ms since broadcast if this is the FIRST sighting of one of our own txs;
+     *         {@code -1} if the hash isn't ours or was already counted.
+     */
+    long markSeen(Bytes32 hash, long nowMs) {
+        Watch[] firstSeen = {null};
+        watched.computeIfPresent(hash, (h, w) -> {
+            if (w.seenAtMs() >= 0) return w;            // already counted — leave as is
+            firstSeen[0] = w;
+            return new Watch(w.broadcastAtMs(), nowMs);
+        });
+        return firstSeen[0] == null ? -1L : nowMs - firstSeen[0].broadcastAtMs();
+    }
+
+    /** Stop watching a tx once it's confirmed mined (verified inclusion). */
+    void confirmMined(Bytes32 hash) {
+        watched.remove(hash);
+    }
+
+    /** True iff this is one of ours and we've seen it on gossip. */
+    boolean wasSeen(Bytes32 hash) {
+        Watch w = watched.get(hash);
+        return w != null && w.seenAtMs() >= 0;
+    }
+
+    /** Drop entries older than the TTL (a send that never mined and stopped mattering).
+     *  @return how many were evicted. */
+    int evictExpired(long nowMs) {
+        int[] removed = {0};
+        watched.entrySet().removeIf(e -> {
+            boolean expired = nowMs - e.getValue().broadcastAtMs() > ttlMs;
+            if (expired) removed[0]++;
+            return expired;
+        });
+        return removed[0];
+    }
+
+    int size() {
+        return watched.size();
+    }
+}

--- a/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
+++ b/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
@@ -185,6 +185,13 @@ public final class VerifiedRpcBackend implements io.myotis.jsonrpc.MyotisRpcBack
      *  elsewhere landing in the gap), while tolerating mobile build cadence. */
     private static final long RPC_NONCE_SERVE_STALE_MAX_MS = 120_000;
 
+    /** How long a broadcast-but-unmined nonce stays in {@link #pendingNonces}. After
+     *  this the overlay drops it even if the mined count never caught up, so a tx that
+     *  was dropped or replaced by the network can't permanently wedge the account at a
+     *  nonce the chain will never reach. 90s comfortably covers normal inclusion (a few
+     *  blocks) while bounding the wedge window if a send never lands. */
+    private static final long PENDING_NONCE_TTL_MS = 90_000;
+
     /** keccak256("") — an account with this codeHash is an EOA (no contract code). */
     private static final byte[] EMPTY_CODE_HASH = Hash.keccak256(Bytes.EMPTY).toArrayUnsafe();
 
@@ -360,6 +367,19 @@ public final class VerifiedRpcBackend implements io.myotis.jsonrpc.MyotisRpcBack
                     return size() > 256;
                 }
             });
+
+    /** Highest nonce this node has broadcast for a sender but not yet seen mined,
+     *  keyed by lowercase 0x sender address, with the broadcast timestamp. A light
+     *  node has no mempool, so without this two back-to-back sends from the same
+     *  account collide on one nonce: the second reads {@code eth_getTransactionCount}
+     *  while the first is still pending, gets the not-yet-incremented mined count, and
+     *  reuses the first tx's nonce (MetaMask's "confirm screen hangs on the second
+     *  send" symptom). We relayed these txs ourselves and hold the signed bytes, so
+     *  reporting their nonce as pending is our own honest knowledge of the mempool we
+     *  fed, not a trust assumption. The tracker expires an entry when the chain's mined
+     *  count passes it (tx mined) or after {@link #PENDING_NONCE_TTL_MS} (tx likely
+     *  dropped/replaced — never wedge the account). */
+    private final PendingNonceTracker pendingNonces = new PendingNonceTracker(PENDING_NONCE_TTL_MS);
 
     /** Suggested tip + when it was computed, one immutable unit behind a single
      *  volatile so a reader can't pair a fresh tip with a stale timestamp
@@ -561,7 +581,18 @@ public final class VerifiedRpcBackend implements io.myotis.jsonrpc.MyotisRpcBack
             return null;
         }
         io.myotis.evm.world.AccountState a = rpcAccountState(address, block);
-        return a == null ? null : Long.valueOf(a.nonce());
+        if (a == null) return null;
+        long mined = a.nonce();
+        // "pending" is the tag MetaMask uses to pick the next nonce for a new tx. A
+        // light node has no mempool, so overlay our own just-broadcast sends: report
+        // next = ourPendingNonce + 1 so a second back-to-back send doesn't reuse the
+        // first's nonce. "latest"/numbered tags stay exactly the mined count. The
+        // overlay only ever RAISES the nonce (max of mined and our pending+1) and only
+        // for txs we relayed ourselves — never serves a value below the verified chain.
+        if (block != null && block.equals("pending")) {
+            return Long.valueOf(pendingNonceOverlay(address, mined));
+        }
+        return Long.valueOf(mined);
     }
 
     @Override
@@ -1627,6 +1658,7 @@ public final class VerifiedRpcBackend implements io.myotis.jsonrpc.MyotisRpcBack
             if (sent == 0) return null;   // no peer reached → let the router report it
             byte[] txHash = Hash.keccak256(Bytes.wrap(rawTx)).toArrayUnsafe();
             sentTxCache.put(Bytes.wrap(txHash).toHexString(), rawTx.clone());
+            recordPendingNonce(rawTx);
             log.info("[rpc] eth_sendRawTransaction broadcast to " + sent
                     + " peer(s), hash=" + Bytes.wrap(txHash).toHexString());
             return txHash;
@@ -1634,6 +1666,40 @@ public final class VerifiedRpcBackend implements io.myotis.jsonrpc.MyotisRpcBack
             log.info("[rpc] eth_sendRawTransaction failed: " + unwrap(e));
             return null;
         }
+    }
+
+    /** Record the (sender, nonce) of a tx we just broadcast so a follow-up
+     *  eth_getTransactionCount("pending") from that sender reports next = nonce + 1
+     *  instead of reusing this still-pending nonce. Decodes the sender from the signed
+     *  bytes (ECDSA recovery — our own tx, no trust involved). Keeps only the highest
+     *  nonce per sender; a malformed/undecodable tx is silently skipped (we already
+     *  broadcast it — the overlay is best-effort, not a gate). */
+    private void recordPendingNonce(byte[] rawTx) {
+        try {
+            var t = com.jaeckel.ethp2p.networking.eth.messages.EthTxDecoder.decode(Bytes.wrap(rawTx));
+            if (t == null || t.from() == null) return;
+            String key = t.from().toHexString().toLowerCase();
+            pendingNonces.record(key, t.nonce(), clock.elapsedMillis());
+            log.info("[rpc] pending-nonce: " + key + " -> " + t.nonce() + " (broadcast)");
+        } catch (Exception e) {
+            // best-effort overlay; never fail the send over bookkeeping
+        }
+    }
+
+    /** Overlay our own broadcast-but-unmined nonce onto a freshly-read mined count.
+     *  Returns {@code max(minedCount, ourPendingNonce + 1)} while the chain hasn't yet
+     *  reflected our send, so a second back-to-back send from the same account gets the
+     *  next nonce instead of colliding. Only consulted for the "pending" tag. */
+    private long pendingNonceOverlay(byte[] address, long minedCount) {
+        String key = Bytes.wrap(address).toHexString().toLowerCase();
+        long now = clock.elapsedMillis();
+        long pending = pendingNonces.pendingNonce(key);
+        long next = pendingNonces.overlay(key, minedCount, now);
+        if (next != minedCount) {
+            log.info("[rpc] pending-nonce: " + key + " overlay mined=" + minedCount
+                    + " -> " + next + " (our nonce " + pending + " still pending)");
+        }
+        return next;
     }
 
     // ---------------------------------------------------------------------

--- a/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
+++ b/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
@@ -43,7 +43,8 @@ import java.util.concurrent.TimeUnit;
  * (stops every executor this backend owns). The injected components are NOT
  * closed here — the host owns them.
  */
-public final class VerifiedRpcBackend implements io.myotis.jsonrpc.MyotisRpcBackend, AutoCloseable {
+public final class VerifiedRpcBackend implements io.myotis.jsonrpc.MyotisRpcBackend,
+        com.jaeckel.ethp2p.networking.eth.TxGossipObserver, AutoCloseable {
 
     // ---------------------------------------------------------------------
     // Constants (ported from NodeService's RPC region)
@@ -191,6 +192,12 @@ public final class VerifiedRpcBackend implements io.myotis.jsonrpc.MyotisRpcBack
      *  nonce the chain will never reach. 90s comfortably covers normal inclusion (a few
      *  blocks) while bounding the wedge window if a send never lands. */
     private static final long PENDING_NONCE_TTL_MS = 90_000;
+
+    /** How long we keep watching a broadcast tx for its hash to come back over gossip.
+     *  Generous vs. typical inclusion (a few blocks): once a tx mines we stop watching
+     *  it explicitly (verified inclusion), and the warmer evicts anything older than
+     *  this so the gossip-decode hot path goes quiet when nothing of ours is live. */
+    private static final long SENT_TX_WATCH_TTL_MS = 180_000;
 
     /** keccak256("") — an account with this codeHash is an EOA (no contract code). */
     private static final byte[] EMPTY_CODE_HASH = Hash.keccak256(Bytes.EMPTY).toArrayUnsafe();
@@ -381,6 +388,12 @@ public final class VerifiedRpcBackend implements io.myotis.jsonrpc.MyotisRpcBack
      *  dropped/replaced — never wedge the account). */
     private final PendingNonceTracker pendingNonces = new PendingNonceTracker(PENDING_NONCE_TTL_MS);
 
+    /** Mini-mempool of our own broadcast txs, watched for their hashes returning over
+     *  devp2p gossip (Transactions 0x12 / NewPooledTransactionHashes 0x18) to confirm
+     *  propagation. Fed by {@link #onTxHashSeen} (the {@code TxGossipObserver} this
+     *  backend registers on the connector); cleared on verified mining or TTL. */
+    private final SentTxTracker sentTxWatch = new SentTxTracker(SENT_TX_WATCH_TTL_MS);
+
     /** Suggested tip + when it was computed, one immutable unit behind a single
      *  volatile so a reader can't pair a fresh tip with a stale timestamp
      *  (same pattern as {@link HeadWithTimestamp}). */
@@ -488,6 +501,9 @@ public final class VerifiedRpcBackend implements io.myotis.jsonrpc.MyotisRpcBack
      */
     public synchronized void start() {
         if (headWarmer != null || closed) return;
+        // Register as the mempool-gossip observer so peers report tx hashes for our
+        // mini-mempool. Cheap when idle: handlers consult watchingAny() first.
+        connector.setTxGossipObserver(this);
         headWarmer = java.util.concurrent.Executors.newSingleThreadScheduledExecutor(r -> {
             Thread t = new Thread(r, "rpc-head-warmer");
             t.setDaemon(true);
@@ -508,6 +524,13 @@ public final class VerifiedRpcBackend implements io.myotis.jsonrpc.MyotisRpcBack
             } catch (Throwable ignored) {
                 // never kill the warmer tick
             }
+            // Age out gossip-watch entries for sends that never mined, so the
+            // event-loop gossip-decode path goes quiet once nothing of ours is live.
+            try {
+                sentTxWatch.evictExpired(clock.elapsedMillis());
+            } catch (Throwable ignored) {
+                // never kill the warmer tick
+            }
         }, 3, 5, TimeUnit.SECONDS);
     }
 
@@ -516,6 +539,13 @@ public final class VerifiedRpcBackend implements io.myotis.jsonrpc.MyotisRpcBack
     @Override
     public synchronized void close() {
         closed = true;
+        // Stop receiving gossip callbacks before tearing down (connector is the host's
+        // to close, but our observer registration is ours to retract).
+        try {
+            connector.setTxGossipObserver(null);
+        } catch (Exception ignored) {
+            // connector may already be torn down — nothing to retract.
+        }
         if (headWarmer != null) {
             headWarmer.shutdownNow();
             headWarmer = null;
@@ -1659,6 +1689,8 @@ public final class VerifiedRpcBackend implements io.myotis.jsonrpc.MyotisRpcBack
             byte[] txHash = Hash.keccak256(Bytes.wrap(rawTx)).toArrayUnsafe();
             sentTxCache.put(Bytes.wrap(txHash).toHexString(), rawTx.clone());
             recordPendingNonce(rawTx);
+            // Watch for this hash to come back over gossip (propagation confirmation).
+            sentTxWatch.watch(Bytes32.wrap(txHash), clock.elapsedMillis());
             log.info("[rpc] eth_sendRawTransaction broadcast to " + sent
                     + " peer(s), hash=" + Bytes.wrap(txHash).toHexString());
             return txHash;
@@ -1674,6 +1706,28 @@ public final class VerifiedRpcBackend implements io.myotis.jsonrpc.MyotisRpcBack
      *  bytes (ECDSA recovery — our own tx, no trust involved). Keeps only the highest
      *  nonce per sender; a malformed/undecodable tx is silently skipped (we already
      *  broadcast it — the overlay is best-effort, not a gate). */
+    // ---------------------------------------------------------------------
+    // TxGossipObserver: watch our own broadcast txs propagate over gossip
+    // ---------------------------------------------------------------------
+
+    /** Hot-path guard read by every peer's gossip handler — true only while we hold an
+     *  unconfirmed broadcast of our own, so the firehose is otherwise dropped untouched. */
+    @Override
+    public boolean watchingAny() {
+        return sentTxWatch.watchingAny();
+    }
+
+    /** A tx hash observed on the network. We only act when it's one of OUR broadcasts
+     *  (cheap miss otherwise), logging the first sighting as propagation confirmation. */
+    @Override
+    public void onTxHashSeen(Bytes32 txHash) {
+        long ms = sentTxWatch.markSeen(txHash, clock.elapsedMillis());
+        if (ms >= 0) {
+            log.info("[mini-mempool] our tx " + txHash.toHexString()
+                    + " seen propagating on the network " + ms + "ms after broadcast");
+        }
+    }
+
     private void recordPendingNonce(byte[] rawTx) {
         try {
             var t = com.jaeckel.ethp2p.networking.eth.messages.EthTxDecoder.decode(Bytes.wrap(rawTx));
@@ -1751,6 +1805,8 @@ public final class VerifiedRpcBackend implements io.myotis.jsonrpc.MyotisRpcBack
                     if (Hash.keccak256(txs.get(i)).equals(want)) {
                         log.info("[rpc] eth_getTransactionByHash found in block #"
                                 + h.number + " index " + i);
+                        // Verified inclusion: stop watching it for gossip propagation.
+                        sentTxWatch.confirmMined(want);
                         return buildTxJson(txs.get(i).toArrayUnsafe(), want, blockHash, h.number, i);
                     }
                 }

--- a/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
+++ b/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
@@ -613,12 +613,29 @@ public final class VerifiedRpcBackend implements io.myotis.jsonrpc.MyotisRpcBack
         io.myotis.evm.world.AccountState a = rpcAccountState(address, block);
         if (a == null) return null;
         long mined = a.nonce();
-        // "pending" is the tag MetaMask uses to pick the next nonce for a new tx. A
-        // light node has no mempool, so overlay our own just-broadcast sends: report
-        // next = ourPendingNonce + 1 so a second back-to-back send doesn't reuse the
-        // first's nonce. "latest"/numbered tags stay exactly the mined count. The
-        // overlay only ever RAISES the nonce (max of mined and our pending+1) and only
-        // for txs we relayed ourselves — never serves a value below the verified chain.
+        // TRUST NOTE — the value returned for "latest"/numbered tags IS cryptographically
+        // verified: it's the account nonce proven by a SNAP proof against a beacon-verified
+        // state root. The "pending" overlay below is the one exception, and deliberately so:
+        //
+        //   * "pending" is by definition UN-provable — there is no state root for "not yet
+        //     mined", so the SNAP-proof standard cannot apply to it. The honest meaning of
+        //     "pending" is "latest mined + what's in flight".
+        //   * The overlay's increment is NOT proof-backed against chain state, but it isn't
+        //     arbitrary either: ourPendingNonce comes from a tx WE signed and broadcast
+        //     (sender recovered by ECDSA from our own signature) — authenticated intent, not
+        //     a peer's claim. We never trust a peer for it.
+        //   * It only ever RAISES the nonce: max(verified mined, ourPending + 1). It can
+        //     never report BELOW the proven mined count, and only ever for txs we relayed
+        //     ourselves.
+        //   * Worst case if our view is wrong (the tx was dropped/replaced): the wallet
+        //     signs against a too-high nonce and that tx waits until the gap fills; the
+        //     PENDING_NONCE_TTL_MS self-heals it. The failure mode is a delayed tx, never
+        //     acceptance of forged chain state.
+        //
+        // So this is consistent with the "everything verified" anchor (the un-provable tag
+        // gets our own authenticated knowledge, bounded above the verified floor) — but the
+        // asymmetry is real: do NOT extend this overlay to "latest"/numbered tags, which
+        // callers and on-chain logic treat as settled, proof-backed values.
         if (block != null && block.equals("pending")) {
             return Long.valueOf(pendingNonceOverlay(address, mined));
         }

--- a/rpc-backend/src/test/java/io/myotis/rpc/PendingNonceTrackerTest.java
+++ b/rpc-backend/src/test/java/io/myotis/rpc/PendingNonceTrackerTest.java
@@ -1,0 +1,76 @@
+package io.myotis.rpc;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PendingNonceTrackerTest {
+
+    private static final String A = "0x00000000000000000000000000000000000000aa";
+    private static final long TTL = 90_000;
+
+    @Test
+    void noPendingEntryServesMinedCountUnchanged() {
+        PendingNonceTracker t = new PendingNonceTracker(TTL);
+        assertEquals(5, t.overlay(A, 5, 1_000));
+        assertFalse(t.has(A));
+        assertEquals(-1, t.pendingNonce(A));
+    }
+
+    @Test
+    void pendingSendRaisesNextNonceUntilMined() {
+        PendingNonceTracker t = new PendingNonceTracker(TTL);
+        // account has sent nonces 0..4 -> mined count 5; we broadcast nonce 5.
+        t.record(A, 5, 1_000);
+        // chain hasn't reflected our send yet (still 5) -> next must be 6, not 5.
+        assertEquals(6, t.overlay(A, 5, 2_000));
+        // a second back-to-back send takes nonce 6; broadcast it.
+        t.record(A, 6, 2_500);
+        assertEquals(7, t.overlay(A, 5, 3_000));
+    }
+
+    @Test
+    void overlayNeverLowersTheMinedCount() {
+        PendingNonceTracker t = new PendingNonceTracker(TTL);
+        t.record(A, 5, 1_000);
+        // chain advanced past our pending nonce by other means -> trust the chain.
+        assertEquals(9, t.overlay(A, 9, 2_000));
+    }
+
+    @Test
+    void entryClearsOnceTheChainReflectsOurSend() {
+        PendingNonceTracker t = new PendingNonceTracker(TTL);
+        t.record(A, 5, 1_000);
+        assertEquals(6, t.overlay(A, 5, 2_000));
+        assertTrue(t.has(A));
+        // our tx mined -> mined count is now 6 (> our nonce 5): entry expires.
+        assertEquals(6, t.overlay(A, 6, 3_000));
+        assertFalse(t.has(A));
+        // and a later read is the plain mined count.
+        assertEquals(6, t.overlay(A, 6, 4_000));
+    }
+
+    @Test
+    void entryExpiresAfterTtlWhenNeverMined() {
+        PendingNonceTracker t = new PendingNonceTracker(TTL);
+        t.record(A, 5, 1_000);
+        // within TTL the overlay still holds.
+        assertEquals(6, t.overlay(A, 5, 1_000 + TTL));
+        assertTrue(t.has(A));
+        // past TTL with the chain never reflecting it (tx dropped) -> stop wedging.
+        assertEquals(5, t.overlay(A, 5, 1_001 + TTL));
+        assertFalse(t.has(A));
+    }
+
+    @Test
+    void recordKeepsHighestNoncePerSender() {
+        PendingNonceTracker t = new PendingNonceTracker(TTL);
+        t.record(A, 5, 1_000);
+        // an out-of-order/replacement record with a lower nonce must not lower it.
+        t.record(A, 3, 1_500);
+        assertEquals(5, t.pendingNonce(A));
+        assertEquals(6, t.overlay(A, 5, 2_000));
+    }
+}

--- a/rpc-backend/src/test/java/io/myotis/rpc/SentTxTrackerTest.java
+++ b/rpc-backend/src/test/java/io/myotis/rpc/SentTxTrackerTest.java
@@ -1,0 +1,75 @@
+package io.myotis.rpc;
+
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SentTxTrackerTest {
+
+    private static final Bytes32 H1 = Bytes32.fromHexString(
+            "0x1111111111111111111111111111111111111111111111111111111111111111");
+    private static final Bytes32 H2 = Bytes32.fromHexString(
+            "0x2222222222222222222222222222222222222222222222222222222222222222");
+    private static final long TTL = 180_000;
+
+    @Test
+    void notWatchingWhenEmpty() {
+        SentTxTracker t = new SentTxTracker(TTL);
+        assertFalse(t.watchingAny());
+        // a gossip hit for something we never sent is a cheap miss.
+        assertEquals(-1, t.markSeen(H1, 1_000));
+    }
+
+    @Test
+    void firstSightingReportsLatencyThenStopsCounting() {
+        SentTxTracker t = new SentTxTracker(TTL);
+        t.watch(H1, 1_000);
+        assertTrue(t.watchingAny());
+        assertFalse(t.wasSeen(H1));
+        // first time the hash comes back: ms since broadcast.
+        assertEquals(500, t.markSeen(H1, 1_500));
+        assertTrue(t.wasSeen(H1));
+        // every subsequent sighting is a no-op (already counted).
+        assertEquals(-1, t.markSeen(H1, 1_800));
+        assertEquals(-1, t.markSeen(H1, 9_999));
+    }
+
+    @Test
+    void watchesAreIndependentPerHash() {
+        SentTxTracker t = new SentTxTracker(TTL);
+        t.watch(H1, 1_000);
+        t.watch(H2, 1_000);
+        assertEquals(2, t.size());
+        assertEquals(200, t.markSeen(H1, 1_200));
+        // H2 never seen; an unrelated hash is still a miss.
+        assertEquals(-1, t.markSeen(
+                Bytes32.fromHexString("0x3333333333333333333333333333333333333333333333333333333333333333"),
+                1_300));
+        assertTrue(t.wasSeen(H1));
+        assertFalse(t.wasSeen(H2));
+    }
+
+    @Test
+    void confirmMinedStopsWatching() {
+        SentTxTracker t = new SentTxTracker(TTL);
+        t.watch(H1, 1_000);
+        t.confirmMined(H1);
+        assertFalse(t.watchingAny());
+        assertEquals(-1, t.markSeen(H1, 1_500));
+    }
+
+    @Test
+    void ttlEvictionClearsStaleWatchesAndQuietsTheGuard() {
+        SentTxTracker t = new SentTxTracker(TTL);
+        t.watch(H1, 1_000);
+        // within TTL: nothing evicted, still watching.
+        assertEquals(0, t.evictExpired(1_000 + TTL));
+        assertTrue(t.watchingAny());
+        // past TTL with no mining: evicted, guard goes quiet.
+        assertEquals(1, t.evictExpired(1_001 + TTL));
+        assertFalse(t.watchingAny());
+    }
+}


### PR DESCRIPTION
Fixes the "second back-to-back send hangs on MetaMask's confirm screen" symptom on both the daemon and Android (shared `:rpc-backend`). A light node has no mempool, so `eth_getTransactionCount("pending")` could only ever return the mined count — two sends from the same account collided on one nonce.

## Stage A — pending-nonce overlay (`3f53d91`)
On `eth_sendRawTransaction` we recover the sender (existing `EthTxDecoder` ECDSA — no new crypto) and the nonce, and for the **`"pending"` tag only** report `next = max(minedCount, ourNonce + 1)`.

- Only ever **raises** the nonce, only for txs **we relayed ourselves**, never below the verified chain count.
- `"latest"`/numbered tags stay exactly the SNAP-proof-verified mined count.
- Self-heals: an entry clears the moment the chain's mined count passes it, or after a 90s TTL (dropped/replaced tx → never wedge the account).
- Logic lives in a pure, clock-injected `PendingNonceTracker` (6 unit tests).

## Stage B — gossip-confirmed mini-mempool (`e62cfbe`)
After broadcasting, watch for our own tx hash returning over devp2p gossip (Transactions `0x12` / NewPooledTransactionHashes `0x18`) as propagation confirmation.

- `EthHandler` decodes gossip **only while** a `TxGossipObserver` reports `watchingAny()` — the firehose stays dropped untouched on the event loop the rest of the time.
- Two never-throw, capped decoders: `TransactionsMessage.hashes` (keccak of each tx's canonical bytes, version-independent) and `NewPooledTransactionHashesMessage.hashes` (version-aware: flat list for eth/66–67, `[types,sizes,hashes]` for eth/68+).
- `SentTxTracker` keyed by `Bytes32` (no hex alloc on the hot path); cleared on verified inclusion or a 180s TTL. First sighting logs propagation latency.
- Unit-tested: tracker lifecycle, both `0x18` wire layouts, per-msg cap, malformed-input tolerance.

## Trust note (`aa80f54`)
Documents the one deliberate verification asymmetry: `"latest"`/numbered nonces are proof-backed; the `"pending"` overlay is not (and can't be — "pending" is un-provable), but its increment is our own ECDSA-authenticated broadcast, strictly bounded above the verified mined floor, self-healing via TTL. Explicit warning not to extend the overlay to settled tags.

Full `:rpc-backend`, `:networking`, and `:myotis-evm` suites green; daemon + Android compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)