### PR TITLE
desktop: clearCaches wipes the LIVE peer-cache instance, not just the file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,12 +25,14 @@ out/
 .DS_Store
 ._*
 
-# Node key (contains private key)
+# Node key (contains private key) — mainnet and per-network (nodekey-<net>.hex)
 nodekey.hex
+nodekey-*.hex
 app/peers.cache
 *.cache
-# Persisted light-client sync snapshots (per-network runtime state)
+# Persisted light-client sync snapshots (per-network runtime state) + their .roots accumulators
 *.snapshot
+*.snapshot.roots
 app/devp2p.log
 app/devlibp2p.log
 .gradle-home/

--- a/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
@@ -44,6 +44,10 @@ class DesktopNodeController(private val dataDir: Path, private val settings: Set
     // (each add/get/remove is already thread-safe), so these locks only guard the per-network
     // check-then-build so two boots of the same network can't race.
     private val bootLocks = ConcurrentHashMap<String, Any>()
+    // Live per-network cache instances (keyed by canonical name), retained so clearCaches can wipe
+    // the authoritative in-memory state — not just the file, which a running stack would rewrite.
+    private val peerCaches = ConcurrentHashMap<String, PeerCache>()
+    private val clPeerCaches = ConcurrentHashMap<String, CLPeerCache>()
     private fun bootLock(canonical: String): Any = bootLocks.computeIfAbsent(canonical) { Any() }
 
     init {
@@ -78,6 +82,9 @@ class DesktopNodeController(private val dataDir: Path, private val settings: Set
                 val suffix = if (canonical == "mainnet") "" else "-$canonical"
                 val peerCache = PeerCache(dataDir.resolve("peers$suffix.cache"))
                 val clPeerCache = CLPeerCache(dataDir.resolve("cl-peers$suffix.cache"))
+                // Retain the live instances so clearCaches can wipe their in-memory state.
+                peerCaches[canonical] = peerCache
+                clPeerCaches[canonical] = clPeerCache
                 val stack = ChainStack(
                     network, ports, nodeKey,
                     PeerCacheAdapter(peerCache), ClPeerCacheAdapter(clPeerCache),
@@ -95,17 +102,24 @@ class DesktopNodeController(private val dataDir: Path, private val settings: Set
                 val ok = try {
                     stack.start()
                 } catch (t: Throwable) {
-                    registry.remove(canonical)
+                    dropStack(canonical)
                     throw t
                 }
-                if (!ok) registry.remove(canonical)
+                if (!ok) dropStack(canonical)
             }
         }, "desktop-boot-$canonical").apply { isDaemon = true }.start()
     }
 
+    /** Drop a network's registry entry and forget its retained cache instances. */
+    private fun dropStack(canonical: String) {
+        registry.remove(canonical)
+        peerCaches.remove(canonical)
+        clPeerCaches.remove(canonical)
+    }
+
     override fun disableNetwork(name: String) {
         val canonical = NetworkConfig.byName(name).name()
-        synchronized(bootLock(canonical)) { registry.remove(canonical) }
+        synchronized(bootLock(canonical)) { dropStack(canonical) }
     }
 
     override fun rebootNetwork(name: String) {
@@ -118,6 +132,10 @@ class DesktopNodeController(private val dataDir: Path, private val settings: Set
         // close tears every stack down promptly without waiting behind an in-progress boot of an
         // unrelated network.
         registry.shutdownAll()
+        // Forget the (now-closed) cache instances so a stray post-shutdown clearCaches takes the
+        // stopped-chain purge path rather than clear()ing a closed instance.
+        peerCaches.clear()
+        clPeerCaches.clear()
     }
 
     override fun setTargetSnapPeers(target: Int) {
@@ -134,14 +152,28 @@ class DesktopNodeController(private val dataDir: Path, private val settings: Set
     override fun clearCaches(network: String) {
         val canonical = NetworkConfig.byName(network).name()
         // File deletes are IO — never on the Compose UI thread. Run on a daemon thread (mirrors
-        // Android's NodeService.doClearCaches offloading).
+        // Android's NodeService.doClearCaches offloading). Serialize with enable/disable via the
+        // per-network boot lock so "is the stack live?" and the clear/purge can't race a teardown.
         Thread({
-            // Clear the live stack's backoff/blacklist (fresh discovery slate) when it's up...
-            registry.get(canonical)?.let { it.backoff().clear(); it.blacklistedNodeIds().clear() }
-            // ...and purge the on-disk EL/CL peer caches (mirrors the daemon's purge-cache).
-            val suffix = if (canonical == "mainnet") "" else "-$canonical"
-            PeerCache.purge(dataDir.resolve("peers$suffix.cache"))
-            CLPeerCache.purge(dataDir.resolve("cl-peers$suffix.cache"))
+            synchronized(bootLock(canonical)) {
+                val suffix = if (canonical == "mainnet") "" else "-$canonical"
+                val stack = registry.get(canonical)
+                if (stack != null) {
+                    // Chain is up: clear the LIVE instances (memory + file) so the running stack
+                    // can't rewrite the old peers back, plus the backoff/blacklist.
+                    stack.backoff().clear(); stack.blacklistedNodeIds().clear()
+                    peerCaches[canonical]?.clear() ?: PeerCache.purge(dataDir.resolve("peers$suffix.cache"))
+                    clPeerCaches[canonical]?.clear() ?: CLPeerCache.purge(dataDir.resolve("cl-peers$suffix.cache"))
+                } else {
+                    // Chain stopped: any retained instance is CLOSED (its diskWriter is shut down, so
+                    // clear() would silently drop the file delete on RejectedExecutionException).
+                    // Forget the stale references and purge the on-disk files directly.
+                    peerCaches.remove(canonical)
+                    clPeerCaches.remove(canonical)
+                    PeerCache.purge(dataDir.resolve("peers$suffix.cache"))
+                    CLPeerCache.purge(dataDir.resolve("cl-peers$suffix.cache"))
+                }
+            }
         }, "desktop-clear-caches-$canonical").apply { isDaemon = true }.start()
     }
 

--- a/app/src/main/java/com/jaeckel/ethp2p/app/CLPeerCache.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/CLPeerCache.java
@@ -274,6 +274,25 @@ public final class CLPeerCache {
         return result;
     }
 
+    /**
+     * Wipe the in-memory cache and delete the on-disk file, giving CL discovery a fresh slate.
+     * Unlike the static {@link #purge(Path)}, this clears the LIVE instance's authoritative
+     * in-memory sets too, so a running node can't rewrite the old peers back.
+     */
+    public synchronized void clear() {
+        seen.clear();
+        failures.clear();
+        servedRange.clear();
+        bootstrapPeriod.clear();
+        lcConfirmed.clear();
+        lcDenied.clear();
+        try {
+            Files.deleteIfExists(cacheFile);
+        } catch (IOException e) {
+            log.warn("[cl-cache] failed to delete CL cache file {}: {}", cacheFile, e.getMessage());
+        }
+    }
+
     /** Delete the cache file. */
     public static void purge(Path cacheFile) {
         try {

--- a/app/src/main/java/com/jaeckel/ethp2p/app/PeerCache.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/PeerCache.java
@@ -327,6 +327,24 @@ public final class PeerCache implements Closeable {
         }
     }
 
+    /**
+     * Wipe the in-memory cache and delete the on-disk file, giving discovery a fresh slate. Unlike
+     * the static {@link #purge(Path)}, this clears the LIVE instance's authoritative in-memory maps
+     * too, so a running node can't rewrite the old peers back on the next {@code add}/serve event.
+     */
+    public synchronized void clear() {
+        entries.clear();
+        snapConfirmed.clear();
+        snapDenied.clear();
+        snapFailures.clear();
+        loaded = true;  // memory is now the (empty) authority; don't re-read the file we're deleting
+        submitWrite(() -> {
+            if (!cacheFile.toFile().delete() && cacheFile.toFile().exists()) {
+                log.warn("[cache] failed to delete cache file {}", cacheFile);
+            }
+        });
+    }
+
     /** Delete the cache file (CLI {@code purge-cache}, runs without a daemon). */
     public static void purge(Path cacheFile) {
         try {


### PR DESCRIPTION
Follow-up to the #108 review (task #31). On desktop, **Clear peer caches** was a no-op while a chain was running.

## Problem
`DesktopNodeController.clearCaches` purged the on-disk cache files and cleared the stack's backoff/blacklist — but while a stack runs, the live `PeerCache`/`CLPeerCache` instance holds the **authoritative in-memory** copy and rewrites the old peers back to disk on the next `add`/serve event. So the file purge was immediately undone; only backoff/blacklist actually cleared. (Android already clears the live instance via `NodeService.doClearCaches`.)

## Fix
- Add an instance `clear()` to `PeerCache` and `CLPeerCache` (`:app`) that wipes the in-memory maps/sets **and** deletes the file — mirroring `AndroidPeerCache.clear()`.
- `DesktopNodeController` now retains the per-network cache instances (`peerCaches`/`clPeerCaches`), stored at boot and forgotten via a new `dropStack()` on disable / boot-failure. `clearCaches` clears the **live** instance when the chain is up, falling back to the static file `purge` only when the chain is stopped.

## Verification
- `./gradlew :app:compileJava` → green
- `./gradlew :app-desktop:compileKotlin` → green
- `./gradlew :android-app:assembleDebug` → green (unaffected; the `:app` change is additive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)