### PR TITLE
fix(networking): make snapServingFailed a cooldown, not a permanent flag

### DIFF
--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/EthHandler.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/EthHandler.java
@@ -88,7 +88,17 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
     private volatile boolean incompatibleNetwork; // confirmed wrong chain
     private volatile boolean snapNegotiated = false;
     private volatile String clientId;
-    private volatile boolean snapServingFailed = false;
+    /** How long an empty snap response benches a peer from the serving pool. NOT permanent:
+     *  an empty response usually means the peer's flat snapshot hadn't yet caught up to the
+     *  (often bleeding-edge) root we asked for — it serves a slightly older/newer root fine.
+     *  Permanent exclusion monotonically decayed the serving pool to zero over a long session
+     *  (every confirm-screen / balance-sweep storage fetch that came back empty retired
+     *  another good peer), so a node with 50+ snap-negotiated peers went amber and could not
+     *  build a verified head while the UI still counted them. A short cooldown routes around a
+     *  momentarily-lagging peer without throwing it away for the rest of the connection. */
+    private static final long SNAP_SERVING_COOLDOWN_MS = 30_000L;
+    /** Epoch-ms until which this peer is benched from the snap serving pool (0 = not benched). */
+    private volatile long snapServingFailedUntilMs = 0L;
     private volatile org.apache.tuweni.bytes.Bytes32 latestStateRoot;
     private volatile long latestStateRootBlockNumber = -1;
 
@@ -1341,9 +1351,16 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
 
     public boolean isSnapNegotiated() { return snapNegotiated; }
 
-    public boolean isSnapServingFailed() { return snapServingFailed; }
+    public boolean isSnapServingFailed() {
+        return System.currentTimeMillis() < snapServingFailedUntilMs;
+    }
 
-    public void markSnapServingFailed() { snapServingFailed = true; }
+    /** Bench this peer from the serving pool for {@link #SNAP_SERVING_COOLDOWN_MS}, after
+     *  which it automatically rejoins and gets another chance (its snapshot will have
+     *  advanced). Replaces the old permanent flag that decayed the pool to zero. */
+    public void markSnapServingFailed() {
+        snapServingFailedUntilMs = System.currentTimeMillis() + SNAP_SERVING_COOLDOWN_MS;
+    }
 
     public State getState() {
         return state;

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/EthHandler.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/EthHandler.java
@@ -96,9 +96,11 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
      *  another good peer), so a node with 50+ snap-negotiated peers went amber and could not
      *  build a verified head while the UI still counted them. A short cooldown routes around a
      *  momentarily-lagging peer without throwing it away for the rest of the connection. */
-    private static final long SNAP_SERVING_COOLDOWN_MS = 30_000L;
-    /** Epoch-ms until which this peer is benched from the snap serving pool (0 = not benched). */
-    private volatile long snapServingFailedUntilMs = 0L;
+    private static final long SNAP_SERVING_COOLDOWN_NS = TimeUnit.MILLISECONDS.toNanos(30_000L);
+    /** Monotonic {@link System#nanoTime()} deadline until which this peer is benched from the
+     *  snap serving pool (0 = not benched). nanoTime, not currentTimeMillis: a wall-clock
+     *  adjustment (NTP / manual) must not extend or prematurely expire the cooldown. */
+    private volatile long snapServingFailedUntilNs = 0L;
     private volatile org.apache.tuweni.bytes.Bytes32 latestStateRoot;
     private volatile long latestStateRootBlockNumber = -1;
 
@@ -1352,14 +1354,18 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
     public boolean isSnapNegotiated() { return snapNegotiated; }
 
     public boolean isSnapServingFailed() {
-        return System.currentTimeMillis() < snapServingFailedUntilMs;
+        long until = snapServingFailedUntilNs;
+        // `now - until < 0` (not `now < until`) is the overflow-safe nanoTime comparison.
+        return until != 0L && (System.nanoTime() - until < 0);
     }
 
-    /** Bench this peer from the serving pool for {@link #SNAP_SERVING_COOLDOWN_MS}, after
+    /** Bench this peer from the serving pool for {@link #SNAP_SERVING_COOLDOWN_NS}, after
      *  which it automatically rejoins and gets another chance (its snapshot will have
      *  advanced). Replaces the old permanent flag that decayed the pool to zero. */
     public void markSnapServingFailed() {
-        snapServingFailedUntilMs = System.currentTimeMillis() + SNAP_SERVING_COOLDOWN_MS;
+        long until = System.nanoTime() + SNAP_SERVING_COOLDOWN_NS;
+        // nanoTime can legitimately be 0; remap so 0 keeps meaning "not benched".
+        snapServingFailedUntilNs = (until == 0L) ? 1L : until;
     }
 
     public State getState() {


### PR DESCRIPTION
A peer was **permanently** retired from the snap serving pool on the first empty snap storage response. But an empty response usually just means the peer's flat snapshot hadn't yet caught up to the (often bleeding-edge) root we asked for — it serves a slightly older/newer root fine.

Permanent exclusion made the serving pool (`activeSnapHandlers()`, which filters `!isSnapServingFailed`) **decay monotonically to zero** over a long session: every confirm-screen / balance-sweep storage fetch that came back empty retired another good peer, until a node with 50+ snap-negotiated peers went amber and could no longer build a verified head — while the UI still counted the negotiated peers, masking the collapse. (Observed live: green at T+0, amber/stuck ~4.5h later, same node.)

Replace the permanent boolean with a **30s cooldown**: a momentarily-lagging peer is benched briefly, then automatically rejoins and gets another chance (its snapshot will have advanced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_019KGkWsCN1NcaeQnCV11V27