### PR TITLE
cmp: shared Logs tab — LogSource seam + in-memory capture on both hosts

### DIFF
--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/cmp/AndroidLogSource.kt
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/cmp/AndroidLogSource.kt
@@ -1,0 +1,20 @@
+package com.jaeckel.ethp2p.android.cmp
+
+import com.jaeckel.ethp2p.android.log.LogBuffer
+import io.myotis.ui.LogLine
+import io.myotis.ui.LogSource
+
+/**
+ * Android actual of [LogSource]: wraps the existing [LogBuffer] (which the in-tree SLF4J
+ * provider tees consensus/networking/libp2p logs into, alongside the app's own LogBuffer
+ * calls), so the shared Logs tab renders the same lines the Android UI shows today.
+ */
+class AndroidLogSource : LogSource {
+    override fun version(): Long = LogBuffer.version()
+
+    override fun snapshot(): List<LogLine> = LogBuffer.snapshot().map { e ->
+        LogLine(e.sequence(), e.timestampMillis(), e.level(), e.tag(), e.message())
+    }
+
+    override fun clear() = LogBuffer.clear()
+}

--- a/app-desktop/build.gradle.kts
+++ b/app-desktop/build.gradle.kts
@@ -54,7 +54,9 @@ dependencies {
     implementation(compose.desktop.currentOs)
     implementation(libs.kotlinx.coroutines.core)
 
-    runtimeOnly(libs.logback.classic)
+    // implementation (not runtimeOnly): DesktopLogAppender compiles against logback's
+    // AppenderBase/ILoggingEvent to tee logs into the in-app Logs tab's in-memory ring.
+    implementation(libs.logback.classic)
 }
 
 // Headless check that the Desktop controller drives node-core (no display needed).

--- a/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopLog.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopLog.kt
@@ -1,0 +1,63 @@
+package io.myotis.desktop
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.classic.spi.ThrowableProxyUtil
+import ch.qos.logback.core.AppenderBase
+import io.myotis.ui.LogLine
+import io.myotis.ui.LogSource
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Desktop actual of [LogSource]: an in-memory ring fed by [DesktopLogAppender] (wired into
+ * logback-desktop.xml). A process-wide singleton because logback instantiates the appender
+ * itself, so the appender and the UI must meet on the same instance. Mirrors Android's
+ * `LogBuffer` (50k-line ring, monotonic version + sequence).
+ */
+object DesktopLogSource : LogSource {
+    private const val MAX_LINES = 50_000
+    private val lock = Any()
+    private val buffer = ArrayDeque<LogLine>()
+    private val version = AtomicLong()
+    private val seq = AtomicLong()
+
+    /** Append a captured line (called from [DesktopLogAppender]). */
+    fun append(timestampMillis: Long, level: Char, tag: String, message: String) {
+        synchronized(lock) {
+            buffer.addLast(LogLine(seq.incrementAndGet(), timestampMillis, level, tag, message))
+            while (buffer.size > MAX_LINES) buffer.removeFirst()
+        }
+        version.incrementAndGet()
+    }
+
+    override fun version(): Long = version.get()
+    override fun snapshot(): List<LogLine> = synchronized(lock) { buffer.toList() }
+    override fun clear() {
+        synchronized(lock) { buffer.clear() }
+        version.incrementAndGet()
+    }
+}
+
+/**
+ * Logback appender that tees every event into [DesktopLogSource] so the in-app Logs tab sees the
+ * same lines as the console/file (subject to the per-logger levels in logback-desktop.xml).
+ */
+class DesktopLogAppender : AppenderBase<ILoggingEvent>() {
+    override fun append(event: ILoggingEvent) {
+        val level = when (event.level.toInt()) {
+            Level.TRACE_INT -> 'V'
+            Level.DEBUG_INT -> 'D'
+            Level.INFO_INT -> 'I'
+            Level.WARN_INT -> 'W'
+            Level.ERROR_INT -> 'E'
+            else -> 'I'
+        }
+        val tp = event.throwableProxy
+        val message = if (tp != null) {
+            event.formattedMessage + "\n" + ThrowableProxyUtil.asString(tp)
+        } else {
+            event.formattedMessage
+        }
+        DesktopLogSource.append(event.timeStamp, level, event.loggerName, message)
+    }
+}

--- a/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopLog.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopLog.kt
@@ -53,11 +53,9 @@ class DesktopLogAppender : AppenderBase<ILoggingEvent>() {
             else -> 'I'
         }
         val tp = event.throwableProxy
-        val message = if (tp != null) {
-            event.formattedMessage + "\n" + ThrowableProxyUtil.asString(tp)
-        } else {
-            event.formattedMessage
-        }
+        // formattedMessage can be null in logback; coalesce to "" to keep append non-null.
+        val msg = event.formattedMessage ?: ""
+        val message = if (tp != null) msg + "\n" + ThrowableProxyUtil.asString(tp) else msg
         DesktopLogSource.append(event.timeStamp, level, event.loggerName, message)
     }
 }

--- a/app-desktop/src/main/kotlin/io/myotis/desktop/Main.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/Main.kt
@@ -23,7 +23,7 @@ fun main() {
             onCloseRequest = { controller.shutdown(); exitApplication() },
             title = "Myotis",
         ) {
-            NodeScreen(controller, settings)
+            NodeScreen(controller, settings, DesktopLogSource)
         }
     }
 }

--- a/app-desktop/src/main/resources/logback-desktop.xml
+++ b/app-desktop/src/main/resources/logback-desktop.xml
@@ -30,13 +30,19 @@
          render them. Subject to the same per-logger levels below as console/file. -->
     <appender name="MEMORY" class="io.myotis.desktop.DesktopLogAppender"/>
 
+    <!-- Disk-usage cap for on-disk logs, all tunable at launch (defaults in parens):
+           -Dmyotis.log.totalSizeCap   hard ceiling on ALL log files combined  (50MB)
+           -Dmyotis.log.maxFileSize    roll the active file at this size        (10MB)
+           -Dmyotis.log.maxHistory     max rolled (gzip) files to keep          (7)
+         Once totalSizeCap is reached the OLDEST rolled file is deleted, so the logs can never
+         exceed the cap. E.g. cap everything at 200 MB:  -Dmyotis.log.totalSizeCap=200MB -->
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${LOG_DIR}/myotis.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>${LOG_DIR}/myotis.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
-            <maxFileSize>10MB</maxFileSize>
-            <maxHistory>7</maxHistory>
-            <totalSizeCap>50MB</totalSizeCap>
+            <maxFileSize>${myotis.log.maxFileSize:-10MB}</maxFileSize>
+            <maxHistory>${myotis.log.maxHistory:-7}</maxHistory>
+            <totalSizeCap>${myotis.log.totalSizeCap:-50MB}</totalSizeCap>
         </rollingPolicy>
         <encoder><pattern>${PATTERN}</pattern></encoder>
     </appender>

--- a/app-desktop/src/main/resources/logback-desktop.xml
+++ b/app-desktop/src/main/resources/logback-desktop.xml
@@ -26,6 +26,10 @@
         <encoder><pattern>${PATTERN}</pattern></encoder>
     </appender>
 
+    <!-- Tees every event into DesktopLogSource (in-memory ring) so the in-app Logs tab can
+         render them. Subject to the same per-logger levels below as console/file. -->
+    <appender name="MEMORY" class="io.myotis.desktop.DesktopLogAppender"/>
+
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${LOG_DIR}/myotis.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
@@ -53,5 +57,6 @@
     <root level="INFO">
         <appender-ref ref="CONSOLE"/>
         <appender-ref ref="FILE"/>
+        <appender-ref ref="MEMORY"/>
     </root>
 </configuration>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,6 +35,7 @@ activity-compose = "1.9.3"
 ktor = "3.0.3"
 kotlinx-coroutines = "1.9.0"
 kotlinx-serialization = "1.7.3"
+kotlinx-datetime = "0.6.1"
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -97,3 +98,4 @@ ktor-client-core           = { module = "io.ktor:ktor-client-core",  version.ref
 ktor-client-cio            = { module = "io.ktor:ktor-client-cio",   version.ref = "ktor" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 kotlinx-coroutines-core    = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core",    version.ref = "kotlinx-coroutines" }
+kotlinx-datetime           = { module = "org.jetbrains.kotlinx:kotlinx-datetime",           version.ref = "kotlinx-datetime" }

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -24,6 +24,7 @@ kotlin {
                 implementation(compose.material3)
                 implementation(compose.ui)
                 implementation(libs.kotlinx.coroutines.core)
+                implementation(libs.kotlinx.datetime)  // local-time formatting in the Logs tab
             }
         }
     }

--- a/ui/src/commonMain/kotlin/io/myotis/ui/LogSource.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/LogSource.kt
@@ -1,0 +1,27 @@
+package io.myotis.ui
+
+/**
+ * A live in-memory log ring the Logs tab reads. Platform-specific capture feeds it: on Android
+ * the existing `LogBuffer` (which the in-tree SLF4J provider tees into); on Desktop a logback
+ * appender into an in-memory ring. The UI polls [version] (cheap) and only re-[snapshot]s when
+ * it changes — the same change-detection shape as [NodeController]'s snapshot flow.
+ */
+interface LogSource {
+    /** Monotonic counter; bumped on every append and on [clear]. Cheap to read for change-polling. */
+    fun version(): Long
+
+    /** Snapshot of the ring in chronological (oldest-first) order. */
+    fun snapshot(): List<LogLine>
+
+    /** Drop all buffered lines (bumps [version]). */
+    fun clear()
+}
+
+/** One captured log line. Mirrors the Android `LogBuffer.Entry` shape. */
+data class LogLine(
+    val sequence: Long,           // monotonic id, stable across ring rotation (used as list key)
+    val timestampMillis: Long,    // wall-clock millis at capture
+    val level: Char,              // 'V' / 'D' / 'I' / 'W' / 'E'
+    val tag: String,              // full logger name / source tag
+    val message: String,          // message (+ appended stacktrace, if any)
+)

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
@@ -40,8 +40,11 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
@@ -254,33 +257,44 @@ private fun StatusRow(key: String, value: String, color: Color? = null) {
 private fun LogsTab(logs: LogSource) {
     val scope = rememberCoroutineScope()
     val clipboard = LocalClipboardManager.current
+    val tz = remember { TimeZone.currentSystemDefault() }  // resolve once, not per row
     var lines by remember { mutableStateOf<List<LogLine>>(emptyList()) }
+    var shown by remember { mutableStateOf<List<LogLine>>(emptyList()) }
     var lastVersion by remember { mutableStateOf(-1L) }
     var filter by remember { mutableStateOf("") }
 
+    // Poll the cheap version counter; the O(n) snapshot of up to 50k lines runs off the main
+    // thread so it can't jank the UI.
     LaunchedEffect(logs) {
         while (true) {
             val v = logs.version()
             if (v != lastVersion) {
-                lines = logs.snapshot()
+                lines = withContext(Dispatchers.Default) { logs.snapshot() }
                 lastVersion = v
             }
             delay(250)
         }
     }
 
-    val shown = remember(lines, filter) {
+    // Filter off the main thread too, and cooperatively cancel superseded passes (rapid typing).
+    LaunchedEffect(lines, filter) {
         val f = filter.trim().lowercase()
-        if (f.isEmpty()) lines
-        else lines.filter { it.tag.lowercase().contains(f) || it.message.lowercase().contains(f) }
+        shown = if (f.isEmpty()) lines
+        else withContext(Dispatchers.Default) {
+            lines.filter {
+                ensureActive()  // withContext receiver is the CoroutineScope
+                it.tag.lowercase().contains(f) || it.message.lowercase().contains(f)
+            }
+        }
     }
 
     val listState = rememberLazyListState()
-    // Auto-follow: true while the last line is visible (i.e. the user hasn't scrolled up).
-    val atBottom by remember {
+    // Auto-follow: key on `shown` so the derived state re-reads the current list (not a stale
+    // capture); size-2 tolerates the one-frame lag before a freshly-appended item is laid out.
+    val atBottom by remember(shown) {
         derivedStateOf {
             val last = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
-            last >= shown.size - 1
+            last >= shown.size - 2
         }
     }
     LaunchedEffect(shown.size) {
@@ -297,14 +311,20 @@ private fun LogsTab(logs: LogSource) {
                 modifier = Modifier.weight(1f),
             )
             Spacer(Modifier.width(8.dp))
-            OutlinedButton(onClick = { clipboard.setText(AnnotatedString(formatLogs(shown))) }) { Text("Copy") }
+            OutlinedButton(onClick = {
+                scope.launch {
+                    // Formatting up to 50k lines also goes off the main thread.
+                    val text = withContext(Dispatchers.Default) { formatLogs(shown, tz) }
+                    clipboard.setText(AnnotatedString(text))
+                }
+            }) { Text("Copy") }
             Spacer(Modifier.width(4.dp))
             OutlinedButton(onClick = { logs.clear() }) { Text("Clear") }
         }
         Spacer(Modifier.height(8.dp))
         Box(Modifier.weight(1f).fillMaxWidth()) {
             LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
-                items(shown, key = { it.sequence }) { LogLineRow(it) }
+                items(shown, key = { it.sequence }) { LogLineRow(it, tz) }
             }
             if (!atBottom && shown.isNotEmpty()) {
                 Button(
@@ -318,7 +338,7 @@ private fun LogsTab(logs: LogSource) {
 }
 
 @Composable
-private fun LogLineRow(line: LogLine) {
+private fun LogLineRow(line: LogLine, tz: TimeZone) {
     val color = when (line.level) {
         'E' -> MaterialTheme.colorScheme.error
         'W' -> Color(0xFFB58900)            // dim amber
@@ -327,23 +347,23 @@ private fun LogLineRow(line: LogLine) {
     }
     val shortTag = line.tag.substringAfterLast('.')
     Text(
-        "${formatLogTime(line.timestampMillis)} ${line.level} $shortTag: ${line.message}",
+        "${formatLogTime(line.timestampMillis, tz)} ${line.level} $shortTag: ${line.message}",
         fontSize = 11.sp,
         fontFamily = FontFamily.Monospace,
         color = color,
     )
 }
 
-private fun formatLogs(lines: List<LogLine>): String = buildString {
+private fun formatLogs(lines: List<LogLine>, tz: TimeZone): String = buildString {
     for (l in lines) {
-        append(formatLogTime(l.timestampMillis)).append(' ').append(l.level)
+        append(formatLogTime(l.timestampMillis, tz)).append(' ').append(l.level)
         append(' ').append(l.tag).append(": ").append(l.message).append('\n')
     }
 }
 
-/** HH:mm:ss.SSS in the local time zone (matches the logback console/file pattern). */
-private fun formatLogTime(ms: Long): String {
-    val dt = Instant.fromEpochMilliseconds(ms).toLocalDateTime(TimeZone.currentSystemDefault())
+/** HH:mm:ss.SSS in [tz] (matches the logback console/file pattern). */
+private fun formatLogTime(ms: Long, tz: TimeZone): String {
+    val dt = Instant.fromEpochMilliseconds(ms).toLocalDateTime(tz)
     fun p2(n: Int) = n.toString().padStart(2, '0')
     fun p3(n: Int) = n.toString().padStart(3, '0')
     return "${p2(dt.hour)}:${p2(dt.minute)}:${p2(dt.second)}.${p3(dt.nanosecond / 1_000_000)}"

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
@@ -1,5 +1,6 @@
 package io.myotis.ui
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -9,6 +10,9 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
@@ -18,7 +22,9 @@ import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -26,17 +32,26 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
 
 /**
  * The shared Myotis screen — identical on Android and Desktop. A tab host over the per-network
- * [NodeController]/[Settings] seam. Status + Query are ported; Logs / Settings follow.
+ * [NodeController]/[Settings]/[LogSource] seam. Status + Query + Logs are ported; Settings follows.
  */
 @Composable
-fun NodeScreen(controller: NodeController, settings: Settings) {
+fun NodeScreen(controller: NodeController, settings: Settings, logs: LogSource) {
     // remember(controller): snapshots() returns a fresh Flow each call, so collecting it
     // directly would re-subscribe on every recomposition. Retain it across recompositions.
     val snapshotsFlow = remember(controller) { controller.snapshots() }
@@ -52,12 +67,14 @@ fun NodeScreen(controller: NodeController, settings: Settings) {
             TabRow(selectedTabIndex = tab) {
                 Tab(selected = tab == 0, onClick = { tab = 0 }, text = { Text("Status") })
                 Tab(selected = tab == 1, onClick = { tab = 1 }, text = { Text("Query") })
+                Tab(selected = tab == 2, onClick = { tab = 2 }, text = { Text("Logs") })
             }
             Spacer(Modifier.height(16.dp))
 
             when (tab) {
                 0 -> StatusTab(controller, snapshots[primary], primary)
                 1 -> QueryTab(controller, primary)
+                2 -> LogsTab(logs)
             }
         }
     }
@@ -216,14 +233,118 @@ private fun EnsResultView(e: EnsResult) {
 }
 
 @Composable
-private fun StatusRow(key: String, value: String, color: androidx.compose.ui.graphics.Color? = null) {
+private fun StatusRow(key: String, value: String, color: Color? = null) {
     Row(Modifier.fillMaxWidth().padding(vertical = 2.dp)) {
         Text(key, Modifier.width(160.dp))
         Text(
             value,
-            color = color ?: androidx.compose.ui.graphics.Color.Unspecified,
+            color = color ?: Color.Unspecified,
             maxLines = 2,
             overflow = TextOverflow.Ellipsis,
         )
     }
+}
+
+/**
+ * Live log viewer over [LogSource]: poll the cheap version counter and re-snapshot only on
+ * change; filter by substring on tag/message; auto-follow the tail unless the user scrolls up;
+ * copy the visible lines or clear the ring. Mirrors the Android Logs tab.
+ */
+@Composable
+private fun LogsTab(logs: LogSource) {
+    val scope = rememberCoroutineScope()
+    val clipboard = LocalClipboardManager.current
+    var lines by remember { mutableStateOf<List<LogLine>>(emptyList()) }
+    var lastVersion by remember { mutableStateOf(-1L) }
+    var filter by remember { mutableStateOf("") }
+
+    LaunchedEffect(logs) {
+        while (true) {
+            val v = logs.version()
+            if (v != lastVersion) {
+                lines = logs.snapshot()
+                lastVersion = v
+            }
+            delay(250)
+        }
+    }
+
+    val shown = remember(lines, filter) {
+        val f = filter.trim().lowercase()
+        if (f.isEmpty()) lines
+        else lines.filter { it.tag.lowercase().contains(f) || it.message.lowercase().contains(f) }
+    }
+
+    val listState = rememberLazyListState()
+    // Auto-follow: true while the last line is visible (i.e. the user hasn't scrolled up).
+    val atBottom by remember {
+        derivedStateOf {
+            val last = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+            last >= shown.size - 1
+        }
+    }
+    LaunchedEffect(shown.size) {
+        if (atBottom && shown.isNotEmpty()) listState.scrollToItem(shown.size - 1)
+    }
+
+    Column(Modifier.fillMaxSize()) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            OutlinedTextField(
+                value = filter,
+                onValueChange = { filter = it },
+                label = { Text("Filter — tag or message") },
+                singleLine = true,
+                modifier = Modifier.weight(1f),
+            )
+            Spacer(Modifier.width(8.dp))
+            OutlinedButton(onClick = { clipboard.setText(AnnotatedString(formatLogs(shown))) }) { Text("Copy") }
+            Spacer(Modifier.width(4.dp))
+            OutlinedButton(onClick = { logs.clear() }) { Text("Clear") }
+        }
+        Spacer(Modifier.height(8.dp))
+        Box(Modifier.weight(1f).fillMaxWidth()) {
+            LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
+                items(shown, key = { it.sequence }) { LogLineRow(it) }
+            }
+            if (!atBottom && shown.isNotEmpty()) {
+                Button(
+                    onClick = { scope.launch { listState.scrollToItem(shown.size - 1) } },
+                    modifier = Modifier.align(Alignment.BottomEnd).padding(8.dp),
+                ) { Text("↓ Latest") }
+            }
+        }
+        Text("${shown.size} / ${lines.size} lines", style = MaterialTheme.typography.labelSmall)
+    }
+}
+
+@Composable
+private fun LogLineRow(line: LogLine) {
+    val color = when (line.level) {
+        'E' -> MaterialTheme.colorScheme.error
+        'W' -> Color(0xFFB58900)            // dim amber
+        'D', 'V' -> MaterialTheme.colorScheme.onSurfaceVariant
+        else -> MaterialTheme.colorScheme.onSurface
+    }
+    val shortTag = line.tag.substringAfterLast('.')
+    Text(
+        "${formatLogTime(line.timestampMillis)} ${line.level} $shortTag: ${line.message}",
+        fontSize = 11.sp,
+        fontFamily = FontFamily.Monospace,
+        color = color,
+    )
+}
+
+private fun formatLogs(lines: List<LogLine>): String = buildString {
+    for (l in lines) {
+        append(formatLogTime(l.timestampMillis)).append(' ').append(l.level)
+        append(' ').append(l.tag).append(": ").append(l.message).append('\n')
+    }
+}
+
+/** HH:mm:ss.SSS in the local time zone (matches the logback console/file pattern). */
+private fun formatLogTime(ms: Long): String {
+    val dt = Instant.fromEpochMilliseconds(ms).toLocalDateTime(TimeZone.currentSystemDefault())
+    fun p2(n: Int) = n.toString().padStart(2, '0')
+    fun p3(n: Int) = n.toString().padStart(3, '0')
+    return "${p2(dt.hour)}:${p2(dt.minute)}:${p2(dt.second)}.${p3(dt.nanosecond / 1_000_000)}"
 }

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
@@ -278,12 +278,14 @@ private fun LogsTab(logs: LogSource) {
 
     // Filter off the main thread too, and cooperatively cancel superseded passes (rapid typing).
     LaunchedEffect(lines, filter) {
-        val f = filter.trim().lowercase()
+        val f = filter.trim()
         shown = if (f.isEmpty()) lines
         else withContext(Dispatchers.Default) {
             lines.filter {
                 ensureActive()  // withContext receiver is the CoroutineScope
-                it.tag.lowercase().contains(f) || it.message.lowercase().contains(f)
+                // contains(ignoreCase = true) avoids allocating a lowercased copy of every
+                // tag/message per keystroke (up to 50k lines).
+                it.tag.contains(f, ignoreCase = true) || it.message.contains(f, ignoreCase = true)
             }
         }
     }


### PR DESCRIPTION
## CMP increment 3: shared Logs tab

Third tab-by-tab CMP increment (after Status #102 and Query #103). Adds a live **Logs** tab
to the shared `:ui`, fed by a platform-specific in-memory ring on each host — the viewer
lives once.

### Seam (`:ui` commonMain)
- `LogSource` (`version()` / `snapshot()` / `clear()`) + `LogLine(sequence, timestampMillis,
  level, tag, message)` — same cheap change-poll shape as the snapshots flow.
- `LogsTab` composable: polls the version counter and re-snapshots only on change; substring
  filter on tag/message; monospace, level-coloured rows; **auto-follow** the tail unless you
  scroll up (with a "↓ Latest" jump button); **Copy** (`LocalClipboardManager`) and **Clear**.
  `NodeScreen` gains a Logs tab + a `logs: LogSource` parameter.
- `kotlinx-datetime` added for local-time `HH:mm:ss.SSS` (commonMain can't use `java.text`).

### Actuals
- **Desktop**: `DesktopLogSource` (50k-line in-memory ring singleton) + `DesktopLogAppender`
  (a logback `AppenderBase` wired into `logback-desktop.xml`'s root) tee every event into the
  ring, so the Logs tab shows the same lines as console/file (subject to the same per-logger
  levels). `logback` moves `runtimeOnly` → `implementation` so the appender compiles.
- **Android**: `AndroidLogSource` wraps the existing `LogBuffer` (already fed by the in-tree
  SLF4J provider), mapping `Entry` → `LogLine`.

### Verification
- `./gradlew build -x test` green (daemon, Android APK, desktop image, KMP `:ui`).
- The packaged app-image runs under `xvfb` with the `MEMORY` appender loading cleanly (no
  logback errors) and ~170 boot lines flowing through it into the ring.

### Next
- Settings tab (the last one), then flip Android `MainActivity` to render the shared `NodeScreen`.
- Still tracked: dedup the daemon `get-account` onto `VerifiedAccountQuery`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
