### PR TITLE
Extract daemon lifecycle into DaemonRuntime; add desktop GUI

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -83,7 +83,18 @@ jobs:
           if [ -n "${{ steps.ver.outputs.value }}" ]; then
             ARGS="$ARGS -PappVersion=${{ steps.ver.outputs.value }}"
           fi
-          ./gradlew $ARGS
+          # Retry transient dependency-resolution failures: the Compose Desktop plugin
+          # fetches small internal artifacts (e.g. gradle-plugin-internal-jdk-version-probe)
+          # only from Maven Central, which intermittently returns HTTP 403 — and Gradle
+          # treats 403 as fatal (no fall-through to other repos). A couple of retries ride
+          # out the transient CDN blip instead of failing the whole installer matrix.
+          ok=0
+          for attempt in 1 2 3; do
+            if ./gradlew $ARGS; then ok=1; break; fi
+            echo "::warning::Gradle attempt $attempt failed; retrying in $((attempt*20))s"
+            sleep $((attempt*20))
+          done
+          [ "$ok" = "1" ]
 
       # jpackage names macOS .dmg/.pkg without an arch, so the arm64 and x64 builds
       # would collide as release assets. Suffix them with the runner arch.

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -27,6 +27,13 @@ on:
       - '.github/workflows/desktop-release.yml'
   workflow_dispatch:
 
+# Supersede in-progress runs for the same ref so a new push doesn't pile a second
+# 4-OS matrix on top of one that's still building (or stuck). Per-ref grouping keeps
+# distinct release tags independent.
+concurrency:
+  group: desktop-installers-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   package:
     name: Package (${{ matrix.os }})
@@ -58,12 +65,19 @@ jobs:
         if: runner.os != 'Windows'
         run: chmod +x gradlew
 
+      # jpackage builds the .rpm via rpmbuild and the .deb via dpkg/fakeroot. dpkg is
+      # preinstalled on ubuntu-latest but rpmbuild is NOT, so the .rpm target fails
+      # without this. Required (no `|| true`).
+      - name: Install Linux packaging tools
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y rpm fakeroot
+
       # Optional: generate the Linux app icon from the SVG. Best-effort — the build
       # wires icons only when present and falls back to a default icon otherwise.
       - name: Generate Linux icon
         if: runner.os == 'Linux'
         run: |
-          sudo apt-get update && sudo apt-get install -y librsvg2-bin imagemagick || true
+          sudo apt-get install -y librsvg2-bin imagemagick || true
           ./tools/make-icons.sh || true
 
       - name: Resolve version

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1,11 +1,30 @@
 name: Desktop Installers
 
 # Builds native desktop installers for Linux, Windows and macOS with jpackage
-# (via the Compose Desktop Gradle plugin) and, on a version tag, attaches them to
-# the GitHub Release. Manual runs (workflow_dispatch) build + upload artifacts only.
+# (via the Compose Desktop Gradle plugin). On a version tag the installers are
+# attached to the GitHub Release; on pull requests (and manual dispatch) they are
+# uploaded as downloadable workflow artifacts only — no Release is published.
 on:
   push:
     tags: [ "v*" ]
+  pull_request:
+    # Only when something that can change the installers is touched — a full
+    # 4-OS jpackage matrix is expensive to run on every push.
+    paths:
+      - 'desktop-app/**'
+      - 'app/**'
+      - 'core/**'
+      - 'networking/**'
+      - 'consensus/**'
+      - 'myotis-evm/**'
+      - 'myotis-ens/**'
+      - 'jsonrpc-server/**'
+      - 'rpc-backend/**'
+      - 'gradle/**'
+      - 'gradle.properties'
+      - 'settings.gradle.kts'
+      - 'build.gradle.kts'
+      - '.github/workflows/desktop-release.yml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1,0 +1,116 @@
+name: Desktop Installers
+
+# Builds native desktop installers for Linux, Windows and macOS with jpackage
+# (via the Compose Desktop Gradle plugin) and, on a version tag, attaches them to
+# the GitHub Release. Manual runs (workflow_dispatch) build + upload artifacts only.
+on:
+  push:
+    tags: [ "v*" ]
+  workflow_dispatch:
+
+jobs:
+  package:
+    name: Package (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest    # .deb + .rpm
+          - os: windows-latest   # .msi + .exe
+          - os: macos-14         # .dmg + .pkg (Apple Silicon / arm64)
+          - os: macos-13         # .dmg + .pkg (Intel / x64)
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Make gradlew executable
+        if: runner.os != 'Windows'
+        run: chmod +x gradlew
+
+      # Optional: generate the Linux app icon from the SVG. Best-effort — the build
+      # wires icons only when present and falls back to a default icon otherwise.
+      - name: Generate Linux icon
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update && sudo apt-get install -y librsvg2-bin imagemagick || true
+          ./tools/make-icons.sh || true
+
+      - name: Resolve version
+        id: ver
+        shell: bash
+        run: |
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build installers
+        shell: bash
+        run: |
+          ARGS=":desktop-app:packageReleaseDistributionForCurrentOS --stacktrace"
+          if [ -n "${{ steps.ver.outputs.value }}" ]; then
+            ARGS="$ARGS -PappVersion=${{ steps.ver.outputs.value }}"
+          fi
+          ./gradlew $ARGS
+
+      # jpackage names macOS .dmg/.pkg without an arch, so the arm64 and x64 builds
+      # would collide as release assets. Suffix them with the runner arch.
+      - name: Disambiguate macOS arch
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          cd desktop-app/build/compose/binaries/main-release
+          for f in dmg/*.dmg pkg/*.pkg; do
+            [ -e "$f" ] || continue
+            dir=$(dirname "$f"); base=$(basename "$f")
+            mv "$f" "$dir/${base%.*}-${{ runner.arch }}.${base##*.}"
+          done
+
+      - name: Upload installers
+        uses: actions/upload-artifact@v4
+        with:
+          name: myotis-installers-${{ matrix.os }}
+          path: |
+            desktop-app/build/compose/binaries/main-release/deb/*.deb
+            desktop-app/build/compose/binaries/main-release/rpm/*.rpm
+            desktop-app/build/compose/binaries/main-release/msi/*.msi
+            desktop-app/build/compose/binaries/main-release/exe/*.exe
+            desktop-app/build/compose/binaries/main-release/dmg/*.dmg
+            desktop-app/build/compose/binaries/main-release/pkg/*.pkg
+          if-no-files-found: warn
+          retention-days: 14
+
+  release:
+    name: Attach to Release
+    needs: package
+    runs-on: ubuntu-latest
+    if: github.ref_type == 'tag'
+    permissions:
+      contents: write
+    steps:
+      - name: Download all installers
+        uses: actions/download-artifact@v4
+        with:
+          path: installers
+          merge-multiple: true
+
+      - name: Attach to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: installers/**/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -185,15 +185,19 @@ jobs:
           fi
 
       # createReleaseDistributable produces build/compose/binaries/main-release/app/Myotis.app.
-      # --rerun-tasks forces the runtime-image + app-image tasks to re-execute so the cached
-      # (or just-built other-arch) image is never reused — javaHome is not a tracked task
-      # input, so without this the second pass could silently ship the first pass's runtime.
+      # It bundles BOTH a jlink runtime image and the arch-specific Skiko native lib
+      # (Contents/app/libskiko-macos-<arch>.dylib). Both follow the arch of the JDK/JVM
+      # Gradle runs under — jpackage's runtime via the default javaHome, Skiko via
+      # compose.desktop.currentOs — so each arch must run Gradle under the matching JDK
+      # (the x64 pass via Rosetta). --rerun-tasks forces the runtime-image + app-image tasks
+      # to re-execute so the other arch's cached output is never reused; --no-daemon keeps the
+      # two arch builds from ever sharing a Gradle daemon.
       - name: Build arm64 app-image
         shell: bash
         env:
           JAVA_HOME: ${{ steps.jdk_arm.outputs.path }}
         run: |
-          ARGS=":desktop-app:createReleaseDistributable --rerun-tasks --stacktrace -PdesktopJavaHome=${{ steps.jdk_arm.outputs.path }}"
+          ARGS=":desktop-app:createReleaseDistributable --rerun-tasks --no-daemon --stacktrace"
           if [ -n "${{ steps.ver.outputs.value }}" ]; then
             ARGS="$ARGS -PappVersion=${{ steps.ver.outputs.value }}"
           fi
@@ -210,10 +214,10 @@ jobs:
       - name: Build x64 app-image
         shell: bash
         env:
-          JAVA_HOME: ${{ steps.jdk_arm.outputs.path }}   # Gradle stays native arm64; only jlink/jpackage use x64
+          JAVA_HOME: ${{ steps.jdk_x64.outputs.path }}   # Rosetta: x64 JVM => x64 runtime image + x64 Skiko
         run: |
           rm -rf desktop-app/build/compose/binaries/main-release/app
-          ARGS=":desktop-app:createReleaseDistributable --rerun-tasks --stacktrace -PdesktopJavaHome=${{ steps.jdk_x64.outputs.path }}"
+          ARGS=":desktop-app:createReleaseDistributable --rerun-tasks --no-daemon --stacktrace"
           if [ -n "${{ steps.ver.outputs.value }}" ]; then
             ARGS="$ARGS -PappVersion=${{ steps.ver.outputs.value }}"
           fi
@@ -227,12 +231,18 @@ jobs:
           rm -rf /tmp/x64 && mkdir -p /tmp/x64
           cp -R desktop-app/build/compose/binaries/main-release/app/Myotis.app /tmp/x64/
 
-      # lipo every Mach-O file that exists in both bundles into a fat binary; everything
-      # else (resources, the runtime's java classes, symlinks) is identical across arches
-      # and comes from the arm64 copy untouched. Then re-sign ad-hoc: lipo invalidates the
-      # per-arch ad-hoc signatures jpackage applied, and an inconsistent signature makes
-      # Gatekeeper refuse to launch. (CI has no Developer ID cert, so this matches the
-      # per-arch builds' existing unnotarized, ad-hoc-signed status — no regression.)
+      # Merge the two bundles into one universal .app. The universal bundle is seeded from a
+      # copy of the arm64 bundle, then:
+      #   - files present in BOTH paths as Mach-O of DIFFERENT archs (launcher, libjvm, most
+      #     runtime .dylibs) are replaced with a fat arm64+x86_64 binary via lipo;
+      #   - files present only in the x64 bundle (notably libskiko-macos-x64.dylib — the
+      #     arch is in the filename, so the two Skiko libs coexist rather than lipo together)
+      #     are copied across so the universal app carries both arches' native libs.
+      # Equal-arch / non-Mach-O files are left as the arm64 copy (lipo would reject equal
+      # archs anyway). Then re-sign ad-hoc: lipo/copies invalidate the per-arch ad-hoc
+      # signatures jpackage applied, and an inconsistent signature makes Gatekeeper refuse to
+      # launch. (CI has no Developer ID cert, so this matches the per-arch builds' existing
+      # unnotarized, ad-hoc-signed status — no regression.)
       - name: Merge into universal app-image
         shell: bash
         run: |
@@ -242,16 +252,28 @@ jobs:
           UNI=/tmp/universal/Myotis.app
           rm -rf /tmp/universal && mkdir -p /tmp/universal
           cp -R "$ARM" "$UNI"
-          merged=0
+          merged=0; copied=0
+          # Pass 1: arm64 files that also exist in x64 as a different-arch Mach-O -> fat binary.
           while IFS= read -r f; do
-            if lipo -info "$ARM/$f" >/dev/null 2>&1 && lipo -info "$X64/$f" >/dev/null 2>&1; then
+            [ -f "$X64/$f" ] || continue
+            aarch=$(lipo -archs "$ARM/$f" 2>/dev/null) || continue   # skip non-Mach-O
+            xarch=$(lipo -archs "$X64/$f" 2>/dev/null) || continue
+            if [ "$aarch" != "$xarch" ]; then
               lipo -create "$ARM/$f" "$X64/$f" -output "$UNI/$f"
               merged=$((merged+1))
             fi
           done < <(cd "$ARM" && find . -type f)
-          echo "Merged $merged Mach-O files into universal binaries"
+          # Pass 2: x64-only files (e.g. libskiko-macos-x64.dylib) -> bring them across.
+          while IFS= read -r f; do
+            if [ ! -e "$ARM/$f" ]; then
+              mkdir -p "$(dirname "$UNI/$f")"
+              cp -p "$X64/$f" "$UNI/$f"
+              copied=$((copied+1))
+            fi
+          done < <(cd "$X64" && find . -type f)
+          echo "Merged $merged fat binaries; copied $copied x64-only files"
           # Fail loudly if the merge didn't actually produce fat binaries for the two files
-          # that matter most — the launcher and the JVM.
+          # that matter most — the launcher and the JVM — and confirm both Skiko libs are present.
           launcher="$UNI/Contents/MacOS/Myotis"
           libjvm="$UNI/Contents/runtime/Contents/Home/lib/server/libjvm.dylib"
           echo "launcher archs: $(lipo -archs "$launcher")"
@@ -262,6 +284,11 @@ jobs:
               *arm64*x86_64*|*x86_64*arm64*) ;;
               *) echo "::error::$bin is not universal (archs: $archs)"; exit 1 ;;
             esac
+          done
+          for skiko in libskiko-macos-arm64.dylib libskiko-macos-x64.dylib; do
+            if [ ! -e "$UNI/Contents/app/$skiko" ]; then
+              echo "::error::missing $skiko in universal bundle — Compose would fail to start on that arch"; exit 1
+            fi
           done
           codesign --remove-signature "$UNI" 2>/dev/null || true
           codesign --force --deep --sign - "$UNI"

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -4,12 +4,17 @@ name: Desktop Installers
 # (via the Compose Desktop Gradle plugin). On a version tag the installers are
 # attached to the GitHub Release; on pull requests (and manual dispatch) they are
 # uploaded as downloadable workflow artifacts only — no Release is published.
+#
+# macOS is built as a single *universal* (arm64 + x86_64) installer on one Apple
+# Silicon runner — see the `package-macos` job — instead of a per-arch matrix. This
+# avoids depending on the scarce/queued Intel `macos-13` runners while still shipping
+# a binary that runs natively on both Apple Silicon and Intel Macs.
 on:
   push:
     tags: [ "v*" ]
   pull_request:
     # Only when something that can change the installers is touched — a full
-    # 4-OS jpackage matrix is expensive to run on every push.
+    # jpackage build is expensive to run on every push.
     paths:
       - 'desktop-app/**'
       - 'app/**'
@@ -28,13 +33,15 @@ on:
   workflow_dispatch:
 
 # Supersede in-progress runs for the same ref so a new push doesn't pile a second
-# 4-OS matrix on top of one that's still building (or stuck). Per-ref grouping keeps
+# build on top of one that's still building (or stuck). Per-ref grouping keeps
 # distinct release tags independent.
 concurrency:
   group: desktop-installers-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  # Linux (.deb + .rpm) and Windows (.msi + .exe). macOS is handled separately by
+  # `package-macos` because the universal build needs a bespoke two-JDK + lipo pipeline.
   package:
     name: Package (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -44,8 +51,6 @@ jobs:
         include:
           - os: ubuntu-latest    # .deb + .rpm
           - os: windows-latest   # .msi + .exe
-          - os: macos-14         # .dmg + .pkg (Apple Silicon / arm64)
-          - os: macos-13         # .dmg + .pkg (Intel / x64)
     permissions:
       contents: read
     steps:
@@ -110,19 +115,6 @@ jobs:
           done
           [ "$ok" = "1" ]
 
-      # jpackage names macOS .dmg/.pkg without an arch, so the arm64 and x64 builds
-      # would collide as release assets. Suffix them with the runner arch.
-      - name: Disambiguate macOS arch
-        if: runner.os == 'macOS'
-        shell: bash
-        run: |
-          cd desktop-app/build/compose/binaries/main-release
-          for f in dmg/*.dmg pkg/*.pkg; do
-            [ -e "$f" ] || continue
-            dir=$(dirname "$f"); base=$(basename "$f")
-            mv "$f" "$dir/${base%.*}-${{ runner.arch }}.${base##*.}"
-          done
-
       - name: Upload installers
         uses: actions/upload-artifact@v4
         with:
@@ -132,6 +124,190 @@ jobs:
             desktop-app/build/compose/binaries/main-release/rpm/*.rpm
             desktop-app/build/compose/binaries/main-release/msi/*.msi
             desktop-app/build/compose/binaries/main-release/exe/*.exe
+          if-no-files-found: warn
+          retention-days: 14
+
+  # macOS universal (arm64 + x86_64) installer, built on a single Apple Silicon runner.
+  #
+  # jpackage/jlink can only emit a runtime image for the arch they run as, so there is no
+  # one-shot universal build. Instead we build the app-image twice — once with a native
+  # arm64 JDK, once with an x64 JDK under Rosetta 2 — then lipo-merge the two .app bundles
+  # into a single fat bundle, re-sign it ad-hoc, and let jpackage wrap that into a
+  # universal .dmg / .pkg. This is the standard "merge two JREs with lipo" recipe.
+  package-macos:
+    name: Package (macOS universal)
+    runs-on: macos-14
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      # Two JDKs of the *same* version. arm64 is native and also runs Gradle + the final
+      # jpackage wrap; x64 runs under Rosetta only to emit the x86_64 runtime image.
+      # `path` outputs give us each JAVA_HOME without guessing setup-java's env-var names.
+      - name: Set up JDK 21 (arm64)
+        id: jdk_arm
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          architecture: 'aarch64'
+          cache: gradle
+
+      - name: Set up JDK 21 (x64)
+        id: jdk_x64
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          architecture: 'x64'
+
+      # The x64 jlink/jpackage binaries are x86_64; Rosetta 2 lets them run on the arm64
+      # runner. Idempotent and already present on GitHub's macOS arm runners — `|| true`
+      # keeps it from failing if it's a no-op.
+      - name: Ensure Rosetta 2
+        run: softwareupdate --install-rosetta --agree-to-license || true
+
+      - name: Make gradlew executable
+        run: chmod +x gradlew
+
+      - name: Resolve version
+        id: ver
+        shell: bash
+        run: |
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=" >> "$GITHUB_OUTPUT"
+          fi
+
+      # createReleaseDistributable produces build/compose/binaries/main-release/app/Myotis.app.
+      # --rerun-tasks forces the runtime-image + app-image tasks to re-execute so the cached
+      # (or just-built other-arch) image is never reused — javaHome is not a tracked task
+      # input, so without this the second pass could silently ship the first pass's runtime.
+      - name: Build arm64 app-image
+        shell: bash
+        env:
+          JAVA_HOME: ${{ steps.jdk_arm.outputs.path }}
+        run: |
+          ARGS=":desktop-app:createReleaseDistributable --rerun-tasks --stacktrace -PdesktopJavaHome=${{ steps.jdk_arm.outputs.path }}"
+          if [ -n "${{ steps.ver.outputs.value }}" ]; then
+            ARGS="$ARGS -PappVersion=${{ steps.ver.outputs.value }}"
+          fi
+          ok=0
+          for attempt in 1 2 3; do
+            if ./gradlew $ARGS; then ok=1; break; fi
+            echo "::warning::Gradle attempt $attempt failed; retrying in $((attempt*20))s"
+            sleep $((attempt*20))
+          done
+          [ "$ok" = "1" ]
+          rm -rf /tmp/arm64 && mkdir -p /tmp/arm64
+          cp -R desktop-app/build/compose/binaries/main-release/app/Myotis.app /tmp/arm64/
+
+      - name: Build x64 app-image
+        shell: bash
+        env:
+          JAVA_HOME: ${{ steps.jdk_arm.outputs.path }}   # Gradle stays native arm64; only jlink/jpackage use x64
+        run: |
+          rm -rf desktop-app/build/compose/binaries/main-release/app
+          ARGS=":desktop-app:createReleaseDistributable --rerun-tasks --stacktrace -PdesktopJavaHome=${{ steps.jdk_x64.outputs.path }}"
+          if [ -n "${{ steps.ver.outputs.value }}" ]; then
+            ARGS="$ARGS -PappVersion=${{ steps.ver.outputs.value }}"
+          fi
+          ok=0
+          for attempt in 1 2 3; do
+            if ./gradlew $ARGS; then ok=1; break; fi
+            echo "::warning::Gradle attempt $attempt failed; retrying in $((attempt*20))s"
+            sleep $((attempt*20))
+          done
+          [ "$ok" = "1" ]
+          rm -rf /tmp/x64 && mkdir -p /tmp/x64
+          cp -R desktop-app/build/compose/binaries/main-release/app/Myotis.app /tmp/x64/
+
+      # lipo every Mach-O file that exists in both bundles into a fat binary; everything
+      # else (resources, the runtime's java classes, symlinks) is identical across arches
+      # and comes from the arm64 copy untouched. Then re-sign ad-hoc: lipo invalidates the
+      # per-arch ad-hoc signatures jpackage applied, and an inconsistent signature makes
+      # Gatekeeper refuse to launch. (CI has no Developer ID cert, so this matches the
+      # per-arch builds' existing unnotarized, ad-hoc-signed status — no regression.)
+      - name: Merge into universal app-image
+        shell: bash
+        run: |
+          set -euo pipefail
+          ARM=/tmp/arm64/Myotis.app
+          X64=/tmp/x64/Myotis.app
+          UNI=/tmp/universal/Myotis.app
+          rm -rf /tmp/universal && mkdir -p /tmp/universal
+          cp -R "$ARM" "$UNI"
+          merged=0
+          while IFS= read -r f; do
+            if lipo -info "$ARM/$f" >/dev/null 2>&1 && lipo -info "$X64/$f" >/dev/null 2>&1; then
+              lipo -create "$ARM/$f" "$X64/$f" -output "$UNI/$f"
+              merged=$((merged+1))
+            fi
+          done < <(cd "$ARM" && find . -type f)
+          echo "Merged $merged Mach-O files into universal binaries"
+          # Fail loudly if the merge didn't actually produce fat binaries for the two files
+          # that matter most — the launcher and the JVM.
+          launcher="$UNI/Contents/MacOS/Myotis"
+          libjvm="$UNI/Contents/runtime/Contents/Home/lib/server/libjvm.dylib"
+          echo "launcher archs: $(lipo -archs "$launcher")"
+          echo "libjvm archs:   $(lipo -archs "$libjvm")"
+          for bin in "$launcher" "$libjvm"; do
+            archs=$(lipo -archs "$bin")
+            case "$archs" in
+              *arm64*x86_64*|*x86_64*arm64*) ;;
+              *) echo "::error::$bin is not universal (archs: $archs)"; exit 1 ;;
+            esac
+          done
+          codesign --remove-signature "$UNI" 2>/dev/null || true
+          codesign --force --deep --sign - "$UNI"
+          codesign --verify --deep --strict "$UNI" && echo "ad-hoc signature OK"
+
+      # Wrap the universal .app into installers. --app-image packaging is arch-agnostic, so
+      # the native arm64 jpackage handles it. App version must match jpackage's rules: no
+      # pre-release suffix, and macOS rejects a leading-zero major (0.x -> 1.x), mirroring
+      # the Gradle build's macVersion coercion.
+      - name: Package universal dmg + pkg
+        shell: bash
+        env:
+          JAVA_HOME: ${{ steps.jdk_arm.outputs.path }}
+        run: |
+          set -euo pipefail
+          VER="${{ steps.ver.outputs.value }}"
+          VER="${VER:-1.0.0}"
+          VER="${VER%%-*}"
+          IFS=. read -r a b c <<< "$VER"
+          if [ "${a:-0}" = "0" ]; then a=1; fi
+          MACVER="${a:-1}.${b:-0}.${c:-0}"
+          echo "Packaging universal installers as version $MACVER"
+          OUT=desktop-app/build/compose/binaries/main-release
+          rm -rf "$OUT/dmg" "$OUT/pkg"
+          mkdir -p "$OUT/dmg" "$OUT/pkg"
+          for T in dmg pkg; do
+            "${{ steps.jdk_arm.outputs.path }}/bin/jpackage" \
+              --type "$T" \
+              --app-image /tmp/universal/Myotis.app \
+              --name Myotis \
+              --app-version "$MACVER" \
+              --dest "$OUT/$T"
+          done
+          # Mark the assets as universal (and avoid any name clash with future per-arch builds).
+          for f in "$OUT"/dmg/*.dmg "$OUT"/pkg/*.pkg; do
+            [ -e "$f" ] || continue
+            d=$(dirname "$f"); base=$(basename "$f")
+            mv "$f" "$d/${base%.*}-universal.${base##*.}"
+          done
+          ls -la "$OUT"/dmg "$OUT"/pkg
+
+      - name: Upload installers
+        uses: actions/upload-artifact@v4
+        with:
+          name: myotis-installers-macos-universal
+          path: |
             desktop-app/build/compose/binaries/main-release/dmg/*.dmg
             desktop-app/build/compose/binaries/main-release/pkg/*.pkg
           if-no-files-found: warn
@@ -139,7 +315,7 @@ jobs:
 
   release:
     name: Attach to Release
-    needs: package
+    needs: [ package, package-macos ]
     runs-on: ubuntu-latest
     if: github.ref_type == 'tag'
     permissions:

--- a/README.md
+++ b/README.md
@@ -69,7 +69,26 @@ A number-pinned read (wallets pin every read to the block they just saw) is serv
 
 ## Run
 
-Myotis runs in two forms: the **Android app** (the wallet node, with the verified JSON-RPC server for a same-device wallet) and the **desktop daemon/CLI** (the same engine for development, with a CLI/IPC command surface). Both run the full devp2p + libp2p stack, the beacon light client, and the local EVM.
+Myotis runs in three forms: the **Android app** (the wallet node, with the verified JSON-RPC server for a same-device wallet), the **desktop app** (an installable Compose GUI that embeds the same node), and the **desktop daemon/CLI** (the same engine for development, with a CLI/IPC command surface). All run the full devp2p + libp2p stack, the beacon light client, and the local EVM.
+
+### Desktop app (download & install)
+
+The desktop app is a Compose GUI that embeds the node in-process — start/stop the daemon, watch beacon sync + peers, and run verified account lookups — and ships as a native installer per OS.
+
+- **Download:** grab the installer for your platform from the [GitHub Releases](../../releases) page (published by the *Desktop Installers* workflow on each `vX.Y.Z` tag):
+  - **Linux** — `.deb` or `.rpm`
+  - **Windows** — `.msi` or `.exe`
+  - **macOS** — `.dmg` (separate Apple-Silicon / Intel builds)
+- **Build from source** (produces the installer for the current OS under `desktop-app/build/compose/binaries/main-release/`):
+  ```bash
+  ./gradlew :desktop-app:packageReleaseDistributionForCurrentOS
+  # or just run it without packaging:
+  ./gradlew :desktop-app:run
+  ```
+
+Each installer bundles its own JDK 21 runtime — no separate Java install needed. Node data (keys, peer caches, verified-state snapshot) lives in a per-user directory: `~/.local/share/myotis` (Linux), `~/Library/Application Support/Myotis` (macOS), or `%LOCALAPPDATA%\Myotis` (Windows).
+
+> **Unsigned builds:** releases are not yet code-signed, so the OS will warn on first launch. On **macOS**, right-click the app → *Open* (or `xattr -dr com.apple.quarantine /Applications/Myotis.app`). On **Windows**, click *More info → Run anyway* on the SmartScreen prompt. Signing/notarization is a planned follow-up.
 
 ### Android
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ The desktop app is a Compose GUI that embeds the node in-process — start/stop 
   - **Linux** — `.deb` or `.rpm`
   - **Windows** — `.msi` or `.exe`
   - **macOS** — `.dmg` (separate Apple-Silicon / Intel builds)
+- **Unreleased / dev builds:** the *Desktop Installers* workflow also runs on pull requests, uploading the per-OS installers as downloadable run **artifacts** (`myotis-installers-<os>`, 14-day retention) without publishing a Release — open the workflow run and look under *Artifacts*.
 - **Build from source** (produces the installer for the current OS under `desktop-app/build/compose/binaries/main-release/`):
   ```bash
   ./gradlew :desktop-app:packageReleaseDistributionForCurrentOS

--- a/app/src/main/java/com/jaeckel/ethp2p/app/AppPaths.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/AppPaths.java
@@ -1,0 +1,120 @@
+package com.jaeckel.ethp2p.app;
+
+import com.jaeckel.ethp2p.networking.NetworkConfig;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Locale;
+
+/**
+ * Per-user, per-OS locations for a packaged desktop install.
+ *
+ * <p>The CLI daemon historically writes its socket/lock to {@code /tmp} and its keys/caches
+ * into the process working directory. That's fine for {@code ./gradlew :app:run} from a repo
+ * checkout, but a jpackage'd desktop app has a read-only install directory and (on Windows)
+ * no {@code /tmp}. This helper resolves OS-appropriate writable locations instead:
+ *
+ * <ul>
+ *   <li><b>Linux</b> — {@code $XDG_DATA_HOME/myotis} (default {@code ~/.local/share/myotis});
+ *       socket in {@code $XDG_RUNTIME_DIR} when set.</li>
+ *   <li><b>macOS</b> — {@code ~/Library/Application Support/Myotis}; socket in {@code $TMPDIR}
+ *       (kept short so the {@code AF_UNIX} path stays under the ~104-char limit).</li>
+ *   <li><b>Windows</b> — {@code %LOCALAPPDATA%\Myotis}.</li>
+ * </ul>
+ *
+ * <p>Everything can be overridden with {@code MYOTIS_DATA_DIR}; the socket path additionally
+ * honours the daemon's existing {@code ETHP2P_SOCKET} override (handled in {@link Main}).
+ */
+public final class AppPaths {
+
+    private AppPaths() {}
+
+    private static boolean isWindows() {
+        return System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("win");
+    }
+
+    private static boolean isMac() {
+        String os = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
+        return os.contains("mac") || os.contains("darwin");
+    }
+
+    private static boolean isBlank(String s) {
+        return s == null || s.isBlank();
+    }
+
+    /** Writable base directory for keys, caches, and the verified-state snapshot. */
+    public static Path dataDir() {
+        String override = System.getenv("MYOTIS_DATA_DIR");
+        if (!isBlank(override)) return Path.of(override);
+
+        String home = System.getProperty("user.home", ".");
+        if (isWindows()) {
+            String local = System.getenv("LOCALAPPDATA");
+            Path base = isBlank(local) ? Path.of(home, "AppData", "Local") : Path.of(local);
+            return base.resolve("Myotis");
+        }
+        if (isMac()) {
+            return Path.of(home, "Library", "Application Support", "Myotis");
+        }
+        String xdg = System.getenv("XDG_DATA_HOME");
+        Path base = isBlank(xdg) ? Path.of(home, ".local", "share") : Path.of(xdg);
+        return base.resolve("myotis");
+    }
+
+    /**
+     * Short-lived runtime directory for the {@code AF_UNIX} IPC socket. Kept separate from
+     * {@link #dataDir()} because {@code sun.nio} caps the socket path length (~108 on Linux,
+     * ~104 on macOS) and the data dir can be long.
+     */
+    public static Path runtimeDir() {
+        if (isWindows()) {
+            // No /tmp on Windows, and the embedded GUI doesn't need the socket for itself.
+            return dataDir();
+        }
+        if (isMac()) {
+            String tmp = System.getenv("TMPDIR");
+            return isBlank(tmp) ? Path.of("/tmp") : Path.of(tmp);
+        }
+        String run = System.getenv("XDG_RUNTIME_DIR");
+        return isBlank(run) ? Path.of("/tmp") : Path.of(run);
+    }
+
+    /** Network suffix mirroring {@link Main}'s socket/cache naming ("" for mainnet). */
+    private static String suffix(String networkName) {
+        return "mainnet".equals(networkName) ? "" : "-" + networkName;
+    }
+
+    /**
+     * Build a {@link DaemonRuntime.Config} rooted at the per-OS locations, creating the
+     * directories if needed. Honours {@code ETHP2P_SOCKET} for the socket path so an
+     * external CLI can be pointed at the GUI's daemon.
+     */
+    public static DaemonRuntime.Config daemonConfig(NetworkConfig network, int port, boolean gossipsubEnabled) {
+        Path data = dataDir();
+        Path runtime = runtimeDir();
+        try {
+            Files.createDirectories(data);
+            Files.createDirectories(runtime);
+        } catch (IOException e) {
+            throw new RuntimeException("Cannot create Myotis data directory at " + data + ": " + e.getMessage(), e);
+        }
+
+        String suffix = suffix(network.name());
+        String socketEnv = System.getenv("ETHP2P_SOCKET");
+        Path socket = isBlank(socketEnv)
+                ? runtime.resolve("ethp2p" + suffix + ".sock")
+                : Path.of(socketEnv);
+
+        return new DaemonRuntime.Config(
+                network,
+                port,
+                gossipsubEnabled,
+                socket,
+                data.resolve("ethp2p" + suffix + ".lock"),
+                data.resolve("nodekey.hex"),
+                data.resolve("peers" + suffix + ".cache"),
+                data.resolve("cl-peers" + suffix + ".cache"),
+                data.resolve("sync-state" + suffix + ".snapshot"));
+    }
+}

--- a/app/src/main/java/com/jaeckel/ethp2p/app/DaemonRuntime.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/DaemonRuntime.java
@@ -146,13 +146,10 @@ public final class DaemonRuntime implements AutoCloseable {
 
     public void start() throws Exception {
         final NetworkConfig network = config.network();
-        final int port = config.port();
-        final boolean gossipsubEnabled = config.gossipsubEnabled();
-        final Path socketPath = config.socketPath();
         final Path lockPath = config.lockPath();
 
         log.info("=== ethp2p Daemon ({}) ===", network.name());
-        log.info("IPC socket: {}", socketPath);
+        log.info("IPC socket: {}", config.socketPath());
 
         // 0. Acquire exclusive lock file — auto-released on process death (even kill -9)
         lockChannel = FileChannel.open(lockPath,
@@ -163,6 +160,27 @@ public final class DaemonRuntime implements AutoCloseable {
             lockChannel = null;
             throw new DaemonStartException("Daemon already running (lock held: " + lockPath + ")");
         }
+
+        // From here the lock is held. Any failure in the remaining startup MUST release it
+        // (and close whatever was partially started) rather than leak it. The CLI tolerated a
+        // leak because a failed start ended in System.exit and the OS dropped the lock; the
+        // embedded GUI process survives, so a leaked lock would make every retry in the same
+        // session fail with "Daemon already running".
+        boolean ok = false;
+        try {
+            startLocked();
+            ok = true;
+        } finally {
+            if (!ok) close();
+        }
+    }
+
+    /** Startup steps that run while the daemon lock is held (see {@link #start()}). */
+    private void startLocked() throws Exception {
+        final NetworkConfig network = config.network();
+        final int port = config.port();
+        final boolean gossipsubEnabled = config.gossipsubEnabled();
+        final Path socketPath = config.socketPath();
 
         // 1. Load or generate node key
         NodeKey nodeKey = NodeKey.loadOrGenerate(config.nodeKeyFile());
@@ -183,8 +201,23 @@ public final class DaemonRuntime implements AutoCloseable {
                 () -> dnsResolver.resolveAllFromStrings(network.elEnrTreeUrls(), dnsDeadline));
         CompletableFuture<List<Enr>> clFuture = CompletableFuture.supplyAsync(
                 () -> dnsResolver.resolveAllFromStrings(network.clEnrTreeUrls(), dnsDeadline));
-        List<Enr> dnsElEnrs = elFuture.join();
-        List<Enr> dnsClEnrs = clFuture.join();
+        // The resolver is contractually best-effort (returns empty on timeout / bad TXT /
+        // bad signature), but guard the joins anyway so an unexpected resolver failure can
+        // never abort startup — DNS discovery is an optimization, not a precondition.
+        List<Enr> dnsElEnrs;
+        try {
+            dnsElEnrs = elFuture.join();
+        } catch (Exception e) {
+            log.warn("[main] DNS EL ENR resolution failed; continuing without it: {}", e.getMessage());
+            dnsElEnrs = List.of();
+        }
+        List<Enr> dnsClEnrs;
+        try {
+            dnsClEnrs = clFuture.join();
+        } catch (Exception e) {
+            log.warn("[main] DNS CL ENR resolution failed; continuing without it: {}", e.getMessage());
+            dnsClEnrs = List.of();
+        }
 
         List<InetSocketAddress> mergedBootnodes = new ArrayList<>(network.bootnodes());
         // Dedupe by (host, port) so trees that overlap with the hardcoded list
@@ -238,7 +271,10 @@ public final class DaemonRuntime implements AutoCloseable {
         // ones first (mirrors NodeService's snapDialRank ordering).
         cached.sort(java.util.Comparator.comparingInt(DaemonRuntime::snapDialRank));
         for (PeerCache.CachedPeer peer : cached) {
-            String peerKey = peer.address().getAddress().getHostAddress()
+            // getHostString() never NPEs on an unresolved address (unlike
+            // getAddress().getHostAddress()); for the IP-literal cache keys it returns the
+            // same string, so the attempted/backoff dedup key is unchanged.
+            String peerKey = peer.address().getHostString()
                     + ":" + peer.address().getPort();
             attempted.add(peerKey);
             try {
@@ -348,7 +384,7 @@ public final class DaemonRuntime implements AutoCloseable {
                     ? "Cannot bind UDP port " + port + ": " + cause.getMessage()
                     + "\nIs another instance already running?"
                     : "Failed to start discovery: " + e.getMessage();
-            close();
+            // Cleanup is handled by start()'s finally (which calls close()).
             throw new DaemonStartException(msg);
         }
         log.info("[daemon] discv4 started on UDP port {}. Waiting for peers...", port);
@@ -494,11 +530,10 @@ public final class DaemonRuntime implements AutoCloseable {
         try {
             server.start();
         } catch (BindException e) {
-            close();
+            // Cleanup is handled by start()'s finally (which calls close()).
             throw new DaemonStartException("Cannot bind IPC socket " + socketPath + ": " + e.getMessage()
                     + "\nIs another instance already running?");
         } catch (Exception e) {
-            close();
             throw new DaemonStartException("Failed to start IPC server: " + e.getMessage());
         }
 

--- a/app/src/main/java/com/jaeckel/ethp2p/app/DaemonRuntime.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/DaemonRuntime.java
@@ -1,0 +1,672 @@
+package com.jaeckel.ethp2p.app;
+
+import com.jaeckel.ethp2p.consensus.BeaconLightClient;
+import com.jaeckel.ethp2p.consensus.BeaconSyncState;
+import com.jaeckel.ethp2p.core.crypto.NodeKey;
+import com.jaeckel.ethp2p.core.enr.Enr;
+import com.jaeckel.ethp2p.core.types.BlockHeader;
+import com.jaeckel.ethp2p.networking.NetworkConfig;
+import com.jaeckel.ethp2p.networking.discv4.DiscV4Service;
+import com.jaeckel.ethp2p.networking.discv4.KademliaTable;
+import com.jaeckel.ethp2p.networking.discv5.DiscV5Service;
+import com.jaeckel.ethp2p.networking.dns.DnsEnrResolver;
+import com.jaeckel.ethp2p.networking.eth.messages.BlockHeadersMessage;
+import com.jaeckel.ethp2p.networking.rlpx.RLPxConnector;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.crypto.SECP256K1;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.BindException;
+import java.net.InetSocketAddress;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Embeddable lifecycle for the ethp2p node — discovery (discv4/discv5), the RLPx
+ * connector, the beacon light client, the Unix-domain IPC server, and the verified
+ * loopback JSON-RPC endpoint.
+ *
+ * <p>Extracted from {@code Main.runDaemon} so the same daemon can be driven two ways:
+ * <ul>
+ *   <li>The CLI ({@link Main}) starts it, registers a JVM shutdown hook, and blocks on
+ *       {@link #awaitStop()} until a {@code stop} command or signal arrives.</li>
+ *   <li>A GUI / embedder (the desktop app) starts it on a background thread and observes
+ *       live state through {@link #beaconSyncState()} / {@link #connector()} /
+ *       {@link #commandHandler()}, then calls {@link #close()} to tear it down.</li>
+ * </ul>
+ *
+ * <p>Unlike the old in-method bootstrap, {@code start()} never calls {@code System.exit}:
+ * a fatal startup failure cleans up any partially-started components and throws
+ * {@link DaemonStartException}, leaving exit-code policy to the caller. {@link #close()}
+ * is idempotent and counts down the stop latch so any awaiter wakes.
+ */
+public final class DaemonRuntime implements AutoCloseable {
+
+    private static final Logger log = LoggerFactory.getLogger(DaemonRuntime.class);
+
+    private static final long BACKOFF_INCOMPATIBLE_MS = 10 * 60 * 1000L; // 10 min for wrong-chain peers
+    private static final long BACKOFF_TRANSIENT_MS = 30 * 1000L; // 30s for transient failures (too many peers, etc.)
+    // Cap on how many DNS-resolved (EIP-1459) EL enodes we RLPx-dial directly at startup,
+    // bypassing discv4. Enough to land a snap peer on NAT'd hosts (Android emulator) without
+    // a dial storm where discv4 already works.
+    private static final int DNS_DIRECT_DIAL_LIMIT = 50;
+
+    /**
+     * Where the daemon keeps its socket, lock, keys and caches. The CLI maps these to its
+     * historical {@code /tmp} + working-directory paths; an installed desktop app maps them
+     * to per-user OS directories (see {@link AppPaths}).
+     */
+    public record Config(
+            NetworkConfig network,
+            int port,
+            boolean gossipsubEnabled,
+            Path socketPath,
+            Path lockPath,
+            Path nodeKeyFile,
+            Path peerCacheFile,
+            Path clPeerCacheFile,
+            Path syncSnapshotFile) {
+    }
+
+    /** Thrown when the daemon cannot start (lock held, port in use, …). */
+    public static final class DaemonStartException extends Exception {
+        public DaemonStartException(String message) {
+            super(message);
+        }
+    }
+
+    private final Config config;
+    private final CountDownLatch stopLatch = new CountDownLatch(1);
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    // Started components — written by start(), read by accessors / close(). All
+    // null until start() reaches them, so close() and the accessors null-guard.
+    private volatile FileChannel lockChannel;
+    private volatile FileLock fileLock;
+    private volatile PeerCache peerCache;
+    private volatile RLPxConnector connector;
+    private volatile DiscV4Service discV4;
+    private volatile DiscV5Service discV5;
+    private volatile BeaconSyncState beaconSyncState;
+    private volatile BeaconLightClient beaconLightClient;
+    private volatile CommandHandler commandHandler;
+    private volatile DaemonServer server;
+    private volatile io.myotis.rpc.VerifiedRpcBackend rpcBackend;
+    private volatile io.myotis.jsonrpc.MyotisRpcServer rpcServer;
+
+    public DaemonRuntime(Config config) {
+        this.config = config;
+    }
+
+    // -------------------------------------------------------------------------
+    // Accessors for embedders (GUI). Null until start() has progressed far enough.
+    // -------------------------------------------------------------------------
+
+    public BeaconSyncState beaconSyncState() {
+        return beaconSyncState;
+    }
+
+    public RLPxConnector connector() {
+        return connector;
+    }
+
+    public BeaconLightClient beaconLightClient() {
+        return beaconLightClient;
+    }
+
+    public CommandHandler commandHandler() {
+        return commandHandler;
+    }
+
+    public CountDownLatch stopLatch() {
+        return stopLatch;
+    }
+
+    /** Block until {@link #close()} or a {@code stop} command fires the latch. */
+    public void awaitStop() throws InterruptedException {
+        stopLatch.await();
+    }
+
+    // -------------------------------------------------------------------------
+    // Lifecycle
+    // -------------------------------------------------------------------------
+
+    public void start() throws Exception {
+        final NetworkConfig network = config.network();
+        final int port = config.port();
+        final boolean gossipsubEnabled = config.gossipsubEnabled();
+        final Path socketPath = config.socketPath();
+        final Path lockPath = config.lockPath();
+
+        log.info("=== ethp2p Daemon ({}) ===", network.name());
+        log.info("IPC socket: {}", socketPath);
+
+        // 0. Acquire exclusive lock file — auto-released on process death (even kill -9)
+        lockChannel = FileChannel.open(lockPath,
+                StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+        fileLock = lockChannel.tryLock();
+        if (fileLock == null) {
+            lockChannel.close();
+            lockChannel = null;
+            throw new DaemonStartException("Daemon already running (lock held: " + lockPath + ")");
+        }
+
+        // 1. Load or generate node key
+        NodeKey nodeKey = NodeKey.loadOrGenerate(config.nodeKeyFile());
+        log.info("Node ID: {}", nodeKey.nodeId().toHexString());
+
+        // 3. Peer cache
+        peerCache = new PeerCache(config.peerCacheFile());
+
+        // 3a. EIP-1459 DNS-based peer discovery. Best-effort: on any failure (timeout,
+        // missing TXT, bad signature) the resolver returns an empty list and we fall
+        // through to the hardcoded + cached peers. Run EL and CL resolution concurrently
+        // on virtual threads so total startup cost is max(elTimeout, clTimeout), not
+        // sum. Layers stay separated so EL-tree entries only feed discv4 bootnodes and
+        // CL-tree entries only feed the libp2p peer list.
+        DnsEnrResolver dnsResolver = new DnsEnrResolver();
+        Duration dnsDeadline = Duration.ofSeconds(10);
+        CompletableFuture<List<Enr>> elFuture = CompletableFuture.supplyAsync(
+                () -> dnsResolver.resolveAllFromStrings(network.elEnrTreeUrls(), dnsDeadline));
+        CompletableFuture<List<Enr>> clFuture = CompletableFuture.supplyAsync(
+                () -> dnsResolver.resolveAllFromStrings(network.clEnrTreeUrls(), dnsDeadline));
+        List<Enr> dnsElEnrs = elFuture.join();
+        List<Enr> dnsClEnrs = clFuture.join();
+
+        List<InetSocketAddress> mergedBootnodes = new ArrayList<>(network.bootnodes());
+        // Dedupe by (host, port) so trees that overlap with the hardcoded list
+        // (or contain internal duplicates) don't produce repeated dial attempts.
+        Set<String> seenHostPort = new java.util.HashSet<>();
+        for (InetSocketAddress sa : mergedBootnodes) {
+            seenHostPort.add(sa.getAddress().getHostAddress() + ":" + sa.getPort());
+        }
+        int bootnodesBeforeDns = mergedBootnodes.size();
+        for (Enr enr : dnsElEnrs) {
+            // discv4 speaks UDP; fall back to the TCP endpoint only if UDP is missing.
+            enr.udpAddress().or(enr::tcpAddress).ifPresent(sa -> {
+                String key = sa.getAddress().getHostAddress() + ":" + sa.getPort();
+                if (seenHostPort.add(key)) mergedBootnodes.add(sa);
+            });
+        }
+        if (mergedBootnodes.size() > bootnodesBeforeDns) {
+            log.info("[main] DNS discovery added {} EL bootnode(s) (total: {})",
+                    mergedBootnodes.size() - bootnodesBeforeDns, mergedBootnodes.size());
+        }
+
+        // 4. RLPx connector
+        Set<String> attempted = ConcurrentHashMap.newKeySet();
+        Map<String, Long> backoff = new ConcurrentHashMap<>();
+        Set<String> blacklistedNodeIds = ConcurrentHashMap.newKeySet();
+        connector = new RLPxConnector(nodeKey, port, network, headers -> {
+            if (!headers.isEmpty()) {
+                log.info("\n=== BLOCK HEADERS RECEIVED ===");
+                for (BlockHeadersMessage.VerifiedHeader vh : headers) {
+                    BlockHeader h = vh.header();
+                    log.info("  Block #{}", h.number);
+                    log.info("  Hash:      {}", vh.hash().toHexString());
+                    log.info("  StateRoot: {}", h.stateRoot.toHexString());
+                    log.info("  TxRoot:    {}", h.transactionsRoot.toHexString());
+                    if (h.baseFeePerGas != null) {
+                        log.info("  BaseFee:   {} gwei",
+                                h.baseFeePerGas.divide(java.math.BigInteger.valueOf(1_000_000_000L)));
+                    }
+                }
+            }
+        }, peerCache::add);
+        final RLPxConnector connector = this.connector;
+
+        // 5. Connect to cached peers immediately
+        List<PeerCache.CachedPeer> cached = peerCache.load();
+        // Reconnect snap/1-capable peers first so state queries (get-account,
+        // get-storage) have a snap peer available sooner after a restart. Within
+        // the snap set, peers proven to serve proofs (CONFIRMED) come ahead of
+        // unproven ones, and known hangers (DENIED) come last — so a restart
+        // converges on a working snap peer instead of re-timing-out the bad
+        // ones first (mirrors NodeService's snapDialRank ordering).
+        cached.sort(java.util.Comparator.comparingInt(DaemonRuntime::snapDialRank));
+        for (PeerCache.CachedPeer peer : cached) {
+            String peerKey = peer.address().getAddress().getHostAddress()
+                    + ":" + peer.address().getPort();
+            attempted.add(peerKey);
+            try {
+                SECP256K1.PublicKey pubKey = SECP256K1.PublicKey.fromBytes(
+                        Bytes.fromHexString(peer.publicKeyHex()));
+                log.info("[main] Connecting to cached peer {}", peer.address());
+                connector.connect(peer.address(), pubKey, (incompatible, nodeIdHex) -> {
+                            if (incompatible) {
+                                blacklistedNodeIds.add(nodeIdHex);
+                                log.info("[main] Blacklisted node {} (incompatible network, cached peer)", nodeIdHex.substring(0, 16) + "...");
+                            }
+                            long backoffMs = incompatible ? BACKOFF_INCOMPATIBLE_MS : BACKOFF_TRANSIENT_MS;
+                            backoff.putIfAbsent(peerKey, System.currentTimeMillis() + backoffMs);
+                            attempted.remove(peerKey);
+                        })
+                        .addListener(future -> {
+                            if (!future.isSuccess()) {
+                                // Don't blacklist cached peers on first attempt
+                                attempted.remove(peerKey);
+                            }
+                        });
+            } catch (Exception e) {
+                log.warn("[main] Failed to connect to cached peer {}: {}",
+                        peer.address(), e.getMessage());
+                attempted.remove(peerKey);
+            }
+        }
+
+        // 5b. Directly RLPx-dial DNS-resolved EL enodes (EIP-1459), bypassing discv4.
+        // discv4's endpoint proof needs the remote to send us an *unsolicited* inbound
+        // PING before it returns NEIGHBORS — which QEMU/SLIRP user-mode NAT (the Android
+        // emulator's default) silently drops, so discv4 never bootstraps there. RLPx is
+        // an *outbound* TCP connection, which SLIRP allows, and the ENR carries the
+        // peer's secp256k1 key + TCP endpoint — everything connect() needs. So we get
+        // EL/snap peers on the emulator with no discv4 and no TAP networking. Harmless
+        // on the daemon (just a faster warm start). Capped so this doesn't become a dial
+        // storm on platforms where discv4 already populates the table.
+        int directDialed = 0;
+        for (Enr enr : dnsElEnrs) {
+            if (directDialed >= DNS_DIRECT_DIAL_LIMIT) break;
+            // Whole body guarded so a single malformed ENR can't abort the loop;
+            // getHostString() avoids an NPE if the ENR address is unresolved.
+            String peerKey = null;
+            try {
+                Optional<InetSocketAddress> tcp = enr.tcpAddress();
+                Optional<SECP256K1.PublicKey> pub = enr.publicKey();
+                if (tcp.isEmpty() || pub.isEmpty()) continue;
+                InetSocketAddress peerTcp = tcp.get();
+                peerKey = peerTcp.getHostString() + ":" + peerTcp.getPort();
+                if (!attempted.add(peerKey)) continue;
+                directDialed++;
+                final String key = peerKey;
+                log.info("[main] Direct RLPx dial of DNS EL enode {}", peerTcp);
+                connector.connect(peerTcp, pub.get(), (incompatible, nodeIdHex) -> {
+                            if (incompatible) {
+                                blacklistedNodeIds.add(nodeIdHex);
+                            }
+                            long backoffMs = incompatible ? BACKOFF_INCOMPATIBLE_MS : BACKOFF_TRANSIENT_MS;
+                            backoff.putIfAbsent(key, System.currentTimeMillis() + backoffMs);
+                            attempted.remove(key);
+                        })
+                        .addListener(future -> {
+                            if (!future.isSuccess()) attempted.remove(key);
+                        });
+            } catch (Exception e) {
+                log.warn("[main] Failed direct dial of DNS EL enode: {}", e.getMessage());
+                if (peerKey != null) attempted.remove(peerKey);
+            }
+        }
+        if (directDialed > 0) {
+            log.info("[main] Direct-dialed {} DNS EL enode(s) (discv4-independent path)", directDialed);
+        }
+
+        // 6. discv4 discovery
+        discV4 = new DiscV4Service(nodeKey, mergedBootnodes, entry -> {
+            // Pause acquiring NEW peers while an ENS resolution is running: its
+            // snap round-trips share the event loop with outbound dials, and a
+            // dial burst inflates resolution latency. Existing peers stay.
+            if (connector.isSnapHeavy()) return;
+            if (entry.tcpPort() > 0 && attempted.size() < 2000) {
+                String nodeIdHex = entry.nodeId().toHexString();
+                if (blacklistedNodeIds.contains(nodeIdHex)) {
+                    log.debug("[main] Skipping blacklisted node {}", nodeIdHex.substring(0, 16) + "...");
+                    return;
+                }
+                String peerKey = entry.udpAddr().getAddress().getHostAddress()
+                        + ":" + entry.tcpPort();
+                Long expiry = backoff.get(peerKey);
+                if (expiry != null) {
+                    if (System.currentTimeMillis() < expiry) return;
+                    backoff.remove(peerKey);
+                }
+                if (attempted.add(peerKey)) {
+                    InetSocketAddress peerTcp = new InetSocketAddress(
+                            entry.udpAddr().getAddress(), entry.tcpPort());
+                    log.info("[main] Attempting RLPx connection to {}", peerTcp);
+                    tryConnectWithKnownKey(connector, entry, peerTcp, nodeKey, attempted, peerKey, backoff, blacklistedNodeIds);
+                }
+            }
+        });
+
+        try {
+            discV4.start(port);
+        } catch (Exception e) {
+            Throwable cause = e instanceof BindException ? e : e.getCause();
+            String msg = (cause instanceof BindException)
+                    ? "Cannot bind UDP port " + port + ": " + cause.getMessage()
+                    + "\nIs another instance already running?"
+                    : "Failed to start discovery: " + e.getMessage();
+            close();
+            throw new DaemonStartException(msg);
+        }
+        log.info("[daemon] discv4 started on UDP port {}. Waiting for peers...", port);
+
+        // Beacon light client scaffolding (moved ahead of discv5 so its callback can
+        // write to CLPeerCache as peers are discovered).
+        beaconSyncState = new BeaconSyncState();
+        final BeaconSyncState beaconSyncState = this.beaconSyncState;
+        CLPeerCache clPeerCache = new CLPeerCache(config.clPeerCacheFile());
+
+        // 6b. discv5 — the canonical CL peer discovery mechanism. Runs on a separate
+        // UDP port from discv4 (default 9000, matching CL libp2p convention). The
+        // callback filters to ENRs carrying the eth2 field with a matching fork digest,
+        // converts to a libp2p multiaddr, and writes to CLPeerCache so the next
+        // daemon start seeds BeaconLightClient with a refreshed list.
+        //
+        // Runtime integration with the running BLC is a follow-up: BLC freezes its
+        // peer list at construction. The feedback loop is one daemon restart today.
+        List<byte[]> acceptedForkDigests = network.acceptedForkDigests();
+        log.info("[discv5] accepted fork_digests for network {}: {}",
+                network.name(),
+                acceptedForkDigests.stream()
+                        .map(d -> "0x" + java.util.HexFormat.of().formatHex(d))
+                        .toList());
+        // Log the first few mismatches so we can tell whether the filter is
+        // rejecting every peer (wrong expected digest?) vs. no peers arriving.
+        java.util.concurrent.atomic.AtomicInteger mismatchesLogged =
+                new java.util.concurrent.atomic.AtomicInteger();
+        // Discovered peers land here; BLC is constructed a few lines below and
+        // has this reference set once it's up so the discv5 callback can feed
+        // fresh peers directly into its live pool, not just the on-disk cache.
+        java.util.concurrent.atomic.AtomicReference<BeaconLightClient> blcRef =
+                new java.util.concurrent.atomic.AtomicReference<>();
+        discV5 = new DiscV5Service(nodeKey, network.clDiscv5Bootnodes(), enr -> {
+            var eth2 = enr.eth2();
+            if (eth2.isEmpty()) return;
+            byte[] peerDigest = eth2.get().forkDigest();
+            int matchIdx = -1;
+            for (int i = 0; i < acceptedForkDigests.size(); i++) {
+                if (java.util.Arrays.equals(peerDigest, acceptedForkDigests.get(i))) {
+                    matchIdx = i;
+                    break;
+                }
+            }
+            if (matchIdx < 0) {
+                int n = mismatchesLogged.incrementAndGet();
+                if (n <= 5) {
+                    log.info("[discv5] eth2 peer fork_digest=0x{} not in accepted set — rejected{}",
+                            java.util.HexFormat.of().formatHex(peerDigest),
+                            n == 5 ? " [further mismatch logs suppressed]" : "");
+                }
+                return;
+            }
+            final int mi = matchIdx;
+            enr.toLibp2pMultiaddr().ifPresent(ma -> {
+                String tier = mi == 0 ? "current" : "prior";
+                clPeerCache.add(ma);
+                BeaconLightClient blc = blcRef.get();
+                boolean liveAdded = blc != null && blc.addPeer(ma);
+                log.info("[discv5] CL peer {} (fork_digest {} match){}", ma, tier,
+                        liveAdded ? " → live pool" : "");
+            });
+        });
+        try {
+            discV5.start(9000);
+        } catch (Throwable t) {
+            // Catch Throwable, not Exception: earlier we hit a NoClassDefFoundError
+            // (library static-init) which slipped past an Exception handler and
+            // killed the main thread while the Netty event loop kept the JVM alive
+            // — the daemon lock stayed held but the IPC socket never got created.
+            // discv5 is non-essential; EL keeps working and CL falls back to the
+            // cache + hardcoded seed list.
+            log.warn("[discv5] failed to start, continuing without CL discovery: {}", t.toString());
+        }
+
+        // 7. Beacon light client (consensus layer, runs on virtual thread)
+        List<String> clPeers = new java.util.ArrayList<>(clPeerCache.load());
+        // Append configured peers after cached ones (cached peers are tried first)
+        for (String peer : network.clPeerMultiaddrs()) {
+            if (!clPeers.contains(peer)) clPeers.add(peer);
+        }
+        // Append DNS-discovered CL peers (from enrtree:// resolution above). Deduped
+        // against cached + configured entries.
+        int clPeersBeforeDns = clPeers.size();
+        for (Enr enr : dnsClEnrs) {
+            enr.toLibp2pMultiaddr().ifPresent(ma -> {
+                if (!clPeers.contains(ma)) clPeers.add(ma);
+            });
+        }
+        if (clPeers.size() > clPeersBeforeDns) {
+            log.info("[main] DNS discovery added {} CL peer(s) (total: {})",
+                    clPeers.size() - clPeersBeforeDns, clPeers.size());
+        }
+        beaconLightClient = new BeaconLightClient(
+                clPeers,
+                network.checkpointRoot(),
+                network.checkpointSlot(),
+                network.currentForkVersion(),
+                network.genesisValidatorsRoot(),
+                beaconSyncState,
+                network.beaconApiUrl(),
+                clPeerCache::add,
+                clPeerCache::markFailure,
+                network.clGenesisTime());
+        final BeaconLightClient beaconLightClient = this.beaconLightClient;
+        // EIP-7892: apply active BPO blob-parameters so compute_fork_digest
+        // folds them in per the Fulu spec (XOR of base fork_data_root[0..4]
+        // with sha256(u64_le(epoch)||u64_le(max_blobs))[0..4]).
+        beaconLightClient.setBlobParameters(
+                network.activeBlobParamsEpoch(),
+                network.activeBlobParamsMaxBlobs());
+        // Prefer peers proven to serve catch-up last session (seeded with the
+        // period they served), and persist new ones, so restarts target peers
+        // that actually retain the checkpoint period instead of discovery noise.
+        beaconLightClient.setProvenCatchUpServers(clPeerCache.servedPeriods());
+        beaconLightClient.setOnCatchUpServed(clPeerCache::recordServed);
+        // Seed light_client-capability verdicts from last session and persist new ones, so a
+        // restart dials confirmed light-client servers first and deprioritizes peers proven
+        // not to serve LC — instead of re-Identifying the whole fork-matched cache.
+        beaconLightClient.setProvenLightClient(clPeerCache.lightClientConfirmed());
+        beaconLightClient.setProvenNonLightClient(clPeerCache.lightClientDenied());
+        beaconLightClient.setOnLightClientVerdict(clPeerCache::markLightClientBatch);
+        // Persist/resume verified sync-committee state so restarts resume from the
+        // last verified period and only catch up the delta (architecture-doc §
+        // "recent sync committee data persisted locally"). purge-cache removes it.
+        beaconLightClient.setSnapshotFile(config.syncSnapshotFile());
+        // Off by default (short-session clients churn the mesh). Enable
+        // with `-Pgossipsub=true` via gradle or `--gossipsub` on the CLI.
+        beaconLightClient.setGossipsubEnabled(gossipsubEnabled);
+        if (gossipsubEnabled) {
+            log.info("[main] Gossipsub subscription ENABLED (observation-only)");
+        }
+        // Publish to discv5 callback; any eth2-matching ENRs seen from here on
+        // out get added to BLC's live peer pool (not just the on-disk cache).
+        blcRef.set(beaconLightClient);
+        beaconLightClient.start();
+        log.info("[daemon] Beacon light client started with {} CL peer(s) ({} cached)",
+                clPeers.size(), clPeers.size() - network.clPeerMultiaddrs().size());
+
+        // 8. IPC server
+        commandHandler = new CommandHandler(discV4, discV5, connector, stopLatch, backoff, blacklistedNodeIds, beaconSyncState, beaconLightClient, network.clGenesisTime());
+        server = new DaemonServer(socketPath, commandHandler);
+        try {
+            server.start();
+        } catch (BindException e) {
+            close();
+            throw new DaemonStartException("Cannot bind IPC socket " + socketPath + ": " + e.getMessage()
+                    + "\nIs another instance already running?");
+        } catch (Exception e) {
+            close();
+            throw new DaemonStartException("Failed to start IPC server: " + e.getMessage());
+        }
+
+        // 8b. Verified JSON-RPC endpoint: the shared VerifiedRpcBackend (same
+        // implementation the Android app hosts in NodeService) served over the
+        // Ktor MyotisRpcServer. Bound loopback-only — the endpoint is
+        // unauthenticated and TLS-less, so it must not be exposed on a routable
+        // interface — and STRICT (null upstream): the daemon never proxies; a
+        // method that can't be answered cryptographically verified errors.
+        // Best-effort: if port 8545 is taken (another node / dev tool), the
+        // daemon keeps running without RPC instead of crashing.
+        try {
+            // Deterministic port check up front: Ktor's CIO engine surfaces a bind
+            // failure asynchronously, which a try/catch around start() can miss.
+            try (java.net.ServerSocket probe = new java.net.ServerSocket()) {
+                probe.setReuseAddress(true);
+                probe.bind(new InetSocketAddress("127.0.0.1", 8545));
+            }
+            // Persist per-peer snap-serving verdicts into the EL peer cache so
+            // proven snap-servers are dialed first on restart and repeat hangers
+            // are deprioritized (same wiring as NodeService → AndroidPeerCache).
+            final PeerCache peerCache = this.peerCache;
+            io.myotis.rpc.SnapQualitySink snapQualitySink = new io.myotis.rpc.SnapQualitySink() {
+                @Override public void recordSnapServed(InetSocketAddress address) {
+                    peerCache.recordSnapServed(address);
+                }
+                @Override public void recordSnapFailure(InetSocketAddress address) {
+                    peerCache.recordSnapFailure(address);
+                }
+            };
+            io.myotis.rpc.RpcLogger rpcLogger = new io.myotis.rpc.RpcLogger() {
+                @Override public void info(String message) { log.info(message); }
+                @Override public void warn(String message) { log.warn(message); }
+            };
+            io.myotis.rpc.VerifiedRpcBackend backend = new io.myotis.rpc.VerifiedRpcBackend(
+                    connector, beaconLightClient, beaconSyncState,
+                    new com.jaeckel.ethp2p.app.rpc.JavaHttpCcipGateway(),
+                    rpcLogger, io.myotis.rpc.RpcClock.monotonic(), snapQualitySink);
+            try {
+                // start() spins up the head warmer; a throw here (or in the server
+                // start below) must still close the backend so its threads don't leak.
+                backend.start();
+                io.myotis.jsonrpc.MyotisRpcServer rpcServer =
+                        new io.myotis.jsonrpc.MyotisRpcServer(8545, null, "127.0.0.1", backend);
+                rpcServer.start();
+                this.rpcServer = rpcServer;
+                this.rpcBackend = backend;
+                log.info("JSON-RPC listening on http://127.0.0.1:8545 (verified, strict)");
+            } catch (Throwable serverEx) {
+                backend.close();
+                throw serverEx;
+            }
+        } catch (java.io.IOException bindEx) {
+            log.warn("[rpc] port 8545 unavailable ({}); continuing without JSON-RPC",
+                    bindEx.getMessage());
+        } catch (Throwable t) {
+            log.warn("[rpc] failed to start JSON-RPC server; continuing without it: {}",
+                    t.toString());
+        }
+
+        log.info("[daemon] ready");
+    }
+
+    /**
+     * Tear everything down. Idempotent and safe to call from a JVM shutdown hook,
+     * a {@code stop} command, or a partially-failed {@link #start()}. Fires the stop
+     * latch so any {@link #awaitStop()} caller wakes.
+     */
+    @Override
+    public void close() {
+        if (closed.getAndSet(true)) {
+            // Still make sure a late awaiter wakes even on a redundant close.
+            stopLatch.countDown();
+            return;
+        }
+        log.info("[daemon] Shutting down");
+        // Stop the RPC endpoint first so the port frees and no in-flight
+        // request builds against torn-down components.
+        if (rpcServer != null) {
+            try { rpcServer.stop(); } catch (Throwable ignored) {}
+        }
+        if (rpcBackend != null) {
+            try { rpcBackend.close(); } catch (Throwable ignored) {}
+        }
+        if (beaconLightClient != null) {
+            try { beaconLightClient.close(); } catch (Throwable ignored) {}
+        }
+        if (server != null) {
+            try { server.close(); } catch (Throwable ignored) {}
+        }
+        if (connector != null) {
+            try { connector.close(); } catch (Throwable ignored) {}
+        }
+        if (discV5 != null) {
+            try { discV5.close(); } catch (Throwable ignored) {}
+        }
+        if (discV4 != null) {
+            try { discV4.close(); } catch (Throwable ignored) {}
+        }
+        if (peerCache != null) {
+            try { peerCache.close(); } catch (Throwable ignored) {}   // last: drain queued cache writes after the final add()
+        }
+        try {
+            if (fileLock != null) fileLock.release();
+            if (lockChannel != null) lockChannel.close();
+        } catch (Exception ignored) {}
+        stopLatch.countDown();
+        log.info("[daemon] Done.");
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Dial-priority rank for a cached peer (lower = dialed first): proven
+     * snap-servers, then snap-capable-but-unproven, then known snap hangers, then
+     * plain-eth peers. Denied snap peers still outrank non-snap peers — state
+     * roots change, so a peer that couldn't serve an old pivot may serve the
+     * current head, and it's still snap-capable. Mirrors NodeService.snapDialRank.
+     */
+    private static int snapDialRank(PeerCache.CachedPeer p) {
+        if (!p.snap()) return 3;
+        return switch (p.snapQuality()) {
+            case CONFIRMED -> 0;
+            case UNKNOWN -> 1;
+            case DENIED -> 2;
+        };
+    }
+
+    /**
+     * In discv4, the Neighbors response includes 64-byte node IDs (public keys).
+     * We reconstruct the SECP256K1 public key and attempt connection.
+     */
+    private static void tryConnectWithKnownKey(
+            RLPxConnector connector, KademliaTable.Entry entry,
+            InetSocketAddress peerTcp, NodeKey localKey,
+            Set<String> attempted, String peerKey,
+            Map<String, Long> backoff, Set<String> blacklistedNodeIds) {
+        try {
+            Bytes nodeId = entry.nodeId();
+            if (nodeId.size() != 64) {
+                log.warn("[main] Node ID is not 64 bytes ({}b), skipping", nodeId.size());
+                attempted.remove(peerKey);
+                return;
+            }
+            SECP256K1.PublicKey peerPubkey = SECP256K1.PublicKey.fromBytes(nodeId);
+            connector.connect(peerTcp, peerPubkey, (incompatible, nodeIdHex) -> {
+                        if (incompatible) {
+                            blacklistedNodeIds.add(nodeIdHex);
+                            log.info("[main] Blacklisted node {} (incompatible network)", nodeIdHex.substring(0, 16) + "...");
+                        }
+                        long backoffMs = incompatible ? BACKOFF_INCOMPATIBLE_MS : BACKOFF_TRANSIENT_MS;
+                        backoff.putIfAbsent(peerKey, System.currentTimeMillis() + backoffMs);
+                        attempted.remove(peerKey);
+                    })
+                    .addListener(future -> {
+                        if (!future.isSuccess()) {
+                            log.warn("[main] Connection to {} failed: {}",
+                                    peerTcp, future.cause().getMessage());
+                            backoff.putIfAbsent(peerKey, System.currentTimeMillis() + BACKOFF_TRANSIENT_MS);
+                            attempted.remove(peerKey);
+                        }
+                    });
+        } catch (Exception e) {
+            log.warn("[main] Failed to connect to {}: {}", peerTcp, e.getMessage());
+            backoff.putIfAbsent(peerKey, System.currentTimeMillis() + BACKOFF_TRANSIENT_MS);
+            attempted.remove(peerKey);
+        }
+    }
+}

--- a/app/src/main/java/com/jaeckel/ethp2p/app/Main.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/Main.java
@@ -1,24 +1,9 @@
 package com.jaeckel.ethp2p.app;
 
-import com.jaeckel.ethp2p.consensus.BeaconLightClient;
-import com.jaeckel.ethp2p.consensus.BeaconSyncState;
-import com.jaeckel.ethp2p.core.crypto.NodeKey;
-import com.jaeckel.ethp2p.core.enr.Enr;
-import com.jaeckel.ethp2p.core.types.BlockHeader;
 import com.jaeckel.ethp2p.networking.NetworkConfig;
-import com.jaeckel.ethp2p.networking.discv4.DiscV4Service;
-import com.jaeckel.ethp2p.networking.discv4.KademliaTable;
-import com.jaeckel.ethp2p.networking.discv5.DiscV5Service;
-import com.jaeckel.ethp2p.networking.dns.DnsEnrResolver;
-import com.jaeckel.ethp2p.networking.eth.messages.BlockHeadersMessage;
-import com.jaeckel.ethp2p.networking.rlpx.RLPxConnector;
-import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.crypto.SECP256K1;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.net.BindException;
-import java.net.InetSocketAddress;
 import java.net.StandardProtocolFamily;
 import java.net.UnixDomainSocketAddress;
 import java.nio.channels.FileChannel;
@@ -27,15 +12,8 @@ import java.nio.channels.SocketChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CountDownLatch;
 
 /**
  * ethp2p — daemon + CLI client.
@@ -73,12 +51,6 @@ public final class Main {
     private static final Logger log = LoggerFactory.getLogger(Main.class);
 
     private static final int DEFAULT_PORT = 30303;
-    private static final long BACKOFF_INCOMPATIBLE_MS = 10 * 60 * 1000L; // 10 min for wrong-chain peers
-    private static final long BACKOFF_TRANSIENT_MS = 30 * 1000L; // 30s for transient failures (too many peers, etc.)
-    // Cap on how many DNS-resolved (EIP-1459) EL enodes we RLPx-dial directly at startup,
-    // bypassing discv4. Enough to land a snap peer on NAT'd hosts (Android emulator) without
-    // a dial storm where discv4 already works.
-    private static final int DNS_DIRECT_DIAL_LIMIT = 50;
 
     /** Socket path; override via {@code ETHP2P_SOCKET} env var. Network-specific suffix for non-mainnet. */
     static Path socketPath(String networkName) {
@@ -185,505 +157,36 @@ public final class Main {
 
     private static void runDaemon(Path socketPath, Path lockPath, NetworkConfig network, int port,
                                   boolean gossipsubEnabled) throws Exception {
-        log.info("=== ethp2p Daemon ({}) ===", network.name());
-        log.info("IPC socket: {}", socketPath);
-
-        // 0. Acquire exclusive lock file — auto-released on process death (even kill -9)
-        FileChannel lockChannel = FileChannel.open(lockPath,
-                StandardOpenOption.CREATE, StandardOpenOption.WRITE);
-        FileLock fileLock = lockChannel.tryLock();
-        if (fileLock == null) {
-            System.err.println("Daemon already running (lock held: " + lockPath + ")");
-            lockChannel.close();
+        DaemonRuntime.Config config = new DaemonRuntime.Config(
+                network, port, gossipsubEnabled, socketPath, lockPath,
+                Path.of("nodekey.hex"),
+                cacheFile(network.name()),
+                clCacheFile(network.name()),
+                syncSnapshotFile(network.name()));
+        DaemonRuntime runtime = new DaemonRuntime(config);
+        try {
+            runtime.start();
+        } catch (DaemonRuntime.DaemonStartException e) {
+            System.err.println(e.getMessage());
             System.exit(1);
             return;
         }
-
-        // 1. Load or generate node key
-        Path keyFile = Path.of("nodekey.hex");
-        NodeKey nodeKey = NodeKey.loadOrGenerate(keyFile);
-        log.info("Node ID: {}", nodeKey.nodeId().toHexString());
-
-        // 2. Latch that triggers graceful shutdown (stop command or SIGTERM)
-        CountDownLatch stopLatch = new CountDownLatch(1);
-
-        // 3. Peer cache
-        PeerCache peerCache = new PeerCache(cacheFile(network.name()));
-
-        // 3a. EIP-1459 DNS-based peer discovery. Best-effort: on any failure (timeout,
-        // missing TXT, bad signature) the resolver returns an empty list and we fall
-        // through to the hardcoded + cached peers. Run EL and CL resolution concurrently
-        // on virtual threads so total startup cost is max(elTimeout, clTimeout), not
-        // sum. Layers stay separated so EL-tree entries only feed discv4 bootnodes and
-        // CL-tree entries only feed the libp2p peer list.
-        DnsEnrResolver dnsResolver = new DnsEnrResolver();
-        Duration dnsDeadline = Duration.ofSeconds(10);
-        CompletableFuture<List<Enr>> elFuture = CompletableFuture.supplyAsync(
-                () -> dnsResolver.resolveAllFromStrings(network.elEnrTreeUrls(), dnsDeadline));
-        CompletableFuture<List<Enr>> clFuture = CompletableFuture.supplyAsync(
-                () -> dnsResolver.resolveAllFromStrings(network.clEnrTreeUrls(), dnsDeadline));
-        List<Enr> dnsElEnrs = elFuture.join();
-        List<Enr> dnsClEnrs = clFuture.join();
-
-        List<InetSocketAddress> mergedBootnodes = new ArrayList<>(network.bootnodes());
-        // Dedupe by (host, port) so trees that overlap with the hardcoded list
-        // (or contain internal duplicates) don't produce repeated dial attempts.
-        Set<String> seenHostPort = new java.util.HashSet<>();
-        for (InetSocketAddress sa : mergedBootnodes) {
-            seenHostPort.add(sa.getAddress().getHostAddress() + ":" + sa.getPort());
-        }
-        int bootnodesBeforeDns = mergedBootnodes.size();
-        for (Enr enr : dnsElEnrs) {
-            // discv4 speaks UDP; fall back to the TCP endpoint only if UDP is missing.
-            enr.udpAddress().or(enr::tcpAddress).ifPresent(sa -> {
-                String key = sa.getAddress().getHostAddress() + ":" + sa.getPort();
-                if (seenHostPort.add(key)) mergedBootnodes.add(sa);
-            });
-        }
-        if (mergedBootnodes.size() > bootnodesBeforeDns) {
-            log.info("[main] DNS discovery added {} EL bootnode(s) (total: {})",
-                    mergedBootnodes.size() - bootnodesBeforeDns, mergedBootnodes.size());
-        }
-
-        // 4. RLPx connector
-        Set<String> attempted = ConcurrentHashMap.newKeySet();
-        Map<String, Long> backoff = new ConcurrentHashMap<>();
-        Set<String> blacklistedNodeIds = ConcurrentHashMap.newKeySet();
-        RLPxConnector connector = new RLPxConnector(nodeKey, port, network, headers -> {
-            if (!headers.isEmpty()) {
-                log.info("\n=== BLOCK HEADERS RECEIVED ===");
-                for (BlockHeadersMessage.VerifiedHeader vh : headers) {
-                    BlockHeader h = vh.header();
-                    log.info("  Block #{}", h.number);
-                    log.info("  Hash:      {}", vh.hash().toHexString());
-                    log.info("  StateRoot: {}", h.stateRoot.toHexString());
-                    log.info("  TxRoot:    {}", h.transactionsRoot.toHexString());
-                    if (h.baseFeePerGas != null) {
-                        log.info("  BaseFee:   {} gwei",
-                                h.baseFeePerGas.divide(java.math.BigInteger.valueOf(1_000_000_000L)));
-                    }
-                }
-            }
-        }, peerCache::add);
-
-        // 5. Connect to cached peers immediately
-        List<PeerCache.CachedPeer> cached = peerCache.load();
-        // Reconnect snap/1-capable peers first so state queries (get-account,
-        // get-storage) have a snap peer available sooner after a restart. Within
-        // the snap set, peers proven to serve proofs (CONFIRMED) come ahead of
-        // unproven ones, and known hangers (DENIED) come last — so a restart
-        // converges on a working snap peer instead of re-timing-out the bad
-        // ones first (mirrors NodeService's snapDialRank ordering).
-        cached.sort(java.util.Comparator.comparingInt(Main::snapDialRank));
-        for (PeerCache.CachedPeer peer : cached) {
-            String peerKey = peer.address().getAddress().getHostAddress()
-                    + ":" + peer.address().getPort();
-            attempted.add(peerKey);
-            try {
-                SECP256K1.PublicKey pubKey = SECP256K1.PublicKey.fromBytes(
-                        Bytes.fromHexString(peer.publicKeyHex()));
-                log.info("[main] Connecting to cached peer {}", peer.address());
-                connector.connect(peer.address(), pubKey, (incompatible, nodeIdHex) -> {
-                            if (incompatible) {
-                                blacklistedNodeIds.add(nodeIdHex);
-                                log.info("[main] Blacklisted node {} (incompatible network, cached peer)", nodeIdHex.substring(0, 16) + "...");
-                            }
-                            long backoffMs = incompatible ? BACKOFF_INCOMPATIBLE_MS : BACKOFF_TRANSIENT_MS;
-                            backoff.putIfAbsent(peerKey, System.currentTimeMillis() + backoffMs);
-                            attempted.remove(peerKey);
-                        })
-                        .addListener(future -> {
-                            if (!future.isSuccess()) {
-                                // Don't blacklist cached peers on first attempt
-                                attempted.remove(peerKey);
-                            }
-                        });
-            } catch (Exception e) {
-                log.warn("[main] Failed to connect to cached peer {}: {}",
-                        peer.address(), e.getMessage());
-                attempted.remove(peerKey);
-            }
-        }
-
-        // 5b. Directly RLPx-dial DNS-resolved EL enodes (EIP-1459), bypassing discv4.
-        // discv4's endpoint proof needs the remote to send us an *unsolicited* inbound
-        // PING before it returns NEIGHBORS — which QEMU/SLIRP user-mode NAT (the Android
-        // emulator's default) silently drops, so discv4 never bootstraps there. RLPx is
-        // an *outbound* TCP connection, which SLIRP allows, and the ENR carries the
-        // peer's secp256k1 key + TCP endpoint — everything connect() needs. So we get
-        // EL/snap peers on the emulator with no discv4 and no TAP networking. Harmless
-        // on the daemon (just a faster warm start). Capped so this doesn't become a dial
-        // storm on platforms where discv4 already populates the table.
-        int directDialed = 0;
-        for (Enr enr : dnsElEnrs) {
-            if (directDialed >= DNS_DIRECT_DIAL_LIMIT) break;
-            // Whole body guarded so a single malformed ENR can't abort the loop;
-            // getHostString() avoids an NPE if the ENR address is unresolved.
-            String peerKey = null;
-            try {
-                Optional<InetSocketAddress> tcp = enr.tcpAddress();
-                Optional<SECP256K1.PublicKey> pub = enr.publicKey();
-                if (tcp.isEmpty() || pub.isEmpty()) continue;
-                InetSocketAddress peerTcp = tcp.get();
-                peerKey = peerTcp.getHostString() + ":" + peerTcp.getPort();
-                if (!attempted.add(peerKey)) continue;
-                directDialed++;
-                final String key = peerKey;
-                log.info("[main] Direct RLPx dial of DNS EL enode {}", peerTcp);
-                connector.connect(peerTcp, pub.get(), (incompatible, nodeIdHex) -> {
-                            if (incompatible) {
-                                blacklistedNodeIds.add(nodeIdHex);
-                            }
-                            long backoffMs = incompatible ? BACKOFF_INCOMPATIBLE_MS : BACKOFF_TRANSIENT_MS;
-                            backoff.putIfAbsent(key, System.currentTimeMillis() + backoffMs);
-                            attempted.remove(key);
-                        })
-                        .addListener(future -> {
-                            if (!future.isSuccess()) attempted.remove(key);
-                        });
-            } catch (Exception e) {
-                log.warn("[main] Failed direct dial of DNS EL enode: {}", e.getMessage());
-                if (peerKey != null) attempted.remove(peerKey);
-            }
-        }
-        if (directDialed > 0) {
-            log.info("[main] Direct-dialed {} DNS EL enode(s) (discv4-independent path)", directDialed);
-        }
-
-        // 6. discv4 discovery
-        DiscV4Service discV4 = new DiscV4Service(nodeKey, mergedBootnodes, entry -> {
-            // Pause acquiring NEW peers while an ENS resolution is running: its
-            // snap round-trips share the event loop with outbound dials, and a
-            // dial burst inflates resolution latency. Existing peers stay.
-            if (connector.isSnapHeavy()) return;
-            if (entry.tcpPort() > 0 && attempted.size() < 2000) {
-                String nodeIdHex = entry.nodeId().toHexString();
-                if (blacklistedNodeIds.contains(nodeIdHex)) {
-                    log.debug("[main] Skipping blacklisted node {}", nodeIdHex.substring(0, 16) + "...");
-                    return;
-                }
-                String peerKey = entry.udpAddr().getAddress().getHostAddress()
-                        + ":" + entry.tcpPort();
-                Long expiry = backoff.get(peerKey);
-                if (expiry != null) {
-                    if (System.currentTimeMillis() < expiry) return;
-                    backoff.remove(peerKey);
-                }
-                if (attempted.add(peerKey)) {
-                    InetSocketAddress peerTcp = new InetSocketAddress(
-                            entry.udpAddr().getAddress(), entry.tcpPort());
-                    log.info("[main] Attempting RLPx connection to {}", peerTcp);
-                    tryConnectWithKnownKey(connector, entry, peerTcp, nodeKey, attempted, peerKey, backoff, blacklistedNodeIds);
-                }
-            }
-        });
-
-        try {
-            discV4.start(port);
-        } catch (Exception e) {
-            Throwable cause = e instanceof BindException ? e : e.getCause();
-            if (cause instanceof BindException) {
-                System.err.println("Cannot bind UDP port " + port + ": " + cause.getMessage());
-                System.err.println("Is another instance already running?");
-            } else {
-                System.err.println("Failed to start discovery: " + e.getMessage());
-            }
-            fileLock.release();
-            lockChannel.close();
-            System.exit(1);
-            return;
-        }
-        log.info("[daemon] discv4 started on UDP port {}. Waiting for peers...", port);
-
-        // Beacon light client scaffolding (moved ahead of discv5 so its callback can
-        // write to CLPeerCache as peers are discovered).
-        BeaconSyncState beaconSyncState = new BeaconSyncState();
-        CLPeerCache clPeerCache = new CLPeerCache(clCacheFile(network.name()));
-
-        // 6b. discv5 — the canonical CL peer discovery mechanism. Runs on a separate
-        // UDP port from discv4 (default 9000, matching CL libp2p convention). The
-        // callback filters to ENRs carrying the eth2 field with a matching fork digest,
-        // converts to a libp2p multiaddr, and writes to CLPeerCache so the next
-        // daemon start seeds BeaconLightClient with a refreshed list.
-        //
-        // Runtime integration with the running BLC is a follow-up: BLC freezes its
-        // peer list at construction. The feedback loop is one daemon restart today.
-        List<byte[]> acceptedForkDigests = network.acceptedForkDigests();
-        log.info("[discv5] accepted fork_digests for network {}: {}",
-                network.name(),
-                acceptedForkDigests.stream()
-                        .map(d -> "0x" + java.util.HexFormat.of().formatHex(d))
-                        .toList());
-        // Log the first few mismatches so we can tell whether the filter is
-        // rejecting every peer (wrong expected digest?) vs. no peers arriving.
-        java.util.concurrent.atomic.AtomicInteger mismatchesLogged =
-                new java.util.concurrent.atomic.AtomicInteger();
-        // Discovered peers land here; BLC is constructed a few lines below and
-        // has this reference set once it's up so the discv5 callback can feed
-        // fresh peers directly into its live pool, not just the on-disk cache.
-        java.util.concurrent.atomic.AtomicReference<BeaconLightClient> blcRef =
-                new java.util.concurrent.atomic.AtomicReference<>();
-        DiscV5Service discV5 = new DiscV5Service(nodeKey, network.clDiscv5Bootnodes(), enr -> {
-            var eth2 = enr.eth2();
-            if (eth2.isEmpty()) return;
-            byte[] peerDigest = eth2.get().forkDigest();
-            int matchIdx = -1;
-            for (int i = 0; i < acceptedForkDigests.size(); i++) {
-                if (java.util.Arrays.equals(peerDigest, acceptedForkDigests.get(i))) {
-                    matchIdx = i;
-                    break;
-                }
-            }
-            if (matchIdx < 0) {
-                int n = mismatchesLogged.incrementAndGet();
-                if (n <= 5) {
-                    log.info("[discv5] eth2 peer fork_digest=0x{} not in accepted set — rejected{}",
-                            java.util.HexFormat.of().formatHex(peerDigest),
-                            n == 5 ? " [further mismatch logs suppressed]" : "");
-                }
-                return;
-            }
-            final int mi = matchIdx;
-            enr.toLibp2pMultiaddr().ifPresent(ma -> {
-                String tier = mi == 0 ? "current" : "prior";
-                clPeerCache.add(ma);
-                BeaconLightClient blc = blcRef.get();
-                boolean liveAdded = blc != null && blc.addPeer(ma);
-                log.info("[discv5] CL peer {} (fork_digest {} match){}", ma, tier,
-                        liveAdded ? " → live pool" : "");
-            });
-        });
-        try {
-            discV5.start(9000);
-        } catch (Throwable t) {
-            // Catch Throwable, not Exception: earlier we hit a NoClassDefFoundError
-            // (library static-init) which slipped past an Exception handler and
-            // killed the main thread while the Netty event loop kept the JVM alive
-            // — the daemon lock stayed held but the IPC socket never got created.
-            // discv5 is non-essential; EL keeps working and CL falls back to the
-            // cache + hardcoded seed list.
-            log.warn("[discv5] failed to start, continuing without CL discovery: {}", t.toString());
-        }
-
-        // 7. Beacon light client (consensus layer, runs on virtual thread)
-        List<String> clPeers = new java.util.ArrayList<>(clPeerCache.load());
-        // Append configured peers after cached ones (cached peers are tried first)
-        for (String peer : network.clPeerMultiaddrs()) {
-            if (!clPeers.contains(peer)) clPeers.add(peer);
-        }
-        // Append DNS-discovered CL peers (from enrtree:// resolution above). Deduped
-        // against cached + configured entries.
-        int clPeersBeforeDns = clPeers.size();
-        for (Enr enr : dnsClEnrs) {
-            enr.toLibp2pMultiaddr().ifPresent(ma -> {
-                if (!clPeers.contains(ma)) clPeers.add(ma);
-            });
-        }
-        if (clPeers.size() > clPeersBeforeDns) {
-            log.info("[main] DNS discovery added {} CL peer(s) (total: {})",
-                    clPeers.size() - clPeersBeforeDns, clPeers.size());
-        }
-        BeaconLightClient beaconLightClient = new BeaconLightClient(
-                clPeers,
-                network.checkpointRoot(),
-                network.checkpointSlot(),
-                network.currentForkVersion(),
-                network.genesisValidatorsRoot(),
-                beaconSyncState,
-                network.beaconApiUrl(),
-                clPeerCache::add,
-                clPeerCache::markFailure,
-                network.clGenesisTime());
-        // EIP-7892: apply active BPO blob-parameters so compute_fork_digest
-        // folds them in per the Fulu spec (XOR of base fork_data_root[0..4]
-        // with sha256(u64_le(epoch)||u64_le(max_blobs))[0..4]).
-        beaconLightClient.setBlobParameters(
-                network.activeBlobParamsEpoch(),
-                network.activeBlobParamsMaxBlobs());
-        // Prefer peers proven to serve catch-up last session (seeded with the
-        // period they served), and persist new ones, so restarts target peers
-        // that actually retain the checkpoint period instead of discovery noise.
-        beaconLightClient.setProvenCatchUpServers(clPeerCache.servedPeriods());
-        beaconLightClient.setOnCatchUpServed(clPeerCache::recordServed);
-        // Seed light_client-capability verdicts from last session and persist new ones, so a
-        // restart dials confirmed light-client servers first and deprioritizes peers proven
-        // not to serve LC — instead of re-Identifying the whole fork-matched cache.
-        beaconLightClient.setProvenLightClient(clPeerCache.lightClientConfirmed());
-        beaconLightClient.setProvenNonLightClient(clPeerCache.lightClientDenied());
-        beaconLightClient.setOnLightClientVerdict(clPeerCache::markLightClientBatch);
-        // Persist/resume verified sync-committee state so restarts resume from the
-        // last verified period and only catch up the delta (architecture-doc §
-        // "recent sync committee data persisted locally"). purge-cache removes it.
-        beaconLightClient.setSnapshotFile(syncSnapshotFile(network.name()));
-        // Off by default (short-session clients churn the mesh). Enable
-        // with `-Pgossipsub=true` via gradle or `--gossipsub` on the CLI.
-        beaconLightClient.setGossipsubEnabled(gossipsubEnabled);
-        if (gossipsubEnabled) {
-            log.info("[main] Gossipsub subscription ENABLED (observation-only)");
-        }
-        // Publish to discv5 callback; any eth2-matching ENRs seen from here on
-        // out get added to BLC's live peer pool (not just the on-disk cache).
-        blcRef.set(beaconLightClient);
-        beaconLightClient.start();
-        log.info("[daemon] Beacon light client started with {} CL peer(s) ({} cached)",
-                clPeers.size(), clPeers.size() - network.clPeerMultiaddrs().size());
-
-        // 8. IPC server
-        CommandHandler commandHandler = new CommandHandler(discV4, discV5, connector, stopLatch, backoff, blacklistedNodeIds, beaconSyncState, beaconLightClient, network.clGenesisTime());
-        DaemonServer server = new DaemonServer(socketPath, commandHandler);
-        try {
-            server.start();
-        } catch (BindException e) {
-            System.err.println("Cannot bind IPC socket " + socketPath + ": " + e.getMessage());
-            System.err.println("Is another instance already running?");
-            beaconLightClient.close();
-            connector.close();
-            discV5.close();
-            discV4.close();
-            fileLock.release();
-            lockChannel.close();
-            System.exit(1);
-            return;
-        } catch (Exception e) {
-            System.err.println("Failed to start IPC server: " + e.getMessage());
-            beaconLightClient.close();
-            connector.close();
-            discV5.close();
-            discV4.close();
-            fileLock.release();
-            lockChannel.close();
-            System.exit(1);
-            return;
-        }
-
-        // 8b. Verified JSON-RPC endpoint: the shared VerifiedRpcBackend (same
-        // implementation the Android app hosts in NodeService) served over the
-        // Ktor MyotisRpcServer. Bound loopback-only — the endpoint is
-        // unauthenticated and TLS-less, so it must not be exposed on a routable
-        // interface — and STRICT (null upstream): the daemon never proxies; a
-        // method that can't be answered cryptographically verified errors.
-        // Best-effort: if port 8545 is taken (another node / dev tool), the
-        // daemon keeps running without RPC instead of crashing.
-        io.myotis.rpc.VerifiedRpcBackend rpcBackendTmp = null;
-        io.myotis.jsonrpc.MyotisRpcServer rpcServerTmp = null;
-        try {
-            // Deterministic port check up front: Ktor's CIO engine surfaces a bind
-            // failure asynchronously, which a try/catch around start() can miss.
-            try (java.net.ServerSocket probe = new java.net.ServerSocket()) {
-                probe.setReuseAddress(true);
-                probe.bind(new InetSocketAddress("127.0.0.1", 8545));
-            }
-            // Persist per-peer snap-serving verdicts into the EL peer cache so
-            // proven snap-servers are dialed first on restart and repeat hangers
-            // are deprioritized (same wiring as NodeService → AndroidPeerCache).
-            io.myotis.rpc.SnapQualitySink snapQualitySink = new io.myotis.rpc.SnapQualitySink() {
-                @Override public void recordSnapServed(InetSocketAddress address) {
-                    peerCache.recordSnapServed(address);
-                }
-                @Override public void recordSnapFailure(InetSocketAddress address) {
-                    peerCache.recordSnapFailure(address);
-                }
-            };
-            io.myotis.rpc.RpcLogger rpcLogger = new io.myotis.rpc.RpcLogger() {
-                @Override public void info(String message) { log.info(message); }
-                @Override public void warn(String message) { log.warn(message); }
-            };
-            io.myotis.rpc.VerifiedRpcBackend backend = new io.myotis.rpc.VerifiedRpcBackend(
-                    connector, beaconLightClient, beaconSyncState,
-                    new com.jaeckel.ethp2p.app.rpc.JavaHttpCcipGateway(),
-                    rpcLogger, io.myotis.rpc.RpcClock.monotonic(), snapQualitySink);
-            try {
-                // start() spins up the head warmer; a throw here (or in the server
-                // start below) must still close the backend so its threads don't leak.
-                backend.start();
-                io.myotis.jsonrpc.MyotisRpcServer rpcServer =
-                        new io.myotis.jsonrpc.MyotisRpcServer(8545, null, "127.0.0.1", backend);
-                rpcServer.start();
-                rpcServerTmp = rpcServer;
-                rpcBackendTmp = backend;
-                log.info("JSON-RPC listening on http://127.0.0.1:8545 (verified, strict)");
-            } catch (Throwable serverEx) {
-                backend.close();
-                throw serverEx;
-            }
-        } catch (java.io.IOException bindEx) {
-            log.warn("[rpc] port 8545 unavailable ({}); continuing without JSON-RPC",
-                    bindEx.getMessage());
-        } catch (Throwable t) {
-            log.warn("[rpc] failed to start JSON-RPC server; continuing without it: {}",
-                    t.toString());
-        }
-        final io.myotis.rpc.VerifiedRpcBackend rpcBackend = rpcBackendTmp;
-        final io.myotis.jsonrpc.MyotisRpcServer rpcServer = rpcServerTmp;
-
-        // 9. Shutdown hook for Ctrl-C / SIGTERM — cleanup happens here
-        //    because the JVM may exit before the main thread resumes after await().
+        // Shutdown hook for Ctrl-C / SIGTERM. close() is idempotent with the
+        // graceful "stop" path below, so either route cleans up exactly once.
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             log.info("[daemon] Shutdown hook triggered");
-            // Stop the RPC endpoint first so the port frees and no in-flight
-            // request builds against torn-down components.
-            if (rpcServer != null) {
-                try { rpcServer.stop(); } catch (Throwable ignored) {}
-            }
-            if (rpcBackend != null) {
-                try { rpcBackend.close(); } catch (Throwable ignored) {}
-            }
-            beaconLightClient.close();
-            server.close();
-            connector.close();
-            discV5.close();
-            discV4.close();
-            peerCache.close();   // last: drain queued cache writes after the final add()
-            try { fileLock.release(); lockChannel.close(); } catch (Exception ignored) {}
-            stopLatch.countDown();
-            log.info("[daemon] Done.");
+            runtime.close();
         }, "shutdown-hook"));
-
-        // 9. Block until "stop" command or signal
-        stopLatch.await();
-
-        // Cleanup for graceful "stop" command (shutdown hook handles Ctrl-C/SIGTERM)
-        if (rpcServer != null) {
-            try { rpcServer.stop(); } catch (Throwable ignored) {}
-        }
-        if (rpcBackend != null) {
-            try { rpcBackend.close(); } catch (Throwable ignored) {}
-        }
-        beaconLightClient.close();
-        server.close();
-        connector.close();
-        discV5.close();
-        discV4.close();
-        peerCache.close();
-        try { fileLock.release(); lockChannel.close(); } catch (Exception ignored) {}
-        log.info("[daemon] Done.");
+        // Block until the "stop" command or a signal fires the latch, then clean up.
+        runtime.awaitStop();
+        runtime.close();
     }
+
 
     // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
 
-    /**
-     * Dial-priority rank for a cached peer (lower = dialed first): proven
-     * snap-servers, then snap-capable-but-unproven, then known snap hangers, then
-     * plain-eth peers. Denied snap peers still outrank non-snap peers — state
-     * roots change, so a peer that couldn't serve an old pivot may serve the
-     * current head, and it's still snap-capable. Mirrors NodeService.snapDialRank.
-     */
-    private static int snapDialRank(PeerCache.CachedPeer p) {
-        if (!p.snap()) return 3;
-        return switch (p.snapQuality()) {
-            case CONFIRMED -> 0;
-            case UNKNOWN -> 1;
-            case DENIED -> 2;
-        };
-    }
-
-    /**
-     * Check if a daemon is actually listening on the socket.
-     * Tries to connect; if it succeeds the daemon is alive.
-     * If the socket file exists but no one is listening, it's stale — delete it.
-     */
     private static boolean isDaemonRunning(Path socketPath, Path lockPath) {
         // Try socket first
         if (Files.exists(socketPath)) {
@@ -717,46 +220,5 @@ public final class Main {
             try { Files.deleteIfExists(socketPath); } catch (Exception ignored) {}
         }
         return false;
-    }
-
-    /**
-     * In discv4, the Neighbors response includes 64-byte node IDs (public keys).
-     * We reconstruct the SECP256K1 public key and attempt connection.
-     */
-    private static void tryConnectWithKnownKey(
-            RLPxConnector connector, KademliaTable.Entry entry,
-            InetSocketAddress peerTcp, NodeKey localKey,
-            Set<String> attempted, String peerKey,
-            Map<String, Long> backoff, Set<String> blacklistedNodeIds) {
-        try {
-            Bytes nodeId = entry.nodeId();
-            if (nodeId.size() != 64) {
-                log.warn("[main] Node ID is not 64 bytes ({}b), skipping", nodeId.size());
-                attempted.remove(peerKey);
-                return;
-            }
-            SECP256K1.PublicKey peerPubkey = SECP256K1.PublicKey.fromBytes(nodeId);
-            connector.connect(peerTcp, peerPubkey, (incompatible, nodeIdHex) -> {
-                        if (incompatible) {
-                            blacklistedNodeIds.add(nodeIdHex);
-                            log.info("[main] Blacklisted node {} (incompatible network)", nodeIdHex.substring(0, 16) + "...");
-                        }
-                        long backoffMs = incompatible ? BACKOFF_INCOMPATIBLE_MS : BACKOFF_TRANSIENT_MS;
-                        backoff.putIfAbsent(peerKey, System.currentTimeMillis() + backoffMs);
-                        attempted.remove(peerKey);
-                    })
-                    .addListener(future -> {
-                        if (!future.isSuccess()) {
-                            log.warn("[main] Connection to {} failed: {}",
-                                    peerTcp, future.cause().getMessage());
-                            backoff.putIfAbsent(peerKey, System.currentTimeMillis() + BACKOFF_TRANSIENT_MS);
-                            attempted.remove(peerKey);
-                        }
-                    });
-        } catch (Exception e) {
-            log.warn("[main] Failed to connect to {}: {}", peerTcp, e.getMessage());
-            backoff.putIfAbsent(peerKey, System.currentTimeMillis() + BACKOFF_TRANSIENT_MS);
-            attempted.remove(peerKey);
-        }
     }
 }

--- a/desktop-app/build.gradle.kts
+++ b/desktop-app/build.gradle.kts
@@ -1,0 +1,128 @@
+import org.jetbrains.compose.desktop.application.dsl.TargetFormat
+
+// Installable desktop GUI for Linux / Windows / macOS. Embeds the real :app daemon
+// (DaemonRuntime) in-process — the same node stack the CLI and Android app run — and
+// packages it with jpackage via the Compose Desktop Gradle plugin.
+//
+// JVM 21: this module is NOT on the Android consumption path (CLAUDE.md's JVM-17
+// rule is about staying Android-consumable). It depends on :networking and
+// :myotis-evm, which ship JVM-21 class files, and the bundled jpackage runtime is
+// a full JDK 21 — so 21 is both required and free of Android cost here.
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.jetbrains.compose)
+}
+
+// Same netty story as :app and :android-app: jvm-libp2p (via :consensus) and Besu's
+// netty-bom (via :myotis-evm) drag upstream io.netty onto the classpath, which clashes
+// with the JitPack netty-kotlin fork (republished under the same io.netty.* package
+// names). Strip upstream group-wide so only the fork — pulled in transitively from
+// :networking / :consensus, and pinned explicitly below — assembles into the runtime image.
+configurations.all {
+    exclude(group = "io.netty")
+}
+
+kotlin {
+    jvmToolchain(21)
+}
+
+dependencies {
+    // The embedded daemon (DaemonRuntime, AppPaths, CommandHandler) plus the node
+    // stack types the controller observes (NetworkConfig, BeaconSyncState, RLPxConnector).
+    // :app exposes its module deps only as `implementation`, so :networking and
+    // :consensus are declared here too for compile-time visibility of those types.
+    implementation(project(":app"))
+    implementation(project(":networking"))
+    implementation(project(":consensus"))
+
+    // Netty fork — same artifacts :app pins. Present transitively at runtime, declared
+    // explicitly so the jpackage runtime image is satisfied regardless of resolution order.
+    implementation(libs.netty.transport)
+    implementation(libs.netty.codec)
+    implementation(libs.netty.handler)
+
+    // Compose Desktop UI.
+    implementation(compose.desktop.currentOs)
+    implementation(compose.material3)
+    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.kotlinx.coroutines.swing)
+
+    implementation(libs.slf4j.api)
+    runtimeOnly(libs.logback.classic)
+
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.junit.jupiter)
+}
+
+tasks.test {
+    useJUnitPlatform()
+}
+
+// jpackage rejects Maven-style versions: no "-SNAPSHOT", strictly MAJOR.MINOR.PATCH.
+// Releases pass the git tag via -PappVersion=vX.Y.Z; local builds fall back to a
+// sanitized project version. macOS additionally rejects a leading-zero major, so the
+// app-bundle version coerces 0.x -> 1.x (real releases tag >= 1.0.0, where it's a no-op).
+val rawVersion = (findProperty("appVersion") as String? ?: project.version.toString())
+val cleanVersion = rawVersion.removePrefix("v").substringBefore("-").ifBlank { "1.0.0" }
+val macVersion = cleanVersion.split(".").toMutableList()
+    .also { if (it.isNotEmpty() && it[0] == "0") it[0] = "1" }
+    .joinToString(".")
+
+// Optional per-OS icons. Wired only when present so the module builds before art exists
+// (jpackage falls back to a default icon otherwise). Generate with tools/make-icons.sh.
+val linuxIcon = layout.projectDirectory.file("icons/myotis.png")
+val windowsIcon = layout.projectDirectory.file("icons/myotis.ico")
+val macIcon = layout.projectDirectory.file("icons/myotis.icns")
+
+compose.desktop {
+    application {
+        mainClass = "com.jaeckel.ethp2p.desktop.MainKt"
+
+        // Force our logback config over any that dependency jars (trueblocks-kotlin, etc.)
+        // bundle under the same resource name.
+        jvmArgs += listOf("-Dlogback.configurationFile=logback-desktop.xml")
+
+        nativeDistributions {
+            targetFormats(
+                TargetFormat.Deb, TargetFormat.Rpm,   // Linux
+                TargetFormat.Msi, TargetFormat.Exe,   // Windows
+                TargetFormat.Dmg, TargetFormat.Pkg,   // macOS
+            )
+            packageName = "Myotis"
+            packageVersion = cleanVersion
+            description = "Myotis — trustless Ethereum light-client wallet"
+            vendor = "Myotis"
+            copyright = "© 2026 Myotis"
+
+            // Bundle a full JDK runtime image. includeAllModules is the safe default for
+            // the Besu / jvm-libp2p / Netty(Unsafe) / BouncyCastle classpath — trim to an
+            // explicit modules(...) set later to shrink the installer.
+            includeAllModules = true
+
+            linux {
+                packageName = "myotis"
+                menuGroup = "Network"
+                if (linuxIcon.asFile.exists()) iconFile.set(linuxIcon)
+            }
+            windows {
+                menuGroup = "Myotis"
+                // Stable so installers upgrade in place instead of stacking side-by-side.
+                upgradeUuid = "7E3B2C10-9A4D-4F2B-8C1E-2D6F5A9B3C40"
+                perUserInstall = true
+                if (windowsIcon.asFile.exists()) iconFile.set(windowsIcon)
+            }
+            macOS {
+                bundleID = "com.jaeckel.myotis"
+                packageVersion = macVersion
+                if (macIcon.asFile.exists()) iconFile.set(macIcon)
+            }
+        }
+
+        // Keep ProGuard/minification off for now: the reflective Besu/BouncyCastle/libp2p
+        // surface needs a keep-rule audit before shrinking is safe.
+        buildTypes.release.proguard {
+            isEnabled.set(false)
+        }
+    }
+}

--- a/desktop-app/build.gradle.kts
+++ b/desktop-app/build.gradle.kts
@@ -83,13 +83,6 @@ compose.desktop {
         // bundle under the same resource name.
         jvmArgs += listOf("-Dlogback.configurationFile=logback-desktop.xml")
 
-        // jpackage/jlink run from this JDK (defaults to the Gradle JVM). CI builds the
-        // macOS *universal* installer by running createReleaseDistributable twice — once
-        // with an arm64 JDK, once with an x64 JDK under Rosetta — then lipo-merging the two
-        // .app bundles. -PdesktopJavaHome selects the JDK for a given pass; unset leaves
-        // normal local/desktop builds on the Gradle JVM, unchanged.
-        (findProperty("desktopJavaHome") as String?)?.takeIf { it.isNotBlank() }?.let { javaHome = it }
-
         nativeDistributions {
             targetFormats(
                 TargetFormat.Deb, TargetFormat.Rpm,   // Linux

--- a/desktop-app/build.gradle.kts
+++ b/desktop-app/build.gradle.kts
@@ -83,6 +83,13 @@ compose.desktop {
         // bundle under the same resource name.
         jvmArgs += listOf("-Dlogback.configurationFile=logback-desktop.xml")
 
+        // jpackage/jlink run from this JDK (defaults to the Gradle JVM). CI builds the
+        // macOS *universal* installer by running createReleaseDistributable twice — once
+        // with an arm64 JDK, once with an x64 JDK under Rosetta — then lipo-merging the two
+        // .app bundles. -PdesktopJavaHome selects the JDK for a given pass; unset leaves
+        // normal local/desktop builds on the Gradle JVM, unchanged.
+        (findProperty("desktopJavaHome") as String?)?.takeIf { it.isNotBlank() }?.let { javaHome = it }
+
         nativeDistributions {
             targetFormats(
                 TargetFormat.Deb, TargetFormat.Rpm,   // Linux

--- a/desktop-app/icons/README.md
+++ b/desktop-app/icons/README.md
@@ -1,0 +1,11 @@
+# Desktop app icons
+
+Generated from `assets/myotis_logo.svg` by `tools/make-icons.sh`:
+
+- `myotis.png`  — Linux (512×512)
+- `myotis.ico`  — Windows (multi-size)
+- `myotis.icns` — macOS
+
+These binaries are **not** committed; `desktop-app/build.gradle.kts` wires each icon
+only when the file is present, and jpackage falls back to a default icon otherwise.
+The release CI workflow regenerates them before packaging.

--- a/desktop-app/src/main/kotlin/com/jaeckel/ethp2p/desktop/App.kt
+++ b/desktop-app/src/main/kotlin/com/jaeckel/ethp2p/desktop/App.kt
@@ -1,0 +1,184 @@
+package com.jaeckel.ethp2p.desktop
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.launch
+
+private val NETWORKS = listOf("mainnet", "sepolia", "holesky")
+
+@Composable
+fun App(controller: DesktopNodeController) {
+    val state by controller.state.collectAsState()
+    val scope = rememberCoroutineScope()
+
+    var selectedNetwork by remember { mutableStateOf(state.network) }
+    var addressInput by remember { mutableStateOf("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045") }
+    var output by remember { mutableStateOf("") }
+    var busy by remember { mutableStateOf(false) }
+
+    val running = state.status == NodeStatus.RUNNING
+    val starting = state.status == NodeStatus.STARTING
+    val stopping = state.status == NodeStatus.STOPPING
+
+    MaterialTheme {
+        Surface(modifier = Modifier.fillMaxSize()) {
+            Column(
+                modifier = Modifier.fillMaxSize().padding(20.dp).verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                Text("Myotis", style = MaterialTheme.typography.headlineMedium)
+                Text(
+                    "Trustless Ethereum light-client wallet",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+
+                // ── Network + run controls ──────────────────────────────────
+                Card(modifier = Modifier.fillMaxWidth()) {
+                    Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                        Text("Network", style = MaterialTheme.typography.titleMedium)
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            NETWORKS.forEach { net ->
+                                FilterChip(
+                                    selected = selectedNetwork == net,
+                                    onClick = { if (!running && !starting) selectedNetwork = net },
+                                    enabled = !running && !starting && !stopping,
+                                    label = { Text(net) },
+                                )
+                            }
+                        }
+                        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                            if (running) {
+                                Button(onClick = { controller.stop() }, enabled = !stopping) { Text("Stop node") }
+                            } else {
+                                Button(
+                                    onClick = { controller.start(selectedNetwork) },
+                                    enabled = !starting && !stopping,
+                                ) { Text("Start node") }
+                            }
+                            if (starting || stopping) {
+                                CircularProgressIndicator(modifier = Modifier.width(20.dp))
+                            }
+                            Text(statusLabel(state.status), style = MaterialTheme.typography.bodyMedium)
+                        }
+                        state.error?.let { err ->
+                            Text("Error: $err", color = MaterialTheme.colorScheme.error)
+                        }
+                    }
+                }
+
+                // ── Live status ─────────────────────────────────────────────
+                Card(modifier = Modifier.fillMaxWidth()) {
+                    Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                        Text("Status", style = MaterialTheme.typography.titleMedium)
+                        StatRow("Network", state.network)
+                        StatRow("Beacon sync", state.beaconState)
+                        StatRow("Peers", state.peerCount.toString())
+                        StatRow("Snap peers", state.snapPeerCount.toString())
+                        StatRow("Finalized slot", if (state.finalizedSlot > 0) state.finalizedSlot.toString() else "—")
+                        StatRow("Execution block", if (state.executionBlock > 0) state.executionBlock.toString() else "—")
+                    }
+                }
+
+                // ── Account lookup ──────────────────────────────────────────
+                Card(modifier = Modifier.fillMaxWidth()) {
+                    Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                        Text("Verified account lookup", style = MaterialTheme.typography.titleMedium)
+                        OutlinedTextField(
+                            value = addressInput,
+                            onValueChange = { addressInput = it },
+                            label = { Text("Address (0x…)") },
+                            singleLine = true,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                            Button(
+                                enabled = running && !busy,
+                                onClick = {
+                                    busy = true
+                                    output = ""
+                                    scope.launch {
+                                        val addr = DesktopNodeController.jsonEscape(addressInput.trim())
+                                        output = controller.command("""{"cmd":"get-account","address":"$addr"}""")
+                                        busy = false
+                                    }
+                                },
+                            ) { Text("Get account") }
+                            OutlinedButton(
+                                enabled = running && !busy,
+                                onClick = {
+                                    busy = true
+                                    output = ""
+                                    scope.launch {
+                                        output = controller.command("""{"cmd":"status"}""")
+                                        busy = false
+                                    }
+                                },
+                            ) { Text("Status JSON") }
+                            if (busy) CircularProgressIndicator(modifier = Modifier.width(20.dp))
+                        }
+                        if (!running) {
+                            Text(
+                                "Start the node to run verified lookups.",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                        if (output.isNotBlank()) {
+                            Text(
+                                output,
+                                fontFamily = FontFamily.Monospace,
+                                fontSize = 12.sp,
+                                modifier = Modifier.fillMaxWidth(),
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatRow(label: String, value: String) {
+    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+        Text(label, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Text(value, fontFamily = FontFamily.Monospace)
+    }
+}
+
+private fun statusLabel(status: NodeStatus): String = when (status) {
+    NodeStatus.STOPPED -> "Stopped"
+    NodeStatus.STARTING -> "Starting…"
+    NodeStatus.RUNNING -> "Running"
+    NodeStatus.STOPPING -> "Stopping…"
+    NodeStatus.ERROR -> "Error"
+}

--- a/desktop-app/src/main/kotlin/com/jaeckel/ethp2p/desktop/DesktopNodeController.kt
+++ b/desktop-app/src/main/kotlin/com/jaeckel/ethp2p/desktop/DesktopNodeController.kt
@@ -59,11 +59,12 @@ class DesktopNodeController(private val scope: CoroutineScope) {
         if (current == NodeStatus.RUNNING || current == NodeStatus.STARTING) return
         _state.value = NodeUiState(status = NodeStatus.STARTING, network = networkName)
         scope.launch(Dispatchers.IO) {
+            var rt: DaemonRuntime? = null
             try {
                 val network = NetworkConfig.byName(networkName)
                 clGenesisTime = network.clGenesisTime()
                 val config = AppPaths.daemonConfig(network, DEFAULT_PORT, gossipsub)
-                val rt = DaemonRuntime(config)
+                rt = DaemonRuntime(config)
                 rt.start()
                 runtime = rt
                 _state.value = _state.value.copy(status = NodeStatus.RUNNING)
@@ -71,6 +72,13 @@ class DesktopNodeController(private val scope: CoroutineScope) {
                 startPolling()
             } catch (e: Throwable) {
                 log.error("Failed to start embedded daemon", e)
+                // DaemonRuntime.start() already self-cleans on failure; close() again here is
+                // an idempotent no-op, and covers the case where rt was created but start()
+                // threw before its own guard engaged.
+                try {
+                    rt?.close()
+                } catch (ignored: Throwable) {
+                }
                 runtime = null
                 _state.value = _state.value.copy(
                     status = NodeStatus.ERROR,

--- a/desktop-app/src/main/kotlin/com/jaeckel/ethp2p/desktop/DesktopNodeController.kt
+++ b/desktop-app/src/main/kotlin/com/jaeckel/ethp2p/desktop/DesktopNodeController.kt
@@ -1,0 +1,167 @@
+package com.jaeckel.ethp2p.desktop
+
+import com.jaeckel.ethp2p.app.AppPaths
+import com.jaeckel.ethp2p.app.DaemonRuntime
+import com.jaeckel.ethp2p.networking.NetworkConfig
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.slf4j.LoggerFactory
+
+/** Coarse lifecycle of the embedded daemon, surfaced to the UI. */
+enum class NodeStatus { STOPPED, STARTING, RUNNING, STOPPING, ERROR }
+
+/** Immutable snapshot the Compose UI renders. Polled from the live node every few seconds. */
+data class NodeUiState(
+    val status: NodeStatus = NodeStatus.STOPPED,
+    val network: String = "mainnet",
+    val beaconState: String = "—",
+    val peerCount: Int = 0,
+    val snapPeerCount: Int = 0,
+    val finalizedSlot: Long = 0,
+    val executionBlock: Long = 0,
+    val error: String? = null,
+)
+
+/**
+ * Drives the in-process {@link DaemonRuntime} on behalf of the desktop UI: start/stop on
+ * background threads, a 2s poll loop that snapshots live node state into an observable
+ * {@link StateFlow}, and a helper to run IPC commands (account/storage/ENS) off the UI thread.
+ *
+ * <p>This is the desktop analogue of Android's {@code NodeService} — except it embeds the real
+ * {@code :app} daemon rather than re-porting it, so the GUI, the CLI, and CI all exercise one
+ * node implementation.
+ */
+class DesktopNodeController(private val scope: CoroutineScope) {
+
+    private val log = LoggerFactory.getLogger(DesktopNodeController::class.java)
+
+    private val _state = MutableStateFlow(NodeUiState())
+    val state: StateFlow<NodeUiState> = _state.asStateFlow()
+
+    @Volatile
+    private var runtime: DaemonRuntime? = null
+
+    @Volatile
+    private var clGenesisTime: Long = 0L
+
+    private var pollJob: Job? = null
+
+    fun start(networkName: String, gossipsub: Boolean = false) {
+        val current = _state.value.status
+        if (current == NodeStatus.RUNNING || current == NodeStatus.STARTING) return
+        _state.value = NodeUiState(status = NodeStatus.STARTING, network = networkName)
+        scope.launch(Dispatchers.IO) {
+            try {
+                val network = NetworkConfig.byName(networkName)
+                clGenesisTime = network.clGenesisTime()
+                val config = AppPaths.daemonConfig(network, DEFAULT_PORT, gossipsub)
+                val rt = DaemonRuntime(config)
+                rt.start()
+                runtime = rt
+                _state.value = _state.value.copy(status = NodeStatus.RUNNING)
+                log.info("Embedded daemon started on {}", networkName)
+                startPolling()
+            } catch (e: Throwable) {
+                log.error("Failed to start embedded daemon", e)
+                runtime = null
+                _state.value = _state.value.copy(
+                    status = NodeStatus.ERROR,
+                    error = e.message ?: e.toString(),
+                )
+            }
+        }
+    }
+
+    fun stop() {
+        val rt = runtime ?: return
+        val net = _state.value.network
+        _state.value = _state.value.copy(status = NodeStatus.STOPPING)
+        scope.launch(Dispatchers.IO) {
+            try {
+                pollJob?.cancel()
+                pollJob = null
+                rt.close()
+            } catch (e: Throwable) {
+                log.warn("Error during shutdown", e)
+            } finally {
+                runtime = null
+                _state.value = NodeUiState(status = NodeStatus.STOPPED, network = net)
+            }
+        }
+    }
+
+    /**
+     * Synchronously close the embedded node on the calling thread. Used on window-close /
+     * JVM shutdown so the daemon's Netty + Ktor threads are torn down before the process exits
+     * (the runtime no longer registers its own JVM shutdown hook — the embedder owns lifecycle).
+     */
+    fun shutdownBlocking() {
+        pollJob?.cancel()
+        pollJob = null
+        val rt = runtime
+        runtime = null
+        if (rt != null) {
+            try {
+                rt.close()
+            } catch (e: Throwable) {
+                log.warn("Error during blocking shutdown", e)
+            }
+        }
+    }
+
+    /** Run a JSON-Lines IPC command against the live node, off the UI thread. */
+    suspend fun command(json: String): String = withContext(Dispatchers.IO) {
+        val rt = runtime ?: return@withContext """{"error":"node not running"}"""
+        try {
+            rt.commandHandler().handle(json)
+        } catch (e: Throwable) {
+            """{"error":"${jsonEscape(e.message ?: e.toString())}"}"""
+        }
+    }
+
+    private fun startPolling() {
+        pollJob?.cancel()
+        pollJob = scope.launch(Dispatchers.Default) {
+            while (isActive) {
+                refresh()
+                delay(POLL_INTERVAL_MS)
+            }
+        }
+    }
+
+    private fun refresh() {
+        val rt = runtime ?: return
+        try {
+            val sync = rt.beaconSyncState()
+            val connector = rt.connector()
+            val peers = connector?.activePeers ?: emptyList()
+            val snapPeers = peers.count { it.snapSupported() }
+            val beaconState = sync?.getSyncState(clGenesisTime)?.name ?: "—"
+            _state.value = _state.value.copy(
+                beaconState = beaconState,
+                peerCount = peers.size,
+                snapPeerCount = snapPeers,
+                finalizedSlot = sync?.finalizedSlot ?: 0,
+                executionBlock = sync?.executionBlockNumber ?: 0,
+            )
+        } catch (e: Throwable) {
+            log.debug("refresh failed: {}", e.toString())
+        }
+    }
+
+    companion object {
+        private const val DEFAULT_PORT = 30303
+        private const val POLL_INTERVAL_MS = 2000L
+
+        fun jsonEscape(s: String): String =
+            s.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", " ")
+    }
+}

--- a/desktop-app/src/main/kotlin/com/jaeckel/ethp2p/desktop/Main.kt
+++ b/desktop-app/src/main/kotlin/com/jaeckel/ethp2p/desktop/Main.kt
@@ -1,0 +1,38 @@
+package com.jaeckel.ethp2p.desktop
+
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.application
+import androidx.compose.ui.window.rememberWindowState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlin.system.exitProcess
+
+/**
+ * Desktop entry point. Owns an application-scoped coroutine scope and the embedded-node
+ * controller, renders the single main window, and guarantees a clean process exit: the
+ * window close fires {@code exitApplication()}, after which we synchronously tear down the
+ * node (Netty/Ktor non-daemon threads) and {@code exitProcess(0)} so the JVM always
+ * terminates. A JVM shutdown hook covers SIGINT/SIGTERM as well.
+ */
+fun main() {
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    val controller = DesktopNodeController(scope)
+    Runtime.getRuntime().addShutdownHook(Thread({ controller.shutdownBlocking() }, "myotis-shutdown"))
+
+    application {
+        val windowState = rememberWindowState(size = DpSize(560.dp, 760.dp))
+        Window(
+            onCloseRequest = ::exitApplication,
+            title = "Myotis",
+            state = windowState,
+        ) {
+            App(controller)
+        }
+    }
+
+    controller.shutdownBlocking()
+    exitProcess(0)
+}

--- a/desktop-app/src/main/resources/logback-desktop.xml
+++ b/desktop-app/src/main/resources/logback-desktop.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Console logging for the Myotis desktop app. The embedded daemon is verbose at INFO;
+     keep the node at INFO but quiet the noisiest discovery/netty chatter to WARN. -->
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%thread] %logger{28} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="io.netty" level="WARN"/>
+    <logger name="io.libp2p" level="WARN"/>
+    <logger name="org.hyperledger.besu" level="WARN"/>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,9 @@ dnsjava = "3.6.2"
 besu = "24.12.2"
 agp = "8.7.3"
 kotlin = "2.0.21"
+# Compose Multiplatform (desktop) — used by :desktop-app for the installable GUI.
+# 1.7.3 is the stable line aligned with Kotlin 2.0.21 / the compose-compiler plugin.
+compose-multiplatform = "1.7.3"
 compose-bom = "2024.11.00"
 activity-compose = "1.9.3"
 # JSON-RPC server (:jsonrpc-server). Ktor server+client + kotlinx are chosen for
@@ -34,6 +37,7 @@ kotlin-android      = { id = "org.jetbrains.kotlin.android",         version.ref
 kotlin-jvm          = { id = "org.jetbrains.kotlin.jvm",             version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 compose-compiler    = { id = "org.jetbrains.kotlin.plugin.compose",  version.ref = "kotlin" }
+jetbrains-compose   = { id = "org.jetbrains.compose",               version.ref = "compose-multiplatform" }
 
 [libraries]
 tuweni-bytes        = { module = "com.github.biafra23.tuweni-kotlin:tuweni-bytes",       version.ref = "tuweni" }
@@ -85,3 +89,5 @@ ktor-client-core           = { module = "io.ktor:ktor-client-core",  version.ref
 ktor-client-cio            = { module = "io.ktor:ktor-client-cio",   version.ref = "ktor" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 kotlinx-coroutines-core    = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core",    version.ref = "kotlinx-coroutines" }
+# Swing dispatcher (Dispatchers.Main) for the Compose Desktop UI in :desktop-app.
+kotlinx-coroutines-swing   = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing",   version.ref = "kotlinx-coroutines" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -36,4 +36,4 @@ dependencyResolutionManagement {
     }
 }
 
-include("core", "networking", "consensus", "app", "android-app", "myotis-evm", "myotis-ens", "jsonrpc-server", "rpc-backend")
+include("core", "networking", "consensus", "app", "android-app", "myotis-evm", "myotis-ens", "jsonrpc-server", "rpc-backend", "desktop-app")

--- a/tools/make-icons.sh
+++ b/tools/make-icons.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# Generate the per-OS application icons for the :desktop-app installer from the
+# source SVG (assets/myotis_logo.svg).
+#
+# Outputs (consumed by desktop-app/build.gradle.kts when present):
+#   desktop-app/icons/myotis.png    — Linux  (512x512)
+#   desktop-app/icons/myotis.ico    — Windows (multi-size)
+#   desktop-app/icons/myotis.icns   — macOS   (iconset)
+#
+# Requirements: rsvg-convert (librsvg) or inkscape, ImageMagick (`magick`/`convert`),
+# and either `iconutil` (macOS) or `png2icns` (libicns) for the .icns.
+#
+# This is intentionally a manual/CI step rather than a Gradle task so the build
+# stays toolchain-only (no native image deps required just to compile).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SVG="$ROOT/assets/myotis_logo.svg"
+OUT="$ROOT/desktop-app/icons"
+mkdir -p "$OUT"
+
+rasterize() { # rasterize <size> <outfile>
+    local size="$1" out="$2"
+    if command -v rsvg-convert >/dev/null 2>&1; then
+        rsvg-convert -w "$size" -h "$size" "$SVG" -o "$out"
+    elif command -v inkscape >/dev/null 2>&1; then
+        inkscape "$SVG" --export-type=png --export-filename="$out" -w "$size" -h "$size"
+    else
+        echo "Need rsvg-convert or inkscape to rasterize the SVG." >&2
+        exit 1
+    fi
+}
+
+im() { command -v magick >/dev/null 2>&1 && magick "$@" || convert "$@"; }
+
+# Linux PNG
+rasterize 512 "$OUT/myotis.png"
+
+# Windows .ico (bundle common sizes)
+tmp="$(mktemp -d)"
+for s in 16 32 48 64 128 256; do rasterize "$s" "$tmp/icon_$s.png"; done
+im "$tmp"/icon_*.png "$OUT/myotis.ico"
+
+# macOS .icns
+iconset="$tmp/myotis.iconset"; mkdir -p "$iconset"
+for s in 16 32 64 128 256 512; do
+    rasterize "$s"            "$iconset/icon_${s}x${s}.png"
+    rasterize "$((s*2))"      "$iconset/icon_${s}x${s}@2x.png"
+done
+if command -v iconutil >/dev/null 2>&1; then
+    iconutil -c icns "$iconset" -o "$OUT/myotis.icns"
+elif command -v png2icns >/dev/null 2>&1; then
+    png2icns "$OUT/myotis.icns" "$iconset"/icon_512x512.png "$iconset"/icon_256x256.png \
+        "$iconset"/icon_128x128.png "$iconset"/icon_32x32.png "$iconset"/icon_16x16.png
+else
+    echo "No iconutil/png2icns; skipped .icns (Windows/Linux icons still generated)." >&2
+fi
+
+rm -rf "$tmp"
+echo "Icons written to $OUT"


### PR DESCRIPTION
## Summary

Refactors the monolithic daemon bootstrap logic from `Main.runDaemon()` into a reusable `DaemonRuntime` class, enabling two new use cases: (1) a desktop GUI (`desktop-app`) that embeds the same node stack in-process, and (2) cleaner separation of concerns for CLI vs. embedded deployments. The daemon now throws `DaemonStartException` on startup failure instead of calling `System.exit()`, leaving exit-code policy to the caller.

## Key Changes

- **`DaemonRuntime` (new)**: Encapsulates the full daemon lifecycle (discovery, RLPx, beacon light client, IPC server, JSON-RPC backend). Implements `AutoCloseable` for clean teardown. Exposes accessors (`beaconSyncState()`, `connector()`, `commandHandler()`) for embedders to observe live state. `start()` throws `DaemonStartException` on fatal errors; `close()` is idempotent and fires the stop latch.

- **`AppPaths` (new)**: Resolves OS-appropriate writable directories for a packaged desktop install (Linux `$XDG_DATA_HOME`, macOS `~/Library/Application Support`, Windows `%LOCALAPPDATA%`). Allows CLI to continue using `/tmp` + working directory while desktop app uses per-user OS paths.

- **`Main.runDaemon()` refactored**: Now delegates to `DaemonRuntime`, registers a JVM shutdown hook, and blocks on `awaitStop()`. Removed ~500 lines of bootstrap code; exit-code handling remains in `main()`.

- **Desktop GUI (`desktop-app` module, new)**:
  - `DesktopNodeController`: Drives `DaemonRuntime` on background threads, polls live state into a `StateFlow` for reactive UI updates, runs IPC commands off the UI thread.
  - `App.kt`: Compose Material 3 UI with network selector, start/stop controls, account/storage query forms, and live sync state display.
  - `Main.kt`: Window setup and clean process exit (tears down Netty/Ktor non-daemon threads, calls `exitProcess(0)`).
  - `build.gradle.kts`: Compose Desktop plugin, jpackage configuration, multi-platform icon generation.

- **Desktop release workflow** (`.github/workflows/desktop-release.yml`, new): Builds native installers (`.deb`/`.rpm` on Linux, `.msi`/`.exe` on Windows, `.dmg`/`.pkg` on macOS) via jpackage. Runs on version tags or manual dispatch; attaches artifacts to GitHub Releases.

- **Icon tooling** (`tools/make-icons.sh`, new): Generates per-OS app icons from `assets/myotis_logo.svg` (PNG for Linux, ICO for Windows, ICNS for macOS).

- **Dependencies**: Added Compose Multiplatform 1.7.3 (aligned with Kotlin 2.0.21) and Compose Material 3 for the desktop UI. Desktop module targets JVM 21 (jpackage runtime is full JDK 21; not on Android consumption path).

## Notable Implementation Details

- **Lock file & exclusive access**: Moved from `Main` into `DaemonRuntime.start()`. Held for the daemon's lifetime; auto-released on process death.
- **Peer cache sorting**: Snap/1-capable peers reconnect first; within snap set, CONFIRMED peers ahead of DENIED ones (mirrors `NodeService` ranking).
- **DNS-resolved peer dialing**: Direct RLPx dials of EIP-1459 EL enodes (capped at 50) bypass discv4, enabling bootstrap on NAT'd hosts (Android emulator) where discv4 endpoint proof fails.
- **Backoff tracking**: Incompatible peers (wrong chain) backoff 10 min; transient failures 30s. Shared state via `ConcurrentHashMap`.
- **Desktop state polling**: 2-second poll loop snapshots beacon sync state, peer counts, finalized slot, and execution block into an immutable `NodeUiState` for the UI to

https://claude.ai/code/session_012xHtjMPKes2ErHWTyUGRgc