### PR TITLE
Track served period ranges and bootstrap peers in CL cache

### DIFF
--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/AndroidCLPeerCache.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/AndroidCLPeerCache.java
@@ -23,8 +23,10 @@ import java.util.concurrent.ConcurrentHashMap;
  * but uses {@code android.util.Log} and {@code java.io} streams instead of
  * {@code java.nio.file.Files}, matching {@link AndroidPeerCache}.
  *
- * <p>Format: one libp2p multiaddr per line, e.g.
- * {@code /ip4/1.2.3.4/tcp/9000/p2p/16Uiu2...}. Peers are evicted after
+ * <p>Format: one peer per line, {@code multiaddr[\t<token>]...}, with optional
+ * tab-separated tokens {@code <low>-<high>} (served period range), {@code b<period>}
+ * (bootstrap period), {@code lc}/{@code nolc} (light_client confirmed/denied), and a
+ * bare {@code <period>} for legacy files. Peers are evicted after
  * {@link #FAILURE_THRESHOLD} consecutive failures.
  */
 public final class AndroidCLPeerCache {
@@ -37,8 +39,10 @@ public final class AndroidCLPeerCache {
     private final Path cacheFile;
     private final Set<String> seen = ConcurrentHashMap.newKeySet();
     private final Map<String, Integer> failures = new ConcurrentHashMap<>();
-    /** multiaddr -> lowest sync-committee period it served during catch-up. */
-    private final Map<String, Long> servedPeriod = new ConcurrentHashMap<>();
+    /** multiaddr -> the sync-committee period range it demonstrably served during catch-up. */
+    private final Map<String, Range> servedRange = new ConcurrentHashMap<>();
+    /** multiaddr -> the sync-committee period of a LightClientBootstrap it served (deepest kept). */
+    private final Map<String, Long> bootstrapPeriod = new ConcurrentHashMap<>();
     /** Peers whose Identify confirmed light_client protocol support — dial these first. */
     private final Set<String> lcConfirmed = ConcurrentHashMap.newKeySet();
     /** Peers proven NOT to serve light_client (no LC protocols / negotiation failure) — dial last. */
@@ -46,6 +50,17 @@ public final class AndroidCLPeerCache {
 
     public AndroidCLPeerCache(Path cacheFile) {
         this.cacheFile = cacheFile;
+    }
+
+    /** A demonstrably-served sync-committee period envelope {@code [low, high]}. Immutable;
+     *  {@link #union} widens it. {@code low} never grows, {@code high} never shrinks. */
+    public record Range(long low, long high) {
+        public Range {
+            if (high < low) { long t = low; low = high; high = t; } // normalize hand-edited files
+        }
+        Range union(Range o) {
+            return new Range(Math.min(low, o.low), Math.max(high, o.high));
+        }
     }
 
     public synchronized void add(String multiaddr) {
@@ -60,23 +75,60 @@ public final class AndroidCLPeerCache {
     }
 
     /**
-     * Record that a peer served catch-up down to {@code period}. Keeps the lowest
-     * period (deepest history). Persisted as {@code multiaddr\t<period>} so a
-     * restart can prefer peers proven to serve the checkpoint period.
+     * Record that a peer served catch-up across the period range {@code [low, high]}.
+     * Widens any existing range (lowest low / highest high). Persisted as
+     * {@code multiaddr\t<low>-<high>} so a restart can prefer peers whose range covers
+     * the period we need.
      */
-    public synchronized void recordServed(String multiaddr, long period) {
+    public synchronized void recordServed(String multiaddr, long low, long high) {
         if (multiaddr == null || multiaddr.isEmpty()) return;
         failures.remove(multiaddr);
         seen.add(multiaddr);
-        Long prev = servedPeriod.get(multiaddr);
-        if (prev != null && prev <= period) return;
-        servedPeriod.put(multiaddr, period);
+        Range incoming = new Range(low, high);
+        Range prev = servedRange.get(multiaddr);
+        Range merged = prev == null ? incoming : prev.union(incoming);
+        if (merged.equals(prev)) return;
+        servedRange.put(multiaddr, merged);
         rewriteFile();
     }
 
-    /** multiaddr -> lowest served period, for peers proven to serve catch-up. */
+    /** Convenience overload for a single served period (degenerate range {@code [p, p]}). */
+    public synchronized void recordServed(String multiaddr, long period) {
+        recordServed(multiaddr, period, period);
+    }
+
+    /**
+     * Record that a peer served a {@code LightClientBootstrap} for {@code period}. Keeps
+     * the deepest (highest) checkpoint period. Persisted as {@code multiaddr\tb<period>}
+     * so a restart prefers it as the bootstrap peer.
+     */
+    public synchronized void recordBootstrap(String multiaddr, long period) {
+        if (multiaddr == null || multiaddr.isEmpty()) return;
+        failures.remove(multiaddr);
+        seen.add(multiaddr);
+        Long prev = bootstrapPeriod.get(multiaddr);
+        if (prev != null && prev >= period) return;
+        bootstrapPeriod.put(multiaddr, period);
+        rewriteFile();
+    }
+
+    /** multiaddr -> {low, high} served period range, for peers proven to serve catch-up. */
+    public Map<String, long[]> servedRanges() {
+        Map<String, long[]> out = new java.util.HashMap<>();
+        servedRange.forEach((ma, r) -> out.put(ma, new long[]{r.low(), r.high()}));
+        return out;
+    }
+
+    /** multiaddr -> lowest served period (range floor), for peers proven to serve catch-up. */
     public Map<String, Long> servedPeriods() {
-        return new java.util.HashMap<>(servedPeriod);
+        Map<String, Long> out = new java.util.HashMap<>();
+        servedRange.forEach((ma, r) -> out.put(ma, r.low()));
+        return out;
+    }
+
+    /** multiaddr -> bootstrap period served, for peers proven to serve a LightClientBootstrap. */
+    public Map<String, Long> bootstrapPeers() {
+        return new java.util.HashMap<>(bootstrapPeriod);
     }
 
     /** Record that a peer's Identify confirmed light_client protocol support. Persisted so
@@ -140,7 +192,8 @@ public final class AndroidCLPeerCache {
         if (count >= FAILURE_THRESHOLD) {
             if (seen.remove(multiaddr)) {
                 failures.remove(multiaddr);
-                servedPeriod.remove(multiaddr);
+                servedRange.remove(multiaddr);
+                bootstrapPeriod.remove(multiaddr);
                 lcConfirmed.remove(multiaddr);
                 lcDenied.remove(multiaddr);
                 rewriteFile();
@@ -158,7 +211,7 @@ public final class AndroidCLPeerCache {
             while ((line = r.readLine()) != null) {
                 line = line.strip();
                 if (line.isEmpty() || !line.startsWith("/")) continue;
-                // multiaddr [TAB token]...  token = <period int> | "lc" | "nolc"
+                // multiaddr [TAB token]...  token = <low>-<high> | b<period> | <period int> | lc | nolc
                 String[] parts = line.split(String.valueOf(SEP));
                 String multiaddr = parts[0].strip();
                 if (multiaddr.isEmpty() || !multiaddr.startsWith("/")) continue;
@@ -166,9 +219,21 @@ public final class AndroidCLPeerCache {
                     String tok = parts[i].strip();
                     if (tok.equals("lc")) lcConfirmed.add(multiaddr);
                     else if (tok.equals("nolc")) lcDenied.add(multiaddr);
-                    else {
-                        try { servedPeriod.put(multiaddr, Long.parseLong(tok)); }
+                    else if (tok.startsWith("b")) {
+                        try { bootstrapPeriod.put(multiaddr, Long.parseLong(tok.substring(1))); }
                         catch (NumberFormatException ignored) {}
+                    } else {
+                        int dash = tok.indexOf('-');
+                        try {
+                            if (dash > 0) {
+                                long lo = Long.parseLong(tok.substring(0, dash));
+                                long hi = Long.parseLong(tok.substring(dash + 1));
+                                servedRange.put(multiaddr, new Range(lo, hi));
+                            } else {
+                                long p = Long.parseLong(tok); // legacy floor -> degenerate range
+                                servedRange.put(multiaddr, new Range(p, p));
+                            }
+                        } catch (NumberFormatException ignored) {}
                     }
                 }
                 result.add(multiaddr);
@@ -176,7 +241,8 @@ public final class AndroidCLPeerCache {
             }
             if (!result.isEmpty()) {
                 LogBuffer.i(TAG, "loaded " + result.size() + " cached CL peer(s) ("
-                        + servedPeriod.size() + " catch-up servers, "
+                        + servedRange.size() + " catch-up servers, "
+                        + bootstrapPeriod.size() + " bootstrap peers, "
                         + lcConfirmed.size() + " light-client, " + lcDenied.size() + " non-LC)");
             }
         } catch (IOException e) {
@@ -188,7 +254,8 @@ public final class AndroidCLPeerCache {
     public synchronized void clear() {
         seen.clear();
         failures.clear();
-        servedPeriod.clear();
+        servedRange.clear();
+        bootstrapPeriod.clear();
         lcConfirmed.clear();
         lcDenied.clear();
         if (!cacheFile.toFile().delete() && cacheFile.toFile().exists()) {
@@ -203,8 +270,10 @@ public final class AndroidCLPeerCache {
                 new FileOutputStream(cacheFile.toFile(), false), StandardCharsets.UTF_8)) {
             for (String p : peers) {
                 w.write(p);
-                Long sp = servedPeriod.get(p);
-                if (sp != null) { w.write(SEP); w.write(Long.toString(sp)); }
+                Range r = servedRange.get(p);
+                if (r != null) { w.write(SEP); w.write(r.low() + "-" + r.high()); }
+                Long bp = bootstrapPeriod.get(p);
+                if (bp != null) { w.write(SEP); w.write("b" + bp); }
                 if (lcConfirmed.contains(p)) { w.write(SEP); w.write("lc"); }
                 else if (lcDenied.contains(p)) { w.write(SEP); w.write("nolc"); }
                 w.write('\n');

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/AndroidCLPeerCache.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/AndroidCLPeerCache.java
@@ -220,19 +220,19 @@ public final class AndroidCLPeerCache {
                     if (tok.equals("lc")) lcConfirmed.add(multiaddr);
                     else if (tok.equals("nolc")) lcDenied.add(multiaddr);
                     else if (tok.startsWith("b")) {
-                        try { bootstrapPeriod.put(multiaddr, Long.parseLong(tok.substring(1))); }
+                        // Keep the deepest bootstrap period if a line carries more than one.
+                        try { bootstrapPeriod.merge(multiaddr, Long.parseLong(tok.substring(1)), Math::max); }
                         catch (NumberFormatException ignored) {}
                     } else {
                         int dash = tok.indexOf('-');
                         try {
-                            if (dash > 0) {
-                                long lo = Long.parseLong(tok.substring(0, dash));
-                                long hi = Long.parseLong(tok.substring(dash + 1));
-                                servedRange.put(multiaddr, new Range(lo, hi));
-                            } else {
-                                long p = Long.parseLong(tok); // legacy floor -> degenerate range
-                                servedRange.put(multiaddr, new Range(p, p));
-                            }
+                            Range incoming = dash > 0
+                                    ? new Range(Long.parseLong(tok.substring(0, dash)),
+                                                Long.parseLong(tok.substring(dash + 1)))
+                                    : new Range(Long.parseLong(tok), Long.parseLong(tok)); // legacy floor
+                            // Widen (not overwrite) if a line carries multiple range/legacy tokens,
+                            // so duplicates keep the envelope instead of silently dropping data.
+                            servedRange.merge(multiaddr, incoming, Range::union);
                         } catch (NumberFormatException ignored) {}
                     }
                 }

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -1127,8 +1127,12 @@ public final class NodeService extends Service {
             // they served) and persist new ones, so a cold start prefers the
             // peers that actually retained the checkpoint's light-client updates
             // instead of fanning out across discovery peers that don't serve LC.
-            localBlc.setProvenCatchUpServers(clCacheRef.servedPeriods());
+            localBlc.setProvenCatchUpServers(clCacheRef.servedRanges());
             localBlc.setOnCatchUpServed(clCacheRef::recordServed);
+            // Persist which peer served the bootstrap (and for which period) so a restart
+            // front-loads a proven light-client server instead of re-fanning discovery.
+            localBlc.setProvenBootstrapPeers(clCacheRef.bootstrapPeers());
+            localBlc.setOnBootstrapServed(clCacheRef::recordBootstrap);
             // Seed light_client-capability verdicts from last session and persist new ones,
             // so a restart dials confirmed light-client servers first and deprioritizes peers
             // proven not to serve LC — instead of re-Identifying the whole fork-matched cache

--- a/app/src/main/java/com/jaeckel/ethp2p/app/CLPeerCache.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/CLPeerCache.java
@@ -243,19 +243,19 @@ public final class CLPeerCache {
                     if (tok.equals("lc")) lcConfirmed.add(multiaddr);
                     else if (tok.equals("nolc")) lcDenied.add(multiaddr);
                     else if (tok.startsWith("b")) {
-                        try { bootstrapPeriod.put(multiaddr, Long.parseLong(tok.substring(1))); }
+                        // Keep the deepest bootstrap period if a line carries more than one.
+                        try { bootstrapPeriod.merge(multiaddr, Long.parseLong(tok.substring(1)), Math::max); }
                         catch (NumberFormatException ignored) {}
                     } else {
                         int dash = tok.indexOf('-');
                         try {
-                            if (dash > 0) {
-                                long lo = Long.parseLong(tok.substring(0, dash));
-                                long hi = Long.parseLong(tok.substring(dash + 1));
-                                servedRange.put(multiaddr, new Range(lo, hi));
-                            } else {
-                                long p = Long.parseLong(tok); // legacy floor -> degenerate range
-                                servedRange.put(multiaddr, new Range(p, p));
-                            }
+                            Range incoming = dash > 0
+                                    ? new Range(Long.parseLong(tok.substring(0, dash)),
+                                                Long.parseLong(tok.substring(dash + 1)))
+                                    : new Range(Long.parseLong(tok), Long.parseLong(tok)); // legacy floor
+                            // Widen (not overwrite) if a line carries multiple range/legacy tokens,
+                            // so duplicates keep the envelope instead of silently dropping data.
+                            servedRange.merge(multiaddr, incoming, Range::union);
                         } catch (NumberFormatException ignored) {}
                     }
                 }

--- a/app/src/main/java/com/jaeckel/ethp2p/app/CLPeerCache.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/CLPeerCache.java
@@ -17,12 +17,21 @@ import java.util.concurrent.ConcurrentHashMap;
  * Persists Consensus Layer peers that successfully served light client responses
  * so they can be reconnected on restart without discovery.
  *
- * <p>File format: one peer per line, {@code multiaddr[\t<lowestServedPeriod>]}.
- * The optional trailing sync-committee period records the oldest period this peer
- * actually served during catch-up — proof it retains light-client updates that
- * deep. On restart we prefer peers whose served period covers the checkpoint,
- * instead of fanning out to discovery peers that don't serve catch-up at all.
- * The field is optional so older cache files load unchanged.
+ * <p>File format: one peer per line, {@code multiaddr[\t<token>]...}. Each optional
+ * tab-separated token is self-describing by prefix and order-independent:
+ * <ul>
+ *   <li>{@code <low>-<high>} — the sync-committee period <em>range</em> this peer
+ *       demonstrably served during catch-up. Knowing both ends (not just the floor)
+ *       lets restart prefer peers whose range actually <em>covers</em> the period we
+ *       need, instead of assuming monotonic-forward coverage from the floor alone.</li>
+ *   <li>{@code b<period>} — the sync-committee period of a {@code LightClientBootstrap}
+ *       this peer served. Proof it retained the checkpoint committee; seeds the
+ *       preferred bootstrap peer on restart.</li>
+ *   <li>{@code lc} / {@code nolc} — Identify confirmed / denied light_client support.</li>
+ *   <li>a bare {@code <period>} integer — legacy lowest-served-period from older cache
+ *       files; loaded as the degenerate range {@code [period, period]}.</li>
+ * </ul>
+ * All tokens are optional, so older cache files load unchanged.
  *
  * <p>Peers are evicted after {@link #FAILURE_THRESHOLD} consecutive failures so the
  * cache does not accumulate dead peers across restarts. Any success resets a peer's
@@ -40,8 +49,10 @@ public final class CLPeerCache {
     private final Path cacheFile;
     private final Set<String> seen = ConcurrentHashMap.newKeySet();
     private final Map<String, Integer> failures = new ConcurrentHashMap<>();
-    /** multiaddr -> lowest sync-committee period it served during catch-up. */
-    private final Map<String, Long> servedPeriod = new ConcurrentHashMap<>();
+    /** multiaddr -> the sync-committee period range it demonstrably served during catch-up. */
+    private final Map<String, Range> servedRange = new ConcurrentHashMap<>();
+    /** multiaddr -> the sync-committee period of a LightClientBootstrap it served (deepest kept). */
+    private final Map<String, Long> bootstrapPeriod = new ConcurrentHashMap<>();
     /** Peers whose Identify confirmed light_client protocol support — dial these first. */
     private final Set<String> lcConfirmed = ConcurrentHashMap.newKeySet();
     /** Peers proven NOT to serve light_client (no LC protocols / negotiation failure) — dial last. */
@@ -49,6 +60,17 @@ public final class CLPeerCache {
 
     public CLPeerCache(Path cacheFile) {
         this.cacheFile = cacheFile;
+    }
+
+    /** A demonstrably-served sync-committee period envelope {@code [low, high]}. Immutable;
+     *  {@link #union} widens it. {@code low} never grows, {@code high} never shrinks. */
+    public record Range(long low, long high) {
+        public Range {
+            if (high < low) { long t = low; low = high; high = t; } // normalize hand-edited files
+        }
+        Range union(Range o) {
+            return new Range(Math.min(low, o.low), Math.max(high, o.high));
+        }
     }
 
     /**
@@ -82,7 +104,8 @@ public final class CLPeerCache {
         if (count >= FAILURE_THRESHOLD) {
             if (seen.remove(multiaddr)) {
                 failures.remove(multiaddr);
-                servedPeriod.remove(multiaddr);
+                servedRange.remove(multiaddr);
+                bootstrapPeriod.remove(multiaddr);
                 lcConfirmed.remove(multiaddr);
                 lcDenied.remove(multiaddr);
                 rewriteFile();
@@ -92,23 +115,60 @@ public final class CLPeerCache {
     }
 
     /**
-     * Record that a peer served catch-up down to {@code period}. Keeps the lowest
-     * period seen (deepest history) so a peer that once served the checkpoint is
-     * remembered as such. Persisted so restarts prefer proven catch-up servers.
+     * Record that a peer served catch-up across the period range {@code [low, high]}.
+     * Widens any existing range (lowest low / highest high) so a peer's full served
+     * envelope is remembered. Persisted so restarts prefer peers whose range covers
+     * the period we need.
      */
-    public synchronized void recordServed(String multiaddr, long period) {
+    public synchronized void recordServed(String multiaddr, long low, long high) {
         if (multiaddr == null || multiaddr.isEmpty()) return;
         failures.remove(multiaddr);
         seen.add(multiaddr);
-        Long prev = servedPeriod.get(multiaddr);
-        if (prev != null && prev <= period) return; // already know it goes deeper
-        servedPeriod.put(multiaddr, period);
+        Range incoming = new Range(low, high);
+        Range prev = servedRange.get(multiaddr);
+        Range merged = prev == null ? incoming : prev.union(incoming);
+        if (merged.equals(prev)) return; // no widening — nothing to persist
+        servedRange.put(multiaddr, merged);
         rewriteFile();
     }
 
-    /** multiaddr -> lowest served period, for peers proven to serve catch-up. */
+    /** Convenience overload for a single served period (degenerate range {@code [p, p]}). */
+    public synchronized void recordServed(String multiaddr, long period) {
+        recordServed(multiaddr, period, period);
+    }
+
+    /**
+     * Record that a peer served a {@code LightClientBootstrap} for {@code period}. Keeps
+     * the deepest (highest) checkpoint period a peer ever served — proof it retains the
+     * checkpoint committee. Persisted so a restart prefers it as the bootstrap peer.
+     */
+    public synchronized void recordBootstrap(String multiaddr, long period) {
+        if (multiaddr == null || multiaddr.isEmpty()) return;
+        failures.remove(multiaddr);
+        seen.add(multiaddr);
+        Long prev = bootstrapPeriod.get(multiaddr);
+        if (prev != null && prev >= period) return; // already know a deeper bootstrap
+        bootstrapPeriod.put(multiaddr, period);
+        rewriteFile();
+    }
+
+    /** multiaddr -> {low, high} served period range, for peers proven to serve catch-up. */
+    public Map<String, long[]> servedRanges() {
+        Map<String, long[]> out = new java.util.HashMap<>();
+        servedRange.forEach((ma, r) -> out.put(ma, new long[]{r.low(), r.high()}));
+        return out;
+    }
+
+    /** multiaddr -> lowest served period (range floor), for peers proven to serve catch-up. */
     public Map<String, Long> servedPeriods() {
-        return new java.util.HashMap<>(servedPeriod);
+        Map<String, Long> out = new java.util.HashMap<>();
+        servedRange.forEach((ma, r) -> out.put(ma, r.low()));
+        return out;
+    }
+
+    /** multiaddr -> bootstrap period served, for peers proven to serve a LightClientBootstrap. */
+    public Map<String, Long> bootstrapPeers() {
+        return new java.util.HashMap<>(bootstrapPeriod);
     }
 
     /** Record that a peer's Identify confirmed light_client protocol support. Persisted so
@@ -174,7 +234,7 @@ public final class CLPeerCache {
             for (String line : Files.readAllLines(cacheFile)) {
                 line = line.strip();
                 if (line.isEmpty() || !line.startsWith("/")) continue;
-                // multiaddr [TAB token]...  token = <period int> | "lc" | "nolc"
+                // multiaddr [TAB token]...  token = <low>-<high> | b<period> | <period int> | lc | nolc
                 String[] parts = line.split(String.valueOf(SEP));
                 String multiaddr = parts[0].strip();
                 if (multiaddr.isEmpty() || !multiaddr.startsWith("/")) continue;
@@ -182,9 +242,21 @@ public final class CLPeerCache {
                     String tok = parts[i].strip();
                     if (tok.equals("lc")) lcConfirmed.add(multiaddr);
                     else if (tok.equals("nolc")) lcDenied.add(multiaddr);
-                    else {
-                        try { servedPeriod.put(multiaddr, Long.parseLong(tok)); }
+                    else if (tok.startsWith("b")) {
+                        try { bootstrapPeriod.put(multiaddr, Long.parseLong(tok.substring(1))); }
                         catch (NumberFormatException ignored) {}
+                    } else {
+                        int dash = tok.indexOf('-');
+                        try {
+                            if (dash > 0) {
+                                long lo = Long.parseLong(tok.substring(0, dash));
+                                long hi = Long.parseLong(tok.substring(dash + 1));
+                                servedRange.put(multiaddr, new Range(lo, hi));
+                            } else {
+                                long p = Long.parseLong(tok); // legacy floor -> degenerate range
+                                servedRange.put(multiaddr, new Range(p, p));
+                            }
+                        } catch (NumberFormatException ignored) {}
                     }
                 }
                 result.add(multiaddr);
@@ -192,8 +264,8 @@ public final class CLPeerCache {
             }
             if (!result.isEmpty()) {
                 log.info("[cl-cache] Loaded {} cached CL peer(s) from {} ({} catch-up servers, "
-                                + "{} light-client, {} non-LC)",
-                        result.size(), cacheFile, servedPeriod.size(),
+                                + "{} bootstrap peers, {} light-client, {} non-LC)",
+                        result.size(), cacheFile, servedRange.size(), bootstrapPeriod.size(),
                         lcConfirmed.size(), lcDenied.size());
             }
         } catch (Exception e) {
@@ -224,8 +296,10 @@ public final class CLPeerCache {
             StringBuilder sb = new StringBuilder();
             for (String p : peers) {
                 sb.append(p);
-                Long sp = servedPeriod.get(p);
-                if (sp != null) sb.append(SEP).append(sp);
+                Range r = servedRange.get(p);
+                if (r != null) sb.append(SEP).append(r.low()).append('-').append(r.high());
+                Long bp = bootstrapPeriod.get(p);
+                if (bp != null) sb.append(SEP).append('b').append(bp);
                 if (lcConfirmed.contains(p)) sb.append(SEP).append("lc");
                 else if (lcDenied.contains(p)) sb.append(SEP).append("nolc");
                 sb.append('\n');

--- a/app/src/main/java/com/jaeckel/ethp2p/app/Main.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/Main.java
@@ -503,8 +503,12 @@ public final class Main {
         // Prefer peers proven to serve catch-up last session (seeded with the
         // period they served), and persist new ones, so restarts target peers
         // that actually retain the checkpoint period instead of discovery noise.
-        beaconLightClient.setProvenCatchUpServers(clPeerCache.servedPeriods());
+        beaconLightClient.setProvenCatchUpServers(clPeerCache.servedRanges());
         beaconLightClient.setOnCatchUpServed(clPeerCache::recordServed);
+        // Persist which peer served the bootstrap (and for which period) so a restart
+        // front-loads a proven light-client server instead of re-fanning discovery.
+        beaconLightClient.setProvenBootstrapPeers(clPeerCache.bootstrapPeers());
+        beaconLightClient.setOnBootstrapServed(clPeerCache::recordBootstrap);
         // Seed light_client-capability verdicts from last session and persist new ones, so a
         // restart dials confirmed light-client servers first and deprioritizes peers proven
         // not to serve LC — instead of re-Identifying the whole fork-matched cache.

--- a/app/src/test/java/com/jaeckel/ethp2p/app/CLPeerCacheTest.java
+++ b/app/src/test/java/com/jaeckel/ethp2p/app/CLPeerCacheTest.java
@@ -98,6 +98,19 @@ class CLPeerCacheTest {
     }
 
     @Test
+    void duplicateTokensOnOneLineMergeNotOverwrite(@TempDir Path dir) throws Exception {
+        // A hand-edited/merged line with multiple range and bootstrap tokens must widen the
+        // range (union) and keep the deepest bootstrap, not let the last token silently win.
+        Path file = dir.resolve("cl-peers.cache");
+        Files.writeString(file, MA + "\t128-130\t125-135\t512\tb200\tb256\n");
+        CLPeerCache cache = new CLPeerCache(file);
+        cache.load();
+        assertEquals(125L, cache.servedRanges().get(MA)[0], "low must be the smallest seen");
+        assertEquals(512L, cache.servedRanges().get(MA)[1], "high must be the largest seen");
+        assertEquals(256L, cache.bootstrapPeers().get(MA), "bootstrap must keep the deepest period");
+    }
+
+    @Test
     void evictionClearsRangeAndBootstrap(@TempDir Path dir) {
         CLPeerCache cache = new CLPeerCache(dir.resolve("c.cache"));
         cache.add(MA);

--- a/app/src/test/java/com/jaeckel/ethp2p/app/CLPeerCacheTest.java
+++ b/app/src/test/java/com/jaeckel/ethp2p/app/CLPeerCacheTest.java
@@ -1,0 +1,133 @@
+package com.jaeckel.ethp2p.app;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CLPeerCacheTest {
+
+    private static final String MA = "/ip4/1.2.3.4/tcp/9000/p2p/16Uiu2HAmTestPeer";
+    private static final String MB = "/ip4/5.6.7.8/tcp/9000/p2p/16Uiu2HAmOtherPeer";
+
+    @Test
+    void servedRangeRoundTrips(@TempDir Path dir) throws Exception {
+        Path file = dir.resolve("cl-peers.cache");
+        CLPeerCache cache = new CLPeerCache(file);
+        cache.recordServed(MA, 128, 130);
+
+        // File carries the range token.
+        assertTrue(Files.readString(file).contains("\t128-130"), "range token must be persisted");
+
+        // A fresh instance loads the same range.
+        CLPeerCache reloaded = new CLPeerCache(file);
+        reloaded.load();
+        assertEquals(128L, reloaded.servedRanges().get(MA)[0]);
+        assertEquals(130L, reloaded.servedRanges().get(MA)[1]);
+        assertEquals(128L, reloaded.servedPeriods().get(MA), "servedPeriods() must expose the floor");
+    }
+
+    @Test
+    void servedRangeMergesMinAndMax(@TempDir Path dir) {
+        CLPeerCache cache = new CLPeerCache(dir.resolve("c.cache"));
+        cache.recordServed(MA, 130, 130);
+        cache.recordServed(MA, 128, 135);
+        assertEquals(128L, cache.servedRanges().get(MA)[0]);
+        assertEquals(135L, cache.servedRanges().get(MA)[1]);
+
+        // Order-independent.
+        CLPeerCache rev = new CLPeerCache(dir.resolve("d.cache"));
+        rev.recordServed(MB, 128, 135);
+        rev.recordServed(MB, 130, 130);
+        assertEquals(128L, rev.servedRanges().get(MB)[0]);
+        assertEquals(135L, rev.servedRanges().get(MB)[1]);
+    }
+
+    @Test
+    void twoArgOverloadIsDegenerateRange(@TempDir Path dir) {
+        CLPeerCache cache = new CLPeerCache(dir.resolve("c.cache"));
+        cache.recordServed(MA, 200);
+        assertEquals(200L, cache.servedRanges().get(MA)[0]);
+        assertEquals(200L, cache.servedRanges().get(MA)[1]);
+    }
+
+    @Test
+    void bootstrapPeriodRoundTripsAndKeepsMax(@TempDir Path dir) throws Exception {
+        Path file = dir.resolve("cl-peers.cache");
+        CLPeerCache cache = new CLPeerCache(file);
+        cache.recordBootstrap(MA, 256);
+        cache.recordBootstrap(MA, 250); // shallower — must not lower the kept value
+        assertEquals(256L, cache.bootstrapPeers().get(MA));
+        assertTrue(Files.readString(file).contains("\tb256"), "bootstrap token must be persisted");
+
+        CLPeerCache reloaded = new CLPeerCache(file);
+        reloaded.load();
+        assertEquals(256L, reloaded.bootstrapPeers().get(MA));
+    }
+
+    @Test
+    void legacyFloorFormatLoadsAsDegenerateRange(@TempDir Path dir) throws Exception {
+        Path file = dir.resolve("cl-peers.cache");
+        Files.writeString(file, MA + "\t512\tlc\n");
+        CLPeerCache cache = new CLPeerCache(file);
+        cache.load();
+        assertEquals(512L, cache.servedRanges().get(MA)[0]);
+        assertEquals(512L, cache.servedRanges().get(MA)[1]);
+        assertTrue(cache.lightClientConfirmed().contains(MA));
+        assertNull(cache.bootstrapPeers().get(MA));
+    }
+
+    @Test
+    void combinedLineParsesAllTokens(@TempDir Path dir) throws Exception {
+        Path file = dir.resolve("cl-peers.cache");
+        Files.writeString(file, MA + "\t128-135\tb256\tlc\n");
+        CLPeerCache cache = new CLPeerCache(file);
+        cache.load();
+        assertEquals(128L, cache.servedRanges().get(MA)[0]);
+        assertEquals(135L, cache.servedRanges().get(MA)[1]);
+        assertEquals(256L, cache.bootstrapPeers().get(MA));
+        assertTrue(cache.lightClientConfirmed().contains(MA));
+    }
+
+    @Test
+    void evictionClearsRangeAndBootstrap(@TempDir Path dir) {
+        CLPeerCache cache = new CLPeerCache(dir.resolve("c.cache"));
+        cache.add(MA);
+        cache.recordServed(MA, 128, 135);
+        cache.recordBootstrap(MA, 256);
+        for (int i = 0; i < CLPeerCache.FAILURE_THRESHOLD; i++) {
+            cache.markFailure(MA);
+        }
+        assertTrue(cache.servedRanges().isEmpty(), "served range must be dropped on eviction");
+        assertTrue(cache.bootstrapPeers().isEmpty(), "bootstrap period must be dropped on eviction");
+        assertFalse(cache.load().contains(MA), "evicted peer must be gone from the file");
+    }
+
+    @Test
+    void writeIsIdempotentAcrossReload(@TempDir Path dir) throws Exception {
+        Path file = dir.resolve("cl-peers.cache");
+        CLPeerCache cache = new CLPeerCache(file);
+        cache.recordServed(MA, 128, 135);
+        cache.recordBootstrap(MA, 256);
+        cache.markLightClient(MA);
+        String first = Files.readString(file);
+
+        CLPeerCache reloaded = new CLPeerCache(file);
+        List<String> loaded = reloaded.load();
+        assertEquals(List.of(MA), loaded);
+        // Re-persist via a no-op-ish rewrite path and confirm the format is stable.
+        reloaded.markLightClient(MA); // already confirmed -> no change, file untouched
+        assertEquals(first, Files.readString(file));
+        Map<String, long[]> ranges = reloaded.servedRanges();
+        assertEquals(128L, ranges.get(MA)[0]);
+        assertEquals(135L, ranges.get(MA)[1]);
+    }
+}

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
@@ -120,7 +120,14 @@ public class BeaconLightClient implements AutoCloseable {
 
     /** Seed proven catch-up servers (multiaddr -> {low, high} served range) from a cache. */
     public void setProvenCatchUpServers(Map<String, long[]> seed) {
-        if (seed != null) provenCatchUpRanges.putAll(seed);
+        if (seed == null) return;
+        // Defensive copy to a fixed length-2 array: the map is caller-owned and arrays are
+        // mutable, so storing references directly would let later mutation (or a short array)
+        // corrupt prioritization or throw AIOOBE on the r[0]/r[1] reads.
+        seed.forEach((ma, r) -> {
+            if (ma == null || r == null || r.length < 2) return;
+            provenCatchUpRanges.put(ma, new long[]{r[0], r[1]});
+        });
     }
 
     /** Set the callback persisting (multiaddr, low, high) when a peer advances catch-up. */

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
@@ -90,24 +90,59 @@ public class BeaconLightClient implements AutoCloseable {
     // protocol they don't have. Remember and skip them.
     private final Set<String> peersNoLcUpdates = java.util.concurrent.ConcurrentHashMap.newKeySet();
 
-    // Peers proven to serve catch-up, multiaddr -> lowest sync-committee period
-    // they served. Seeded from the CL peer cache at startup so a cold start can
-    // immediately prefer peers that actually retained the checkpoint period last
-    // time, instead of fanning out across discovery peers (most of which don't
-    // serve light-client updates at all). Updated live on every catch-up success.
-    private final Map<String, Long> provenCatchUpServers =
+    // Peers proven to serve catch-up, multiaddr -> {low, high} sync-committee period
+    // range they served. Seeded from the CL peer cache at startup so a cold start can
+    // immediately prefer peers that actually retained the period we need last time,
+    // instead of fanning out across discovery peers (most of which don't serve
+    // light-client updates at all). Updated live on every catch-up success. Tracking
+    // both ends (not just the floor) lets prioritization ask "does this peer's range
+    // cover period N?" instead of assuming monotonic-forward coverage from the floor.
+    private final Map<String, long[]> provenCatchUpRanges =
             new java.util.concurrent.ConcurrentHashMap<>();
-    /** Notified (multiaddr, servedPeriod) whenever a peer advances catch-up, for cache persistence. */
-    private volatile java.util.function.BiConsumer<String, Long> onCatchUpServed;
+    /** Notified (multiaddr, low, high) whenever a peer advances catch-up, for cache persistence. */
+    private volatile ServedRangeListener onCatchUpServed;
 
-    /** Seed proven catch-up servers (multiaddr -> lowest served period) from a cache. */
-    public void setProvenCatchUpServers(Map<String, Long> seed) {
-        if (seed != null) provenCatchUpServers.putAll(seed);
+    // Peers proven to serve a LightClientBootstrap, multiaddr -> the (deepest) checkpoint
+    // period they served. Seeded from the cache; also seeds lastBootstrapPeer so a cold
+    // start front-loads a peer that demonstrably retained the checkpoint committee.
+    private final Map<String, Long> provenBootstrapPeers =
+            new java.util.concurrent.ConcurrentHashMap<>();
+    /** Notified (multiaddr, bootstrapPeriod) whenever a peer serves a bootstrap, for cache persistence. */
+    private volatile java.util.function.BiConsumer<String, Long> onBootstrapServed;
+
+    /** Listener for a peer that served catch-up across the period range {@code [low, high]}.
+     *  A 3-arg shape (Java has no {@code TriConsumer}) kept on plain types so the API stays
+     *  multiplatform-friendly (no {@code CompletableFuture}). */
+    @FunctionalInterface
+    public interface ServedRangeListener {
+        void accept(String peer, long low, long high);
     }
 
-    /** Set the callback persisting (multiaddr, servedPeriod) when a peer advances catch-up. */
-    public void setOnCatchUpServed(java.util.function.BiConsumer<String, Long> cb) {
+    /** Seed proven catch-up servers (multiaddr -> {low, high} served range) from a cache. */
+    public void setProvenCatchUpServers(Map<String, long[]> seed) {
+        if (seed != null) provenCatchUpRanges.putAll(seed);
+    }
+
+    /** Set the callback persisting (multiaddr, low, high) when a peer advances catch-up. */
+    public void setOnCatchUpServed(ServedRangeListener cb) {
         this.onCatchUpServed = cb;
+    }
+
+    /** Seed proven bootstrap peers (multiaddr -> bootstrap period) from a cache. Also seeds
+     *  {@link #lastBootstrapPeer} (highest-period entry) so it is tried first on a cold start. */
+    public void setProvenBootstrapPeers(Map<String, Long> seed) {
+        if (seed == null || seed.isEmpty()) return;
+        provenBootstrapPeers.putAll(seed);
+        if (lastBootstrapPeer == null) {
+            provenBootstrapPeers.entrySet().stream()
+                    .max(Map.Entry.comparingByValue())
+                    .ifPresent(e -> lastBootstrapPeer = e.getKey());
+        }
+    }
+
+    /** Set the callback persisting (multiaddr, bootstrapPeriod) when a peer serves a bootstrap. */
+    public void setOnBootstrapServed(java.util.function.BiConsumer<String, Long> cb) {
+        this.onBootstrapServed = cb;
     }
 
     // Peers whose Identify confirmed light_client protocol support — dialed first by
@@ -327,14 +362,26 @@ public class BeaconLightClient implements AutoCloseable {
         t.start();
     }
 
-    /** Remember a peer that served catch-up from {@code period} (lowest wins) and persist it. */
-    private void recordCatchUpServer(String peer, long period) {
+    /** Remember a peer that served catch-up across {@code [low, high]} (range widens) and persist it. */
+    private void recordCatchUpServer(String peer, long low, long high) {
         if (peer == null) return;
-        provenCatchUpServers.merge(peer, period, Math::min);
-        java.util.function.BiConsumer<String, Long> cb = onCatchUpServed;
+        provenCatchUpRanges.merge(peer, new long[]{low, high},
+                (a, b) -> new long[]{Math.min(a[0], b[0]), Math.max(a[1], b[1])});
+        ServedRangeListener cb = onCatchUpServed;
+        if (cb != null) {
+            try { cb.accept(peer, low, high); }
+            catch (Exception e) { log.debug("[beacon] onCatchUpServed failed: {}", e.getMessage()); }
+        }
+    }
+
+    /** Remember a peer that served a LightClientBootstrap for {@code period} (deepest wins) and persist it. */
+    private void recordBootstrapServer(String peer, long period) {
+        if (peer == null) return;
+        provenBootstrapPeers.merge(peer, period, Math::max);
+        java.util.function.BiConsumer<String, Long> cb = onBootstrapServed;
         if (cb != null) {
             try { cb.accept(peer, period); }
-            catch (Exception e) { log.debug("[beacon] onCatchUpServed failed: {}", e.getMessage()); }
+            catch (Exception e) { log.debug("[beacon] onBootstrapServed failed: {}", e.getMessage()); }
         }
     }
 
@@ -508,7 +555,8 @@ public class BeaconLightClient implements AutoCloseable {
             if (clPeerMultiaddrs.size() > MAX_CL_PEERS) {
                 for (int i = clPeerMultiaddrs.size() - 1; i >= 0; i--) {
                     String cand = clPeerMultiaddrs.get(i);
-                    if (!provenCatchUpServers.containsKey(cand)
+                    if (!provenCatchUpRanges.containsKey(cand)
+                            && !provenBootstrapPeers.containsKey(cand)
                             && !provenLightClient.contains(cand)) {
                         clPeerMultiaddrs.remove(i);
                         knownPeerAddrs.remove(cand);
@@ -1149,6 +1197,11 @@ public class BeaconLightClient implements AutoCloseable {
                                     winnerFuture.complete(response);
                                     successPeer = peer;
                                     lastBootstrapPeer = peer;
+                                    // Remember (and persist) that this peer served the
+                                    // bootstrap for this checkpoint period, so a restart
+                                    // front-loads it as a proven light-client server.
+                                    recordBootstrapServer(peer, BeaconChainSpec.computeSyncCommitteePeriod(
+                                            bootstrap.header().beacon().slot()));
                                     // Cache the bootstrap so we can relay it to any peer
                                     // that asks us for the same block root.
                                     p2pService.cacheBootstrap(checkpointRoot, response);
@@ -1293,10 +1346,21 @@ public class BeaconLightClient implements AutoCloseable {
         // updates_by_range. These are the peers that actually retained light-client
         // data; everything else is a fork-matched node that probably doesn't serve it.
         java.util.LinkedHashSet<String> priority = new java.util.LinkedHashSet<>();
+        // Tier 1: proven last session to serve a range that actually COVERS this period.
+        // The range check (not just floor <= period) avoids the false positive where a peer
+        // that only served [100,110] was assumed to cover period 900.
         for (String p : capable) {
-            Long sp = provenCatchUpServers.get(p);
-            if (sp != null && sp <= bootstrapPeriod) priority.add(p);
+            long[] r = provenCatchUpRanges.get(p);
+            if (r != null && r[0] <= bootstrapPeriod && bootstrapPeriod <= r[1]) priority.add(p);
         }
+        // Tier 2: proven to serve a bootstrap at/below this period — it retained at least
+        // the checkpoint committee that deep, a strong signal it also serves catch-up here.
+        for (String p : capable) {
+            if (priority.contains(p)) continue;
+            Long bp = provenBootstrapPeers.get(p);
+            if (bp != null && bp <= bootstrapPeriod) priority.add(p);
+        }
+        // Tier 3: Identify-confirmed light-client support / advertises updates_by_range.
         for (String p : capable) {
             if (priority.contains(p)) continue;
             if (provenLightClient.contains(p)
@@ -1453,8 +1517,9 @@ public class BeaconLightClient implements AutoCloseable {
                         // serves catch-up from servedFromPeriod. Record it NOW (not
                         // after the whole response, which can be dozens of updates
                         // ≈ minutes of BLS verifies) so the proof survives even if
-                        // we restart mid-catch-up.
-                        recordCatchUpServer(peer, servedFromPeriod);
+                        // we restart mid-catch-up. The range is widened to the deepest
+                        // period actually delivered after the loop below.
+                        recordCatchUpServer(peer, servedFromPeriod, servedFromPeriod);
                     }
                     // Rotate BEFORE updateSyncState so the committee-period pushed to
                     // BeaconSyncState reflects the post-rotation value — otherwise
@@ -1471,6 +1536,12 @@ public class BeaconLightClient implements AutoCloseable {
             } catch (Exception e) {
                 log.debug("[beacon] Failed to decode/process catch-up update: {}", e.getMessage());
             }
+        }
+        if (applied > 0) {
+            // Widen the served range to the deepest period this peer actually delivered.
+            // Read the store (the source of truth) rather than computing start+applied-1,
+            // which would mis-count if any update in the batch was skipped as inapplicable.
+            recordCatchUpServer(peer, servedFromPeriod, store.getCurrentSyncCommitteePeriod());
         }
         return applied;
     }

--- a/consensus/src/test/java/com/jaeckel/ethp2p/consensus/BeaconLightClientPeerPoolTest.java
+++ b/consensus/src/test/java/com/jaeckel/ethp2p/consensus/BeaconLightClientPeerPoolTest.java
@@ -64,8 +64,8 @@ class BeaconLightClientPeerPoolTest {
         String lc = addr(2);
         c.addPeer(proven);
         c.addPeer(lc);
-        // Mark positive signal (the eviction guard reads these sets).
-        c.setProvenCatchUpServers(Map.of(proven, 1700L));
+        // Mark positive signal (the eviction guard reads these maps/sets).
+        c.setProvenCatchUpServers(Map.of(proven, new long[]{1700L, 1710L}));
         c.setProvenLightClient(List.of(lc));
 
         for (int i = 1000; i < 1000 + cap() + 500; i++) {
@@ -75,6 +75,32 @@ class BeaconLightClientPeerPoolTest {
         assertTrue(p.contains(proven), "proven catch-up server must survive eviction");
         assertTrue(p.contains(lc), "LC-confirmed peer must survive eviction");
         assertTrue(p.size() <= cap());
+    }
+
+    @Test
+    void neverEvictsProvenBootstrapPeers() throws Exception {
+        BeaconLightClient c = newClient();
+        String boot = addr(3);
+        c.addPeer(boot);
+        c.setProvenBootstrapPeers(Map.of(boot, 1700L));
+
+        for (int i = 2000; i < 2000 + cap() + 500; i++) {
+            c.addPeer(addr(i));
+        }
+        assertTrue(pool(c).contains(boot), "proven bootstrap peer must survive eviction");
+    }
+
+    @Test
+    void seedsLastBootstrapPeerToHighestPeriod() throws Exception {
+        BeaconLightClient c = newClient();
+        String shallow = addr(4);
+        String deep = addr(5);
+        c.setProvenBootstrapPeers(Map.of(shallow, 1700L, deep, 1750L));
+
+        Field f = BeaconLightClient.class.getDeclaredField("lastBootstrapPeer");
+        f.setAccessible(true);
+        assertEquals(deep, f.get(c),
+                "lastBootstrapPeer should seed to the highest-period bootstrap peer");
     }
 
     @Test


### PR DESCRIPTION
## Summary

Enhance the Consensus Layer peer cache to track both the low and high bounds of sync-committee periods that peers have demonstrably served, plus the deepest checkpoint period for which they served a `LightClientBootstrap`. This enables smarter peer prioritization during catch-up by checking if a peer's range actually *covers* the period needed, rather than assuming monotonic-forward coverage from a floor value alone.

## Key Changes

- **CLPeerCache & AndroidCLPeerCache**: 
  - Replace single `servedPeriod` (floor) with `servedRange` (immutable `Range` record tracking `[low, high]`)
  - Add `bootstrapPeriod` map to track the deepest checkpoint period each peer served
  - Implement `recordServed(multiaddr, low, high)` to widen ranges; keep `recordServed(multiaddr, period)` as a convenience overload
  - Add `recordBootstrap(multiaddr, period)` to track bootstrap service; keep highest period seen
  - Expose `servedRanges()` (returns `Map<String, long[]>`), `servedPeriods()` (returns floor from range), and `bootstrapPeers()` methods
  - Update file format to persist ranges as `<low>-<high>`, bootstrap as `b<period>`, and legacy bare integers as degenerate ranges `[p, p]`
  - Clear both range and bootstrap on peer eviction

- **BeaconLightClient**:
  - Rename `provenCatchUpServers` to `provenCatchUpRanges` (now `Map<String, long[]>`)
  - Add `provenBootstrapPeers` map and `lastBootstrapPeer` seeding from cache
  - Introduce `ServedRangeListener` functional interface (3-arg callback) for range persistence
  - Add `setProvenBootstrapPeers()` and `setOnBootstrapServed()` setters
  - Update `recordCatchUpServer()` to accept and merge `[low, high]` ranges
  - Add `recordBootstrapServer()` to persist bootstrap service
  - Call `recordBootstrapServer()` after successful bootstrap response
  - Enhance catch-up peer prioritization: Tier 1 checks if range covers the period (not just floor ≤ period); Tier 2 uses bootstrap period as a signal; Tier 3 falls back to Identify-confirmed LC support
  - Widen served range to the deepest period actually delivered after processing catch-up responses

- **Main & NodeService**:
  - Update calls to `setProvenCatchUpServers()` to pass `servedRanges()` instead of `servedPeriods()`
  - Wire up `setOnCatchUpServed()` and `setOnBootstrapServed()` callbacks to cache persistence

- **Tests**:
  - Add comprehensive `CLPeerCacheTest` covering range merging, bootstrap tracking, legacy format loading, combined token parsing, eviction, and idempotent rewrites
  - Add `BeaconLightClientPeerPoolTest` cases for bootstrap peer eviction guard and `lastBootstrapPeer` seeding

## Notable Implementation Details

- `Range` record normalizes hand-edited files (swaps if `high < low`) and provides `union()` to widen bounds
- File format is backward-compatible: legacy bare integers load as degenerate ranges; all tokens are optional and order-independent
- Range widening only triggers a rewrite if bounds actually expand, avoiding unnecessary I/O
- Bootstrap period keeps the *highest* (deepest) value seen, signaling the deepest checkpoint the peer retained
- Catch-up range check `r[0] <= period <= r[1]` prevents false positives where a peer serving `[100, 110]` was assumed to cover period 900

https://claude.ai/code/session_01VpbNCCKZfAD9Yoqyc6hFHS