### PR TITLE
ci(dmg): cross-build the Intel (x64) dmg on Apple Silicon via Rosetta

### DIFF
--- a/.github/workflows/desktop-dmg.yml
+++ b/.github/workflows/desktop-dmg.yml
@@ -7,23 +7,27 @@ on:
 jobs:
   build:
     name: Build macOS .dmg (${{ matrix.arch }})
-    # jpackage bundles a single-architecture JRE and can't emit a universal binary, so we
-    # build one .dmg per arch on its native runner:
-    #   macos-14 = Apple Silicon → arm64  (runs on M-series Macs)
-    #   macos-13 = Intel         → x64    (runs on Intel Macs, macOS Ventura and back to
-    #                                       Big Sur — JDK 21's floor)
-    # An arm64 .dmg will NOT launch on an Intel Mac (Rosetta only translates x86→arm), which
-    # is why the single arm64 build didn't run on Intel/Ventura. Download the one matching
-    # your Mac. jpackage only builds installers for the host OS, so both must run on macOS.
+    # jpackage bundles a single-architecture JRE and can't emit a universal binary, so we build
+    # one .dmg per arch. jpackage stamps the .app with the architecture of the JDK it runs under,
+    # NOT the host — so we can cross-build the Intel dmg on Apple Silicon by running an x86_64 JDK
+    # under Rosetta 2. BOTH jobs therefore run on macos-14 (Apple Silicon):
+    #   arm64 → native aarch64 JDK           (dmg runs on M-series Macs)
+    #   x64   → x86_64 JDK under Rosetta 2    (dmg runs on Intel Macs, macOS Ventura and back to
+    #                                          Big Sur — JDK 21's floor)
+    # We do NOT use the macos-13 Intel runner: GitHub is winding down Intel macOS capacity, so
+    # those jobs queue until the 24h cap and get cancelled (never produced an Intel dmg). Rosetta
+    # cross-build on the always-available arm64 runner removes that dependency.
+    # An arm64 .dmg will NOT launch on an Intel Mac (Rosetta only translates x86→arm), so download
+    # the one matching your Mac.
     strategy:
       fail-fast: false
       matrix:
         include:
-          - runner: macos-14
-            arch: arm64
-          - runner: macos-13
-            arch: x64
-    runs-on: ${{ matrix.runner }}
+          - arch: arm64
+            java-arch: aarch64
+          - arch: x64
+            java-arch: x64
+    runs-on: macos-14
     permissions:
       contents: read
 
@@ -33,11 +37,21 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Set up JDK 21
+      # Rosetta 2 lets the x86_64 JDK (and the jlink/jpackage it drives) execute on the arm64
+      # runner. Idempotent — a no-op if already present; `|| true` so an "already installed"
+      # non-zero exit doesn't fail the job. Only needed for the cross-built x64 job.
+      - name: Install Rosetta 2 (x64 cross-build)
+        if: matrix.arch == 'x64'
+        run: softwareupdate --install-rosetta --agree-to-license || true
+
+      # Installs a JDK 21 of the requested architecture and points JAVA_HOME at it. For x64 this
+      # is the x86_64 Temurin build (run via Rosetta); for arm64 the native aarch64 build.
+      - name: Set up JDK 21 (${{ matrix.java-arch }})
         uses: actions/setup-java@v4
         with:
           java-version: '21'
           distribution: 'temurin'
+          architecture: ${{ matrix.java-arch }}
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
@@ -45,16 +59,22 @@ jobs:
       - name: Make gradlew executable
         run: chmod +x gradlew
 
-      # Compose Desktop's packageDmg wraps jpackage (bundles a jlink'd JRE + the app) for the
-      # HOST architecture — so the arm64 runner emits an arm64 .dmg and the Intel runner an
-      # x64 one. NON-minified (main, not main-release): the Java backend (Netty / Besu /
-      # BouncyCastle / libp2p) is reflection-heavy and proguard would break it. Unsigned —
-      # Gatekeeper will need a right-click → Open the first time; notarization (Apple
-      # Developer ID) is a follow-up. Retry to ride out transient repo-resolution blips.
+      # Compose Desktop's packageDmg wraps jpackage (bundles a jlink'd JRE + the app). We pin the
+      # Gradle toolchain to EXACTLY the JDK setup-java just installed
+      # (auto-detect=false + installations.paths=$JAVA_HOME): the build's `javaHome =
+      # launcherFor(21)` then resolves to that arch's JDK, so jpackage emits a matching-arch dmg
+      # instead of possibly picking a stray pre-installed aarch64 JDK. The Gradle daemon itself
+      # also runs under JAVA_HOME (x86_64 under Rosetta for the x64 job), so jlink produces an
+      # x86_64 runtime image.
+      # NON-minified (main, not main-release): the Java backend (Netty / Besu / BouncyCastle /
+      # libp2p) is reflection-heavy and proguard would break it. Unsigned — Gatekeeper needs a
+      # right-click → Open the first time; notarization (Apple Developer ID) is a follow-up.
+      # Retry to ride out transient repo-resolution blips.
       - name: Build macOS .dmg (${{ matrix.arch }})
         run: |
+          GRADLE_ARGS="-Porg.gradle.java.installations.auto-detect=false -Porg.gradle.java.installations.auto-download=false -Porg.gradle.java.installations.paths=$JAVA_HOME"
           for attempt in 1 2 3; do
-            ./gradlew :app-desktop:packageDmg --stacktrace && exit 0
+            ./gradlew :app-desktop:packageDmg --stacktrace $GRADLE_ARGS && exit 0
             echo "::warning::DMG build attempt $attempt failed; retrying in 25s (transient dependency resolution?)"
             sleep 25
           done


### PR DESCRIPTION
## Problem
No Intel (x86/x64) `.dmg` has ever been produced — for latest `main` or any commit. The x64 job targeted the `macos-13` Intel runner, which never gets scheduled (GitHub is winding down Intel macOS capacity), so every run queued to the 24h cap and was cancelled. Only the arm64 dmg is ever built, and it won't launch on an Intel Mac.

## Fix
`jpackage` stamps the `.app` with the architecture of the JDK it runs under, **not** the host — so we cross-build the Intel dmg on Apple Silicon:
- Both matrix jobs now run on `macos-14` (always-available arm64).
- The **x64** job installs an **x86_64 Temurin 21 under Rosetta 2**.
- The Gradle toolchain is pinned to exactly that JDK (`auto-detect=false` + `installations.paths=$JAVA_HOME`), so the build's `javaHome = launcherFor(21)` resolves to the x64 JDK and jpackage emits an **x64 dmg** (not a stray pre-installed aarch64 JDK). The Gradle daemon runs under `JAVA_HOME` too, so jlink builds an x86_64 runtime image.

Removes the dependency on the scarce Intel runner. The arm64 job is unchanged.

## Validation
This PR's own run should now produce **both** `myotis-desktop-dmg-arm64-<sha>` and `myotis-desktop-dmg-x64-<sha>` artifacts — the x64 one being the first Intel build. (Needs the real run to confirm; can't build macOS on the Linux dev box.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)