### PR TITLE
consensus: poll finality at the network slot time (Gnosis 5s, not hardcoded 12s)

### DIFF
--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
@@ -644,8 +644,11 @@ public class BeaconLightClient implements AutoCloseable {
             }
         }
 
-        // Phase 2: steady-state poll loop — one slot = 12 seconds.
+        // Phase 2: steady-state poll loop — one slot (mainnet 12s, Gnosis 5s).
         // If not yet synced, each cycle disconnects stale connections and retries.
+        // Using the network slot time matters on Gnosis: a hardcoded 12s polled
+        // finality 2.4x too slowly there, prolonging CATCHING_UP and staling the head.
+        long pollIntervalMs = secondsPerSlot * 1000L;
         int cycleCount = 0;
         while (running) {
             try {
@@ -653,7 +656,7 @@ public class BeaconLightClient implements AutoCloseable {
                 // whether LC-capable peers are accumulating or bleeding off.
                 if (++cycleCount % 5 == 0) logPeerPoolStats();
                 pollFinalityUpdate();
-                Thread.sleep(12_000);
+                Thread.sleep(pollIntervalMs);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 break;

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
@@ -648,7 +648,11 @@ public class BeaconLightClient implements AutoCloseable {
         // If not yet synced, each cycle disconnects stale connections and retries.
         // Using the network slot time matters on Gnosis: a hardcoded 12s polled
         // finality 2.4x too slowly there, prolonging CATCHING_UP and staling the head.
-        long pollIntervalMs = secondsPerSlot * 1000L;
+        // Guard a misconfigured preset: a non-positive slot time would make
+        // Thread.sleep() throw (negative) or busy-loop the network (zero), so fall
+        // back to the mainnet default rather than crash or spin.
+        int slotSeconds = secondsPerSlot > 0 ? secondsPerSlot : BeaconChainSpec.SECONDS_PER_SLOT;
+        long pollIntervalMs = slotSeconds * 1000L;
         int cycleCount = 0;
         while (running) {
             try {


### PR DESCRIPTION
## What & why

While debugging a report that **CATCHING_UP "doesn't work" on Gnosis**, I confirmed it actually reaches **SYNCED** on latest `main` (the bootstrap fix in `59d48d1` + the refreshed Gnosis checkpoint resolved the original stuck state). But I found one genuine latent bug along the way.

The light-client steady-state sync loop slept a **hardcoded `12_000` ms** between `pollFinalityUpdate()` calls — one *mainnet* slot. On **Gnosis (5s slots)** that polls finality **2.4× too slowly**, prolonging CATCHING_UP and letting the verified head go stale between updates.

## Change

`BeaconLightClient.syncLoop()` now sleeps `secondsPerSlot * 1000` (the value already threaded in via `setBeaconPreset(secondsPerSlot, slotsPerEpoch)`), so Gnosis polls every 5s.

- **Mainnet behavior is unchanged** (`12 * 1000 == 12_000`).
- Only the steady-state poll cadence changes; the 30s error-backoff sleep is left as-is (network-agnostic).

## Verification (live Gnosis daemon, `-Pnetwork=gnosis`)

- ✅ Fresh bootstrap (no cache) → catch-up → **SYNCED** in ~110s, stays SYNCED, `knownStateRoots` climbing via finality updates.
- ✅ Re-synced cleanly on the rebuilt binary with the 5s cadence.
- ✅ `./gradlew :consensus:compileJava` green.

## Out of scope / not a code bug

`fillChainStateRoots` (`beacon_blocks_by_range`) still fails on Gnosis peers with "Protocol negotiation failed" — peers negotiate then drop our light-client connection. That's the documented Gnosis peer-availability/retention issue, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)