### PR TITLE
deps: bump jvm-libp2p 1.2.2 → 1.3.2 (fix yamux Muxer exception + ByteBuf leak)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ slf4j = "2.0.12"
 logback = "1.5.6"
 snappy = "0.4"
 milagro = "0.4.0"
-jvm-libp2p = "1.2.2-RELEASE"
+jvm-libp2p = "1.3.2-RELEASE"
 trueblocks-kotlin = "main-SNAPSHOT"
 dnsjava = "3.6.2"
 # Hyperledger Besu, used by myotis-evm. Pinned to a recent stable that ships


### PR DESCRIPTION
## What & why

Bumps `jvm-libp2p` `1.2.2-RELEASE` → `1.3.2-RELEASE` (`gradle/libs.versions.toml`).

Fixes the recurring runtime log:
```
Muxer exception
io.libp2p.mux.UnknownStreamIdMuxerException: Stream with id …/4 not found
  at io.libp2p.mux.yamux.YamuxHandler.getStreamHandlerOrReleaseAndThrow(...)
```
The CL light client (`BeaconP2PService`) opens short-lived reqresp streams (`/status`, `/light_client_*`, `identify`) and tears them down on timeouts; against flaky/non-serving beacon peers a stream gets reset while the remote still has a frame in flight → yamux gets a frame for an id it no longer holds. It was never fatal (libp2p logs + drops the frame; no connection close, no data-integrity impact — everything stays BLS/proof-verified), but on 1.2.2 it's logged loudly **and** the invalid-stream frame's `ByteBuf` wasn't released — a small direct-memory drip per occurrence at high churn.

1.3.x:
- reclassifies that log to **DEBUG**, and
- **1.3.1** adds *"Release ByteBuf on control frames and invalid stream tag"* — the actual fix that frees the buffer.

## Risk
Low for the transport stack: `:consensus` already **excludes `io.netty` from jvm-libp2p** and pins the Netty fork explicitly (for JVM↔Android parity), so this changes only libp2p's own code, not Netty. (1.3.x also adds QUIC + gossipsub v1.3, which we don't use.)

## Verification
- `:consensus:test` green; `:app` + `:android-app` compile.
- Mainnet daemon smoke test (~2.5 min): libp2p host up, CL peers connect, **finality updates apply and BLS-verify** (`participation=510/512`), and **0 `UnknownStreamIdMuxerException`** over ~105k log lines (was recurring on 1.2.2). Remaining libp2p lines are normal churn (peer timeouts, empty-response errors), not the muxer exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)