### PR TITLE
node-core: host multiple networks (mainnet + Gnosis) in one process — daemon (Phase A)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,6 +19,10 @@ dependencies {
     // Android app hosts in NodeService.
     implementation(project(":jsonrpc-server"))
     implementation(project(":rpc-backend"))
+    // Shared per-network host core: ChainStack/NodeRegistry. The daemon supplies
+    // file-backed cache adapters + the JVM CCIP gateway and hosts the same stacks
+    // the Android app does.
+    implementation(project(":node-core"))
     // :app source references io.netty.channel.* (via :networking's RLPxConnector
     // API). With io.netty excluded group-wide, the fork must be on :app's compile
     // classpath explicitly (:networking declares it as implementation, so it

--- a/app/src/main/java/com/jaeckel/ethp2p/app/ClPeerCacheAdapter.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/ClPeerCacheAdapter.java
@@ -1,0 +1,36 @@
+package com.jaeckel.ethp2p.app;
+
+import io.myotis.node.ClPeerCachePort;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Adapts the daemon's file-backed {@link CLPeerCache} to the {@link ClPeerCachePort}
+ * that {@code ChainStack} consumes. Pure delegation. {@code CLPeerCache} flushes its
+ * writes inline (no {@code close()}), so {@link #close()} is a no-op.
+ */
+public final class ClPeerCacheAdapter implements ClPeerCachePort {
+
+    private final CLPeerCache delegate;
+
+    public ClPeerCacheAdapter(CLPeerCache delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override public List<String> load() { return delegate.load(); }
+    @Override public void add(String multiaddr) { delegate.add(multiaddr); }
+    @Override public void markFailure(String multiaddr) { delegate.markFailure(multiaddr); }
+    @Override public Map<String, long[]> servedRanges() { return delegate.servedRanges(); }
+    @Override public void recordServed(String multiaddr, long low, long high) { delegate.recordServed(multiaddr, low, high); }
+    @Override public Map<String, Long> bootstrapPeers() { return delegate.bootstrapPeers(); }
+    @Override public void recordBootstrap(String multiaddr, long period) { delegate.recordBootstrap(multiaddr, period); }
+    @Override public Set<String> lightClientConfirmed() { return delegate.lightClientConfirmed(); }
+    @Override public Set<String> lightClientDenied() { return delegate.lightClientDenied(); }
+    @Override public void markLightClientBatch(Collection<String> confirmed, Collection<String> denied) {
+        delegate.markLightClientBatch(confirmed, denied);
+    }
+    @Override public void close() { /* CLPeerCache flushes writes inline; nothing to close */ }
+}

--- a/app/src/main/java/com/jaeckel/ethp2p/app/Main.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/Main.java
@@ -263,23 +263,28 @@ public final class Main {
             servers.add(server);
         }
 
-        // 2. Shutdown hook for Ctrl-C / SIGTERM — cleanup happens here because the JVM
-        //    may exit before the main thread resumes after await(). A `stop` command on
-        //    ANY network's socket trips the shared latch and tears the whole process down.
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            log.info("[daemon] Shutdown hook triggered");
+        // 2. Run cleanup exactly once, whether reached via the await() below or the
+        //    shutdown hook (Ctrl-C / SIGTERM, or normal exit after await returns).
+        java.util.concurrent.atomic.AtomicBoolean cleaned = new java.util.concurrent.atomic.AtomicBoolean(false);
+        Runnable cleanup = () -> {
+            if (!cleaned.compareAndSet(false, true)) return;
             registry.shutdownAll();
             closeAll(servers);
             releaseAll(fileLocks, lockChannels);
+        };
+
+        // A `stop` command on ANY network's socket trips the shared latch and tears the
+        // whole process down. The hook covers the JVM-exits-before-main-resumes case.
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            log.info("[daemon] Shutdown hook triggered");
+            cleanup.run();
             stopLatch.countDown();
             log.info("[daemon] Done.");
         }, "shutdown-hook"));
 
-        // 3. Block until "stop" command or signal, then clean up (hook covers Ctrl-C).
+        // 3. Block until "stop" command or signal, then clean up.
         stopLatch.await();
-        registry.shutdownAll();
-        closeAll(servers);
-        releaseAll(fileLocks, lockChannels);
+        cleanup.run();
         log.info("[daemon] Done.");
     }
 

--- a/app/src/main/java/com/jaeckel/ethp2p/app/Main.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/Main.java
@@ -1,24 +1,12 @@
 package com.jaeckel.ethp2p.app;
 
-import com.jaeckel.ethp2p.consensus.BeaconLightClient;
-import com.jaeckel.ethp2p.consensus.BeaconSyncState;
 import com.jaeckel.ethp2p.core.crypto.NodeKey;
-import com.jaeckel.ethp2p.core.enr.Enr;
-import com.jaeckel.ethp2p.core.types.BlockHeader;
 import com.jaeckel.ethp2p.networking.NetworkConfig;
-import com.jaeckel.ethp2p.networking.discv4.DiscV4Service;
-import com.jaeckel.ethp2p.networking.discv4.KademliaTable;
-import com.jaeckel.ethp2p.networking.discv5.DiscV5Service;
-import com.jaeckel.ethp2p.networking.dns.DnsEnrResolver;
-import com.jaeckel.ethp2p.networking.eth.messages.BlockHeadersMessage;
-import com.jaeckel.ethp2p.networking.rlpx.RLPxConnector;
-import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.crypto.SECP256K1;
+import io.myotis.node.ChainPorts;
+import io.myotis.node.ChainStack;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.net.BindException;
-import java.net.InetSocketAddress;
 import java.net.StandardProtocolFamily;
 import java.net.UnixDomainSocketAddress;
 import java.nio.channels.FileChannel;
@@ -27,14 +15,8 @@ import java.nio.channels.SocketChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 
 /**
@@ -67,18 +49,17 @@ import java.util.concurrent.CountDownLatch;
  *   <li>If the IPC socket exists → client mode: send one command, print response, exit.
  *   <li>If the IPC socket is absent → daemon mode: run discovery + RLPx, serve commands.
  * </ul>
+ *
+ * <p>The per-network node stack (EL + discv4 + discv5 + beacon light client + verified
+ * JSON-RPC) lives in {@link ChainStack} (module {@code :node-core}), shared with the
+ * Android app. This class owns the daemon-specific shell: the lock file, the Unix-socket
+ * IPC server, and the shutdown latch.
  */
 public final class Main {
 
     private static final Logger log = LoggerFactory.getLogger(Main.class);
 
     private static final int DEFAULT_PORT = 30303;
-    private static final long BACKOFF_INCOMPATIBLE_MS = 10 * 60 * 1000L; // 10 min for wrong-chain peers
-    private static final long BACKOFF_TRANSIENT_MS = 30 * 1000L; // 30s for transient failures (too many peers, etc.)
-    // Cap on how many DNS-resolved (EIP-1459) EL enodes we RLPx-dial directly at startup,
-    // bypassing discv4. Enough to land a snap peer on NAT'd hosts (Android emulator) without
-    // a dial storm where discv4 already works.
-    private static final int DNS_DIRECT_DIAL_LIMIT = 50;
 
     /** Socket path; override via {@code ETHP2P_SOCKET} env var. Network-specific suffix for non-mainnet. */
     static Path socketPath(String networkName) {
@@ -199,469 +180,70 @@ public final class Main {
             return;
         }
 
-        // 1. Load or generate node key
-        Path keyFile = Path.of("nodekey.hex");
-        NodeKey nodeKey = NodeKey.loadOrGenerate(keyFile);
-        log.info("Node ID: {}", nodeKey.nodeId().toHexString());
+        // 1. Node identity (one network per daemon today → the shared nodekey.hex).
+        NodeKey nodeKey = NodeKey.loadOrGenerate(Path.of("nodekey.hex"));
 
-        // 2. Latch that triggers graceful shutdown (stop command or SIGTERM)
+        // 2. Latch that triggers graceful shutdown (stop command or SIGTERM).
         CountDownLatch stopLatch = new CountDownLatch(1);
 
-        // 3. Peer cache
+        // 3. File-backed peer caches, exposed to ChainStack via adapters.
         PeerCache peerCache = new PeerCache(cacheFile(network.name()));
+        CLPeerCache clPeerCache = new CLPeerCache(clCacheFile(network.name()));
 
-        // 3a. EIP-1459 DNS-based peer discovery. Best-effort: on any failure (timeout,
-        // missing TXT, bad signature) the resolver returns an empty list and we fall
-        // through to the hardcoded + cached peers. Run EL and CL resolution concurrently
-        // on virtual threads so total startup cost is max(elTimeout, clTimeout), not
-        // sum. Layers stay separated so EL-tree entries only feed discv4 bootnodes and
-        // CL-tree entries only feed the libp2p peer list.
-        DnsEnrResolver dnsResolver = new DnsEnrResolver();
-        Duration dnsDeadline = Duration.ofSeconds(10);
-        CompletableFuture<List<Enr>> elFuture = CompletableFuture.supplyAsync(
-                () -> dnsResolver.resolveAllFromStrings(network.elEnrTreeUrls(), dnsDeadline));
-        CompletableFuture<List<Enr>> clFuture = CompletableFuture.supplyAsync(
-                () -> dnsResolver.resolveAllFromStrings(network.clEnrTreeUrls(), dnsDeadline));
-        List<Enr> dnsElEnrs = elFuture.join();
-        List<Enr> dnsClEnrs = clFuture.join();
+        // 4. The network's full stack. EL port honors the legacy --port flag (default
+        //    30303); CL discv5 stays 9000 and verified JSON-RPC stays 8545 — unchanged
+        //    single-network behavior. (Per-network default ports kick in once the
+        //    registry runs several stacks at once.)
+        ChainStack stack = new ChainStack(
+                network,
+                new ChainPorts(port, 9000, 8545),
+                nodeKey,
+                new PeerCacheAdapter(peerCache),
+                new ClPeerCacheAdapter(clPeerCache),
+                new com.jaeckel.ethp2p.app.rpc.JavaHttpCcipGateway(),
+                syncSnapshotFile(network.name()),
+                gossipsubEnabled);
 
-        List<InetSocketAddress> mergedBootnodes = new ArrayList<>(network.bootnodes());
-        // Dedupe by (host, port) so trees that overlap with the hardcoded list
-        // (or contain internal duplicates) don't produce repeated dial attempts.
-        Set<String> seenHostPort = new java.util.HashSet<>();
-        for (InetSocketAddress sa : mergedBootnodes) {
-            seenHostPort.add(sa.getAddress().getHostAddress() + ":" + sa.getPort());
-        }
-        int bootnodesBeforeDns = mergedBootnodes.size();
-        for (Enr enr : dnsElEnrs) {
-            // discv4 speaks UDP; fall back to the TCP endpoint only if UDP is missing.
-            enr.udpAddress().or(enr::tcpAddress).ifPresent(sa -> {
-                String key = sa.getAddress().getHostAddress() + ":" + sa.getPort();
-                if (seenHostPort.add(key)) mergedBootnodes.add(sa);
-            });
-        }
-        if (mergedBootnodes.size() > bootnodesBeforeDns) {
-            log.info("[main] DNS discovery added {} EL bootnode(s) (total: {})",
-                    mergedBootnodes.size() - bootnodesBeforeDns, mergedBootnodes.size());
-        }
-
-        // 4. RLPx connector
-        Set<String> attempted = ConcurrentHashMap.newKeySet();
-        Map<String, Long> backoff = new ConcurrentHashMap<>();
-        Set<String> blacklistedNodeIds = ConcurrentHashMap.newKeySet();
-        RLPxConnector connector = new RLPxConnector(nodeKey, port, network, headers -> {
-            if (!headers.isEmpty()) {
-                log.info("\n=== BLOCK HEADERS RECEIVED ===");
-                for (BlockHeadersMessage.VerifiedHeader vh : headers) {
-                    BlockHeader h = vh.header();
-                    log.info("  Block #{}", h.number);
-                    log.info("  Hash:      {}", vh.hash().toHexString());
-                    log.info("  StateRoot: {}", h.stateRoot.toHexString());
-                    log.info("  TxRoot:    {}", h.transactionsRoot.toHexString());
-                    if (h.baseFeePerGas != null) {
-                        log.info("  BaseFee:   {} gwei",
-                                h.baseFeePerGas.divide(java.math.BigInteger.valueOf(1_000_000_000L)));
-                    }
-                }
-            }
-        }, peerCache::add);
-
-        // 5. Connect to cached peers immediately
-        List<PeerCache.CachedPeer> cached = peerCache.load();
-        // Reconnect snap/1-capable peers first so state queries (get-account,
-        // get-storage) have a snap peer available sooner after a restart. Within
-        // the snap set, peers proven to serve proofs (CONFIRMED) come ahead of
-        // unproven ones, and known hangers (DENIED) come last — so a restart
-        // converges on a working snap peer instead of re-timing-out the bad
-        // ones first (mirrors NodeService's snapDialRank ordering).
-        cached.sort(java.util.Comparator.comparingInt(Main::snapDialRank));
-        for (PeerCache.CachedPeer peer : cached) {
-            String peerKey = peer.address().getAddress().getHostAddress()
-                    + ":" + peer.address().getPort();
-            attempted.add(peerKey);
-            try {
-                SECP256K1.PublicKey pubKey = SECP256K1.PublicKey.fromBytes(
-                        Bytes.fromHexString(peer.publicKeyHex()));
-                log.info("[main] Connecting to cached peer {}", peer.address());
-                connector.connect(peer.address(), pubKey, (incompatible, nodeIdHex) -> {
-                            if (incompatible) {
-                                blacklistedNodeIds.add(nodeIdHex);
-                                log.info("[main] Blacklisted node {} (incompatible network, cached peer)", nodeIdHex.substring(0, 16) + "...");
-                            }
-                            long backoffMs = incompatible ? BACKOFF_INCOMPATIBLE_MS : BACKOFF_TRANSIENT_MS;
-                            backoff.putIfAbsent(peerKey, System.currentTimeMillis() + backoffMs);
-                            attempted.remove(peerKey);
-                        })
-                        .addListener(future -> {
-                            if (!future.isSuccess()) {
-                                // Don't blacklist cached peers on first attempt
-                                attempted.remove(peerKey);
-                            }
-                        });
-            } catch (Exception e) {
-                log.warn("[main] Failed to connect to cached peer {}: {}",
-                        peer.address(), e.getMessage());
-                attempted.remove(peerKey);
-            }
-        }
-
-        // 5b. Directly RLPx-dial DNS-resolved EL enodes (EIP-1459), bypassing discv4.
-        // discv4's endpoint proof needs the remote to send us an *unsolicited* inbound
-        // PING before it returns NEIGHBORS — which QEMU/SLIRP user-mode NAT (the Android
-        // emulator's default) silently drops, so discv4 never bootstraps there. RLPx is
-        // an *outbound* TCP connection, which SLIRP allows, and the ENR carries the
-        // peer's secp256k1 key + TCP endpoint — everything connect() needs. So we get
-        // EL/snap peers on the emulator with no discv4 and no TAP networking. Harmless
-        // on the daemon (just a faster warm start). Capped so this doesn't become a dial
-        // storm on platforms where discv4 already populates the table.
-        int directDialed = 0;
-        for (Enr enr : dnsElEnrs) {
-            if (directDialed >= DNS_DIRECT_DIAL_LIMIT) break;
-            // Whole body guarded so a single malformed ENR can't abort the loop;
-            // getHostString() avoids an NPE if the ENR address is unresolved.
-            String peerKey = null;
-            try {
-                Optional<InetSocketAddress> tcp = enr.tcpAddress();
-                Optional<SECP256K1.PublicKey> pub = enr.publicKey();
-                if (tcp.isEmpty() || pub.isEmpty()) continue;
-                InetSocketAddress peerTcp = tcp.get();
-                peerKey = peerTcp.getHostString() + ":" + peerTcp.getPort();
-                if (!attempted.add(peerKey)) continue;
-                directDialed++;
-                final String key = peerKey;
-                log.info("[main] Direct RLPx dial of DNS EL enode {}", peerTcp);
-                connector.connect(peerTcp, pub.get(), (incompatible, nodeIdHex) -> {
-                            if (incompatible) {
-                                blacklistedNodeIds.add(nodeIdHex);
-                            }
-                            long backoffMs = incompatible ? BACKOFF_INCOMPATIBLE_MS : BACKOFF_TRANSIENT_MS;
-                            backoff.putIfAbsent(key, System.currentTimeMillis() + backoffMs);
-                            attempted.remove(key);
-                        })
-                        .addListener(future -> {
-                            if (!future.isSuccess()) attempted.remove(key);
-                        });
-            } catch (Exception e) {
-                log.warn("[main] Failed direct dial of DNS EL enode: {}", e.getMessage());
-                if (peerKey != null) attempted.remove(peerKey);
-            }
-        }
-        if (directDialed > 0) {
-            log.info("[main] Direct-dialed {} DNS EL enode(s) (discv4-independent path)", directDialed);
-        }
-
-        // 6. discv4 discovery
-        DiscV4Service discV4 = new DiscV4Service(nodeKey, mergedBootnodes, entry -> {
-            // Pause acquiring NEW peers while an ENS resolution is running: its
-            // snap round-trips share the event loop with outbound dials, and a
-            // dial burst inflates resolution latency. Existing peers stay.
-            if (connector.isSnapHeavy()) return;
-            if (entry.tcpPort() > 0 && attempted.size() < 2000) {
-                String nodeIdHex = entry.nodeId().toHexString();
-                if (blacklistedNodeIds.contains(nodeIdHex)) {
-                    log.debug("[main] Skipping blacklisted node {}", nodeIdHex.substring(0, 16) + "...");
-                    return;
-                }
-                String peerKey = entry.udpAddr().getAddress().getHostAddress()
-                        + ":" + entry.tcpPort();
-                Long expiry = backoff.get(peerKey);
-                if (expiry != null) {
-                    if (System.currentTimeMillis() < expiry) return;
-                    backoff.remove(peerKey);
-                }
-                if (attempted.add(peerKey)) {
-                    InetSocketAddress peerTcp = new InetSocketAddress(
-                            entry.udpAddr().getAddress(), entry.tcpPort());
-                    log.info("[main] Attempting RLPx connection to {}", peerTcp);
-                    tryConnectWithKnownKey(connector, entry, peerTcp, nodeKey, attempted, peerKey, backoff, blacklistedNodeIds);
-                }
-            }
-        });
-
-        try {
-            discV4.start(port);
-        } catch (Exception e) {
-            Throwable cause = e instanceof BindException ? e : e.getCause();
-            if (cause instanceof BindException) {
-                System.err.println("Cannot bind UDP port " + port + ": " + cause.getMessage());
-                System.err.println("Is another instance already running?");
-            } else {
-                System.err.println("Failed to start discovery: " + e.getMessage());
-            }
-            fileLock.release();
-            lockChannel.close();
+        if (!stack.start()) {
+            System.err.println("Failed to start " + network.name() + " node stack");
+            try { fileLock.release(); lockChannel.close(); } catch (Exception ignored) {}
             System.exit(1);
             return;
         }
-        log.info("[daemon] discv4 started on UDP port {}. Waiting for peers...", port);
 
-        // Beacon light client scaffolding (moved ahead of discv5 so its callback can
-        // write to CLPeerCache as peers are discovered).
-        BeaconSyncState beaconSyncState = new BeaconSyncState();
-        CLPeerCache clPeerCache = new CLPeerCache(clCacheFile(network.name()));
-
-        // 6b. discv5 — the canonical CL peer discovery mechanism. Runs on a separate
-        // UDP port from discv4 (default 9000, matching CL libp2p convention). The
-        // callback filters to ENRs carrying the eth2 field with a matching fork digest,
-        // converts to a libp2p multiaddr, and writes to CLPeerCache so the next
-        // daemon start seeds BeaconLightClient with a refreshed list.
-        //
-        // Runtime integration with the running BLC is a follow-up: BLC freezes its
-        // peer list at construction. The feedback loop is one daemon restart today.
-        List<byte[]> acceptedForkDigests = network.acceptedForkDigests();
-        log.info("[discv5] accepted fork_digests for network {}: {}",
-                network.name(),
-                acceptedForkDigests.stream()
-                        .map(d -> "0x" + java.util.HexFormat.of().formatHex(d))
-                        .toList());
-        // Log the first few mismatches so we can tell whether the filter is
-        // rejecting every peer (wrong expected digest?) vs. no peers arriving.
-        java.util.concurrent.atomic.AtomicInteger mismatchesLogged =
-                new java.util.concurrent.atomic.AtomicInteger();
-        // Discovered peers land here; BLC is constructed a few lines below and
-        // has this reference set once it's up so the discv5 callback can feed
-        // fresh peers directly into its live pool, not just the on-disk cache.
-        java.util.concurrent.atomic.AtomicReference<BeaconLightClient> blcRef =
-                new java.util.concurrent.atomic.AtomicReference<>();
-        DiscV5Service discV5 = new DiscV5Service(nodeKey, network.clDiscv5Bootnodes(), enr -> {
-            var eth2 = enr.eth2();
-            if (eth2.isEmpty()) return;
-            byte[] peerDigest = eth2.get().forkDigest();
-            int matchIdx = -1;
-            for (int i = 0; i < acceptedForkDigests.size(); i++) {
-                if (java.util.Arrays.equals(peerDigest, acceptedForkDigests.get(i))) {
-                    matchIdx = i;
-                    break;
-                }
-            }
-            if (matchIdx < 0) {
-                int n = mismatchesLogged.incrementAndGet();
-                if (n <= 5) {
-                    log.info("[discv5] eth2 peer fork_digest=0x{} not in accepted set — rejected{}",
-                            java.util.HexFormat.of().formatHex(peerDigest),
-                            n == 5 ? " [further mismatch logs suppressed]" : "");
-                }
-                return;
-            }
-            final int mi = matchIdx;
-            enr.toLibp2pMultiaddr().ifPresent(ma -> {
-                String tier = mi == 0 ? "current" : "prior";
-                clPeerCache.add(ma);
-                BeaconLightClient blc = blcRef.get();
-                boolean liveAdded = blc != null && blc.addPeer(ma);
-                log.info("[discv5] CL peer {} (fork_digest {} match){}", ma, tier,
-                        liveAdded ? " → live pool" : "");
-            });
-        });
-        try {
-            discV5.start(9000);
-        } catch (Throwable t) {
-            // Catch Throwable, not Exception: earlier we hit a NoClassDefFoundError
-            // (library static-init) which slipped past an Exception handler and
-            // killed the main thread while the Netty event loop kept the JVM alive
-            // — the daemon lock stayed held but the IPC socket never got created.
-            // discv5 is non-essential; EL keeps working and CL falls back to the
-            // cache + hardcoded seed list.
-            log.warn("[discv5] failed to start, continuing without CL discovery: {}", t.toString());
-        }
-
-        // 7. Beacon light client (consensus layer, runs on virtual thread)
-        List<String> clPeers = new java.util.ArrayList<>(clPeerCache.load());
-        // Append configured peers after cached ones (cached peers are tried first)
-        for (String peer : network.clPeerMultiaddrs()) {
-            if (!clPeers.contains(peer)) clPeers.add(peer);
-        }
-        // Append DNS-discovered CL peers (from enrtree:// resolution above). Deduped
-        // against cached + configured entries.
-        int clPeersBeforeDns = clPeers.size();
-        for (Enr enr : dnsClEnrs) {
-            enr.toLibp2pMultiaddr().ifPresent(ma -> {
-                if (!clPeers.contains(ma)) clPeers.add(ma);
-            });
-        }
-        if (clPeers.size() > clPeersBeforeDns) {
-            log.info("[main] DNS discovery added {} CL peer(s) (total: {})",
-                    clPeers.size() - clPeersBeforeDns, clPeers.size());
-        }
-        BeaconLightClient beaconLightClient = new BeaconLightClient(
-                clPeers,
-                network.checkpointRoot(),
-                network.checkpointSlot(),
-                network.currentForkVersion(),
-                network.genesisValidatorsRoot(),
-                beaconSyncState,
-                network.beaconApiUrl(),
-                clPeerCache::add,
-                clPeerCache::markFailure,
-                network.clGenesisTime());
-        // EIP-7892: apply active BPO blob-parameters so compute_fork_digest
-        // folds them in per the Fulu spec (XOR of base fork_data_root[0..4]
-        // with sha256(u64_le(epoch)||u64_le(max_blobs))[0..4]).
-        beaconLightClient.setBlobParameters(
-                network.activeBlobParamsEpoch(),
-                network.activeBlobParamsMaxBlobs());
-        // Network slot-timing preset (mainnet 12s/32, Gnosis 5s/16). Affects
-        // wall-clock sync-committee period estimation and Status finalized_epoch.
-        beaconLightClient.setBeaconPreset(network.secondsPerSlot(), network.slotsPerEpoch());
-        // Prefer peers proven to serve catch-up last session (seeded with the
-        // period they served), and persist new ones, so restarts target peers
-        // that actually retain the checkpoint period instead of discovery noise.
-        beaconLightClient.setProvenCatchUpServers(clPeerCache.servedRanges());
-        beaconLightClient.setOnCatchUpServed(clPeerCache::recordServed);
-        // Persist which peer served the bootstrap (and for which period) so a restart
-        // front-loads a proven light-client server instead of re-fanning discovery.
-        beaconLightClient.setProvenBootstrapPeers(clPeerCache.bootstrapPeers());
-        beaconLightClient.setOnBootstrapServed(clPeerCache::recordBootstrap);
-        // Seed light_client-capability verdicts from last session and persist new ones, so a
-        // restart dials confirmed light-client servers first and deprioritizes peers proven
-        // not to serve LC — instead of re-Identifying the whole fork-matched cache.
-        beaconLightClient.setProvenLightClient(clPeerCache.lightClientConfirmed());
-        beaconLightClient.setProvenNonLightClient(clPeerCache.lightClientDenied());
-        beaconLightClient.setOnLightClientVerdict(clPeerCache::markLightClientBatch);
-        // Persist/resume verified sync-committee state so restarts resume from the
-        // last verified period and only catch up the delta (architecture-doc §
-        // "recent sync committee data persisted locally"). purge-cache removes it.
-        beaconLightClient.setSnapshotFile(syncSnapshotFile(network.name()));
-        // Off by default (short-session clients churn the mesh). Enable
-        // with `-Pgossipsub=true` via gradle or `--gossipsub` on the CLI.
-        beaconLightClient.setGossipsubEnabled(gossipsubEnabled);
-        if (gossipsubEnabled) {
-            log.info("[main] Gossipsub subscription ENABLED (observation-only)");
-        }
-        // Publish to discv5 callback; any eth2-matching ENRs seen from here on
-        // out get added to BLC's live peer pool (not just the on-disk cache).
-        blcRef.set(beaconLightClient);
-        beaconLightClient.start();
-        log.info("[daemon] Beacon light client started with {} CL peer(s) ({} cached)",
-                clPeers.size(), clPeers.size() - network.clPeerMultiaddrs().size());
-
-        // 8. IPC server
-        CommandHandler commandHandler = new CommandHandler(discV4, discV5, connector, stopLatch, backoff, blacklistedNodeIds, beaconSyncState, beaconLightClient, network.clGenesisTime(), network.secondsPerSlot());
+        // 5. IPC server over the stack's live components.
+        CommandHandler commandHandler = new CommandHandler(
+                stack.discV4(), stack.discV5(), stack.connector(), stopLatch,
+                stack.backoff(), stack.blacklistedNodeIds(),
+                stack.beaconSyncState(), stack.beaconLightClient(),
+                network.clGenesisTime(), network.secondsPerSlot());
         DaemonServer server = new DaemonServer(socketPath, commandHandler);
         try {
             server.start();
-        } catch (BindException e) {
-            System.err.println("Cannot bind IPC socket " + socketPath + ": " + e.getMessage());
-            System.err.println("Is another instance already running?");
-            beaconLightClient.close();
-            connector.close();
-            discV5.close();
-            discV4.close();
-            fileLock.release();
-            lockChannel.close();
-            System.exit(1);
-            return;
         } catch (Exception e) {
             System.err.println("Failed to start IPC server: " + e.getMessage());
-            beaconLightClient.close();
-            connector.close();
-            discV5.close();
-            discV4.close();
-            fileLock.release();
-            lockChannel.close();
+            stack.shutdown();
+            try { fileLock.release(); lockChannel.close(); } catch (Exception ignored) {}
             System.exit(1);
             return;
         }
 
-        // 8b. Verified JSON-RPC endpoint: the shared VerifiedRpcBackend (same
-        // implementation the Android app hosts in NodeService) served over the
-        // Ktor MyotisRpcServer. Bound loopback-only — the endpoint is
-        // unauthenticated and TLS-less, so it must not be exposed on a routable
-        // interface — and STRICT (null upstream): the daemon never proxies; a
-        // method that can't be answered cryptographically verified errors.
-        // Best-effort: if port 8545 is taken (another node / dev tool), the
-        // daemon keeps running without RPC instead of crashing.
-        io.myotis.rpc.VerifiedRpcBackend rpcBackendTmp = null;
-        io.myotis.jsonrpc.MyotisRpcServer rpcServerTmp = null;
-        try {
-            // Deterministic port check up front: Ktor's CIO engine surfaces a bind
-            // failure asynchronously, which a try/catch around start() can miss.
-            try (java.net.ServerSocket probe = new java.net.ServerSocket()) {
-                probe.setReuseAddress(true);
-                probe.bind(new InetSocketAddress("127.0.0.1", 8545));
-            }
-            // Persist per-peer snap-serving verdicts into the EL peer cache so
-            // proven snap-servers are dialed first on restart and repeat hangers
-            // are deprioritized (same wiring as NodeService → AndroidPeerCache).
-            io.myotis.rpc.SnapQualitySink snapQualitySink = new io.myotis.rpc.SnapQualitySink() {
-                @Override public void recordSnapServed(InetSocketAddress address) {
-                    peerCache.recordSnapServed(address);
-                }
-                @Override public void recordSnapFailure(InetSocketAddress address) {
-                    peerCache.recordSnapFailure(address);
-                }
-            };
-            io.myotis.rpc.RpcLogger rpcLogger = new io.myotis.rpc.RpcLogger() {
-                @Override public void info(String message) { log.info(message); }
-                @Override public void warn(String message) { log.warn(message); }
-            };
-            io.myotis.rpc.VerifiedRpcBackend backend = new io.myotis.rpc.VerifiedRpcBackend(
-                    connector, beaconLightClient, beaconSyncState,
-                    new com.jaeckel.ethp2p.app.rpc.JavaHttpCcipGateway(),
-                    rpcLogger, io.myotis.rpc.RpcClock.monotonic(), snapQualitySink);
-            try {
-                // start() spins up the head warmer; a throw here (or in the server
-                // start below) must still close the backend so its threads don't leak.
-                backend.start();
-                io.myotis.jsonrpc.MyotisRpcServer rpcServer =
-                        new io.myotis.jsonrpc.MyotisRpcServer(8545, null, "127.0.0.1", backend);
-                rpcServer.start();
-                rpcServerTmp = rpcServer;
-                rpcBackendTmp = backend;
-                log.info("JSON-RPC listening on http://127.0.0.1:8545 (verified, strict)");
-            } catch (Throwable serverEx) {
-                backend.close();
-                throw serverEx;
-            }
-        } catch (java.io.IOException bindEx) {
-            log.warn("[rpc] port 8545 unavailable ({}); continuing without JSON-RPC",
-                    bindEx.getMessage());
-        } catch (Throwable t) {
-            log.warn("[rpc] failed to start JSON-RPC server; continuing without it: {}",
-                    t.toString());
-        }
-        final io.myotis.rpc.VerifiedRpcBackend rpcBackend = rpcBackendTmp;
-        final io.myotis.jsonrpc.MyotisRpcServer rpcServer = rpcServerTmp;
-
-        // 9. Shutdown hook for Ctrl-C / SIGTERM — cleanup happens here
-        //    because the JVM may exit before the main thread resumes after await().
+        // 6. Shutdown hook for Ctrl-C / SIGTERM — cleanup happens here because the JVM
+        //    may exit before the main thread resumes after await().
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             log.info("[daemon] Shutdown hook triggered");
-            // Stop the RPC endpoint first so the port frees and no in-flight
-            // request builds against torn-down components.
-            if (rpcServer != null) {
-                try { rpcServer.stop(); } catch (Throwable ignored) {}
-            }
-            if (rpcBackend != null) {
-                try { rpcBackend.close(); } catch (Throwable ignored) {}
-            }
-            beaconLightClient.close();
-            server.close();
-            connector.close();
-            discV5.close();
-            discV4.close();
-            peerCache.close();   // last: drain queued cache writes after the final add()
+            stack.shutdown();
+            try { server.close(); } catch (Throwable ignored) {}
             try { fileLock.release(); lockChannel.close(); } catch (Exception ignored) {}
             stopLatch.countDown();
             log.info("[daemon] Done.");
         }, "shutdown-hook"));
 
-        // 9. Block until "stop" command or signal
+        // 7. Block until "stop" command or signal, then clean up (the hook covers the
+        //    Ctrl-C/SIGTERM path).
         stopLatch.await();
-
-        // Cleanup for graceful "stop" command (shutdown hook handles Ctrl-C/SIGTERM)
-        if (rpcServer != null) {
-            try { rpcServer.stop(); } catch (Throwable ignored) {}
-        }
-        if (rpcBackend != null) {
-            try { rpcBackend.close(); } catch (Throwable ignored) {}
-        }
-        beaconLightClient.close();
-        server.close();
-        connector.close();
-        discV5.close();
-        discV4.close();
-        peerCache.close();
+        stack.shutdown();
+        try { server.close(); } catch (Throwable ignored) {}
         try { fileLock.release(); lockChannel.close(); } catch (Exception ignored) {}
         log.info("[daemon] Done.");
     }
@@ -669,22 +251,6 @@ public final class Main {
     // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
-
-    /**
-     * Dial-priority rank for a cached peer (lower = dialed first): proven
-     * snap-servers, then snap-capable-but-unproven, then known snap hangers, then
-     * plain-eth peers. Denied snap peers still outrank non-snap peers — state
-     * roots change, so a peer that couldn't serve an old pivot may serve the
-     * current head, and it's still snap-capable. Mirrors NodeService.snapDialRank.
-     */
-    private static int snapDialRank(PeerCache.CachedPeer p) {
-        if (!p.snap()) return 3;
-        return switch (p.snapQuality()) {
-            case CONFIRMED -> 0;
-            case UNKNOWN -> 1;
-            case DENIED -> 2;
-        };
-    }
 
     /**
      * Check if a daemon is actually listening on the socket.
@@ -724,46 +290,5 @@ public final class Main {
             try { Files.deleteIfExists(socketPath); } catch (Exception ignored) {}
         }
         return false;
-    }
-
-    /**
-     * In discv4, the Neighbors response includes 64-byte node IDs (public keys).
-     * We reconstruct the SECP256K1 public key and attempt connection.
-     */
-    private static void tryConnectWithKnownKey(
-            RLPxConnector connector, KademliaTable.Entry entry,
-            InetSocketAddress peerTcp, NodeKey localKey,
-            Set<String> attempted, String peerKey,
-            Map<String, Long> backoff, Set<String> blacklistedNodeIds) {
-        try {
-            Bytes nodeId = entry.nodeId();
-            if (nodeId.size() != 64) {
-                log.warn("[main] Node ID is not 64 bytes ({}b), skipping", nodeId.size());
-                attempted.remove(peerKey);
-                return;
-            }
-            SECP256K1.PublicKey peerPubkey = SECP256K1.PublicKey.fromBytes(nodeId);
-            connector.connect(peerTcp, peerPubkey, (incompatible, nodeIdHex) -> {
-                        if (incompatible) {
-                            blacklistedNodeIds.add(nodeIdHex);
-                            log.info("[main] Blacklisted node {} (incompatible network)", nodeIdHex.substring(0, 16) + "...");
-                        }
-                        long backoffMs = incompatible ? BACKOFF_INCOMPATIBLE_MS : BACKOFF_TRANSIENT_MS;
-                        backoff.putIfAbsent(peerKey, System.currentTimeMillis() + backoffMs);
-                        attempted.remove(peerKey);
-                    })
-                    .addListener(future -> {
-                        if (!future.isSuccess()) {
-                            log.warn("[main] Connection to {} failed: {}",
-                                    peerTcp, future.cause().getMessage());
-                            backoff.putIfAbsent(peerKey, System.currentTimeMillis() + BACKOFF_TRANSIENT_MS);
-                            attempted.remove(peerKey);
-                        }
-                    });
-        } catch (Exception e) {
-            log.warn("[main] Failed to connect to {}: {}", peerTcp, e.getMessage());
-            backoff.putIfAbsent(peerKey, System.currentTimeMillis() + BACKOFF_TRANSIENT_MS);
-            attempted.remove(peerKey);
-        }
     }
 }

--- a/app/src/main/java/com/jaeckel/ethp2p/app/Main.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/Main.java
@@ -4,6 +4,7 @@ import com.jaeckel.ethp2p.core.crypto.NodeKey;
 import com.jaeckel.ethp2p.networking.NetworkConfig;
 import io.myotis.node.ChainPorts;
 import io.myotis.node.ChainStack;
+import io.myotis.node.NodeRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,33 +28,30 @@ import java.util.concurrent.CountDownLatch;
  *   # Start daemon (blocks; creates /tmp/ethp2p.sock):
  *   ./gradlew :app:run
  *
- *   # Send a command to the running daemon (from a second terminal):
+ *   # Host several networks in ONE process, each on its own ports + IPC socket:
+ *   ./gradlew :app:run -Pnetwork=mainnet,gnosis
+ *
+ *   # Send a command to a running daemon (targets one network's socket):
  *   ./gradlew :app:run -Pargs=status
- *   ./gradlew :app:run -Pargs=peers
- *   ./gradlew :app:run -Pargs="get-headers 21000000 3"
+ *   ./gradlew :app:run -Pnetwork=gnosis -Pargs=beacon-status
  *   ./gradlew :app:run -Pargs=stop
  *
- *   # Purge cached peers:
+ *   # Purge cached peers / use a testnet:
  *   ./gradlew :app:run -Pargs=purge-cache
- *
- *   # Use a testnet (default: mainnet):
  *   ./gradlew :app:run -Pnetwork=sepolia
- *   ./gradlew :app:run -Pnetwork=sepolia -Pargs=peers
- *
- *   # Or use nc directly:
- *   echo '{"cmd":"status"}' | nc -U /tmp/ethp2p.sock
  * </pre>
  *
  * <h2>Behaviour</h2>
  * <ul>
- *   <li>If the IPC socket exists → client mode: send one command, print response, exit.
- *   <li>If the IPC socket is absent → daemon mode: run discovery + RLPx, serve commands.
+ *   <li>With command args → client mode: send one command to the (first) network's
+ *       socket, print the response, exit.
+ *   <li>Without args → daemon mode: host every {@code --network} in this process.
  * </ul>
  *
- * <p>The per-network node stack (EL + discv4 + discv5 + beacon light client + verified
+ * <p>Each network's node stack (EL + discv4 + discv5 + beacon light client + verified
  * JSON-RPC) lives in {@link ChainStack} (module {@code :node-core}), shared with the
- * Android app. This class owns the daemon-specific shell: the lock file, the Unix-socket
- * IPC server, and the shutdown latch.
+ * Android app, and is held by a {@link NodeRegistry}. This class owns the daemon shell:
+ * the per-network lock files + Unix-socket IPC servers, and the shutdown latch.
  */
 public final class Main {
 
@@ -91,16 +89,30 @@ public final class Main {
         return cacheFile(networkName).resolveSibling("sync-state" + suffix + ".snapshot");
     }
 
+    /**
+     * Node-identity key file. A single-network daemon keeps the shared {@code nodekey.hex}
+     * (unchanged). When hosting several networks in one process each gets a distinct key
+     * ({@code nodekey-<net>.hex}; mainnet keeps {@code nodekey.hex}) so each advertises its
+     * own ENR/fork-id instead of colliding under one node id in the discovery DHTs.
+     */
+    static Path nodeKeyFile(String networkName, boolean perNetwork) {
+        if (!perNetwork || "mainnet".equals(networkName)) return Path.of("nodekey.hex");
+        return Path.of("nodekey-" + networkName + ".hex");
+    }
+
 
     public static void main(String[] args) throws Exception {
-        // Parse --network and --port flags from anywhere in args
-        String networkName = "mainnet";
+        // Parse --network (comma-separated list), --port, --gossipsub from anywhere in args.
+        List<String> networkNames = new ArrayList<>();
         int port = DEFAULT_PORT;
         boolean gossipsubEnabled = false;
         List<String> remaining = new ArrayList<>();
         for (int i = 0; i < args.length; i++) {
             if ("--network".equals(args[i]) && i + 1 < args.length) {
-                networkName = args[++i];
+                for (String n : args[++i].split(",")) {
+                    String trimmed = n.trim();
+                    if (!trimmed.isEmpty() && !networkNames.contains(trimmed)) networkNames.add(trimmed);
+                }
             } else if ("--port".equals(args[i]) && i + 1 < args.length) {
                 port = Integer.parseInt(args[++i]);
             } else if ("--gossipsub".equals(args[i])) {
@@ -109,6 +121,7 @@ public final class Main {
                 remaining.add(args[i]);
             }
         }
+        if (networkNames.isEmpty()) networkNames.add("mainnet");
         // System property fallback so Android / other embedders can opt in
         // without touching CLI args.
         if (!gossipsubEnabled
@@ -117,17 +130,18 @@ public final class Main {
         }
         String[] cmdArgs = remaining.toArray(new String[0]);
 
-        Path socketPath = socketPath(networkName);
-        Path lockPath = lockPath(networkName);
-        boolean daemonAlive = isDaemonRunning(socketPath, lockPath);
+        // Client commands / purge target a single network — the first listed.
+        String primary = networkNames.get(0);
+        Path primarySocket = socketPath(primary);
+        Path primaryLock = lockPath(primary);
 
         // Handle purge-cache before socket check — works without a running daemon
         if (cmdArgs.length > 0 && "purge-cache".equals(cmdArgs[0])) {
-            PeerCache.purge(cacheFile(networkName));
-            CLPeerCache.purge(clCacheFile(networkName));
+            PeerCache.purge(cacheFile(primary));
+            CLPeerCache.purge(clCacheFile(primary));
             try {
-                if (java.nio.file.Files.deleteIfExists(syncSnapshotFile(networkName))) {
-                    System.out.println("Sync snapshot purged: " + syncSnapshotFile(networkName));
+                if (java.nio.file.Files.deleteIfExists(syncSnapshotFile(primary))) {
+                    System.out.println("Sync snapshot purged: " + syncSnapshotFile(primary));
                 }
             } catch (java.io.IOException e) {
                 System.err.println("Failed to purge sync snapshot: " + e.getMessage());
@@ -136,116 +150,152 @@ public final class Main {
         }
 
         if (cmdArgs.length > 0) {
-            // ── Client mode ──────────────────────────────────────────────────
-            if (!daemonAlive) {
-                System.err.println("Daemon not running (cannot connect to: " + socketPath + ")");
+            // ── Client mode (single network) ─────────────────────────────────
+            if (!isDaemonRunning(primarySocket, primaryLock)) {
+                System.err.println("Daemon not running (cannot connect to: " + primarySocket + ")");
                 System.err.println("Start the daemon first: ./gradlew :app:run");
                 System.exit(1);
             }
-            DaemonClient.sendCommand(cmdArgs, socketPath);
-        } else if (daemonAlive) {
-            // ── Daemon already running ────────────────────────────────────────
-            System.err.println("Daemon already running (socket: " + socketPath + ")");
-            System.err.println("Commands:");
-            System.err.println("  ./gradlew :app:run -Pargs=status");
-            System.err.println("  ./gradlew :app:run -Pargs=peers");
-            System.err.println("  ./gradlew :app:run -Pargs=\"get-headers 21000000 3\"");
-            System.err.println("  ./gradlew :app:run -Pargs=stop");
-            System.err.println("  ./gradlew :app:run -Pargs=purge-cache");
-            System.exit(1);
-        } else {
-            // ── Daemon mode ──────────────────────────────────────────────────
-            NetworkConfig network = NetworkConfig.byName(networkName);
-            runDaemon(socketPath, lockPath, network, port, gossipsubEnabled);
+            DaemonClient.sendCommand(cmdArgs, primarySocket);
+            return;
         }
+
+        // ── Daemon mode (one or more networks in this process) ───────────────
+        List<NetworkConfig> networks = new ArrayList<>();
+        for (String n : networkNames) networks.add(NetworkConfig.byName(n));
+        for (NetworkConfig net : networks) {
+            if (isDaemonRunning(socketPath(net.name()), lockPath(net.name()))) {
+                System.err.println("Daemon already running for " + net.name()
+                        + " (socket: " + socketPath(net.name()) + ")");
+                if (networks.size() == 1) {
+                    System.err.println("Commands:");
+                    System.err.println("  ./gradlew :app:run -Pargs=status");
+                    System.err.println("  ./gradlew :app:run -Pargs=peers");
+                    System.err.println("  ./gradlew :app:run -Pargs=stop");
+                }
+                System.exit(1);
+            }
+        }
+        runDaemon(networks, port, gossipsubEnabled);
     }
 
     // -------------------------------------------------------------------------
     // Daemon
     // -------------------------------------------------------------------------
 
-    private static void runDaemon(Path socketPath, Path lockPath, NetworkConfig network, int port,
+    private static void runDaemon(List<NetworkConfig> networks, int portOverride,
                                   boolean gossipsubEnabled) throws Exception {
-        log.info("=== ethp2p Daemon ({}) ===", network.name());
-        log.info("IPC socket: {}", socketPath);
+        boolean multi = networks.size() > 1;
+        log.info("=== ethp2p Daemon ({}) ===",
+                String.join(", ", networks.stream().map(NetworkConfig::name).toList()));
 
-        // 0. Acquire exclusive lock file — auto-released on process death (even kill -9)
-        FileChannel lockChannel = FileChannel.open(lockPath,
-                StandardOpenOption.CREATE, StandardOpenOption.WRITE);
-        FileLock fileLock = lockChannel.tryLock();
-        if (fileLock == null) {
-            System.err.println("Daemon already running (lock held: " + lockPath + ")");
-            lockChannel.close();
-            System.exit(1);
-            return;
+        // 0. Acquire every target network's exclusive lock up front; release all and
+        //    abort if any is held (another daemon already owns that network).
+        List<FileChannel> lockChannels = new ArrayList<>();
+        List<FileLock> fileLocks = new ArrayList<>();
+        for (NetworkConfig network : networks) {
+            FileChannel ch = FileChannel.open(lockPath(network.name()),
+                    StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+            FileLock lk = ch.tryLock();
+            if (lk == null) {
+                System.err.println("Daemon already running (lock held: " + lockPath(network.name()) + ")");
+                ch.close();
+                releaseAll(fileLocks, lockChannels);
+                System.exit(1);
+                return;
+            }
+            lockChannels.add(ch);
+            fileLocks.add(lk);
         }
 
-        // 1. Node identity (one network per daemon today → the shared nodekey.hex).
-        NodeKey nodeKey = NodeKey.loadOrGenerate(Path.of("nodekey.hex"));
-
-        // 2. Latch that triggers graceful shutdown (stop command or SIGTERM).
         CountDownLatch stopLatch = new CountDownLatch(1);
+        NodeRegistry registry = new NodeRegistry();
+        List<DaemonServer> servers = new ArrayList<>();
 
-        // 3. File-backed peer caches, exposed to ChainStack via adapters.
-        PeerCache peerCache = new PeerCache(cacheFile(network.name()));
-        CLPeerCache clPeerCache = new CLPeerCache(clCacheFile(network.name()));
+        // 1. Build, start, and IPC-wire each network's stack.
+        for (NetworkConfig network : networks) {
+            log.info("IPC socket ({}): {}", network.name(), socketPath(network.name()));
 
-        // 4. The network's full stack. EL port honors the legacy --port flag (default
-        //    30303); CL discv5 stays 9000 and verified JSON-RPC stays 8545 — unchanged
-        //    single-network behavior. (Per-network default ports kick in once the
-        //    registry runs several stacks at once.)
-        ChainStack stack = new ChainStack(
-                network,
-                new ChainPorts(port, 9000, 8545),
-                nodeKey,
-                new PeerCacheAdapter(peerCache),
-                new ClPeerCacheAdapter(clPeerCache),
-                new com.jaeckel.ethp2p.app.rpc.JavaHttpCcipGateway(),
-                syncSnapshotFile(network.name()),
-                gossipsubEnabled);
+            // Single-network stays byte-identical: legacy --port/30303 + discv5 9000 +
+            // RPC 8545 + shared nodekey.hex. Multi-network uses pinned per-network ports
+            // + per-network identity so the stacks don't collide.
+            ChainPorts ports = multi
+                    ? ChainPorts.defaultsFor(network)
+                    : new ChainPorts(portOverride, 9000, 8545);
+            NodeKey nodeKey = NodeKey.loadOrGenerate(nodeKeyFile(network.name(), multi));
 
-        if (!stack.start()) {
-            System.err.println("Failed to start " + network.name() + " node stack");
-            try { fileLock.release(); lockChannel.close(); } catch (Exception ignored) {}
-            System.exit(1);
-            return;
+            PeerCache peerCache = new PeerCache(cacheFile(network.name()));
+            CLPeerCache clPeerCache = new CLPeerCache(clCacheFile(network.name()));
+            ChainStack stack = new ChainStack(
+                    network, ports, nodeKey,
+                    new PeerCacheAdapter(peerCache),
+                    new ClPeerCacheAdapter(clPeerCache),
+                    new com.jaeckel.ethp2p.app.rpc.JavaHttpCcipGateway(),
+                    syncSnapshotFile(network.name()),
+                    gossipsubEnabled);
+
+            if (!stack.start()) {
+                System.err.println("Failed to start " + network.name() + " node stack");
+                registry.shutdownAll();
+                closeAll(servers);
+                releaseAll(fileLocks, lockChannels);
+                System.exit(1);
+                return;
+            }
+            registry.add(stack);
+
+            CommandHandler commandHandler = new CommandHandler(
+                    stack.discV4(), stack.discV5(), stack.connector(), stopLatch,
+                    stack.backoff(), stack.blacklistedNodeIds(),
+                    stack.beaconSyncState(), stack.beaconLightClient(),
+                    network.clGenesisTime(), network.secondsPerSlot());
+            DaemonServer server = new DaemonServer(socketPath(network.name()), commandHandler);
+            try {
+                server.start();
+            } catch (Exception e) {
+                System.err.println("Failed to start IPC server for " + network.name() + ": " + e.getMessage());
+                registry.shutdownAll();
+                closeAll(servers);
+                releaseAll(fileLocks, lockChannels);
+                System.exit(1);
+                return;
+            }
+            servers.add(server);
         }
 
-        // 5. IPC server over the stack's live components.
-        CommandHandler commandHandler = new CommandHandler(
-                stack.discV4(), stack.discV5(), stack.connector(), stopLatch,
-                stack.backoff(), stack.blacklistedNodeIds(),
-                stack.beaconSyncState(), stack.beaconLightClient(),
-                network.clGenesisTime(), network.secondsPerSlot());
-        DaemonServer server = new DaemonServer(socketPath, commandHandler);
-        try {
-            server.start();
-        } catch (Exception e) {
-            System.err.println("Failed to start IPC server: " + e.getMessage());
-            stack.shutdown();
-            try { fileLock.release(); lockChannel.close(); } catch (Exception ignored) {}
-            System.exit(1);
-            return;
-        }
-
-        // 6. Shutdown hook for Ctrl-C / SIGTERM — cleanup happens here because the JVM
-        //    may exit before the main thread resumes after await().
+        // 2. Shutdown hook for Ctrl-C / SIGTERM — cleanup happens here because the JVM
+        //    may exit before the main thread resumes after await(). A `stop` command on
+        //    ANY network's socket trips the shared latch and tears the whole process down.
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             log.info("[daemon] Shutdown hook triggered");
-            stack.shutdown();
-            try { server.close(); } catch (Throwable ignored) {}
-            try { fileLock.release(); lockChannel.close(); } catch (Exception ignored) {}
+            registry.shutdownAll();
+            closeAll(servers);
+            releaseAll(fileLocks, lockChannels);
             stopLatch.countDown();
             log.info("[daemon] Done.");
         }, "shutdown-hook"));
 
-        // 7. Block until "stop" command or signal, then clean up (the hook covers the
-        //    Ctrl-C/SIGTERM path).
+        // 3. Block until "stop" command or signal, then clean up (hook covers Ctrl-C).
         stopLatch.await();
-        stack.shutdown();
-        try { server.close(); } catch (Throwable ignored) {}
-        try { fileLock.release(); lockChannel.close(); } catch (Exception ignored) {}
+        registry.shutdownAll();
+        closeAll(servers);
+        releaseAll(fileLocks, lockChannels);
         log.info("[daemon] Done.");
+    }
+
+    private static void closeAll(List<DaemonServer> servers) {
+        for (DaemonServer s : servers) {
+            try { s.close(); } catch (Throwable ignored) {}
+        }
+    }
+
+    private static void releaseAll(List<FileLock> locks, List<FileChannel> channels) {
+        for (FileLock lk : locks) {
+            try { lk.release(); } catch (Exception ignored) {}
+        }
+        for (FileChannel ch : channels) {
+            try { ch.close(); } catch (Exception ignored) {}
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/app/src/main/java/com/jaeckel/ethp2p/app/PeerCacheAdapter.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/PeerCacheAdapter.java
@@ -1,0 +1,57 @@
+package com.jaeckel.ethp2p.app;
+
+import io.myotis.node.CachedPeer;
+import io.myotis.node.PeerCachePort;
+import io.myotis.node.SnapQuality;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Adapts the daemon's file-backed {@link PeerCache} to the {@link PeerCachePort}
+ * that {@code ChainStack} consumes, so {@code node-core} stays independent of the
+ * daemon module. Pure delegation plus a {@link PeerCache.SnapQuality} → shared
+ * {@link SnapQuality} mapping.
+ */
+public final class PeerCacheAdapter implements PeerCachePort {
+
+    private final PeerCache delegate;
+
+    public PeerCacheAdapter(PeerCache delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override public void add(InetSocketAddress address, String publicKeyHex, boolean snap) {
+        delegate.add(address, publicKeyHex, snap);
+    }
+
+    @Override public void recordSnapServed(InetSocketAddress address) {
+        delegate.recordSnapServed(address);
+    }
+
+    @Override public void recordSnapFailure(InetSocketAddress address) {
+        delegate.recordSnapFailure(address);
+    }
+
+    @Override public List<CachedPeer> load() {
+        List<PeerCache.CachedPeer> src = delegate.load();
+        List<CachedPeer> out = new ArrayList<>(src.size());
+        for (PeerCache.CachedPeer p : src) {
+            out.add(new CachedPeer(p.address(), p.publicKeyHex(), p.snap(), map(p.snapQuality())));
+        }
+        return out;
+    }
+
+    @Override public void close() {
+        delegate.close();
+    }
+
+    private static SnapQuality map(PeerCache.SnapQuality q) {
+        return switch (q) {
+            case CONFIRMED -> SnapQuality.CONFIRMED;
+            case UNKNOWN -> SnapQuality.UNKNOWN;
+            case DENIED -> SnapQuality.DENIED;
+        };
+    }
+}

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/NetworkConfig.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/NetworkConfig.java
@@ -400,6 +400,15 @@ public record NetworkConfig(
     }
 
     /**
+     * All supported networks, in display order. Drives multi-network UIs and the
+     * daemon's registry so adding a network here is the single point of expansion
+     * (the static instance + a {@link #byName} case + this list).
+     */
+    public static List<NetworkConfig> allNetworks() {
+        return List.of(MAINNET, GNOSIS, SEPOLIA);
+    }
+
+    /**
      * Beacon-chain slot time in seconds. Mainnet and the mainnet-preset testnets
      * use 12; Gnosis Beacon Chain uses 5. Used for wall-clock sync-committee period
      * estimation in the light client.
@@ -415,6 +424,41 @@ public record NetworkConfig(
      */
     public int slotsPerEpoch() {
         return networkId == 100 ? 16 : 32;
+    }
+
+    // -------------------------------------------------------------------------
+    // Per-network default ports. Pinned per network (not index-allocated) so a
+    // wallet pointed at a given RPC port always reaches the same chain regardless
+    // of which other networks are enabled, and so adding a network carries its own
+    // ports. Distinct across networks so several can run in one process without
+    // colliding. Mainnet keeps the historical 30303/9000/8545 (proven path).
+    // -------------------------------------------------------------------------
+
+    /** RLPx TCP + discv4 UDP port. */
+    public int defaultElPort() {
+        return switch ((int) networkId) {
+            case 100 -> 30304;       // gnosis
+            case 11155111 -> 30305;  // sepolia
+            default -> 30303;        // mainnet (and unknown)
+        };
+    }
+
+    /** Consensus-layer discv5 UDP port. */
+    public int defaultDiscv5Port() {
+        return switch ((int) networkId) {
+            case 100 -> 9001;       // gnosis
+            case 11155111 -> 9002;  // sepolia
+            default -> 9000;        // mainnet (and unknown)
+        };
+    }
+
+    /** Verified JSON-RPC HTTP port. */
+    public int defaultRpcPort() {
+        return switch ((int) networkId) {
+            case 100 -> 8546;       // gnosis
+            case 11155111 -> 8547;  // sepolia
+            default -> 8545;        // mainnet (and unknown)
+        };
     }
 
     // -------------------------------------------------------------------------

--- a/networking/src/test/java/com/jaeckel/ethp2p/networking/NetworkConfigPortsTest.java
+++ b/networking/src/test/java/com/jaeckel/ethp2p/networking/NetworkConfigPortsTest.java
@@ -1,0 +1,58 @@
+package com.jaeckel.ethp2p.networking;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Per-network default ports must be distinct across all networks so several
+ * stacks can run in one process without colliding, and mainnet must keep its
+ * historical 30303/9000/8545 (proven path).
+ */
+class NetworkConfigPortsTest {
+
+    @Test
+    void mainnetKeepsHistoricalPorts() {
+        NetworkConfig m = NetworkConfig.MAINNET;
+        assertEquals(30303, m.defaultElPort());
+        assertEquals(9000, m.defaultDiscv5Port());
+        assertEquals(8545, m.defaultRpcPort());
+    }
+
+    @Test
+    void gnosisRpcPortIsDistinct() {
+        assertEquals(8546, NetworkConfig.GNOSIS.defaultRpcPort());
+        assertEquals(30304, NetworkConfig.GNOSIS.defaultElPort());
+        assertEquals(9001, NetworkConfig.GNOSIS.defaultDiscv5Port());
+    }
+
+    @Test
+    void allNetworksHaveDistinctPortsAcrossEveryFamily() {
+        List<NetworkConfig> nets = NetworkConfig.allNetworks();
+        assertNoDuplicates(nets.stream().map(NetworkConfig::defaultElPort).toList(), "EL/discv4");
+        assertNoDuplicates(nets.stream().map(NetworkConfig::defaultDiscv5Port).toList(), "discv5");
+        assertNoDuplicates(nets.stream().map(NetworkConfig::defaultRpcPort).toList(), "RPC");
+    }
+
+    @Test
+    void allNetworksIncludesTheKnownConfigs() {
+        List<NetworkConfig> nets = NetworkConfig.allNetworks();
+        assertTrue(nets.contains(NetworkConfig.MAINNET));
+        assertTrue(nets.contains(NetworkConfig.GNOSIS));
+        assertTrue(nets.contains(NetworkConfig.SEPOLIA));
+    }
+
+    private static void assertNoDuplicates(List<Integer> ports, String label) {
+        Set<Integer> seen = new HashSet<>();
+        List<Integer> dupes = new ArrayList<>();
+        for (int p : ports) {
+            if (!seen.add(p)) dupes.add(p);
+        }
+        assertTrue(dupes.isEmpty(), label + " ports collide: " + dupes + " in " + ports);
+    }
+}

--- a/node-core/build.gradle.kts
+++ b/node-core/build.gradle.kts
@@ -1,0 +1,61 @@
+// :node-core — the shared multi-network host core.
+//
+// Owns `ChainStack` (one network's full stack: RLPxConnector + DiscV4Service +
+// DiscV5Service + BeaconLightClient + BeaconSyncState + VerifiedRpcBackend +
+// MyotisRpcServer, on its own ports + identity) and `NodeRegistry`
+// (Map<String,ChainStack>). BOTH the :app CLI daemon and :android-app NodeService
+// host the SAME registry; platform-specific pieces (peer caches, node-key file
+// location, CCIP gateway, RPC upstream) are injected via small interfaces defined
+// here, so the per-network lifecycle + dial logic + N-RPC wiring live once instead
+// of being duplicated across the two hosts.
+//
+// Java 21 source/target: it depends on :networking (discv5), :consensus (libp2p),
+// :myotis-evm (Besu) and :rpc-backend, all of which publish JVM-21 Gradle metadata,
+// so a 21 consumer is required (same rationale as :rpc-backend; CLAUDE.md's 17
+// default yields when a transitive forces 21). AGP 8.7's D8 dexes 21 class files
+// for :android-app.
+
+configurations.all {
+    // Mirror :app / :android-app: strip upstream io.netty so the JitPack
+    // netty-kotlin fork (republished under the same io.netty.* names, supplied by
+    // :networking/:consensus) is the single netty on the runtime classpath.
+    exclude(group = "io.netty")
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
+
+dependencies {
+    implementation(project(":core"))
+    implementation(project(":networking"))
+    implementation(project(":consensus"))
+    implementation(project(":myotis-evm"))
+    implementation(project(":myotis-ens"))
+    // The verified backend + the Ktor JSON-RPC server each ChainStack hosts.
+    implementation(project(":jsonrpc-server"))
+    implementation(project(":rpc-backend"))
+
+    // node-core source references io.netty.channel.* via :networking's RLPxConnector
+    // API; with io.netty excluded group-wide the fork must be on the compile
+    // classpath explicitly (same as :app).
+    implementation(libs.netty.transport)
+    implementation(libs.netty.codec)
+    implementation(libs.netty.handler)
+
+    implementation(libs.tuweni.bytes)
+    implementation(libs.tuweni.units)
+    implementation(libs.tuweni.crypto)
+    implementation(libs.tuweni.rlp)
+
+    implementation(libs.slf4j.api)
+
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.junit.jupiter)
+    testRuntimeOnly(libs.logback.classic)
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/node-core/src/main/java/io/myotis/node/CachedPeer.java
+++ b/node-core/src/main/java/io/myotis/node/CachedPeer.java
@@ -1,0 +1,12 @@
+package io.myotis.node;
+
+import java.net.InetSocketAddress;
+
+/**
+ * A cached EL peer: its address, secp256k1 public key (hex), whether it advertised
+ * snap/1, and its learned snap-serving verdict. Host peer caches return these from
+ * {@link PeerCachePort#load()} so {@code ChainStack} can re-dial in snap-quality order.
+ */
+public record CachedPeer(InetSocketAddress address, String publicKeyHex,
+                         boolean snap, SnapQuality snapQuality) {
+}

--- a/node-core/src/main/java/io/myotis/node/ChainPorts.java
+++ b/node-core/src/main/java/io/myotis/node/ChainPorts.java
@@ -1,0 +1,27 @@
+package io.myotis.node;
+
+import com.jaeckel.ethp2p.networking.NetworkConfig;
+
+/**
+ * The three ports a single network's {@code ChainStack} owns: the EL (RLPx TCP +
+ * discv4 UDP) port, the CL discv5 UDP port, and the verified JSON-RPC HTTP port.
+ *
+ * <p>Defaults come from {@link NetworkConfig} (pinned per network so several stacks
+ * can run in one process without colliding); a host may override any of them (e.g.
+ * the Android app persists a user-chosen RPC port per network).
+ */
+public record ChainPorts(int elPort, int discv5Port, int rpcPort) {
+
+    /** The per-network default ports for {@code network}. */
+    public static ChainPorts defaultsFor(NetworkConfig network) {
+        return new ChainPorts(
+                network.defaultElPort(),
+                network.defaultDiscv5Port(),
+                network.defaultRpcPort());
+    }
+
+    /** Same EL/discv5 defaults, but with the RPC port overridden (host-configurable). */
+    public ChainPorts withRpcPort(int overriddenRpcPort) {
+        return new ChainPorts(elPort, discv5Port, overriddenRpcPort);
+    }
+}

--- a/node-core/src/main/java/io/myotis/node/ChainStack.java
+++ b/node-core/src/main/java/io/myotis/node/ChainStack.java
@@ -105,8 +105,13 @@ public final class ChainStack {
      * Build and start this network's stack. Returns {@code true} on success. On any
      * failure, closes whatever was constructed and returns {@code false} without
      * affecting sibling stacks (fault isolation).
+     *
+     * <p>{@code synchronized} on the same monitor as {@link #shutdown()} so the two
+     * never interleave: a {@code shutdown()} that races an in-progress {@code start()}
+     * waits until startup finishes, then tears the fully-built stack down — rather than
+     * flipping {@code running} mid-build and leaking the components started afterward.
      */
-    public boolean start() {
+    public synchronized boolean start() {
         if (!running.compareAndSet(false, true)) return true; // already started
         try {
             log.info("[{}] Node ID: {}", network.name(), nodeKey.nodeId().toHexString());
@@ -220,7 +225,9 @@ public final class ChainStack {
         List<CachedPeer> cached = new ArrayList<>(peerCache.load());
         cached.sort(Comparator.comparingInt(ChainStack::snapDialRank));
         for (CachedPeer peer : cached) {
-            String peerKey = peer.address().getAddress().getHostAddress() + ":" + peer.address().getPort();
+            // getHostString() (not getAddress().getHostAddress()) — the latter NPEs on
+            // an unresolved address; getHostString() returns the literal IP/host directly.
+            String peerKey = peer.address().getHostString() + ":" + peer.address().getPort();
             attempted.add(peerKey);
             try {
                 SECP256K1.PublicKey pubKey = SECP256K1.PublicKey.fromBytes(

--- a/node-core/src/main/java/io/myotis/node/ChainStack.java
+++ b/node-core/src/main/java/io/myotis/node/ChainStack.java
@@ -1,0 +1,437 @@
+package io.myotis.node;
+
+import com.jaeckel.ethp2p.consensus.BeaconLightClient;
+import com.jaeckel.ethp2p.consensus.BeaconSyncState;
+import com.jaeckel.ethp2p.core.crypto.NodeKey;
+import com.jaeckel.ethp2p.core.enr.Enr;
+import com.jaeckel.ethp2p.networking.NetworkConfig;
+import com.jaeckel.ethp2p.networking.discv4.DiscV4Service;
+import com.jaeckel.ethp2p.networking.discv4.KademliaTable;
+import com.jaeckel.ethp2p.networking.discv5.DiscV5Service;
+import com.jaeckel.ethp2p.networking.dns.DnsEnrResolver;
+import com.jaeckel.ethp2p.networking.rlpx.RLPxConnector;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.crypto.SECP256K1;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.InetSocketAddress;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * One Ethereum network's full node stack — RLPx (EL) + discv4 + discv5 (CL discovery)
+ * + the beacon light client + the verified JSON-RPC server — on its own ports and with
+ * its own identity and per-stack dial bookkeeping. Several {@code ChainStack}s run side
+ * by side in one process (see {@code NodeRegistry}) without colliding.
+ *
+ * <p>Hosted identically by the {@code :app} daemon and {@code :android-app}; everything
+ * platform-specific (peer caches, the node key file location, the snapshot file, the
+ * CCIP gateway) is injected, so this per-network lifecycle lives once instead of being
+ * duplicated across the two hosts.
+ *
+ * <p>{@link #start()} is fault-isolated: any failure closes only this stack's resources
+ * and returns {@code false}; it never affects sibling stacks or the host process.
+ */
+public final class ChainStack {
+
+    private static final Logger log = LoggerFactory.getLogger(ChainStack.class);
+
+    private static final long BACKOFF_INCOMPATIBLE_MS = 10 * 60 * 1000L; // 10 min, wrong-chain peers
+    private static final long BACKOFF_TRANSIENT_MS = 30 * 1000L;         // 30s, transient failures
+    /** Cap on DNS-resolved (EIP-1459) EL enodes RLPx-dialed directly at startup, bypassing discv4. */
+    private static final int DNS_DIRECT_DIAL_LIMIT = 50;
+
+    // -- injected configuration ------------------------------------------------
+    private final NetworkConfig network;
+    private final ChainPorts ports;
+    private final NodeKey nodeKey;
+    private final PeerCachePort peerCache;
+    private final ClPeerCachePort clPeerCache;
+    private final io.myotis.evm.ccipread.CcipGateway ccipGateway;
+    private final Path syncSnapshotFile;
+    private final boolean gossipsubEnabled;
+
+    // -- per-stack mutable state (formerly Main/NodeService singletons) ---------
+    private final Set<String> attempted = ConcurrentHashMap.newKeySet();
+    private final Map<String, Long> backoff = new ConcurrentHashMap<>();
+    private final Set<String> blacklistedNodeIds = ConcurrentHashMap.newKeySet();
+    private final AtomicBoolean running = new AtomicBoolean(false);
+
+    // -- live components (built in start()) ------------------------------------
+    private volatile RLPxConnector connector;
+    private volatile DiscV4Service discV4;
+    private volatile DiscV5Service discV5;
+    private volatile BeaconSyncState beaconSyncState;
+    private volatile BeaconLightClient beaconLightClient;
+    private volatile io.myotis.rpc.VerifiedRpcBackend rpcBackend;
+    private volatile io.myotis.jsonrpc.MyotisRpcServer rpcServer;
+
+    public ChainStack(NetworkConfig network,
+                      ChainPorts ports,
+                      NodeKey nodeKey,
+                      PeerCachePort peerCache,
+                      ClPeerCachePort clPeerCache,
+                      io.myotis.evm.ccipread.CcipGateway ccipGateway,
+                      Path syncSnapshotFile,
+                      boolean gossipsubEnabled) {
+        this.network = network;
+        this.ports = ports;
+        this.nodeKey = nodeKey;
+        this.peerCache = peerCache;
+        this.clPeerCache = clPeerCache;
+        this.ccipGateway = ccipGateway;
+        this.syncSnapshotFile = syncSnapshotFile;
+        this.gossipsubEnabled = gossipsubEnabled;
+    }
+
+    // -------------------------------------------------------------------------
+    // Lifecycle
+    // -------------------------------------------------------------------------
+
+    /**
+     * Build and start this network's stack. Returns {@code true} on success. On any
+     * failure, closes whatever was constructed and returns {@code false} without
+     * affecting sibling stacks (fault isolation).
+     */
+    public boolean start() {
+        if (!running.compareAndSet(false, true)) return true; // already started
+        try {
+            log.info("[{}] Node ID: {}", network.name(), nodeKey.nodeId().toHexString());
+
+            // 1. EIP-1459 DNS discovery (EL + CL trees), concurrent + best-effort.
+            DnsEnrResolver dnsResolver = new DnsEnrResolver();
+            Duration dnsDeadline = Duration.ofSeconds(10);
+            CompletableFuture<List<Enr>> elFuture = CompletableFuture.supplyAsync(
+                    () -> dnsResolver.resolveAllFromStrings(network.elEnrTreeUrls(), dnsDeadline));
+            CompletableFuture<List<Enr>> clFuture = CompletableFuture.supplyAsync(
+                    () -> dnsResolver.resolveAllFromStrings(network.clEnrTreeUrls(), dnsDeadline));
+            List<Enr> dnsElEnrs = elFuture.join();
+            List<Enr> dnsClEnrs = clFuture.join();
+
+            List<InetSocketAddress> mergedBootnodes = mergeBootnodes(dnsElEnrs);
+
+            // 2. RLPx connector + immediate cached / DNS-direct dials.
+            this.connector = buildConnector();
+            dialCachedPeers();
+            directDialDnsEnodes(dnsElEnrs);
+
+            // 3. discv4.
+            this.discV4 = buildDiscV4(mergedBootnodes);
+            try {
+                discV4.start(ports.elPort());
+            } catch (Exception e) {
+                log.error("[{}] discv4 failed to bind UDP {}: {}", network.name(), ports.elPort(), e.toString());
+                throw e; // EL is essential — fail this stack
+            }
+            log.info("[{}] discv4 started on UDP port {}", network.name(), ports.elPort());
+
+            // 4. Beacon: sync-state + discv5 (CL discovery) + light client.
+            this.beaconSyncState = new BeaconSyncState();
+            startDiscV5AndBeacon(dnsClEnrs);
+
+            // 5. Verified JSON-RPC (best-effort; a bind failure here does not fail the stack).
+            startRpc();
+
+            return true;
+        } catch (Throwable t) {
+            log.error("[{}] stack failed to start: {}", network.name(), t.toString());
+            shutdown();
+            return false;
+        }
+    }
+
+    /** Tear down this stack's components (reverse order) and release its caches. */
+    public synchronized void shutdown() {
+        running.set(false);
+        if (rpcServer != null) { try { rpcServer.stop(); } catch (Throwable ignored) {} }
+        if (rpcBackend != null) { try { rpcBackend.close(); } catch (Throwable ignored) {} }
+        if (beaconLightClient != null) { try { beaconLightClient.close(); } catch (Throwable ignored) {} }
+        if (connector != null) { try { connector.close(); } catch (Throwable ignored) {} }
+        if (discV5 != null) { try { discV5.close(); } catch (Throwable ignored) {} }
+        if (discV4 != null) { try { discV4.close(); } catch (Throwable ignored) {} }
+        try { peerCache.close(); } catch (Throwable ignored) {}
+        try { clPeerCache.close(); } catch (Throwable ignored) {}
+        attempted.clear();
+        backoff.clear();
+        blacklistedNodeIds.clear();
+    }
+
+    // -------------------------------------------------------------------------
+    // Accessors (for the host's IPC / UI layer)
+    // -------------------------------------------------------------------------
+
+    public NetworkConfig network() { return network; }
+    public ChainPorts ports() { return ports; }
+    public boolean isRunning() { return running.get(); }
+    public RLPxConnector connector() { return connector; }
+    public DiscV4Service discV4() { return discV4; }
+    public DiscV5Service discV5() { return discV5; }
+    public BeaconSyncState beaconSyncState() { return beaconSyncState; }
+    public BeaconLightClient beaconLightClient() { return beaconLightClient; }
+    public Map<String, Long> backoff() { return backoff; }
+    public Set<String> blacklistedNodeIds() { return blacklistedNodeIds; }
+
+    // -------------------------------------------------------------------------
+    // Construction helpers (faithful ports of Main.runDaemon)
+    // -------------------------------------------------------------------------
+
+    private List<InetSocketAddress> mergeBootnodes(List<Enr> dnsElEnrs) {
+        List<InetSocketAddress> merged = new ArrayList<>(network.bootnodes());
+        Set<String> seen = new HashSet<>();
+        for (InetSocketAddress sa : merged) {
+            seen.add(sa.getAddress().getHostAddress() + ":" + sa.getPort());
+        }
+        int before = merged.size();
+        for (Enr enr : dnsElEnrs) {
+            enr.udpAddress().or(enr::tcpAddress).ifPresent(sa -> {
+                String key = sa.getAddress().getHostAddress() + ":" + sa.getPort();
+                if (seen.add(key)) merged.add(sa);
+            });
+        }
+        if (merged.size() > before) {
+            log.info("[{}] DNS discovery added {} EL bootnode(s) (total: {})",
+                    network.name(), merged.size() - before, merged.size());
+        }
+        return merged;
+    }
+
+    private RLPxConnector buildConnector() {
+        return new RLPxConnector(nodeKey, ports.elPort(), network, headers -> {
+            if (!headers.isEmpty()) {
+                log.debug("[{}] {} block header(s) received", network.name(), headers.size());
+            }
+        }, (address, publicKeyHex, snap) -> peerCache.add(address, publicKeyHex, snap));
+    }
+
+    private void dialCachedPeers() {
+        List<CachedPeer> cached = new ArrayList<>(peerCache.load());
+        cached.sort(Comparator.comparingInt(ChainStack::snapDialRank));
+        for (CachedPeer peer : cached) {
+            String peerKey = peer.address().getAddress().getHostAddress() + ":" + peer.address().getPort();
+            attempted.add(peerKey);
+            try {
+                SECP256K1.PublicKey pubKey = SECP256K1.PublicKey.fromBytes(
+                        Bytes.fromHexString(peer.publicKeyHex()));
+                connector.connect(peer.address(), pubKey, (incompatible, nodeIdHex) -> {
+                            if (incompatible) blacklistedNodeIds.add(nodeIdHex);
+                            long backoffMs = incompatible ? BACKOFF_INCOMPATIBLE_MS : BACKOFF_TRANSIENT_MS;
+                            backoff.putIfAbsent(peerKey, System.currentTimeMillis() + backoffMs);
+                            attempted.remove(peerKey);
+                        })
+                        .addListener(future -> { if (!future.isSuccess()) attempted.remove(peerKey); });
+            } catch (Exception e) {
+                log.warn("[{}] Failed to connect to cached peer {}: {}", network.name(), peer.address(), e.getMessage());
+                attempted.remove(peerKey);
+            }
+        }
+    }
+
+    private void directDialDnsEnodes(List<Enr> dnsElEnrs) {
+        int directDialed = 0;
+        for (Enr enr : dnsElEnrs) {
+            if (directDialed >= DNS_DIRECT_DIAL_LIMIT) break;
+            String peerKey = null;
+            try {
+                Optional<InetSocketAddress> tcp = enr.tcpAddress();
+                Optional<SECP256K1.PublicKey> pub = enr.publicKey();
+                if (tcp.isEmpty() || pub.isEmpty()) continue;
+                InetSocketAddress peerTcp = tcp.get();
+                peerKey = peerTcp.getHostString() + ":" + peerTcp.getPort();
+                if (!attempted.add(peerKey)) continue;
+                directDialed++;
+                final String key = peerKey;
+                connector.connect(peerTcp, pub.get(), (incompatible, nodeIdHex) -> {
+                            if (incompatible) blacklistedNodeIds.add(nodeIdHex);
+                            long backoffMs = incompatible ? BACKOFF_INCOMPATIBLE_MS : BACKOFF_TRANSIENT_MS;
+                            backoff.putIfAbsent(key, System.currentTimeMillis() + backoffMs);
+                            attempted.remove(key);
+                        })
+                        .addListener(future -> { if (!future.isSuccess()) attempted.remove(key); });
+            } catch (Exception e) {
+                log.warn("[{}] Failed direct dial of DNS EL enode: {}", network.name(), e.getMessage());
+                if (peerKey != null) attempted.remove(peerKey);
+            }
+        }
+        if (directDialed > 0) {
+            log.info("[{}] Direct-dialed {} DNS EL enode(s)", network.name(), directDialed);
+        }
+    }
+
+    private DiscV4Service buildDiscV4(List<InetSocketAddress> mergedBootnodes) {
+        return new DiscV4Service(nodeKey, mergedBootnodes, entry -> {
+            if (connector.isSnapHeavy()) return;
+            if (entry.tcpPort() > 0 && attempted.size() < 2000) {
+                String nodeIdHex = entry.nodeId().toHexString();
+                if (blacklistedNodeIds.contains(nodeIdHex)) return;
+                String peerKey = entry.udpAddr().getAddress().getHostAddress() + ":" + entry.tcpPort();
+                Long expiry = backoff.get(peerKey);
+                if (expiry != null) {
+                    if (System.currentTimeMillis() < expiry) return;
+                    backoff.remove(peerKey);
+                }
+                if (attempted.add(peerKey)) {
+                    InetSocketAddress peerTcp = new InetSocketAddress(entry.udpAddr().getAddress(), entry.tcpPort());
+                    tryConnectWithKnownKey(entry, peerTcp, peerKey);
+                }
+            }
+        });
+    }
+
+    private void startDiscV5AndBeacon(List<Enr> dnsClEnrs) {
+        List<byte[]> acceptedForkDigests = network.acceptedForkDigests();
+        AtomicInteger mismatchesLogged = new AtomicInteger();
+        AtomicReference<BeaconLightClient> blcRef = new AtomicReference<>();
+
+        this.discV5 = new DiscV5Service(nodeKey, network.clDiscv5Bootnodes(), enr -> {
+            var eth2 = enr.eth2();
+            if (eth2.isEmpty()) return;
+            byte[] peerDigest = eth2.get().forkDigest();
+            int matchIdx = -1;
+            for (int i = 0; i < acceptedForkDigests.size(); i++) {
+                if (java.util.Arrays.equals(peerDigest, acceptedForkDigests.get(i))) { matchIdx = i; break; }
+            }
+            if (matchIdx < 0) {
+                int n = mismatchesLogged.incrementAndGet();
+                if (n <= 5) {
+                    log.info("[{}][discv5] eth2 fork_digest=0x{} not accepted — rejected{}",
+                            network.name(), java.util.HexFormat.of().formatHex(peerDigest),
+                            n == 5 ? " [further mismatch logs suppressed]" : "");
+                }
+                return;
+            }
+            final int mi = matchIdx;
+            enr.toLibp2pMultiaddr().ifPresent(ma -> {
+                clPeerCache.add(ma);
+                BeaconLightClient blc = blcRef.get();
+                boolean liveAdded = blc != null && blc.addPeer(ma);
+                log.info("[{}][discv5] CL peer {} ({} match){}", network.name(), ma,
+                        mi == 0 ? "current" : "prior", liveAdded ? " → live pool" : "");
+            });
+        });
+        try {
+            discV5.start(ports.discv5Port());
+        } catch (Throwable t) {
+            // discv5 is non-essential: EL keeps working and CL falls back to cache + seed list.
+            log.warn("[{}][discv5] failed to start on UDP {}, continuing without CL discovery: {}",
+                    network.name(), ports.discv5Port(), t.toString());
+        }
+
+        // Beacon light client.
+        List<String> clPeers = new ArrayList<>(clPeerCache.load());
+        for (String peer : network.clPeerMultiaddrs()) {
+            if (!clPeers.contains(peer)) clPeers.add(peer);
+        }
+        for (Enr enr : dnsClEnrs) {
+            enr.toLibp2pMultiaddr().ifPresent(ma -> { if (!clPeers.contains(ma)) clPeers.add(ma); });
+        }
+        BeaconLightClient blc = new BeaconLightClient(
+                clPeers, network.checkpointRoot(), network.checkpointSlot(),
+                network.currentForkVersion(), network.genesisValidatorsRoot(),
+                beaconSyncState, network.beaconApiUrl(),
+                clPeerCache::add, clPeerCache::markFailure, network.clGenesisTime());
+        blc.setBlobParameters(network.activeBlobParamsEpoch(), network.activeBlobParamsMaxBlobs());
+        blc.setBeaconPreset(network.secondsPerSlot(), network.slotsPerEpoch());
+        blc.setProvenCatchUpServers(clPeerCache.servedRanges());
+        blc.setOnCatchUpServed(clPeerCache::recordServed);
+        blc.setProvenBootstrapPeers(clPeerCache.bootstrapPeers());
+        blc.setOnBootstrapServed(clPeerCache::recordBootstrap);
+        blc.setProvenLightClient(clPeerCache.lightClientConfirmed());
+        blc.setProvenNonLightClient(clPeerCache.lightClientDenied());
+        blc.setOnLightClientVerdict(clPeerCache::markLightClientBatch);
+        blc.setSnapshotFile(syncSnapshotFile);
+        blc.setGossipsubEnabled(gossipsubEnabled);
+        blcRef.set(blc);
+        blc.start();
+        this.beaconLightClient = blc;
+        log.info("[{}] Beacon light client started with {} CL peer(s)", network.name(), clPeers.size());
+    }
+
+    private void startRpc() {
+        int rpcPort = ports.rpcPort();
+        try {
+            // Deterministic up-front bind probe: Ktor's CIO engine surfaces bind
+            // failures asynchronously, which a try/catch around start() can miss.
+            try (java.net.ServerSocket probe = new java.net.ServerSocket()) {
+                probe.setReuseAddress(true);
+                probe.bind(new InetSocketAddress("127.0.0.1", rpcPort));
+            }
+            io.myotis.rpc.SnapQualitySink snapQualitySink = new io.myotis.rpc.SnapQualitySink() {
+                @Override public void recordSnapServed(InetSocketAddress address) { peerCache.recordSnapServed(address); }
+                @Override public void recordSnapFailure(InetSocketAddress address) { peerCache.recordSnapFailure(address); }
+            };
+            io.myotis.rpc.RpcLogger rpcLogger = new io.myotis.rpc.RpcLogger() {
+                @Override public void info(String message) { log.info(message); }
+                @Override public void warn(String message) { log.warn(message); }
+            };
+            io.myotis.rpc.VerifiedRpcBackend backend = new io.myotis.rpc.VerifiedRpcBackend(
+                    connector, beaconLightClient, beaconSyncState, ccipGateway,
+                    rpcLogger, io.myotis.rpc.RpcClock.monotonic(), snapQualitySink);
+            try {
+                backend.start();
+                io.myotis.jsonrpc.MyotisRpcServer server =
+                        new io.myotis.jsonrpc.MyotisRpcServer(rpcPort, null, "127.0.0.1", backend);
+                server.start();
+                this.rpcServer = server;
+                this.rpcBackend = backend;
+                log.info("[{}] JSON-RPC listening on http://127.0.0.1:{} (verified, strict)",
+                        network.name(), rpcPort);
+            } catch (Throwable serverEx) {
+                backend.close();
+                throw serverEx;
+            }
+        } catch (java.io.IOException bindEx) {
+            log.warn("[{}][rpc] port {} unavailable ({}); continuing without JSON-RPC",
+                    network.name(), rpcPort, bindEx.getMessage());
+        } catch (Throwable t) {
+            log.warn("[{}][rpc] failed to start JSON-RPC; continuing without it: {}",
+                    network.name(), t.toString());
+        }
+    }
+
+    private void tryConnectWithKnownKey(KademliaTable.Entry entry, InetSocketAddress peerTcp, String peerKey) {
+        try {
+            Bytes nodeId = entry.nodeId();
+            if (nodeId.size() != 64) { attempted.remove(peerKey); return; }
+            SECP256K1.PublicKey peerPubkey = SECP256K1.PublicKey.fromBytes(nodeId);
+            connector.connect(peerTcp, peerPubkey, (incompatible, nodeIdHex) -> {
+                        if (incompatible) blacklistedNodeIds.add(nodeIdHex);
+                        long backoffMs = incompatible ? BACKOFF_INCOMPATIBLE_MS : BACKOFF_TRANSIENT_MS;
+                        backoff.putIfAbsent(peerKey, System.currentTimeMillis() + backoffMs);
+                        attempted.remove(peerKey);
+                    })
+                    .addListener(future -> {
+                        if (!future.isSuccess()) {
+                            backoff.putIfAbsent(peerKey, System.currentTimeMillis() + BACKOFF_TRANSIENT_MS);
+                            attempted.remove(peerKey);
+                        }
+                    });
+        } catch (Exception e) {
+            backoff.putIfAbsent(peerKey, System.currentTimeMillis() + BACKOFF_TRANSIENT_MS);
+            attempted.remove(peerKey);
+        }
+    }
+
+    /** Dial-priority rank (lower = dialed first): proven snap-servers, then snap-capable
+     *  unproven, then known snap hangers, then plain-eth peers. */
+    private static int snapDialRank(CachedPeer p) {
+        if (!p.snap()) return 3;
+        return switch (p.snapQuality()) {
+            case CONFIRMED -> 0;
+            case UNKNOWN -> 1;
+            case DENIED -> 2;
+        };
+    }
+}

--- a/node-core/src/main/java/io/myotis/node/ClPeerCachePort.java
+++ b/node-core/src/main/java/io/myotis/node/ClPeerCachePort.java
@@ -1,0 +1,49 @@
+package io.myotis.node;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The CL (beacon libp2p) peer-cache operations a {@code ChainStack} needs, abstracted
+ * so the daemon ({@code CLPeerCache}) and Android ({@code AndroidCLPeerCache}) can each
+ * supply their own file-backed implementation via a thin adapter. Method shapes mirror
+ * what {@code BeaconLightClient}'s seed/listener setters consume, so they wire as direct
+ * method references.
+ */
+public interface ClPeerCachePort {
+
+    /** Cached CL peer multiaddrs to seed the light client, in stored order. */
+    List<String> load();
+
+    /** Record a responsive CL peer multiaddr (idempotent). */
+    void add(String multiaddr);
+
+    /** Record that a CL peer failed (for deprioritization). */
+    void markFailure(String multiaddr);
+
+    /** Peer → [low, high] sync-committee period range it has served (for catch-up seeding). */
+    Map<String, long[]> servedRanges();
+
+    /** Record that {@code multiaddr} served catch-up across [low, high]. */
+    void recordServed(String multiaddr, long low, long high);
+
+    /** Peer → period it served a bootstrap from (front-loads proven LC servers on restart). */
+    Map<String, Long> bootstrapPeers();
+
+    /** Record that {@code multiaddr} served a bootstrap for {@code period}. */
+    void recordBootstrap(String multiaddr, long period);
+
+    /** Peers confirmed to serve light_client protocols. */
+    Set<String> lightClientConfirmed();
+
+    /** Peers proven NOT to serve light_client protocols. */
+    Set<String> lightClientDenied();
+
+    /** Persist a batch of light-client capability verdicts (confirmed + denied). */
+    void markLightClientBatch(Collection<String> confirmed, Collection<String> denied);
+
+    /** Flush queued writes and release resources. */
+    void close();
+}

--- a/node-core/src/main/java/io/myotis/node/NodeRegistry.java
+++ b/node-core/src/main/java/io/myotis/node/NodeRegistry.java
@@ -1,0 +1,63 @@
+package io.myotis.node;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Holds the live {@link ChainStack}s a single process is hosting, keyed by network
+ * name. The host (the {@code :app} daemon or {@code :android-app} {@code NodeService})
+ * builds stacks with its own platform adapters, registers them here, and uses the
+ * registry to iterate (for snapshots), look one up (to route a per-network command),
+ * and tear them all down.
+ *
+ * <p>One process can hold several stacks at once (mainnet + Gnosis + …), each on its
+ * own ports. A failure in one stack is isolated to that stack (see
+ * {@link ChainStack#start()}); the registry never assumes all stacks are healthy.
+ */
+public final class NodeRegistry {
+
+    private final Map<String, ChainStack> stacks = new ConcurrentHashMap<>();
+
+    /** Register an already-built stack (call {@link ChainStack#start()} separately). */
+    public void add(ChainStack stack) {
+        stacks.put(stack.network().name(), stack);
+    }
+
+    /** The stack for {@code networkName}, or {@code null} if not hosted. */
+    public ChainStack get(String networkName) {
+        return stacks.get(networkName);
+    }
+
+    /** All hosted stacks (live view). */
+    public Collection<ChainStack> all() {
+        return stacks.values();
+    }
+
+    /** Network names currently hosted. */
+    public java.util.Set<String> networkNames() {
+        return stacks.keySet();
+    }
+
+    public boolean isEmpty() {
+        return stacks.isEmpty();
+    }
+
+    public int size() {
+        return stacks.size();
+    }
+
+    /** Shut down and remove a single stack (no-op if absent). */
+    public void remove(String networkName) {
+        ChainStack stack = stacks.remove(networkName);
+        if (stack != null) stack.shutdown();
+    }
+
+    /** Shut down every stack and clear the registry. */
+    public void shutdownAll() {
+        for (ChainStack stack : stacks.values()) {
+            try { stack.shutdown(); } catch (Throwable ignored) {}
+        }
+        stacks.clear();
+    }
+}

--- a/node-core/src/main/java/io/myotis/node/PeerCachePort.java
+++ b/node-core/src/main/java/io/myotis/node/PeerCachePort.java
@@ -1,0 +1,28 @@
+package io.myotis.node;
+
+import java.net.InetSocketAddress;
+import java.util.List;
+
+/**
+ * The EL peer-cache operations a {@code ChainStack} needs, abstracted so the daemon
+ * ({@code PeerCache}) and Android ({@code AndroidPeerCache}) can each supply their own
+ * file-backed implementation (via a thin adapter) without {@code node-core} depending
+ * on either host module.
+ */
+public interface PeerCachePort {
+
+    /** Record a freshly-handshaked peer (idempotent). Wired as the RLPx connector callback. */
+    void add(InetSocketAddress address, String publicKeyHex, boolean snap);
+
+    /** Mark that {@code address} served a snap proof (promotes it toward CONFIRMED). */
+    void recordSnapServed(InetSocketAddress address);
+
+    /** Mark that {@code address} failed to serve snap (demotes it toward DENIED). */
+    void recordSnapFailure(InetSocketAddress address);
+
+    /** Cached peers to re-dial on startup, in the cache's stored order. */
+    List<CachedPeer> load();
+
+    /** Flush queued writes and release resources. */
+    void close();
+}

--- a/node-core/src/main/java/io/myotis/node/SnapQuality.java
+++ b/node-core/src/main/java/io/myotis/node/SnapQuality.java
@@ -1,0 +1,8 @@
+package io.myotis.node;
+
+/**
+ * Learned snap-serving verdict for an EL peer, persisted across restarts and used
+ * to order dial priority (CONFIRMED first, DENIED last). Shared by the daemon and
+ * Android peer caches via {@link PeerCachePort}.
+ */
+public enum SnapQuality { CONFIRMED, UNKNOWN, DENIED }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -36,4 +36,4 @@ dependencyResolutionManagement {
     }
 }
 
-include("core", "networking", "consensus", "app", "android-app", "myotis-evm", "myotis-ens", "jsonrpc-server", "rpc-backend")
+include("core", "networking", "consensus", "app", "android-app", "myotis-evm", "myotis-ens", "jsonrpc-server", "rpc-backend", "node-core")


### PR DESCRIPTION
## What & why

First step toward running **mainnet + Gnosis (+ more) concurrently in one process**, each serving JSON-RPC on its own port — ultimately for the Android wallet, but built **daemon-first** so it's verifiable end-to-end without a device. This PR is **Phase A: the shared core + the daemon**. Android (Phase B) reuses this core in a follow-up.

Today both the daemon and the Android app run exactly one network per process and each independently builds the same per-network stack. This factors that stack into a shared module so the logic lives once instead of being duplicated and drifting.

## Changes

**New `:node-core` module** (Java 21, Android-safe) — the shared multi-network host core:
- **`ChainStack`** — one network's full stack (DNS discovery → RLPx + cached/DNS-direct dials → discv4 → discv5 CL discovery → beacon light client → verified JSON-RPC) on its own ports + identity + per-stack dial state. `start()` is **fault-isolated**: any failure closes only its own resources and returns `false`, never touching sibling stacks.
- **`NodeRegistry`** — `Map<String,ChainStack>` the host iterates / looks up / tears down.
- **`ChainPorts`**, and cache **ports** (`PeerCachePort` / `ClPeerCachePort` + shared `CachedPeer`/`SnapQuality`) so `node-core` stays independent of either host module.

**`NetworkConfig`** — per-network default ports (`defaultElPort()`/`defaultDiscv5Port()`/`defaultRpcPort()`), distinct across networks (mainnet 30303/9000/8545, gnosis 30304/9001/8546, sepolia 30305/9002/8547), plus `allNetworks()`. Single point of expansion for a new network.

**`:app` daemon** — `Main` now hosts a **list** of networks via the registry. `-Pnetwork=mainnet,gnosis` runs both in one JVM, each on its pinned ports + its own `nodekey-<net>.hex` + its own IPC socket. A `stop` on any socket trips the shared latch and tears the whole process down. Thin `PeerCacheAdapter`/`ClPeerCacheAdapter` wrap the **untouched** `PeerCache`/`CLPeerCache`.

**Single-network behavior is byte-identical** — one network still uses the legacy `--port`/30303 + discv5 9000 + RPC 8545 + shared `nodekey.hex`.

## Verification (live on a real host, one process)

- ✅ mainnet + gnosis concurrently: distinct ports (30303/9000/8545 vs 30304/9001/8546), **no collisions**
- ✅ distinct identities: `nodekey.hex` vs freshly-generated `nodekey-gnosis.hex`
- ✅ `eth_chainId` on **:8545 → 0x1** and **:8546 → 0x64** at the same time
- ✅ **both** beacon light clients reach **SYNCED**
- ✅ `stop` on either socket cleanly tears down both stacks and the JVM exits
- ✅ single-network mainnet path unchanged (reaches SYNCED on 30303/9000/8545); full build + tests green

## Not in this PR

Android (`NodeService` hosting the same `NodeRegistry` + per-network UI) is **Phase B** — it reuses this core rather than duplicating it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)