### PR TITLE
Implement eth_getProof (EIP-1186) with beacon-verified proofs

### DIFF
--- a/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/MyotisRpcBackend.kt
+++ b/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/MyotisRpcBackend.kt
@@ -60,6 +60,21 @@ interface MyotisRpcBackend {
     fun getStorageAt(address: ByteArray, slot: ByteArray, block: String): ByteArray?
 
     /**
+     * eth_getProof (EIP-1186): a pre-built JSON object string carrying the account's
+     * {balance, nonce, codeHash, storageHash}, the {@code accountProof} (RLP trie
+     * nodes proving the account against the verified state root), and one
+     * {@code storageProof} entry {key,value,proof[]} per requested 32-byte
+     * [storageKeys] slot. The proofs and values are extracted from the SNAP-served
+     * trie nodes and re-verified here against the beacon-anchored state root — an
+     * absent account/slot yields the canonical empty/zero values with its exclusion
+     * proof. Returns Kotlin null when it can't be served verified (not synced, no
+     * snap peer, or a historical block the peers have pruned), so the router errors
+     * rather than emitting an unverified or fabricated proof. A JSON string keeps the
+     * nested proof arrays host-built (no array assembly in the router).
+     */
+    fun getProof(address: ByteArray, storageKeys: List<ByteArray>, block: String): String? = null
+
+    /**
      * eth_sendRawTransaction: gossip an already-signed [rawTx] to the devp2p
      * network and return its hash (keccak256 of the raw bytes), or null if it
      * couldn't be broadcast (no peer) so the router can fall back to the proxy.

--- a/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/RpcRouter.kt
+++ b/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/RpcRouter.kt
@@ -41,7 +41,7 @@ class RpcRouter(
          *  serve this verified at all" (-32601). Keep in sync with tryVerified's cases. */
         private val VERIFIED_METHODS = setOf(
             "eth_chainId", "net_version", "eth_blockNumber", "eth_call", "eth_getBalance",
-            "eth_getTransactionCount", "eth_getCode", "eth_getStorageAt",
+            "eth_getTransactionCount", "eth_getCode", "eth_getStorageAt", "eth_getProof",
             "eth_sendRawTransaction", "eth_getTransactionReceipt", "eth_getBlockByNumber",
             "eth_gasPrice", "eth_maxPriorityFeePerGas", "eth_feeHistory", "eth_estimateGas",
             "eth_getTransactionByHash", "web3_clientVersion",
@@ -180,6 +180,22 @@ class RpcRouter(
                 val block = p.blockTag(2)
                 val v = withContext(Dispatchers.IO) { b.getStorageAt(addr, slot, block) } ?: return null
                 resultEnvelope(id, JsonPrimitive(hexData(v)))
+            }
+            "eth_getProof" -> {
+                val p = root.params()
+                val addr = (p?.getOrNull(0) as? JsonPrimitive)?.asHexBytes() ?: return null
+                // params[1] is an array of storage keys (QUANTITY or 32-byte DATA);
+                // each is normalized to a left-padded 32-byte key. A present-but-
+                // non-array, or any malformed key, falls through rather than guessing.
+                val keysElem = p?.getOrNull(1)
+                val keys: List<ByteArray> = when (keysElem) {
+                    null, is JsonNull -> emptyList()
+                    is JsonArray -> keysElem.map { it.asWord32() ?: return null }
+                    else -> return null
+                }
+                val block = p.blockTag(2)
+                val proofJson = withContext(Dispatchers.IO) { b.getProof(addr, keys, block) } ?: return null
+                resultEnvelope(id, json.parseToJsonElement(proofJson))
             }
             "eth_sendRawTransaction" -> {
                 val raw = (root.params()?.getOrNull(0) as? JsonPrimitive)?.asHexBytes() ?: return null

--- a/jsonrpc-server/src/test/kotlin/io/myotis/jsonrpc/RpcRouterTest.kt
+++ b/jsonrpc-server/src/test/kotlin/io/myotis/jsonrpc/RpcRouterTest.kt
@@ -47,6 +47,13 @@ class RpcRouterTest {
         override fun getStorageAt(address: ByteArray, slot: ByteArray, block: String): ByteArray? {
             lastSlot = slot; return storage
         }
+        var lastProofAddr: ByteArray? = null
+        var lastProofKeys: List<ByteArray>? = null
+        var lastProofBlock: String? = null
+        var proofJson: String? = null
+        override fun getProof(address: ByteArray, storageKeys: List<ByteArray>, block: String): String? {
+            lastProofAddr = address; lastProofKeys = storageKeys; lastProofBlock = block; return proofJson
+        }
         var lastRawTx: ByteArray? = null
         var txHash: ByteArray? = null
         override fun sendRawTransaction(rawTx: ByteArray): ByteArray? {
@@ -215,6 +222,53 @@ class RpcRouterTest {
     @Test fun getStorageAt_backendNull_fallsThrough() {
         assertTrue(hasError(route(FakeBackend(storage = null),
             """{"jsonrpc":"2.0","id":1,"method":"eth_getStorageAt","params":["0xabc0000000000000000000000000000000000001","0x1"]}""")))
+    }
+
+    // ---- eth_getProof ---------------------------------------------------------------
+
+    @Test fun getProof_verified_embedsObject_andDecodesAddrKeysBlock() {
+        val b = FakeBackend().apply {
+            proofJson = """{"address":"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance":"0x0","nonce":"0x1","codeHash":"0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+                "storageHash":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+                "accountProof":["0xabcd"],"storageProof":[{"key":"0x00","value":"0x2a","proof":["0xbeef"]}]}"""
+        }
+        val resp = route(b, """{"jsonrpc":"2.0","id":1,"method":"eth_getProof",
+            "params":["0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",["0x0","0x7b"],"latest"]}""")
+        val obj = json.parseToJsonElement(resp).jsonObject["result"]!!.jsonObject
+        assertEquals("0x1", obj["nonce"]!!.jsonPrimitive.content)            // verified object passed through
+        assertEquals(1, obj["storageProof"]!!.jsonArray.size)
+        assertEquals(20, b.lastProofAddr!!.size)
+        assertEquals(0xA0.toByte(), b.lastProofAddr!![0])
+        assertEquals("latest", b.lastProofBlock)
+        // both slot keys decoded + left-padded to 32 bytes
+        assertEquals(2, b.lastProofKeys!!.size)
+        assertArrayEquals(ByteArray(32), b.lastProofKeys!![0])               // "0x0"
+        assertArrayEquals(ByteArray(32).also { it[31] = 0x7b }, b.lastProofKeys!![1])
+    }
+
+    @Test fun getProof_noStorageKeys_passesEmptyList() {
+        val b = FakeBackend().apply { proofJson = """{"address":"0x00","accountProof":[],"storageProof":[]}""" }
+        route(b, """{"jsonrpc":"2.0","id":1,"method":"eth_getProof",
+            "params":["0xabc0000000000000000000000000000000000001",[]]}""")
+        assertTrue(b.lastProofKeys!!.isEmpty())
+        assertEquals("latest", b.lastProofBlock)                             // block defaults when absent
+    }
+
+    @Test fun getProof_malformedSlotKey_fallsThrough() {
+        val b = FakeBackend().apply { proofJson = """{"address":"0x00"}""" }
+        val resp = route(b, """{"jsonrpc":"2.0","id":1,"method":"eth_getProof",
+            "params":["0xabc0000000000000000000000000000000000001",["0xZZ"]]}""")
+        assertTrue(hasError(resp))
+        assertNull(b.lastProofKeys)                                          // backend never invoked
+    }
+
+    @Test fun getProof_cannotVerify_errorsRetryable() {
+        val resp = route(FakeBackend(),  // proofJson null → can't serve verified → strict error
+            """{"jsonrpc":"2.0","id":1,"method":"eth_getProof",
+               "params":["0xabc0000000000000000000000000000000000001",["0x0"]]}""")
+        assertTrue(hasError(resp))
+        assertEquals(-32000, errorCode(resp))                                // implemented, retryable — not -32601
     }
 
     @Test fun sendRawTransaction_decodesRaw_andReturnsHashAsData() {

--- a/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
+++ b/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
@@ -1688,20 +1688,30 @@ public final class VerifiedRpcBackend implements io.myotis.jsonrpc.MyotisRpcBack
             }
 
             // --- Storage proofs ------------------------------------------------
-            // A slot in an empty storage trie (EOA, fresh contract, or absent account)
-            // is provably zero with no trie to query — short-circuit the network call
-            // and return the canonical empty proof, as Geth does.
+            // Pipeline the per-slot SNAP requests: launch them all up front, then await,
+            // so total latency is ~one round-trip rather than the sum over N keys. A slot
+            // in an empty storage trie (EOA, fresh contract, or absent account) is provably
+            // zero with no trie to query, so skip the network there and emit the canonical
+            // empty proof, as Geth does.
             boolean emptyStorage = storageRoot.equals(MerklePatriciaProofVerifier.EMPTY_TRIE_ROOT);
+            java.util.List<Bytes32> keyHashes = new java.util.ArrayList<>(keys.size());
+            java.util.List<CompletableFuture<
+                    com.jaeckel.ethp2p.networking.snap.messages.StorageRangesMessage.DecodeResult>>
+                    slotFutures = new java.util.ArrayList<>(keys.size());
+            for (byte[] k : keys) {
+                Bytes32 keyHash = Hash.keccak256(Bytes.wrap(k));
+                keyHashes.add(keyHash);
+                slotFutures.add(emptyStorage ? null : connector.requestStorage(addr, keyHash, stateRoot));
+            }
             StringBuilder storageSb = new StringBuilder("[");
             for (int i = 0; i < keys.size(); i++) {
                 Bytes keyBytes = Bytes.wrap(keys.get(i));
                 java.math.BigInteger value = java.math.BigInteger.ZERO;
                 java.util.List<Bytes> slotProof = java.util.List.of();
                 if (!emptyStorage) {
-                    Bytes32 keyHash = Hash.keccak256(keyBytes);
+                    Bytes32 keyHash = keyHashes.get(i);
                     com.jaeckel.ethp2p.networking.snap.messages.StorageRangesMessage.DecodeResult sr =
-                            connector.requestStorage(addr, keyHash, stateRoot)
-                                    .get(RPC_CALL_TIMEOUT_SEC, TimeUnit.SECONDS);
+                            slotFutures.get(i).get(RPC_CALL_TIMEOUT_SEC, TimeUnit.SECONDS);
                     slotProof = sr.proof();
                     MerklePatriciaProofVerifier.Result slotRes =
                             MerklePatriciaProofVerifier.verify(storageRoot, keyHash.toArrayUnsafe(), slotProof);
@@ -1744,6 +1754,12 @@ public final class VerifiedRpcBackend implements io.myotis.jsonrpc.MyotisRpcBack
                     .append("}");
             sb.append("}");
             return sb.toString();
+        } catch (InterruptedException e) {
+            // Future.get() clears the interrupt flag on throw — restore it so the
+            // blocking call's cancellation still propagates to the IO worker.
+            Thread.currentThread().interrupt();
+            log.info("[rpc] eth_getProof -> interrupted");
+            return null;
         } catch (Exception e) {
             log.info("[rpc] eth_getProof -> error: " + unwrap(e));
             if (isStateUnavailable(e)) evictUnservableHead(h);

--- a/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
+++ b/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
@@ -3,6 +3,7 @@ package io.myotis.rpc;
 import com.jaeckel.ethp2p.consensus.BeaconLightClient;
 import com.jaeckel.ethp2p.consensus.BeaconSyncState;
 import com.jaeckel.ethp2p.consensus.proof.OrderedTrieRoot;
+import com.jaeckel.ethp2p.core.trie.MerklePatriciaProofVerifier;
 import com.jaeckel.ethp2p.core.types.BlockHeader;
 import com.jaeckel.ethp2p.networking.eth.EthHandler;
 import com.jaeckel.ethp2p.networking.eth.messages.BlockBodiesMessage;
@@ -16,6 +17,7 @@ import io.myotis.rpc.snap.EthHandlerSnapPeer;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.crypto.Hash;
+import org.apache.tuweni.rlp.RLP;
 
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
@@ -650,6 +652,11 @@ public final class VerifiedRpcBackend implements io.myotis.jsonrpc.MyotisRpcBack
     @Override
     public byte[] getStorageAt(byte[] address, byte[] slot, String block) {
         return rpcStorageAt(address, slot, block);
+    }
+
+    @Override
+    public String getProof(byte[] address, java.util.List<byte[]> storageKeys, String block) {
+        return rpcGetProof(address, storageKeys, block);
     }
 
     @Override
@@ -1626,6 +1633,167 @@ public final class VerifiedRpcBackend implements io.myotis.jsonrpc.MyotisRpcBack
             if (isStateUnavailable(e)) evictUnservableHead(h);
             return null;
         }
+    }
+
+    /**
+     * eth_getProof (EIP-1186): build the account proof + per-slot storage proofs
+     * against the verified head's beacon-anchored state root, re-verify every proof
+     * here (inclusion or exclusion), and emit the standard JSON object plus a
+     * {@code myotisVerification} block. Returns null (→ router errors) when the head
+     * can't be served verified or any proof fails to verify — a fabricated or
+     * unverifiable proof is never returned.
+     *
+     * <p>All values come from the PROOF-VERIFIED trie nodes (account leaf for
+     * balance/nonce/storageRoot/codeHash; storage leaves for slot values), never a
+     * peer's slim body — the same anti-forgery stance as get-account/get-storage.
+     */
+    private String rpcGetProof(byte[] address, java.util.List<byte[]> storageKeys, String block) {
+        RpcCallContext h = verifiedHeadFor(block);
+        if (h == null || address == null || address.length != 20) return null;
+        java.util.List<byte[]> keys = storageKeys != null ? storageKeys : java.util.List.of();
+        for (byte[] k : keys) {
+            if (k == null || k.length != 32) return null;  // malformed key → error, don't guess
+        }
+        Bytes32 stateRoot = Bytes32.wrap(h.blockCtx().stateRoot());
+        Bytes addr = Bytes.wrap(address);
+        Bytes32 accountHash = Hash.keccak256(addr);
+        try {
+            // --- Account proof -------------------------------------------------
+            com.jaeckel.ethp2p.networking.snap.messages.AccountRangeMessage.DecodeResult acct =
+                    connector.requestAccount(addr, stateRoot).get(RPC_ACCOUNT_TIMEOUT_SEC, TimeUnit.SECONDS);
+            java.util.List<Bytes> accountProof = acct.proof();
+            MerklePatriciaProofVerifier.Result accRes =
+                    MerklePatriciaProofVerifier.verify(stateRoot, accountHash.toArrayUnsafe(), accountProof);
+
+            java.math.BigInteger balance;
+            long nonce;
+            Bytes32 storageRoot;
+            Bytes32 codeHash;
+            if (accRes instanceof MerklePatriciaProofVerifier.Result.Found f) {
+                AccountLeaf leaf = decodeAccountLeaf(f.value());
+                if (leaf == null) return null;
+                balance = leaf.balance();
+                nonce = leaf.nonce();
+                storageRoot = leaf.storageRoot();
+                codeHash = leaf.codeHash();
+            } else if (accRes instanceof MerklePatriciaProofVerifier.Result.Absent) {
+                balance = java.math.BigInteger.ZERO;
+                nonce = 0L;
+                storageRoot = MerklePatriciaProofVerifier.EMPTY_TRIE_ROOT;
+                codeHash = Bytes32.wrap(EMPTY_CODE_HASH);
+            } else {
+                log.info("[rpc] eth_getProof: account proof invalid for " + addr.toShortHexString()
+                        + ": " + ((MerklePatriciaProofVerifier.Result.Invalid) accRes).reason());
+                return null;  // never serve an unverifiable proof
+            }
+
+            // --- Storage proofs ------------------------------------------------
+            // A slot in an empty storage trie (EOA, fresh contract, or absent account)
+            // is provably zero with no trie to query — short-circuit the network call
+            // and return the canonical empty proof, as Geth does.
+            boolean emptyStorage = storageRoot.equals(MerklePatriciaProofVerifier.EMPTY_TRIE_ROOT);
+            StringBuilder storageSb = new StringBuilder("[");
+            for (int i = 0; i < keys.size(); i++) {
+                Bytes keyBytes = Bytes.wrap(keys.get(i));
+                java.math.BigInteger value = java.math.BigInteger.ZERO;
+                java.util.List<Bytes> slotProof = java.util.List.of();
+                if (!emptyStorage) {
+                    Bytes32 keyHash = Hash.keccak256(keyBytes);
+                    com.jaeckel.ethp2p.networking.snap.messages.StorageRangesMessage.DecodeResult sr =
+                            connector.requestStorage(addr, keyHash, stateRoot)
+                                    .get(RPC_CALL_TIMEOUT_SEC, TimeUnit.SECONDS);
+                    slotProof = sr.proof();
+                    MerklePatriciaProofVerifier.Result slotRes =
+                            MerklePatriciaProofVerifier.verify(storageRoot, keyHash.toArrayUnsafe(), slotProof);
+                    if (slotRes instanceof MerklePatriciaProofVerifier.Result.Found sf) {
+                        // Storage leaf value is RLP(bytes); the verifier already stripped the
+                        // RLP header, so this is the big-endian value with leading zeros trimmed.
+                        value = sf.value().isEmpty()
+                                ? java.math.BigInteger.ZERO
+                                : new java.math.BigInteger(1, sf.value().toArrayUnsafe());
+                    } else if (!(slotRes instanceof MerklePatriciaProofVerifier.Result.Absent)) {
+                        log.info("[rpc] eth_getProof: storage proof invalid for slot "
+                                + keyBytes.toShortHexString() + ": "
+                                + ((MerklePatriciaProofVerifier.Result.Invalid) slotRes).reason());
+                        return null;
+                    }
+                }
+                if (i > 0) storageSb.append(",");
+                storageSb.append("{\"key\":\"").append(keyBytes.toHexString()).append("\"")
+                        .append(",\"value\":\"").append(quantity(value)).append("\"")
+                        .append(",\"proof\":").append(proofArray(slotProof)).append("}");
+            }
+            storageSb.append("]");
+
+            // --- Assemble EIP-1186 object + Myotis verification metadata -------
+            StringBuilder sb = new StringBuilder("{");
+            sb.append("\"address\":\"").append(addr.toHexString()).append("\"");
+            sb.append(",\"accountProof\":").append(proofArray(accountProof));
+            sb.append(",\"balance\":\"").append(quantity(balance)).append("\"");
+            sb.append(",\"codeHash\":\"").append(codeHash.toHexString()).append("\"");
+            sb.append(",\"nonce\":\"").append(quantity(nonce)).append("\"");
+            sb.append(",\"storageHash\":\"").append(storageRoot.toHexString()).append("\"");
+            sb.append(",\"storageProof\":").append(storageSb);
+            // Non-standard: lets a Myotis-aware client confirm the stateRoot these proofs
+            // anchor to was itself beacon (sync-committee) verified — a vanilla client
+            // verifying only the MPT path still has to trust the root's provenance.
+            sb.append(",\"myotisVerification\":{")
+                    .append("\"beaconVerified\":").append(h.beaconVerified())
+                    .append(",\"blockNumber\":").append(h.blockNumber())
+                    .append(",\"stateRoot\":\"").append(stateRoot.toHexString()).append("\"")
+                    .append("}");
+            sb.append("}");
+            return sb.toString();
+        } catch (Exception e) {
+            log.info("[rpc] eth_getProof -> error: " + unwrap(e));
+            if (isStateUnavailable(e)) evictUnservableHead(h);
+            return null;
+        }
+    }
+
+    /** Proof-verified account leaf fields, decoded from RLP[nonce, balance, storageRoot, codeHash]. */
+    private record AccountLeaf(long nonce, java.math.BigInteger balance,
+                               Bytes32 storageRoot, Bytes32 codeHash) {}
+
+    /** Decode an account leaf {@code RLP[nonce, balance, storageRoot, codeHash]}, or null. */
+    private static AccountLeaf decodeAccountLeaf(Bytes accountRlp) {
+        if (accountRlp == null || accountRlp.isEmpty()) return null;
+        try {
+            long[] nonce = new long[1];
+            java.math.BigInteger[] balance = new java.math.BigInteger[1];
+            Bytes32[] storageRoot = new Bytes32[1];
+            Bytes32[] codeHash = new Bytes32[1];
+            RLP.decodeList(accountRlp, reader -> {
+                Bytes nonceBytes = reader.readValue();
+                nonce[0] = nonceBytes.isEmpty() ? 0L : nonceBytes.toLong();
+                Bytes balBytes = reader.readValue();
+                balance[0] = balBytes.isEmpty()
+                        ? java.math.BigInteger.ZERO
+                        : new java.math.BigInteger(1, balBytes.toArrayUnsafe());
+                storageRoot[0] = Bytes32.leftPad(reader.readValue());
+                codeHash[0] = Bytes32.leftPad(reader.readValue());
+                return null;
+            });
+            return new AccountLeaf(nonce[0], balance[0], storageRoot[0], codeHash[0]);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /** JSON array of 0x-hex RLP trie nodes. */
+    private static String proofArray(java.util.List<Bytes> nodes) {
+        StringBuilder sb = new StringBuilder("[");
+        for (int i = 0; i < nodes.size(); i++) {
+            if (i > 0) sb.append(",");
+            sb.append("\"").append(nodes.get(i).toHexString()).append("\"");
+        }
+        return sb.append("]").toString();
+    }
+
+    /** Ethereum JSON-RPC QUANTITY: minimal hex, no leading zeros, 0 -> "0x0". */
+    private static String quantity(long v) { return "0x" + Long.toHexString(v); }
+    private static String quantity(java.math.BigInteger v) {
+        return v.signum() == 0 ? "0x0" : "0x" + v.toString(16);
     }
 
     /** True iff the throwable chain carries the oracle's "no connected snap peer serves


### PR DESCRIPTION
## Summary

Adds support for the `eth_getProof` RPC method (EIP-1186), which returns cryptographically verified account and storage proofs anchored to the beacon-verified state root. Proofs are extracted from SNAP-served trie nodes, re-verified locally, and returned with a non-standard `myotisVerification` block that confirms the state root itself was sync-committee verified.

## Key Changes

- **Backend implementation** (`VerifiedRpcBackend.java`):
  - Added `rpcGetProof()` method that requests account and storage proofs from SNAP peers via `connector.requestAccount()` and `connector.requestStorage()`
  - Re-verifies all proofs using `MerklePatriciaProofVerifier` against the beacon-anchored state root
  - Handles both inclusion (found leaf) and exclusion (absent) cases, returning canonical empty values for absent accounts/slots
  - Decodes account leaf RLP (`nonce`, `balance`, `storageRoot`, `codeHash`) and storage slot values
  - Returns null (triggering router error) if the head can't be served verified or any proof fails verification — never serves an unverifiable proof
  - Includes `myotisVerification` metadata (beaconVerified flag, blockNumber, stateRoot) so Myotis-aware clients can confirm the root's provenance

- **Router integration** (`RpcRouter.kt`):
  - Added `eth_getProof` to `VERIFIED_METHODS` set
  - Implemented parameter parsing: address (20 bytes), storage keys array (each normalized to 32-byte left-padded), block tag (defaults to "latest")
  - Validates malformed keys and falls through on parse errors rather than guessing
  - Parses the returned JSON proof object and embeds it in the response

- **Interface definition** (`MyotisRpcBackend.kt`):
  - Added `getProof()` method signature with documentation explaining the EIP-1186 format and verification guarantees

- **Test coverage** (`RpcRouterTest.kt`):
  - Added `FakeBackend` support for `getProof()` with tracking of address, keys, and block parameters
  - Tests verify: object passthrough, address/key decoding and left-padding, empty key list handling, malformed key rejection, and retryable error on unverifiable proofs

## Implementation Details

- Storage proofs for empty storage tries (EOA, fresh contract, absent account) short-circuit the network call and return the canonical empty proof with no trie nodes, matching Geth behavior
- Account leaf decoding handles variable-length RLP fields (nonce and balance can be 0-length for zero values)
- Storage slot values are decoded as big-endian with leading zeros trimmed, matching Ethereum's QUANTITY format
- All proof nodes are returned as 0x-hex RLP-encoded trie nodes in JSON arrays
- Follows the trust model: only SNAP-verified trie nodes are used; unverifiable proofs are never returned

https://claude.ai/code/session_01UA1zAsZLNQb2QpiA6zXmyQ