### PR TITLE
android: fix uptime counter freezing after Stop->Start

### DIFF
--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -1524,7 +1524,15 @@ public final class NodeService extends Service {
         cachedPeerCount = 0;
         cachedClPeerCount = 0;
         clGenesisTime = 0L;
-        startTimeMs = 0L;
+        // NB: do NOT clear startTimeMs here. doShutdown() runs on a worker thread
+        // and its teardown takes seconds; a quick Stop -> Start has onStartCommand()
+        // flip RUNNING back to true and stamp a fresh startTimeMs while we're still
+        // mid-teardown (startNode()'s synchronized startAndPublish blocks on the lock
+        // we hold). Writing startTimeMs = 0L here would clobber that fresh stamp, and
+        // since the UI shows the uptime row whenever running==true, uptime would jump
+        // to now - 0 (~epoch millis) and freeze. startTimeMs is owned by the next
+        // start (onStartCommand / the restart branch below both stamp it); the UI
+        // only reads it when running, so leaving the old value here is harmless.
         clPeersDiscovered.set(0);
         LogBuffer.i(TAG, "node shutdown complete");
         if (restartAfterShutdown) {


### PR DESCRIPTION
## Problem

On Android, after stopping and starting the node the uptime counter sometimes freezes at a large fixed value (e.g. ~49892 hours) instead of counting up from zero. It may count up correctly for a few seconds first, then switch to the frozen value.

## Root cause

A Stop->Start race in `NodeService`:

1. **Stop** → `shutdown()` flips `RUNNING=false` and kicks `doShutdown()` onto a worker thread. Its teardown (libp2p `host.stop().join()`, Netty `shutdownGracefully`, `syncThread.join`) takes a few seconds and is `synchronized`.
2. **Start** (tapped quickly) → `onStartCommand()` does `RUNNING.compareAndSet(false,true)`, stamps a fresh `startTimeMs`, and launches `startNode()`. The UI now sees `running=true` with a fresh stamp and uptime counts up from 0. `startNode → startAndPublish` is also `synchronized`, so it blocks on the lock `doShutdown` still holds.
3. `doShutdown()` finally reaches `startTimeMs = 0L`, clobbering the fresh stamp. Since the UI shows the uptime row whenever `running==true` and computes `now - startTimeMs`, uptime jumps to `now - 0` (~epoch millis) and freezes.

This is intermittent because it only triggers when teardown finishes *after* the new Start has already stamped `startTimeMs`.

## Fix

Drop the `startTimeMs = 0L` write in `doShutdown()`. `startTimeMs` is owned by the next start (both `onStartCommand` and the in-service restart branch stamp it), and the UI only reads it when running — so clearing it on shutdown was unnecessary and was the sole source of the clobber.

## Testing

To verify on-device: tap Stop then Start quickly a few times (best repro after the node has been running a while with many peers, so teardown is slow). The uptime should keep counting from 0 each time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)