### PR TITLE
ci: stop double-running APK/DMG/replay workflows; cancel superseded runs

### DIFF
--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -1,8 +1,20 @@
 name: Android APK
 
 on:
+  # Scope push to main + release tags so a branch push that also has an open PR
+  # doesn't build twice (the PR is covered by pull_request below). Tags still
+  # build the release .apk.
   push:
+    branches: [ "main" ]
+    tags: [ "v*" ]
+  # pull_request stays unscoped (any base branch) — the double-run is already
+  # killed by narrowing push above, and this keeps CI on PRs that don't target main.
   pull_request:
+
+# Cancel a superseded run when new commits land on the same branch/PR.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/desktop-dmg.yml
+++ b/.github/workflows/desktop-dmg.yml
@@ -1,8 +1,21 @@
 name: Desktop DMG (macOS)
 
 on:
+  # Scope push to main + release tags so a branch push that also has an open PR
+  # doesn't build twice (the PR is covered by pull_request below). Tags still
+  # build the release .dmg.
   push:
+    branches: [ "main" ]
+    tags: [ "v*" ]
+  # pull_request stays unscoped (any base branch) — the double-run is already
+  # killed by narrowing push above, and this keeps CI on PRs that don't target main.
   pull_request:
+
+# Cancel a superseded run when new commits land on the same branch/PR (each of
+# the two arch jobs is cancelled/restarted together).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/mm-replay-tests.yml
+++ b/.github/workflows/mm-replay-tests.yml
@@ -1,8 +1,19 @@
 name: mm-replay tests
 
 on:
+  # Scope push to main + release tags so a branch push that also has an open PR
+  # doesn't run twice (the PR is covered by pull_request below).
   push:
+    branches: [ "main" ]
+    tags: [ "v*" ]
+  # pull_request stays unscoped (any base branch) — the double-run is already
+  # killed by narrowing push above, and this keeps CI on PRs that don't target main.
   pull_request:
+
+# Cancel a superseded run when new commits land on the same branch/PR.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 # Unit tests for the MetaMask replay harness (tools/mm-replay/replay.py) and the
 # golden session fixture. Pure stdlib Python — no Gradle, no external Maven


### PR DESCRIPTION
## Problem
The **Android APK**, **Desktop DMG**, and **mm-replay tests** workflows each used bare `on: push:` + `on: pull_request:`. For any push to a branch that also has an open PR, GitHub fires **both** triggers → **two identical runs** per push (the duplicate check runs the screenshot flagged).

## Fix #1 — kill the double-run
Scope `push:` to `branches: [main]` + `tags: [v*]`:
- **PRs** build via the `pull_request` trigger (one run).
- **Merges to main** build via `push: branches: [main]`.
- **Release tags `v*`** build via `push: tags: [v*]` (still emit the release `.apk`/`.dmg`).

`pull_request` is left **unscoped** (any base branch): narrowing `push` already removes the duplicate, and leaving `pull_request` open keeps CI running on PRs that don't target `main` (stacked PRs) — no coverage regression.

### Deliberately NO `paths:` filters
The desktop `.dmg` and android `.apk` **must** rebuild when the backend changes so they can be tested against every change. Path-scoping was considered and rejected for that reason.

## Fix #3 — cancel superseded runs
Added a top-level `concurrency` block to each:
```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```
Keying on `github.ref` means PR / main / tag runs never cross-cancel (each ref is its own group), and the two `desktop-dmg` matrix arch jobs share one run so they aren't affected — only an outdated in-flight run for the *same* branch/PR is cancelled when new commits land.

## Verification
- All three files parse (`yaml.safe_load`); `concurrency` is a top-level sibling of `on:`/`jobs:`.
- Independent pre-PR review confirmed the dedupe works, the concurrency group is safe against wrongful cross-ref cancellation, and flagged the original `pull_request: branches:[main]` over-narrowing — reverted before opening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)