### PR TITLE
Rename project from ethp2p to Myotis

### DIFF
--- a/android-app/src/main/AndroidManifest.xml
+++ b/android-app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
 
     <application
         android:name=".EthP2PApplication"
-        android:label="ethp2p"
+        android:label="Myotis"
         android:allowBackup="false"
         android:theme="@android:style/Theme.DeviceDefault.DayNight">
 

--- a/android-app/src/main/AndroidManifest.xml
+++ b/android-app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
 
     <application
         android:name=".EthP2PApplication"
-        android:label="Myotis"
+        android:label="@string/app_name"
         android:allowBackup="false"
         android:theme="@android:style/Theme.DeviceDefault.DayNight">
 

--- a/android-app/src/main/res/values/strings.xml
+++ b/android-app/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Myotis</string>
+</resources>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,4 @@
-rootProject.name = "ethp2p"
+rootProject.name = "Myotis"
 
 pluginManagement {
     repositories {


### PR DESCRIPTION
## Summary
Renames the project from `ethp2p` to `Myotis`:
- `settings.gradle.kts`: `rootProject.name` → `Myotis`
- `android-app/src/main/AndroidManifest.xml`: `android:label` → `Myotis`

## Test plan
- [ ] `./gradlew build` succeeds with the new root project name
- [ ] Android app displays the "Myotis" launcher label

🤖 Generated with [Claude Code](https://claude.com/claude-code)