### PR TITLE
Multichain Phase B (Android): foundation + ChainStack maintainer + plan

### DIFF
--- a/android-app/build.gradle.kts
+++ b/android-app/build.gradle.kts
@@ -201,6 +201,11 @@ dependencies {
     // SnapQualitySink (the host seams) onto the compile classpath too.
     implementation(project(":rpc-backend"))
 
+    // Shared per-network host core: ChainStack + NodeRegistry (same the :app daemon
+    // hosts). NodeService builds one ChainStack per enabled network via Android cache
+    // adapters, so the per-network EL+CL+RPC lifecycle lives once for both hosts.
+    implementation(project(":node-core"))
+
     // Force the JRE *variant* of Guava. Guava publishes jre and android
     // variants under one module; on an Android project Gradle's
     // org.gradle.jvm.environment=android attribute selects the `android`

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/AndroidClPeerCacheAdapter.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/AndroidClPeerCacheAdapter.java
@@ -18,7 +18,7 @@ public final class AndroidClPeerCacheAdapter implements ClPeerCachePort {
     private final AndroidCLPeerCache delegate;
 
     public AndroidClPeerCacheAdapter(AndroidCLPeerCache delegate) {
-        this.delegate = delegate;
+        this.delegate = java.util.Objects.requireNonNull(delegate, "delegate");
     }
 
     @Override public List<String> load() { return delegate.load(); }

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/AndroidClPeerCacheAdapter.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/AndroidClPeerCacheAdapter.java
@@ -1,0 +1,37 @@
+package com.jaeckel.ethp2p.android;
+
+import io.myotis.node.ClPeerCachePort;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Adapts {@link AndroidCLPeerCache} to the {@link ClPeerCachePort} that {@code ChainStack}
+ * consumes. Pure delegation. {@code AndroidCLPeerCache} flushes writes inline (no
+ * {@code close()}), so {@link #close()} is a no-op. Mirrors the daemon's
+ * {@code ClPeerCacheAdapter}.
+ */
+public final class AndroidClPeerCacheAdapter implements ClPeerCachePort {
+
+    private final AndroidCLPeerCache delegate;
+
+    public AndroidClPeerCacheAdapter(AndroidCLPeerCache delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override public List<String> load() { return delegate.load(); }
+    @Override public void add(String multiaddr) { delegate.add(multiaddr); }
+    @Override public void markFailure(String multiaddr) { delegate.markFailure(multiaddr); }
+    @Override public Map<String, long[]> servedRanges() { return delegate.servedRanges(); }
+    @Override public void recordServed(String multiaddr, long low, long high) { delegate.recordServed(multiaddr, low, high); }
+    @Override public Map<String, Long> bootstrapPeers() { return delegate.bootstrapPeers(); }
+    @Override public void recordBootstrap(String multiaddr, long period) { delegate.recordBootstrap(multiaddr, period); }
+    @Override public Set<String> lightClientConfirmed() { return delegate.lightClientConfirmed(); }
+    @Override public Set<String> lightClientDenied() { return delegate.lightClientDenied(); }
+    @Override public void markLightClientBatch(Collection<String> confirmed, Collection<String> denied) {
+        delegate.markLightClientBatch(confirmed, denied);
+    }
+    @Override public void close() { /* AndroidCLPeerCache flushes writes inline; nothing to close */ }
+}

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/AndroidPeerCacheAdapter.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/AndroidPeerCacheAdapter.java
@@ -1,0 +1,57 @@
+package com.jaeckel.ethp2p.android;
+
+import io.myotis.node.CachedPeer;
+import io.myotis.node.PeerCachePort;
+import io.myotis.node.SnapQuality;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Adapts {@link AndroidPeerCache} to the {@link PeerCachePort} that {@code ChainStack}
+ * consumes, so {@code node-core} stays independent of the Android module. Pure
+ * delegation plus an {@link AndroidPeerCache.SnapQuality} → shared {@link SnapQuality}
+ * mapping. Mirrors the daemon's {@code PeerCacheAdapter}.
+ */
+public final class AndroidPeerCacheAdapter implements PeerCachePort {
+
+    private final AndroidPeerCache delegate;
+
+    public AndroidPeerCacheAdapter(AndroidPeerCache delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override public void add(InetSocketAddress address, String publicKeyHex, boolean snap) {
+        delegate.add(address, publicKeyHex, snap);
+    }
+
+    @Override public void recordSnapServed(InetSocketAddress address) {
+        delegate.recordSnapServed(address);
+    }
+
+    @Override public void recordSnapFailure(InetSocketAddress address) {
+        delegate.recordSnapFailure(address);
+    }
+
+    @Override public List<CachedPeer> load() {
+        List<AndroidPeerCache.CachedPeer> src = delegate.load();
+        List<CachedPeer> out = new ArrayList<>(src.size());
+        for (AndroidPeerCache.CachedPeer p : src) {
+            out.add(new CachedPeer(p.address(), p.publicKeyHex(), p.snap(), map(p.snapQuality())));
+        }
+        return out;
+    }
+
+    @Override public void close() {
+        delegate.close();
+    }
+
+    private static SnapQuality map(AndroidPeerCache.SnapQuality q) {
+        return switch (q) {
+            case CONFIRMED -> SnapQuality.CONFIRMED;
+            case UNKNOWN -> SnapQuality.UNKNOWN;
+            case DENIED -> SnapQuality.DENIED;
+        };
+    }
+}

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/AndroidPeerCacheAdapter.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/AndroidPeerCacheAdapter.java
@@ -19,7 +19,7 @@ public final class AndroidPeerCacheAdapter implements PeerCachePort {
     private final AndroidPeerCache delegate;
 
     public AndroidPeerCacheAdapter(AndroidPeerCache delegate) {
-        this.delegate = delegate;
+        this.delegate = java.util.Objects.requireNonNull(delegate, "delegate");
     }
 
     @Override public void add(InetSocketAddress address, String publicKeyHex, boolean snap) {

--- a/app/src/main/java/com/jaeckel/ethp2p/app/ClPeerCacheAdapter.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/ClPeerCacheAdapter.java
@@ -17,7 +17,7 @@ public final class ClPeerCacheAdapter implements ClPeerCachePort {
     private final CLPeerCache delegate;
 
     public ClPeerCacheAdapter(CLPeerCache delegate) {
-        this.delegate = delegate;
+        this.delegate = java.util.Objects.requireNonNull(delegate, "delegate");
     }
 
     @Override public List<String> load() { return delegate.load(); }

--- a/app/src/main/java/com/jaeckel/ethp2p/app/Main.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/Main.java
@@ -58,6 +58,8 @@ public final class Main {
     private static final Logger log = LoggerFactory.getLogger(Main.class);
 
     private static final int DEFAULT_PORT = 30303;
+    /** Snap-peer target the daemon's per-stack maintainer keeps topped up. */
+    private static final int SNAP_PEER_TARGET = 32;
 
     /** Socket path; override via {@code ETHP2P_SOCKET} env var. Network-specific suffix for non-mainnet. */
     static Path socketPath(String networkName) {
@@ -233,6 +235,11 @@ public final class Main {
                     new com.jaeckel.ethp2p.app.rpc.JavaHttpCcipGateway(),
                     syncSnapshotFile(network.name()),
                     gossipsubEnabled);
+            // Keep snap peers topped up from the cache + a refreshing EIP-1459 DNS pool —
+            // the discv4-independent path. Helps networks with scarce snap peers (Gnosis)
+            // retain a snap/1 peer for verified state reads. dnsServers=null → resolver's
+            // default DNS (the daemon, unlike Android, has system DNS config).
+            stack.configureSnapMaintainer(SNAP_PEER_TARGET, null);
 
             if (!stack.start()) {
                 System.err.println("Failed to start " + network.name() + " node stack");

--- a/app/src/main/java/com/jaeckel/ethp2p/app/PeerCacheAdapter.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/PeerCacheAdapter.java
@@ -19,7 +19,7 @@ public final class PeerCacheAdapter implements PeerCachePort {
     private final PeerCache delegate;
 
     public PeerCacheAdapter(PeerCache delegate) {
-        this.delegate = delegate;
+        this.delegate = java.util.Objects.requireNonNull(delegate, "delegate");
     }
 
     @Override public void add(InetSocketAddress address, String publicKeyHex, boolean snap) {

--- a/docs/multichain-android-phase-b.md
+++ b/docs/multichain-android-phase-b.md
@@ -1,0 +1,162 @@
+# Multichain Phase B — Android (`NodeService` registry + per-network UI)
+
+Status: **plan.** The shared core (Phase A) is merged (PR #83), and the Phase B
+*foundation* is on this branch (`feat/multichain-android`) and compiles:
+
+- `android-app` depends on `:node-core`.
+- `AndroidPeerCacheAdapter` / `AndroidClPeerCacheAdapter` wrap the existing Android
+  caches as the node-core `PeerCachePort` / `ClPeerCachePort`.
+- `ChainStack.rpcBackend()` getter added for the host.
+- **The snap-peer maintainer is now in `ChainStack`** (opt-in via
+  `configureSnapMaintainer(target, DnsServerProvider)`), de-Android-ified, and
+  **verified running on the daemon**. Android will reuse this instead of its own copy.
+
+What remains is the device-tested part: make `NodeService` host a
+`Map<String,ChainStack>` and add the per-network UI. **This needs a connected device
+to verify** (NAT handling, the Stop→Start race from PR #82, the foreground service),
+which is why it's handed off to the Mac.
+
+Decisions already taken (from the approved plan): default **mainnet ON / Gnosis
+opt-in**; **full per-network UI**; maintainer **moved into `ChainStack`** (shared).
+The daemon currently **enables** the maintainer (`Main.SNAP_PEER_TARGET = 32`); leave
+on (helps Gnosis snap retention) or flip off — cosmetic.
+
+---
+
+## Step 8b — `NodeService` hosts `Map<String,ChainStack>`
+
+Goal: replace the single inline stack with one `ChainStack` per *enabled* network,
+built through the Android adapters. Keep mainnet-only as the default so the proven
+path is what runs unless the user toggles a second chain.
+
+### Per-network holder
+`NodeService` currently keeps the stack as singleton fields
+(`discV4/discV5/connector/rpcServer/rpcBackend/beaconLightClient/beaconSyncState/
+clGenesisTime/peerCache/clPeerCache/peerMaintainer` ~lines 310–330) plus the dial
+state (`attempted/backoff/blacklistedNodeIds`, `dnsElEnrs` ~288–305). All of that now
+lives inside `ChainStack`. Replace it with:
+
+```java
+private final java.util.Map<String, ChainStack> stacks = new java.util.concurrent.ConcurrentHashMap<>();
+// keep per-network the Android cache refs the maintainer/snapshot don't need, only if
+// a screen still needs them; otherwise drop — ChainStack owns the caches via adapters.
+```
+
+Keep the process-global `ccipPool` (line 333) and `queryHistory` (342) as-is.
+
+### Building a stack (port from `startNode()`/`startAndPublish()`, ~1070–1460)
+For a network name `n`:
+
+```java
+NetworkConfig net = NetworkConfig.byName(n);
+ChainPorts ports = ChainPorts.defaultsFor(net)                 // 30303/9000/8545, gnosis 30304/9001/8546
+        .withRpcPort(rpcPortFor(this, n));                     // honor the per-network pref
+Path keyFile = new File(getFilesDir(),
+        n.equals("mainnet") ? "nodekey.hex" : "nodekey-" + n + ".hex").toPath();
+NodeKey key = NodeKey.loadOrGenerate(keyFile);
+AndroidPeerCache pc = new AndroidPeerCache(netCacheFor(n, "peers", ".cache").toPath());
+AndroidCLPeerCache cl = new AndroidCLPeerCache(netCacheFor(n, "cl-peers", ".cache").toPath());
+ChainStack stack = new ChainStack(net, ports, key,
+        new AndroidPeerCacheAdapter(pc), new AndroidClPeerCacheAdapter(cl),
+        new com.jaeckel.ethp2p.android.ens.AndroidCcipGateway(ccipPool),
+        netCacheFor(n, "sync-state", ".snapshot").toPath(),
+        /*gossipsub*/ false);
+stack.configureSnapMaintainer(snapTarget(this), this::activeNetworkDnsServers); // DnsServerProvider
+stacks.put(n, stack);
+new Thread(() -> { if (!stack.start()) stacks.remove(n); }, "ethp2p-boot-" + n).start();
+```
+
+- `netCache(base, ext)` (~278) is keyed on the single `activeNetwork` today — generalize
+  to `netCacheFor(String network, base, ext)` (suffix `-<net>` for non-mainnet). The
+  existing one-arg `netCache` can delegate for any remaining single-network callers.
+- `activeNetworkDnsServers()` (~928, `ConnectivityManager`) becomes the
+  `DnsServerProvider` passed to the stack — it stays in `NodeService` (Android API),
+  matching `DnsServerProvider.get()`.
+- `snapTarget`/`rpcPortFor` prefs already exist and are per-network for RPC port.
+
+### Lifecycle methods (new)
+- `enableNetwork(String n)`: if absent, build+start as above; persist `enabled_<n>=true`;
+  `startForegroundService` if the service isn't up.
+- `disableNetwork(String n)`: `stacks.remove(n)` then `stack.shutdown()` on a worker; if
+  `stacks.isEmpty()` → `stopForeground(STOP_FOREGROUND_REMOVE); stopSelf()`.
+- `onStartCommand` (~the RUNNING guard): iterate the **enabled-set** pref (default
+  `{mainnet}`) and `enableNetwork(n)` each. The global `RUNNING` stays the "service up"
+  flag; per-stack liveness is `ChainStack.isRunning()`.
+- `doShutdown`/`onDestroy`: iterate `stacks.values()`, `shutdown()` each, clear the map.
+  **Move the all-stacks-down `stopForeground/stopSelf` here** — today the single-stack
+  boot-failure path calls it (~1332); per-stack failures must NOT stop the service.
+- Delete `switchNetwork`/`restartWithCurrentSettings`/`restartAfterShutdown` (~254–276,
+  174). An RPC-port change for `n` = `disableNetwork(n); enableNetwork(n)` (only that
+  stack reboots). Keep the **Stop→Start race** safety: `ChainStack.start()`/`shutdown()`
+  are already `synchronized` together, so a fast disable→enable on one stack serializes
+  on that stack's monitor (this replaces the old service-wide `restartAfterShutdown`
+  dance — verify on device that a port-change reboot of one chain doesn't flap the
+  notification).
+
+### Snapshot + query, per-stack
+- `snapshot()` → `snapshots()` returning `Map<String, Snapshot>` (one per live stack).
+  Keep the `Snapshot` record shape; build each from a `ChainStack`'s getters
+  (`connector()`, `discV4()`, `discV5()`, `beaconLightClient()`, `beaconSyncState()`,
+  `network()`), exactly as the current single-network `snapshot()`/`beaconStatsSnapshot()`
+  read the singletons. The `network` field is the map key.
+- `requestAccount(addr)` / `resolveEns(name)` take (or default) a network and route to
+  `stacks.get(n).connector()` / `.rpcBackend()`. Default to the primary enabled network
+  for back-compat.
+- **Remove** `startPeerMaintainer/maintainSnapPeers/refreshDnsPool/dnsDialBudget/dialEnr/
+  dialCachedSnapPeer/snapDialRank` and the `attempted/backoff/blacklistedNodeIds/dns*`
+  fields from `NodeService` — they now live in `ChainStack`. `setTargetSnapPeers` becomes
+  "set on every live stack" (`stacks.values().forEach(s -> s.setTargetSnapPeers(v))`).
+
+### Prefs migration
+- Add `enabled_<net>` booleans (default: mainnet true, others false). Seed from the
+  legacy `K_NETWORK` if the `enabled_*` keys are absent (so existing installs keep their
+  chain). Retire `K_NETWORK`/`selectedNetwork`/`setSelectedNetwork` once the UI uses the
+  enabled-set. `rpcPortFor`/`setRpcPort` stay (already per-network); generalize
+  `setRpcPort(ctx, port)` → `setRpcPort(ctx, network, port)`.
+
+---
+
+## Step 9 — `MainActivity` per-network UI
+
+- **Settings** (`SettingsScreen`, ~503–605): replace the mainnet/gnosis **radio**
+  (~541–558) with a `Switch` per network → `onEnableNetwork(id, on)`; give each row its
+  own RPC-port `OutlinedTextField` bound to `rpcPortFor(ctx, id)`. Drive the list from
+  `NetworkConfig.allNetworks()` so adding a config entry auto-adds a row. Keep the snap
+  target + deep-pool fields (apply to all stacks).
+- **Status** (`NodeScreen`/`StatusTab`): hold `snapshots: Map<String,Snapshot>` from
+  `svc.snapshots()`; add a small network selector (chips/segmented) above the existing
+  `StatusTab` and render it per selected chain. `SyncProgressBar`/`ReadinessStrip` already
+  take one `Snapshot` — call per chain.
+- **Query/ENS**: add a chain selector; route via the selected stack. Default to the
+  primary enabled network.
+- Activity callbacks (~227–251): `switchNetwork` → `enableNetwork(name, on)`;
+  `applyTunables` takes a network for the RPC port.
+
+---
+
+## Device verification (on the Mac, phone connected)
+
+```bash
+adb forward tcp:8545 tcp:8545
+adb forward tcp:8546 tcp:8546
+```
+
+1. Default launch → only mainnet runs; `eth_chainId` on :8545 → `0x1`; Status shows
+   mainnet reaching SYNCED; behavior matches today (regression check).
+2. Toggle **Gnosis on** in Settings → a second stack boots; `eth_chainId` on :8546 →
+   `0x64`; both chains show in Status; no port collision in logs (discv4 30303/30304,
+   discv5 9000/9001); `nodekey-gnosis.hex` appears in `getFilesDir()`.
+3. Both reach SYNCED concurrently; the per-network snap-peer maintainer logs show it
+   topping up each chain.
+4. Toggle Gnosis **off** → only its stack stops; mainnet keeps serving; service stays
+   foreground.
+5. Change a network's RPC port → only that stack reboots (notification doesn't flap).
+6. Add both `http://<host>:8545` and `:8546` as MetaMask custom RPCs → both resolve.
+7. Memory/battery sanity with two stacks; confirm one foreground notification.
+
+## Risks / watch-items
+- Stop→Start race (PR #82): now per-stack via `ChainStack`'s synchronized start/shutdown
+  — verify a port-change reboot doesn't flap the foreground notification.
+- Snapshot polling must tolerate a stack mid-boot (null getters) — guard like today.
+- `AndroidCcipGateway`/`ccipPool` shared across stacks is fine (stateless per call).
+- Keep the proven single-network path the default; only the toggle enables concurrency.

--- a/node-core/src/main/java/io/myotis/node/ChainStack.java
+++ b/node-core/src/main/java/io/myotis/node/ChainStack.java
@@ -19,14 +19,19 @@ import java.net.InetSocketAddress;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -53,6 +58,12 @@ public final class ChainStack {
     private static final long BACKOFF_TRANSIENT_MS = 30 * 1000L;         // 30s, transient failures
     /** Cap on DNS-resolved (EIP-1459) EL enodes RLPx-dialed directly at startup, bypassing discv4. */
     private static final int DNS_DIRECT_DIAL_LIMIT = 50;
+    // Snap-peer maintainer tunables (ported from the Android NodeService).
+    private static final int MAX_ATTEMPTED = 200;
+    private static final int DNS_MAINTAIN_DIAL_BATCH = 15;   // per-cycle dial budget from the DNS pool
+    private static final int DNS_DIALS_PER_MIN = 60;         // rolling-minute rate cap
+    private static final int DNS_POOL_MAX = 600;             // candidate-pool size cap
+    private static final long DNS_REFRESH_INTERVAL_MS = 4 * 60 * 1000L;
 
     // -- injected configuration ------------------------------------------------
     private final NetworkConfig network;
@@ -69,6 +80,17 @@ public final class ChainStack {
     private final Map<String, Long> backoff = new ConcurrentHashMap<>();
     private final Set<String> blacklistedNodeIds = ConcurrentHashMap.newKeySet();
     private final AtomicBoolean running = new AtomicBoolean(false);
+
+    // -- snap-peer maintainer (optional; enabled via configureSnapMaintainer) --
+    private volatile boolean maintainerEnabled = false;
+    private volatile int targetSnapPeers = 32;
+    private DnsServerProvider dnsServerProvider;            // null → resolver's default DNS
+    private volatile List<Enr> dnsElPool = List.of();
+    private final AtomicBoolean dnsResolving = new AtomicBoolean(false);
+    private volatile long lastDnsResolveMs = 0L;
+    private volatile long dnsDialWindowStartMs = 0L;
+    private final AtomicInteger dnsDialsInWindow = new AtomicInteger(0);
+    private volatile ScheduledExecutorService peerMaintainer;
 
     // -- live components (built in start()) ------------------------------------
     private volatile RLPxConnector connector;
@@ -95,6 +117,27 @@ public final class ChainStack {
         this.ccipGateway = ccipGateway;
         this.syncSnapshotFile = syncSnapshotFile;
         this.gossipsubEnabled = gossipsubEnabled;
+    }
+
+    /**
+     * Enable the snap-peer maintainer for this stack — a background loop that keeps
+     * {@code connector.activeSnapHandlers() >= targetSnapPeers} by re-dialing cached snap
+     * peers and a refreshing EIP-1459 DNS-resolved ENR pool (the discv4-independent path
+     * NAT'd mobile hosts rely on, where discv4 can't bootstrap). Must be called before
+     * {@link #start()}. {@code dnsServers} may be null → the resolver uses its default DNS.
+     *
+     * <p>Off by default: a bare daemon relies on continuous discv4 discovery; mobile (and
+     * any host wanting aggressive snap-peer retention) turns it on.
+     */
+    public void configureSnapMaintainer(int targetSnapPeers, DnsServerProvider dnsServers) {
+        this.maintainerEnabled = true;
+        this.targetSnapPeers = targetSnapPeers;
+        this.dnsServerProvider = dnsServers;
+    }
+
+    /** Live-update the snap-peer target (no restart). */
+    public void setTargetSnapPeers(int target) {
+        this.targetSnapPeers = target;
     }
 
     // -------------------------------------------------------------------------
@@ -125,6 +168,7 @@ public final class ChainStack {
                     () -> dnsResolver.resolveAllFromStrings(network.clEnrTreeUrls(), dnsDeadline));
             List<Enr> dnsElEnrs = elFuture.join();
             List<Enr> dnsClEnrs = clFuture.join();
+            this.dnsElPool = dnsElEnrs;  // seed the maintainer's candidate pool
 
             List<InetSocketAddress> mergedBootnodes = mergeBootnodes(dnsElEnrs);
 
@@ -150,6 +194,10 @@ public final class ChainStack {
             // 5. Verified JSON-RPC (best-effort; a bind failure here does not fail the stack).
             startRpc();
 
+            // 6. Snap-peer maintainer (optional): keep snap peers topped up from cache +
+            //    the refreshing DNS pool. The discv4-independent path NAT'd hosts need.
+            if (maintainerEnabled) startPeerMaintainer();
+
             return true;
         } catch (Throwable t) {
             log.error("[{}] stack failed to start: {}", network.name(), t.toString());
@@ -161,6 +209,8 @@ public final class ChainStack {
     /** Tear down this stack's components (reverse order) and release its caches. */
     public synchronized void shutdown() {
         running.set(false);
+        ScheduledExecutorService pm = peerMaintainer;
+        if (pm != null) { pm.shutdownNow(); peerMaintainer = null; }
         if (rpcServer != null) { try { rpcServer.stop(); } catch (Throwable ignored) {} }
         if (rpcBackend != null) { try { rpcBackend.close(); } catch (Throwable ignored) {} }
         if (beaconLightClient != null) { try { beaconLightClient.close(); } catch (Throwable ignored) {} }
@@ -442,5 +492,193 @@ public final class ChainStack {
             case UNKNOWN -> 1;
             case DENIED -> 2;
         };
+    }
+
+    // -------------------------------------------------------------------------
+    // Snap-peer maintainer (ported from NodeService; optional per-stack)
+    // -------------------------------------------------------------------------
+
+    private void startPeerMaintainer() {
+        if (peerMaintainer != null) return;
+        peerMaintainer = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "snap-peer-maintainer-" + network.name());
+            t.setDaemon(true);
+            return t;
+        });
+        peerMaintainer.scheduleWithFixedDelay(this::maintainSnapPeers, 5, 10, TimeUnit.SECONDS);
+    }
+
+    /** Keep {@code activeSnapHandlers() >= targetSnapPeers}: re-dial cached snap peers,
+     *  then top up from the DNS ENR pool (rate-capped), then refresh the pool if still low. */
+    private void maintainSnapPeers() {
+        if (!running.get()) return;
+        // Guard the whole body: an uncaught throw would make scheduleWithFixedDelay
+        // silently stop all future runs.
+        try {
+            RLPxConnector conn = connector;
+            if (conn == null) return;
+            int snapPeers = conn.activeSnapHandlers().size();
+            if (snapPeers >= targetSnapPeers) return;
+            long now = System.currentTimeMillis();
+            log.info("[{}][peers] {} snap peer(s) < target {}; re-dialing cached + DNS pool",
+                    network.name(), snapPeers, targetSnapPeers);
+            // 1) Re-dial known snap peers from the cache, proven snap-servers first.
+            List<CachedPeer> snapCached = new ArrayList<>();
+            for (CachedPeer p : peerCache.load()) {
+                if (p.snap()) snapCached.add(p);
+            }
+            snapCached.sort(Comparator.comparingInt(ChainStack::snapDialRank));
+            for (CachedPeer p : snapCached) {
+                if (conn.activeSnapHandlers().size() >= targetSnapPeers) break;
+                try {
+                    dialCachedSnapPeer(conn, p, now);
+                } catch (Exception e) {
+                    log.warn("[{}][peers] skipping cached peer: {}", network.name(), e.getMessage());
+                }
+            }
+            // 2) Top up from the DNS-resolved ENR pool (discv4 substitute on NAT'd hosts),
+            //    bounded by a per-cycle batch and a rolling-minute rate cap.
+            List<Enr> pool = dnsElPool;
+            if (!pool.isEmpty() && conn.activeSnapHandlers().size() < targetSnapPeers) {
+                int budget = Math.min(DNS_MAINTAIN_DIAL_BATCH, dnsDialBudget());
+                int dialed = 0;
+                for (Enr enr : pool) {
+                    if (dialed >= budget || attempted.size() >= MAX_ATTEMPTED) break;
+                    if (dialEnr(conn, enr, now)) {
+                        dialed++;
+                        dnsDialsInWindow.incrementAndGet();
+                    }
+                }
+                if (dialed > 0) {
+                    log.info("[{}][peers] topped up {} dial(s) from DNS ENR pool ({} known)",
+                            network.name(), dialed, pool.size());
+                }
+            }
+            // 3) Grow/refresh the candidate pool — only while still below target and no
+            //    more often than DNS_REFRESH_INTERVAL_MS.
+            if (conn.activeSnapHandlers().size() < targetSnapPeers
+                    && !dnsResolving.get()
+                    && System.currentTimeMillis() - lastDnsResolveMs > DNS_REFRESH_INTERVAL_MS) {
+                Thread t = new Thread(this::refreshDnsPool, "dns-el-refresh-" + network.name());
+                t.setDaemon(true);
+                t.start();
+            }
+        } catch (Throwable t) {
+            log.warn("[{}][peers] maintenance loop error: {}", network.name(), t.toString());
+        }
+    }
+
+    /** Re-walk the EL ENR trees, fork-filter, and merge into the rolling candidate pool
+     *  (dedup by enode address, capped at {@link #DNS_POOL_MAX}). Guarded to one walk at a time. */
+    private void refreshDnsPool() {
+        if (!dnsResolving.compareAndSet(false, true)) return;
+        try {
+            DnsEnrResolver resolver = new DnsEnrResolver();
+            // On Android dnsjava has no system resolver config, so the host supplies DNS
+            // server IPs; on the daemon dnsServerProvider is null and the resolver uses
+            // its own default/public-DNS fallback.
+            if (dnsServerProvider != null) {
+                List<String> servers = dnsServerProvider.get();
+                if (servers != null && !servers.isEmpty()) resolver.setDnsServerIps(servers);
+            }
+            List<Enr> resolved = resolver.resolveAllFromStrings(
+                    network.elEnrTreeUrls(), Duration.ofSeconds(25));
+            lastDnsResolveMs = System.currentTimeMillis();
+
+            byte[] ourFork = network.forkIdHash();
+            LinkedHashMap<String, Enr> merged = new LinkedHashMap<>();
+            for (Enr e : dnsElPool) {
+                e.tcpAddress().ifPresent(a -> merged.put(a.getHostString() + ":" + a.getPort(), e));
+            }
+            int added = 0, dropped = 0;
+            for (Enr e : resolved) {
+                if (merged.size() >= DNS_POOL_MAX) break;
+                try {
+                    Optional<InetSocketAddress> tcp = e.tcpAddress();
+                    if (tcp.isEmpty() || e.publicKey().isEmpty()) continue;
+                    Optional<byte[]> fork = e.ethForkIdHash();
+                    if (fork.isPresent() && !Arrays.equals(fork.get(), ourFork)) { dropped++; continue; }
+                    String key = tcp.get().getHostString() + ":" + tcp.get().getPort();
+                    if (merged.putIfAbsent(key, e) == null) added++;
+                } catch (Exception ex) {
+                    dropped++; // malformed ENR — skip, don't abort the refresh
+                }
+            }
+            dnsElPool = new ArrayList<>(merged.values());
+            log.info("[{}] DNS EL pool: +{} new, {} off-fork dropped, {} total",
+                    network.name(), added, dropped, dnsElPool.size());
+        } catch (Exception e) {
+            log.warn("[{}] DNS EL pool refresh failed: {}", network.name(), e.getMessage());
+        } finally {
+            dnsResolving.set(false);
+        }
+    }
+
+    /** Remaining DNS-pool dials allowed in the current rolling minute (see DNS_DIALS_PER_MIN). */
+    private int dnsDialBudget() {
+        long now = System.currentTimeMillis();
+        if (now - dnsDialWindowStartMs >= 60_000L) {
+            dnsDialWindowStartMs = now;
+            dnsDialsInWindow.set(0);
+        }
+        return Math.max(0, DNS_DIALS_PER_MIN - dnsDialsInWindow.get());
+    }
+
+    /** Dial one DNS-resolved (EIP-1459) EL enode over RLPx — same attempted/backoff/blacklist
+     *  bookkeeping as the other dial paths; returns true if a connect was started. */
+    private boolean dialEnr(RLPxConnector conn, Enr enr, long now) {
+        String peerKey = null;
+        try {
+            Optional<InetSocketAddress> tcp = enr.tcpAddress();
+            Optional<SECP256K1.PublicKey> pub = enr.publicKey();
+            if (tcp.isEmpty() || pub.isEmpty()) return false;
+            InetSocketAddress peerTcp = tcp.get();
+            peerKey = peerTcp.getHostString() + ":" + peerTcp.getPort();
+            Long expiry = backoff.get(peerKey);
+            if (expiry != null) {
+                if (now < expiry) return false;
+                backoff.remove(peerKey);
+            }
+            if (attempted.size() >= MAX_ATTEMPTED || !attempted.add(peerKey)) return false;
+            final String key = peerKey;
+            conn.connect(peerTcp, pub.get(), (incompatible, idHex) -> {
+                if (incompatible) blacklistedNodeIds.add(idHex);
+                long ms = incompatible ? BACKOFF_INCOMPATIBLE_MS : BACKOFF_TRANSIENT_MS;
+                backoff.putIfAbsent(key, System.currentTimeMillis() + ms);
+                attempted.remove(key);
+            }).addListener(future -> {
+                if (!future.isSuccess()) {
+                    backoff.putIfAbsent(key, System.currentTimeMillis() + BACKOFF_TRANSIENT_MS);
+                    attempted.remove(key);
+                }
+            });
+            return true;
+        } catch (Exception e) {
+            log.warn("[{}] DNS EL dial failed: {}", network.name(), e.getMessage());
+            if (peerKey != null) attempted.remove(peerKey);
+            return false;
+        }
+    }
+
+    /** Dial a cached snap peer with the same backoff/blacklist/attempted bookkeeping. */
+    private void dialCachedSnapPeer(RLPxConnector conn, CachedPeer p, long now) {
+        String peerKey = p.address().getHostString() + ":" + p.address().getPort();
+        Long expiry = backoff.get(peerKey);
+        if (expiry != null) {
+            if (now < expiry) return;
+            backoff.remove(peerKey);
+        }
+        if (attempted.size() >= MAX_ATTEMPTED || !attempted.add(peerKey)) return;
+        try {
+            SECP256K1.PublicKey pubKey = SECP256K1.PublicKey.fromBytes(Bytes.fromHexString(p.publicKeyHex()));
+            conn.connect(p.address(), pubKey, (incompatible, idHex) -> {
+                if (incompatible) blacklistedNodeIds.add(idHex);
+                long ms = incompatible ? BACKOFF_INCOMPATIBLE_MS : BACKOFF_TRANSIENT_MS;
+                backoff.putIfAbsent(peerKey, System.currentTimeMillis() + ms);
+                attempted.remove(peerKey);
+            });
+        } catch (Exception e) {
+            attempted.remove(peerKey);
+        }
     }
 }

--- a/node-core/src/main/java/io/myotis/node/ChainStack.java
+++ b/node-core/src/main/java/io/myotis/node/ChainStack.java
@@ -186,6 +186,8 @@ public final class ChainStack {
     public DiscV5Service discV5() { return discV5; }
     public BeaconSyncState beaconSyncState() { return beaconSyncState; }
     public BeaconLightClient beaconLightClient() { return beaconLightClient; }
+    /** The verified backend (for ENS resolution / verified reads), or null if RPC didn't start. */
+    public io.myotis.rpc.VerifiedRpcBackend rpcBackend() { return rpcBackend; }
     public Map<String, Long> backoff() { return backoff; }
     public Set<String> blacklistedNodeIds() { return blacklistedNodeIds; }
 

--- a/node-core/src/main/java/io/myotis/node/ChainStack.java
+++ b/node-core/src/main/java/io/myotis/node/ChainStack.java
@@ -130,6 +130,9 @@ public final class ChainStack {
      * any host wanting aggressive snap-peer retention) turns it on.
      */
     public void configureSnapMaintainer(int targetSnapPeers, DnsServerProvider dnsServers) {
+        if (running.get()) {
+            throw new IllegalStateException("configureSnapMaintainer must be called before start()");
+        }
         this.maintainerEnabled = true;
         this.targetSnapPeers = targetSnapPeers;
         this.dnsServerProvider = dnsServers;
@@ -161,6 +164,13 @@ public final class ChainStack {
 
             // 1. EIP-1459 DNS discovery (EL + CL trees), concurrent + best-effort.
             DnsEnrResolver dnsResolver = new DnsEnrResolver();
+            // Apply the host's DNS servers (Android: dnsjava has no system resolver config,
+            // so without these the initial EL/CL resolve — and the maintainer's pool seed —
+            // come back empty). Null/empty → resolver uses its default/public-DNS fallback.
+            if (dnsServerProvider != null) {
+                List<String> servers = dnsServerProvider.get();
+                if (servers != null && !servers.isEmpty()) dnsResolver.setDnsServerIps(servers);
+            }
             Duration dnsDeadline = Duration.ofSeconds(10);
             CompletableFuture<List<Enr>> elFuture = CompletableFuture.supplyAsync(
                     () -> dnsResolver.resolveAllFromStrings(network.elEnrTreeUrls(), dnsDeadline));
@@ -583,6 +593,9 @@ public final class ChainStack {
             }
             List<Enr> resolved = resolver.resolveAllFromStrings(
                     network.elEnrTreeUrls(), Duration.ofSeconds(25));
+            // The resolve can take ~25s; if the stack was shut down meanwhile, drop the
+            // result instead of merging into / writing the pool of a dead stack.
+            if (!running.get()) return;
             lastDnsResolveMs = System.currentTimeMillis();
 
             byte[] ourFork = network.forkIdHash();
@@ -605,7 +618,7 @@ public final class ChainStack {
                 }
             }
             dnsElPool = new ArrayList<>(merged.values());
-            log.info("[{}] DNS EL pool: +{} new, {} off-fork dropped, {} total",
+            log.info("[{}] DNS EL pool: +{} new, {} dropped (off-fork/malformed), {} total",
                     network.name(), added, dropped, dnsElPool.size());
         } catch (Exception e) {
             log.warn("[{}] DNS EL pool refresh failed: {}", network.name(), e.getMessage());
@@ -676,6 +689,14 @@ public final class ChainStack {
                 long ms = incompatible ? BACKOFF_INCOMPATIBLE_MS : BACKOFF_TRANSIENT_MS;
                 backoff.putIfAbsent(peerKey, System.currentTimeMillis() + ms);
                 attempted.remove(peerKey);
+            }).addListener(future -> {
+                // TCP-level failure (refused/timeout) fires here, not the handshake
+                // callback above — free the slot and back off so a dead peer can't pin
+                // `attempted` and eventually starve the pool at MAX_ATTEMPTED.
+                if (!future.isSuccess()) {
+                    backoff.putIfAbsent(peerKey, System.currentTimeMillis() + BACKOFF_TRANSIENT_MS);
+                    attempted.remove(peerKey);
+                }
             });
         } catch (Exception e) {
             attempted.remove(peerKey);

--- a/node-core/src/main/java/io/myotis/node/DnsServerProvider.java
+++ b/node-core/src/main/java/io/myotis/node/DnsServerProvider.java
@@ -1,0 +1,16 @@
+package io.myotis.node;
+
+import java.util.List;
+
+/**
+ * Supplies the DNS server IPs to use for EIP-1459 ENR-tree (TXT) lookups when refreshing
+ * the snap-peer maintainer's candidate pool. dnsjava has no system-resolver config on
+ * Android, so the Android host provides the active network's DNS servers; the daemon can
+ * pass {@code null} (or a provider returning an empty list) to let the resolver use its
+ * own default/public-DNS fallback.
+ */
+@FunctionalInterface
+public interface DnsServerProvider {
+    /** DNS server IPs (may be empty → resolver falls back to its default). */
+    List<String> get();
+}


### PR DESCRIPTION
## What & why

Phase B of multichain (the Android side) building on the merged Phase A (PR #83). This PR carries the **compiling foundation + the shared maintainer**, plus a **detailed implementation plan** for the remaining device-tested work (`docs/multichain-android-phase-b.md`). It's meant to be resumed on a machine with a phone connected.

## In this PR (compiles; maintainer verified on the daemon)

- `android-app` depends on `:node-core`; `AndroidPeerCacheAdapter` / `AndroidClPeerCacheAdapter` expose the Android caches as node-core's `PeerCachePort` / `ClPeerCachePort`.
- `ChainStack.rpcBackend()` getter for the host.
- **Snap-peer maintainer moved into `ChainStack`** (`refreshDnsPool` / `maintainSnapPeers` / dial helpers + rolling rate cap), de-Android-ified — DNS servers injected via a new `DnsServerProvider` so node-core stays Android-free. Opt-in via `configureSnapMaintainer(target, dnsServers)`. The **daemon now enables it** and it's **verified running live** (per-network loop tops up snap peers from cache + a refreshing EIP-1459 DNS pool — the discv4-independent path NAT'd mobile needs, and which also helps Gnosis snap retention).
- `docs/multichain-android-phase-b.md` — the step-by-step plan for what's left.

## Remaining (device-tested — see the plan doc)

- **8b:** `NodeService` → `Map<String,ChainStack>` registry (per-network stacks via the Android adapters, enable/disable, `enabled_<net>` prefs migration, per-stack snapshot/query). Replaces the singleton fields and `switchNetwork`/`restartAfterShutdown`.
- **9:** `MainActivity` per-network UI (enable toggles + per-network RPC port + per-chain Status/Query).

## Verification so far

- ✅ `:node-core`, `:app`, `:android-app` all compile.
- ✅ Daemon maintainer verified live (per-network `snap-peer-maintainer` loop + DNS-pool refresh).
- ⏭️ NodeService registry + UI are intentionally deferred to on-device work (NAT handling, Stop→Start race, foreground service) — plan + verification steps in the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)