### PR TITLE
fix(rpc): thread msg.sender (from) and value through eth_call

### DIFF
--- a/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/MyotisRpcBackend.kt
+++ b/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/MyotisRpcBackend.kt
@@ -36,9 +36,17 @@ interface MyotisRpcBackend {
 
     /**
      * eth_call: run [data] against contract [to] in a local EVM over verified
-     * state, returning the raw ABI return bytes. Null falls through to the proxy.
+     * state, as if sent by [from] carrying [value] wei, returning the raw ABI
+     * return bytes. Null falls through to the proxy.
+     *
+     * [from] is the simulated `msg.sender`; null means an anonymous zero-address
+     * caller (Geth's default for a from-less call). Contracts that gate on
+     * `msg.sender` — every ERC-20 transfer/approve, most dapp calls — need the
+     * real caller, else they revert ("transfer from the zero address"). [value]
+     * is the wei attached to the call; null means zero.
      */
-    fun call(to: ByteArray, data: ByteArray, block: String): ByteArray?
+    fun call(from: ByteArray?, to: ByteArray, data: ByteArray,
+             value: java.math.BigInteger?, block: String): ByteArray?
 
     /** eth_getBalance: account balance in wei, or null to proxy. */
     fun getBalance(address: ByteArray, block: String): java.math.BigInteger?

--- a/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/RpcRouter.kt
+++ b/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/RpcRouter.kt
@@ -154,18 +154,12 @@ class RpcRouter(
                 // (don't silently run the call with empty calldata).
                 val dataElement = (callObj["data"] ?: callObj["input"])?.takeUnless { it is JsonNull }
                 val data = if (dataElement != null) (dataElement.asHexBytes() ?: return null) else ByteArray(0)
-                // Optional call value (wei) — QUANTITY hex or decimal; malformed or
-                // negative -> proxy (wei is non-negative; a negative would throw in Wei.of).
+                // Optional call value (wei) — QUANTITY, unsigned <=256-bit; malformed /
+                // negative / out-of-range -> proxy (a negative would throw in Wei.of).
                 val valueElement = callObj["value"]?.takeUnless { it is JsonNull }
                 val value = if (valueElement != null) {
                     val s = (valueElement as? JsonPrimitive)?.contentOrNull ?: return null
-                    try {
-                        val parsed = if (s.startsWith("0x") || s.startsWith("0X"))
-                            java.math.BigInteger(s.substring(2).ifEmpty { "0" }, 16)
-                        else java.math.BigInteger(s)
-                        if (parsed.signum() < 0) return null
-                        parsed
-                    } catch (e: NumberFormatException) { return null }
+                    parseWeiQuantity(s) ?: return null
                 } else null
                 val block = p.blockTag(1)
                 val out = withContext(Dispatchers.IO) { b.call(from, to, data, value, block) } ?: return null
@@ -302,11 +296,7 @@ class RpcRouter(
                 val valueElement = callObj["value"]?.takeUnless { it is JsonNull }
                 val value = if (valueElement != null) {
                     val s = (valueElement as? JsonPrimitive)?.contentOrNull ?: return null
-                    try {
-                        if (s.startsWith("0x") || s.startsWith("0X"))
-                            java.math.BigInteger(s.substring(2).ifEmpty { "0" }, 16)
-                        else java.math.BigInteger(s)
-                    } catch (e: NumberFormatException) { return null }
+                    parseWeiQuantity(s) ?: return null
                 } else null
                 val gas = withContext(Dispatchers.IO) { b.estimateGas(from, to, data, value) } ?: return null
                 resultEnvelope(id, JsonPrimitive(hexQuantity(gas)))
@@ -355,6 +345,24 @@ class RpcRouter(
     /** Ethereum JSON-RPC QUANTITY encoding: minimal hex, no leading zeros, 0 -> "0x0". */
     private fun hexQuantity(v: Long): String = "0x" + java.lang.Long.toHexString(v)
     private fun hexQuantity(v: java.math.BigInteger): String = "0x" + v.toString(16)
+
+    /** Parse a JSON-RPC QUANTITY (hex `0x…` or decimal) as a wei value, enforcing EVM
+     *  semantics: unsigned and <= 256 bits. Returns null for malformed / negative /
+     *  out-of-range input. The length cap is checked BEFORE constructing the BigInteger so
+     *  an absurdly long string can't amplify parsing cost (0x + 64 hex digits, or ~78
+     *  decimal digits, covers the full 2^256 range). Shared by eth_call and eth_estimateGas
+     *  so both apply identical value validation. */
+    private fun parseWeiQuantity(s: String): java.math.BigInteger? {
+        if (s.isEmpty() || s.length > 80) return null
+        return try {
+            val v = if (s.startsWith("0x") || s.startsWith("0X"))
+                java.math.BigInteger(s.substring(2).ifEmpty { "0" }, 16)
+            else java.math.BigInteger(s)
+            if (v.signum() < 0 || v.bitLength() > 256) null else v
+        } catch (e: NumberFormatException) {
+            null
+        }
+    }
 
     /** Ethereum JSON-RPC DATA encoding: 0x-prefixed, every byte rendered (leading
      *  zeros kept). Allocation-free — eth_getCode returns up to ~24KB of bytecode,

--- a/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/RpcRouter.kt
+++ b/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/RpcRouter.kt
@@ -144,12 +144,28 @@ class RpcRouter(
                 val p = root.params()
                 val callObj = p?.getOrNull(0) as? JsonObject ?: return null
                 val to = callObj["to"]?.asHexBytes() ?: return null   // contract creation (to=null) -> proxy
+                // The caller (msg.sender). Absent/null -> anonymous (backend uses the
+                // zero-address default); present-but-malformed -> proxy. Threading this
+                // is what lets a wallet's confirm-screen simulation of a sender-gated
+                // call (ERC-20 transfer/approve, …) run as the real `from` instead of
+                // reverting "transfer from the zero address".
+                val from = (callObj["from"]?.takeUnless { it is JsonNull })?.let { it.asHexBytes() ?: return null }
                 // Absent/null calldata -> empty; present-but-malformed -> proxy
                 // (don't silently run the call with empty calldata).
                 val dataElement = (callObj["data"] ?: callObj["input"])?.takeUnless { it is JsonNull }
                 val data = if (dataElement != null) (dataElement.asHexBytes() ?: return null) else ByteArray(0)
+                // Optional call value (wei) — QUANTITY hex or decimal; malformed -> proxy.
+                val valueElement = callObj["value"]?.takeUnless { it is JsonNull }
+                val value = if (valueElement != null) {
+                    val s = (valueElement as? JsonPrimitive)?.contentOrNull ?: return null
+                    try {
+                        if (s.startsWith("0x") || s.startsWith("0X"))
+                            java.math.BigInteger(s.substring(2).ifEmpty { "0" }, 16)
+                        else java.math.BigInteger(s)
+                    } catch (e: NumberFormatException) { return null }
+                } else null
                 val block = p.blockTag(1)
-                val out = withContext(Dispatchers.IO) { b.call(to, data, block) } ?: return null
+                val out = withContext(Dispatchers.IO) { b.call(from, to, data, value, block) } ?: return null
                 resultEnvelope(id, JsonPrimitive(hexData(out)))
             }
             "eth_getBalance" -> {

--- a/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/RpcRouter.kt
+++ b/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/RpcRouter.kt
@@ -154,14 +154,17 @@ class RpcRouter(
                 // (don't silently run the call with empty calldata).
                 val dataElement = (callObj["data"] ?: callObj["input"])?.takeUnless { it is JsonNull }
                 val data = if (dataElement != null) (dataElement.asHexBytes() ?: return null) else ByteArray(0)
-                // Optional call value (wei) — QUANTITY hex or decimal; malformed -> proxy.
+                // Optional call value (wei) — QUANTITY hex or decimal; malformed or
+                // negative -> proxy (wei is non-negative; a negative would throw in Wei.of).
                 val valueElement = callObj["value"]?.takeUnless { it is JsonNull }
                 val value = if (valueElement != null) {
                     val s = (valueElement as? JsonPrimitive)?.contentOrNull ?: return null
                     try {
-                        if (s.startsWith("0x") || s.startsWith("0X"))
+                        val parsed = if (s.startsWith("0x") || s.startsWith("0X"))
                             java.math.BigInteger(s.substring(2).ifEmpty { "0" }, 16)
                         else java.math.BigInteger(s)
+                        if (parsed.signum() < 0) return null
+                        parsed
                     } catch (e: NumberFormatException) { return null }
                 } else null
                 val block = p.blockTag(1)

--- a/jsonrpc-server/src/test/kotlin/io/myotis/jsonrpc/RpcRouterTest.kt
+++ b/jsonrpc-server/src/test/kotlin/io/myotis/jsonrpc/RpcRouterTest.kt
@@ -31,15 +31,19 @@ class RpcRouterTest {
         var code: ByteArray? = null,
         var storage: ByteArray? = null,
     ) : MyotisRpcBackend {
+        var lastFrom: ByteArray? = null
         var lastTo: ByteArray? = null
         var lastData: ByteArray? = null
+        var lastValue: BigInteger? = null
         var lastBlock: String? = null
         var lastSlot: ByteArray? = null
         override fun chainId() = 1L
         override fun headBlockNumber() = head
         override fun syncState() = "SYNCED"
-        override fun call(to: ByteArray, data: ByteArray, block: String): ByteArray? {
-            lastTo = to; lastData = data; lastBlock = block; return callResult
+        override fun call(from: ByteArray?, to: ByteArray, data: ByteArray,
+                          value: BigInteger?, block: String): ByteArray? {
+            lastFrom = from; lastTo = to; lastData = data; lastValue = value; lastBlock = block
+            return callResult
         }
         override fun getBalance(address: ByteArray, block: String): BigInteger? = balance
         override fun getTransactionCount(address: ByteArray, block: String): Long? = nonce
@@ -111,6 +115,26 @@ class RpcRouterTest {
         assertEquals(0xA0.toByte(), b.lastTo!![0])
         assertEquals("0x313ce567", b.lastData!!.toHex())           // decoded calldata
         assertEquals("latest", b.lastBlock)
+    }
+
+    @Test fun ethCall_threadsFromAndValue_toBackend() {            // confirm-screen sim: msg.sender + value
+        val b = FakeBackend(callResult = byteArrayOf(0, 6))
+        route(b,
+            """{"jsonrpc":"2.0","id":1,"method":"eth_call",
+               "params":[{"from":"0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+                          "to":"0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                          "data":"0xa9059cbb","value":"0x0"},"latest"]}""")
+        assertEquals(20, b.lastFrom!!.size)                        // from decoded + passed through
+        assertEquals(0xd8.toByte(), b.lastFrom!![0])
+        assertEquals(BigInteger.ZERO, b.lastValue)                 // value decoded
+    }
+
+    @Test fun ethCall_absentFrom_passesNull() {                    // anonymous read -> backend's zero-addr default
+        val b = FakeBackend(callResult = byteArrayOf(1))
+        route(b, """{"jsonrpc":"2.0","id":1,"method":"eth_call",
+               "params":[{"to":"0x00000000219ab540356cBB839Cbe05303d7705Fa","data":"0xabcd"}]}""")
+        assertNull(b.lastFrom)                                     // no from -> null (not zero-length)
+        assertNull(b.lastValue)                                    // no value -> null
     }
 
     @Test fun ethCall_acceptsInputAlias_forData() {

--- a/myotis-evm/src/main/java/io/myotis/evm/CcipReadEvmExecutor.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/CcipReadEvmExecutor.java
@@ -72,7 +72,13 @@ public final class CcipReadEvmExecutor implements EvmExecutor {
 
     @Override
     public CompletableFuture<byte[]> callView(Address target, byte[] calldata, BlockContext blockContext) {
-        return tryWithCcipRead(target, calldata, blockContext, 0);
+        return tryWithCcipRead(null, target, calldata, null, blockContext, 0);
+    }
+
+    @Override
+    public CompletableFuture<byte[]> callView(Address sender, Address target, byte[] calldata,
+                                              java.math.BigInteger value, BlockContext blockContext) {
+        return tryWithCcipRead(sender, target, calldata, value, blockContext, 0);
     }
 
     /** Estimation passes straight through — CCIP-Read (ERC-3668) only applies to
@@ -84,12 +90,14 @@ public final class CcipReadEvmExecutor implements EvmExecutor {
     }
 
     private CompletableFuture<byte[]> tryWithCcipRead(
-            Address target, byte[] calldata, BlockContext ctx, int depth) {
-        return delegate.callView(target, calldata, ctx)
-                .exceptionallyCompose(t -> handleException(t, ctx, depth));
+            Address sender, Address target, byte[] calldata, java.math.BigInteger value,
+            BlockContext ctx, int depth) {
+        return delegate.callView(sender, target, calldata, value, ctx)
+                .exceptionallyCompose(t -> handleException(sender, value, t, ctx, depth));
     }
 
-    private CompletableFuture<byte[]> handleException(Throwable t, BlockContext ctx, int depth) {
+    private CompletableFuture<byte[]> handleException(Address sender, java.math.BigInteger value,
+                                                      Throwable t, BlockContext ctx, int depth) {
         Throwable cause = unwrap(t);
         Optional<OffchainLookupRevert> lookup = extractLookup(cause);
         if (lookup.isEmpty()) {
@@ -113,9 +121,12 @@ public final class CcipReadEvmExecutor implements EvmExecutor {
         return handler.handle(lookup.get())
                 .thenCompose(gatewayResponse -> {
                     byte[] callbackCalldata = encodeCallback(lookup.get(), gatewayResponse);
-                    log.debug("[ccip] re-entering EVM (sender={}, depth={})",
+                    log.debug("[ccip] re-entering EVM (callbackTarget={}, depth={})",
                             lookup.get().sender(), depth + 1);
-                    return tryWithCcipRead(lookup.get().sender(), callbackCalldata, ctx, depth + 1);
+                    // The OffchainLookup's `sender` is the contract that raised it — the
+                    // callback TARGET. Keep the original msg.sender/value for the re-entry
+                    // so sender-gated callbacks still see the real caller.
+                    return tryWithCcipRead(sender, lookup.get().sender(), callbackCalldata, value, ctx, depth + 1);
                 });
     }
 

--- a/myotis-evm/src/main/java/io/myotis/evm/DefaultEvmExecutor.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/DefaultEvmExecutor.java
@@ -64,7 +64,14 @@ public final class DefaultEvmExecutor implements EvmExecutor {
 
     @Override
     public CompletableFuture<byte[]> callView(Address target, byte[] calldata, BlockContext blockContext) {
-        return CompletableFuture.supplyAsync(() -> runOnce(target, calldata, blockContext), executor);
+        return callView(null, target, calldata, null, blockContext);
+    }
+
+    @Override
+    public CompletableFuture<byte[]> callView(Address sender, Address target, byte[] calldata,
+                                              java.math.BigInteger value, BlockContext blockContext) {
+        return CompletableFuture.supplyAsync(
+                () -> runOnce(sender, target, calldata, value, blockContext), executor);
     }
 
     @Override
@@ -220,10 +227,11 @@ public final class DefaultEvmExecutor implements EvmExecutor {
         return gas;
     }
 
-    private byte[] runOnce(Address target, byte[] calldata, BlockContext blockContext) {
+    private byte[] runOnce(Address sender, Address target, byte[] calldata,
+                           java.math.BigInteger value, BlockContext blockContext) {
         AccessTracker tracker = new AccessTracker();
         SyncStateView view = new SyncStateView(oracle, blockContext.stateRoot(), bytecodeCache, tracker);
-        return runOnTracedView(target, calldata, blockContext, view, OperationTracer.NO_TRACING);
+        return runOnTracedView(sender, target, calldata, value, blockContext, view, OperationTracer.NO_TRACING);
     }
 
     /**
@@ -235,7 +243,8 @@ public final class DefaultEvmExecutor implements EvmExecutor {
      * <p>Package-private: it's the seam the prefetch layer plugs into, but it's
      * not part of the public {@link EvmExecutor} contract.
      */
-    byte[] runOnTracedView(Address target, byte[] calldata, BlockContext blockContext,
+    byte[] runOnTracedView(Address sender, Address target, byte[] calldata,
+                           java.math.BigInteger value, BlockContext blockContext,
                            SyncStateView view, OperationTracer tracer) {
         CryptoProviders.ensureRegistered();
         EvmFactory.EvmAndPrecompiles bundle = EvmFactory.buildForBlock(blockContext);
@@ -246,10 +255,16 @@ public final class DefaultEvmExecutor implements EvmExecutor {
         // outer call doesn't pollute the read-through cache.
         org.hyperledger.besu.evm.worldstate.WorldUpdater scope = root.updater();
 
+        // A null sender means a from-less call → the anonymous VIEW_CALLER (Geth's
+        // default). When the caller DID supply a from (eth_call from a wallet), use
+        // it: contracts that gate on msg.sender (ERC-20 transfer/approve, …) must see
+        // the real caller, else they revert ("transfer from the zero address").
+        io.myotis.evm.Address effectiveSender = sender != null ? sender : VIEW_CALLER;
+        Wei callValue = value != null ? Wei.of(value) : Wei.ZERO;
         org.hyperledger.besu.datatypes.Address besuTarget =
                 org.hyperledger.besu.datatypes.Address.wrap(Bytes.wrap(target.toByteArray()));
         org.hyperledger.besu.datatypes.Address besuSender =
-                org.hyperledger.besu.datatypes.Address.wrap(Bytes.wrap(VIEW_CALLER.toByteArray()));
+                org.hyperledger.besu.datatypes.Address.wrap(Bytes.wrap(effectiveSender.toByteArray()));
         org.hyperledger.besu.datatypes.Address besuCoinbase =
                 org.hyperledger.besu.datatypes.Address.wrap(Bytes.wrap(blockContext.coinbase().toByteArray()));
 
@@ -267,8 +282,8 @@ public final class DefaultEvmExecutor implements EvmExecutor {
                 .blobGasPrice(Wei.ZERO)
                 .inputData(Bytes.wrap(calldata))
                 .sender(besuSender)
-                .value(Wei.ZERO)
-                .apparentValue(Wei.ZERO)
+                .value(callValue)
+                .apparentValue(callValue)
                 .code(code)
                 .blockValues(new BlockContextValues(blockContext))
                 .completer(f -> {})
@@ -283,7 +298,14 @@ public final class DefaultEvmExecutor implements EvmExecutor {
                     throw new UnsupportedOperationException(
                             "BLOCKHASH not implemented; needs a verified block-hash provider");
                 })
-                .isStatic(true)
+                // eth_call is a NON-static message call (matching Geth/Besu and our own
+                // estimateGas path): the simulated tx may SSTORE — every ERC-20
+                // transfer/approve does — and under isStatic(true) those state writes
+                // halt with ILLEGAL_STATE_CHANGE, so even with the correct sender a
+                // transfer simulation would fail. Writes are journalled into the
+                // per-call child updater and discarded when the future completes;
+                // nothing is committed, so view reads are unaffected.
+                .isStatic(false)
                 .build();
 
         MessageCallProcessor processor = new MessageCallProcessor(evm, bundle.precompiles());

--- a/myotis-evm/src/main/java/io/myotis/evm/EvmExecutor.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/EvmExecutor.java
@@ -35,6 +35,33 @@ public interface EvmExecutor {
     CompletableFuture<byte[]> callView(Address target, byte[] calldata, BlockContext blockContext);
 
     /**
+     * Sender- and value-aware view call: run {@code target.calldata} as if sent
+     * by {@code sender} carrying {@code value} wei, against the state at
+     * {@code blockContext.stateRoot()}, returning the raw return bytes. As with
+     * {@link #callView(Address, byte[], BlockContext)}, state writes are journalled
+     * and discarded — nothing is committed.
+     *
+     * <p>This is the entry point {@code eth_call} uses. MetaMask's confirm-screen
+     * simulation sends a {@code from} (and sometimes a {@code value}), and any
+     * contract whose logic depends on {@code msg.sender} — every ERC-20
+     * {@code transfer}/{@code approve}, most dapp calls — must see the real caller.
+     * Running such a call as the zero address makes it revert (e.g. USDC's
+     * "ERC20: transfer from the zero address"), which is exactly the bug a
+     * {@code from}-dropping eth_call produced.
+     *
+     * <p>A null {@code sender} means an anonymous zero-address caller (Geth's
+     * default for a {@code from}-less call); a null {@code value} means zero.
+     *
+     * <p>The default implementation ignores {@code sender}/{@code value} and
+     * behaves like {@link #callView(Address, byte[], BlockContext)}; the
+     * production executors override it to thread both into the EVM frame.
+     */
+    default CompletableFuture<byte[]> callView(Address sender, Address target, byte[] calldata,
+                                               java.math.BigInteger value, BlockContext blockContext) {
+        return callView(target, calldata, blockContext);
+    }
+
+    /**
      * Estimate the gas required to execute {@code tx} against the state at
      * {@code blockContext.stateRoot()}.
      *

--- a/myotis-evm/src/main/java/io/myotis/evm/PrefetchingEvmExecutor.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/PrefetchingEvmExecutor.java
@@ -93,9 +93,15 @@ public final class PrefetchingEvmExecutor implements EvmExecutor {
 
     @Override
     public CompletableFuture<byte[]> callView(Address target, byte[] calldata, BlockContext blockContext) {
+        return callView(null, target, calldata, null, blockContext);
+    }
+
+    @Override
+    public CompletableFuture<byte[]> callView(Address sender, Address target, byte[] calldata,
+                                              java.math.BigInteger value, BlockContext blockContext) {
         Executor executor = delegate.executor();
         return CompletableFuture.supplyAsync(
-                () -> runConvergent(target, calldata, blockContext), executor);
+                () -> runConvergent(sender, target, calldata, value, blockContext), executor);
     }
 
     /** Estimation delegates directly: the prefetch/convergence loop exists to batch
@@ -106,7 +112,8 @@ public final class PrefetchingEvmExecutor implements EvmExecutor {
         return delegate.estimateGas(tx, blockContext);
     }
 
-    private byte[] runConvergent(Address target, byte[] calldata, BlockContext blockContext) {
+    private byte[] runConvergent(Address sender, Address target, byte[] calldata,
+                                 java.math.BigInteger value, BlockContext blockContext) {
         SnapStateOracle oracle = delegate.oracle();
         BytecodeCache bytecodeCache = delegate.bytecodeCache();
 
@@ -161,7 +168,7 @@ public final class PrefetchingEvmExecutor implements EvmExecutor {
             long missesBefore = view.sentinelMissCount();
             byte[] result;
             try {
-                result = delegate.runOnTracedView(target, calldata, blockContext, view, tracer);
+                result = delegate.runOnTracedView(sender, target, calldata, value, blockContext, view, tracer);
             } catch (EvmExecutionException e) {
                 if (!sentinelMode) {
                     // Real iteration produced an actual revert / halt — propagate.

--- a/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
+++ b/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
@@ -674,8 +674,9 @@ public final class VerifiedRpcBackend implements io.myotis.jsonrpc.MyotisRpcBack
     }
 
     @Override
-    public byte[] call(byte[] to, byte[] data, String block) {
-        return rpcCall(to, data, block);
+    public byte[] call(byte[] from, byte[] to, byte[] data,
+                       java.math.BigInteger value, String block) {
+        return rpcCall(from, to, data, value, block);
     }
 
     @Override
@@ -1617,12 +1618,20 @@ public final class VerifiedRpcBackend implements io.myotis.jsonrpc.MyotisRpcBack
     // ---------------------------------------------------------------------
 
     /** eth_call over the shared anchored head. Returns raw ABI bytes, or null to error. */
-    private byte[] rpcCall(byte[] to, byte[] data, String block) {
-        // Identify the call up front: target + 4-byte selector + calldata size + block
-        // tag. eth_call failures were undiagnosable as "eth_call -> proxy: Timeout" —
-        // with hundreds of MetaMask poll variants we need to know WHICH contract/method
-        // is being asked for (e.g. its confirm-screen simulation multicall).
-        String desc = (to != null && to.length == 20 ? Bytes.wrap(to).toHexString() : "?")
+    private byte[] rpcCall(byte[] from, byte[] to, byte[] data,
+                           java.math.BigInteger value, String block) {
+        if (from != null && from.length != 20) {
+            log.info("[rpc] eth_call -> malformed from (len=" + from.length + ")");
+            return null;
+        }
+        // Identify the call up front: caller + target + 4-byte selector + calldata size
+        // + block tag. eth_call failures were undiagnosable as "eth_call -> proxy:
+        // Timeout" — with hundreds of MetaMask poll variants we need to know WHICH
+        // contract/method is being asked for (e.g. its confirm-screen simulation
+        // multicall), and by WHOM (a from-gated transfer/approve simulation differs
+        // from an anonymous read).
+        String desc = "from=" + (from != null && from.length == 20 ? Bytes.wrap(from).toHexString() : "0x0")
+                + " to=" + (to != null && to.length == 20 ? Bytes.wrap(to).toHexString() : "?")
                 + " sel=" + (data != null && data.length >= 4
                         ? Bytes.wrap(data, 0, 4).toHexString() : "0x")
                 + " dataLen=" + (data == null ? 0 : data.length)
@@ -1645,8 +1654,13 @@ public final class VerifiedRpcBackend implements io.myotis.jsonrpc.MyotisRpcBack
         // share one execution — this changes scheduling, never verification. Each
         // waiter keeps its own 30s deadline; the entry is removed when the execution
         // completes so a later retry re-executes fresh.
+        // Key by (stateRoot, from, to, value, calldata): the sender and value are now
+        // part of the input — a transfer simulated by vitalik vs by the zero address
+        // computes a DIFFERENT verified result, so they must not share an execution.
         String flightKey = Bytes.wrap(h.blockCtx().stateRoot()).toHexString()
+                + ":" + (from == null ? "0x0" : Bytes.wrap(from).toHexString())
                 + ":" + Bytes.wrap(to).toHexString()
+                + ":" + (value == null ? "0" : value.toString())
                 + ":" + (data == null ? "0x" : Hash.keccak256(Bytes.wrap(data)).toHexString());
         // Route small calls onto the reserved EVM lane so a confirm screen's tiny
         // probes/simulations never queue behind a ~32KB token-sweep storm. The hint
@@ -1671,8 +1685,10 @@ public final class VerifiedRpcBackend implements io.myotis.jsonrpc.MyotisRpcBack
                 // and complete exceptionally so waiters fail fast and a retry re-executes.
                 try {
                     h.offchainExecutor()
-                            .callView(io.myotis.evm.Address.of(to),
-                                    data == null ? new byte[0] : data, h.blockCtx())
+                            .callView(from == null ? null : io.myotis.evm.Address.of(from),
+                                    io.myotis.evm.Address.of(to),
+                                    data == null ? new byte[0] : data,
+                                    value, h.blockCtx())
                             .whenComplete((out, ex) -> {
                                 inflightCalls.remove(flightKey, mine);
                                 if (ex != null) mine.completeExceptionally(ex);

--- a/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
+++ b/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
@@ -1620,15 +1620,19 @@ public final class VerifiedRpcBackend implements io.myotis.jsonrpc.MyotisRpcBack
     /** eth_call over the shared anchored head. Returns raw ABI bytes, or null to error. */
     private byte[] rpcCall(byte[] from, byte[] to, byte[] data,
                            java.math.BigInteger value, String block) {
+        // Keep the early-rejection logs correlatable with the wallet call that triggered
+        // them: include target + 4-byte selector, matching the richer `desc` logging below.
+        String callCtx = " to=" + (to != null && to.length == 20 ? Bytes.wrap(to).toHexString() : "?")
+                + " sel=" + (data != null && data.length >= 4 ? Bytes.wrap(data, 0, 4).toHexString() : "0x");
         if (from != null && from.length != 20) {
-            log.info("[rpc] eth_call -> malformed from (len=" + from.length + ")");
+            log.info("[rpc] eth_call -> malformed from (len=" + from.length + ")" + callCtx);
             return null;
         }
         // Defence in depth (the router already screens this): wei is non-negative, and a
         // negative value would throw IllegalArgumentException in Wei.of down in the executor.
         // Return null so the router centrally manages the fallback instead.
         if (value != null && value.signum() < 0) {
-            log.info("[rpc] eth_call -> negative value (" + value + ")");
+            log.info("[rpc] eth_call -> negative value (" + value + ")" + callCtx);
             return null;
         }
         // Identify the call up front: caller + target + 4-byte selector + calldata size

--- a/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
+++ b/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
@@ -1624,6 +1624,13 @@ public final class VerifiedRpcBackend implements io.myotis.jsonrpc.MyotisRpcBack
             log.info("[rpc] eth_call -> malformed from (len=" + from.length + ")");
             return null;
         }
+        // Defence in depth (the router already screens this): wei is non-negative, and a
+        // negative value would throw IllegalArgumentException in Wei.of down in the executor.
+        // Return null so the router centrally manages the fallback instead.
+        if (value != null && value.signum() < 0) {
+            log.info("[rpc] eth_call -> negative value (" + value + ")");
+            return null;
+        }
         // Identify the call up front: caller + target + 4-byte selector + calldata size
         // + block tag. eth_call failures were undiagnosable as "eth_call -> proxy:
         // Timeout" — with hundreds of MetaMask poll variants we need to know WHICH


### PR DESCRIPTION
`eth_call` dropped the `from` field entirely — `RpcRouter` → `MyotisRpcBackend.call` → `EvmExecutor.callView` had no sender, so every simulation ran as the **zero address**. Any contract call gating on `msg.sender` (every ERC-20 transfer/approve, a wallet's confirm-screen simulation) reverted ("ERC20: transfer from the zero address"), surfaced as the misleading `-32000 no peer / not synced`.

Thread `from`/`value` through the whole call path (mirroring how `estimateGas` already passes `from`). Two companion fixes the same path needed:
- `runOnTracedView` ran `isStatic(true)`, which halts the SSTOREs a transfer performs even with the right sender; `eth_call` is non-static (like Geth/Besu and our `estimateGas`) — writes are journalled and discarded. Flip to `isStatic(false)`.
- the single-flight dedup key now includes `from`/`value` so one sender can't get another's cached result.

The new 5-arg `callView` is a default that delegates to the 3-arg form, so other `EvmExecutor` impls keep compiling. Verified on-device: a USDC transfer simulation with `from` returns the real ABI result (`0x..01`) instead of the zero-address revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_019KGkWsCN1NcaeQnCV11V27