### PR TITLE
fix(android): RPC serving reliability + Logs/Settings UX

### DIFF
--- a/OPTIMISATIONS_AND_LIMITATIONS.md
+++ b/OPTIMISATIONS_AND_LIMITATIONS.md
@@ -287,6 +287,36 @@ Notes from measuring the unbounded version on-device:
 - **discv5 free-port fallback**: avoid the emulator's OpenThread squatting on UDP 9000.
 *Attacks:* ART/runtime limits (§1.2).
 
+### 2.14 State-read freshness: why we kept it STRICT (a tried-and-reverted relaxation)
+The tight `RPC_STATE_HEAD_MAX_STALE_MS` = 120 s bound (§2.1) makes **state-execution** reads
+— `eth_call`, `eth_getBalance`, `eth_getCode`, `eth_getStorageAt`, `eth_estimateGas` —
+**fast-error** (`-32000`) when no fresh snap-servable head exists. Observed live as
+**"fee calculation failed despite 18 SNAP peers"**: a peer's **flat state lags its own
+head**, so it advertises a head root it won't snap-serve; the build drops to the ~12-min
+finalized root, and if that peer also drops, every state read errors at once.
+
+The tempting fix — **relax** state reads to the same ~13-min stale-serve horizon
+(`RPC_HEAD_SERVE_STALE_MAX_MS`) header reads use, so they serve an older still-anchored root
+instead of erroring — **was implemented and then reverted**, because it made things *worse*:
+
+> The cheap stale-serve `anyPeerServesRoot` probe (§2.4) checks **one** account at the older
+> root. That can pass while the root isn't *fully* servable for a real execution — so
+> `eth_estimateGas` then ground the **entire 120 s `RPC_CALL_TIMEOUT`** fetching state no peer
+> serves, and the **confirm screen HUNG for two minutes** instead of failing fast. Measured
+> on-device: estimateGas `120.1 s → -32000` under relaxed vs `0.1–9 s → result` under strict
+> (the fresh head was available the whole time; relaxing only dragged the estimate onto a
+> stale, partially-unservable root). Staleness was never the real blocker — *no fully
+> servable root existed at that instant*, and a fast `-32000` the wallet retries beats a 2-min
+> freeze.
+
+So the default stays **strict / fast-fail**. The relaxation survives as an **explicit
+opt-in** for environments with reliably deep snap peers (where the older root *is* fully
+servable): system property `-Dmyotis.rpc.strictStateFreshness=false` (daemon), or the
+Android **Settings → Node tuning → "Relaxed state freshness"** toggle (OFF by default;
+applies on the next node restart). The durable fix for the underlying "fee calc fails under
+churn" is **better snap-peer quality/retention**, not staler serving. *Attacks:* peer churn /
+flat-state lag (§1.1).
+
 ---
 
 ## Part 3 — Where it stands

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/MainActivity.kt
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/MainActivity.kt
@@ -1156,9 +1156,14 @@ private fun LogsTab(
     // then keep it fresh from a sample()-throttled view of the buffer so each scan has
     // room to complete (collectLatest only supersedes the prior *sampled* pass, not every
     // 250ms tick). The unfiltered view stays fully live — a cheap direct assignment.
+    //
+    // We observe the `lastVersion` Long (updated atomically with `entries`) rather than
+    // `entries` itself: snapshotFlow dedupes by structural equality, and an equals() over
+    // a 50k-entry list on every tick would be an O(N) main-thread cost. lastVersion gives
+    // the same change signal as an O(1) primitive compare; we then read `entries` inside.
     LaunchedEffect(filter) {
         if (filter.isBlank()) {
-            snapshotFlow { entries }.collect { shown = it }
+            snapshotFlow { lastVersion }.collect { shown = entries }
         } else {
             val matches = { e: LogBuffer.Entry ->
                 e.tag.contains(filter, ignoreCase = true) ||
@@ -1166,9 +1171,10 @@ private fun LogsTab(
             }
             // ensureActive() bails a superseded scan promptly rather than running it out.
             shown = withContext(Dispatchers.Default) { entries.filter { ensureActive(); matches(it) } }
-            snapshotFlow { entries }
+            snapshotFlow { lastVersion }
                 .sample(500L)
-                .collectLatest { snap ->
+                .collectLatest {
+                    val snap = entries
                     shown = withContext(Dispatchers.Default) { snap.filter { ensureActive(); matches(it) } }
                 }
         }

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/MainActivity.kt
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/MainActivity.kt
@@ -19,6 +19,7 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.foundation.clickable
@@ -91,7 +92,9 @@ import com.jaeckel.ethp2p.networking.NetworkConfig
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.sample
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -579,6 +582,7 @@ private fun SettingsScreen(
     }
     var snapTarget by remember { mutableStateOf(NodeService.snapTarget(context).toString()) }
     var deepPool by remember { mutableStateOf(NodeService.deepPoolThreshold(context).toString()) }
+    var strictFreshness by remember { mutableStateOf(NodeService.strictStateFreshness(context)) }
 
     Scaffold(
         topBar = {
@@ -596,6 +600,10 @@ private fun SettingsScreen(
             Modifier
                 .fillMaxSize()
                 .padding(padding)
+                // Scrollable: on the cover display the Networks + Node tuning content
+                // (and the Save button) overflows the screen — without this the toggle
+                // and Save fall below the fold and are unreachable.
+                .verticalScroll(rememberScrollState())
                 .padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
@@ -649,6 +657,29 @@ private fun SettingsScreen(
                 singleLine = true,
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                 modifier = Modifier.fillMaxWidth(),
+            )
+            Row(
+                Modifier.fillMaxWidth().padding(top = 4.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text("Relaxed state freshness")
+                Switch(
+                    checked = !strictFreshness,
+                    onCheckedChange = { relaxed ->
+                        strictFreshness = !relaxed
+                        NodeService.setStrictStateFreshness(context, !relaxed)
+                    },
+                )
+            }
+            Text(
+                "Off (default, recommended): strict 2-minute freshness — fee calc / eth_call " +
+                    "fast-fail when no fresh servable root exists, and the wallet retries. " +
+                    "On (opt-in, experimental): serve a slightly older verified root — but if " +
+                    "it isn’t fully servable this can HANG the confirm screen for up to 2 min " +
+                    "instead of failing fast. Applies on the next node (re)start.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             Text(
                 "An RPC-port change reboots that chain; snap-peer target and the readiness " +
@@ -736,7 +767,9 @@ private fun SyncProgressBar(snapshot: NodeService.Snapshot?) {
  *                peers that even a heavy confirm screen converges. Fully ready.
  *
  * The green gates read [NodeService.Snapshot.verifiedHeadAgeMs] (shared backend's
- * warmer) and [NodeService.Snapshot.snapPeers]. The head threshold is generous vs.
+ * warmer) and [NodeService.Snapshot.snapServingPeers] (the *serving* pool, not the
+ * negotiated count — heavy confirm screens converge on peers that actually serve).
+ * The head threshold is generous vs.
  * the head TTL+build time on mobile (~12s TTL + 20-26s build) so a healthy node
  * stays green between rebuilds instead of flickering amber.
  */
@@ -764,7 +797,7 @@ private fun ReadinessStrip(snapshot: NodeService.Snapshot?, deepPoolThreshold: I
             Triple(Color(0xFFD32F2F), 3.dp, "Node readiness: not synced")
         s.verifiedHeadAgeMs > READY_HEAD_WARM_MS ->
             Triple(Color(0xFFF9A825), 3.dp, "Node readiness: warming up, not ready to transact")
-        s.snapPeers >= deepPoolThreshold ->
+        s.snapServingPeers >= deepPoolThreshold ->
             Triple(Color(0xFF00E676), 6.dp,
                 "Node readiness: fully ready — deep peer pool, heavy confirm screens will load")
         else ->
@@ -1113,20 +1146,31 @@ private fun LogsTab(
     // / 4 Hz buffer poll would jank the UI and laggy the typing. The unfiltered
     // view shows the whole buffer (no line cap); the LazyColumn renders lazily.
     var shown by remember { mutableStateOf<List<LogBuffer.Entry>>(emptyList()) }
-    LaunchedEffect(entries, filter) {
-        shown = if (filter.isBlank()) entries
-        else withContext(Dispatchers.Default) {
-            entries.filter {
-                // Cooperative cancellation: a new keystroke cancels this effect, but
-                // Collection.filter isn't cancellation-aware on its own, so a 50k-entry
-                // scan would run to completion on Dispatchers.Default even though its
-                // result is already superseded. ensureActive() bails the moment the
-                // coroutine is cancelled, so rapid typing drops stale passes instead of
-                // piling concurrent scans onto the CPU.
-                ensureActive()
-                it.tag.contains(filter, ignoreCase = true) ||
-                    it.message.contains(filter, ignoreCase = true)
+    // Filtered view — keyed on `filter` ONLY, deliberately NOT on `entries`. The live
+    // buffer refreshes `entries` ~4x/s; the previous version keyed this effect on
+    // `entries` too, so every refresh cancelled and restarted the up-to-50k-entry
+    // case-insensitive scan. Under heavy log churn (most visibly with two networks
+    // running at once) the scan never finished before the next refresh killed it, so the
+    // filtered list stayed permanently empty — it looked like the filter was broken or
+    // that no requests were happening. Fix: run one immediate pass for responsiveness,
+    // then keep it fresh from a sample()-throttled view of the buffer so each scan has
+    // room to complete (collectLatest only supersedes the prior *sampled* pass, not every
+    // 250ms tick). The unfiltered view stays fully live — a cheap direct assignment.
+    LaunchedEffect(filter) {
+        if (filter.isBlank()) {
+            snapshotFlow { entries }.collect { shown = it }
+        } else {
+            val matches = { e: LogBuffer.Entry ->
+                e.tag.contains(filter, ignoreCase = true) ||
+                    e.message.contains(filter, ignoreCase = true)
             }
+            // ensureActive() bails a superseded scan promptly rather than running it out.
+            shown = withContext(Dispatchers.Default) { entries.filter { ensureActive(); matches(it) } }
+            snapshotFlow { entries }
+                .sample(500L)
+                .collectLatest { snap ->
+                    shown = withContext(Dispatchers.Default) { snap.filter { ensureActive(); matches(it) } }
+                }
         }
     }
 
@@ -1512,6 +1556,9 @@ private fun StatusSummary(s: NodeService.Snapshot) {
         StatusRow("connected (RLPx)", s.connectedPeers.toString())
         StatusRow("ready (eth handshake)", s.readyPeers.toString())
         StatusRow("snap supported", s.snapPeers.toString())
+        // The pool head builds / heavy confirm screens actually draw from — when this drops
+        // well below "snap supported", reads stall even though the headline count looks fine.
+        StatusRow("snap serving", s.snapServingPeers.toString())
         StatusRow("cached at boot", s.cachedPeers.toString())
         StatusRow("dialing", s.attemptedPeers.toString())
         StatusRow("in backoff", s.backedOffPeers.toString())

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -245,7 +245,7 @@ public final class NodeService extends Service {
      *  estimateGas serve an older root — but that *backfired* into 120-s confirm-screen
      *  HANGS when the older root isn't fully servable, so strict (fast-fail) is the default;
      *  relaxed is an explicit opt-in. Read by VerifiedRpcBackend via a system property.
-     *  See docs/limitations.md. */
+     *  See OPTIMISATIONS_AND_LIMITATIONS.md §2.14. */
     public static boolean strictStateFreshness(android.content.Context c) {
         return prefs(c).getBoolean(K_STRICT_FRESHNESS, true);
     }

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -125,6 +125,7 @@ public final class NodeService extends Service {
     private static final String K_RPC_PORT = "rpcPort";
     private static final String K_SNAP_TARGET = "snapTarget";
     private static final String K_DEEP_POOL = "deepPoolThreshold";
+    private static final String K_STRICT_FRESHNESS = "strictStateFreshness";
     public static final int DEFAULT_RPC_PORT = 8545;
     // Gnosis defaults to a distinct port so both networks can be added to MetaMask
     // at once: MetaMask refuses to save two RPC endpoints that share the same URL
@@ -238,6 +239,18 @@ public final class NodeService extends Service {
     }
     public static void setDeepPoolThreshold(android.content.Context c, int v) {
         prefs(c).edit().putInt(K_DEEP_POOL, clampInt(v, 1, 128, DEFAULT_DEEP_POOL)).apply();
+    }
+    /** Whether RPC state reads use the strict 2-min head-staleness bound. Default true
+     *  (strict). Relaxing it (toggle OFF strict / ON "relaxed") lets eth_call / balance /
+     *  estimateGas serve an older root — but that *backfired* into 120-s confirm-screen
+     *  HANGS when the older root isn't fully servable, so strict (fast-fail) is the default;
+     *  relaxed is an explicit opt-in. Read by VerifiedRpcBackend via a system property.
+     *  See docs/limitations.md. */
+    public static boolean strictStateFreshness(android.content.Context c) {
+        return prefs(c).getBoolean(K_STRICT_FRESHNESS, true);
+    }
+    public static void setStrictStateFreshness(android.content.Context c, boolean v) {
+        prefs(c).edit().putBoolean(K_STRICT_FRESHNESS, v).apply();
     }
     /** Live-update the snap-peer target (no restart) on every live stack and persist it. */
     public void setTargetSnapPeers(int v) {
@@ -402,7 +415,12 @@ public final class NodeService extends Service {
             int discoveredPeers,
             int connectedPeers,
             int readyPeers,
-            int snapPeers,
+            int snapPeers,            // peers that NEGOTIATED snap/1 (capability flag)
+            int snapServingPeers,     // peers actually in the serving pool right now
+                                      // (negotiated, READY, not benched by snapServingFailed) —
+                                      // this is what head builds / heavy confirm screens use.
+                                      // Can be far below snapPeers when peers bench out, which
+                                      // is what made "54 snap peers but amber/stuck" so confusing.
             int cachedPeers,
             int attemptedPeers,
             int backedOffPeers,
@@ -925,8 +943,14 @@ public final class NodeService extends Service {
         try {
             NetworkConfig network = NetworkConfig.byName(n);
             int rpcPort = rpcPortFor(this, n);
+            // VerifiedRpcBackend (built inside ChainStack.start() below) reads its state-read
+            // freshness mode from this process-wide property; mirror the user's Settings choice
+            // into it before the stack builds. Process-global, shared across all stacks.
+            System.setProperty(io.myotis.rpc.VerifiedRpcBackend.STRICT_STATE_FRESHNESS_PROP,
+                    String.valueOf(strictStateFreshness(this)));
             LogBuffer.i(TAG, "[" + n + "] booting (snap target " + snapTarget(this)
-                    + ", rpc port " + rpcPort + ")");
+                    + ", rpc port " + rpcPort
+                    + ", state-freshness " + (strictStateFreshness(this) ? "strict" : "relaxed") + ")");
 
             // Identity: legacy mainnet keeps nodekey.hex; other chains get a per-network key
             // so two chains in one process never share an identity.
@@ -1158,7 +1182,7 @@ public final class NodeService extends Service {
         BeaconStats bs = beaconStatsSnapshot(s);
         RLPxConnector connector = s.connector();
         if (!running || connector == null) {
-            return new Snapshot(running, startTimeMs, 0, 0, 0, 0,
+            return new Snapshot(running, startTimeMs, 0, 0, 0, 0, /*snapServing*/0,
                     cachedEl, attemptedN, backoffN,
                     blacklistedN, discv5Live, 0,
                     bs.state, bs.bootstrapped, bs.connected, bs.lc,
@@ -1183,7 +1207,11 @@ public final class NodeService extends Service {
         int tableSize = discV4 != null ? discV4.table().size() : 0;
         io.myotis.rpc.VerifiedRpcBackend backend = s.rpcBackend();
         long headAge = backend != null ? backend.verifiedHeadAgeMs() : Long.MAX_VALUE;
-        return new Snapshot(true, startTimeMs, tableSize, active.size(), ready.size(), snapCount,
+        // Serving pool = what head builds / heavy confirm screens actually use (filters out
+        // peers benched by snapServingFailed). Distinct from snapCount (negotiated) — surfacing
+        // it makes a serving-pool collapse visible instead of hidden behind the headline count.
+        int snapServing = connector.activeSnapHandlers().size();
+        return new Snapshot(true, startTimeMs, tableSize, active.size(), ready.size(), snapCount, snapServing,
                 cachedEl, attemptedN, backoffN,
                 blacklistedN, discv5Live, 0,
                 bs.state, bs.bootstrapped, bs.connected, bs.lc,

--- a/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
+++ b/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
@@ -514,23 +514,21 @@ public final class VerifiedRpcBackend implements io.myotis.jsonrpc.MyotisRpcBack
     // Construction / lifecycle
     // ---------------------------------------------------------------------
 
-    /** System property to opt OUT of relaxed state-read freshness (back to the tight
-     *  2-min {@link #RPC_STATE_HEAD_MAX_STALE_MS} bound). The Android app surfaces this as
-     *  a Settings toggle (it sets the property before building its stacks); the daemon
-     *  takes {@code -Dmyotis.rpc.strictStateFreshness=true}. See docs/limitations.md. */
+    /** System property controlling state-read freshness. Default is STRICT (the tight 2-min
+     *  {@link #RPC_STATE_HEAD_MAX_STALE_MS} bound, fast-fail); set
+     *  {@code -Dmyotis.rpc.strictStateFreshness=false} to opt INTO relaxed serving. The
+     *  Android app surfaces this as a Settings toggle (OFF by default; it sets the property
+     *  before building its stacks). See OPTIMISATIONS_AND_LIMITATIONS.md §2.14. */
     public static final String STRICT_STATE_FRESHNESS_PROP = "myotis.rpc.strictStateFreshness";
 
     /** Max age a stale-but-anchored head may have and still be served for a STATE-execution
-     *  read (eth_call / getBalance / getCode / getStorageAt / estimateGas). RELAXED BY
-     *  DEFAULT to the same ~13-min horizon header reads and the beacon-finalized fallback
-     *  already use, so a fee estimate / balance read serves an older-but-still-snap-servable
-     *  anchored root instead of hard-erroring when only the bleeding-edge head is missing
-     *  (the common case: a peer's flat state lags its own head, so its head root isn't
-     *  snap-served). This stays cryptographically VERIFIED — the head is beacon-anchored and
-     *  its verification doesn't expire, and the stale-serve path PROBES that a peer actually
-     *  serves the root before returning it, so we never hand a doomed root to a 30s callView.
-     *  Only freshness ages. Opt back into the tight 2-min bound via
-     *  {@link #STRICT_STATE_FRESHNESS_PROP}. */
+     *  read (eth_call / getBalance / getCode / getStorageAt / estimateGas). STRICT BY DEFAULT
+     *  (the tight 2-min {@link #RPC_STATE_HEAD_MAX_STALE_MS} bound) so a read fast-fails when
+     *  no fresh fully-servable root exists, rather than grinding the 120s call timeout on a
+     *  stale root that passes the cheap probe but isn't fully servable. The relaxed ~13-min
+     *  horizon ({@link #RPC_HEAD_SERVE_STALE_MAX_MS}) is an explicit OPT-IN via
+     *  {@link #STRICT_STATE_FRESHNESS_PROP} — see the constructor and
+     *  OPTIMISATIONS_AND_LIMITATIONS.md §2.14 for why relaxing the default backfired. */
     private final long stateHeadStaleCapMs;
 
     public VerifiedRpcBackend(RLPxConnector connector,
@@ -559,7 +557,7 @@ public final class VerifiedRpcBackend implements io.myotis.jsonrpc.MyotisRpcBack
         // staleness was never the true blocker; when no fully-servable root exists, failing
         // fast is the right move. Relaxed stays available as an explicit OPT-IN for anyone who
         // wants to experiment (e.g. a chain with reliably deep snap peers). Default true =
-        // strict; set the property false to opt into relaxed. See docs/limitations.md.
+        // strict; set the property false to opt into relaxed. See OPTIMISATIONS_AND_LIMITATIONS.md §2.14.
         boolean strictFreshness = Boolean.parseBoolean(
                 System.getProperty(STRICT_STATE_FRESHNESS_PROP, "true"));
         this.stateHeadStaleCapMs =

--- a/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
+++ b/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
@@ -514,6 +514,25 @@ public final class VerifiedRpcBackend implements io.myotis.jsonrpc.MyotisRpcBack
     // Construction / lifecycle
     // ---------------------------------------------------------------------
 
+    /** System property to opt OUT of relaxed state-read freshness (back to the tight
+     *  2-min {@link #RPC_STATE_HEAD_MAX_STALE_MS} bound). The Android app surfaces this as
+     *  a Settings toggle (it sets the property before building its stacks); the daemon
+     *  takes {@code -Dmyotis.rpc.strictStateFreshness=true}. See docs/limitations.md. */
+    public static final String STRICT_STATE_FRESHNESS_PROP = "myotis.rpc.strictStateFreshness";
+
+    /** Max age a stale-but-anchored head may have and still be served for a STATE-execution
+     *  read (eth_call / getBalance / getCode / getStorageAt / estimateGas). RELAXED BY
+     *  DEFAULT to the same ~13-min horizon header reads and the beacon-finalized fallback
+     *  already use, so a fee estimate / balance read serves an older-but-still-snap-servable
+     *  anchored root instead of hard-erroring when only the bleeding-edge head is missing
+     *  (the common case: a peer's flat state lags its own head, so its head root isn't
+     *  snap-served). This stays cryptographically VERIFIED — the head is beacon-anchored and
+     *  its verification doesn't expire, and the stale-serve path PROBES that a peer actually
+     *  serves the root before returning it, so we never hand a doomed root to a 30s callView.
+     *  Only freshness ages. Opt back into the tight 2-min bound via
+     *  {@link #STRICT_STATE_FRESHNESS_PROP}. */
+    private final long stateHeadStaleCapMs;
+
     public VerifiedRpcBackend(RLPxConnector connector,
                               BeaconLightClient beaconLightClient,
                               BeaconSyncState beaconSyncState,
@@ -532,6 +551,21 @@ public final class VerifiedRpcBackend implements io.myotis.jsonrpc.MyotisRpcBack
         this.log = log != null ? log : RpcLogger.noop();
         this.clock = clock != null ? clock : RpcClock.monotonic();
         this.snapQuality = snapQuality != null ? snapQuality : SnapQualitySink.noop();
+        // STRICT by default. Relaxing the cap *backfired*: the cheap single-account
+        // stale-serve probe can pass on an older root that isn't FULLY servable for a real
+        // execution, so eth_estimateGas / eth_call then grind the full 120 s RPC_CALL_TIMEOUT
+        // on unservable state instead of fast-erroring — a confirm-screen *hang* that is
+        // strictly worse than the prior instant -32000 (which the wallet retries). The
+        // staleness was never the true blocker; when no fully-servable root exists, failing
+        // fast is the right move. Relaxed stays available as an explicit OPT-IN for anyone who
+        // wants to experiment (e.g. a chain with reliably deep snap peers). Default true =
+        // strict; set the property false to opt into relaxed. See docs/limitations.md.
+        boolean strictFreshness = Boolean.parseBoolean(
+                System.getProperty(STRICT_STATE_FRESHNESS_PROP, "true"));
+        this.stateHeadStaleCapMs =
+                strictFreshness ? RPC_STATE_HEAD_MAX_STALE_MS : RPC_HEAD_SERVE_STALE_MAX_MS;
+        this.log.info("[rpc] state-read head staleness cap = " + (stateHeadStaleCapMs / 1000)
+                + "s (" + (strictFreshness ? "strict" : "relaxed") + ")");
         final RpcClock clk = this.clock;
         final RpcLogger lg = this.log;
         this.evmPool = task -> {
@@ -963,7 +997,7 @@ public final class VerifiedRpcBackend implements io.myotis.jsonrpc.MyotisRpcBack
                 return frozen.head();
             }
         }
-        RpcCallContext ctx = anchoredHeadOrWait(RPC_STATE_HEAD_MAX_STALE_MS, true);
+        RpcCallContext ctx = anchoredHeadOrWait(stateHeadStaleCapMs, true);
         if (ctx == null) return null;
         if (requestedNum >= 0) {
             // A pinned number means "the latest block I saw" — wallets fetch
@@ -3065,7 +3099,7 @@ public final class VerifiedRpcBackend implements io.myotis.jsonrpc.MyotisRpcBack
                                                 java.math.BigInteger value) {
         if (to == null || to.length != 20) return null;
         if (from != null && from.length != 20) return null;
-        RpcCallContext h = anchoredHeadOrWait(RPC_STATE_HEAD_MAX_STALE_MS, true);
+        RpcCallContext h = anchoredHeadOrWait(stateHeadStaleCapMs, true);
         if (h == null) return null;
         try {
             // Fast path: a value transfer with no calldata to a plain account costs


### PR DESCRIPTION
Four related fixes from one on-device debugging session. They share `MainActivity.kt`/`NodeService.java`, so they ride together; each is independent in intent.

1. **Surface the snap _serving_ pool, not just the negotiated count.** Status showed "snap supported" = peers that *negotiated* snap/1, while head builds + heavy confirm screens draw from `activeSnapHandlers()` (serving). When the serving pool collapsed, the headline count hid it ("54 snap peers but amber/stuck"). Adds a "snap serving" row + `Snapshot.snapServingPeers`, and keys the bright-green readiness gate on the *serving* count.
2. **State-read freshness stays STRICT by default (relaxed = opt-in).** Relaxing the 2-min state-read cap was tried and reverted: an older root that passes the cheap single-account probe but isn't *fully* servable makes `eth_estimateGas`/`eth_call` grind the full 120s timeout — a confirm-screen **hang** worse than the prior fast `-32000` (measured 120.1s vs 0.1–9s). Default strict; relaxed via Settings toggle (off) or `-Dmyotis.rpc.strictStateFreshness=false`. Documented in §2.14.
3. **Fix the Logs filter starving under load.** The filtered view re-ran a ≤50k-entry scan on every ~4Hz buffer tick and got cancelled before finishing, so it stayed empty (looked like a broken filter / no requests). Key on `filter` only + `sample()`-throttle.
4. **Make Settings scrollable.** No `verticalScroll` → lower controls + the Save button fell below the fold on the cover display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_019KGkWsCN1NcaeQnCV11V27