### PR TITLE
cmp: shared Settings tab — network toggles + node tuning over the seam

### DIFF
--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/cmp/AndroidNodeBridge.kt
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/cmp/AndroidNodeBridge.kt
@@ -36,6 +36,8 @@ class AndroidNodeController(private val service: NodeService) : NodeController {
     override fun rebootNetwork(name: String) { service.rebootNetwork(name) }
     override fun shutdown() { service.shutdown() }
     override fun setTargetSnapPeers(target: Int) { service.setTargetSnapPeers(target) }
+    // NodeService is a Context, so it doubles as the arg to the SharedPreferences-backed static.
+    override fun applyBlsBackend() { NodeService.applyBlsBackend(service) }
 
     override suspend fun requestAccount(network: String, address: String): AccountResult =
         service.requestAccount(network, address).await().let { r ->
@@ -81,4 +83,14 @@ class AndroidSettings(private val ctx: Context) : Settings {
     override fun setRpcPort(network: String, port: Int) = NodeService.setRpcPort(ctx, network, port)
     override fun snapTarget(): Int = NodeService.snapTarget(ctx)
     override fun setSnapTarget(v: Int) = NodeService.setSnapTargetPref(ctx, v)
+
+    override fun displayName(network: String): String = NetworkConfig.byName(network).displayName()
+    override fun defaultRpcPort(network: String): Int = NetworkConfig.byName(network).defaultRpcPort()
+
+    override fun deepPoolThreshold(): Int = NodeService.deepPoolThreshold(ctx)
+    override fun setDeepPool(v: Int) = NodeService.setDeepPoolThreshold(ctx, v)
+    override fun strictStateFreshness(): Boolean = NodeService.strictStateFreshness(ctx)
+    override fun setStrictStateFreshness(v: Boolean) = NodeService.setStrictStateFreshness(ctx, v)
+    override fun nativeBlsEnabled(): Boolean = NodeService.nativeBlsEnabled(ctx)
+    override fun setNativeBlsEnabled(v: Boolean) = NodeService.setNativeBlsEnabled(ctx, v)
 }

--- a/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
@@ -119,6 +119,13 @@ class DesktopNodeController(private val dataDir: Path) : NodeController {
         registry.all().forEach { it.setTargetSnapPeers(target) }
     }
 
+    override fun applyBlsBackend() {
+        // No-op on desktop: there's no bundled native blst library yet (the macOS dylib is a
+        // follow-up — see the CMP plan), so desktop always runs the pure-Java Milagro backend and
+        // the Settings toggle has nothing to swap. Wire this to BlsBackends.set(...) once the
+        // native library ships for desktop.
+    }
+
     override suspend fun requestAccount(network: String, address: String): AccountResult {
         // VerifiedAccountQuery handles a null/!running stack itself (failed future → throws).
         val stack = registry.get(NetworkConfig.byName(network).name())
@@ -190,6 +197,11 @@ class DesktopSettings : Settings {
     private val enabled = linkedSetOf("mainnet")
     private val ports = HashMap<String, Int>()
     private var snap = 32
+    private var deep = 16
+    private var strict = true
+    // Desktop has no bundled native blst yet (Milagro-only), so the honest default is off; the
+    // toggle persists but DesktopNodeController.applyBlsBackend() is a no-op until the dylib ships.
+    private var nativeBls = false
 
     override fun enabledNetworks(): List<String> = synchronized(this) { enabled.toList() }
     override fun primaryNetwork(): String = synchronized(this) { enabled.firstOrNull() ?: "mainnet" }
@@ -208,6 +220,16 @@ class DesktopSettings : Settings {
     }
     override fun snapTarget(): Int = synchronized(this) { snap }
     override fun setSnapTarget(v: Int) = synchronized(this) { snap = v }
+
+    override fun displayName(network: String): String = NetworkConfig.byName(network).displayName()
+    override fun defaultRpcPort(network: String): Int = NetworkConfig.byName(network).defaultRpcPort()
+
+    override fun deepPoolThreshold(): Int = synchronized(this) { deep }
+    override fun setDeepPool(v: Int) = synchronized(this) { deep = v }
+    override fun strictStateFreshness(): Boolean = synchronized(this) { strict }
+    override fun setStrictStateFreshness(v: Boolean) = synchronized(this) { strict = v }
+    override fun nativeBlsEnabled(): Boolean = synchronized(this) { nativeBls }
+    override fun setNativeBlsEnabled(v: Boolean) = synchronized(this) { nativeBls = v }
 }
 
 /** Desktop is treated as always-online (no Android ConnectivityManager). */

--- a/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
@@ -32,7 +32,7 @@ import kotlin.io.path.createDirectories
  * `ChainStack`/`NodeRegistry`) the daemon and Android use, in-process — no Android Service,
  * no IPC. Reuses the daemon's file-backed caches + CCIP gateway from `:app`.
  */
-class DesktopNodeController(private val dataDir: Path) : NodeController {
+class DesktopNodeController(private val dataDir: Path, private val settings: Settings) : NodeController {
 
     private val registry = NodeRegistry()
     // nanoTime, not currentTimeMillis: wall-clock / NTP steps must not skew uptime.
@@ -68,7 +68,10 @@ class DesktopNodeController(private val dataDir: Path) : NodeController {
         Thread({
             synchronized(bootLock(canonical)) {
                 if (registry.get(canonical) != null) return@synchronized
-                val ports = ChainPorts.defaultsFor(network)
+                // Honor the configured JSON-RPC port from Settings (the Settings tab's port field),
+                // falling back to the network default — otherwise editing the port on desktop would
+                // be inert. A reboot (disable+enable) after a port change re-reads this.
+                val ports = ChainPorts.defaultsFor(network).withRpcPort(settings.rpcPortFor(canonical))
                 val keyFile = if (canonical == "mainnet") "nodekey.hex" else "nodekey-$canonical.hex"
                 val nodeKey = NodeKey.loadOrGenerate(dataDir.resolve(keyFile))
                 val suffix = if (canonical == "mainnet") "" else "-$canonical"
@@ -81,7 +84,8 @@ class DesktopNodeController(private val dataDir: Path) : NodeController {
                     dataDir.resolve("sync-state$suffix.snapshot"),
                     false,
                 )
-                stack.configureSnapMaintainer(32, null)  // desktop has system DNS → null provider
+                // Configured snap-peer target (Settings tab), not a hardcoded 32. system DNS → null.
+                stack.configureSnapMaintainer(settings.snapTarget(), null)
                 registry.add(stack)
                 // ChainStack.start() is fault-isolated: it returns false (and closes its own
                 // resources) on failure rather than throwing. Either way — false return or a
@@ -215,7 +219,9 @@ class DesktopSettings : Settings {
         ports[network] ?: NetworkConfig.byName(network).defaultRpcPort()
     }
     override fun setRpcPort(network: String, port: Int) = synchronized(this) {
-        ports[network] = port
+        // Clamp to the valid TCP range, falling back to the network default on out-of-range input
+        // (parity with Android's NodeService.setRpcPort) so we never try to bind an unusable port.
+        ports[network] = if (port in 1024..65535) port else NetworkConfig.byName(network).defaultRpcPort()
         Unit
     }
     override fun snapTarget(): Int = synchronized(this) { snap }

--- a/app-desktop/src/main/kotlin/io/myotis/desktop/Main.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/Main.kt
@@ -12,8 +12,9 @@ import java.nio.file.Path
  */
 fun main() {
     val dataDir = Path.of(System.getProperty("user.home"), ".myotis")
-    val controller = DesktopNodeController(dataDir)
+    // settings first: the controller reads it at boot (configured RPC port + snap target).
     val settings = DesktopSettings()
+    val controller = DesktopNodeController(dataDir, settings)
     controller.enableNetwork(settings.primaryNetwork())
 
     application {

--- a/app-desktop/src/main/kotlin/io/myotis/desktop/SyncSmoke.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/SyncSmoke.kt
@@ -12,8 +12,8 @@ import kotlin.system.exitProcess
  */
 fun main() = runBlocking {
     val dataDir = Files.createTempDirectory("myotis-smoke")
-    val controller = DesktopNodeController(dataDir)
     val settings = DesktopSettings()
+    val controller = DesktopNodeController(dataDir, settings)
     val net = settings.primaryNetwork()
     println("[smoke] enabling $net (dataDir=$dataDir)")
     controller.enableNetwork(net)

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeController.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeController.kt
@@ -24,6 +24,14 @@ interface NodeController {
     fun setTargetSnapPeers(target: Int)
 
     /**
+     * Re-apply the BLS backend to the process-global selector after [Settings.setNativeBlsEnabled]
+     * flips the preference (Android: native blst ⇄ pure-Java Milagro). Takes effect immediately —
+     * the decompressed-pubkey cache is process-global so the swap is cheap. Desktop currently has
+     * no bundled native library, so its actual is a no-op until the macOS blst dylib ships.
+     */
+    fun applyBlsBackend()
+
+    /**
      * Query an account on [network] and verify the returned proof against the beacon-attested
      * state root (the shared `VerifiedAccountQuery` ladder). Suspends until verification
      * completes. Throws on a bad address or a network that isn't running; verification
@@ -79,6 +87,22 @@ interface Settings {
     fun setRpcPort(network: String, port: Int)
     fun snapTarget(): Int
     fun setSnapTarget(v: Int)
+
+    // --- network metadata (so commonMain need not reference the Java NetworkConfig) ---
+    /** Human-facing name for the Settings row, e.g. "Gnosis Chain". */
+    fun displayName(network: String): String
+    /** The network's built-in default JSON-RPC port, shown as the field hint. */
+    fun defaultRpcPort(network: String): Int
+
+    // --- shared node-tuning knobs ---
+    fun deepPoolThreshold(): Int
+    fun setDeepPool(v: Int)
+    /** true = strict 2-minute state freshness (default); false = relaxed/experimental. */
+    fun strictStateFreshness(): Boolean
+    fun setStrictStateFreshness(v: Boolean)
+    /** true = use bundled native blst (default on Android); false = pure-Java Milagro. */
+    fun nativeBlsEnabled(): Boolean
+    fun setNativeBlsEnabled(v: Boolean)
 }
 
 /** Whether the device currently has network connectivity (Android: ConnectivityManager). */

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
@@ -1,5 +1,6 @@
 package io.myotis.ui
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -13,11 +14,16 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
@@ -26,6 +32,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -36,6 +43,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -71,6 +79,7 @@ fun NodeScreen(controller: NodeController, settings: Settings, logs: LogSource) 
                 Tab(selected = tab == 0, onClick = { tab = 0 }, text = { Text("Status") })
                 Tab(selected = tab == 1, onClick = { tab = 1 }, text = { Text("Query") })
                 Tab(selected = tab == 2, onClick = { tab = 2 }, text = { Text("Logs") })
+                Tab(selected = tab == 3, onClick = { tab = 3 }, text = { Text("Settings") })
             }
             Spacer(Modifier.height(16.dp))
 
@@ -78,8 +87,168 @@ fun NodeScreen(controller: NodeController, settings: Settings, logs: LogSource) 
                 0 -> StatusTab(controller, snapshots[primary], primary)
                 1 -> QueryTab(controller, primary)
                 2 -> LogsTab(logs)
+                3 -> SettingsTab(controller, settings, snapshots)
             }
         }
+    }
+}
+
+/**
+ * Settings: enable/disable each network (each runs concurrently as its own node with its own
+ * JSON-RPC port) and tune the shared snap/readiness/BLS/freshness knobs. Toggles that affect
+ * a running stack apply live; RPC-port edits are deferred to Save and reboot only the changed
+ * chain. Mirrors the Android SettingsScreen over the [Settings]/[NodeController] seam.
+ */
+@Composable
+private fun SettingsTab(
+    controller: NodeController,
+    settings: Settings,
+    snapshots: Map<String, NodeSnapshot>,
+) {
+    val networks = remember { settings.allNetworks() }
+    // Per-network enabled toggle + RPC-port text, seeded from persisted settings. Toggling a
+    // switch acts immediately (persists + boots/stops that chain); the RPC port is deferred to Save.
+    val enabled = remember {
+        mutableStateMapOf<String, Boolean>().apply {
+            networks.forEach { put(it, settings.isNetworkEnabled(it)) }
+        }
+    }
+    val rpcPorts = remember {
+        mutableStateMapOf<String, String>().apply {
+            networks.forEach { put(it, settings.rpcPortFor(it).toString()) }
+        }
+    }
+    var snapTarget by remember { mutableStateOf(settings.snapTarget().toString()) }
+    var deepPool by remember { mutableStateOf(settings.deepPoolThreshold().toString()) }
+    var strictFreshness by remember { mutableStateOf(settings.strictStateFreshness()) }
+    var nativeBls by remember { mutableStateOf(settings.nativeBlsEnabled()) }
+
+    Column(
+        Modifier.fillMaxSize().verticalScroll(rememberScrollState()),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Text("Networks", style = MaterialTheme.typography.titleMedium)
+        Text(
+            "Toggle a chain to run it. Each enabled chain runs concurrently as its own node " +
+                "with its own JSON-RPC port — add each port to MetaMask as a separate RPC URL.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        networks.forEach { id ->
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Row(
+                    Modifier.fillMaxWidth().padding(top = 4.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(settings.displayName(id))
+                    Switch(
+                        checked = enabled[id] == true,
+                        onCheckedChange = { on ->
+                            enabled[id] = on
+                            settings.setNetworkEnabled(id, on)
+                            if (on) controller.enableNetwork(id) else controller.disableNetwork(id)
+                        },
+                    )
+                }
+                OutlinedTextField(
+                    value = rpcPorts[id] ?: "",
+                    onValueChange = { rpcPorts[id] = it.filter(Char::isDigit).take(5) },
+                    label = { Text("JSON-RPC port (default ${settings.defaultRpcPort(id)})") },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        }
+
+        HorizontalDivider()
+
+        Text("Node tuning", style = MaterialTheme.typography.titleMedium)
+        OutlinedTextField(
+            value = snapTarget,
+            onValueChange = { snapTarget = it.filter(Char::isDigit).take(3) },
+            label = { Text("Snap-peer target (default 32)") },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+            modifier = Modifier.fillMaxWidth(),
+        )
+        OutlinedTextField(
+            value = deepPool,
+            onValueChange = { deepPool = it.filter(Char::isDigit).take(3) },
+            label = { Text("Readiness \"deep pool\" threshold (default 16)") },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+            modifier = Modifier.fillMaxWidth(),
+        )
+
+        // Strict freshness is the default; the switch exposes the RELAXED (opt-in) state, so the
+        // checked value is the negation. Persisted immediately; applies on the next node restart.
+        SwitchRow(
+            label = "Relaxed state freshness",
+            checked = !strictFreshness,
+            onChange = { relaxed -> strictFreshness = !relaxed; settings.setStrictStateFreshness(!relaxed) },
+        )
+        Text(
+            "Off (default, recommended): strict 2-minute freshness — fee calc / eth_call " +
+                "fast-fail when no fresh servable root exists, and the wallet retries. " +
+                "On (opt-in, experimental): serve a slightly older verified root — but if " +
+                "it isn't fully servable this can HANG the confirm screen for up to 2 min " +
+                "instead of failing fast. Applies on the next node (re)start.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        // Native BLS applies immediately — flips the process-global backend live.
+        SwitchRow(
+            label = "Native BLS acceleration",
+            checked = nativeBls,
+            onChange = { on -> nativeBls = on; settings.setNativeBlsEnabled(on); controller.applyBlsBackend() },
+        )
+        Text(
+            "On (default): use the bundled native blst library for sync-committee BLS " +
+                "verification (much faster than pure-Java). Off: force the pure-Java Milagro path — " +
+                "slower, but useful if the native library fails to load. Applies immediately.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            "An RPC-port change reboots that chain; snap-peer target applies live to every " +
+                "running chain, and the readiness threshold persists for the next check.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Button(
+            onClick = {
+                val snap = snapTarget.toIntOrNull() ?: 32
+                val deep = deepPool.toIntOrNull() ?: 16
+                settings.setSnapTarget(snap)          // persist
+                settings.setDeepPool(deep)            // persist (read at readiness-check time)
+                controller.setTargetSnapPeers(snap)   // live-apply to running stacks
+                networks.forEach { id ->
+                    val port = rpcPorts[id]?.toIntOrNull() ?: settings.defaultRpcPort(id)
+                    val changed = port != settings.rpcPortFor(id)
+                    settings.setRpcPort(id, port)
+                    // Reboot only a RUNNING chain whose port actually changed — rebind that one
+                    // RPC server without disturbing the others or reviving a stopped chain.
+                    if (changed && snapshots[id] != null) controller.rebootNetwork(id)
+                }
+            },
+            modifier = Modifier.fillMaxWidth(),
+        ) { Text("Save") }
+    }
+}
+
+/** A label + right-aligned [Switch] row — the repeated toggle layout in [SettingsTab]. */
+@Composable
+private fun SwitchRow(label: String, checked: Boolean, onChange: (Boolean) -> Unit) {
+    Row(
+        Modifier.fillMaxWidth().padding(top = 4.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(label)
+        Switch(checked = checked, onCheckedChange = onChange)
     }
 }
 

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
@@ -226,12 +226,16 @@ private fun SettingsTab(
                 settings.setDeepPool(deep)            // persist (read at readiness-check time)
                 controller.setTargetSnapPeers(snap)   // live-apply to running stacks
                 networks.forEach { id ->
-                    val port = rpcPorts[id]?.toIntOrNull() ?: settings.defaultRpcPort(id)
-                    val changed = port != settings.rpcPortFor(id)
-                    settings.setRpcPort(id, port)
+                    // Compare the EFFECTIVE (post-clamp) persisted port before vs after, not the
+                    // raw typed value: setRpcPort clamps out-of-range input to the network default,
+                    // so an invalid entry on an already-default chain must NOT count as "changed"
+                    // and needlessly reboot a live RPC server. Mirrors the original applyTunables,
+                    // which compared rpcPortFor() before/after the set.
+                    val oldPort = settings.rpcPortFor(id)
+                    settings.setRpcPort(id, rpcPorts[id]?.toIntOrNull() ?: settings.defaultRpcPort(id))
                     // Reboot only a RUNNING chain whose port actually changed — rebind that one
                     // RPC server without disturbing the others or reviving a stopped chain.
-                    if (changed && snapshots[id] != null) controller.rebootNetwork(id)
+                    if (settings.rpcPortFor(id) != oldPort && snapshots[id] != null) controller.rebootNetwork(id)
                 }
             },
             modifier = Modifier.fillMaxWidth(),


### PR DESCRIPTION
Ports the Android `SettingsScreen` into `:ui` as a 4th **Settings** tab, so the same Compose screen renders on Android and Desktop through the `NodeController`/`Settings` seam only. This is the last remaining CMP tab (Status #102, Query #103, Logs #104 already merged).

## Seam (`ui/.../NodeController.kt`)
- `Settings` gains network metadata (`displayName`, `defaultRpcPort`) so commonMain needn't reference the Java `NetworkConfig`, plus shared tuning knobs `deepPoolThreshold` / `strictStateFreshness` / `nativeBlsEnabled` (+ setters).
- `NodeController` gains `applyBlsBackend()` — re-applies the process-global BLS backend live after the native-BLS pref flips.

## UI (`ui/.../NodeScreen.kt`)
`SettingsTab`: per-network enable toggle + JSON-RPC port field, snap-peer target, readiness deep-pool threshold, relaxed-freshness and native-BLS switches, and a **Save** that persists ports/knobs and reboots only a *running* chain whose port actually changed. Network toggles and native-BLS apply live; freshness applies on next restart; RPC ports defer to Save.

## Actuals
- **Android** (`AndroidNodeBridge.kt`): delegate to the existing `NodeService` SharedPreferences statics + `applyBlsBackend` (`NodeService` is a `Context`).
- **Desktop** (`DesktopNode.kt`): extend in-memory `DesktopSettings`; `applyBlsBackend()` is a documented no-op — desktop has no bundled native blst yet (Milagro only; the macOS dylib is a follow-up).

## Verification
- `./gradlew :app-desktop:compileKotlin` → BUILD SUCCESSFUL
- `./gradlew :android-app:assembleDebug` → BUILD SUCCESSFUL

Android still renders its own `MainActivity` `NodeScreen` for now; the shared `SettingsTab` is Desktop-consumed here. The Android switchover (delete MainActivity's screens, point `setContent` at the shared `NodeScreen`) is the follow-up once all tabs are ported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)