### PR TITLE
cmp: shared Compose-Multiplatform :ui + Desktop actual + macOS .dmg CI (Step 1)

### DIFF
--- a/.github/workflows/desktop-dmg.yml
+++ b/.github/workflows/desktop-dmg.yml
@@ -1,0 +1,55 @@
+name: Desktop DMG (macOS)
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    name: Build macOS .dmg
+    # macos-14 = Apple Silicon → an arm64 .dmg. jpackage only builds installers for the
+    # host OS, so the macOS .dmg can only be produced here (not on the Linux/ubuntu jobs).
+    runs-on: macos-14
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Make gradlew executable
+        run: chmod +x gradlew
+
+      # Compose Desktop's packageDmg wraps jpackage (bundles a jlink'd JRE + the app).
+      # NON-minified (main, not main-release): the Java backend (Netty / Besu / BouncyCastle /
+      # libp2p) is reflection-heavy and proguard would break it. Unsigned — Gatekeeper will
+      # need a right-click → Open the first time; notarization (Apple Developer ID) is a
+      # follow-up. Retry to ride out transient repo-resolution blips (mirrors the APK job).
+      - name: Build macOS .dmg
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew :app-desktop:packageDmg --stacktrace && exit 0
+            echo "::warning::DMG build attempt $attempt failed; retrying in 25s (transient dependency resolution?)"
+            sleep 25
+          done
+          echo "::error::DMG build failed after 3 attempts"
+          exit 1
+
+      - name: Upload DMG
+        uses: actions/upload-artifact@v4
+        with:
+          name: myotis-desktop-dmg-${{ github.sha }}
+          path: app-desktop/build/compose/binaries/main/dmg/*.dmg
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/desktop-dmg.yml
+++ b/.github/workflows/desktop-dmg.yml
@@ -6,10 +6,24 @@ on:
 
 jobs:
   build:
-    name: Build macOS .dmg
-    # macos-14 = Apple Silicon → an arm64 .dmg. jpackage only builds installers for the
-    # host OS, so the macOS .dmg can only be produced here (not on the Linux/ubuntu jobs).
-    runs-on: macos-14
+    name: Build macOS .dmg (${{ matrix.arch }})
+    # jpackage bundles a single-architecture JRE and can't emit a universal binary, so we
+    # build one .dmg per arch on its native runner:
+    #   macos-14 = Apple Silicon → arm64  (runs on M-series Macs)
+    #   macos-13 = Intel         → x64    (runs on Intel Macs, macOS Ventura and back to
+    #                                       Big Sur — JDK 21's floor)
+    # An arm64 .dmg will NOT launch on an Intel Mac (Rosetta only translates x86→arm), which
+    # is why the single arm64 build didn't run on Intel/Ventura. Download the one matching
+    # your Mac. jpackage only builds installers for the host OS, so both must run on macOS.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-14
+            arch: arm64
+          - runner: macos-13
+            arch: x64
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
 
@@ -31,12 +45,13 @@ jobs:
       - name: Make gradlew executable
         run: chmod +x gradlew
 
-      # Compose Desktop's packageDmg wraps jpackage (bundles a jlink'd JRE + the app).
-      # NON-minified (main, not main-release): the Java backend (Netty / Besu / BouncyCastle /
-      # libp2p) is reflection-heavy and proguard would break it. Unsigned — Gatekeeper will
-      # need a right-click → Open the first time; notarization (Apple Developer ID) is a
-      # follow-up. Retry to ride out transient repo-resolution blips (mirrors the APK job).
-      - name: Build macOS .dmg
+      # Compose Desktop's packageDmg wraps jpackage (bundles a jlink'd JRE + the app) for the
+      # HOST architecture — so the arm64 runner emits an arm64 .dmg and the Intel runner an
+      # x64 one. NON-minified (main, not main-release): the Java backend (Netty / Besu /
+      # BouncyCastle / libp2p) is reflection-heavy and proguard would break it. Unsigned —
+      # Gatekeeper will need a right-click → Open the first time; notarization (Apple
+      # Developer ID) is a follow-up. Retry to ride out transient repo-resolution blips.
+      - name: Build macOS .dmg (${{ matrix.arch }})
         run: |
           for attempt in 1 2 3; do
             ./gradlew :app-desktop:packageDmg --stacktrace && exit 0
@@ -46,10 +61,18 @@ jobs:
           echo "::error::DMG build failed after 3 attempts"
           exit 1
 
+      # Compose names both arches' output the same (Myotis-1.0.0.dmg); rename so the
+      # downloaded file itself states the architecture, not just the artifact wrapper.
+      - name: Tag .dmg with architecture
+        run: |
+          set -e
+          dmg=$(ls app-desktop/build/compose/binaries/main/dmg/*.dmg | head -n1)
+          mv "$dmg" "app-desktop/build/compose/binaries/main/dmg/Myotis-${{ matrix.arch }}.dmg"
+
       - name: Upload DMG
         uses: actions/upload-artifact@v4
         with:
-          name: myotis-desktop-dmg-${{ github.sha }}
+          name: myotis-desktop-dmg-${{ matrix.arch }}-${{ github.sha }}
           path: app-desktop/build/compose/binaries/main/dmg/*.dmg
           if-no-files-found: error
           retention-days: 30

--- a/android-app/build.gradle.kts
+++ b/android-app/build.gradle.kts
@@ -206,6 +206,11 @@ dependencies {
     // adapters, so the per-network EL+CL+RPC lifecycle lives once for both hosts.
     implementation(project(":node-core"))
 
+    // Shared Compose-Multiplatform UI + the NodeController/Settings seam. The Android
+    // actuals (AndroidNodeController/AndroidSettings) back it with NodeService, so the
+    // same NodeScreen renders on Android and Desktop.
+    implementation(project(":ui"))
+
     // Force the JRE *variant* of Guava. Guava publishes jre and android
     // variants under one module; on an Android project Gradle's
     // org.gradle.jvm.environment=android attribute selects the `android`

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/cmp/AndroidNodeBridge.kt
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/cmp/AndroidNodeBridge.kt
@@ -1,0 +1,66 @@
+package com.jaeckel.ethp2p.android.cmp
+
+import android.content.Context
+import com.jaeckel.ethp2p.android.NodeService
+import com.jaeckel.ethp2p.networking.NetworkConfig
+import io.myotis.ui.NodeController
+import io.myotis.ui.NodeSnapshot
+import io.myotis.ui.Settings
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+/**
+ * Android actuals for the shared `:ui` seam: back {@link NodeController}/{@link Settings}
+ * with the existing {@link NodeService} + its SharedPreferences statics, so the same
+ * Compose `NodeScreen` renders on Android and Desktop. Additive — wired into MainActivity
+ * as the Status/other tabs are ported to `:ui`.
+ */
+class AndroidNodeController(private val service: NodeService) : NodeController {
+
+    override val running: Boolean
+        get() = NodeService.isRunning()
+
+    override fun snapshots(): Flow<Map<String, NodeSnapshot>> = flow {
+        while (true) {
+            emit(service.snapshots().mapValues { (_, s) -> s.toModel() })
+            delay(2000)
+        }
+    }
+
+    override fun enableNetwork(name: String) { service.enableNetwork(name) }
+    override fun disableNetwork(name: String) { service.disableNetwork(name) }
+    override fun rebootNetwork(name: String) { service.rebootNetwork(name) }
+    override fun shutdown() { service.shutdown() }
+    override fun setTargetSnapPeers(target: Int) { service.setTargetSnapPeers(target) }
+}
+
+/** Map the Java `NodeService.Snapshot` record into the shared Kotlin model. */
+private fun NodeService.Snapshot.toModel(): NodeSnapshot = NodeSnapshot(
+    running = running(),
+    network = network(),
+    beaconState = beaconState(),
+    connectedPeers = connectedPeers(),
+    readyPeers = readyPeers(),
+    snapPeers = snapPeers(),
+    discoveredPeers = discoveredPeers(),
+    executionBlockNumber = executionBlockNumber(),
+    finalizedSlot = finalizedSlot(),
+    syncCurrentPeriod = syncCurrentPeriod(),
+    syncTargetPeriod = syncTargetPeriod(),
+    verifiedHeadAgeMs = verifiedHeadAgeMs(),
+    uptimeSeconds = if (startTimeMs() > 0) (System.currentTimeMillis() - startTimeMs()) / 1000 else 0,
+)
+
+/** Android actual of {@link Settings} over the NodeService SharedPreferences statics. */
+class AndroidSettings(private val ctx: Context) : Settings {
+    override fun enabledNetworks(): List<String> = NodeService.enabledNetworks(ctx)
+    override fun primaryNetwork(): String = NodeService.primaryNetwork(ctx)
+    override fun allNetworks(): List<String> = NetworkConfig.allNetworks().map { it.name() }
+    override fun isNetworkEnabled(name: String): Boolean = NodeService.isNetworkEnabled(ctx, name)
+    override fun setNetworkEnabled(name: String, on: Boolean) = NodeService.setNetworkEnabled(ctx, name, on)
+    override fun rpcPortFor(network: String): Int = NodeService.rpcPortFor(ctx, network)
+    override fun setRpcPort(network: String, port: Int) = NodeService.setRpcPort(ctx, network, port)
+    override fun snapTarget(): Int = NodeService.snapTarget(ctx)
+    override fun setSnapTarget(v: Int) = NodeService.setSnapTargetPref(ctx, v)
+}

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/cmp/AndroidNodeBridge.kt
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/cmp/AndroidNodeBridge.kt
@@ -11,8 +11,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
 /**
- * Android actuals for the shared `:ui` seam: back {@link NodeController}/{@link Settings}
- * with the existing {@link NodeService} + its SharedPreferences statics, so the same
+ * Android actuals for the shared `:ui` seam: back [NodeController]/[Settings]
+ * with the existing [NodeService] + its SharedPreferences statics, so the same
  * Compose `NodeScreen` renders on Android and Desktop. Additive — wired into MainActivity
  * as the Status/other tabs are ported to `:ui`.
  */
@@ -52,7 +52,7 @@ private fun NodeService.Snapshot.toModel(): NodeSnapshot = NodeSnapshot(
     uptimeSeconds = if (startTimeMs() > 0) (System.currentTimeMillis() - startTimeMs()) / 1000 else 0,
 )
 
-/** Android actual of {@link Settings} over the NodeService SharedPreferences statics. */
+/** Android actual of [Settings] over the NodeService SharedPreferences statics. */
 class AndroidSettings(private val ctx: Context) : Settings {
     override fun enabledNetworks(): List<String> = NodeService.enabledNetworks(ctx)
     override fun primaryNetwork(): String = NodeService.primaryNetwork(ctx)

--- a/app-desktop/build.gradle.kts
+++ b/app-desktop/build.gradle.kts
@@ -47,6 +47,15 @@ tasks.register<JavaExec>("syncSmoke") {
 compose.desktop {
     application {
         mainClass = "io.myotis.desktop.MainKt"
+        // Pin the runtime jpackage bundles (via jlink) to the Java 21 toolchain. Our bytecode
+        // is class-file 65 (jvmToolchain(21)) and the backend (:networking discv5, :myotis-evm
+        // Besu) ships Java-21 classes that NEED a 21 runtime to load. Without this, jpackage
+        // defaults to whatever JDK runs Gradle — a Java 17 default JAVA_HOME bundles a 17 JRE
+        // that can't load our classes (UnsupportedClassVersionError: class file 65.0 vs 61.0).
+        // CI happened to work only because its JAVA_HOME is already 21.
+        javaHome = javaToolchains.launcherFor {
+            languageVersion.set(JavaLanguageVersion.of(21))
+        }.get().metadata.installationPath.asFile.absolutePath
         nativeDistributions {
             // macOS first (Apple Silicon). The .dmg can only be PRODUCED on macOS (jpackage
             // is host-OS-bound) — build/run on Linux for dev; package the dmg on a macOS CI

--- a/app-desktop/build.gradle.kts
+++ b/app-desktop/build.gradle.kts
@@ -22,6 +22,10 @@ dependencies {
     implementation(project(":consensus"))
     implementation(project(":myotis-evm"))
     implementation(project(":rpc-backend"))
+    // VerifiedRpcBackend implements jsonrpc-server's MyotisRpcBackend; calling
+    // verifiedHeadAgeMs() forces Kotlin to resolve that supertype, so it must be on the
+    // compile classpath (rpc-backend exposes VerifiedRpcBackend only as `implementation`).
+    implementation(project(":jsonrpc-server"))
     implementation(project(":core"))
 
     implementation(compose.desktop.currentOs)

--- a/app-desktop/build.gradle.kts
+++ b/app-desktop/build.gradle.kts
@@ -12,6 +12,18 @@ plugins {
 
 kotlin { jvmToolchain(21) }
 
+// Besu (via :myotis-evm) drags in the pre-rename tuweni coordinates io.tmio:tuweni-* 2.4.2,
+// whose org.apache.tuweni.bytes.Bytes collides with the JitPack Kotlin fork we use
+// (com.github.biafra23.tuweni-kotlin 2.7.2). A single classloader loads only ONE Bytes for
+// that FQN: tuweni-rlp 2.7.2 (BytesRLPWriter.kt) needs the 2.7.2 Bytes' Kotlin `Companion`,
+// which the 2.4.2 class lacks → NoSuchFieldError at launch. The `gradle run` daemon happens
+// to load the 2.7.2 jar first; jpackage's flattened classpath lets the 2.4.2 one win. Strip
+// io.tmio so only the 2.7.2 fork remains (same packages; Besu already runs against 2.7.2 on
+// the daemon, so 2.4.2 is unneeded) — mirrors the :android-app exclusion.
+configurations.all {
+    exclude(group = "io.tmio")
+}
+
 dependencies {
     implementation(project(":ui"))
 

--- a/app-desktop/build.gradle.kts
+++ b/app-desktop/build.gradle.kts
@@ -20,8 +20,17 @@ kotlin { jvmToolchain(21) }
 // to load the 2.7.2 jar first; jpackage's flattened classpath lets the 2.4.2 one win. Strip
 // io.tmio so only the 2.7.2 fork remains (same packages; Besu already runs against 2.7.2 on
 // the daemon, so 2.4.2 is unneeded) — mirrors the :android-app exclusion.
+//
+// io.netty: the same class of conflict. The JitPack netty-kotlin fork
+// (com.github.biafra23.netty-kotlin, 4.2.x) republishes io.netty.* classes; Besu / vertx /
+// jvm-libp2p drag in upstream io.netty 4.1.115. Both ship e.g. io.netty.channel
+// .SingleThreadEventLoop, and the fork's NioEventLoopGroup calls a 4.2.x constructor the
+// 4.1.115 class lacks → NoSuchMethodError, so the stack fails to start in the flattened
+// jpackage bundle. The :app daemon excludes io.netty group-wide and runs end-to-end on only
+// the fork (reaches SYNCED), so it's safe to do the same here.
 configurations.all {
     exclude(group = "io.tmio")
+    exclude(group = "io.netty")
 }
 
 dependencies {
@@ -75,6 +84,13 @@ compose.desktop {
             targetFormats(TargetFormat.Dmg)
             packageName = "Myotis"
             packageVersion = "1.0.0"  // jpackage/dmg requires MAJOR > 0
+            // Bundle the FULL JDK module graph. jlink otherwise strips the runtime to the
+            // modules it can statically detect, but the backend reaches them reflectively —
+            // DNS (java.naming), JDBC-style lookups, EC TLS (jdk.crypto.ec), XML, etc. — so a
+            // stripped runtime dies at launch with NoClassDefFoundError (first seen:
+            // javax/naming/NamingException). includeAllModules trades a bigger bundle for a
+            // runtime that can actually load Netty / Besu / jvm-libp2p / BouncyCastle.
+            includeAllModules = true
             macOS {
                 bundleID = "io.myotis.desktop"
             }

--- a/app-desktop/build.gradle.kts
+++ b/app-desktop/build.gradle.kts
@@ -68,6 +68,10 @@ tasks.register<JavaExec>("syncSmoke") {
 compose.desktop {
     application {
         mainClass = "io.myotis.desktop.MainKt"
+        // Use our desktop logback config (rolling, size-capped, ~/.myotis/logs, app level
+        // adjustable via -Dmyotis.log.level) instead of the DEBUG-to-unbounded-file logback.xml
+        // that :app puts on the classpath. Applies to both the packaged app and :app-desktop:run.
+        jvmArgs += listOf("-Dlogback.configurationFile=logback-desktop.xml")
         // Pin the runtime jpackage bundles (via jlink) to the Java 21 toolchain. Our bytecode
         // is class-file 65 (jvmToolchain(21)) and the backend (:networking discv5, :myotis-evm
         // Besu) ships Java-21 classes that NEED a 21 runtime to load. Without this, jpackage

--- a/app-desktop/build.gradle.kts
+++ b/app-desktop/build.gradle.kts
@@ -1,0 +1,58 @@
+// :app-desktop — the Compose-Multiplatform DESKTOP app. Hosts the shared `:ui` NodeScreen
+// and drives the Java backend (`node-core`) in-process via DesktopNodeController — the same
+// backend the daemon and Android use, so there's no duplication. (JVM target; not iOS.)
+
+import org.jetbrains.compose.desktop.application.dsl.TargetFormat
+
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.compose.multiplatform)
+    alias(libs.plugins.compose.compiler)
+}
+
+kotlin { jvmToolchain(21) }
+
+dependencies {
+    implementation(project(":ui"))
+
+    // The shared backend + the daemon's file-backed cache adapters / CCIP gateway, reused.
+    implementation(project(":node-core"))
+    implementation(project(":app"))
+    implementation(project(":networking"))
+    implementation(project(":consensus"))
+    implementation(project(":myotis-evm"))
+    implementation(project(":rpc-backend"))
+    implementation(project(":core"))
+
+    implementation(compose.desktop.currentOs)
+    implementation(libs.kotlinx.coroutines.core)
+
+    runtimeOnly(libs.logback.classic)
+}
+
+// Headless check that the Desktop controller drives node-core (no display needed).
+tasks.register<JavaExec>("syncSmoke") {
+    group = "verification"
+    description = "Start the primary network in-process and exit 0 on SYNCED (no GUI)."
+    mainClass.set("io.myotis.desktop.SyncSmokeKt")
+    classpath = sourceSets["main"].runtimeClasspath
+    javaLauncher.set(javaToolchains.launcherFor { languageVersion.set(JavaLanguageVersion.of(21)) })
+    systemProperty("myotis.logfile", rootProject.file("devp2p.log").absolutePath)
+}
+
+compose.desktop {
+    application {
+        mainClass = "io.myotis.desktop.MainKt"
+        nativeDistributions {
+            // macOS first (Apple Silicon). The .dmg can only be PRODUCED on macOS (jpackage
+            // is host-OS-bound) — build/run on Linux for dev; package the dmg on a macOS CI
+            // runner. Add Deb/Msi when those hosts exist.
+            targetFormats(TargetFormat.Dmg)
+            packageName = "Myotis"
+            packageVersion = "1.0.0"  // jpackage/dmg requires MAJOR > 0
+            macOS {
+                bundleID = "io.myotis.desktop"
+            }
+        }
+    }
+}

--- a/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
@@ -29,7 +29,11 @@ import kotlin.io.path.createDirectories
 class DesktopNodeController(private val dataDir: Path) : NodeController {
 
     private val registry = NodeRegistry()
-    private val startMs = System.currentTimeMillis()
+    // nanoTime, not currentTimeMillis: wall-clock / NTP steps must not skew uptime.
+    private val startNs = System.nanoTime()
+    // Serialize lifecycle ops (enable/disable/reboot/shutdown) — they're triggered from the
+    // UI thread but mutate the shared registry; `lock` guards against interleaving.
+    private val lock = Any()
 
     init {
         dataDir.createDirectories()
@@ -39,34 +43,52 @@ class DesktopNodeController(private val dataDir: Path) : NodeController {
         get() = !registry.isEmpty
 
     override fun enableNetwork(name: String) {
-        if (registry.get(name) != null) return
-        val network = NetworkConfig.byName(name)
-        val ports = ChainPorts.defaultsFor(network)
-        val keyFile = if (name == "mainnet") "nodekey.hex" else "nodekey-$name.hex"
-        val nodeKey = NodeKey.loadOrGenerate(dataDir.resolve(keyFile))
-        val suffix = if (name == "mainnet") "" else "-$name"
-        val peerCache = PeerCache(dataDir.resolve("peers$suffix.cache"))
-        val clPeerCache = CLPeerCache(dataDir.resolve("cl-peers$suffix.cache"))
-        val stack = ChainStack(
-            network, ports, nodeKey,
-            PeerCacheAdapter(peerCache), ClPeerCacheAdapter(clPeerCache),
-            JavaHttpCcipGateway(),
-            dataDir.resolve("sync-state$suffix.snapshot"),
-            false,
-        )
-        stack.configureSnapMaintainer(32, null)  // desktop has system DNS → null provider
-        registry.add(stack)
-        Thread({ stack.start() }, "desktop-boot-$name").apply { isDaemon = true }.start()
+        // All of this (key load/generate, cache init, stack.start()) does blocking disk I/O
+        // and network setup — never run it on the UI thread. Boot on a daemon thread, holding
+        // `lock` so concurrent enable/reboot calls can't double-add or race the registry.
+        Thread({
+            synchronized(lock) {
+                if (registry.get(name) != null) return@synchronized
+                val network = NetworkConfig.byName(name)
+                val ports = ChainPorts.defaultsFor(network)
+                val keyFile = if (name == "mainnet") "nodekey.hex" else "nodekey-$name.hex"
+                val nodeKey = NodeKey.loadOrGenerate(dataDir.resolve(keyFile))
+                val suffix = if (name == "mainnet") "" else "-$name"
+                val peerCache = PeerCache(dataDir.resolve("peers$suffix.cache"))
+                val clPeerCache = CLPeerCache(dataDir.resolve("cl-peers$suffix.cache"))
+                val stack = ChainStack(
+                    network, ports, nodeKey,
+                    PeerCacheAdapter(peerCache), ClPeerCacheAdapter(clPeerCache),
+                    JavaHttpCcipGateway(),
+                    dataDir.resolve("sync-state$suffix.snapshot"),
+                    false,
+                )
+                stack.configureSnapMaintainer(32, null)  // desktop has system DNS → null provider
+                registry.add(stack)
+                // If start() fails, drop the stack so a later enable can retry — leaving a
+                // dead entry in the registry would permanently block this network.
+                try {
+                    stack.start()
+                } catch (t: Throwable) {
+                    registry.remove(name)
+                    throw t
+                }
+            }
+        }, "desktop-boot-$name").apply { isDaemon = true }.start()
     }
 
-    override fun disableNetwork(name: String) = registry.remove(name)
+    override fun disableNetwork(name: String) {
+        synchronized(lock) { registry.remove(name) }
+    }
 
     override fun rebootNetwork(name: String) {
         disableNetwork(name)
         enableNetwork(name)
     }
 
-    override fun shutdown() = registry.shutdownAll()
+    override fun shutdown() {
+        synchronized(lock) { registry.shutdownAll() }
+    }
 
     override fun setTargetSnapPeers(target: Int) {
         registry.all().forEach { it.setTargetSnapPeers(target) }
@@ -101,24 +123,35 @@ class DesktopNodeController(private val dataDir: Path) : NodeController {
             syncCurrentPeriod = bss?.currentSyncCommitteePeriod ?: 0L,
             syncTargetPeriod = BeaconChainSpec.currentPeriod(net.clGenesisTime(), net.secondsPerSlot()),
             verifiedHeadAgeMs = 0L,
-            uptimeSeconds = (System.currentTimeMillis() - startMs) / 1000,
+            uptimeSeconds = (System.nanoTime() - startNs) / 1_000_000_000L,
         )
     }
 }
 
-/** Minimal in-memory desktop settings (Step 1). File-backed persistence is a follow-up. */
+/**
+ * Minimal in-memory desktop settings (Step 1). File-backed persistence is a follow-up.
+ * Read/written from both the UI thread and the boot threads, so every access is guarded by
+ * `synchronized(this)` over the non-thread-safe backing collections.
+ */
 class DesktopSettings : Settings {
     private val enabled = linkedSetOf("mainnet")
     private val ports = HashMap<String, Int>()
 
-    override fun enabledNetworks(): List<String> = enabled.toList()
-    override fun primaryNetwork(): String = enabled.firstOrNull() ?: "mainnet"
+    override fun enabledNetworks(): List<String> = synchronized(this) { enabled.toList() }
+    override fun primaryNetwork(): String = synchronized(this) { enabled.firstOrNull() ?: "mainnet" }
     override fun allNetworks(): List<String> = NetworkConfig.allNetworks().map { it.name() }
-    override fun isNetworkEnabled(name: String): Boolean = name in enabled
-    override fun setNetworkEnabled(name: String, on: Boolean) { if (on) enabled.add(name) else enabled.remove(name) }
-    override fun rpcPortFor(network: String): Int =
+    override fun isNetworkEnabled(name: String): Boolean = synchronized(this) { name in enabled }
+    override fun setNetworkEnabled(name: String, on: Boolean) = synchronized(this) {
+        if (on) enabled.add(name) else enabled.remove(name)
+        Unit
+    }
+    override fun rpcPortFor(network: String): Int = synchronized(this) {
         ports[network] ?: NetworkConfig.byName(network).defaultRpcPort()
-    override fun setRpcPort(network: String, port: Int) { ports[network] = port }
+    }
+    override fun setRpcPort(network: String, port: Int) = synchronized(this) {
+        ports[network] = port
+        Unit
+    }
     override fun snapTarget(): Int = 32
     override fun setSnapTarget(v: Int) {}
 }

--- a/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import java.nio.file.Path
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.io.path.createDirectories
 
 /**
@@ -31,9 +32,13 @@ class DesktopNodeController(private val dataDir: Path) : NodeController {
     private val registry = NodeRegistry()
     // nanoTime, not currentTimeMillis: wall-clock / NTP steps must not skew uptime.
     private val startNs = System.nanoTime()
-    // Serialize lifecycle ops (enable/disable/reboot/shutdown) — they're triggered from the
-    // UI thread but mutate the shared registry; `lock` guards against interleaving.
-    private val lock = Any()
+    // Per-network boot locks keyed by CANONICAL name, mirroring Android's NodeService.bootLocks:
+    // serialize enable/disable for one network without a global lock, so a slow boot of network
+    // A never blocks shutdown or lifecycle ops on B. NodeRegistry is ConcurrentHashMap-backed
+    // (each add/get/remove is already thread-safe), so these locks only guard the per-network
+    // check-then-build so two boots of the same network can't race.
+    private val bootLocks = ConcurrentHashMap<String, Any>()
+    private fun bootLock(canonical: String): Any = bootLocks.computeIfAbsent(canonical) { Any() }
 
     init {
         dataDir.createDirectories()
@@ -45,17 +50,23 @@ class DesktopNodeController(private val dataDir: Path) : NodeController {
         get() = registry.all().any { it.isRunning }
 
     override fun enableNetwork(name: String) {
+        // Resolve the canonical name up front: NetworkConfig.byName aliases (xdai/gbc → gnosis,
+        // case-folds, etc.). Everything below — registry keys, the boot lock, and the key/cache
+        // filenames — must use the canonical form, or an alias would double-boot and leak (the
+        // registry keys stacks by network().name(), so a raw-alias remove() would miss).
+        val network = NetworkConfig.byName(name)
+        val canonical = network.name()
         // All of this (key load/generate, cache init, stack.start()) does blocking disk I/O
-        // and network setup — never run it on the UI thread. Boot on a daemon thread, holding
-        // `lock` so concurrent enable/reboot calls can't double-add or race the registry.
+        // and network setup — never run it on the UI thread. Boot on a daemon thread; the
+        // per-network lock (not a global one) keeps two boots of the SAME network from racing
+        // while leaving shutdown / other networks free to proceed.
         Thread({
-            synchronized(lock) {
-                if (registry.get(name) != null) return@synchronized
-                val network = NetworkConfig.byName(name)
+            synchronized(bootLock(canonical)) {
+                if (registry.get(canonical) != null) return@synchronized
                 val ports = ChainPorts.defaultsFor(network)
-                val keyFile = if (name == "mainnet") "nodekey.hex" else "nodekey-$name.hex"
+                val keyFile = if (canonical == "mainnet") "nodekey.hex" else "nodekey-$canonical.hex"
                 val nodeKey = NodeKey.loadOrGenerate(dataDir.resolve(keyFile))
-                val suffix = if (name == "mainnet") "" else "-$name"
+                val suffix = if (canonical == "mainnet") "" else "-$canonical"
                 val peerCache = PeerCache(dataDir.resolve("peers$suffix.cache"))
                 val clPeerCache = CLPeerCache(dataDir.resolve("cl-peers$suffix.cache"))
                 val stack = ChainStack(
@@ -74,16 +85,17 @@ class DesktopNodeController(private val dataDir: Path) : NodeController {
                 val ok = try {
                     stack.start()
                 } catch (t: Throwable) {
-                    registry.remove(name)
+                    registry.remove(canonical)
                     throw t
                 }
-                if (!ok) registry.remove(name)
+                if (!ok) registry.remove(canonical)
             }
-        }, "desktop-boot-$name").apply { isDaemon = true }.start()
+        }, "desktop-boot-$canonical").apply { isDaemon = true }.start()
     }
 
     override fun disableNetwork(name: String) {
-        synchronized(lock) { registry.remove(name) }
+        val canonical = NetworkConfig.byName(name).name()
+        synchronized(bootLock(canonical)) { registry.remove(canonical) }
     }
 
     override fun rebootNetwork(name: String) {
@@ -92,7 +104,10 @@ class DesktopNodeController(private val dataDir: Path) : NodeController {
     }
 
     override fun shutdown() {
-        synchronized(lock) { registry.shutdownAll() }
+        // No global lock: NodeRegistry and ChainStack.shutdown() are each thread-safe, so window
+        // close tears every stack down promptly without waiting behind an in-progress boot of an
+        // unrelated network.
+        registry.shutdownAll()
     }
 
     override fun setTargetSnapPeers(target: Int) {

--- a/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
@@ -22,7 +22,7 @@ import java.nio.file.Path
 import kotlin.io.path.createDirectories
 
 /**
- * The Desktop actual of {@link NodeController}: drives the SAME Java backend (`node-core`
+ * The Desktop actual of [NodeController]: drives the SAME Java backend (`node-core`
  * `ChainStack`/`NodeRegistry`) the daemon and Android use, in-process — no Android Service,
  * no IPC. Reuses the daemon's file-backed caches + CCIP gateway from `:app`.
  */
@@ -39,8 +39,10 @@ class DesktopNodeController(private val dataDir: Path) : NodeController {
         dataDir.createDirectories()
     }
 
+    // A registered stack may still be booting (or have failed start()); report running only
+    // when at least one stack is actually up, not merely present in the registry.
     override val running: Boolean
-        get() = !registry.isEmpty
+        get() = registry.all().any { it.isRunning }
 
     override fun enableNetwork(name: String) {
         // All of this (key load/generate, cache init, stack.start()) does blocking disk I/O
@@ -65,14 +67,17 @@ class DesktopNodeController(private val dataDir: Path) : NodeController {
                 )
                 stack.configureSnapMaintainer(32, null)  // desktop has system DNS → null provider
                 registry.add(stack)
-                // If start() fails, drop the stack so a later enable can retry — leaving a
-                // dead entry in the registry would permanently block this network.
-                try {
+                // ChainStack.start() is fault-isolated: it returns false (and closes its own
+                // resources) on failure rather than throwing. Either way — false return or a
+                // stray throwable — drop the stack from the registry so a later enable can
+                // retry; leaving a dead entry would report "running" forever and block retries.
+                val ok = try {
                     stack.start()
                 } catch (t: Throwable) {
                     registry.remove(name)
                     throw t
                 }
+                if (!ok) registry.remove(name)
             }
         }, "desktop-boot-$name").apply { isDaemon = true }.start()
     }
@@ -110,19 +115,26 @@ class DesktopNodeController(private val dataDir: Path) : NodeController {
         val state = if (bss != null)
             bss.getSyncState(net.clGenesisTime(), net.secondsPerSlot()).name
         else "STARTING"
+        val active = conn?.activePeers ?: emptyList()
+        // "ready" = peers past the eth handshake, matching Android's filtered count (the raw
+        // active list also includes peers still negotiating Hello/Status).
+        val ready = active.count { "READY" == it.state() }
+        val backend = stack.rpcBackend()
         return NodeSnapshot(
             running = stack.isRunning,
             network = net.name(),
             beaconState = state,
-            connectedPeers = conn?.activePeers?.size ?: 0,
-            readyPeers = conn?.activePeers?.size ?: 0,
+            connectedPeers = active.size,
+            readyPeers = ready,
             snapPeers = conn?.activeSnapHandlers()?.size ?: 0,
             discoveredPeers = disc4?.table()?.size() ?: 0,
             executionBlockNumber = bss?.executionBlockNumber ?: 0L,
             finalizedSlot = bss?.finalizedSlot ?: 0L,
             syncCurrentPeriod = bss?.currentSyncCommitteePeriod ?: 0L,
             syncTargetPeriod = BeaconChainSpec.currentPeriod(net.clGenesisTime(), net.secondsPerSlot()),
-            verifiedHeadAgeMs = 0L,
+            // Real age of the last verified RPC head, or MAX_VALUE if RPC hasn't built one yet
+            // (same sentinel Android's NodeService uses; the UI renders it as "—").
+            verifiedHeadAgeMs = backend?.verifiedHeadAgeMs() ?: Long.MAX_VALUE,
             uptimeSeconds = (System.nanoTime() - startNs) / 1_000_000_000L,
         )
     }
@@ -136,6 +148,7 @@ class DesktopNodeController(private val dataDir: Path) : NodeController {
 class DesktopSettings : Settings {
     private val enabled = linkedSetOf("mainnet")
     private val ports = HashMap<String, Int>()
+    private var snap = 32
 
     override fun enabledNetworks(): List<String> = synchronized(this) { enabled.toList() }
     override fun primaryNetwork(): String = synchronized(this) { enabled.firstOrNull() ?: "mainnet" }
@@ -152,8 +165,8 @@ class DesktopSettings : Settings {
         ports[network] = port
         Unit
     }
-    override fun snapTarget(): Int = 32
-    override fun setSnapTarget(v: Int) {}
+    override fun snapTarget(): Int = synchronized(this) { snap }
+    override fun setSnapTarget(v: Int) = synchronized(this) { snap = v }
 }
 
 /** Desktop is treated as always-online (no Android ConnectivityManager). */

--- a/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
@@ -1,0 +1,129 @@
+package io.myotis.desktop
+
+import com.jaeckel.ethp2p.app.CLPeerCache
+import com.jaeckel.ethp2p.app.ClPeerCacheAdapter
+import com.jaeckel.ethp2p.app.PeerCache
+import com.jaeckel.ethp2p.app.PeerCacheAdapter
+import com.jaeckel.ethp2p.app.rpc.JavaHttpCcipGateway
+import com.jaeckel.ethp2p.consensus.lightclient.BeaconChainSpec
+import com.jaeckel.ethp2p.core.crypto.NodeKey
+import com.jaeckel.ethp2p.networking.NetworkConfig
+import io.myotis.node.ChainPorts
+import io.myotis.node.ChainStack
+import io.myotis.node.NodeRegistry
+import io.myotis.ui.NetworkStatus
+import io.myotis.ui.NodeController
+import io.myotis.ui.NodeSnapshot
+import io.myotis.ui.Settings
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+
+/**
+ * The Desktop actual of {@link NodeController}: drives the SAME Java backend (`node-core`
+ * `ChainStack`/`NodeRegistry`) the daemon and Android use, in-process — no Android Service,
+ * no IPC. Reuses the daemon's file-backed caches + CCIP gateway from `:app`.
+ */
+class DesktopNodeController(private val dataDir: Path) : NodeController {
+
+    private val registry = NodeRegistry()
+    private val startMs = System.currentTimeMillis()
+
+    init {
+        dataDir.createDirectories()
+    }
+
+    override val running: Boolean
+        get() = !registry.isEmpty
+
+    override fun enableNetwork(name: String) {
+        if (registry.get(name) != null) return
+        val network = NetworkConfig.byName(name)
+        val ports = ChainPorts.defaultsFor(network)
+        val keyFile = if (name == "mainnet") "nodekey.hex" else "nodekey-$name.hex"
+        val nodeKey = NodeKey.loadOrGenerate(dataDir.resolve(keyFile))
+        val suffix = if (name == "mainnet") "" else "-$name"
+        val peerCache = PeerCache(dataDir.resolve("peers$suffix.cache"))
+        val clPeerCache = CLPeerCache(dataDir.resolve("cl-peers$suffix.cache"))
+        val stack = ChainStack(
+            network, ports, nodeKey,
+            PeerCacheAdapter(peerCache), ClPeerCacheAdapter(clPeerCache),
+            JavaHttpCcipGateway(),
+            dataDir.resolve("sync-state$suffix.snapshot"),
+            false,
+        )
+        stack.configureSnapMaintainer(32, null)  // desktop has system DNS → null provider
+        registry.add(stack)
+        Thread({ stack.start() }, "desktop-boot-$name").apply { isDaemon = true }.start()
+    }
+
+    override fun disableNetwork(name: String) = registry.remove(name)
+
+    override fun rebootNetwork(name: String) {
+        disableNetwork(name)
+        enableNetwork(name)
+    }
+
+    override fun shutdown() = registry.shutdownAll()
+
+    override fun setTargetSnapPeers(target: Int) {
+        registry.all().forEach { it.setTargetSnapPeers(target) }
+    }
+
+    /** Poll the live stacks every 2s and emit a per-network snapshot map for the UI. */
+    override fun snapshots(): Flow<Map<String, NodeSnapshot>> = flow {
+        while (true) {
+            emit(registry.all().associate { it.network().name() to snapshotOf(it) })
+            delay(2000)
+        }
+    }
+
+    private fun snapshotOf(stack: ChainStack): NodeSnapshot {
+        val net = stack.network()
+        val conn = stack.connector()
+        val bss = stack.beaconSyncState()
+        val disc4 = stack.discV4()
+        val state = if (bss != null)
+            bss.getSyncState(net.clGenesisTime(), net.secondsPerSlot()).name
+        else "STARTING"
+        return NodeSnapshot(
+            running = stack.isRunning,
+            network = net.name(),
+            beaconState = state,
+            connectedPeers = conn?.activePeers?.size ?: 0,
+            readyPeers = conn?.activePeers?.size ?: 0,
+            snapPeers = conn?.activeSnapHandlers()?.size ?: 0,
+            discoveredPeers = disc4?.table()?.size() ?: 0,
+            executionBlockNumber = bss?.executionBlockNumber ?: 0L,
+            finalizedSlot = bss?.finalizedSlot ?: 0L,
+            syncCurrentPeriod = bss?.currentSyncCommitteePeriod ?: 0L,
+            syncTargetPeriod = BeaconChainSpec.currentPeriod(net.clGenesisTime(), net.secondsPerSlot()),
+            verifiedHeadAgeMs = 0L,
+            uptimeSeconds = (System.currentTimeMillis() - startMs) / 1000,
+        )
+    }
+}
+
+/** Minimal in-memory desktop settings (Step 1). File-backed persistence is a follow-up. */
+class DesktopSettings : Settings {
+    private val enabled = linkedSetOf("mainnet")
+    private val ports = HashMap<String, Int>()
+
+    override fun enabledNetworks(): List<String> = enabled.toList()
+    override fun primaryNetwork(): String = enabled.firstOrNull() ?: "mainnet"
+    override fun allNetworks(): List<String> = NetworkConfig.allNetworks().map { it.name() }
+    override fun isNetworkEnabled(name: String): Boolean = name in enabled
+    override fun setNetworkEnabled(name: String, on: Boolean) { if (on) enabled.add(name) else enabled.remove(name) }
+    override fun rpcPortFor(network: String): Int =
+        ports[network] ?: NetworkConfig.byName(network).defaultRpcPort()
+    override fun setRpcPort(network: String, port: Int) { ports[network] = port }
+    override fun snapTarget(): Int = 32
+    override fun setSnapTarget(v: Int) {}
+}
+
+/** Desktop is treated as always-online (no Android ConnectivityManager). */
+object DesktopNetworkStatus : NetworkStatus {
+    override val online: Boolean = true
+}

--- a/app-desktop/src/main/kotlin/io/myotis/desktop/Main.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/Main.kt
@@ -7,7 +7,7 @@ import java.nio.file.Path
 
 /**
  * Desktop GUI entry: the SAME shared `:ui` NodeScreen Android renders, driven by the
- * in-process Java backend via {@link DesktopNodeController}. Starts the primary network on
+ * in-process Java backend via [DesktopNodeController]. Starts the primary network on
  * launch so the Status view fills in as it syncs.
  */
 fun main() {
@@ -17,7 +17,12 @@ fun main() {
     controller.enableNetwork(settings.primaryNetwork())
 
     application {
-        Window(onCloseRequest = ::exitApplication, title = "Myotis") {
+        Window(
+            // Tear down the in-process node stack (Netty event loops, libp2p, sync threads)
+            // before exiting so closing the window doesn't leak resources or hang shutdown.
+            onCloseRequest = { controller.shutdown(); exitApplication() },
+            title = "Myotis",
+        ) {
             NodeScreen(controller, settings)
         }
     }

--- a/app-desktop/src/main/kotlin/io/myotis/desktop/Main.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/Main.kt
@@ -1,0 +1,24 @@
+package io.myotis.desktop
+
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.application
+import io.myotis.ui.NodeScreen
+import java.nio.file.Path
+
+/**
+ * Desktop GUI entry: the SAME shared `:ui` NodeScreen Android renders, driven by the
+ * in-process Java backend via {@link DesktopNodeController}. Starts the primary network on
+ * launch so the Status view fills in as it syncs.
+ */
+fun main() {
+    val dataDir = Path.of(System.getProperty("user.home"), ".myotis")
+    val controller = DesktopNodeController(dataDir)
+    val settings = DesktopSettings()
+    controller.enableNetwork(settings.primaryNetwork())
+
+    application {
+        Window(onCloseRequest = ::exitApplication, title = "Myotis") {
+            NodeScreen(controller, settings)
+        }
+    }
+}

--- a/app-desktop/src/main/kotlin/io/myotis/desktop/SyncSmoke.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/SyncSmoke.kt
@@ -18,7 +18,9 @@ fun main() = runBlocking {
     println("[smoke] enabling $net (dataDir=$dataDir)")
     controller.enableNetwork(net)
 
-    val deadline = System.currentTimeMillis() + 180_000
+    // nanoTime deadline — immune to wall-clock / NTP steps that could prematurely fire or
+    // never fire a currentTimeMillis() deadline.
+    val deadline = System.nanoTime() + 180_000_000_000L
     controller.snapshots().collect { snaps ->
         snaps[net]?.let { s ->
             println("[smoke] ${s.network} state=${s.beaconState} blk=${s.executionBlockNumber} " +
@@ -29,7 +31,7 @@ fun main() = runBlocking {
                 exitProcess(0)
             }
         }
-        if (System.currentTimeMillis() > deadline) {
+        if (System.nanoTime() - deadline >= 0) {  // overflow-safe nanoTime comparison
             println("[smoke] timeout (no SYNCED in 180s)")
             controller.shutdown()
             exitProcess(1)

--- a/app-desktop/src/main/kotlin/io/myotis/desktop/SyncSmoke.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/SyncSmoke.kt
@@ -1,0 +1,38 @@
+package io.myotis.desktop
+
+import kotlinx.coroutines.runBlocking
+import java.nio.file.Files
+import kotlin.system.exitProcess
+
+/**
+ * Headless verification that the Desktop `NodeController` actually drives the Java backend
+ * in-process (no GUI / display needed): start the primary network, poll snapshots, exit 0 on
+ * SYNCED. Run: `./gradlew :app-desktop:syncSmoke`. Proves the desktop↔node-core wiring on a
+ * headless host; the GUI render itself is verified on macOS.
+ */
+fun main() = runBlocking {
+    val dataDir = Files.createTempDirectory("myotis-smoke")
+    val controller = DesktopNodeController(dataDir)
+    val settings = DesktopSettings()
+    val net = settings.primaryNetwork()
+    println("[smoke] enabling $net (dataDir=$dataDir)")
+    controller.enableNetwork(net)
+
+    val deadline = System.currentTimeMillis() + 180_000
+    controller.snapshots().collect { snaps ->
+        snaps[net]?.let { s ->
+            println("[smoke] ${s.network} state=${s.beaconState} blk=${s.executionBlockNumber} " +
+                "peers=${s.connectedPeers} snap=${s.snapPeers} period=${s.syncCurrentPeriod}/${s.syncTargetPeriod}")
+            if (s.beaconState == "SYNCED") {
+                println("[smoke] SYNCED — Desktop controller drives node-core in-process OK")
+                controller.shutdown()
+                exitProcess(0)
+            }
+        }
+        if (System.currentTimeMillis() > deadline) {
+            println("[smoke] timeout (no SYNCED in 180s)")
+            controller.shutdown()
+            exitProcess(1)
+        }
+    }
+}

--- a/app-desktop/src/main/resources/logback-desktop.xml
+++ b/app-desktop/src/main/resources/logback-desktop.xml
@@ -1,0 +1,57 @@
+<!-- Desktop logging config. Forced via -Dlogback.configurationFile=logback-desktop.xml
+     (set as a jvmArg in app-desktop/build.gradle.kts) so it wins over the logback.xml that
+     :app puts on the classpath — that default logs com.jaeckel.ethp2p at DEBUG to a
+     non-rotating ${user.dir}/devp2p.log, which floods the console and grows without bound.
+
+     Here instead:
+       * Rolling, size-capped FILE appender under ~/.myotis/logs (the app's data dir), so the
+         log can't grow unbounded: 10 MB/file, gzip-rolled daily, 7 days kept, 50 MB total.
+       * App log level is adjustable at launch:  -Dmyotis.log.level=DEBUG  (default INFO).
+         INFO keeps the noisy RLPx/eth/discovery DEBUG lines out of the console; bump to DEBUG
+         to diagnose. Third-party libraries stay pinned (netty/tuweni/libp2p at WARN) so a
+         DEBUG bump only makes OUR code verbose, not the whole dependency tree.
+     Override the log directory with -Dmyotis.logdir=/some/path if desired. -->
+<configuration>
+    <property name="LOG_DIR" value="${myotis.logdir:-${user.home}/.myotis/logs}"/>
+    <property name="APP_LEVEL" value="${myotis.log.level:-INFO}"/>
+    <!-- The P2P wire layer (eth/rlpx/discovery) is extremely chatty during normal sync — not
+         just INFO per-message traffic (snap AccountRange, eth headers) but WARN/ERROR-with-
+         stacktrace for every benign peer disconnect / connection reset as flaky peers churn.
+         Default it to ERROR so a GUI launch isn't a wall of stack traces; raise with
+         -Dmyotis.log.wire.level=WARN (or INFO/DEBUG) to actually watch the wire. -->
+    <property name="WIRE_LEVEL" value="${myotis.log.wire.level:-ERROR}"/>
+    <property name="PATTERN" value="%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder><pattern>${PATTERN}</pattern></encoder>
+    </appender>
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_DIR}/myotis.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_DIR}/myotis.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+            <maxFileSize>10MB</maxFileSize>
+            <maxHistory>7</maxHistory>
+            <totalSizeCap>50MB</totalSizeCap>
+        </rollingPolicy>
+        <encoder><pattern>${PATTERN}</pattern></encoder>
+    </appender>
+
+    <!-- Our code — verbosity controlled by -Dmyotis.log.level (default INFO). -->
+    <logger name="com.jaeckel.ethp2p" level="${APP_LEVEL}"/>
+    <logger name="io.myotis" level="${APP_LEVEL}"/>
+    <!-- ...but the chatty per-message networking layer defaults to WARN. Raise it with
+         -Dmyotis.log.wire.level=INFO (or DEBUG) to watch the wire during diagnosis. -->
+    <logger name="com.jaeckel.ethp2p.networking" level="${WIRE_LEVEL}"/>
+
+    <!-- Third-party noise stays pinned regardless of APP_LEVEL. -->
+    <logger name="io.netty" level="WARN"/>
+    <logger name="org.apache.tuweni" level="WARN"/>
+    <logger name="io.libp2p" level="WARN"/>
+    <logger name="org.jetbrains.skiko" level="WARN"/>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="FILE"/>
+    </root>
+</configuration>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,8 +19,12 @@ allprojects {
 }
 
 subprojects {
-    // android-app uses the Android Gradle Plugin, not the java plugin
-    if (name == "android-app") {
+    // These bring their own plugins (Android Gradle Plugin / Kotlin Multiplatform /
+    // Compose), which are incompatible with the `java` plugin applied below:
+    //   android-app  → com.android.application
+    //   ui           → kotlin-multiplatform + com.android.library + compose
+    //   app-desktop  → kotlin.jvm + compose (desktop)
+    if (name in setOf("android-app", "ui", "app-desktop")) {
         configurations.all {
             exclude(group = "io.netty", module = "netty-transport-native-epoll")
             exclude(group = "io.netty", module = "netty-transport-native-kqueue")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,17 @@ import java.time.format.DateTimeFormatter
 
 plugins {
     java
+    // Load the Android/Kotlin/Compose plugins once on the root classpath (apply false) so
+    // subprojects that apply them via alias don't each load their own copy — required once a
+    // Kotlin-Multiplatform module (:ui) is in the build, which fails hard on duplicate loads.
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.android.library) apply false
+    alias(libs.plugins.kotlin.android) apply false
+    alias(libs.plugins.kotlin.jvm) apply false
+    alias(libs.plugins.kotlin.multiplatform) apply false
+    alias(libs.plugins.kotlin.serialization) apply false
+    alias(libs.plugins.compose.compiler) apply false
+    alias(libs.plugins.compose.multiplatform) apply false
 }
 
 allprojects {

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,3 +10,6 @@ android.useAndroidX=true
 
 # Dexing the AndroidX + Compose classpath overflows the default 512m heap.
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=1g
+
+# KMP tolerates AGP 8.7 (newer than its max-tested 8.5) fine in practice.
+kotlin.mpp.androidGradlePluginCompatibility.nowarn=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,9 @@ besu = "24.12.2"
 agp = "8.7.3"
 kotlin = "2.0.21"
 compose-bom = "2024.11.00"
+# Compose Multiplatform (shared UI for Android + Desktop, iOS later). 1.7.x pairs with
+# Kotlin 2.0.20+. Uses the Kotlin-2.0 compose-compiler plugin (already present).
+compose-multiplatform = "1.7.1"
 activity-compose = "1.9.3"
 # JSON-RPC server (:jsonrpc-server). Ktor server+client + kotlinx are chosen for
 # Android compatibility (no java.net.http / com.sun.net.httpserver) and to match
@@ -35,10 +38,13 @@ kotlinx-serialization = "1.7.3"
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
+android-library     = { id = "com.android.library",     version.ref = "agp" }
 kotlin-android      = { id = "org.jetbrains.kotlin.android",         version.ref = "kotlin" }
 kotlin-jvm          = { id = "org.jetbrains.kotlin.jvm",             version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 compose-compiler    = { id = "org.jetbrains.kotlin.plugin.compose",  version.ref = "kotlin" }
+kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform",  version.ref = "kotlin" }
+compose-multiplatform = { id = "org.jetbrains.compose",             version.ref = "compose-multiplatform" }
 
 [libraries]
 tuweni-bytes        = { module = "com.github.biafra23.tuweni-kotlin:tuweni-bytes",       version.ref = "tuweni" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,6 +5,8 @@ pluginManagement {
         gradlePluginPortal()
         mavenCentral()
         google()
+        // Compose Multiplatform Gradle plugin (org.jetbrains.compose).
+        maven { url = uri("https://maven.pkg.jetbrains.space/public/p/compose/dev") }
     }
 }
 
@@ -36,4 +38,4 @@ dependencyResolutionManagement {
     }
 }
 
-include("core", "networking", "consensus", "app", "android-app", "myotis-evm", "myotis-ens", "jsonrpc-server", "rpc-backend", "node-core")
+include("core", "networking", "consensus", "app", "android-app", "myotis-evm", "myotis-ens", "jsonrpc-server", "rpc-backend", "node-core", "ui", "app-desktop")

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -1,0 +1,42 @@
+// :ui — the shared Compose-Multiplatform UI + the pure-Kotlin NodeController/Settings seam.
+// commonMain holds the screens + seam interfaces (no backend dependency); the Android and
+// Desktop hosts each supply the actuals. Targets: Android + Desktop JVM now (iOS later, once
+// the backend has a native/KMP path — see docs/bls-rust-acceleration.md for the on-ramp).
+
+plugins {
+    alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.compose.multiplatform)
+    alias(libs.plugins.compose.compiler)
+}
+
+kotlin {
+    jvmToolchain(21)
+
+    androidTarget()
+    jvm("desktop")
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                implementation(compose.runtime)
+                implementation(compose.foundation)
+                implementation(compose.material3)
+                implementation(compose.ui)
+                implementation(libs.kotlinx.coroutines.core)
+            }
+        }
+    }
+}
+
+android {
+    namespace = "io.myotis.ui"
+    compileSdk = 34
+    defaultConfig {
+        minSdk = 29
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
+    }
+}

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeController.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeController.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.flow.Flow
 /**
  * The backend operations the shared UI needs, abstracted so each platform supplies its own
  * actual: Android wraps `NodeService`; Desktop drives `node-core` in-process. commonMain
- * (the screens) depends only on this + {@link Settings} + the models below — never on the
+ * (the screens) depends only on this + [Settings] + the models below — never on the
  * Java/JVM backend, so the same UI compiles for Android, Desktop (and iOS later).
  */
 interface NodeController {

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeController.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeController.kt
@@ -1,0 +1,66 @@
+package io.myotis.ui
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * The backend operations the shared UI needs, abstracted so each platform supplies its own
+ * actual: Android wraps `NodeService`; Desktop drives `node-core` in-process. commonMain
+ * (the screens) depends only on this + {@link Settings} + the models below — never on the
+ * Java/JVM backend, so the same UI compiles for Android, Desktop (and iOS later).
+ */
+interface NodeController {
+    /** Whether any network stack is currently running. */
+    val running: Boolean
+
+    /** Live per-network snapshots, keyed by network name, for the UI to render. */
+    fun snapshots(): Flow<Map<String, NodeSnapshot>>
+
+    fun enableNetwork(name: String)
+    fun disableNetwork(name: String)
+    fun rebootNetwork(name: String)
+    fun shutdown()
+
+    /** Live-update the snap-peer target on all running stacks. */
+    fun setTargetSnapPeers(target: Int)
+
+    // Query + maintenance ops are added with their screens (Query/Logs/Settings).
+}
+
+/** Persisted per-network + shared settings, abstracted from Android SharedPreferences. */
+interface Settings {
+    fun enabledNetworks(): List<String>
+    fun primaryNetwork(): String
+    fun allNetworks(): List<String>
+    fun isNetworkEnabled(name: String): Boolean
+    fun setNetworkEnabled(name: String, enabled: Boolean)
+    fun rpcPortFor(network: String): Int
+    fun setRpcPort(network: String, port: Int)
+    fun snapTarget(): Int
+    fun setSnapTarget(v: Int)
+}
+
+/** Whether the device currently has network connectivity (Android: ConnectivityManager). */
+interface NetworkStatus {
+    val online: Boolean
+}
+
+/**
+ * One network's status, mirroring `NodeService.Snapshot` (the actual maps the Java record
+ * into this Kotlin model). Trimmed to what the shared screens render today; extend as more
+ * screens are ported.
+ */
+data class NodeSnapshot(
+    val running: Boolean,
+    val network: String,
+    val beaconState: String,        // STOPPED / SYNCING / CATCHING_UP / SYNCED
+    val connectedPeers: Int,
+    val readyPeers: Int,
+    val snapPeers: Int,
+    val discoveredPeers: Int,
+    val executionBlockNumber: Long,
+    val finalizedSlot: Long,
+    val syncCurrentPeriod: Long,
+    val syncTargetPeriod: Long,
+    val verifiedHeadAgeMs: Long,
+    val uptimeSeconds: Long,
+)

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 
@@ -25,7 +26,10 @@ import androidx.compose.ui.unit.dp
  */
 @Composable
 fun NodeScreen(controller: NodeController, settings: Settings) {
-    val snapshots by controller.snapshots().collectAsState(initial = emptyMap())
+    // remember(controller): snapshots() returns a fresh Flow each call, so collecting it
+    // directly would re-subscribe on every recomposition. Retain it across recompositions.
+    val snapshotsFlow = remember(controller) { controller.snapshots() }
+    val snapshots by snapshotsFlow.collectAsState(initial = emptyMap())
     MaterialTheme {
         Column(Modifier.fillMaxSize().padding(16.dp)) {
             Text("Myotis", style = MaterialTheme.typography.headlineSmall)

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
@@ -1,0 +1,72 @@
+package io.myotis.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/**
+ * The shared Myotis screen — identical on Android and Desktop. This Step-1 slice renders the
+ * Status view for the primary network from {@link NodeController}'s snapshot flow; the Query
+ * / Logs / Settings tabs are ported next (this composable becomes the tab host).
+ */
+@Composable
+fun NodeScreen(controller: NodeController, settings: Settings) {
+    val snapshots by controller.snapshots().collectAsState(initial = emptyMap())
+    MaterialTheme {
+        Column(Modifier.fillMaxSize().padding(16.dp)) {
+            Text("Myotis", style = MaterialTheme.typography.headlineSmall)
+            Spacer(Modifier.height(12.dp))
+
+            val primary = settings.primaryNetwork()
+            val snap = snapshots[primary]
+            if (snap == null) {
+                Text("Node stopped — no data for $primary")
+            } else {
+                StatusView(snap)
+            }
+
+            Spacer(Modifier.height(16.dp))
+            Row {
+                Button(onClick = { controller.enableNetwork(primary) }) { Text("Start $primary") }
+                Spacer(Modifier.width(8.dp))
+                OutlinedButton(onClick = { controller.shutdown() }) { Text("Stop") }
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatusView(s: NodeSnapshot) {
+    Column {
+        StatusRow("Network", s.network)
+        StatusRow("Beacon", s.beaconState)
+        StatusRow("EL block", s.executionBlockNumber.toString())
+        StatusRow("Peers", "${s.connectedPeers} (ready ${s.readyPeers}, snap ${s.snapPeers})")
+        StatusRow("Discovered", s.discoveredPeers.toString())
+        StatusRow("Sync period", "${s.syncCurrentPeriod} / ${s.syncTargetPeriod}")
+        StatusRow("Verified head age", "${s.verifiedHeadAgeMs} ms")
+        StatusRow("Uptime", "${s.uptimeSeconds}s")
+    }
+}
+
+@Composable
+private fun StatusRow(key: String, value: String) {
+    Row(Modifier.fillMaxWidth().padding(vertical = 2.dp)) {
+        Text(key, Modifier.width(160.dp))
+        Text(value)
+    }
+}

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
@@ -44,10 +44,21 @@ fun NodeScreen(controller: NodeController, settings: Settings) {
             }
 
             Spacer(Modifier.height(16.dp))
+            // A snapshot for `primary` exists only while its stack is registered (running or
+            // mid-boot), so drive button state off it: Start is disabled once the network is
+            // up, Stop only while it is. Stop the primary network specifically (not a global
+            // shutdown) so the pairing reads correctly once more networks are added.
+            val primaryActive = snap != null
             Row {
-                Button(onClick = { controller.enableNetwork(primary) }) { Text("Start $primary") }
+                Button(
+                    onClick = { controller.enableNetwork(primary) },
+                    enabled = !primaryActive,
+                ) { Text("Start $primary") }
                 Spacer(Modifier.width(8.dp))
-                OutlinedButton(onClick = { controller.shutdown() }) { Text("Stop") }
+                OutlinedButton(
+                    onClick = { controller.disableNetwork(primary) },
+                    enabled = primaryActive,
+                ) { Text("Stop") }
             }
         }
     }

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
@@ -21,7 +21,7 @@ import androidx.compose.ui.unit.dp
 
 /**
  * The shared Myotis screen — identical on Android and Desktop. This Step-1 slice renders the
- * Status view for the primary network from {@link NodeController}'s snapshot flow; the Query
+ * Status view for the primary network from [NodeController]'s snapshot flow; the Query
  * / Logs / Settings tabs are ported next (this composable becomes the tab host).
  */
 @Composable
@@ -62,7 +62,9 @@ private fun StatusView(s: NodeSnapshot) {
         StatusRow("Peers", "${s.connectedPeers} (ready ${s.readyPeers}, snap ${s.snapPeers})")
         StatusRow("Discovered", s.discoveredPeers.toString())
         StatusRow("Sync period", "${s.syncCurrentPeriod} / ${s.syncTargetPeriod}")
-        StatusRow("Verified head age", "${s.verifiedHeadAgeMs} ms")
+        // verifiedHeadAgeMs == Long.MAX_VALUE is the "no verified head yet" sentinel — show a
+        // dash instead of the raw ~9.2e18 ms, which would read as a nonsensical age.
+        StatusRow("Verified head age", if (s.verifiedHeadAgeMs == Long.MAX_VALUE) "—" else "${s.verifiedHeadAgeMs} ms")
         StatusRow("Uptime", "${s.uptimeSeconds}s")
     }
 }


### PR DESCRIPTION
## Compose Multiplatform — Step 1: shared `:ui` + Desktop actual + macOS `.dmg` CI

First step of the CMP migration (toward an eventual iOS target). Extracts the UI into a
Compose-Multiplatform `:ui` module that talks to the backend through a pure-Kotlin
`NodeController`/`Settings` seam, adds a **Desktop** actual that drives `node-core`
in-process, and keeps the **unchanged Java backend** consumed by both Android and Desktop —
**zero UI/backend duplication**. iOS is out of scope here (the backend is JVM-only:
Netty / jvm-libp2p / Besu / BLS); this step just makes the *UI* layer iOS-ready.

### What's in this PR
- **`:ui` (KMP + CMP)** — `androidTarget()` + `jvm("desktop")`. `commonMain` holds the
  pure-Kotlin seam (`NodeController`, `Settings`, `NodeSnapshot`, `NetworkStatus`) and the
  shared `NodeScreen` Composable. No dependency on the Java backend.
- **`:app-desktop`** — a Compose Desktop app whose `DesktopNodeController` builds a
  `node-core` `ChainStack` per network in-process (reuses the daemon's PeerCache / CL cache
  adapters / CCIP gateway), plus a headless `syncSmoke` task.
- **Android actuals** — `AndroidNodeController` / `AndroidSettings` back the same seam with
  the existing `NodeService`, so the identical `NodeScreen` renders on both. (Wired in
  additively; MainActivity still hosts its own screens until the tab port lands.)
- **Build wiring** — Compose-Multiplatform 1.7.1 plugin/repo; Android/Kotlin/Compose
  plugins declared once at the root with `apply false` (fixes the "Kotlin plugin loaded
  multiple times" fatal for the KMP metadata task).
- **CI** — `.github/workflows/desktop-dmg.yml` builds the macOS `.dmg` on a `macos-14`
  (Apple Silicon → arm64) runner and uploads it as an artifact. `jpackage` only builds
  installers for the host OS, so the `.dmg` can only be produced on a Mac runner.

### Verified
- Full `./gradlew build` green.
- Desktop `syncSmoke` (headless) reaches **SYNCED** on mainnet in-process — shared UI seam
  driving the shared Java backend end-to-end.

### How to verify the artifact
- Download `myotis-desktop-dmg-<sha>` from the **Desktop DMG (macOS)** run → open on a Mac
  (unsigned: right-click → Open the first time). Status screen should reach SYNCED.
- Android APK is unchanged behaviourally (the shared screen is wired but MainActivity still
  drives its own tabs until the next increment).

### Next (tab-by-tab, verifiable)
Port Query → Logs → Settings into `:ui` one at a time, extending the seam + both actuals,
verifying each via APK/dmg before continuing; the final increment flips MainActivity to
render the shared `NodeScreen`. The Query tab also needs a small shared verified-account-query
backend piece (the beacon-verified `AccountQueryResult` is currently duplicated in the daemon
`CommandHandler` and Android `NodeService`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
