### PR TITLE
consensus: verify execution payload branch in light client headers

### DIFF
--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
@@ -1040,6 +1040,11 @@ public class BeaconLightClient implements AutoCloseable {
                 return false;
             }
 
+            if (!LightClientProcessor.verifyExecutionBranch(bootstrap.header())) {
+                log.warn("[beacon] HTTP bootstrap execution branch invalid");
+                return false;
+            }
+
             store.initialize(bootstrap.header(), bootstrap.currentSyncCommittee());
             updateSyncState();
             log.info("[beacon] HTTP bootstrap complete, slot={}", bootstrap.header().beacon().slot());
@@ -1117,6 +1122,15 @@ public class BeaconLightClient implements AutoCloseable {
 
                             if (!branchValid) {
                                 log.warn("[beacon] Bootstrap sync committee branch invalid from {}", peer);
+                                if (remaining.decrementAndGet() == 0 && !winnerFuture.isDone()) {
+                                    winnerFuture.completeExceptionally(
+                                            new RuntimeException("All peers failed bootstrap"));
+                                }
+                                return;
+                            }
+
+                            if (!LightClientProcessor.verifyExecutionBranch(bootstrap.header())) {
+                                log.warn("[beacon] Bootstrap execution branch invalid from {}", peer);
                                 if (remaining.decrementAndGet() == 0 && !winnerFuture.isDone()) {
                                     winnerFuture.completeExceptionally(
                                             new RuntimeException("All peers failed bootstrap"));

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
@@ -1131,6 +1131,7 @@ public class BeaconLightClient implements AutoCloseable {
 
                             if (!LightClientProcessor.verifyExecutionBranch(bootstrap.header())) {
                                 log.warn("[beacon] Bootstrap execution branch invalid from {}", peer);
+                                notifyPeerFailure(peer);
                                 if (remaining.decrementAndGet() == 0 && !winnerFuture.isDone()) {
                                     winnerFuture.completeExceptionally(
                                             new RuntimeException("All peers failed bootstrap"));

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/lightclient/LightClientProcessor.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/lightclient/LightClientProcessor.java
@@ -2,6 +2,7 @@ package com.jaeckel.ethp2p.consensus.lightclient;
 
 import com.jaeckel.ethp2p.consensus.ssz.SszUtil;
 import com.jaeckel.ethp2p.consensus.types.LightClientFinalityUpdate;
+import com.jaeckel.ethp2p.consensus.types.LightClientHeader;
 import com.jaeckel.ethp2p.consensus.types.LightClientUpdate;
 import com.jaeckel.ethp2p.consensus.types.SyncCommittee;
 import org.slf4j.Logger;
@@ -105,6 +106,17 @@ public class LightClientProcessor {
             return false;
         }
 
+        // Bind each header's execution payload to its beacon body. The headers we store
+        // here feed the execution-layer verification chain (EL state root / block hash),
+        // and the sync-committee signature does NOT cover the execution payload — only
+        // this branch does.
+        if (!verifyExecutionBranch(update.attestedHeader())
+                || !verifyExecutionBranch(update.finalizedHeader())) {
+            log.info("[lc-processor] Finality update rejected (attestedSlot={}): execution branch Merkle proof failed",
+                    attestedSlot);
+            return false;
+        }
+
         long oldFinalizedSlot = store.getFinalizedSlot();
         store.updateFinalized(update.finalizedHeader(), finalizedSlot);
         store.updateOptimistic(update.attestedHeader(), update.signatureSlot());
@@ -193,6 +205,16 @@ public class LightClientProcessor {
             return false;
         }
 
+        // Bind each header's execution payload to its beacon body (see
+        // verifyExecutionBranch): the sync-committee signature covers only the beacon
+        // header, so without this an attacker could swap in a forged execution payload.
+        if (!verifyExecutionBranch(update.attestedHeader())
+                || !verifyExecutionBranch(update.finalizedHeader())) {
+            log.info("[lc-processor] Update rejected (attestedSlot={}): execution branch Merkle proof failed",
+                    attestedSlot);
+            return false;
+        }
+
         // Verify and store next sync committee if present.
         // Always verify and store when the store has no next committee (e.g. after rotation).
         SyncCommittee nextSyncCommittee = update.nextSyncCommittee();
@@ -231,6 +253,33 @@ public class LightClientProcessor {
 
     public LightClientStore getStore() {
         return store;
+    }
+
+    /**
+     * Verify that a light client header's {@code execution} payload header is the one
+     * committed to its beacon block body — i.e. {@code is_valid_light_client_header}
+     * from the consensus spec (Capella+).
+     *
+     * <p>The sync-committee BLS signature only covers the <i>beacon</i> header; the
+     * execution payload (carrying the EL state root and block hash that the whole
+     * execution-layer verification chain anchors to) is bound to the beacon header
+     * solely through this Merkle branch. Without checking it, a peer can forward a
+     * genuine, correctly-signed beacon header while swapping in a forged
+     * {@link com.jaeckel.ethp2p.consensus.types.ExecutionPayloadHeader} with an
+     * attacker-chosen state root / block hash, and every downstream account/storage
+     * proof would verify against forged state.
+     *
+     * @param header the light client header whose execution payload must be proven
+     * @return true if {@code header.execution} is proven to live at the
+     *         execution_payload field of {@code header.beacon.body}
+     */
+    public static boolean verifyExecutionBranch(LightClientHeader header) {
+        return SszUtil.verifyMerkleBranch(
+                header.execution().hashTreeRoot(),
+                header.executionBranch(),
+                BeaconChainSpec.EXECUTION_PAYLOAD_DEPTH,
+                BeaconChainSpec.EXECUTION_PAYLOAD_GINDEX,
+                header.beacon().bodyRoot());
     }
 
     private static String bytesToHex(byte[] bytes) {

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/lightclient/LightClientProcessor.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/lightclient/LightClientProcessor.java
@@ -112,7 +112,7 @@ public class LightClientProcessor {
         // this branch does.
         if (!verifyExecutionBranch(update.attestedHeader())
                 || !verifyExecutionBranch(update.finalizedHeader())) {
-            log.info("[lc-processor] Finality update rejected (attestedSlot={}): execution branch Merkle proof failed",
+            log.debug("[lc-processor] Finality update rejected (attestedSlot={}): execution branch Merkle proof failed",
                     attestedSlot);
             return false;
         }
@@ -274,6 +274,12 @@ public class LightClientProcessor {
      *         execution_payload field of {@code header.beacon.body}
      */
     public static boolean verifyExecutionBranch(LightClientHeader header) {
+        if (header == null
+                || header.beacon() == null
+                || header.execution() == null
+                || header.executionBranch() == null) {
+            return false;
+        }
         return SszUtil.verifyMerkleBranch(
                 header.execution().hashTreeRoot(),
                 header.executionBranch(),

--- a/consensus/src/test/java/com/jaeckel/ethp2p/consensus/TestUtil.java
+++ b/consensus/src/test/java/com/jaeckel/ethp2p/consensus/TestUtil.java
@@ -2,6 +2,7 @@ package com.jaeckel.ethp2p.consensus;
 
 import com.jaeckel.ethp2p.consensus.bls.BlsVerifier;
 import com.jaeckel.ethp2p.consensus.bls.HashToCurve;
+import com.jaeckel.ethp2p.consensus.lightclient.BeaconChainSpec;
 import com.jaeckel.ethp2p.consensus.ssz.SszUtil;
 import com.jaeckel.ethp2p.consensus.types.BeaconBlockHeader;
 import com.jaeckel.ethp2p.consensus.types.ExecutionPayloadHeader;
@@ -132,6 +133,29 @@ public final class TestUtil {
      */
     public static LightClientHeader dummyLightClientHeader(BeaconBlockHeader beacon) {
         return new LightClientHeader(beacon, dummyExecutionPayloadHeader(), zeroExecutionBranch());
+    }
+
+    /**
+     * Build a LightClientHeader whose execution payload is genuinely committed to the
+     * beacon body root via a real execution branch, so it passes
+     * {@code LightClientProcessor.verifyExecutionBranch}. The beacon header uses the
+     * given slot/proposer/parent/state roots and a {@code bodyRoot} derived from the
+     * (dummy) execution payload — callers that need the beacon's hash-tree-root should
+     * read it from {@code header.beacon()} rather than constructing the beacon separately.
+     */
+    public static LightClientHeader consistentLightClientHeader(
+            long slot, long proposerIndex, byte[] parentRoot, byte[] stateRoot) {
+        ExecutionPayloadHeader exec = dummyExecutionPayloadHeader();
+        // execution_payload sits at generalized index 25 (depth 4) under the body root,
+        // i.e. leaf index 9 of a 16-leaf tree.
+        int leafIdx = BeaconChainSpec.EXECUTION_PAYLOAD_GINDEX % (1 << BeaconChainSpec.EXECUTION_PAYLOAD_DEPTH);
+        byte[][] leaves = new byte[1 << BeaconChainSpec.EXECUTION_PAYLOAD_DEPTH][32];
+        leaves[leafIdx] = exec.hashTreeRoot();
+        byte[][] tree = buildMerkleTree(leaves);
+        byte[][] branch = extractBranch(tree, BeaconChainSpec.EXECUTION_PAYLOAD_DEPTH, leafIdx);
+        byte[] bodyRoot = tree[1];
+        BeaconBlockHeader beacon = new BeaconBlockHeader(slot, proposerIndex, parentRoot, stateRoot, bodyRoot);
+        return new LightClientHeader(beacon, exec, branch);
     }
 
     /**

--- a/consensus/src/test/java/com/jaeckel/ethp2p/consensus/lightclient/LightClientProcessorTest.java
+++ b/consensus/src/test/java/com/jaeckel/ethp2p/consensus/lightclient/LightClientProcessorTest.java
@@ -121,6 +121,58 @@ class LightClientProcessorTest {
     }
 
     @Test
+    void rejectsInvalidExecutionBranch() {
+        LightClientFinalityUpdate valid = buildValidFinalityUpdate(900L, 901L);
+
+        // Corrupt one node of the finalized header's execution branch so its execution
+        // payload no longer proves against the beacon body root. The beacon header is
+        // untouched, so the BLS signature and finality branch still verify — only the
+        // execution-branch check can reject this update.
+        LightClientHeader fin = valid.finalizedHeader();
+        byte[][] corruptBranch = new byte[4][];
+        for (int i = 0; i < 4; i++) corruptBranch[i] = Arrays.copyOf(fin.executionBranch()[i], 32);
+        corruptBranch[0][0] ^= 0x01;
+        LightClientHeader corruptFinalized =
+                new LightClientHeader(fin.beacon(), fin.execution(), corruptBranch);
+
+        LightClientFinalityUpdate tampered = new LightClientFinalityUpdate(
+                valid.attestedHeader(), corruptFinalized, valid.finalityBranch(),
+                valid.syncAggregate(), valid.signatureSlot());
+
+        assertFalse(processor.processFinalityUpdate(tampered));
+        assertEquals(100L, store.getFinalizedSlot());
+    }
+
+    @Test
+    void rejectsForgedExecutionPayload() {
+        LightClientFinalityUpdate valid = buildValidFinalityUpdate(950L, 951L);
+
+        // Keep the genuine execution branch but swap in a different execution payload
+        // (attacker-chosen state root). The branch now proves the original payload, not
+        // the forged one, so verifyExecutionBranch must reject it.
+        LightClientHeader fin = valid.finalizedHeader();
+        ExecutionPayloadHeader forged = TestUtil.dummyExecutionPayloadHeader();
+        byte[] forgedStateRoot = new byte[32];
+        forgedStateRoot[0] = (byte) 0xAB; // differs from the all-zero dummy state root
+        ExecutionPayloadHeader forgedPayload = new ExecutionPayloadHeader(
+                forged.parentHash(), forged.feeRecipient(), forgedStateRoot, forged.receiptsRoot(),
+                forged.logsBloom(), forged.prevRandao(), forged.blockNumber(), forged.gasLimit(),
+                forged.gasUsed(), forged.timestamp(), forged.extraData(), forged.baseFeePerGas(),
+                forged.blockHash(), forged.transactionsRoot(), forged.withdrawalsRoot(),
+                forged.blobGasUsed(), forged.excessBlobGas(), forged.depositRequestsRoot(),
+                forged.withdrawalRequestsRoot(), forged.consolidationRequestsRoot());
+        LightClientHeader forgedFinalized =
+                new LightClientHeader(fin.beacon(), forgedPayload, fin.executionBranch());
+
+        LightClientFinalityUpdate tampered = new LightClientFinalityUpdate(
+                valid.attestedHeader(), forgedFinalized, valid.finalityBranch(),
+                valid.syncAggregate(), valid.signatureSlot());
+
+        assertFalse(processor.processFinalityUpdate(tampered));
+        assertEquals(100L, store.getFinalizedSlot());
+    }
+
+    @Test
     void rejectsNullCommittee() {
         // Fresh store without initialization
         LightClientStore emptyStore = new LightClientStore();

--- a/consensus/src/test/java/com/jaeckel/ethp2p/consensus/lightclient/LightClientProcessorTest.java
+++ b/consensus/src/test/java/com/jaeckel/ethp2p/consensus/lightclient/LightClientProcessorTest.java
@@ -137,9 +137,9 @@ class LightClientProcessorTest {
         long signatureSlot = 801L;
 
         // Build finalized header and its Merkle proof in attested state
-        BeaconBlockHeader finalizedBeacon = new BeaconBlockHeader(
-                finalizedSlot, 0L, new byte[32], new byte[32], new byte[32]);
-        byte[] finalizedRoot = finalizedBeacon.hashTreeRoot();
+        LightClientHeader finalizedHeader = TestUtil.consistentLightClientHeader(
+                finalizedSlot, 0L, new byte[32], new byte[32]);
+        byte[] finalizedRoot = finalizedHeader.beacon().hashTreeRoot();
 
         // Build depth-6 tree for finality branch
         int finalityLeafIdx = BeaconChainSpec.FINALIZED_ROOT_GINDEX % 64;
@@ -150,12 +150,10 @@ class LightClientProcessorTest {
 
         // The attested header's stateRoot is the Merkle root for the finality tree
         byte[] attestedStateRoot = finalityTree[1];
-        BeaconBlockHeader attestedBeacon = new BeaconBlockHeader(
-                signatureSlot, 0L, new byte[32], attestedStateRoot, new byte[32]);
-        LightClientHeader attestedHeader = TestUtil.dummyLightClientHeader(attestedBeacon);
-        LightClientHeader finalizedHeader = TestUtil.dummyLightClientHeader(finalizedBeacon);
+        LightClientHeader attestedHeader = TestUtil.consistentLightClientHeader(
+                signatureSlot, 0L, new byte[32], attestedStateRoot);
 
-        SyncAggregate agg = buildSyncAggregate(attestedBeacon, 512);
+        SyncAggregate agg = buildSyncAggregate(attestedHeader.beacon(), 512);
 
         // Build a next sync committee with corrupt branch
         byte[][] corruptCommitteeBranch = new byte[5][32];
@@ -212,10 +210,10 @@ class LightClientProcessorTest {
 
     private LightClientFinalityUpdate buildFinalityUpdateWithParticipation(
             long finalizedSlot, long signatureSlot, int participantCount) {
-        // Build finalized header
-        BeaconBlockHeader finalizedBeacon = new BeaconBlockHeader(
-                finalizedSlot, 0L, new byte[32], new byte[32], new byte[32]);
-        byte[] finalizedRoot = finalizedBeacon.hashTreeRoot();
+        // Build finalized header (execution payload genuinely committed to its body root)
+        LightClientHeader finalizedHeader = TestUtil.consistentLightClientHeader(
+                finalizedSlot, 0L, new byte[32], new byte[32]);
+        byte[] finalizedRoot = finalizedHeader.beacon().hashTreeRoot();
 
         // Build depth-6 tree for finality branch
         // The finalized root sits at gindex 105 in the state tree.
@@ -229,12 +227,10 @@ class LightClientProcessorTest {
 
         // The attested header's stateRoot must be the Merkle root
         byte[] attestedStateRoot = tree[1];
-        BeaconBlockHeader attestedBeacon = new BeaconBlockHeader(
-                signatureSlot, 0L, new byte[32], attestedStateRoot, new byte[32]);
-        LightClientHeader attestedHeader = TestUtil.dummyLightClientHeader(attestedBeacon);
-        LightClientHeader finalizedHeader = TestUtil.dummyLightClientHeader(finalizedBeacon);
+        LightClientHeader attestedHeader = TestUtil.consistentLightClientHeader(
+                signatureSlot, 0L, new byte[32], attestedStateRoot);
 
-        SyncAggregate agg = buildSyncAggregate(attestedBeacon, participantCount);
+        SyncAggregate agg = buildSyncAggregate(attestedHeader.beacon(), participantCount);
 
         return new LightClientFinalityUpdate(
                 attestedHeader, finalizedHeader, finalityBranch, agg, signatureSlot);


### PR DESCRIPTION
The sync-committee BLS signature only covers the beacon header; the
execution payload header (carrying the EL state root and block hash that
the entire execution-layer verification chain anchors to) was decoded
from the LightClientHeader and trusted without ever being proven against
the beacon block body root. The EXECUTION_PAYLOAD_GINDEX/DEPTH constants
existed but were never used.

A malicious peer or MitM could forward a genuine, correctly-signed beacon
header while swapping in a forged ExecutionPayloadHeader with an
attacker-chosen state root / block hash; every downstream account/storage
proof would then verify against forged state and be returned tagged
verifyMethod=headerChain as if proven.

Add LightClientProcessor.verifyExecutionBranch (is_valid_light_client_header
per the consensus spec) and enforce it on the attested and finalized
headers of every update, and on the bootstrap header in both the libp2p
and HTTP bootstrap paths.

Tests: add TestUtil.consistentLightClientHeader, which builds a header
whose execution payload is genuinely committed to a derived body root, and
point the update-builders at it so the existing processor tests exercise
the new check instead of zero branches.