### PR TITLE
android: collapse the top bars into one (app name + network chips)

### DIFF
--- a/android-app/src/main/AndroidManifest.xml
+++ b/android-app/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
         android:name=".EthP2PApplication"
         android:label="@string/app_name"
         android:allowBackup="false"
-        android:theme="@android:style/Theme.DeviceDefault.DayNight">
+        android:theme="@style/Theme.Myotis">
 
         <activity
             android:name=".MainActivity"

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/MainActivity.kt
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/MainActivity.kt
@@ -441,9 +441,22 @@ private fun NodeScreen(
         topBar = {
             TopAppBar(
                 title = {
-                    val net = (currentSnapshot?.network ?: selectedChain ?: "Myotis")
-                        .replaceFirstChar { it.uppercase() }
-                    Text("Myotis · $net")
+                    // App name + network selector on one line. The highlighted chip is the
+                    // selected chain (drives Status + Query), so there's no separate "· <network>"
+                    // text or chip row beneath — the chip is the only place the network is shown.
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        Text("Myotis")
+                        snapshots.keys.forEach { c ->
+                            FilterChip(
+                                selected = c == selectedChain,
+                                onClick = { selectedChain = c },
+                                label = { Text(c.replaceFirstChar { it.uppercase() }) },
+                            )
+                        }
+                    }
                 },
                 actions = {
                     IconButton(onClick = { showSettings = true }) {
@@ -454,15 +467,6 @@ private fun NodeScreen(
         },
     ) { padding ->
       Column(Modifier.fillMaxSize().padding(padding)) {
-        // Chain selector: one chip per live network (Step 9). Drives Status + Query. Only shown
-        // when more than one chain is live — a single chain needs no selector.
-        if (snapshots.size > 1) {
-            ChainSelector(
-                chains = snapshots.keys.toList(),
-                selected = selectedChain,
-                onSelect = { selectedChain = it },
-            )
-        }
         // App-wide sync banner above the tabs: indeterminate while bootstrapping,
         // determinate as the light client catches up sync-committee periods, gone
         // once SYNCED.
@@ -528,29 +532,6 @@ private fun NodeScreen(
             )
         }
       }
-    }
-}
-
-/**
- * One per-network chip; tap to view that chain's Status/Query. Only shown when more than one
- * chain is live.
- */
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun ChainSelector(chains: List<String>, selected: String?, onSelect: (String) -> Unit) {
-    Row(
-        Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 8.dp, vertical = 4.dp),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-        chains.forEach { c ->
-            FilterChip(
-                selected = c == selected,
-                onClick = { onSelect(c) },
-                label = { Text(c.replaceFirstChar { it.uppercase() }) },
-            )
-        }
     }
 }
 

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/MainActivity.kt
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/MainActivity.kt
@@ -17,6 +17,8 @@ import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.foundation.clickable
@@ -395,10 +397,12 @@ private fun NodeScreen(
             }
             running = NodeService.isRunning()
             snapshots = s
-            // Keep the selected chip valid: default to the first live network, and reset if the
-            // selected one went away (e.g. the user disabled it in Settings).
-            if (selectedChain == null || selectedChain !in s.keys) {
-                selectedChain = s.keys.firstOrNull()
+            // Keep the selected chip valid. When stopped, snapshots is empty, so fall back to the
+            // enabled-set — otherwise selectedChain would be wiped to null on every poll. Only reset
+            // when the current selection isn't among the available chains (e.g. disabled in Settings).
+            val activeChains = s.keys.ifEmpty { NodeService.enabledNetworks(context) }
+            if (selectedChain == null || selectedChain !in activeChains) {
+                selectedChain = activeChains.firstOrNull()
             }
             delay(2000)
         }
@@ -441,20 +445,33 @@ private fun NodeScreen(
         topBar = {
             TopAppBar(
                 title = {
-                    // App name + network selector on one line. The highlighted chip is the
-                    // selected chain (drives Status + Query), so there's no separate "· <network>"
-                    // text or chip row beneath — the chip is the only place the network is shown.
+                    // App name + network selector on one line. The highlighted chip is the selected
+                    // chain (drives Status + Query), so there's no separate "· <network>" text or
+                    // chip row beneath. When the node is stopped (snapshots empty) the chips fall back
+                    // to the enabled-set so the user still sees/selects networks, and the chips scroll
+                    // horizontally so a third network can't push the Settings action off-screen.
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
                     ) {
                         Text("Myotis")
-                        snapshots.keys.forEach { c ->
-                            FilterChip(
-                                selected = c == selectedChain,
-                                onClick = { selectedChain = c },
-                                label = { Text(c.replaceFirstChar { it.uppercase() }) },
-                            )
+                        val chipChains = snapshots.keys.toList()
+                            .ifEmpty { NodeService.enabledNetworks(context) }
+                        Row(
+                            modifier = Modifier
+                                .weight(1f)
+                                .horizontalScroll(rememberScrollState()),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            chipChains.forEach { c ->
+                                FilterChip(
+                                    selected = c == selectedChain
+                                        || (selectedChain == null && c == chipChains.firstOrNull()),
+                                    onClick = { selectedChain = c },
+                                    label = { Text(c.replaceFirstChar { it.uppercase() }) },
+                                )
+                            }
                         }
                     }
                 },

--- a/android-app/src/main/res/values/themes.xml
+++ b/android-app/src/main/res/values/themes.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!--
+      The UI is Compose and draws its own Material3 TopAppBar ("Myotis" + the network chips).
+      The platform DayNight theme ships a native ActionBar, which rendered the app label
+      ("Myotis") as a redundant second bar above the Compose one. Disable it so the top is a
+      single bar. We keep the DeviceDefault.DayNight baseline only for the window / system-bar
+      colours; all in-app styling comes from MaterialTheme in Compose.
+    -->
+    <style name="Theme.Myotis" parent="@android:style/Theme.DeviceDefault.DayNight">
+        <item name="android:windowActionBar">false</item>
+        <item name="android:windowNoTitle">true</item>
+    </style>
+</resources>


### PR DESCRIPTION
## What

The top of the screen wasted vertical space across **three stacked bars**:
1. the platform theme's **native ActionBar** (app label "Myotis"),
2. the Compose **TopAppBar** ("Myotis · \<network\>"), and
3. a separate **network-selector chip row**.

The app name showed twice and the selected network was shown both as text *and* as a chip.

## Change → one bar

- **TopAppBar title is now a single row:** `Myotis` + the network chips inline, with the Settings gear in the actions slot. The highlighted chip is the selected chain (drives Status + Query), so the `· <network>` text and the standalone chip row are removed. Deleted the now-unused `ChainSelector` composable.
- **Removed the native ActionBar:** added `Theme.Myotis` (`@android:style/Theme.DeviceDefault.DayNight` + `windowActionBar=false` / `windowNoTitle=true`) and pointed the manifest at it. The UI is Compose and draws its own bar, so the platform ActionBar was pure duplication.

Before: `[native ActionBar: Myotis]` / `[Myotis · Mainnet]` / `[ (Mainnet) (Gnosis) ]`
After: `[ Myotis  (Mainnet) (Gnosis)               ⚙ ]`

## Verified on device

Single top bar (`Myotis` + chips + gear); app boots and the node reaches SYNCED. Builds green.

> Stacked on `feat/android-multinode-8b` (#89), which has the multinode UI this builds on. Base retargets to `main` once #89 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)