### PR TITLE
daemon: per-network node key always, not just in multi-network mode

### DIFF
--- a/app/src/main/java/com/jaeckel/ethp2p/app/Main.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/Main.java
@@ -92,14 +92,16 @@ public final class Main {
     }
 
     /**
-     * Node-identity key file. A single-network daemon keeps the shared {@code nodekey.hex}
-     * (unchanged). When hosting several networks in one process each gets a distinct key
-     * ({@code nodekey-<net>.hex}; mainnet keeps {@code nodekey.hex}) so each advertises its
-     * own ENR/fork-id instead of colliding under one node id in the discovery DHTs.
+     * Node-identity key file, per network — mainnet keeps the legacy {@code nodekey.hex}, every
+     * other network gets {@code nodekey-<net>.hex}. This holds regardless of how many networks the
+     * daemon hosts, so a network always has a stable identity of its own: previously a
+     * single-network run of a non-mainnet chain reused mainnet's {@code nodekey.hex}, meaning
+     * alternating single-network runs advertised the SAME node id on both chains — confusing, and
+     * inconsistent with the Android/desktop hosts, which already key per network unconditionally.
      */
-    static Path nodeKeyFile(String networkName, boolean perNetwork) {
-        if (!perNetwork || "mainnet".equals(networkName)) return Path.of("nodekey.hex");
-        return Path.of("nodekey-" + networkName + ".hex");
+    static Path nodeKeyFile(String networkName) {
+        return "mainnet".equals(networkName) ? Path.of("nodekey.hex")
+                                             : Path.of("nodekey-" + networkName + ".hex");
     }
 
 
@@ -218,13 +220,13 @@ public final class Main {
         for (NetworkConfig network : networks) {
             log.info("IPC socket ({}): {}", network.name(), socketPath(network.name()));
 
-            // Single-network stays byte-identical: legacy --port/30303 + discv5 9000 +
-            // RPC 8545 + shared nodekey.hex. Multi-network uses pinned per-network ports
-            // + per-network identity so the stacks don't collide.
+            // Ports: single-network stays byte-identical (legacy --port/30303 + discv5 9000 +
+            // RPC 8545); multi-network uses pinned per-network ports so the stacks don't collide.
+            // Identity is always per-network (nodeKeyFile below), independent of this.
             ChainPorts ports = multi
                     ? ChainPorts.defaultsFor(network)
                     : new ChainPorts(portOverride, 9000, 8545);
-            NodeKey nodeKey = NodeKey.loadOrGenerate(nodeKeyFile(network.name(), multi));
+            NodeKey nodeKey = NodeKey.loadOrGenerate(nodeKeyFile(network.name()));
 
             PeerCache peerCache = new PeerCache(cacheFile(network.name()));
             CLPeerCache clPeerCache = new CLPeerCache(clCacheFile(network.name()));

--- a/docs/multichain-design.md
+++ b/docs/multichain-design.md
@@ -69,9 +69,9 @@ bolted on.
 The codebase is "one daemon = one network" by construction: a single
 `NetworkConfig` is threaded through every service.
 
-- **`nodekey.hex` is one global identity** (`Main.loadOrGenerate`). Per-network
-  ENRs would want distinct (or per-network-derived) keys so each network
-  advertises its own fork-id.
+- **Node identity is per-network (resolved).** `Main.nodeKeyFile` gives mainnet
+  `nodekey.hex` and every other network `nodekey-<net>.hex`, so each advertises
+  its own fork-id. (Originally a single global `nodekey.hex`.)
 - **discv5 port is hardcoded to 9000** (`Main` → `DiscV5Service.start(9000)`),
   with only an ephemeral fallback. A second network in-process needs its own
   configurable CL port.


### PR DESCRIPTION
## Problem (reported by a user)
The daemon picked its node-identity key file with `nodeKeyFile(name, perNetwork)` where `perNetwork = networks.size() > 1`. So a **single-network** run of a non-mainnet chain (`-Pnetwork=gnosis`) reused mainnet's shared `nodekey.hex`, and only **multi-network** runs (`-Pnetwork=mainnet,gnosis`) gave gnosis its own `nodekey-gnosis.hex`.

Consequence: **alternating single-network runs advertised the same devp2p node id on both chains** — confusing, and inconsistent with the Android (`NodeService`) and desktop (`DesktopNodeController`) hosts, which already key per-network unconditionally.

## Change
`nodeKeyFile` is now always per-network: mainnet keeps `nodekey.hex` (unchanged), every other network gets `nodekey-<net>.hex`, regardless of how many networks run. This aligns the key with the daemon's other per-network filename helpers (`socketPath`, `lockPath`, `cacheFile`, `clCacheFile`, `syncSnapshotFile`) — which were already keyed on network name only; `nodeKeyFile` was the sole outlier. Port selection is still single-vs-multi (unchanged).

Not a security issue — this is a p2p node identity, not a wallet key — but it removes an identity-reuse case and makes the behavior obvious.

## Migration
A single-network non-mainnet daemon generates a fresh `nodekey-<net>.hex` on its next start; **mainnet's `nodekey.hex` is untouched**. No light-client re-sync (sync snapshot unaffected) and no peer-cache loss (caches were already per-network). The only effect is a one-time new devp2p identity for non-mainnet single-network daemons, which the DHT simply re-learns.

Also fixed a now-stale line in `docs/multichain-design.md` (it listed "one global `nodekey.hex`" as an open blocker; per-network keys are implemented). The rest of that doc's "what blocks it today" section is pre-existing staleness (predates `NodeRegistry`), out of scope here.

## Review & verification
- Ran an **independent local review before opening this PR** — verdict: safe to PR. It specifically confirmed no "hidden coupling" (all sibling per-network filenames stay consistent) and that mainnet identity is byte-identical.
- `./gradlew :app:compileJava` → BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)