### PR TITLE
rpc: deep-scan receipts back to a sent tx's broadcast height

### DIFF
--- a/rpc-backend/src/main/java/io/myotis/rpc/SentTxTracker.java
+++ b/rpc-backend/src/main/java/io/myotis/rpc/SentTxTracker.java
@@ -25,8 +25,11 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 final class SentTxTracker {
 
-    /** When we broadcast it, and when we first saw it on gossip ({@code -1} until seen). */
-    private record Watch(long broadcastAtMs, long seenAtMs) {}
+    /** When we broadcast it, when we first saw it on gossip ({@code -1} until seen), and the
+     *  verified head block number at broadcast time ({@code -1} if unknown) — the latter lets
+     *  the receipt scanner deep-scan back to where the tx could first have been mined, instead
+     *  of only the recent forward window. */
+    private record Watch(long broadcastAtMs, long seenAtMs, long broadcastHeadNumber) {}
 
     private final Map<Bytes32, Watch> watched = new ConcurrentHashMap<>();
     private final long ttlMs;
@@ -35,9 +38,17 @@ final class SentTxTracker {
         this.ttlMs = ttlMs;
     }
 
-    /** Start watching a tx we just broadcast. */
-    void watch(Bytes32 hash, long nowMs) {
-        watched.put(hash, new Watch(nowMs, -1L));
+    /** Start watching a tx we just broadcast, recording the verified head block number at
+     *  broadcast time ({@code -1} if not known) so a late receipt lookup can scan back to it. */
+    void watch(Bytes32 hash, long nowMs, long headNumber) {
+        watched.put(hash, new Watch(nowMs, -1L, headNumber));
+    }
+
+    /** Verified head block number recorded when {@code hash} was broadcast, or {@code -1} if
+     *  it isn't one of ours / no head was known at broadcast. */
+    long broadcastHead(Bytes32 hash) {
+        Watch w = watched.get(hash);
+        return w == null ? -1L : w.broadcastHeadNumber();
     }
 
     /** O(1) hot-path guard: do we currently care about any gossip hash at all? */
@@ -56,7 +67,7 @@ final class SentTxTracker {
         watched.computeIfPresent(hash, (h, w) -> {
             if (w.seenAtMs() >= 0) return w;            // already counted — leave as is
             firstSeen[0] = w;
-            return new Watch(w.broadcastAtMs(), nowMs);
+            return new Watch(w.broadcastAtMs(), nowMs, w.broadcastHeadNumber());
         });
         return firstSeen[0] == null ? -1L : nowMs - firstSeen[0].broadcastAtMs();
     }

--- a/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
+++ b/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
@@ -1838,8 +1838,12 @@ public final class VerifiedRpcBackend implements io.myotis.jsonrpc.MyotisRpcBack
             byte[] txHash = Hash.keccak256(Bytes.wrap(rawTx)).toArrayUnsafe();
             sentTxCache.put(Bytes.wrap(txHash).toHexString(), rawTx.clone());
             recordPendingNonce(rawTx);
-            // Watch for this hash to come back over gossip (propagation confirmation).
-            sentTxWatch.watch(Bytes32.wrap(txHash), clock.elapsedMillis());
+            // Watch for this hash to come back over gossip (propagation confirmation), and record
+            // the head block at broadcast so a late receipt poll can deep-scan back to where the
+            // tx could first have been mined (see locateMinedTx) instead of only the recent window.
+            Long broadcastHead = headBlockNumber();
+            sentTxWatch.watch(Bytes32.wrap(txHash), clock.elapsedMillis(),
+                    broadcastHead != null ? broadcastHead : -1L);
             log.info("[rpc] eth_sendRawTransaction broadcast to " + sent
                     + " peer(s), hash=" + Bytes.wrap(txHash).toHexString());
             return txHash;
@@ -2008,6 +2012,15 @@ public final class VerifiedRpcBackend implements io.myotis.jsonrpc.MyotisRpcBack
             long from = (st.highScanned == Long.MIN_VALUE)
                     ? head - RECEIPT_INITIAL_LOOKBACK_BLOCKS + 1
                     : st.highScanned + 1;
+            // For our OWN sent txs, the first scan reaches back to the head block recorded at
+            // broadcast — otherwise the forward-only window misses a tx mined >INITIAL_LOOKBACK
+            // blocks before the first SUCCESSFUL poll (e.g. peers were flaky for a minute, then
+            // the tx's block already scrolled out of the small window). Bounded by capFloor below;
+            // the sent-tx watch TTL keeps the broadcast head recent (well within the cap).
+            if (st.highScanned == Long.MIN_VALUE) {
+                long bcHead = sentTxWatch.broadcastHead(want);
+                if (bcHead >= 0 && bcHead < from) from = bcHead;
+            }
             // Cap catch-up after a gap; blocks below this are skipped (better than the old
             // 8-block ceiling, and the tx is usually long-confirmed by then anyway).
             long capFloor = head - RECEIPT_MAX_SCAN_BLOCKS_PER_POLL + 1;

--- a/rpc-backend/src/test/java/io/myotis/rpc/SentTxTrackerTest.java
+++ b/rpc-backend/src/test/java/io/myotis/rpc/SentTxTrackerTest.java
@@ -26,7 +26,7 @@ class SentTxTrackerTest {
     @Test
     void firstSightingReportsLatencyThenStopsCounting() {
         SentTxTracker t = new SentTxTracker(TTL);
-        t.watch(H1, 1_000);
+        t.watch(H1, 1_000, -1L);
         assertTrue(t.watchingAny());
         assertFalse(t.wasSeen(H1));
         // first time the hash comes back: ms since broadcast.
@@ -40,8 +40,8 @@ class SentTxTrackerTest {
     @Test
     void watchesAreIndependentPerHash() {
         SentTxTracker t = new SentTxTracker(TTL);
-        t.watch(H1, 1_000);
-        t.watch(H2, 1_000);
+        t.watch(H1, 1_000, -1L);
+        t.watch(H2, 1_000, -1L);
         assertEquals(2, t.size());
         assertEquals(200, t.markSeen(H1, 1_200));
         // H2 never seen; an unrelated hash is still a miss.
@@ -55,16 +55,31 @@ class SentTxTrackerTest {
     @Test
     void confirmMinedStopsWatching() {
         SentTxTracker t = new SentTxTracker(TTL);
-        t.watch(H1, 1_000);
+        t.watch(H1, 1_000, -1L);
         t.confirmMined(H1);
         assertFalse(t.watchingAny());
         assertEquals(-1, t.markSeen(H1, 1_500));
     }
 
     @Test
+    void recordsBroadcastHeadAndPreservesItAcrossSighting() {
+        SentTxTracker t = new SentTxTracker(TTL);
+        // unknown hash -> -1
+        assertEquals(-1, t.broadcastHead(H1));
+        t.watch(H1, 1_000, 46_726_900L);
+        assertEquals(46_726_900L, t.broadcastHead(H1));
+        // a gossip sighting must not clobber the recorded broadcast head.
+        t.markSeen(H1, 1_500);
+        assertEquals(46_726_900L, t.broadcastHead(H1));
+        // a tx watched without a known head reports -1.
+        t.watch(H2, 1_000, -1L);
+        assertEquals(-1, t.broadcastHead(H2));
+    }
+
+    @Test
     void ttlEvictionClearsStaleWatchesAndQuietsTheGuard() {
         SentTxTracker t = new SentTxTracker(TTL);
-        t.watch(H1, 1_000);
+        t.watch(H1, 1_000, -1L);
         // within TTL: nothing evicted, still watching.
         assertEquals(0, t.evictExpired(1_000 + TTL));
         assertTrue(t.watchingAny());


### PR DESCRIPTION
Follow-up #3 from the Gnosis wallet debugging session.

## Problem
The incremental receipt scanner (`locateMinedTx`) is **forward-only**: the first poll looks back only `RECEIPT_INITIAL_LOOKBACK_BLOCKS` (8) from the head, then advances. If the first *successful* `eth_getTransactionReceipt` poll lands after the tx's block has already scrolled past that small window — e.g. peers were flaky for ~a minute right after the send (common on peer-thin Gnosis) — the tx is never found, and the receipt returns a verified "not seen yet" **forever**, even though it mined. (This is the deferred gap noted in PR #84.)

## Fix
- `SentTxTracker` now records the **verified head block number at broadcast time** (`watch(hash, nowMs, headNumber)` + `broadcastHead(hash)`), carried through `markSeen`.
- `rpcSendRawTransaction` passes the current `headBlockNumber()` when registering the watch.
- On the **first** scan for one of our **own** sent txs, `locateMinedTx` reaches `from` back to the broadcast height instead of `head - 8`, so a late first poll still covers the block the tx could first have been mined in. Still bounded by `RECEIPT_MAX_SCAN_BLOCKS_PER_POLL`; the sent-tx watch TTL (180s) keeps the broadcast head recent (well within the cap).

Only affects our own sent txs (others retain the recent-window behavior). No new trust assumptions — headers are still beacon-anchored, bodies verified against `transactionsRoot`.

## Testing
- New `SentTxTrackerTest.recordsBroadcastHeadAndPreservesItAcrossSighting`; existing tests updated to the new signature — all green.
- `:rpc-backend` compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)