### PR TITLE
cmp: shared Query history — retained on Android, new on Desktop

### DIFF
--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/MainActivity.kt
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/MainActivity.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Modifier
 import com.jaeckel.ethp2p.android.cmp.AndroidLogSource
 import com.jaeckel.ethp2p.android.cmp.AndroidNetworkStatus
 import com.jaeckel.ethp2p.android.cmp.AndroidNodeController
+import com.jaeckel.ethp2p.android.cmp.AndroidQueryHistoryAdapter
 import com.jaeckel.ethp2p.android.cmp.AndroidSettings
 import io.myotis.ui.NodeScreen
 
@@ -70,9 +71,11 @@ class MainActivity : ComponentActivity() {
             val settings = remember { AndroidSettings(applicationContext) }
             val logs = remember { AndroidLogSource() }
             val netStatus = remember { AndroidNetworkStatus(applicationContext) }
+            // Same filesDir/query-history.tsv the app already used → retains stored queries.
+            val history = remember { AndroidQueryHistoryAdapter(applicationContext) }
             MaterialTheme {
                 Surface(Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
-                    NodeScreen(controller, settings, logs, netStatus, ::openWifiSettings)
+                    NodeScreen(controller, settings, logs, netStatus, ::openWifiSettings, history)
                 }
             }
         }

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/cmp/AndroidNodeBridge.kt
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/cmp/AndroidNodeBridge.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
+import com.jaeckel.ethp2p.android.AndroidQueryHistory
 import com.jaeckel.ethp2p.android.NodeService
 import com.jaeckel.ethp2p.networking.NetworkConfig
 import io.myotis.ui.AccountResult
@@ -11,7 +12,10 @@ import io.myotis.ui.EnsResult
 import io.myotis.ui.NetworkStatus
 import io.myotis.ui.NodeController
 import io.myotis.ui.NodeSnapshot
+import io.myotis.ui.QueryHistory
+import io.myotis.ui.QueryHistoryEntry
 import io.myotis.ui.Settings
+import java.io.File
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.delay
@@ -160,4 +164,17 @@ class AndroidSettings(private val ctx: Context) : Settings {
     override fun setStrictStateFreshness(v: Boolean) = NodeService.setStrictStateFreshness(ctx, v)
     override fun nativeBlsEnabled(): Boolean = NodeService.nativeBlsEnabled(ctx)
     override fun setNativeBlsEnabled(v: Boolean) = NodeService.setNativeBlsEnabled(ctx, v)
+}
+
+/**
+ * Android actual of [QueryHistory]. Wraps the existing file-backed [AndroidQueryHistory] on the
+ * SAME `filesDir/query-history.tsv` the app already used, so previously stored queries are
+ * retained across the switch to the shared UI.
+ */
+class AndroidQueryHistoryAdapter(ctx: Context) : QueryHistory {
+    private val impl = AndroidQueryHistory(File(ctx.filesDir, "query-history.tsv").toPath())
+    override fun entries(): List<QueryHistoryEntry> =
+        impl.list().map { QueryHistoryEntry(it.input(), it.timestampMs(), it.label()) }
+    override fun add(input: String, label: String) = impl.add(input, label)
+    override fun clear() = impl.clear()
 }

--- a/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopQueryHistory.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopQueryHistory.kt
@@ -68,6 +68,8 @@ class DesktopQueryHistory(private val file: Path) : QueryHistory {
 
     private fun rewrite() {
         runCatching {
+            // Ensure the data dir exists — on a first-ever run the app dir may not be created yet.
+            file.parent?.let { Files.createDirectories(it) }
             val sb = StringBuilder()
             entries.forEach {
                 sb.append(it.timestampMillis).append('\t').append(it.input).append('\t').append(it.label).append('\n')

--- a/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopQueryHistory.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopQueryHistory.kt
@@ -1,0 +1,85 @@
+package io.myotis.desktop
+
+import io.myotis.ui.QueryHistory
+import io.myotis.ui.QueryHistoryEntry
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * Desktop actual of [QueryHistory]: a file-backed, most-recent-first history of Query-tab inputs,
+ * mirroring Android's `AndroidQueryHistory` on-disk format (tab-separated
+ * `timestampMs<TAB>input<TAB>label` lines) under the app data dir. Synchronized; capped so the
+ * file and UI list can't grow unbounded.
+ */
+class DesktopQueryHistory(private val file: Path) : QueryHistory {
+    // Most-recent-first. Guarded by `this` (read from the UI thread, written from query coroutines).
+    private val entries = ArrayList<QueryHistoryEntry>()
+    private var loaded = false
+
+    @Synchronized
+    override fun entries(): List<QueryHistoryEntry> {
+        ensureLoaded()
+        return ArrayList(entries)
+    }
+
+    @Synchronized
+    override fun add(input: String, label: String) {
+        ensureLoaded()
+        val trimmed = sanitize(input)
+        if (trimmed.isEmpty()) return
+        // De-dup by input, case-insensitively (ENS names are case-insensitive; addresses in hex).
+        entries.removeAll { it.input.equals(trimmed, ignoreCase = true) }
+        entries.add(0, QueryHistoryEntry(trimmed, System.currentTimeMillis(), sanitize(label)))
+        while (entries.size > MAX) entries.removeAt(entries.size - 1)
+        rewrite()
+    }
+
+    @Synchronized
+    override fun clear() {
+        entries.clear()
+        loaded = true
+        runCatching { Files.deleteIfExists(file) }
+    }
+
+    private fun ensureLoaded() {
+        if (loaded) return
+        loaded = true
+        if (!Files.exists(file)) return
+        runCatching {
+            Files.readAllLines(file, StandardCharsets.UTF_8).forEach { raw ->
+                val line = raw.trim()
+                if (line.isEmpty()) return@forEach
+                val first = line.indexOf('\t')
+                if (first < 0) return@forEach
+                val second = line.indexOf('\t', first + 1)
+                val ts = line.substring(0, first).toLongOrNull() ?: return@forEach
+                val input: String
+                val label: String
+                if (second < 0) {
+                    input = line.substring(first + 1); label = ""
+                } else {
+                    input = line.substring(first + 1, second); label = line.substring(second + 1)
+                }
+                if (input.isNotEmpty()) entries.add(QueryHistoryEntry(input, ts, label))
+            }
+        }
+    }
+
+    private fun rewrite() {
+        runCatching {
+            val sb = StringBuilder()
+            entries.forEach {
+                sb.append(it.timestampMillis).append('\t').append(it.input).append('\t').append(it.label).append('\n')
+            }
+            Files.write(file, sb.toString().toByteArray(StandardCharsets.UTF_8))
+        }
+    }
+
+    private companion object {
+        const val MAX = 50
+        /** Trim and replace TSV-breaking chars so one free-text input can't split a record. */
+        fun sanitize(s: String?): String =
+            (s ?: "").trim().replace('\t', ' ').replace('\r', ' ').replace('\n', ' ')
+    }
+}

--- a/app-desktop/src/main/kotlin/io/myotis/desktop/Main.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/Main.kt
@@ -15,6 +15,7 @@ fun main() {
     // settings first: the controller reads it at boot (configured RPC port + snap target).
     val settings = DesktopSettings()
     val controller = DesktopNodeController(dataDir, settings)
+    val history = DesktopQueryHistory(dataDir.resolve("query-history.tsv"))
     controller.enableNetwork(settings.primaryNetwork())
 
     application {
@@ -24,7 +25,7 @@ fun main() {
             onCloseRequest = { controller.shutdown(); exitApplication() },
             title = "Myotis",
         ) {
-            NodeScreen(controller, settings, DesktopLogSource)
+            NodeScreen(controller, settings, DesktopLogSource, history = history)
         }
     }
 }

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
@@ -1,6 +1,7 @@
 package io.myotis.ui
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -30,6 +31,7 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -71,6 +73,13 @@ private object AlwaysOnline : NetworkStatus {
     override fun online(): kotlinx.coroutines.flow.Flow<Boolean> = kotlinx.coroutines.flow.flowOf(true)
 }
 
+/** Fallback when a host doesn't supply persistence — history simply isn't retained. */
+private object NoQueryHistory : QueryHistory {
+    override fun entries(): List<QueryHistoryEntry> = emptyList()
+    override fun add(input: String, label: String) {}
+    override fun clear() {}
+}
+
 /**
  * The shared Myotis screen — identical on Android and Desktop. A tab host over the per-network
  * [NodeController]/[Settings]/[LogSource] seam (Status / Query / Logs / Settings). [netStatus]
@@ -84,6 +93,7 @@ fun NodeScreen(
     logs: LogSource,
     netStatus: NetworkStatus = AlwaysOnline,
     onOpenNetworkSettings: () -> Unit = {},
+    history: QueryHistory = NoQueryHistory,
 ) {
     // remember(controller): snapshots() returns a fresh Flow each call, so collecting it
     // directly would re-subscribe on every recomposition. Retain it across recompositions.
@@ -125,7 +135,7 @@ fun NodeScreen(
 
             when (tab) {
                 0 -> StatusTab(controller, current, network, online, onOpenNetworkSettings)
-                1 -> QueryTab(controller, settings, current, network)
+                1 -> QueryTab(controller, settings, current, network, history)
                 2 -> LogsTab(logs)
                 3 -> SettingsTab(controller, settings, snapshots)
             }
@@ -465,7 +475,13 @@ private fun StatusView(s: NodeSnapshot) {
  * prominently, and a banner warns when the beacon light client isn't SYNCED (results peer-claimed).
  */
 @Composable
-private fun QueryTab(controller: NodeController, settings: Settings, snap: NodeSnapshot?, network: String) {
+private fun QueryTab(
+    controller: NodeController,
+    settings: Settings,
+    snap: NodeSnapshot?,
+    network: String,
+    history: QueryHistory,
+) {
     val scope = rememberCoroutineScope()
     val running = snap?.running == true
     val ensCapable = remember(network) { settings.hasEns(network) }
@@ -477,10 +493,15 @@ private fun QueryTab(controller: NodeController, settings: Settings, snap: NodeS
     var account by remember(network) { mutableStateOf<AccountResult?>(null) }
     var ens by remember(network) { mutableStateOf<EnsResult?>(null) }
     var error by remember(network) { mutableStateOf<String?>(null) }
+    // History is global (all chains); re-read the local snapshot after each add/clear.
+    var historyList by remember { mutableStateOf(history.entries()) }
 
-    fun submit() {
-        val q = input.trim()
+    // Takes the query string (not the input state) so a tapped history row runs immediately
+    // without waiting for the input state write to settle.
+    fun run(raw: String) {
+        val q = raw.trim()
         if (q.isEmpty() || loading) return
+        input = q
         loading = true; error = null; account = null; ens = null
         scope.launch {
             try {
@@ -508,6 +529,9 @@ private fun QueryTab(controller: NodeController, settings: Settings, snap: NodeS
                 error = t.message ?: t.toString()
             } finally {
                 loading = false
+                // Record for one-tap re-run; label = the resolved address for ENS, else empty.
+                history.add(q, ens?.addressHex ?: "")
+                historyList = history.entries()
             }
         }
     }
@@ -546,7 +570,7 @@ private fun QueryTab(controller: NodeController, settings: Settings, snap: NodeS
         }
         Spacer(Modifier.height(8.dp))
         Button(
-            onClick = { submit() },
+            onClick = { run(input) },
             enabled = running && input.isNotBlank() && !loading,
         ) { Text("Look up") }
         Spacer(Modifier.height(16.dp))
@@ -564,6 +588,45 @@ private fun QueryTab(controller: NodeController, settings: Settings, snap: NodeS
             }
             error != null -> Text("Error: $error", color = MaterialTheme.colorScheme.error)
             account != null -> AccountResultView(account!!)
+        }
+
+        // Recent-query history: tap a row to re-run it (uses the stored input, not the label).
+        if (historyList.isNotEmpty()) {
+            Spacer(Modifier.height(20.dp))
+            Row(
+                Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text("Recent", style = MaterialTheme.typography.titleSmall)
+                TextButton(onClick = { history.clear(); historyList = emptyList() }) { Text("Clear") }
+            }
+            historyList.forEach { e -> QueryHistoryRow(e, enabled = !loading, onClick = { run(e.input) }) }
+        }
+    }
+}
+
+/** One tappable past-query row: the stored input, with the resolved label beneath when present. */
+@Composable
+private fun QueryHistoryRow(e: QueryHistoryEntry, enabled: Boolean, onClick: () -> Unit) {
+    Column(
+        Modifier
+            .fillMaxWidth()
+            .clickable(enabled = enabled, onClick = onClick)
+            .padding(vertical = 6.dp),
+    ) {
+        Text(
+            e.input,
+            fontFamily = FontFamily.Monospace, fontSize = 13.sp,
+            maxLines = 1, overflow = TextOverflow.Ellipsis,
+        )
+        if (e.label.isNotEmpty()) {
+            Text(
+                e.label,
+                fontFamily = FontFamily.Monospace, fontSize = 11.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1, overflow = TextOverflow.Ellipsis,
+            )
         }
     }
 }

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
@@ -493,8 +493,10 @@ private fun QueryTab(
     var account by remember(network) { mutableStateOf<AccountResult?>(null) }
     var ens by remember(network) { mutableStateOf<EnsResult?>(null) }
     var error by remember(network) { mutableStateOf<String?>(null) }
-    // History is global (all chains); re-read the local snapshot after each add/clear.
-    var historyList by remember { mutableStateOf(history.entries()) }
+    // History is global (all chains); re-read the local snapshot after each add/clear. Start empty
+    // and load off the main thread (entries() reads a file) so composition never blocks on disk.
+    var historyList by remember(network) { mutableStateOf<List<QueryHistoryEntry>>(emptyList()) }
+    LaunchedEffect(Unit) { historyList = withContext(Dispatchers.Default) { history.entries() } }
 
     // Takes the query string (not the input state) so a tapped history row runs immediately
     // without waiting for the input state write to settle.
@@ -529,9 +531,10 @@ private fun QueryTab(
                 error = t.message ?: t.toString()
             } finally {
                 loading = false
-                // Record for one-tap re-run; label = the resolved address for ENS, else empty.
-                history.add(q, ens?.addressHex ?: "")
-                historyList = history.entries()
+                // Record for one-tap re-run (off the main thread — file write); label = the
+                // resolved address for ENS, else empty.
+                val label = ens?.addressHex ?: ""
+                historyList = withContext(Dispatchers.Default) { history.add(q, label); history.entries() }
             }
         }
     }
@@ -599,7 +602,13 @@ private fun QueryTab(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text("Recent", style = MaterialTheme.typography.titleSmall)
-                TextButton(onClick = { history.clear(); historyList = emptyList() }) { Text("Clear") }
+                TextButton(onClick = {
+                    // clear() deletes a file — off the main thread.
+                    scope.launch {
+                        withContext(Dispatchers.Default) { history.clear() }
+                        historyList = emptyList()
+                    }
+                }) { Text("Clear") }
             }
             historyList.forEach { e -> QueryHistoryRow(e, enabled = !loading, onClick = { run(e.input) }) }
         }

--- a/ui/src/commonMain/kotlin/io/myotis/ui/QueryHistory.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/QueryHistory.kt
@@ -1,0 +1,29 @@
+package io.myotis.ui
+
+/**
+ * Persistent, most-recent-first history of Query-tab inputs (addresses / ENS names), so the user
+ * can re-run a past query with one tap instead of retyping. Each platform supplies its own
+ * file-backed actual: Android reuses the existing `AndroidQueryHistory` file (so previously stored
+ * queries are retained), Desktop writes its own file under the app data dir.
+ */
+interface QueryHistory {
+    /** Snapshot of history, most-recent-first. */
+    fun entries(): List<QueryHistoryEntry>
+
+    /**
+     * Record [input], moving it to the front (de-duplicated case-insensitively). [label] is the
+     * last thing the input resolved to (e.g. an ENS name's address, or empty for a plain address)
+     * — display sugar only; re-running uses [input].
+     */
+    fun add(input: String, label: String)
+
+    /** Forget all history. */
+    fun clear()
+}
+
+/** One past query. [label] may be empty (never null). */
+data class QueryHistoryEntry(
+    val input: String,
+    val timestampMillis: Long,
+    val label: String,
+)


### PR DESCRIPTION
Restores the persistent **Query-tab history** in the shared `:ui`. It existed on Android before the CMP switchover (#108) but was never ported to the shared UI, and the desktop app never had it at all.

> **Base:** this PR targets `feat/cmp-android-switchover` (#108), because the shared `QueryTab` it extends only exists there. I'll retarget it to `main` once #108 merges.

## What it does
- New `QueryHistory` seam (`entries` / `add` / `clear`) + `QueryHistoryEntry` model in commonMain.
- `QueryTab` records each lookup (label = the resolved ENS address, or empty for a plain address) and renders a most-recent-first **Recent** list. Tapping a row re-runs it — using the stored **input**, not the display label — with a **Clear** button.

## Retaining already-stored Android history
The Android actual (`AndroidQueryHistoryAdapter`) wraps the **existing** file-backed `AndroidQueryHistory` pointing at the **same** `filesDir/query-history.tsv` the app already wrote to (and reuses that same class to parse it). So a user's previously stored queries load and show unchanged — **no migration, nothing lost**. (`NodeService.queryHistory()` became dead code after #108, so there's no second writer to that file.)

## Desktop
New `DesktopQueryHistory` — same tab-separated `timestampMs<TAB>input<TAB>label` format, capped at 50, under `~/.myotis/query-history.tsv`.

## Verification
- `./gradlew :app-desktop:compileKotlin` → BUILD SUCCESSFUL
- `./gradlew :android-app:assembleDebug` → BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)