### PR TITLE
cmp: shared Query tab — extract VerifiedAccountQuery + seam + QueryTab

### DIFF
--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -17,7 +17,6 @@ import com.jaeckel.ethp2p.android.log.LogBuffer;
 import com.jaeckel.ethp2p.consensus.BeaconLightClient;
 import com.jaeckel.ethp2p.consensus.BeaconSyncState;
 import com.jaeckel.ethp2p.consensus.libp2p.BeaconP2PService;
-import com.jaeckel.ethp2p.consensus.proof.MerklePatriciaVerifier;
 import com.jaeckel.ethp2p.consensus.proof.OrderedTrieRoot;
 import com.jaeckel.ethp2p.core.crypto.NodeKey;
 import com.jaeckel.ethp2p.core.types.BlockHeader;
@@ -25,14 +24,9 @@ import com.jaeckel.ethp2p.networking.NetworkConfig;
 import com.jaeckel.ethp2p.networking.discv4.DiscV4Service;
 import com.jaeckel.ethp2p.networking.discv5.DiscV5Service;
 import com.jaeckel.ethp2p.networking.eth.messages.BlockBodiesMessage;
-import com.jaeckel.ethp2p.networking.eth.messages.BlockHeadersMessage;
 import com.jaeckel.ethp2p.networking.eth.messages.Receipt;
 import com.jaeckel.ethp2p.networking.eth.messages.TxFeeFields;
 import com.jaeckel.ethp2p.networking.rlpx.RLPxConnector;
-import com.jaeckel.ethp2p.networking.snap.messages.AccountRangeMessage;
-
-import org.apache.tuweni.bytes.Bytes32;
-import org.apache.tuweni.crypto.Hash;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.crypto.SECP256K1;
@@ -48,7 +42,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -82,14 +75,6 @@ public final class NodeService extends Service {
     /** Live snap-peer target, read from settings at boot; the maintainer reads it each tick
      *  so a settings change applies without a restart. */
     private volatile int targetSnapPeers = DEFAULT_SNAP_TARGET;
-    // Same bound the JVM daemon uses (CommandHandler.MAX_HEADER_CHAIN_GAP).
-    // Caps how many headers we'll fetch to bridge from the beacon-finalized
-    // block to the peer's head — i.e. the maximum gap the headerChain
-    // verification path will tolerate. In normal operation the gap is small
-    // (snap peers track head, BLC finality lags by ~12.8 minutes ≈ 64 blocks),
-    // but the bound has to cover catch-up after the phone wakes from doze.
-    private static final int MAX_HEADER_CHAIN_GAP = 8192;
-    private static final long HEADER_CHAIN_TIMEOUT_SEC = 60;
     // How many recent blocks below the verified head to scan for a tx in
     // eth_getTransactionReceipt. Kept small to bound the bandwidth/battery cost of the
     // (trustless) body scan on mobile: ~8 blocks ≈ 1.5 min covers a wallet polling a
@@ -544,259 +529,18 @@ public final class NodeService extends Service {
         return requestAccount(primaryNetwork(this), hexAddress);
     }
 
-    @SuppressLint("NewApi")
     public CompletableFuture<AccountQueryResult> requestAccount(String network, String hexAddress) {
         io.myotis.node.ChainStack stack = stacks.get(canonicalNetwork(network));
-        RLPxConnector connector = stack != null ? stack.connector() : null;
-        BeaconSyncState beaconSyncState = stack != null ? stack.beaconSyncState() : null;
-        if (!RUNNING.get() || connector == null) {
-            return CompletableFuture.failedFuture(
-                    new IllegalStateException("Node is not running on " + canonicalNetwork(network)));
-        }
-        if (hexAddress == null) {
-            return CompletableFuture.failedFuture(
-                    new IllegalArgumentException("Address is required"));
-        }
-        String hex = hexAddress.strip();
-        if (hex.startsWith("0x") || hex.startsWith("0X")) hex = hex.substring(2);
-        if (hex.length() != 40) {
-            return CompletableFuture.failedFuture(
-                    new IllegalArgumentException("Address must be 20 bytes (40 hex chars)"));
-        }
-        final String hexAddrFinal = hex;
-        Bytes address;
-        try {
-            address = Bytes.fromHexString(hex);
-        } catch (Exception e) {
-            return CompletableFuture.failedFuture(
-                    new IllegalArgumentException("Invalid hex address: " + e.getMessage()));
-        }
-        Bytes32 accountHash = Hash.keccak256(address);
-        BeaconSyncState bss = beaconSyncState;
-        RLPxConnector conn = connector;
-        return connector.requestAccount(address).thenCompose(result ->
-                buildAccountResult("0x" + hexAddrFinal, address, accountHash, result, bss, conn));
+        return io.myotis.node.VerifiedAccountQuery.query(stack, hexAddress)
+                .thenApply(NodeService::toAccountQueryResult);
     }
 
-    /**
-     * Mutable verification scratchpad. Keeps the two verification methods
-     * (headerChain + stateRootMatch) from threading 5 separate parameters
-     * through the async chain.
-     */
-    private static final class Verification {
-        boolean beaconChainVerified;
-        boolean blsVerified;
-        long matchedSlot = -1;
-        String verifyMethod;
-        String failReason;
-    }
-
-    private static CompletableFuture<AccountQueryResult> buildAccountResult(
-            String addr,
-            Bytes address,
-            Bytes32 accountHash,
-            AccountRangeMessage.DecodeResult result,
-            BeaconSyncState bss,
-            RLPxConnector connector) {
-        AccountRangeMessage.AccountData found = null;
-        for (AccountRangeMessage.AccountData a : result.accounts()) {
-            if (a.accountHash().equals(accountHash)) {
-                found = a;
-                break;
-            }
-        }
-        final AccountRangeMessage.AccountData foundFinal = found;
-        long nonce = found != null ? found.nonce() : -1;
-        String balance = found != null ? found.balance().toString() : null;
-
-        boolean peerProofValid = false;
-        MerklePatriciaVerifier.VerifiedAccount verifiedAcct = null;
-        if (result.stateRoot() != null && !result.proof().isEmpty()) {
-            List<byte[]> proofBytes = new ArrayList<>(result.proof().size());
-            for (Bytes b : result.proof()) proofBytes.add(b.toArrayUnsafe());
-            // verifyAndExtractAccount returns the storageRoot/codeHash from the
-            // proof-verified leaf — NOT the peer's slim body — so a peer can't
-            // forge those two fields while keeping nonce/balance honest.
-            verifiedAcct = MerklePatriciaVerifier.verifyAndExtractAccount(
-                    result.stateRoot().toArrayUnsafe(),
-                    address.toArrayUnsafe(),
-                    proofBytes, nonce, balance);
-            peerProofValid = (verifiedAcct != null);
-        }
-        final boolean peerProofValidFinal = peerProofValid;
-        final MerklePatriciaVerifier.VerifiedAccount verifiedAcctFinal = verifiedAcct;
-
-        Verification v = new Verification();
-
-        // Fast-path shortcut: if the BLC has already attested the peer's
-        // exact stateRoot, we're done — no header fetch needed. Rare, but
-        // free to check.
-        if (bss != null && result.stateRoot() != null) {
-            BeaconSyncState.SlottedStateRoot match =
-                    bss.findStateRoot(result.stateRoot().toArrayUnsafe());
-            if (match != null) {
-                v.beaconChainVerified = true;
-                v.matchedSlot = match.slot();
-                v.blsVerified = match.blsVerified();
-                v.verifyMethod = "stateRootMatch";
-                return CompletableFuture.completedFuture(
-                        finalizeResult(addr, foundFinal, result, peerProofValidFinal, verifiedAcctFinal, v));
-            }
-        }
-
-        // Main verification path: headerChain. Walk the failure ladder
-        // (mirrors CommandHandler.buildVerificationJson) — only run the
-        // fetch + chain verification if every prerequisite holds.
-        if (result.stateRoot() == null) {
-            v.failReason = "noPeerStateRoot";
-        } else if (!peerProofValid) {
-            v.failReason = "peerProofInvalid";
-        } else if (bss == null || !bss.isSynced()) {
-            v.failReason = "beaconNotSynced";
-        } else {
-            long peerBlockNumber = result.blockNumber();
-            // Read block number + state root from one atomic snapshot — reading them via
-            // two separate getters can pair a block number with a state root from a
-            // different finalized payload if an update lands between the calls.
-            BeaconSyncState.FinalizedExecution fin = bss.getFinalizedExecution();
-            long finalizedBlock = fin.blockNumber();
-            byte[] beaconRoot = fin.stateRoot();
-
-            if (peerBlockNumber <= 0) {
-                v.failReason = "noPeerBlockNumber";
-            } else if (finalizedBlock <= 0 || beaconRoot == null) {
-                v.failReason = "beaconBlockUnavailable";
-            } else if (peerBlockNumber <= finalizedBlock) {
-                v.failReason = "peerBlockBehindFinalized";
-            } else if (peerBlockNumber - finalizedBlock > MAX_HEADER_CHAIN_GAP) {
-                v.failReason = "headerChainGapTooLarge";
-            } else {
-                // headerChain: fetch [finalized .. peerBlock] inclusive
-                // from a single peer and verify the chain end-to-end.
-                final long finalizedSlot = bss.getFinalizedSlot();
-                LogBuffer.i(TAG, "[verify] headerChain: peerBlock=" + peerBlockNumber
-                        + ", finalizedBlock=" + finalizedBlock
-                        + ", gap=" + (peerBlockNumber - finalizedBlock));
-                return verifyHeaderChainBatched(
-                                connector, finalizedBlock, peerBlockNumber,
-                                beaconRoot, result.stateRoot().toArrayUnsafe())
-                        .handle((chainValid, ex) -> {
-                            if (ex != null) {
-                                LogBuffer.i(TAG, "[verify] headerChain error: " + ex.getMessage());
-                                v.failReason = "headerChainError";
-                            } else if (Boolean.TRUE.equals(chainValid)) {
-                                v.beaconChainVerified = true;
-                                v.matchedSlot = finalizedSlot;
-                                v.blsVerified = true;
-                                v.verifyMethod = "headerChain";
-                                v.failReason = null;
-                            } else {
-                                v.failReason = "headerChainInvalid";
-                            }
-                            return finalizeResult(addr, foundFinal, result, peerProofValidFinal, verifiedAcctFinal, v);
-                        });
-            }
-        }
-
-        return CompletableFuture.completedFuture(
-                finalizeResult(addr, foundFinal, result, peerProofValidFinal, verifiedAcctFinal, v));
-    }
-
-    private static AccountQueryResult finalizeResult(String addr,
-                                                      AccountRangeMessage.AccountData found,
-                                                      AccountRangeMessage.DecodeResult result,
-                                                      boolean peerProofValid,
-                                                      MerklePatriciaVerifier.VerifiedAccount verified,
-                                                      Verification v) {
-        long nonce = found != null ? found.nonce() : -1;
-        String balance = found != null ? found.balance().toString() : null;
-        // storageRoot/codeHash come from the proof-verified leaf when we have it,
-        // so they're cryptographically anchored rather than peer-claimed. Fall
-        // back to the slim body only when the proof didn't verify — in which case
-        // the result is already flagged beaconChainVerified=false.
-        String storageRootHex = verified != null
-                ? Bytes.wrap(verified.storageRoot()).toHexString()
-                : (found != null ? found.storageRoot().toHexString() : null);
-        String codeHashHex = verified != null
-                ? Bytes.wrap(verified.codeHash()).toHexString()
-                : (found != null ? found.codeHash().toHexString() : null);
+    private static AccountQueryResult toAccountQueryResult(io.myotis.node.VerifiedAccountQuery.Result r) {
         return new AccountQueryResult(
-                addr,
-                found != null,
-                nonce,
-                balance,
-                storageRootHex,
-                codeHashHex,
-                result.blockNumber(),
-                result.stateRoot() != null ? result.stateRoot().toHexString() : null,
-                peerProofValid,
-                v.beaconChainVerified,
-                v.blsVerified,
-                v.matchedSlot,
-                v.verifyMethod,
-                v.failReason);
-    }
-
-    /**
-     * Fetch headers in a single batch and verify the chain end-to-end.
-     * Returns a future that completes with {@code true} iff:
-     * <ul>
-     *   <li>the first header's stateRoot equals the beacon-finalized root,</li>
-     *   <li>the last header's stateRoot equals the peer's reported root,</li>
-     *   <li>and every header's hash equals the next header's parentHash.</li>
-     * </ul>
-     */
-    @SuppressLint("NewApi") // CompletableFuture.orTimeout — see requestAccount
-    private static CompletableFuture<Boolean> verifyHeaderChainBatched(
-            RLPxConnector connector, long finalizedBlock, long peerBlock,
-            byte[] beaconStateRoot, byte[] peerStateRoot) {
-        long totalLong = peerBlock - finalizedBlock + 1;
-        if (totalLong < 2 || totalLong > MAX_HEADER_CHAIN_GAP) {
-            LogBuffer.i(TAG, "[verify] headerChain gap " + totalLong
-                    + " out of range [2, " + MAX_HEADER_CHAIN_GAP + "]");
-            return CompletableFuture.completedFuture(false);
-        }
-        int total = (int) totalLong;
-        LogBuffer.i(TAG, "[verify] Fetching " + total + " headers from #"
-                + finalizedBlock + " to #" + peerBlock);
-        return connector.requestBlockHeadersBatched(finalizedBlock, total)
-                .orTimeout(HEADER_CHAIN_TIMEOUT_SEC, TimeUnit.SECONDS)
-                .thenApply(headers -> {
-                    boolean valid = verifyHeaderChain(headers, beaconStateRoot, peerStateRoot);
-                    LogBuffer.i(TAG, "[verify] Full header chain (" + headers.size()
-                            + " blocks) valid: " + valid);
-                    return valid;
-                });
-    }
-
-    /**
-     * Pure verification of a contiguous header range. Identical algorithm to
-     * {@code CommandHandler#verifyHeaderChain} in the JVM daemon.
-     */
-    private static boolean verifyHeaderChain(List<BlockHeadersMessage.VerifiedHeader> headers,
-                                              byte[] expectedFirstStateRoot,
-                                              byte[] expectedLastStateRoot) {
-        if (headers.isEmpty()) return false;
-
-        byte[] firstStateRoot = headers.get(0).header().stateRoot.toArrayUnsafe();
-        if (!java.util.Arrays.equals(firstStateRoot, expectedFirstStateRoot)) return false;
-
-        byte[] lastStateRoot = headers.get(headers.size() - 1).header().stateRoot.toArrayUnsafe();
-        if (!java.util.Arrays.equals(lastStateRoot, expectedLastStateRoot)) return false;
-
-        for (int i = 0; i < headers.size() - 1; i++) {
-            Bytes32 currentHash = headers.get(i).hash();
-            Bytes32 nextParent = headers.get(i + 1).header().parentHash;
-            if (!currentHash.equals(nextParent)) {
-                LogBuffer.i(TAG, "[verify] hash chain break at index " + i
-                        + ": block #" + headers.get(i).header().number
-                        + " hash=" + currentHash.toShortHexString()
-                        + " != block #" + headers.get(i + 1).header().number
-                        + " parentHash=" + nextParent.toShortHexString());
-                return false;
-            }
-        }
-        return true;
+                r.address(), r.exists(), r.nonce(), r.balanceWei(),
+                r.storageRootHex(), r.codeHashHex(), r.blockNumber(),
+                r.peerStateRootHex(), r.peerProofValid(), r.beaconChainVerified(),
+                r.blsVerified(), r.matchedBeaconSlot(), r.verifyMethod(), r.failReason());
     }
 
     // ---------------------------------------------------------------------

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/cmp/AndroidNodeBridge.kt
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/cmp/AndroidNodeBridge.kt
@@ -3,12 +3,15 @@ package com.jaeckel.ethp2p.android.cmp
 import android.content.Context
 import com.jaeckel.ethp2p.android.NodeService
 import com.jaeckel.ethp2p.networking.NetworkConfig
+import io.myotis.ui.AccountResult
+import io.myotis.ui.EnsResult
 import io.myotis.ui.NodeController
 import io.myotis.ui.NodeSnapshot
 import io.myotis.ui.Settings
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.future.await
 
 /**
  * Android actuals for the shared `:ui` seam: back [NodeController]/[Settings]
@@ -33,6 +36,21 @@ class AndroidNodeController(private val service: NodeService) : NodeController {
     override fun rebootNetwork(name: String) { service.rebootNetwork(name) }
     override fun shutdown() { service.shutdown() }
     override fun setTargetSnapPeers(target: Int) { service.setTargetSnapPeers(target) }
+
+    override suspend fun requestAccount(network: String, address: String): AccountResult =
+        service.requestAccount(network, address).await().let { r ->
+            AccountResult(
+                r.address(), r.exists(), r.nonce(), r.balanceWei(),
+                r.storageRootHex(), r.codeHashHex(), r.blockNumber(), r.peerStateRootHex(),
+                r.peerProofValid(), r.beaconChainVerified(), r.blsVerified(), r.matchedBeaconSlot(),
+                r.verifyMethod(), r.failReason(),
+            )
+        }
+
+    override suspend fun resolveEns(network: String, name: String): EnsResult =
+        service.resolveEns(network, name).await().let { r ->
+            EnsResult(r.name(), r.addressHex(), r.blockNumber(), r.beaconVerified(), r.error())
+        }
 }
 
 /** Map the Java `NodeService.Snapshot` record into the shared Kotlin model. */

--- a/app-desktop/build.gradle.kts
+++ b/app-desktop/build.gradle.kts
@@ -42,6 +42,8 @@ dependencies {
     implementation(project(":networking"))
     implementation(project(":consensus"))
     implementation(project(":myotis-evm"))
+    // EnsResolutionRoot is referenced directly when calling rpcBackend().resolveEns(...).
+    implementation(project(":myotis-ens"))
     implementation(project(":rpc-backend"))
     // VerifiedRpcBackend implements jsonrpc-server's MyotisRpcBackend; calling
     // verifiedHeadAgeMs() forces Kotlin to resolve that supertype, so it must be on the

--- a/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
@@ -8,9 +8,13 @@ import com.jaeckel.ethp2p.app.rpc.JavaHttpCcipGateway
 import com.jaeckel.ethp2p.consensus.lightclient.BeaconChainSpec
 import com.jaeckel.ethp2p.core.crypto.NodeKey
 import com.jaeckel.ethp2p.networking.NetworkConfig
+import io.myotis.ens.EnsResolutionRoot
 import io.myotis.node.ChainPorts
 import io.myotis.node.ChainStack
 import io.myotis.node.NodeRegistry
+import io.myotis.node.VerifiedAccountQuery
+import io.myotis.ui.AccountResult
+import io.myotis.ui.EnsResult
 import io.myotis.ui.NetworkStatus
 import io.myotis.ui.NodeController
 import io.myotis.ui.NodeSnapshot
@@ -18,6 +22,7 @@ import io.myotis.ui.Settings
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.future.await
 import java.nio.file.Path
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.io.path.createDirectories
@@ -112,6 +117,27 @@ class DesktopNodeController(private val dataDir: Path) : NodeController {
 
     override fun setTargetSnapPeers(target: Int) {
         registry.all().forEach { it.setTargetSnapPeers(target) }
+    }
+
+    override suspend fun requestAccount(network: String, address: String): AccountResult {
+        // VerifiedAccountQuery handles a null/!running stack itself (failed future → throws).
+        val stack = registry.get(NetworkConfig.byName(network).name())
+        val r = VerifiedAccountQuery.query(stack, address).await()
+        return AccountResult(
+            r.address(), r.exists(), r.nonce(), r.balanceWei(),
+            r.storageRootHex(), r.codeHashHex(), r.blockNumber(), r.peerStateRootHex(),
+            r.peerProofValid(), r.beaconChainVerified(), r.blsVerified(), r.matchedBeaconSlot(),
+            r.verifyMethod(), r.failReason(),
+        )
+    }
+
+    override suspend fun resolveEns(network: String, name: String): EnsResult {
+        val stack = registry.get(NetworkConfig.byName(network).name())
+            ?: throw IllegalStateException("Node is not running on $network")
+        val backend = stack.rpcBackend()
+            ?: throw IllegalStateException("RPC backend not started on $network")
+        val r = backend.resolveEns(name.trim(), EnsResolutionRoot.AUTO).await()
+        return EnsResult(r.name(), r.addressHex(), r.blockNumber(), r.verified(), r.error())
     }
 
     /** Poll the live stacks every 2s and emit a per-network snapshot map for the UI. */

--- a/node-core/src/main/java/io/myotis/node/VerifiedAccountQuery.java
+++ b/node-core/src/main/java/io/myotis/node/VerifiedAccountQuery.java
@@ -1,0 +1,307 @@
+package io.myotis.node;
+
+import com.jaeckel.ethp2p.consensus.BeaconSyncState;
+import com.jaeckel.ethp2p.consensus.proof.MerklePatriciaVerifier;
+import com.jaeckel.ethp2p.networking.eth.messages.BlockHeadersMessage;
+import com.jaeckel.ethp2p.networking.rlpx.RLPxConnector;
+import com.jaeckel.ethp2p.networking.snap.messages.AccountRangeMessage;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.crypto.Hash;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Shared, host-agnostic verified account query: fetch an account proof from a READY+snap peer
+ * and verify it against the beacon-attested state root. Extracted from the Android
+ * {@code NodeService} so the daemon, Android, and the Desktop CMP host all run the SAME
+ * verification ladder instead of each duplicating it.
+ *
+ * <p>Two verification methods, in the order checked:
+ * <ul>
+ *   <li><b>stateRootMatch</b> (fast-path) — if the peer's reported stateRoot is one the beacon
+ *       light client has already attested ({@link BeaconSyncState#findStateRoot}), we're done.
+ *       Rare: only fires when the peer's head briefly aligns with an attested slot.</li>
+ *   <li><b>headerChain</b> (load-bearing) — fetch the contiguous header range
+ *       {@code [finalizedBlock .. peerBlock]} from the same peer, verify the parent-hash chain,
+ *       and require the first header's stateRoot to equal the beacon-finalized execution
+ *       stateRoot and the last header's stateRoot to equal the peer-reported stateRoot.</li>
+ * </ul>
+ * Verification <em>failures</em> are reported via {@link Result#failReason()} — the returned
+ * future only completes exceptionally for bad arguments or a not-running node.
+ */
+public final class VerifiedAccountQuery {
+
+    private static final Logger log = LoggerFactory.getLogger(VerifiedAccountQuery.class);
+
+    /** Same bound the JVM daemon uses (CommandHandler.MAX_HEADER_CHAIN_GAP). */
+    public static final int MAX_HEADER_CHAIN_GAP = 8192;
+    public static final long HEADER_CHAIN_TIMEOUT_SEC = 60;
+
+    private VerifiedAccountQuery() {}
+
+    /** Result of a get-account query. Mirrors the JVM daemon's JSON response shape. */
+    public record Result(
+            String address,                  // 0x-prefixed input
+            boolean exists,                  // false when the account isn't in the trie
+            long nonce,                      // -1 when !exists
+            String balanceWei,               // decimal string (BigInteger.toString); null when !exists
+            String storageRootHex,           // null when !exists
+            String codeHashHex,              // null when !exists
+            long blockNumber,                // peer-reported block number the proof is anchored to
+            String peerStateRootHex,         // 0x… root the proof was built against
+            boolean peerProofValid,          // proof verifies against peerStateRoot
+            boolean beaconChainVerified,     // peerStateRoot matches a beacon-attested root
+            boolean blsVerified,             // beacon match was BLS-signed (vs. unverified header)
+            long matchedBeaconSlot,          // -1 when not matched
+            String verifyMethod,             // "stateRootMatch" or "headerChain" or null
+            String failReason                // null when verified
+    ) {}
+
+    /**
+     * Validate the address, query a peer on {@code stack}, and verify the proof. The future
+     * completes exceptionally only for argument/state errors; verification failures surface as
+     * {@link Result#failReason()}.
+     */
+    public static CompletableFuture<Result> query(ChainStack stack, String hexAddress) {
+        RLPxConnector connector = stack != null ? stack.connector() : null;
+        BeaconSyncState beaconSyncState = stack != null ? stack.beaconSyncState() : null;
+        if (stack == null || !stack.isRunning() || connector == null) {
+            return CompletableFuture.failedFuture(
+                    new IllegalStateException("Node is not running"));
+        }
+        if (hexAddress == null) {
+            return CompletableFuture.failedFuture(
+                    new IllegalArgumentException("Address is required"));
+        }
+        String hex = hexAddress.strip();
+        if (hex.startsWith("0x") || hex.startsWith("0X")) hex = hex.substring(2);
+        if (hex.length() != 40) {
+            return CompletableFuture.failedFuture(
+                    new IllegalArgumentException("Address must be 20 bytes (40 hex chars)"));
+        }
+        final String hexAddrFinal = hex;
+        Bytes address;
+        try {
+            address = Bytes.fromHexString(hex);
+        } catch (Exception e) {
+            return CompletableFuture.failedFuture(
+                    new IllegalArgumentException("Invalid hex address: " + e.getMessage()));
+        }
+        Bytes32 accountHash = Hash.keccak256(address);
+        BeaconSyncState bss = beaconSyncState;
+        RLPxConnector conn = connector;
+        return connector.requestAccount(address).thenCompose(result ->
+                buildAccountResult("0x" + hexAddrFinal, address, accountHash, result, bss, conn));
+    }
+
+    /**
+     * Mutable verification scratchpad. Keeps the two verification methods (headerChain +
+     * stateRootMatch) from threading several separate parameters through the async chain.
+     */
+    private static final class Verification {
+        boolean beaconChainVerified;
+        boolean blsVerified;
+        long matchedSlot = -1;
+        String verifyMethod;
+        String failReason;
+    }
+
+    private static CompletableFuture<Result> buildAccountResult(
+            String addr,
+            Bytes address,
+            Bytes32 accountHash,
+            AccountRangeMessage.DecodeResult result,
+            BeaconSyncState bss,
+            RLPxConnector connector) {
+        AccountRangeMessage.AccountData found = null;
+        for (AccountRangeMessage.AccountData a : result.accounts()) {
+            if (a.accountHash().equals(accountHash)) {
+                found = a;
+                break;
+            }
+        }
+        final AccountRangeMessage.AccountData foundFinal = found;
+        long nonce = found != null ? found.nonce() : -1;
+        String balance = found != null ? found.balance().toString() : null;
+
+        boolean peerProofValid = false;
+        MerklePatriciaVerifier.VerifiedAccount verifiedAcct = null;
+        if (result.stateRoot() != null && !result.proof().isEmpty()) {
+            List<byte[]> proofBytes = new ArrayList<>(result.proof().size());
+            for (Bytes b : result.proof()) proofBytes.add(b.toArrayUnsafe());
+            // verifyAndExtractAccount returns the storageRoot/codeHash from the
+            // proof-verified leaf — NOT the peer's slim body — so a peer can't
+            // forge those two fields while keeping nonce/balance honest.
+            verifiedAcct = MerklePatriciaVerifier.verifyAndExtractAccount(
+                    result.stateRoot().toArrayUnsafe(),
+                    address.toArrayUnsafe(),
+                    proofBytes, nonce, balance);
+            peerProofValid = (verifiedAcct != null);
+        }
+        final boolean peerProofValidFinal = peerProofValid;
+        final MerklePatriciaVerifier.VerifiedAccount verifiedAcctFinal = verifiedAcct;
+
+        Verification v = new Verification();
+
+        // Fast-path shortcut: if the BLC has already attested the peer's exact stateRoot, we're
+        // done — no header fetch needed. Rare, but free to check.
+        if (bss != null && result.stateRoot() != null) {
+            BeaconSyncState.SlottedStateRoot match =
+                    bss.findStateRoot(result.stateRoot().toArrayUnsafe());
+            if (match != null) {
+                v.beaconChainVerified = true;
+                v.matchedSlot = match.slot();
+                v.blsVerified = match.blsVerified();
+                v.verifyMethod = "stateRootMatch";
+                return CompletableFuture.completedFuture(
+                        finalizeResult(addr, foundFinal, result, peerProofValidFinal, verifiedAcctFinal, v));
+            }
+        }
+
+        // Main verification path: headerChain. Walk the failure ladder — only run the fetch +
+        // chain verification if every prerequisite holds.
+        if (result.stateRoot() == null) {
+            v.failReason = "noPeerStateRoot";
+        } else if (!peerProofValid) {
+            v.failReason = "peerProofInvalid";
+        } else if (bss == null || !bss.isSynced()) {
+            v.failReason = "beaconNotSynced";
+        } else {
+            long peerBlockNumber = result.blockNumber();
+            // Read block number + state root from one atomic snapshot — reading them via two
+            // separate getters can pair a block number with a state root from a different
+            // finalized payload if an update lands between the calls.
+            BeaconSyncState.FinalizedExecution fin = bss.getFinalizedExecution();
+            long finalizedBlock = fin.blockNumber();
+            byte[] beaconRoot = fin.stateRoot();
+
+            if (peerBlockNumber <= 0) {
+                v.failReason = "noPeerBlockNumber";
+            } else if (finalizedBlock <= 0 || beaconRoot == null) {
+                v.failReason = "beaconBlockUnavailable";
+            } else if (peerBlockNumber <= finalizedBlock) {
+                v.failReason = "peerBlockBehindFinalized";
+            } else if (peerBlockNumber - finalizedBlock > MAX_HEADER_CHAIN_GAP) {
+                v.failReason = "headerChainGapTooLarge";
+            } else {
+                // headerChain: fetch [finalized .. peerBlock] inclusive from a single peer and
+                // verify the chain end-to-end.
+                final long finalizedSlot = bss.getFinalizedSlot();
+                log.info("[verify] headerChain: peerBlock={}, finalizedBlock={}, gap={}",
+                        peerBlockNumber, finalizedBlock, peerBlockNumber - finalizedBlock);
+                return verifyHeaderChainBatched(
+                                connector, finalizedBlock, peerBlockNumber,
+                                beaconRoot, result.stateRoot().toArrayUnsafe())
+                        .handle((chainValid, ex) -> {
+                            if (ex != null) {
+                                log.info("[verify] headerChain error: {}", ex.getMessage());
+                                v.failReason = "headerChainError";
+                            } else if (Boolean.TRUE.equals(chainValid)) {
+                                v.beaconChainVerified = true;
+                                v.matchedSlot = finalizedSlot;
+                                v.blsVerified = true;
+                                v.verifyMethod = "headerChain";
+                                v.failReason = null;
+                            } else {
+                                v.failReason = "headerChainInvalid";
+                            }
+                            return finalizeResult(addr, foundFinal, result, peerProofValidFinal, verifiedAcctFinal, v);
+                        });
+            }
+        }
+
+        return CompletableFuture.completedFuture(
+                finalizeResult(addr, foundFinal, result, peerProofValidFinal, verifiedAcctFinal, v));
+    }
+
+    private static Result finalizeResult(String addr,
+                                         AccountRangeMessage.AccountData found,
+                                         AccountRangeMessage.DecodeResult result,
+                                         boolean peerProofValid,
+                                         MerklePatriciaVerifier.VerifiedAccount verified,
+                                         Verification v) {
+        long nonce = found != null ? found.nonce() : -1;
+        String balance = found != null ? found.balance().toString() : null;
+        // storageRoot/codeHash come from the proof-verified leaf when we have it, so they're
+        // cryptographically anchored rather than peer-claimed. Fall back to the slim body only
+        // when the proof didn't verify — in which case the result is already flagged
+        // beaconChainVerified=false.
+        String storageRootHex = verified != null
+                ? Bytes.wrap(verified.storageRoot()).toHexString()
+                : (found != null ? found.storageRoot().toHexString() : null);
+        String codeHashHex = verified != null
+                ? Bytes.wrap(verified.codeHash()).toHexString()
+                : (found != null ? found.codeHash().toHexString() : null);
+        return new Result(
+                addr,
+                found != null,
+                nonce,
+                balance,
+                storageRootHex,
+                codeHashHex,
+                result.blockNumber(),
+                result.stateRoot() != null ? result.stateRoot().toHexString() : null,
+                peerProofValid,
+                v.beaconChainVerified,
+                v.blsVerified,
+                v.matchedSlot,
+                v.verifyMethod,
+                v.failReason);
+    }
+
+    /**
+     * Fetch headers in a single batch and verify the chain end-to-end. Completes with
+     * {@code true} iff the first header's stateRoot equals the beacon-finalized root, the last
+     * header's stateRoot equals the peer's reported root, and every header's hash equals the
+     * next header's parentHash.
+     */
+    private static CompletableFuture<Boolean> verifyHeaderChainBatched(
+            RLPxConnector connector, long finalizedBlock, long peerBlock,
+            byte[] beaconStateRoot, byte[] peerStateRoot) {
+        long totalLong = peerBlock - finalizedBlock + 1;
+        if (totalLong < 2 || totalLong > MAX_HEADER_CHAIN_GAP) {
+            log.info("[verify] headerChain gap {} out of range [2, {}]", totalLong, MAX_HEADER_CHAIN_GAP);
+            return CompletableFuture.completedFuture(false);
+        }
+        int total = (int) totalLong;
+        log.info("[verify] Fetching {} headers from #{} to #{}", total, finalizedBlock, peerBlock);
+        return connector.requestBlockHeadersBatched(finalizedBlock, total)
+                .orTimeout(HEADER_CHAIN_TIMEOUT_SEC, TimeUnit.SECONDS)
+                .thenApply(headers -> {
+                    boolean valid = verifyHeaderChain(headers, beaconStateRoot, peerStateRoot);
+                    log.info("[verify] Full header chain ({} blocks) valid: {}", headers.size(), valid);
+                    return valid;
+                });
+    }
+
+    /** Pure verification of a contiguous header range. */
+    private static boolean verifyHeaderChain(List<BlockHeadersMessage.VerifiedHeader> headers,
+                                             byte[] expectedFirstStateRoot,
+                                             byte[] expectedLastStateRoot) {
+        if (headers.isEmpty()) return false;
+
+        byte[] firstStateRoot = headers.get(0).header().stateRoot.toArrayUnsafe();
+        if (!java.util.Arrays.equals(firstStateRoot, expectedFirstStateRoot)) return false;
+
+        byte[] lastStateRoot = headers.get(headers.size() - 1).header().stateRoot.toArrayUnsafe();
+        if (!java.util.Arrays.equals(lastStateRoot, expectedLastStateRoot)) return false;
+
+        for (int i = 0; i < headers.size() - 1; i++) {
+            Bytes32 currentHash = headers.get(i).hash();
+            Bytes32 nextParent = headers.get(i + 1).header().parentHash;
+            if (!currentHash.equals(nextParent)) {
+                log.info("[verify] hash chain break at index {}: block #{} hash={} != block #{} parentHash={}",
+                        i, headers.get(i).header().number, currentHash.toShortHexString(),
+                        headers.get(i + 1).header().number, nextParent.toShortHexString());
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeController.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeController.kt
@@ -23,8 +23,50 @@ interface NodeController {
     /** Live-update the snap-peer target on all running stacks. */
     fun setTargetSnapPeers(target: Int)
 
-    // Query + maintenance ops are added with their screens (Query/Logs/Settings).
+    /**
+     * Query an account on [network] and verify the returned proof against the beacon-attested
+     * state root (the shared `VerifiedAccountQuery` ladder). Suspends until verification
+     * completes. Throws on a bad address or a network that isn't running; verification
+     * *failures* surface as [AccountResult.failReason], not exceptions.
+     */
+    suspend fun requestAccount(network: String, address: String): AccountResult
+
+    /**
+     * Resolve an ENS name to an address on [network]. Beacon-verified when resolved against
+     * finalized state ([EnsResult.verified]). Throws if the network isn't running / has no ENS;
+     * resolution failures surface as [EnsResult.error].
+     */
+    suspend fun resolveEns(network: String, name: String): EnsResult
+
+    // Logs / Settings ops are added with their screens.
 }
+
+/** Verified account-query result. Mirrors `io.myotis.node.VerifiedAccountQuery.Result`. */
+data class AccountResult(
+    val address: String,
+    val exists: Boolean,
+    val nonce: Long,                 // -1 when !exists
+    val balanceWei: String?,         // decimal string or null
+    val storageRootHex: String?,
+    val codeHashHex: String?,
+    val blockNumber: Long,           // peer-reported block the proof anchors to
+    val peerStateRootHex: String?,
+    val peerProofValid: Boolean,     // proof verifies against peerStateRoot
+    val beaconChainVerified: Boolean,// peerStateRoot ties to a beacon-attested root
+    val blsVerified: Boolean,        // the beacon match was BLS-signed
+    val matchedBeaconSlot: Long,     // -1 when not matched
+    val verifyMethod: String?,       // "stateRootMatch" / "headerChain" / null
+    val failReason: String?,         // null when verified
+)
+
+/** ENS resolution result. Mirrors `io.myotis.rpc.EnsResolution`. */
+data class EnsResult(
+    val name: String,
+    val addressHex: String?,         // null when unresolved/errored
+    val blockNumber: Long,           // -1 when none
+    val verified: Boolean,           // true iff beacon-verified finalized state
+    val error: String?,              // null on success
+)
 
 /** Persisted per-network + shared settings, abstracted from Android SharedPreferences. */
 interface Settings {

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 
 /**
@@ -115,11 +116,13 @@ private fun StatusView(s: NodeSnapshot) {
 @Composable
 private fun QueryTab(controller: NodeController, network: String) {
     val scope = rememberCoroutineScope()
-    var input by remember { mutableStateOf("") }
-    var loading by remember { mutableStateOf(false) }
-    var account by remember { mutableStateOf<AccountResult?>(null) }
-    var ens by remember { mutableStateOf<EnsResult?>(null) }
-    var error by remember { mutableStateOf<String?>(null) }
+    // Key on `network`: when the active network changes, reset the query input + results so we
+    // never show one network's account/ENS result under another.
+    var input by remember(network) { mutableStateOf("") }
+    var loading by remember(network) { mutableStateOf(false) }
+    var account by remember(network) { mutableStateOf<AccountResult?>(null) }
+    var ens by remember(network) { mutableStateOf<EnsResult?>(null) }
+    var error by remember(network) { mutableStateOf<String?>(null) }
 
     fun submit() {
         val q = input.trim()
@@ -129,6 +132,8 @@ private fun QueryTab(controller: NodeController, network: String) {
             try {
                 if (q.contains('.')) ens = controller.resolveEns(network, q)
                 else account = controller.requestAccount(network, q)
+            } catch (c: CancellationException) {
+                throw c  // let structured cancellation propagate (e.g. composable disposed)
             } catch (t: Throwable) {
                 error = t.message ?: t.toString()
             } finally {

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
@@ -7,22 +7,32 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
 
 /**
- * The shared Myotis screen — identical on Android and Desktop. This Step-1 slice renders the
- * Status view for the primary network from [NodeController]'s snapshot flow; the Query
- * / Logs / Settings tabs are ported next (this composable becomes the tab host).
+ * The shared Myotis screen — identical on Android and Desktop. A tab host over the per-network
+ * [NodeController]/[Settings] seam. Status + Query are ported; Logs / Settings follow.
  */
 @Composable
 fun NodeScreen(controller: NodeController, settings: Settings) {
@@ -30,36 +40,52 @@ fun NodeScreen(controller: NodeController, settings: Settings) {
     // directly would re-subscribe on every recomposition. Retain it across recompositions.
     val snapshotsFlow = remember(controller) { controller.snapshots() }
     val snapshots by snapshotsFlow.collectAsState(initial = emptyMap())
+    val primary = settings.primaryNetwork()
+    var tab by remember { mutableStateOf(0) }
+
     MaterialTheme {
         Column(Modifier.fillMaxSize().padding(16.dp)) {
             Text("Myotis", style = MaterialTheme.typography.headlineSmall)
             Spacer(Modifier.height(12.dp))
 
-            val primary = settings.primaryNetwork()
-            val snap = snapshots[primary]
-            if (snap == null) {
-                Text("Node stopped — no data for $primary")
-            } else {
-                StatusView(snap)
+            TabRow(selectedTabIndex = tab) {
+                Tab(selected = tab == 0, onClick = { tab = 0 }, text = { Text("Status") })
+                Tab(selected = tab == 1, onClick = { tab = 1 }, text = { Text("Query") })
             }
-
             Spacer(Modifier.height(16.dp))
-            // A snapshot for `primary` exists only while its stack is registered (running or
-            // mid-boot), so drive button state off it: Start is disabled once the network is
-            // up, Stop only while it is. Stop the primary network specifically (not a global
-            // shutdown) so the pairing reads correctly once more networks are added.
-            val primaryActive = snap != null
-            Row {
-                Button(
-                    onClick = { controller.enableNetwork(primary) },
-                    enabled = !primaryActive,
-                ) { Text("Start $primary") }
-                Spacer(Modifier.width(8.dp))
-                OutlinedButton(
-                    onClick = { controller.disableNetwork(primary) },
-                    enabled = primaryActive,
-                ) { Text("Stop") }
+
+            when (tab) {
+                0 -> StatusTab(controller, snapshots[primary], primary)
+                1 -> QueryTab(controller, primary)
             }
+        }
+    }
+}
+
+@Composable
+private fun StatusTab(controller: NodeController, snap: NodeSnapshot?, primary: String) {
+    Column {
+        if (snap == null) {
+            Text("Node stopped — no data for $primary")
+        } else {
+            StatusView(snap)
+        }
+
+        Spacer(Modifier.height(16.dp))
+        // A snapshot for `primary` exists only while its stack is registered (running or
+        // mid-boot): Start disabled once up, Stop only while it is. Stop the primary network
+        // specifically so the pairing reads correctly once more networks are added.
+        val primaryActive = snap != null
+        Row {
+            Button(
+                onClick = { controller.enableNetwork(primary) },
+                enabled = !primaryActive,
+            ) { Text("Start $primary") }
+            Spacer(Modifier.width(8.dp))
+            OutlinedButton(
+                onClick = { controller.disableNetwork(primary) },
+                enabled = primaryActive,
+            ) { Text("Stop") }
         }
     }
 }
@@ -80,10 +106,119 @@ private fun StatusView(s: NodeSnapshot) {
     }
 }
 
+/**
+ * Verified account / ENS query over the shared seam. An input that contains a dot is treated
+ * as an ENS name (→ [NodeController.resolveEns]); otherwise a hex address (→
+ * [NodeController.requestAccount]). Verification status is surfaced prominently — the whole
+ * point is that the result is cryptographically anchored, not peer-claimed.
+ */
 @Composable
-private fun StatusRow(key: String, value: String) {
+private fun QueryTab(controller: NodeController, network: String) {
+    val scope = rememberCoroutineScope()
+    var input by remember { mutableStateOf("") }
+    var loading by remember { mutableStateOf(false) }
+    var account by remember { mutableStateOf<AccountResult?>(null) }
+    var ens by remember { mutableStateOf<EnsResult?>(null) }
+    var error by remember { mutableStateOf<String?>(null) }
+
+    fun submit() {
+        val q = input.trim()
+        if (q.isEmpty() || loading) return
+        loading = true; error = null; account = null; ens = null
+        scope.launch {
+            try {
+                if (q.contains('.')) ens = controller.resolveEns(network, q)
+                else account = controller.requestAccount(network, q)
+            } catch (t: Throwable) {
+                error = t.message ?: t.toString()
+            } finally {
+                loading = false
+            }
+        }
+    }
+
+    Column(Modifier.fillMaxWidth()) {
+        OutlinedTextField(
+            value = input,
+            onValueChange = { input = it },
+            label = { Text("Address (0x…) or ENS name") },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Spacer(Modifier.height(8.dp))
+        Button(onClick = { submit() }, enabled = !loading) { Text("Query on $network") }
+        Spacer(Modifier.height(16.dp))
+
+        when {
+            loading -> Row(verticalAlignment = Alignment.CenterVertically) {
+                CircularProgressIndicator(Modifier.size(18.dp), strokeWidth = 2.dp)
+                Spacer(Modifier.width(8.dp))
+                Text("Querying…")
+            }
+            error != null -> Text("Error: $error", color = MaterialTheme.colorScheme.error)
+            account != null -> AccountResultView(account!!)
+            ens != null -> EnsResultView(ens!!)
+        }
+    }
+}
+
+@Composable
+private fun AccountResultView(a: AccountResult) {
+    Column {
+        StatusRow("Address", a.address)
+        StatusRow("Exists", a.exists.toString())
+        if (a.exists) {
+            StatusRow("Balance (wei)", a.balanceWei ?: "—")
+            StatusRow("Nonce", a.nonce.toString())
+            StatusRow("Storage root", a.storageRootHex ?: "—")
+            StatusRow("Code hash", a.codeHashHex ?: "—")
+        }
+        StatusRow("Block", a.blockNumber.toString())
+        StatusRow("Proof valid", a.peerProofValid.toString())
+        val badge = if (a.beaconChainVerified) {
+            buildString {
+                append("✓ ")
+                append(a.verifyMethod ?: "verified")
+                if (a.blsVerified) append(" (BLS)")
+            }
+        } else {
+            "✗ ${a.failReason ?: "unverified"}"
+        }
+        StatusRow(
+            "Verification",
+            badge,
+            color = if (a.beaconChainVerified) MaterialTheme.colorScheme.primary
+            else MaterialTheme.colorScheme.error,
+        )
+    }
+}
+
+@Composable
+private fun EnsResultView(e: EnsResult) {
+    Column {
+        StatusRow("Name", e.name)
+        StatusRow("Address", e.addressHex ?: "—")
+        StatusRow("Block", if (e.blockNumber >= 0) e.blockNumber.toString() else "—")
+        StatusRow(
+            "Verified",
+            if (e.verified) "✓ finalized" else "unverified (peer head)",
+            color = if (e.verified) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface,
+        )
+        if (e.error != null) {
+            StatusRow("Error", e.error, color = MaterialTheme.colorScheme.error)
+        }
+    }
+}
+
+@Composable
+private fun StatusRow(key: String, value: String, color: androidx.compose.ui.graphics.Color? = null) {
     Row(Modifier.fillMaxWidth().padding(vertical = 2.dp)) {
         Text(key, Modifier.width(160.dp))
-        Text(value)
+        Text(
+            value,
+            color = color ?: androidx.compose.ui.graphics.Color.Unspecified,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+        )
     }
 }


### PR DESCRIPTION
## CMP increment 2: shared Query tab (verified account + ENS)

Second tab-by-tab CMP increment (after the Status baseline in #102). Adds the verified
account/ENS **Query** tab to the shared `:ui`, driven by the same Java backend on Android
and Desktop — **with no new duplication**.

### Backend — de-duplicate the verification ladder
The ~110-line account-verification ladder (proof check → beacon `stateRootMatch` fast-path →
`headerChain` fallback) was duplicated between Android `NodeService` and the daemon
`CommandHandler`, and wasn't callable from a Desktop host. Extracted **verbatim** into a
shared `io.myotis.node.VerifiedAccountQuery` (node-core), compiled against the same
`RLPxConnector`/`BeaconSyncState`/`MerklePatriciaVerifier` types (`LogBuffer` → slf4j).
`NodeService.requestAccount` now delegates to it; its inline ladder + now-unused
imports/constants are deleted.

> The JVM daemon's `CommandHandler` keeps its own copy for now (it emits JSON directly) —
> deduping it is a clearly-scoped follow-up; this PR removes the **Android↔Desktop**
> duplication, which is the CMP goal.

### Shared UI seam (`:ui` commonMain — backend-agnostic)
- `NodeController` gains `suspend requestAccount(network, addr): AccountResult` and
  `resolveEns(network, name): EnsResult`, plus Kotlin `AccountResult`/`EnsResult` models.
- `NodeScreen` becomes a **Status / Query tab host**. `QueryTab` treats a dotted input as an
  ENS name (→ `resolveEns`) and otherwise a hex address (→ verified account query), and
  surfaces verification status prominently (`✓ method (BLS)` / `✗ failReason`).

### Actuals
- **Desktop**: `DesktopNodeController` runs `VerifiedAccountQuery.query` + `rpcBackend().resolveEns`
  in-process (`CompletableFuture` → `suspend` via `kotlinx.coroutines.future.await`).
- **Android**: `AndroidNodeController` delegates to `NodeService` and maps to the shared models.

### Verification
- `./gradlew build -x test` green (daemon, Android APK, desktop image, KMP `:ui`).
- The extraction is a verbatim, type-checked copy of the existing Android path, so the
  stateRootMatch + headerChain ladder is unchanged. A **live** verified-query check is
  peer-gated (needs a synced beacon + snap peers); the daemon `get-account → verifyMethod:
  headerChain` integration test (CLAUDE.md) remains the runtime reference and is untouched.

### Follow-ups
- Dedup the daemon `CommandHandler.get-account` onto `VerifiedAccountQuery`.
- Port remaining tabs (Logs, Settings); final increment flips Android `MainActivity` to render the shared `NodeScreen`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
