### PR TITLE
refactor(daemon): dedup get-account verification onto VerifiedAccountQuery

### DIFF
--- a/app/src/main/java/com/jaeckel/ethp2p/app/CommandHandler.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/CommandHandler.java
@@ -720,6 +720,9 @@ public class CommandHandler {
                 + ",\"proof\":" + proofJson
                 + ",\"verification\":" + verificationJson + "}";
         } catch (Exception e) {
+            // The blocking .get() calls above (requestAccount, verify) can throw
+            // InterruptedException; restore the interrupt status so cancellation propagates.
+            if (e instanceof InterruptedException) Thread.currentThread().interrupt();
             Throwable cause = e.getCause() != null ? e.getCause() : e;
             String msg = cause.getMessage() != null ? cause.getMessage() : cause.getClass().getSimpleName();
             return jsonError(msg);

--- a/app/src/main/java/com/jaeckel/ethp2p/app/CommandHandler.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/CommandHandler.java
@@ -5,6 +5,7 @@ import com.jaeckel.ethp2p.consensus.BeaconSyncState;
 import com.jaeckel.ethp2p.consensus.libp2p.BeaconP2PService;
 import com.jaeckel.ethp2p.consensus.lightclient.BeaconChainSpec;
 import com.jaeckel.ethp2p.consensus.proof.MerklePatriciaVerifier;
+import io.myotis.node.VerifiedAccountQuery;
 import com.jaeckel.ethp2p.core.types.BlockHeader;
 import com.jaeckel.ethp2p.networking.discv4.DiscV4Service;
 import com.jaeckel.ethp2p.networking.discv4.KademliaTable;
@@ -684,23 +685,19 @@ public class CommandHandler {
             proofSb.append("]");
             String proofJson = proofSb.toString();
 
-            // Verify proof against the peer's state root (should always pass if proof is non-empty)
-            // and against the beacon-verified state root (passes only if roots coincide)
-            String verificationJson = buildVerificationJson(address.toArrayUnsafe(), result.proof(),
-                    found != null ? found.nonce() : -1,
-                    found != null ? found.balance().toString() : null,
-                    result.stateRoot(), result.blockNumber());
+            // Run the SHARED verification ladder (io.myotis.node.VerifiedAccountQuery.verify) —
+            // the single home of the trust anchor — instead of a daemon-local copy. One pass
+            // yields both the beacon verdict AND the proof-verified leaf.
+            VerifiedAccountQuery.Verification v =
+                    VerifiedAccountQuery.verify(result, address, beaconSyncState, connector)
+                            .get(90, TimeUnit.SECONDS);
+            String verificationJson = buildVerificationJson(
+                    v, result.stateRoot(), !result.proof().isEmpty(), result.blockNumber());
 
-            // storageRoot/codeHash from the proof-verified leaf, not the peer's
-            // slim body — a peer can forge those two while keeping nonce/balance
-            // honest, and the slim values would otherwise ride along as "verified".
-            MerklePatriciaVerifier.VerifiedAccount verifiedAcct =
-                    (found != null && result.stateRoot() != null && !result.proof().isEmpty())
-                            ? MerklePatriciaVerifier.verifyAndExtractAccount(
-                                    result.stateRoot().toArrayUnsafe(), address.toArrayUnsafe(),
-                                    result.proof().stream().map(Bytes::toArrayUnsafe).toList(),
-                                    found.nonce(), found.balance().toString())
-                            : null;
+            // storageRoot/codeHash from the proof-verified leaf (v.verifiedAcct), not the peer's
+            // slim body — a peer can forge those two while keeping nonce/balance honest, and the
+            // slim values would otherwise ride along as "verified".
+            MerklePatriciaVerifier.VerifiedAccount verifiedAcct = v.verifiedAcct;
 
             if (found == null) {
                 return "{\"ok\":true,\"exists\":false"
@@ -1682,100 +1679,39 @@ public class CommandHandler {
     // Beacon proof verification helpers
     // -------------------------------------------------------------------------
 
-    private String buildVerificationJson(byte[] address, List<Bytes> proofNodes,
-                                          long nonce, String balance,
-                                          Bytes32 peerStateRoot, long peerBlockNumber) {
-        List<byte[]> proofBytes = proofNodes.stream().map(Bytes::toArrayUnsafe).toList();
+    /**
+     * Serialize the shared {@link VerifiedAccountQuery.Verification} verdict into the daemon's
+     * get-account "verification" JSON, plus the daemon-only diagnostics (finalized / wall-clock
+     * period lag, block numbers). The verification LADDER now lives ONLY in VerifiedAccountQuery;
+     * this method is pure serialization (the daemon used to re-implement the ladder here).
+     */
+    private String buildVerificationJson(VerifiedAccountQuery.Verification v,
+                                          Bytes32 peerStateRoot, boolean proofPresent,
+                                          long peerBlockNumber) {
+        String peerStateRootHex = (peerStateRoot != null && proofPresent) ? peerStateRoot.toHexString() : null;
 
-        // Verify against the peer's state root (the root the proof was actually built for)
-        boolean peerProofValid = false;
-        String peerStateRootHex = null;
-        if (peerStateRoot != null && !proofBytes.isEmpty()) {
-            peerProofValid = MerklePatriciaVerifier.verify(
-                    peerStateRoot.toArrayUnsafe(), address, proofBytes, nonce, balance);
-            peerStateRootHex = peerStateRoot.toHexString();
-        }
-
-        // Check if the peer's state root matches any beacon-attested block.
-        boolean beaconChainVerified = false;
-        boolean blsVerified = false;
-        long matchedSlot = -1;
-        String verifyMethod = null;
-        String failReason = null;
-
-        if (peerStateRoot != null) {
-            BeaconSyncState.SlottedStateRoot match =
-                    beaconSyncState.findStateRoot(peerStateRoot.toArrayUnsafe());
-            if (match != null) {
-                beaconChainVerified = true;
-                matchedSlot = match.slot();
-                blsVerified = match.blsVerified();
-                verifyMethod = "stateRootMatch";
-            }
-        }
-
-        // Atomic snapshot — see note at the get-storage verification path. Block number
-        // and state root must describe the same finalized payload.
-        BeaconSyncState.FinalizedExecution fin = beaconSyncState.getFinalizedExecution();
-        long finalizedBlockNum = fin.blockNumber();
-        byte[] beaconRoot = fin.stateRoot();
+        // Daemon-only diagnostics (not carried by the shared Verification).
+        long finalizedBlockNum = beaconSyncState.getFinalizedExecution().blockNumber();
         long finalizedPeriod = beaconSyncState.getFinalizedPeriod();
         long wallClockPeriod = BeaconChainSpec.currentPeriod(clGenesisTime, secondsPerSlot);
         long periodLag = wallClockPeriod - finalizedPeriod;
 
-        if (!beaconChainVerified) {
-            if (peerStateRoot == null) {
-                failReason = "noPeerStateRoot";
-            } else if (!peerProofValid) {
-                failReason = "peerProofInvalid";
-            } else if (!beaconSyncState.isSynced()) {
-                failReason = "beaconNotSynced";
-            } else if (peerBlockNumber <= 0) {
-                failReason = "noPeerBlockNumber";
-            } else if (finalizedBlockNum <= 0 || beaconRoot == null) {
-                failReason = "beaconBlockUnavailable";
-            } else if (peerBlockNumber <= finalizedBlockNum) {
-                failReason = "peerBlockBehindFinalized";
-            } else if (peerBlockNumber - finalizedBlockNum > MAX_HEADER_CHAIN_GAP) {
-                failReason = "headerChainGapTooLarge";
-            } else {
-                log.info("[verify] headerChain: peerBlock={}, finalizedBlock={}, gap={}",
-                        peerBlockNumber, finalizedBlockNum, peerBlockNumber - finalizedBlockNum);
-                try {
-                    boolean chainValid = verifyHeaderChainBatched(
-                            finalizedBlockNum, peerBlockNumber, beaconRoot,
-                            peerStateRoot.toArrayUnsafe());
-                    if (chainValid) {
-                        beaconChainVerified = true;
-                        matchedSlot = beaconSyncState.getFinalizedSlot();
-                        blsVerified = true;
-                        verifyMethod = "headerChain";
-                    } else {
-                        failReason = "headerChainInvalid";
-                    }
-                } catch (Exception e) {
-                    log.info("[verify] Header chain verification failed: {}", e.getMessage());
-                    failReason = "headerChainError";
-                }
-            }
-        }
-
         StringBuilder sb = new StringBuilder("{");
-        sb.append("\"peerProofValid\":").append(peerProofValid);
+        sb.append("\"peerProofValid\":").append(v.peerProofValid);
         if (peerStateRootHex != null) {
             sb.append(",\"peerStateRoot\":\"").append(peerStateRootHex).append("\"");
         }
         sb.append(",\"beaconSynced\":").append(beaconSyncState.isSynced());
-        sb.append(",\"beaconChainVerified\":").append(beaconChainVerified);
-        if (beaconChainVerified) {
-            sb.append(",\"matchedBeaconSlot\":").append(matchedSlot);
-            sb.append(",\"blsVerified\":").append(blsVerified);
-            if (verifyMethod != null) {
-                sb.append(",\"verifyMethod\":\"").append(verifyMethod).append("\"");
+        sb.append(",\"beaconChainVerified\":").append(v.beaconChainVerified);
+        if (v.beaconChainVerified) {
+            sb.append(",\"matchedBeaconSlot\":").append(v.matchedSlot);
+            sb.append(",\"blsVerified\":").append(v.blsVerified);
+            if (v.verifyMethod != null) {
+                sb.append(",\"verifyMethod\":\"").append(v.verifyMethod).append("\"");
             }
         } else {
-            if (failReason != null) {
-                sb.append(",\"failReason\":\"").append(failReason).append("\"");
+            if (v.failReason != null) {
+                sb.append(",\"failReason\":\"").append(v.failReason).append("\"");
             }
             sb.append(",\"finalizedPeriod\":").append(finalizedPeriod);
             sb.append(",\"wallClockPeriod\":").append(wallClockPeriod);

--- a/node-core/src/main/java/io/myotis/node/VerifiedAccountQuery.java
+++ b/node-core/src/main/java/io/myotis/node/VerifiedAccountQuery.java
@@ -104,12 +104,16 @@ public final class VerifiedAccountQuery {
      * Mutable verification scratchpad. Keeps the two verification methods (headerChain +
      * stateRootMatch) from threading several separate parameters through the async chain.
      */
-    private static final class Verification {
-        boolean beaconChainVerified;
-        boolean blsVerified;
-        long matchedSlot = -1;
-        String verifyMethod;
-        String failReason;
+    public static final class Verification {
+        /** Proof verifies against the peer's own stateRoot (necessary, not sufficient for trust). */
+        public boolean peerProofValid;
+        /** The proof-verified leaf (authoritative storageRoot/codeHash); null when the proof didn't verify. */
+        public MerklePatriciaVerifier.VerifiedAccount verifiedAcct;
+        public boolean beaconChainVerified;
+        public boolean blsVerified;
+        public long matchedSlot = -1;
+        public String verifyMethod;
+        public String failReason;
     }
 
     private static CompletableFuture<Result> buildAccountResult(
@@ -127,27 +131,48 @@ public final class VerifiedAccountQuery {
             }
         }
         final AccountRangeMessage.AccountData foundFinal = found;
+        return verify(result, address, bss, connector)
+                .thenApply(v -> finalizeResult(addr, foundFinal, result, v));
+    }
+
+    /**
+     * Run the proof + beacon verification ladder for a snap AccountRange response, returning the
+     * {@link Verification} verdict WITHOUT building the full {@link Result}. This is the single
+     * home of the trust anchor (proof-against-peer-root → beacon stateRootMatch → BLS-attested
+     * headerChain): {@link #query} and the JVM daemon's {@code get-account} both call it, so the
+     * verification logic lives in exactly one place. The returned future completes only
+     * exceptionally for a transport error in the header fetch; verification *failures* set
+     * {@link Verification#failReason}.
+     */
+    public static CompletableFuture<Verification> verify(
+            AccountRangeMessage.DecodeResult result,
+            Bytes address,
+            BeaconSyncState bss,
+            RLPxConnector connector) {
+        Bytes32 accountHash = Hash.keccak256(address);
+        AccountRangeMessage.AccountData found = null;
+        for (AccountRangeMessage.AccountData a : result.accounts()) {
+            if (a.accountHash().equals(accountHash)) {
+                found = a;
+                break;
+            }
+        }
         long nonce = found != null ? found.nonce() : -1;
         String balance = found != null ? found.balance().toString() : null;
 
-        boolean peerProofValid = false;
-        MerklePatriciaVerifier.VerifiedAccount verifiedAcct = null;
+        Verification v = new Verification();
         if (result.stateRoot() != null && !result.proof().isEmpty()) {
             List<byte[]> proofBytes = new ArrayList<>(result.proof().size());
             for (Bytes b : result.proof()) proofBytes.add(b.toArrayUnsafe());
-            // verifyAndExtractAccount returns the storageRoot/codeHash from the
-            // proof-verified leaf — NOT the peer's slim body — so a peer can't
-            // forge those two fields while keeping nonce/balance honest.
-            verifiedAcct = MerklePatriciaVerifier.verifyAndExtractAccount(
+            // verifyAndExtractAccount returns the storageRoot/codeHash from the proof-verified
+            // leaf — NOT the peer's slim body — so a peer can't forge those two while keeping
+            // nonce/balance honest.
+            v.verifiedAcct = MerklePatriciaVerifier.verifyAndExtractAccount(
                     result.stateRoot().toArrayUnsafe(),
                     address.toArrayUnsafe(),
                     proofBytes, nonce, balance);
-            peerProofValid = (verifiedAcct != null);
+            v.peerProofValid = (v.verifiedAcct != null);
         }
-        final boolean peerProofValidFinal = peerProofValid;
-        final MerklePatriciaVerifier.VerifiedAccount verifiedAcctFinal = verifiedAcct;
-
-        Verification v = new Verification();
 
         // Fast-path shortcut: if the BLC has already attested the peer's exact stateRoot, we're
         // done — no header fetch needed. Rare, but free to check.
@@ -159,8 +184,7 @@ public final class VerifiedAccountQuery {
                 v.matchedSlot = match.slot();
                 v.blsVerified = match.blsVerified();
                 v.verifyMethod = "stateRootMatch";
-                return CompletableFuture.completedFuture(
-                        finalizeResult(addr, foundFinal, result, peerProofValidFinal, verifiedAcctFinal, v));
+                return CompletableFuture.completedFuture(v);
             }
         }
 
@@ -168,7 +192,7 @@ public final class VerifiedAccountQuery {
         // chain verification if every prerequisite holds.
         if (result.stateRoot() == null) {
             v.failReason = "noPeerStateRoot";
-        } else if (!peerProofValid) {
+        } else if (!v.peerProofValid) {
             v.failReason = "peerProofInvalid";
         } else if (bss == null || !bss.isSynced()) {
             v.failReason = "beaconNotSynced";
@@ -211,20 +235,17 @@ public final class VerifiedAccountQuery {
                             } else {
                                 v.failReason = "headerChainInvalid";
                             }
-                            return finalizeResult(addr, foundFinal, result, peerProofValidFinal, verifiedAcctFinal, v);
+                            return v;
                         });
             }
         }
 
-        return CompletableFuture.completedFuture(
-                finalizeResult(addr, foundFinal, result, peerProofValidFinal, verifiedAcctFinal, v));
+        return CompletableFuture.completedFuture(v);
     }
 
     private static Result finalizeResult(String addr,
                                          AccountRangeMessage.AccountData found,
                                          AccountRangeMessage.DecodeResult result,
-                                         boolean peerProofValid,
-                                         MerklePatriciaVerifier.VerifiedAccount verified,
                                          Verification v) {
         long nonce = found != null ? found.nonce() : -1;
         String balance = found != null ? found.balance().toString() : null;
@@ -232,11 +253,11 @@ public final class VerifiedAccountQuery {
         // cryptographically anchored rather than peer-claimed. Fall back to the slim body only
         // when the proof didn't verify — in which case the result is already flagged
         // beaconChainVerified=false.
-        String storageRootHex = verified != null
-                ? Bytes.wrap(verified.storageRoot()).toHexString()
+        String storageRootHex = v.verifiedAcct != null
+                ? Bytes.wrap(v.verifiedAcct.storageRoot()).toHexString()
                 : (found != null ? found.storageRoot().toHexString() : null);
-        String codeHashHex = verified != null
-                ? Bytes.wrap(verified.codeHash()).toHexString()
+        String codeHashHex = v.verifiedAcct != null
+                ? Bytes.wrap(v.verifiedAcct.codeHash()).toHexString()
                 : (found != null ? found.codeHash().toHexString() : null);
         return new Result(
                 addr,
@@ -247,7 +268,7 @@ public final class VerifiedAccountQuery {
                 codeHashHex,
                 result.blockNumber(),
                 result.stateRoot() != null ? result.stateRoot().toHexString() : null,
-                peerProofValid,
+                v.peerProofValid,
                 v.beaconChainVerified,
                 v.blsVerified,
                 v.matchedSlot,

--- a/node-core/src/main/java/io/myotis/node/VerifiedAccountQuery.java
+++ b/node-core/src/main/java/io/myotis/node/VerifiedAccountQuery.java
@@ -140,9 +140,10 @@ public final class VerifiedAccountQuery {
      * {@link Verification} verdict WITHOUT building the full {@link Result}. This is the single
      * home of the trust anchor (proof-against-peer-root → beacon stateRootMatch → BLS-attested
      * headerChain): {@link #query} and the JVM daemon's {@code get-account} both call it, so the
-     * verification logic lives in exactly one place. The returned future completes only
-     * exceptionally for a transport error in the header fetch; verification *failures* set
-     * {@link Verification#failReason}.
+     * verification logic lives in exactly one place. The returned future normally completes with
+     * a verdict rather than exceptionally: a transport error in the header fetch is caught and
+     * surfaced as {@code failReason="headerChainError"}, and all other verification *failures*
+     * likewise set {@link Verification#failReason} while completing the future normally.
      */
     public static CompletableFuture<Verification> verify(
             AccountRangeMessage.DecodeResult result,
@@ -250,9 +251,11 @@ public final class VerifiedAccountQuery {
         long nonce = found != null ? found.nonce() : -1;
         String balance = found != null ? found.balance().toString() : null;
         // storageRoot/codeHash come from the proof-verified leaf when we have it, so they're
-        // cryptographically anchored rather than peer-claimed. Fall back to the slim body only
-        // when the proof didn't verify — in which case the result is already flagged
-        // beaconChainVerified=false.
+        // cryptographically anchored rather than peer-claimed. Fall back to the slim (peer-claimed)
+        // body only when the leaf proof didn't verify (v.verifiedAcct == null). Note this is gated
+        // on peerProofValid, NOT beaconChainVerified: the beacon stateRootMatch fast-path can set
+        // beaconChainVerified=true even when the leaf proof didn't verify, so it is not a proxy for
+        // "we have a proof-verified leaf".
         String storageRootHex = v.verifiedAcct != null
                 ? Bytes.wrap(v.verifiedAcct.storageRoot()).toHexString()
                 : (found != null ? found.storageRoot().toHexString() : null);


### PR DESCRIPTION
Task #23. The daemon's `CommandHandler.buildVerificationJson` re-implemented the **exact** stateRootMatch → BLS-attested-headerChain verification ladder that `io.myotis.node.VerifiedAccountQuery` (used by the Android + desktop apps) already owns. That ladder is the project's **trust anchor**, so it should live in exactly one place.

## Change (Option 1 — chosen to keep the daemon JSON byte-identical)
- **`VerifiedAccountQuery`**: extract the ladder into a public `verify(DecodeResult, address, BeaconSyncState, RLPxConnector) → CompletableFuture<Verification>` (the old `buildAccountResult` body, moved verbatim). `query()` now does `verify().thenApply(finalizeResult)`. `Verification` is public and carries `peerProofValid` + the proof-verified leaf.
- **Daemon `handleGetAccount`**: calls `VerifiedAccountQuery.verify(...)` and reads `v.verifiedAcct`; `buildVerificationJson` becomes a **pure serializer** (drops its duplicated ladder).

## Guarantees (independently reviewed before opening)
An adversarial pre-PR review confirmed:
- **App-path `Result` identical** — line-by-line, all 14 fields, all scenarios (stateRootMatch / headerChain / each failReason / non-existent).
- **Daemon JSON byte-identical** — same fields/order/conditions; the `peerStateRoot` emission condition is reproduced via a `proofPresent` param, and `peerProofValid` is unchanged (`MerklePatriciaVerifier.verify(...)` is literally `verifyAndExtractAccount(...) != null`).
- **No verification-weakening path** (the dangerous direction) — none; the ladder, `MAX_HEADER_CHAIN_GAP`, timeouts, and the proof-verified-leaf storageRoot/codeHash are unchanged.
- Header-fetch timeout preserved (`verify` bounds it at 60s; daemon waits 90s; header-fetch errors still surface as a normal `failReason`, not an exception).

## Scope
`get-storage` still has its own inline ladder, so the daemon's `verifyHeaderChainBatched`/`verifyHeaderChain` stay (used by it) — deduping get-storage is a separate follow-up.

## Verification
- `./gradlew :node-core:test :app:compileJava :app-desktop:compileKotlin :android-app:assembleDebug` → all green.
- ⚠️ The SYNCED-node integration test (`get-account … → "verifyMethod":"headerChain"`, per CLAUDE.md) **can't run in CI / here without a synced node**. Static analysis shows byte-identical output; please run it once against a synced daemon before/after merge to close the residual runtime gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)