### PR TITLE
ui(status): richer Status detail + account-result polish (shared)

### DIFF
--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/cmp/AndroidNodeBridge.kt
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/cmp/AndroidNodeBridge.kt
@@ -12,6 +12,7 @@ import io.myotis.ui.EnsResult
 import io.myotis.ui.NetworkStatus
 import io.myotis.ui.NodeController
 import io.myotis.ui.NodeSnapshot
+import io.myotis.ui.PeerRow
 import io.myotis.ui.QueryHistory
 import io.myotis.ui.QueryHistoryEntry
 import io.myotis.ui.Settings
@@ -134,12 +135,17 @@ private fun NodeService.Snapshot.toModel(): NodeSnapshot = NodeSnapshot(
     snapPeers = snapPeers(),
     snapServingPeers = snapServingPeers(),
     discoveredPeers = discoveredPeers(),
+    backedOffPeers = backedOffPeers(),
+    blacklistedPeers = blacklistedPeers(),
+    discv5Peers = discv5Peers(),
     executionBlockNumber = executionBlockNumber(),
     finalizedSlot = finalizedSlot(),
+    syncStartPeriod = syncStartPeriod(),
     syncCurrentPeriod = syncCurrentPeriod(),
     syncTargetPeriod = syncTargetPeriod(),
     verifiedHeadAgeMs = verifiedHeadAgeMs(),
     uptimeSeconds = if (startTimeMs() > 0) (System.currentTimeMillis() - startTimeMs()) / 1000 else 0,
+    readyPeerList = readyPeerList().map { PeerRow(it.remoteAddress(), it.snapSupported(), it.clientId()) },
 )
 
 /** Android actual of [Settings] over the NodeService SharedPreferences statics. */

--- a/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
@@ -18,6 +18,7 @@ import io.myotis.ui.EnsResult
 import io.myotis.ui.NetworkStatus
 import io.myotis.ui.NodeController
 import io.myotis.ui.NodeSnapshot
+import io.myotis.ui.PeerRow
 import io.myotis.ui.Settings
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -231,26 +232,35 @@ class DesktopNodeController(private val dataDir: Path, private val settings: Set
         val active = conn?.activePeers ?: emptyList()
         // "ready" = peers past the eth handshake, matching Android's filtered count (the raw
         // active list also includes peers still negotiating Hello/Status).
-        val ready = active.count { "READY" == it.state() }
+        val readyList = active.filter { "READY" == it.state() }
         val backend = stack.rpcBackend()
         return NodeSnapshot(
             running = stack.isRunning,
             network = net.name(),
             beaconState = state,
             connectedPeers = active.size,
-            readyPeers = ready,
+            readyPeers = readyList.size,
             snapPeers = conn?.activeSnapHandlers()?.size ?: 0,
             // Desktop's connector exposes only the serving handlers, so serving == negotiated here.
             snapServingPeers = conn?.activeSnapHandlers()?.size ?: 0,
             discoveredPeers = disc4?.table()?.size() ?: 0,
+            // Prune expired entries before counting (backoff() leaks expired entries until a peer
+            // is re-encountered) — matches Android's NodeService, which uses this same accessor.
+            backedOffPeers = stack.pruneAndCountActiveBackoff(),
+            blacklistedPeers = stack.blacklistedNodeIds().size,
+            discv5Peers = stack.discV5()?.liveNodeCount() ?: 0,
             executionBlockNumber = bss?.executionBlockNumber ?: 0L,
             finalizedSlot = bss?.finalizedSlot ?: 0L,
+            syncStartPeriod = bss?.catchUpStartPeriod ?: -1L,
             syncCurrentPeriod = bss?.currentSyncCommitteePeriod ?: 0L,
             syncTargetPeriod = BeaconChainSpec.currentPeriod(net.clGenesisTime(), net.secondsPerSlot()),
             // Real age of the last verified RPC head, or MAX_VALUE if RPC hasn't built one yet
             // (same sentinel Android's NodeService uses; the UI renders it as "—").
             verifiedHeadAgeMs = backend?.verifiedHeadAgeMs() ?: Long.MAX_VALUE,
             uptimeSeconds = (System.nanoTime() - startNs) / 1_000_000_000L,
+            // snap-capable peers first (matches Android's ordering).
+            readyPeerList = readyList.sortedByDescending { it.snapSupported() }
+                .map { PeerRow(it.remoteAddress(), it.snapSupported(), it.clientId()) },
         )
     }
 }

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeController.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeController.kt
@@ -142,10 +142,22 @@ data class NodeSnapshot(
     val snapPeers: Int,             // peers that negotiated snap/1 (capability)
     val snapServingPeers: Int,      // peers actually in the serving pool now (drives readiness)
     val discoveredPeers: Int,
+    val backedOffPeers: Int,        // peers in dial backoff right now
+    val blacklistedPeers: Int,      // peers permanently blacklisted this session
+    val discv5Peers: Int,           // live nodes in the discv5 (CL) routing table
     val executionBlockNumber: Long,
     val finalizedSlot: Long,
+    val syncStartPeriod: Long,      // sync-committee catch-up start period (-1 if unknown)
     val syncCurrentPeriod: Long,
     val syncTargetPeriod: Long,
     val verifiedHeadAgeMs: Long,
     val uptimeSeconds: Long,
+    val readyPeerList: List<PeerRow>,  // per-peer detail for the READY peers
+)
+
+/** One connected READY peer, for the Status peer list. */
+data class PeerRow(
+    val remoteAddress: String,
+    val snapSupported: Boolean,
+    val clientId: String?,          // null until the peer sends Hello
 )

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
@@ -388,6 +389,7 @@ private fun StatusTab(
         if (snap == null) {
             Text("Node stopped — no data for $primary")
         } else {
+            SyncProgressBar(snap)
             StatusView(snap)
         }
 
@@ -421,6 +423,60 @@ private fun StatusTab(
             onClick = { controller.resetSyncState(primary) },
             modifier = Modifier.fillMaxWidth(),
         ) { Text("Reset sync state") }
+
+        // Per-peer detail for the READY peers (address, snap support, client id).
+        if (snap != null && snap.readyPeerList.isNotEmpty()) {
+            Spacer(Modifier.height(16.dp))
+            Text("READY peers (${snap.readyPeerList.size})", style = MaterialTheme.typography.titleSmall)
+            Spacer(Modifier.height(4.dp))
+            snap.readyPeerList.forEach { PeerRowView(it) }
+        }
+    }
+}
+
+/** App-wide beacon sync banner: indeterminate while bootstrapping, determinate as the light
+ *  client catches up sync-committee periods, gone once SYNCED. */
+@Composable
+private fun SyncProgressBar(s: NodeSnapshot) {
+    if (!s.running || s.beaconState == "SYNCED" || s.beaconState == "STOPPED") return
+    val start = s.syncStartPeriod
+    val current = s.syncCurrentPeriod
+    val target = s.syncTargetPeriod
+    val determinate = s.beaconState == "CATCHING_UP" && start >= 0 && target > start
+    Column(Modifier.fillMaxWidth().padding(bottom = 10.dp)) {
+        Text(
+            when {
+                !determinate -> "Bootstrapping light client…"
+                current >= target -> "Finishing sync…"
+                else -> "Catching up sync committees — period $current / $target"
+            },
+            style = MaterialTheme.typography.bodySmall,
+        )
+        Spacer(Modifier.height(4.dp))
+        if (determinate) {
+            val progress = ((current - start).toFloat() / (target - start).toFloat()).coerceIn(0f, 1f)
+            LinearProgressIndicator(progress = { progress }, modifier = Modifier.fillMaxWidth())
+        } else {
+            LinearProgressIndicator(Modifier.fillMaxWidth())
+        }
+    }
+}
+
+/** One tappable-free READY-peer row: address + snap flag, with the client id beneath. */
+@Composable
+private fun PeerRowView(p: PeerRow) {
+    Column(Modifier.padding(vertical = 2.dp)) {
+        Text(
+            "${p.remoteAddress}  snap=${p.snapSupported}",
+            fontFamily = FontFamily.Monospace, fontSize = 12.sp,
+            maxLines = 1, overflow = TextOverflow.Ellipsis,
+        )
+        Text(
+            p.clientId ?: "(no clientId)",
+            fontFamily = FontFamily.Monospace, fontSize = 11.sp,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1, overflow = TextOverflow.Ellipsis,
+        )
     }
 }
 
@@ -457,8 +513,11 @@ private fun StatusView(s: NodeSnapshot) {
         StatusRow("Network", s.network)
         StatusRow("Beacon", s.beaconState)
         StatusRow("EL block", s.executionBlockNumber.toString())
-        StatusRow("Peers", "${s.connectedPeers} (ready ${s.readyPeers}, snap ${s.snapPeers})")
+        StatusRow("Peers", "${s.connectedPeers} (ready ${s.readyPeers}, snap ${s.snapPeers}, serving ${s.snapServingPeers})")
         StatusRow("Discovered", s.discoveredPeers.toString())
+        StatusRow("discv5 peers", s.discv5Peers.toString())
+        StatusRow("In backoff", s.backedOffPeers.toString())
+        StatusRow("Blacklisted", s.blacklistedPeers.toString())
         StatusRow("Sync period", "${s.syncCurrentPeriod} / ${s.syncTargetPeriod}")
         // verifiedHeadAgeMs == Long.MAX_VALUE is the "no verified head yet" sentinel — show a
         // dash instead of the raw ~9.2e18 ms, which would read as a nonsensical age.
@@ -653,10 +712,23 @@ private fun looksLikeEnsName(input: String): Boolean {
 
 @Composable
 private fun AccountResultView(a: AccountResult) {
+    val clipboard = LocalClipboardManager.current
     Column {
+        Row(
+            Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text("Result", style = MaterialTheme.typography.titleSmall)
+            // One-tap copy of the FULL result (untruncated hex), for pasting into a block explorer.
+            OutlinedButton(onClick = { clipboard.setText(AnnotatedString(formatAccountResult(a))) }) {
+                Text("Copy")
+            }
+        }
         StatusRow("Address", a.address)
         StatusRow("Exists", a.exists.toString())
         if (a.exists) {
+            StatusRow("Balance (ETH)", formatEth(a.balanceWei))
             StatusRow("Balance (wei)", a.balanceWei ?: "—")
             StatusRow("Nonce", a.nonce.toString())
             StatusRow("Storage root", a.storageRootHex ?: "—")
@@ -682,9 +754,58 @@ private fun AccountResultView(a: AccountResult) {
     }
 }
 
+/** Wei (decimal string) → ETH with 6 dp, truncated toward zero. Pure-Kotlin (commonMain has no
+ *  java.math.BigDecimal): pad to ≥19 digits, split at the 18th from the right. Non-numeric input
+ *  passes through unchanged. */
+private fun formatEth(weiDecimal: String?): String {
+    if (weiDecimal == null) return "—"
+    val neg = weiDecimal.startsWith("-")
+    val digits = weiDecimal.trimStart('-')
+    if (digits.isEmpty() || !digits.all { it in '0'..'9' }) return weiDecimal
+    val padded = digits.padStart(19, '0')
+    val intPart = padded.dropLast(18).trimStart('0').ifEmpty { "0" }
+    val frac = padded.takeLast(18).take(6)
+    return (if (neg) "-" else "") + "$intPart.$frac"
+}
+
+/** Full plaintext dump of an account result for the clipboard (untruncated hex). */
+private fun formatAccountResult(a: AccountResult): String = buildString {
+    appendLine("address: ${a.address}")
+    appendLine("exists: ${a.exists}")
+    if (a.exists) {
+        appendLine("balance (ETH): ${formatEth(a.balanceWei)}")
+        appendLine("balance (wei): ${a.balanceWei ?: "—"}")
+        appendLine("nonce: ${a.nonce}")
+        a.storageRootHex?.let { appendLine("storageRoot: $it") }
+        a.codeHashHex?.let { appendLine("codeHash: $it") }
+    }
+    appendLine("block: ${a.blockNumber}")
+    a.peerStateRootHex?.let { appendLine("peerStateRoot: $it") }
+    appendLine("peerProofValid: ${a.peerProofValid}")
+    appendLine("beaconVerified: ${a.beaconChainVerified}")
+    if (a.beaconChainVerified) {
+        a.verifyMethod?.let { appendLine("method: $it") }
+        appendLine("matchedSlot: ${a.matchedBeaconSlot}")
+        appendLine("blsVerified: ${a.blsVerified}")
+    } else {
+        a.failReason?.let { appendLine("failReason: $it") }
+    }
+}
+
 @Composable
 private fun EnsResultView(e: EnsResult) {
+    val clipboard = LocalClipboardManager.current
     Column {
+        Row(
+            Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text("ENS", style = MaterialTheme.typography.titleSmall)
+            e.addressHex?.let { addr ->
+                OutlinedButton(onClick = { clipboard.setText(AnnotatedString(addr)) }) { Text("Copy address") }
+            }
+        }
         StatusRow("Name", e.name)
         StatusRow("Address", e.addressHex ?: "—")
         StatusRow("Block", if (e.blockNumber >= 0) e.blockNumber.toString() else "—")

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
@@ -445,10 +445,13 @@ private fun SyncProgressBar(s: NodeSnapshot) {
     val determinate = s.beaconState == "CATCHING_UP" && start >= 0 && target > start
     Column(Modifier.fillMaxWidth().padding(bottom = 10.dp)) {
         Text(
+            // Label follows the beacon STATE, not the bar's determinacy — a CATCHING_UP node with
+            // an unknown start period still reads "catching up", never "bootstrapping".
             when {
-                !determinate -> "Bootstrapping light client…"
-                current >= target -> "Finishing sync…"
-                else -> "Catching up sync committees — period $current / $target"
+                s.beaconState != "CATCHING_UP" -> "Bootstrapping light client…"
+                determinate && current >= target -> "Finishing sync…"
+                determinate -> "Catching up sync committees — period $current / $target"
+                else -> "Catching up sync committees…"
             },
             style = MaterialTheme.typography.bodySmall,
         )
@@ -515,7 +518,7 @@ private fun StatusView(s: NodeSnapshot) {
         StatusRow("EL block", s.executionBlockNumber.toString())
         StatusRow("Peers", "${s.connectedPeers} (ready ${s.readyPeers}, snap ${s.snapPeers}, serving ${s.snapServingPeers})")
         StatusRow("Discovered", s.discoveredPeers.toString())
-        StatusRow("discv5 peers", s.discv5Peers.toString())
+        StatusRow("Discv5 peers", s.discv5Peers.toString())
         StatusRow("In backoff", s.backedOffPeers.toString())
         StatusRow("Blacklisted", s.blacklistedPeers.toString())
         StatusRow("Sync period", "${s.syncCurrentPeriod} / ${s.syncTargetPeriod}")


### PR DESCRIPTION
Task #32 — restores Status-tab detail + account-result affordances the old Android UI had, now in the shared `:ui` so **both** platforms gain them.

## Changes
- `NodeSnapshot` gains `backedOffPeers`, `blacklistedPeers`, `discv5Peers`, `syncStartPeriod`, `readyPeerList` (new `PeerRow` model).
- **StatusView**: expanded peer line (`ready / snap / serving`) + discv5 / in-backoff / blacklisted counts.
- **StatusTab**: a **SyncProgressBar** (indeterminate while bootstrapping, determinate while catching up sync-committee periods) and a per-peer **READY peer list** (address, snap, client id).
- **AccountResultView**: a **Balance (ETH)** row (string-based `formatEth` — commonMain has no `java.math.BigDecimal`) + a **Copy** button (full untruncated result); **EnsResultView** gets a Copy-address button.

## Actuals
- Android maps from `NodeService.Snapshot`.
- Desktop computes from `ChainStack`: `pruneAndCountActiveBackoff()` (pruned — matches Android, not the raw leaky `backoff().size`), `discV5().liveNodeCount()`, `catchUpStartPeriod`, READY peers sorted snap-first.

## Review & verification
- **Independent pre-PR review** — verdict was "fix first": it caught a real bug where Desktop used raw `backoff().size` (overcounts leaked/expired entries — I saw "In backoff: 463" after 6 s on the running app). **Fixed** to `pruneAndCountActiveBackoff()`, matching Android. `formatEth` was hand-tested across edge cases and is correct; MP hygiene clean; both snapshot constructors updated.
- **Screenshot-verified** on the actual desktop app (Status shows the progress bar + new stats).
- `./gradlew :app-desktop:compileKotlin` and `:android-app:assembleDebug` → green.

## Deferred (tracked follow-up)
The deep beacon/CL breakdown (bootstrapped, CL peer connected/lc/cached, execution hash, cached-at-boot, dialing count) needs desktop backend accessors `ChainStack`/`BeaconSyncState` don't expose yet — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)