### PR TITLE
ui(logs): runtime-configurable capture level in the Logs tab

### DIFF
--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/cmp/AndroidLogSource.kt
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/cmp/AndroidLogSource.kt
@@ -1,13 +1,17 @@
 package com.jaeckel.ethp2p.android.cmp
 
+import com.jaeckel.ethp2p.android.log.AppSlf4jProvider
 import com.jaeckel.ethp2p.android.log.LogBuffer
+import io.myotis.ui.LogLevel
 import io.myotis.ui.LogLine
 import io.myotis.ui.LogSource
+import org.slf4j.event.Level
 
 /**
  * Android actual of [LogSource]: wraps the existing [LogBuffer] (which the in-tree SLF4J
  * provider tees consensus/networking/libp2p logs into, alongside the app's own LogBuffer
- * calls), so the shared Logs tab renders the same lines the Android UI shows today.
+ * calls), so the shared Logs tab renders the same lines the Android UI shows today. The capture
+ * level is the SLF4J provider's live threshold.
  */
 class AndroidLogSource : LogSource {
     override fun version(): Long = LogBuffer.version()
@@ -17,4 +21,20 @@ class AndroidLogSource : LogSource {
     }
 
     override fun clear() = LogBuffer.clear()
+
+    override fun level(): LogLevel = when (AppSlf4jProvider.minLevel()) {
+        Level.ERROR -> LogLevel.ERROR
+        Level.WARN -> LogLevel.WARN
+        Level.INFO -> LogLevel.INFO
+        else -> LogLevel.DEBUG   // DEBUG/TRACE both surface as the DEBUG floor (TRACE is suppressed)
+    }
+
+    override fun setLevel(level: LogLevel) = AppSlf4jProvider.setMinLevel(
+        when (level) {
+            LogLevel.DEBUG -> Level.DEBUG
+            LogLevel.INFO -> Level.INFO
+            LogLevel.WARN -> Level.WARN
+            LogLevel.ERROR -> Level.ERROR
+        }
+    )
 }

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/log/AppSlf4jProvider.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/log/AppSlf4jProvider.java
@@ -40,8 +40,9 @@ public final class AppSlf4jProvider implements SLF4JServiceProvider {
      */
     private static volatile Level minLevel = Level.DEBUG;
 
-    /** Set the minimum captured level (from the Logs tab). */
-    public static void setMinLevel(Level level) { minLevel = level; }
+    /** Set the minimum captured level (from the Logs tab). Ignores null so the volatile can never
+     *  go null and NPE the hot-path read on the next log call. */
+    public static void setMinLevel(Level level) { if (level != null) minLevel = level; }
 
     /** The current minimum captured level. */
     public static Level minLevel() { return minLevel; }

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/log/AppSlf4jProvider.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/log/AppSlf4jProvider.java
@@ -32,6 +32,20 @@ public final class AppSlf4jProvider implements SLF4JServiceProvider {
     /** Must be a prefix of the slf4j-api version on the classpath. */
     public static final String REQUESTED_API_VERSION = "2.0.99";
 
+    /**
+     * Minimum level captured (logcat + {@link LogBuffer}); calls below it are dropped. TRACE is
+     * always suppressed regardless (libp2p floods it). Defaults to DEBUG — capture everything
+     * above trace, matching the historical behavior — and the Logs tab can raise it to quiet the
+     * ring. Volatile: read on every log call, written from the UI thread.
+     */
+    private static volatile Level minLevel = Level.DEBUG;
+
+    /** Set the minimum captured level (from the Logs tab). */
+    public static void setMinLevel(Level level) { minLevel = level; }
+
+    /** The current minimum captured level. */
+    public static Level minLevel() { return minLevel; }
+
     private final ILoggerFactory loggerFactory = new AppLoggerFactory();
     private final IMarkerFactory markerFactory = new BasicMarkerFactory();
     private final MDCAdapter mdcAdapter = new BasicMDCAdapter();
@@ -56,14 +70,18 @@ public final class AppSlf4jProvider implements SLF4JServiceProvider {
             this.name = name;
         }
 
-        // We don't filter by level — let consumers (logcat / UI) gate display.
-        // TRACE is suppressed because libp2p is *very* chatty at trace level
-        // and would dominate the ring buffer otherwise.
+        // Level gating is a single process-wide threshold (minLevel), adjustable live from the
+        // Logs tab. TRACE is *always* suppressed because libp2p is very chatty at trace level and
+        // would dominate the ring buffer.
         @Override public boolean isTraceEnabled() { return false; }
-        @Override public boolean isDebugEnabled() { return true; }
-        @Override public boolean isInfoEnabled()  { return true; }
-        @Override public boolean isWarnEnabled()  { return true; }
-        @Override public boolean isErrorEnabled() { return true; }
+        @Override public boolean isDebugEnabled() { return enabled(Level.DEBUG); }
+        @Override public boolean isInfoEnabled()  { return enabled(Level.INFO); }
+        @Override public boolean isWarnEnabled()  { return enabled(Level.WARN); }
+        @Override public boolean isErrorEnabled() { return enabled(Level.ERROR); }
+
+        private static boolean enabled(Level level) {
+            return level != Level.TRACE && level.toInt() >= minLevel.toInt();
+        }
 
         @Override
         protected String getFullyQualifiedCallerName() {
@@ -75,6 +93,9 @@ public final class AppSlf4jProvider implements SLF4JServiceProvider {
                                                    String messagePattern,
                                                    Object[] arguments,
                                                    Throwable throwable) {
+            // Belt-and-suspenders: LegacyAbstractLogger already gates on isXEnabled(), but drop
+            // anything below the threshold (or TRACE) here too so no path bypasses it.
+            if (level == Level.TRACE || level.toInt() < minLevel.toInt()) return;
             String formatted = MessageFormatter.basicArrayFormat(messagePattern, arguments);
 
             // Tee to logcat so `adb logcat` continues to work.

--- a/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopLog.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopLog.kt
@@ -1,11 +1,14 @@
 package io.myotis.desktop
 
 import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.classic.spi.ThrowableProxyUtil
 import ch.qos.logback.core.AppenderBase
+import io.myotis.ui.LogLevel
 import io.myotis.ui.LogLine
 import io.myotis.ui.LogSource
+import org.slf4j.LoggerFactory
 import java.util.concurrent.atomic.AtomicLong
 
 /**
@@ -35,6 +38,35 @@ object DesktopLogSource : LogSource {
     override fun clear() {
         synchronized(lock) { buffer.clear() }
         version.incrementAndGet()
+    }
+
+    // The app's own loggers whose level the Logs-tab control drives. Setting the wire logger too
+    // is what lets the control actually reveal the (otherwise ERROR-gated) networking DEBUG lines.
+    private val CONTROLLED_LOGGERS = listOf("com.jaeckel.ethp2p", "io.myotis", "com.jaeckel.ethp2p.networking")
+
+    // Reflects the app-code logger (com.jaeckel.ethp2p). By default the wire logger starts quieter
+    // (ERROR, per logback-desktop.xml) so the chip can read one notch more verbose than the wire is
+    // actually capturing until the user picks a level — at which point setLevel() brings all three
+    // (app, io.myotis, wire) to the selection, so the chip becomes exact.
+    override fun level(): LogLevel =
+        fromLogback((LoggerFactory.getLogger("com.jaeckel.ethp2p") as? Logger)?.effectiveLevel)
+
+    override fun setLevel(level: LogLevel) {
+        val lb = when (level) {
+            LogLevel.DEBUG -> Level.DEBUG
+            LogLevel.INFO -> Level.INFO
+            LogLevel.WARN -> Level.WARN
+            LogLevel.ERROR -> Level.ERROR
+        }
+        CONTROLLED_LOGGERS.forEach { (LoggerFactory.getLogger(it) as? Logger)?.level = lb }
+    }
+
+    private fun fromLogback(lvl: Level?): LogLevel = when {
+        lvl == null -> LogLevel.INFO
+        lvl.toInt() >= Level.ERROR_INT -> LogLevel.ERROR
+        lvl.toInt() >= Level.WARN_INT -> LogLevel.WARN
+        lvl.toInt() >= Level.INFO_INT -> LogLevel.INFO
+        else -> LogLevel.DEBUG
     }
 }
 

--- a/ui/src/commonMain/kotlin/io/myotis/ui/LogSource.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/LogSource.kt
@@ -15,7 +15,25 @@ interface LogSource {
 
     /** Drop all buffered lines (bumps [version]). */
     fun clear()
+
+    /** The current minimum level being captured into the ring. */
+    fun level(): LogLevel
+
+    /**
+     * Set the minimum level captured, live — raise it to quiet the log, lower it (e.g. to DEBUG)
+     * to surface the chatty wire / peer-churn lines when diagnosing. Android gates its SLF4J
+     * provider; Desktop sets the logback level of the app + wire loggers so lower levels are
+     * actually emitted (not merely displayed). Applies to lines captured from now on.
+     */
+    fun setLevel(level: LogLevel)
 }
+
+/**
+ * User-selectable minimum log level for the Logs tab. TRACE/VERBOSE is intentionally NOT selectable
+ * — libp2p floods it — so the ladder starts at DEBUG. Declared in ascending severity so
+ * [Enum.ordinal] ranks levels for filtering.
+ */
+enum class LogLevel { DEBUG, INFO, WARN, ERROR }
 
 /** One captured log line. Mirrors the Android `LogBuffer.Entry` shape. */
 data class LogLine(

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
@@ -726,6 +726,7 @@ private fun LogsTab(logs: LogSource) {
     var shown by remember { mutableStateOf<List<LogLine>>(emptyList()) }
     var lastVersion by remember { mutableStateOf(-1L) }
     var filter by remember { mutableStateOf("") }
+    var level by remember { mutableStateOf(logs.level()) }
 
     // Poll the cheap version counter; the O(n) snapshot of up to 50k lines runs off the main
     // thread so it can't jank the UI.
@@ -741,15 +742,19 @@ private fun LogsTab(logs: LogSource) {
     }
 
     // Filter off the main thread too, and cooperatively cancel superseded passes (rapid typing).
-    LaunchedEffect(lines, filter) {
+    // Filters by the selected minimum level AND the text query; `level` also drives capture (via
+    // logs.setLevel), so this display filter mainly hides already-captured lines below `level`.
+    LaunchedEffect(lines, filter, level) {
         val f = filter.trim()
-        shown = if (f.isEmpty()) lines
+        val minRank = level.ordinal
+        shown = if (f.isEmpty() && level == LogLevel.DEBUG) lines
         else withContext(Dispatchers.Default) {
             lines.filter {
                 ensureActive()  // withContext receiver is the CoroutineScope
-                // contains(ignoreCase = true) avoids allocating a lowercased copy of every
-                // tag/message per keystroke (up to 50k lines).
-                it.tag.contains(f, ignoreCase = true) || it.message.contains(f, ignoreCase = true)
+                logLevelRank(it.level) >= minRank &&
+                    // contains(ignoreCase = true) avoids allocating a lowercased copy of every
+                    // tag/message per keystroke (up to 50k lines).
+                    (f.isEmpty() || it.tag.contains(f, ignoreCase = true) || it.message.contains(f, ignoreCase = true))
             }
         }
     }
@@ -787,6 +792,23 @@ private fun LogsTab(logs: LogSource) {
             Spacer(Modifier.width(4.dp))
             OutlinedButton(onClick = { logs.clear() }) { Text("Clear") }
         }
+        Spacer(Modifier.height(4.dp))
+        // Capture level: lower it (e.g. DEBUG) to surface the chatty wire / peer-churn lines,
+        // raise it to quiet the log. Applies to capture (logs.setLevel) AND hides already-captured
+        // lines below the selection.
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            Text("Level", style = MaterialTheme.typography.labelMedium)
+            LogLevel.entries.forEach { lvl ->
+                FilterChip(
+                    selected = level == lvl,
+                    onClick = { level = lvl; logs.setLevel(lvl) },
+                    label = { Text(lvl.name) },
+                )
+            }
+        }
         Spacer(Modifier.height(8.dp))
         Box(Modifier.weight(1f).fillMaxWidth()) {
             LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
@@ -818,6 +840,15 @@ private fun LogLineRow(line: LogLine, tz: TimeZone) {
         fontFamily = FontFamily.Monospace,
         color = color,
     )
+}
+
+/** Rank a captured line's level char against [LogLevel.ordinal] (DEBUG=0 … ERROR=3). 'V' (TRACE,
+ *  never captured) ranks with DEBUG so a DEBUG selection shows everything. */
+private fun logLevelRank(c: Char): Int = when (c) {
+    'E' -> 3
+    'W' -> 2
+    'I' -> 1
+    else -> 0   // 'D' and 'V'
 }
 
 private fun formatLogs(lines: List<LogLine>, tz: TimeZone): String = buildString {

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
@@ -726,7 +726,7 @@ private fun LogsTab(logs: LogSource) {
     var shown by remember { mutableStateOf<List<LogLine>>(emptyList()) }
     var lastVersion by remember { mutableStateOf(-1L) }
     var filter by remember { mutableStateOf("") }
-    var level by remember { mutableStateOf(logs.level()) }
+    var level by remember(logs) { mutableStateOf(logs.level()) }
 
     // Poll the cheap version counter; the O(n) snapshot of up to 50k lines runs off the main
     // thread so it can't jank the UI.
@@ -842,8 +842,10 @@ private fun LogLineRow(line: LogLine, tz: TimeZone) {
     )
 }
 
-/** Rank a captured line's level char against [LogLevel.ordinal] (DEBUG=0 … ERROR=3). 'V' (TRACE,
- *  never captured) ranks with DEBUG so a DEBUG selection shows everything. */
+/** Rank a captured line's level char against [LogLevel.ordinal] (DEBUG=0 … ERROR=3). 'V' (TRACE)
+ *  ranks with DEBUG so it shows at the DEBUG selection: TRACE isn't a selectable capture level, but
+ *  a 'V' line can still reach the ring if some logger is independently at TRACE (Desktop's appender
+ *  maps TRACE→'V'). */
 private fun logLevelRank(c: Char): Int = when (c) {
     'E' -> 3
     'W' -> 2


### PR DESCRIPTION
Closes #36. Companion to #112 (which moved benign peer-disconnects to DEBUG): a runtime **Level** control in the Logs tab so you can lower to DEBUG to surface the chatty wire / peer-churn lines when diagnosing, or raise it to quiet the log.

## What it does
- **Seam** (`LogSource`): `level()` / `setLevel(LogLevel)` + a `LogLevel` enum (DEBUG/INFO/WARN/ERROR). TRACE stays suppressed (libp2p floods it).
- **UI** (`LogsTab`): a "Level" `FilterChip` row that drives `logs.setLevel(...)` (capture) **and** filters the displayed lines `>=` the selection.

## Why it's a *capture* control, not just a display filter
The two platforms capture differently:
- **Android** (`AppSlf4jProvider`) already captured everything (D+). The change makes that a live `volatile minLevel` threshold gating `isXEnabled()` + the handler (logcat + `LogBuffer`); default DEBUG (unchanged), now raisable to quiet the ring.
- **Desktop** (logback) only captures what passes the logger levels — the **wire logger is ERROR-gated by default**, so its DEBUG lines are never emitted. A display-only filter therefore couldn't reveal them. So `DesktopLogSource.setLevel` sets the logback level of `com.jaeckel.ethp2p`, `io.myotis`, and `com.jaeckel.ethp2p.networking` — lower levels are actually *emitted*, then the display filter also applies.

## Notes
- Defaults differ per platform (Android DEBUG, desktop INFO from `logback-desktop.xml`); the chip reflects `logs.level()`, and picking a level unifies all three desktop loggers to it. The wire logger stays deliberately quieter until you pick a level (documented in a comment).
- Lowering desktop to DEBUG will capture the very chatty networking DEBUG into the 50k ring — that's the point of the control, bounded by the ring.

## Review & verification
- Ran an **independent local review before opening**; verdict "safe to PR", no defects (confirmed both platforms actually work, capture-vs-display is coherent, only the two `LogSource` implementers exist and both are updated). Folded in the one minor it raised (clarified the desktop `level()` comment).
- `./gradlew :app-desktop:compileKotlin` and `:android-app:assembleDebug` → green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)