### PR TITLE
networking: benign peer disconnects log one-line DEBUG, not ERROR+stacktrace

### DIFF
--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/ConnectionErrors.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/ConnectionErrors.java
@@ -1,0 +1,71 @@
+package com.jaeckel.ethp2p.networking;
+
+import java.io.IOException;
+import java.net.PortUnreachableException;
+import java.nio.channels.ClosedChannelException;
+import java.util.Locale;
+
+/**
+ * Classifies the routine peer-churn disconnects that flood the wire handlers' {@code
+ * exceptionCaught} at ERROR-with-stacktrace even though nothing is wrong. Peers drop constantly
+ * during normal discovery/sync — {@code java.net.SocketException: Connection reset}, broken pipe,
+ * a half-open socket timing out, a UDP port-unreachable — and each currently prints a full
+ * stacktrace at ERROR. Those should be a one-line DEBUG instead, leaving ERROR for genuinely
+ * unexpected failures.
+ */
+public final class ConnectionErrors {
+
+    private ConnectionErrors() {}
+
+    /** Bound the cause-chain walk so a pathological cyclic chain can't hang the event loop. */
+    private static final int MAX_CAUSE_DEPTH = 32;
+
+    /**
+     * True if {@code t} (or any cause in its chain) is a benign transport-level disconnect —
+     * connection reset / reset by peer, broken pipe, a connection/read timeout, the OS forcibly
+     * closing the socket, a closed channel, or a UDP port-unreachable. Genuine protocol/decode
+     * failures return false so they keep logging at ERROR with a stacktrace.
+     *
+     * <p>The message substrings are JDK/OS wording (not API contract), so this is best-effort —
+     * but it's gated on {@link IOException}, so a wording drift only mis-classifies a transport
+     * error, never a protocol/logic bug.
+     */
+    public static boolean isBenignDisconnect(Throwable t) {
+        int depth = 0;
+        for (Throwable c = t; c != null && depth < MAX_CAUSE_DEPTH; c = c.getCause(), depth++) {
+            if (c instanceof ClosedChannelException) return true;
+            if (c instanceof PortUnreachableException) return true;
+            if (c instanceof IOException) {   // SocketException / SocketTimeoutException are IOExceptions
+                String m = c.getMessage();
+                if (m != null) {
+                    String lm = m.toLowerCase(Locale.ROOT);
+                    if (lm.contains("connection reset")
+                            || lm.contains("reset by peer")
+                            || lm.contains("broken pipe")
+                            || lm.contains("timed out")            // ETIMEDOUT + SocketTimeoutException
+                            || lm.contains("connection or inbound has closed")
+                            || lm.contains("forcibly closed")) {   // Windows wording
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * A short, single-line description of {@code t} for DEBUG logging — the root cause's message
+     * (e.g. "Connection reset"), falling back to its simple class name when there is no message.
+     * No stacktrace. The walk is depth-bounded so a cyclic cause chain can't loop forever.
+     */
+    public static String describe(Throwable t) {
+        Throwable root = t;
+        int depth = 0;
+        while (root.getCause() != null && root.getCause() != root && depth < MAX_CAUSE_DEPTH) {
+            root = root.getCause();
+            depth++;
+        }
+        String m = root.getMessage();
+        return m != null ? m : root.getClass().getSimpleName();
+    }
+}

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/ConnectionErrors.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/ConnectionErrors.java
@@ -59,6 +59,7 @@ public final class ConnectionErrors {
      * No stacktrace. The walk is depth-bounded so a cyclic cause chain can't loop forever.
      */
     public static String describe(Throwable t) {
+        if (t == null) return "unknown";
         Throwable root = t;
         int depth = 0;
         while (root.getCause() != null && root.getCause() != root && depth < MAX_CAUSE_DEPTH) {

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/ConnectionErrors.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/ConnectionErrors.java
@@ -31,8 +31,9 @@ public final class ConnectionErrors {
      * error, never a protocol/logic bug.
      */
     public static boolean isBenignDisconnect(Throwable t) {
+        Throwable c = t;
         int depth = 0;
-        for (Throwable c = t; c != null && depth < MAX_CAUSE_DEPTH; c = c.getCause(), depth++) {
+        while (c != null && depth < MAX_CAUSE_DEPTH) {
             if (c instanceof ClosedChannelException) return true;
             if (c instanceof PortUnreachableException) return true;
             if (c instanceof IOException) {   // SocketException / SocketTimeoutException are IOExceptions
@@ -49,6 +50,10 @@ public final class ConnectionErrors {
                     }
                 }
             }
+            Throwable next = c.getCause();
+            if (next == c) break;   // self-referential cause — stop, don't spin to the depth cap
+            c = next;
+            depth++;
         }
         return false;
     }

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/discv4/DiscV4Handler.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/discv4/DiscV4Handler.java
@@ -1,6 +1,7 @@
 package com.jaeckel.ethp2p.networking.discv4;
 
 import com.jaeckel.ethp2p.core.crypto.NodeKey;
+import com.jaeckel.ethp2p.networking.ConnectionErrors;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
@@ -201,6 +202,11 @@ public final class DiscV4Handler extends SimpleChannelInboundHandler<DatagramPac
 
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-        log.error("[discv4] Channel error", cause);
+        // Benign transport churn (reset, UDP port-unreachable, …) → one-line DEBUG, no stacktrace.
+        if (ConnectionErrors.isBenignDisconnect(cause)) {
+            log.debug("[discv4] channel closed: {}", ConnectionErrors.describe(cause));
+        } else {
+            log.error("[discv4] Channel error", cause);
+        }
     }
 }

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/EthHandler.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/EthHandler.java
@@ -2,6 +2,7 @@ package com.jaeckel.ethp2p.networking.eth;
 
 import com.jaeckel.ethp2p.core.crypto.NodeKey;
 import com.jaeckel.ethp2p.networking.ChainHead;
+import com.jaeckel.ethp2p.networking.ConnectionErrors;
 import com.jaeckel.ethp2p.networking.NetworkConfig;
 import com.jaeckel.ethp2p.networking.eth.messages.*;
 import com.jaeckel.ethp2p.networking.rlpx.RLPxHandler;
@@ -1431,7 +1432,13 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
 
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-        log.error("[eth] Exception", cause);
+        // Peer-churn disconnects (connection reset, broken pipe, …) are routine — one-line DEBUG,
+        // no stacktrace. Only genuinely unexpected failures log at ERROR with the full cause.
+        if (ConnectionErrors.isBenignDisconnect(cause)) {
+            log.debug("[eth] peer disconnected: {}", ConnectionErrors.describe(cause));
+        } else {
+            log.error("[eth] Exception", cause);
+        }
         ctx.close();
     }
 }

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/rlpx/RLPxHandler.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/rlpx/RLPxHandler.java
@@ -1,6 +1,7 @@
 package com.jaeckel.ethp2p.networking.rlpx;
 
 import com.jaeckel.ethp2p.core.crypto.NodeKey;
+import com.jaeckel.ethp2p.networking.ConnectionErrors;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.*;
 import io.netty.handler.codec.ByteToMessageDecoder;
@@ -212,7 +213,13 @@ public final class RLPxHandler extends ByteToMessageDecoder {
 
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-        log.error("[rlpx] Exception", cause);
+        // Peer-churn disconnects (connection reset, broken pipe, …) are routine — one-line DEBUG,
+        // no stacktrace. Only genuinely unexpected failures log at ERROR with the full cause.
+        if (ConnectionErrors.isBenignDisconnect(cause)) {
+            log.debug("[rlpx] peer disconnected: {}", ConnectionErrors.describe(cause));
+        } else {
+            log.error("[rlpx] Exception", cause);
+        }
         ctx.close();
     }
 }

--- a/networking/src/test/java/com/jaeckel/ethp2p/networking/ConnectionErrorsTest.java
+++ b/networking/src/test/java/com/jaeckel/ethp2p/networking/ConnectionErrorsTest.java
@@ -1,0 +1,73 @@
+package com.jaeckel.ethp2p.networking;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.PortUnreachableException;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.nio.channels.ClosedChannelException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Guards the benign-disconnect classifier — it's easy to regress (message substrings, cause-chain,
+ *  depth cap) and it decides whether a peer drop is a quiet DEBUG line or an ERROR stacktrace. */
+class ConnectionErrorsTest {
+
+    @Test
+    void benignTransportDisconnectsAreBenign() {
+        assertTrue(ConnectionErrors.isBenignDisconnect(new SocketException("Connection reset")));
+        assertTrue(ConnectionErrors.isBenignDisconnect(new SocketException("Connection reset by peer")));
+        assertTrue(ConnectionErrors.isBenignDisconnect(new IOException("Broken pipe")));
+        assertTrue(ConnectionErrors.isBenignDisconnect(new SocketTimeoutException("Read timed out")));
+        assertTrue(ConnectionErrors.isBenignDisconnect(new ClosedChannelException()));
+        assertTrue(ConnectionErrors.isBenignDisconnect(new PortUnreachableException()));
+    }
+
+    @Test
+    void benignCauseIsFoundThroughTheChain() {
+        assertTrue(ConnectionErrors.isBenignDisconnect(
+                new RuntimeException("netty pipeline", new SocketException("Connection reset"))));
+    }
+
+    @Test
+    void genuineFailuresStayNonBenign() {
+        assertFalse(ConnectionErrors.isBenignDisconnect(new RuntimeException("decode failed")));
+        assertFalse(ConnectionErrors.isBenignDisconnect(new NullPointerException()));
+        assertFalse(ConnectionErrors.isBenignDisconnect(new IllegalStateException("bad state")));
+        // An IOException whose message ISN'T a known benign disconnect must stay ERROR.
+        assertFalse(ConnectionErrors.isBenignDisconnect(new IOException("No space left on device")));
+    }
+
+    @Test
+    void nullIsNotBenignAndDescribesSafely() {
+        assertFalse(ConnectionErrors.isBenignDisconnect(null));
+        assertEquals("unknown", ConnectionErrors.describe(null));
+    }
+
+    @Test
+    void describeReturnsRootCauseMessageOrClassName() {
+        assertEquals("Connection reset",
+                ConnectionErrors.describe(new SocketException("Connection reset")));
+        assertEquals("Connection reset",
+                ConnectionErrors.describe(new RuntimeException("wrap", new SocketException("Connection reset"))));
+        // No message → simple class name.
+        assertEquals("ClosedChannelException", ConnectionErrors.describe(new ClosedChannelException()));
+    }
+
+    @Test
+    void selfReferentialCauseDoesNotHang() {
+        // A Throwable whose getCause() returns itself must not loop (would spin to the depth cap
+        // without the self-cause break, and could loop forever if that were removed too).
+        Throwable selfCausing = new RuntimeException("loop") {
+            @Override public synchronized Throwable getCause() { return this; }
+        };
+        assertTimeoutPreemptively(java.time.Duration.ofSeconds(1), () -> {
+            assertFalse(ConnectionErrors.isBenignDisconnect(selfCausing));
+            assertEquals("loop", ConnectionErrors.describe(selfCausing));
+        });
+    }
+}


### PR DESCRIPTION
Closes #34 and #35 (they're the same code sites).

## Problem
Routine peer churn — `java.net.SocketException: Connection reset`, broken pipe, a read/connection timeout, a UDP port-unreachable, a closed channel — fired the three Netty `exceptionCaught` handlers (`rlpx`/`discv4`/`eth`), each of which logged the **full throwable at ERROR**, i.e. a **stacktrace per dropped peer**. Peers drop constantly during normal discovery/sync, so the log fills with ERROR stacktraces for nothing wrong.

## Change
- New `ConnectionErrors` (stateless): `isBenignDisconnect(Throwable)` + `describe(Throwable)`.
- The three `exceptionCaught` handlers now route through it: a **benign disconnect logs a one-line message at DEBUG (no stacktrace)**; genuinely unexpected failures still log at **ERROR with the full cause**. `ctx.close()` behavior is unchanged.

## Design notes
- The classifier is **`IOException`-gated** and only then matches known benign message substrings — so a JDK/OS wording drift can only ever mis-classify a *transport* error, never a protocol/decode/logic bug (those aren't `IOException` and stay at ERROR).
- Cause-chain walk is **depth-bounded** (defense against a pathological cyclic chain hanging the event loop).
- Genuine ERRORs (decode/handshake/MAC failures, etc.) are untouched — verified those are separate log sites.

## Note on visibility
These are now DEBUG under `com.jaeckel.ethp2p.networking`. In the **desktop** app the wire logger defaults to ERROR, so they're hidden unless you raise `-Dmyotis.log.wire.level=DEBUG`. In the **daemon** (`app/.../logback.xml`) `com.jaeckel.ethp2p` defaults to DEBUG, so they show as **one quiet line** instead of a stacktrace — the intended win. (Runtime log-level control in the UI is the separate task #36.)

## Review & verification
- Ran an **independent local review before opening this PR**; verdict "safe to PR". It caught two latent gaps I folded in before pushing: an unbounded cause-chain loop (now depth-capped) and a `SocketTimeoutException` under-match (now covered by a broader "timed out" match). Also swapped inline FQNs for imports.
- `./gradlew :networking:compileJava` → BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)