### PR TITLE
peers: direct-dial static EL enodes for chains without an enrtree (Gnosis)

### DIFF
--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/NetworkConfig.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/NetworkConfig.java
@@ -403,6 +403,42 @@ public record NetworkConfig(
         };
     }
 
+    /**
+     * Full EL enodes (enode:// with node pubkey) for DIRECT RLPx dialing — the discovery
+     * seed for chains that have NO EIP-1459 EL enrtree (e.g. Gnosis). Unlike {@link
+     * #bootnodes()} (bare ip:port, usable only as a discv4 ping target), these carry the
+     * secp256k1 pubkey, so a NAT'd / mobile host can reach them over RLPx directly without
+     * bootstrapping discv4 UDP — the same role the DNS-resolved enrtree enodes play on
+     * networks that publish one. Empty for networks whose {@code elEnrTreeUrls} already
+     * supply a refreshing pool (mainnet, sepolia).
+     *
+     * <p>Source: gnosischain / Nethermind {@code gnosis.json} chainspec {@code nodes} list.
+     */
+    public List<String> elBootEnodes() {
+        return (int) networkId == 100 ? GNOSIS_EL_ENODES : List.of();
+    }
+
+    /** Gnosis EL enodes (chainspec {@code nodes}) — Gnosis publishes no EL enrtree, so these
+     *  are the direct-dial discovery seed (see {@link #elBootEnodes()}). */
+    private static final List<String> GNOSIS_EL_ENODES = List.of(
+            "enode://6765fff89db92aa8d923e28c438af626c8ae95a43093cdccbd6f550a7b6ce6ab5d1a3dc60dd79af3e6d2c2e6731bae629f0e54446a0d9da408c4eca7ebcd8485@3.75.159.31:30303",
+            "enode://9a7c98e8ee8cdd3199db68092b48868847d4743a471b26afc2ff878bafaa829ed43ee405f9aff58ae13fce53b898f7c2e3c30cb80af8eb111682c3c13f686dbb@18.198.130.54:30303",
+            "enode://2c4307831914c237801993eac4f9596d8b2f78e1e76830419b64cb23f0933e52cb1e2bb3009cb4af76454bb5bc296135b36869fd6c13e2c2e536a0780e60fe82@3.64.242.196:30303",
+            "enode://074f68e1a7df5b0859314ff721d55b59d9690e93249c941660609a29b302f02864df4f93ee48884f7ede57dc7f7646379d017a43c9745e34baff049749896b50@3.126.169.151:30303",
+            "enode://d239697375d7586c7ea1de790401c310b0b1d389326849fa3b7c7005833c7a6b9020e49dfb3b61abfa39135237ffc4ff219cb84ca7653069e8548497527aa432@107.22.4.120:30303",
+            "enode://d5852bf415d89b756faa809f4ff3f8beb661dc7d60cfb4a5542f9a5fcdf41e1ed0708a210db64b8c7ca32426e04ef0a50da58974124fdf562a8510314d11e28c@3.26.206.142:30303",
+            "enode://01d372392bb22dd8a91f8b10b6bbb8d80d2dbe98d695801e0df9e4bd4825781df84bba88361f24d1b6580a61313f64e6cec82e8d842ad5f1b3d7cf8d6d132da7@15.152.45.82:30303",
+            "enode://aee88e803b8e54925081957965b2527961cd90f4d6d14664884580b429da44729678a1258a8b49a42d1582c9c7c5ded05733622f7ab442ad9c6f655545a5ecdd@54.207.220.169:30303",
+            "enode://fb14d72321ee823fcf21e163091849ee42e0f6ac0cddc737d79e324b0a734c4fc51823ef0a96b749c954483c25e8d2e534d1d5fc2619ea22d58671aff96f5188@65.109.103.148:30303",
+            "enode://40f40acd78004650cce57aa302de9acbf54becf91b609da93596a18979bb203ba79fcbee5c2e637407b91be23ce72f0cc13dfa38d13e657005ce842eafb6b172@65.109.103.149:30303",
+            "enode://9e50857aa48a7a31bc7b46957e8ced0ef69a7165d3199bea924cb6d02b81f1f35bd8e29d21a54f4a331316bf09bb92716772ea76d3ef75ce027699eccfa14fad@141.94.97.22:30303",
+            "enode://96dc133ce3aeb5d9430f1dce1d77a36418c8789b443ae0445f06f73c6b363f5b35c019086700a098c3e6e54974d64f37e97d72a5c711d1eae34dc06e3e00eed5@141.94.97.74:30303",
+            "enode://516cbfbe9bbf26b6395ed68b24e383401fc33e7fe96b9d235ebca86c9f812fde8d33a7dbebc0fb5595459d2c5cc6381595d96507af89e6b48b5bdd0ebf8af0c0@141.94.97.84:30303",
+            "enode://fc86a93545c56322dd861180b76632b9baeb65af8f304269b489b4623ae060847569c3c3c10c4b39baf221a2cdefea66efabce061a542cdcda374cbba45aa3d4@51.68.39.206:30303",
+            "enode://0e6dd3815a627893515465130c1e95aa73b18fe2f723b2467f3abf94df9be036f27595f301b5e78750ad128e59265f980c92033ae903330c0460c40ae088c04a@35.210.37.245:30303",
+            "enode://b72d6233d50bef7b31c09f3ea39459257520178f985a872bbaa4e371ed619455b7671053ffe985af1b5fb3270606e2a49e4e67084debd75e6c9b93e227c5b01c@35.210.156.59:30303"
+    );
+
     /** Look up a network by name (case-insensitive). */
     public static NetworkConfig byName(String name) {
         return switch (name.toLowerCase(Locale.ROOT)) {

--- a/networking/src/test/java/com/jaeckel/ethp2p/networking/NetworkConfigGnosisTest.java
+++ b/networking/src/test/java/com/jaeckel/ethp2p/networking/NetworkConfigGnosisTest.java
@@ -92,4 +92,31 @@ class NetworkConfigGnosisTest {
     void minSensibleHeadIsSet() {
         assertEquals(40_000_000L, G.minSensibleHeadBlock());
     }
+
+    @Test
+    void elBootEnodesAreDialableForGnosisOnly() {
+        // Gnosis publishes no EL enrtree, so it ships full enode://<pubkey>@host:port seeds for
+        // direct RLPx dialing. Networks that have an enrtree return an empty list.
+        assertTrue(NetworkConfig.MAINNET.elBootEnodes().isEmpty(), "mainnet has an enrtree");
+        assertTrue(NetworkConfig.SEPOLIA.elBootEnodes().isEmpty(), "sepolia has an enrtree");
+
+        var enodes = G.elBootEnodes();
+        assertFalse(enodes.isEmpty(), "Gnosis must ship static EL enode seeds");
+        assertEquals(16, enodes.size());
+        for (String enode : enodes) {
+            // Parse exactly as ChainStack does — proves each entry yields a valid pubkey + addr.
+            assertTrue(enode.startsWith("enode://"), enode);
+            String b = enode.substring(enode.indexOf("//") + 2);
+            int at = b.indexOf('@');
+            assertTrue(at > 0, "missing @ in " + enode);
+            // 64-byte uncompressed secp256k1 pubkey (128 hex chars), must decode to a key.
+            assertEquals(128, at, "pubkey must be 128 hex chars in " + enode);
+            assertNotNull(org.apache.tuweni.crypto.SECP256K1.PublicKey.fromBytes(
+                    Bytes.fromHexString(b.substring(0, at))), enode);
+            String hostPort = b.substring(at + 1);
+            int colon = hostPort.lastIndexOf(':');
+            assertTrue(colon > 0, "missing host:port in " + enode);
+            assertTrue(Integer.parseInt(hostPort.substring(colon + 1)) > 0, enode);
+        }
+    }
 }

--- a/node-core/src/main/java/io/myotis/node/ChainStack.java
+++ b/node-core/src/main/java/io/myotis/node/ChainStack.java
@@ -186,6 +186,7 @@ public final class ChainStack {
             this.connector = buildConnector();
             dialCachedPeers();
             directDialDnsEnodes(dnsElEnrs);
+            directDialStaticEnodes();   // enrtree substitute for chains without one (Gnosis)
 
             // 3. discv4.
             this.discV4 = buildDiscV4(mergedBootnodes);
@@ -268,11 +269,75 @@ public final class ChainStack {
                 if (seen.add(key)) merged.add(sa);
             });
         }
+        // Also seed discv4 from the static EL enodes (chains without an enrtree, e.g. Gnosis):
+        // their ip:port widen the ping set; their pubkeys feed the direct-dial path separately.
+        for (ParsedEnode pe : parseStaticEnodes()) {
+            String key = pe.address().getAddress().getHostAddress() + ":" + pe.address().getPort();
+            if (seen.add(key)) merged.add(pe.address());
+        }
         if (merged.size() > before) {
-            log.info("[{}] DNS discovery added {} EL bootnode(s) (total: {})",
+            log.info("[{}] discovery seeds added {} EL bootnode(s) (total: {})",
                     network.name(), merged.size() - before, merged.size());
         }
         return merged;
+    }
+
+    /** A parsed {@code enode://<pubkey>@<host>:<port>} — address + secp256k1 pubkey. */
+    private record ParsedEnode(InetSocketAddress address, SECP256K1.PublicKey pubkey) {}
+
+    /** Parse {@link NetworkConfig#elBootEnodes()} into dialable (address, pubkey) pairs,
+     *  skipping any malformed entry. */
+    private List<ParsedEnode> parseStaticEnodes() {
+        List<ParsedEnode> out = new ArrayList<>();
+        for (String enode : network.elBootEnodes()) {
+            try {
+                String b = enode.substring(enode.indexOf("//") + 2);
+                int at = b.indexOf('@');
+                SECP256K1.PublicKey pub = SECP256K1.PublicKey.fromBytes(Bytes.fromHexString(b.substring(0, at)));
+                String hostPort = b.substring(at + 1);
+                int colon = hostPort.lastIndexOf(':');
+                out.add(new ParsedEnode(
+                        new InetSocketAddress(hostPort.substring(0, colon),
+                                Integer.parseInt(hostPort.substring(colon + 1))),
+                        pub));
+            } catch (Exception e) {
+                log.warn("[{}] skipping malformed static EL enode '{}': {}",
+                        network.name(), enode, e.getMessage());
+            }
+        }
+        return out;
+    }
+
+    /** Direct-RLPx-dial the network's static EL enodes — the discv4-independent discovery seed
+     *  for chains with no EL enrtree (Gnosis): a NAT'd/mobile host reaches these known peers
+     *  over RLPx without bootstrapping discv4 UDP. Mirrors {@link #directDialDnsEnodes}'s
+     *  attempted/backoff bookkeeping; peers that connect are cached, so the snap-peer maintainer
+     *  keeps re-dialing them from the cache on later cycles. */
+    private void directDialStaticEnodes() {
+        int dialed = 0;
+        for (ParsedEnode pe : parseStaticEnodes()) {
+            if (dialed >= DNS_DIRECT_DIAL_LIMIT) break;
+            String peerKey = pe.address().getHostString() + ":" + pe.address().getPort();
+            if (!attempted.add(peerKey)) continue;
+            dialed++;
+            final String key = peerKey;
+            try {
+                connector.connect(pe.address(), pe.pubkey(), (incompatible, nodeIdHex) -> {
+                            if (incompatible) blacklistedNodeIds.add(nodeIdHex);
+                            backoff.putIfAbsent(key, System.currentTimeMillis()
+                                    + (incompatible ? BACKOFF_INCOMPATIBLE_MS : BACKOFF_TRANSIENT_MS));
+                            attempted.remove(key);
+                        })
+                        .addListener(future -> { if (!future.isSuccess()) attempted.remove(key); });
+            } catch (Exception e) {
+                log.warn("[{}] direct dial of static EL enode {} failed: {}",
+                        network.name(), key, e.getMessage());
+                attempted.remove(key);
+            }
+        }
+        if (dialed > 0) {
+            log.info("[{}] Direct-dialed {} static EL enode(s)", network.name(), dialed);
+        }
     }
 
     private RLPxConnector buildConnector() {

--- a/node-core/src/main/java/io/myotis/node/ChainStack.java
+++ b/node-core/src/main/java/io/myotis/node/ChainStack.java
@@ -272,7 +272,10 @@ public final class ChainStack {
         // Also seed discv4 from the static EL enodes (chains without an enrtree, e.g. Gnosis):
         // their ip:port widen the ping set; their pubkeys feed the direct-dial path separately.
         for (ParsedEnode pe : parseStaticEnodes()) {
-            String key = pe.address().getAddress().getHostAddress() + ":" + pe.address().getPort();
+            // getHostString() (not getAddress().getHostAddress()) — NPE-safe if the address is
+            // unresolved, and consistent with directDialStaticEnodes; Gnosis enodes are IP
+            // literals, so the key still matches the resolved bootnode keys above.
+            String key = pe.address().getHostString() + ":" + pe.address().getPort();
             if (seen.add(key)) merged.add(pe.address());
         }
         if (merged.size() > before) {


### PR DESCRIPTION
Follow-up **#1 (peer acquisition)** from the Gnosis wallet debugging — the root-cause lever behind the snap-peer plateau.

## Problem
Gnosis publishes **no EIP-1459 EL enrtree** (confirmed: Nethermind's `gnosis.json` chainspec has only enode bootnodes, no DNS discovery). So in `ChainStack`:
- the DNS candidate pool (`dnsElPool`) and `directDialDnsEnodes` are **empty** for Gnosis, and
- our config stores Gnosis bootnodes as bare `ip:port` (pubkey discarded), usable only as a **discv4 UDP** ping target.

Net: the only EL discovery path on Gnosis is discv4 UDP, which **NAT'd / mobile hosts (the Android app) can't bootstrap** — there's no enrtree substitute. Snap peers plateau at a handful, starving verified `eth_call` / balance / GREEN (the issue we chased all the way through MetaMask showing zero).

## Fix (shared via `node-core`, so daemon **and** Android Phase B stacks get it)
- **`NetworkConfig.elBootEnodes()`** — full `enode://<pubkey>@host:port` seeds. Gnosis ships the **16** enodes from the gnosischain/Nethermind chainspec; networks with an enrtree return empty.
- **`ChainStack.directDialStaticEnodes()`** — direct-RLPx-dials them at startup. Because they carry the node pubkey, a NAT'd/mobile host reaches them **without** discv4 UDP — the role enrtree enodes play on networks that publish one. Mirrors `directDialDnsEnodes`' attempted/backoff bookkeeping; peers that connect get cached, so the snap-peer maintainer keeps re-dialing them from the cache.
- **`mergeBootnodes()`** also seeds discv4 from the same enodes (wider ping set).

No trust change — these are discovery seeds; all peer data is still verified downstream.

## Testing
- `NetworkConfigGnosisTest.elBootEnodesAreDialableForGnosisOnly` — 16 well-formed Gnosis enodes (each parses to a valid 64-byte secp256k1 pubkey + host:port), empty for mainnet/sepolia. Passes.
- `:networking` + `:node-core` compile.
- **Pending:** live daemon/device verification (look for `Direct-dialed N static EL enode(s)` and a higher Gnosis snap-peer count) — to be confirmed when the daemon runs from `~/myotis`.

Reconciled with the Phase B plan (`docs/multichain-android-phase-b.md`): the snap-peer maintainer is now unified in `ChainStack`, so this is a single shared change — orthogonal to Phase B's `NodeService`/UI work and directly improves its hardest case (Gnosis-on-Android peer starvation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)