### PR TITLE
fix(consensus): don't crash on Android when java.net.http is absent

### DIFF
--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconApiHttp.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconApiHttp.java
@@ -1,0 +1,58 @@
+package com.jaeckel.ethp2p.consensus;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+/**
+ * Isolates <em>all</em> {@code java.net.http} references into one class.
+ *
+ * <p>{@code java.net.http} is not shipped on the Android runtime at any API level, so
+ * resolving {@link HttpClient} et al. throws {@link NoClassDefFoundError} (a
+ * {@link LinkageError}). Keeping every reference here — out of {@link BeaconLightClient}'s
+ * bytecode — means the JVM/ART only resolves (and can only fail to resolve)
+ * {@code java.net.http} at the moment this class is <em>first touched</em>, i.e. inside the
+ * caller's {@code try { … } catch (LinkageError)}. A {@code catch} placed around inline
+ * {@code java.net.http} usage is NOT enough on its own: class verification / method
+ * resolution can throw at the call site (when the enclosing method is resolved) or at class
+ * load, <em>outside</em> the {@code try}. Lazy class loading of this separate class makes the
+ * failure happen exactly where it is caught.
+ *
+ * <p>These beacon-HTTP helpers are JVM-only <em>debug</em> conveniences; the real,
+ * trust-minimised path is libp2p/discv5.
+ */
+final class BeaconApiHttp {
+
+    private BeaconApiHttp() {}
+
+    /** A beacon-API GET response: HTTP status code + raw body bytes. */
+    record Response(int statusCode, byte[] body) {}
+
+    /**
+     * GET {@code url}, returning the status code and raw body bytes.
+     *
+     * @param accept            value for the {@code Accept} header, or {@code null} for none
+     * @param connectTimeoutSec TCP connect timeout, seconds
+     * @param requestTimeoutSec overall request timeout, seconds
+     * @throws LinkageError if {@code java.net.http} is absent on this runtime — the caller
+     *                      catches it and degrades to the P2P path
+     * @throws Exception    on I/O failure / interruption
+     */
+    static Response get(String url, String accept,
+                        int connectTimeoutSec, int requestTimeoutSec) throws Exception {
+        HttpClient client = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(connectTimeoutSec))
+                .build();
+        HttpRequest.Builder builder = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .timeout(Duration.ofSeconds(requestTimeoutSec))
+                .GET();
+        if (accept != null) {
+            builder.header("Accept", accept);
+        }
+        HttpResponse<byte[]> response = client.send(builder.build(), HttpResponse.BodyHandlers.ofByteArray());
+        return new Response(response.statusCode(), response.body());
+    }
+}

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
@@ -17,11 +17,6 @@ import com.jaeckel.ethp2p.consensus.types.SyncCommittee;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -684,15 +679,11 @@ public class BeaconLightClient implements AutoCloseable {
     private void discoverPeersFromBeaconApi() {
         if (beaconApiUrl == null || beaconApiUrl.isEmpty()) return;
         try {
-            HttpClient client = HttpClient.newBuilder()
-                    .connectTimeout(Duration.ofSeconds(5))
-                    .build();
-            HttpRequest request = HttpRequest.newBuilder()
-                    .uri(URI.create(beaconApiUrl + "/eth/v1/node/peers?state=connected"))
-                    .timeout(Duration.ofSeconds(10))
-                    .GET()
-                    .build();
-            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            // All java.net.http usage is isolated in BeaconApiHttp so a NoClassDefFoundError on
+            // Android is thrown HERE (first touch of that class) and caught below, never at this
+            // method's resolution / class verification. See BeaconApiHttp.
+            BeaconApiHttp.Response response = BeaconApiHttp.get(
+                    beaconApiUrl + "/eth/v1/node/peers?state=connected", null, 5, 10);
             if (response.statusCode() != 200) {
                 log.warn("[beacon] Beacon API returned status {}", response.statusCode());
                 return;
@@ -701,7 +692,7 @@ public class BeaconLightClient implements AutoCloseable {
             // Extract peer entries from JSON using regex (avoids adding a JSON library dependency).
             // Each peer object has "peer_id" and "last_seen_p2p_address" fields.
             // Many addresses lack the /p2p/<peer_id> suffix, so we construct it.
-            String body = response.body();
+            String body = new String(response.body(), java.nio.charset.StandardCharsets.UTF_8);
             // Match each peer object: extract peer_id and last_seen_p2p_address together
             Pattern peerPattern = Pattern.compile(
                     "\"peer_id\"\\s*:\\s*\"([^\"]+)\"[^}]*?\"last_seen_p2p_address\"\\s*:\\s*\"([^\"]+)\"");
@@ -1088,16 +1079,8 @@ public class BeaconLightClient implements AutoCloseable {
             String url = beaconApiUrl + "/eth/v1/beacon/light_client/bootstrap/" + rootHex;
             log.info("[beacon] Attempting HTTP bootstrap from {}", url);
 
-            HttpClient client = HttpClient.newBuilder()
-                    .connectTimeout(Duration.ofSeconds(5))
-                    .build();
-            HttpRequest request = HttpRequest.newBuilder()
-                    .uri(URI.create(url))
-                    .timeout(Duration.ofSeconds(15))
-                    .header("Accept", "application/octet-stream")
-                    .GET()
-                    .build();
-            HttpResponse<byte[]> response = client.send(request, HttpResponse.BodyHandlers.ofByteArray());
+            // java.net.http isolated in BeaconApiHttp — see the note in discoverPeersFromBeaconApi.
+            BeaconApiHttp.Response response = BeaconApiHttp.get(url, "application/octet-stream", 5, 15);
             if (response.statusCode() != 200) {
                 log.warn("[beacon] HTTP bootstrap returned status {} from {}", response.statusCode(), url);
                 return false;
@@ -1676,21 +1659,15 @@ public class BeaconLightClient implements AutoCloseable {
         if (beaconApiUrl == null || beaconApiUrl.isEmpty()) return;
         try {
             log.info("[beacon] Attempting seed from beacon HTTP API: {}", beaconApiUrl);
-            HttpClient client = HttpClient.newBuilder()
-                    .connectTimeout(Duration.ofSeconds(5))
-                    .build();
-            HttpRequest request = HttpRequest.newBuilder()
-                    .uri(URI.create(beaconApiUrl + "/eth/v1/beacon/light_client/finality_update"))
-                    .timeout(Duration.ofSeconds(10))
-                    .GET()
-                    .build();
-            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            // java.net.http isolated in BeaconApiHttp — see the note in discoverPeersFromBeaconApi.
+            BeaconApiHttp.Response response = BeaconApiHttp.get(
+                    beaconApiUrl + "/eth/v1/beacon/light_client/finality_update", null, 5, 10);
             if (response.statusCode() != 200) {
                 log.warn("[beacon] Beacon API finality update returned status {}", response.statusCode());
                 return;
             }
 
-            String body = response.body();
+            String body = new String(response.body(), java.nio.charset.StandardCharsets.UTF_8);
 
             // Extract finalized_header.execution.state_root from JSON
             Pattern stateRootPattern = Pattern.compile(

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
@@ -1140,6 +1140,14 @@ public class BeaconLightClient implements AutoCloseable {
             log.info("[beacon] HTTP bootstrap complete, slot={}", bootstrap.header().beacon().slot());
             return true;
 
+        } catch (LinkageError e) {
+            // java.net.http is absent on the Android runtime (not desugared, not shipped at all).
+            // NoClassDefFoundError is an Error, not an Exception, so it slips past the catch below
+            // and would otherwise kill the beacon-sync thread. HTTP bootstrap is a JVM-only debug
+            // convenience; the real bootstrap path is P2P (see bootstrap()), so degrade gracefully.
+            log.debug("[beacon] HTTP bootstrap unavailable on this runtime "
+                    + "(java.net.http absent — Android); falling back to P2P bootstrap: {}", e.getMessage());
+            return false;
         } catch (Exception e) {
             Throwable root = e;
             while (root.getCause() != null) root = root.getCause();
@@ -1749,6 +1757,12 @@ public class BeaconLightClient implements AutoCloseable {
             log.info("[beacon] Seeded from beacon HTTP API, finalizedSlot={}, stateRoot={}",
                     finalizedSlot, stateRootHex);
 
+        } catch (LinkageError e) {
+            // java.net.http is absent on the Android runtime — NoClassDefFoundError (an Error, not an
+            // Exception) would otherwise escape this method. This HTTP seed is a JVM-only debug
+            // fallback; P2P seeding is the real path, so degrade gracefully instead of crashing.
+            log.debug("[beacon] Beacon API finality seed unavailable on this runtime "
+                    + "(java.net.http absent — Android): {}", e.getMessage());
         } catch (Exception e) {
             log.warn("[beacon] Beacon API finality seed failed: {}", e.getMessage());
         }


### PR DESCRIPTION
BeaconLightClient's `bootstrapFromBeaconApi()` and `seedFromBeaconApi()` use `java.net.http.HttpClient`, which the Android runtime doesn't ship at any API level. Resolving the class throws `NoClassDefFoundError` — an `Error`, not an `Exception` — so it sailed past the `catch (Exception)` and **killed the beacon-sync thread, crashing the app on launch**.

Add `catch (LinkageError)` ahead of `catch (Exception)` in both methods (mirroring the fix already in `discoverPeersFromBeaconApi()`). These HTTP helpers are JVM-only debug conveniences; on Android they now degrade gracefully and the node falls back to the real P2P (libp2p/discv5) path.

Verified on-device (Pixel Fold, API 36): app launches without the crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_019KGkWsCN1NcaeQnCV11V27