### PR TITLE
feat: add :myotis-api — the language-neutral engine boundary (API extraction 1/6)

### DIFF
--- a/app/src/main/java/com/jaeckel/ethp2p/app/CommandHandler.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/CommandHandler.java
@@ -687,17 +687,13 @@ public class CommandHandler {
 
             // Run the SHARED verification ladder (io.myotis.node.VerifiedAccountQuery.verify) —
             // the single home of the trust anchor — instead of a daemon-local copy. One pass
-            // yields both the beacon verdict AND the proof-verified leaf.
+            // yields both the beacon verdict AND the proof-verified leaf. Pass the account we
+            // already located so verify() doesn't re-scan the response.
             VerifiedAccountQuery.Verification v =
-                    VerifiedAccountQuery.verify(result, address, beaconSyncState, connector)
+                    VerifiedAccountQuery.verify(result, address, found, beaconSyncState, connector)
                             .get(90, TimeUnit.SECONDS);
             String verificationJson = buildVerificationJson(
                     v, result.stateRoot(), !result.proof().isEmpty(), result.blockNumber());
-
-            // storageRoot/codeHash from the proof-verified leaf (v.verifiedAcct), not the peer's
-            // slim body — a peer can forge those two while keeping nonce/balance honest, and the
-            // slim values would otherwise ride along as "verified".
-            MerklePatriciaVerifier.VerifiedAccount verifiedAcct = v.verifiedAcct;
 
             if (found == null) {
                 return "{\"ok\":true,\"exists\":false"
@@ -706,16 +702,19 @@ public class CommandHandler {
                     + ",\"proof\":" + proofJson
                     + ",\"verification\":" + verificationJson + "}";
             }
+            // storageRoot/codeHash from the proof-verified leaf when available, not the peer's
+            // slim body — a peer can forge those two while keeping nonce/balance honest, and the
+            // slim values would otherwise ride along as "verified".
             return "{\"ok\":true,\"exists\":true"
                 + ",\"address\":\"" + addr + "\""
                 + ",\"accountHash\":\"" + found.accountHash().toHexString() + "\""
                 + ",\"nonce\":" + found.nonce()
                 + ",\"balance\":\"" + found.balance() + "\""
-                + ",\"storageRoot\":\"" + (verifiedAcct != null
-                        ? Bytes.wrap(verifiedAcct.storageRoot()).toHexString()
+                + ",\"storageRoot\":\"" + (v.verifiedStorageRootHex() != null
+                        ? v.verifiedStorageRootHex()
                         : found.storageRoot().toHexString()) + "\""
-                + ",\"codeHash\":\"" + (verifiedAcct != null
-                        ? Bytes.wrap(verifiedAcct.codeHash()).toHexString()
+                + ",\"codeHash\":\"" + (v.verifiedCodeHashHex() != null
+                        ? v.verifiedCodeHashHex()
                         : found.codeHash().toHexString()) + "\""
                 + ",\"proof\":" + proofJson
                 + ",\"verification\":" + verificationJson + "}";
@@ -1700,21 +1699,21 @@ public class CommandHandler {
         long periodLag = wallClockPeriod - finalizedPeriod;
 
         StringBuilder sb = new StringBuilder("{");
-        sb.append("\"peerProofValid\":").append(v.peerProofValid);
+        sb.append("\"peerProofValid\":").append(v.peerProofValid());
         if (peerStateRootHex != null) {
             sb.append(",\"peerStateRoot\":\"").append(peerStateRootHex).append("\"");
         }
         sb.append(",\"beaconSynced\":").append(beaconSyncState.isSynced());
-        sb.append(",\"beaconChainVerified\":").append(v.beaconChainVerified);
-        if (v.beaconChainVerified) {
-            sb.append(",\"matchedBeaconSlot\":").append(v.matchedSlot);
-            sb.append(",\"blsVerified\":").append(v.blsVerified);
-            if (v.verifyMethod != null) {
-                sb.append(",\"verifyMethod\":\"").append(v.verifyMethod).append("\"");
+        sb.append(",\"beaconChainVerified\":").append(v.beaconChainVerified());
+        if (v.beaconChainVerified()) {
+            sb.append(",\"matchedBeaconSlot\":").append(v.matchedSlot());
+            sb.append(",\"blsVerified\":").append(v.blsVerified());
+            if (v.verifyMethod() != null) {
+                sb.append(",\"verifyMethod\":\"").append(v.verifyMethod()).append("\"");
             }
         } else {
-            if (v.failReason != null) {
-                sb.append(",\"failReason\":\"").append(v.failReason).append("\"");
+            if (v.failReason() != null) {
+                sb.append(",\"failReason\":\"").append(v.failReason()).append("\"");
             }
             sb.append(",\"finalizedPeriod\":").append(finalizedPeriod);
             sb.append(",\"wallClockPeriod\":").append(wallClockPeriod);

--- a/myotis-api/build.gradle.kts
+++ b/myotis-api/build.gradle.kts
@@ -1,0 +1,58 @@
+// :myotis-api — the formal, language-neutral engine boundary.
+//
+// This module is the CONTRACT between hosts (the :app daemon, :app-desktop,
+// :android-app) and the engine (node-core + rpc-backend + consensus + networking +
+// myotis-evm/-ens). The Java engine implements it today; a future Rust/Go engine
+// replaces everything behind it via a thin FFI binding implementing the same
+// interfaces (see docs/reimplementation/). Hosts must consume ONLY these types.
+//
+// HARD RULES for everything in this module (FFI-portability + Android minSdk 29):
+//   - ZERO dependencies. Only java.lang / java.util / plain records, interfaces,
+//     enums. The check task below enforces the empty runtime classpath.
+//   - Types crossing the boundary: byte[], String, long/int/boolean, enums, flat
+//     records, java.util.List. NO Tuweni, NO Netty, NO kotlinx, NO
+//     CompletableFuture, NO BigInteger, NO Optional, NO InetSocketAddress,
+//     NO java.nio.file.Path, NO checked exceptions.
+//   - Java 17 bytecode, desugar-safe API only (consumable by :android-app, minSdk 29).
+// Full conventions: io.myotis.api package-info.
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    // `release` (not just source/target) so JDK-21-only library APIs can't slip into
+    // the contract while compiling under the newer toolchain.
+    options.release = 17
+}
+
+dependencies {
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.junit.jupiter)
+}
+
+tasks.test {
+    useJUnitPlatform()
+}
+
+// The API's whole value is being dependency-free (an FFI binding must not have to
+// reproduce third-party types). Fail the build if anything sneaks onto the runtime
+// OR compile classpath — a compileOnly dep would leak third-party types into API
+// signatures while leaving the runtime classpath empty.
+tasks.register("checkZeroDependencies") {
+    val classpaths = mapOf(
+        "runtimeClasspath" to configurations.runtimeClasspath,
+        "compileClasspath" to configurations.compileClasspath,
+    )
+    doLast {
+        for ((label, provider) in classpaths) {
+            val deps = provider.get().resolvedConfiguration.resolvedArtifacts
+            check(deps.isEmpty()) {
+                ":myotis-api must have zero dependencies, but $label has: " +
+                    deps.joinToString { it.name }
+            }
+        }
+    }
+}
+tasks.named("check") { dependsOn("checkZeroDependencies") }

--- a/myotis-api/src/main/java/io/myotis/api/AccountProofResult.java
+++ b/myotis-api/src/main/java/io/myotis/api/AccountProofResult.java
@@ -1,0 +1,60 @@
+package io.myotis.api;
+
+import java.util.List;
+
+/**
+ * A verified account query's full result — the account data, the proof material,
+ * and the verification verdict, plus the beacon diagnostics operator surfaces
+ * emit. Everything the daemon's {@code get-account} IPC JSON contains is
+ * reproducible from this record alone.
+ *
+ * <p>Verification failures set {@link #failReason} (and the relevant booleans);
+ * they are never exceptions.
+ *
+ * @param address               the queried address (0x-hex, as given)
+ * @param exists                whether the account exists in the peer's response
+ * @param nonce                 account nonce; -1 when {@code !exists}
+ * @param balanceWei            decimal wei string, or null when {@code !exists}
+ * @param storageRootHex        from the proof-verified leaf when available (never
+ *                              the peer's slim body in that case), else peer-claimed
+ * @param codeHashHex           same provenance rule as {@code storageRootHex}
+ * @param blockNumber           peer-reported block the proof anchors to
+ * @param peerStateRootHex      the peer's state root the proof was checked against
+ * @param peerProofValid        the MPT proof verifies against {@code peerStateRoot}
+ * @param beaconChainVerified   {@code peerStateRoot} ties to a beacon-attested root
+ * @param blsVerified           the beacon match was BLS-signed
+ * @param matchedBeaconSlot     slot of the matching beacon attestation; -1 if none
+ * @param verifyMethod          "stateRootMatch" / "headerChain" / null
+ * @param failReason            null when verified; otherwise a stable reason token
+ *                              (e.g. "beaconNotSynced", "headerChainGapTooLarge")
+ * @param accountHashHex        keccak256(address) — the snap trie key
+ * @param proofNodesHex         the MPT proof nodes (0x-hex), peer-served
+ * @param beaconSynced          beacon client was SYNCED at query time
+ * @param finalizedPeriod       sync-committee period of the finalized slot
+ * @param wallClockPeriod       wall-clock sync-committee period
+ * @param finalizedBlockNumber  finalized execution block number (0 if none)
+ * @param optimisticBlockNumber optimistic-head execution block number (0 if none)
+ */
+public record AccountProofResult(
+        String address,
+        boolean exists,
+        long nonce,
+        String balanceWei,
+        String storageRootHex,
+        String codeHashHex,
+        long blockNumber,
+        String peerStateRootHex,
+        boolean peerProofValid,
+        boolean beaconChainVerified,
+        boolean blsVerified,
+        long matchedBeaconSlot,
+        String verifyMethod,
+        String failReason,
+        String accountHashHex,
+        List<String> proofNodesHex,
+        boolean beaconSynced,
+        long finalizedPeriod,
+        long wallClockPeriod,
+        long finalizedBlockNumber,
+        long optimisticBlockNumber) {
+}

--- a/myotis-api/src/main/java/io/myotis/api/BeaconState.java
+++ b/myotis-api/src/main/java/io/myotis/api/BeaconState.java
@@ -1,0 +1,7 @@
+package io.myotis.api;
+
+/**
+ * {@link SyncState} plus the pre-bootstrap phase, for status displays:
+ * {@code STARTING} until the beacon client has produced its first state.
+ */
+public enum BeaconState { STARTING, SYNCING, CATCHING_UP, SYNCED }

--- a/myotis-api/src/main/java/io/myotis/api/BlockResult.java
+++ b/myotis-api/src/main/java/io/myotis/api/BlockResult.java
@@ -1,0 +1,50 @@
+package io.myotis.api;
+
+/**
+ * A verified single-block fetch: the header + body summary, plus the beacon
+ * verification verdict. A fetch failure sets {@link #error}; a verification
+ * failure sets {@link #failReason} (e.g. "preMergeBlock",
+ * "headerChainGapTooLarge") with {@code beaconChainVerified=false}.
+ *
+ * @param number              block number
+ * @param hashHex             recomputed block hash (0x-hex)
+ * @param parentHashHex       parent hash
+ * @param stateRootHex        state root
+ * @param transactionsRootHex transactions root
+ * @param receiptsRootHex     receipts root
+ * @param timestamp           block timestamp (unix seconds)
+ * @param gasUsed             gas used
+ * @param gasLimit            gas limit
+ * @param baseFeePerGasWei    base fee in decimal wei, or null pre-London
+ * @param transactionCount    transactions in the body
+ * @param uncleCount          uncles in the body
+ * @param withdrawalCount     withdrawals in the body
+ * @param beaconChainVerified the block ties to a beacon-attested root/hash
+ * @param blsVerified         the beacon match was BLS-signed
+ * @param matchedBeaconSlot   slot of the matching attestation; -1 if none
+ * @param verifyMethod        "stateRootMatch" / "headerChain" / null
+ * @param failReason          null when verified; otherwise a stable reason token
+ * @param error               null when the fetch succeeded; otherwise the fetch
+ *                            failure message (all other fields are zero/null then)
+ */
+public record BlockResult(
+        long number,
+        String hashHex,
+        String parentHashHex,
+        String stateRootHex,
+        String transactionsRootHex,
+        String receiptsRootHex,
+        long timestamp,
+        long gasUsed,
+        long gasLimit,
+        String baseFeePerGasWei,
+        int transactionCount,
+        int uncleCount,
+        int withdrawalCount,
+        boolean beaconChainVerified,
+        boolean blsVerified,
+        long matchedBeaconSlot,
+        String verifyMethod,
+        String failReason,
+        String error) {
+}

--- a/myotis-api/src/main/java/io/myotis/api/ChainHandle.java
+++ b/myotis-api/src/main/java/io/myotis/api/ChainHandle.java
@@ -1,0 +1,106 @@
+package io.myotis.api;
+
+/**
+ * One hosted network's engine surface: lifecycle, live status, verified reads,
+ * ENS, and the verified operator queries the desktop IPC / UIs are built on.
+ *
+ * <p>All methods are blocking — call from a worker thread. The long-running
+ * verification queries are internally timeout-bounded (noted per method) and
+ * return result records whose {@code failReason}/{@code error} fields describe
+ * verification failures; they throw {@link EngineException} only for
+ * programmer/state errors (bad address, network not running).
+ */
+public interface ChainHandle {
+
+    /** Canonical network name this handle serves. */
+    String networkName();
+
+    /** The network's EVM chain id. */
+    long chainId();
+
+    /**
+     * Build and start the stack. Blocking (DNS discovery + component startup,
+     * typically a few seconds). Fault-isolated: on any failure the stack's
+     * resources are closed and {@code false} is returned — never an exception,
+     * and never an effect on sibling networks.
+     */
+    boolean start();
+
+    /** Tear the stack down (reverse component order). Idempotent. */
+    void stop();
+
+    boolean isRunning();
+
+    /** Live-update the snap-peer maintainer target (no restart). */
+    void setTargetSnapPeers(int target);
+
+    /**
+     * Clear the live dial bookkeeping — backoff entries and this session's
+     * blacklist — so discovery re-dials from a fresh slate. On-disk peer-cache
+     * FILES are host-owned; deleting those is the host's job.
+     */
+    void clearPeerState();
+
+    /**
+     * One coherent status snapshot including per-peer rows. Cheap to build;
+     * suitable for polling at 1–2 s.
+     */
+    StatusSnapshot status();
+
+    /**
+     * The verified eth_* read surface, or {@code null} while the RPC backend
+     * isn't started (e.g. the RPC port was unavailable at {@link #start()}).
+     */
+    VerifiedReads reads();
+
+    /**
+     * The ENS resolution surface, or {@code null} when this network has no ENS
+     * registry (see {@link NetworkInfo#hasEns()}).
+     */
+    EnsApi ens();
+
+    // ---- verified operator queries ----
+
+    /**
+     * Fetch {@code hexAddress}'s account from a snap peer and run the full
+     * verification ladder (proof-against-peer-root → beacon stateRootMatch →
+     * BLS-attested headerChain). Blocking, bounded at ~90 s worst case.
+     *
+     * @throws EngineException on a malformed address or when not running
+     */
+    AccountProofResult requestAccount(String hexAddress);
+
+    /**
+     * Fetch and verify one storage slot of {@code hexAddress}. When
+     * {@code holderHexOrNull} is set, the queried key is the Solidity mapping
+     * slot {@code keccak256(holder ‖ slot)} (ERC-20 balance lookups). Blocking,
+     * bounded at ~90 s worst case.
+     *
+     * @throws EngineException on malformed input or when not running
+     */
+    StorageProofResult getStorageProof(String hexAddress, long slot, String holderHexOrNull);
+
+    /**
+     * Fetch {@code count} consecutive block headers starting at
+     * {@code startBlock} from a peer. Headers are integrity-checked (each hash
+     * is recomputed); chain-of-custody verification against the beacon anchor is
+     * the caller's concern ({@link #getBlockVerified} does it for one block).
+     * Blocking, bounded at ~30 s.
+     */
+    HeadersResult getHeaders(long startBlock, int count);
+
+    /**
+     * Fetch one block (header + body summary) and verify it against the beacon
+     * chain (stateRootMatch, else a parent-hash header-chain walk from the
+     * beacon-attested block hash, ≤ 8192 blocks). Blocking, bounded at ~90 s.
+     */
+    BlockResult getBlockVerified(long blockNumber);
+
+    /**
+     * Dial one specific EL peer by endpoint + secp256k1 public key (operator
+     * debugging). Returns immediately after the connect is initiated.
+     *
+     * @throws EngineException on a malformed pubkey or when not running
+     */
+    DialResult dialPeer(String host, int port, String pubkeyHex);
+}

--- a/myotis-api/src/main/java/io/myotis/api/DialResult.java
+++ b/myotis-api/src/main/java/io/myotis/api/DialResult.java
@@ -1,0 +1,12 @@
+package io.myotis.api;
+
+/**
+ * Result of an operator-initiated peer dial. {@code accepted} means the connect
+ * was initiated (the handshake outcome arrives asynchronously and shows up in
+ * {@link StatusSnapshot} peer counts), not that the peer is connected.
+ *
+ * @param accepted the dial was initiated
+ * @param error    null when accepted; otherwise why the dial was rejected
+ */
+public record DialResult(boolean accepted, String error) {
+}

--- a/myotis-api/src/main/java/io/myotis/api/EngineConfig.java
+++ b/myotis-api/src/main/java/io/myotis/api/EngineConfig.java
@@ -1,0 +1,31 @@
+package io.myotis.api;
+
+/**
+ * Host-tunable configuration for one network's stack. Networks are referenced by
+ * canonical name; all protocol constants (genesis, fork IDs, checkpoints,
+ * bootnodes) are embedded in the engine.
+ *
+ * @param networkName          canonical network name (see {@link MyotisEngine#canonicalNetworkName})
+ * @param elPort               RLPx TCP + discv4 UDP port; 0 → the network's default
+ * @param discv5Port           CL discv5 UDP port; 0 → the network's default
+ * @param rpcPort              verified JSON-RPC HTTP port (loopback); 0 → the network's default
+ * @param syncSnapshotPath     file path for the light-client sync snapshot (a private
+ *                             cache, not a trust anchor); null → no snapshot persistence
+ * @param gossipsubEnabled     subscribe to CL gossipsub (live finality updates) in
+ *                             addition to polling
+ * @param targetSnapPeers      snap-peer maintainer target; 0 → maintainer disabled
+ *                             (bare daemons rely on continuous discv4; NAT'd/mobile
+ *                             hosts should enable it)
+ * @param strictStateFreshness true → strict 2-minute state freshness (production);
+ *                             false → relaxed (experimental)
+ */
+public record EngineConfig(
+        String networkName,
+        int elPort,
+        int discv5Port,
+        int rpcPort,
+        String syncSnapshotPath,
+        boolean gossipsubEnabled,
+        int targetSnapPeers,
+        boolean strictStateFreshness) {
+}

--- a/myotis-api/src/main/java/io/myotis/api/EngineException.java
+++ b/myotis-api/src/main/java/io/myotis/api/EngineException.java
@@ -1,0 +1,18 @@
+package io.myotis.api;
+
+/**
+ * The only exception type the engine API throws — reserved for programmer/state
+ * errors (unknown network, malformed address, network not running). Verification
+ * failures are never exceptions; they surface as {@code failReason}/{@code error}
+ * fields on result records.
+ */
+public class EngineException extends RuntimeException {
+
+    public EngineException(String message) {
+        super(message);
+    }
+
+    public EngineException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/myotis-api/src/main/java/io/myotis/api/EnsAbiResult.java
+++ b/myotis-api/src/main/java/io/myotis/api/EnsAbiResult.java
@@ -1,0 +1,20 @@
+package io.myotis.api;
+
+/**
+ * An ENS ABI record lookup (ENSIP-4).
+ *
+ * @param name         the ENS name
+ * @param contentType  the returned encoding (bit from the request mask); 0 when absent
+ * @param dataHex      the ABI payload bytes (0x-hex), null when absent
+ * @param blockNumber  block the resolution state anchors to; -1 when none
+ * @param verified     true iff resolved against beacon-finalized state
+ * @param error        null on success
+ */
+public record EnsAbiResult(
+        String name,
+        long contentType,
+        String dataHex,
+        long blockNumber,
+        boolean verified,
+        String error) {
+}

--- a/myotis-api/src/main/java/io/myotis/api/EnsApi.java
+++ b/myotis-api/src/main/java/io/myotis/api/EnsApi.java
@@ -1,0 +1,43 @@
+package io.myotis.api;
+
+/**
+ * ENS resolution over the local EVM against proof-served state — ENSIP-1 +
+ * ENSIP-10 (wildcard) with transparent CCIP-Read (ERC-3668) for off-chain names.
+ *
+ * <p>All methods are blocking (worker thread; internally timeout-bounded, worst
+ * case ~2 min for a cold CCIP name). Resolution failures set the result record's
+ * {@code error}; only malformed input / not-running throw {@link EngineException}.
+ * {@code verified} is true iff the resolution ran against beacon-finalized state.
+ */
+public interface EnsApi {
+
+    /** Forward-resolve {@code name} to an address. */
+    EnsResolutionResult resolveAddress(String name, EnsRoot root);
+
+    /**
+     * Reverse-resolve an address to its primary name, with mandatory
+     * forward-verification (the claimed name must resolve back to the address).
+     */
+    EnsResolutionResult reverseResolve(String hexAddress);
+
+    /** ENSIP-5 text record. */
+    EnsTextResult resolveText(String name, String key);
+
+    /** ENSIP-7 contenthash. */
+    EnsContenthashResult resolveContenthash(String name);
+
+    /** ENSIP-9 multi-coin address (SLIP-44 coin type). */
+    EnsMultiCoinResult resolveMultiCoinAddr(String name, long coinType);
+
+    /** ENSIP-? pubkey record (secp256k1 x/y). */
+    EnsPubkeyResult resolvePubkey(String name);
+
+    /** ABI record (ENSIP-4); {@code contentTypes} is the accepted-encodings bitmask. */
+    EnsAbiResult resolveAbi(String name, long contentTypes);
+
+    /** DNS record stored in ENS (ENSIP-6). */
+    EnsDnsRecordResult resolveDnsRecord(String name, String dnsName, int recordType);
+
+    /** ERC-165 interface implementer record. */
+    EnsInterfaceResult resolveInterfaceImplementer(String name, byte[] interfaceId4);
+}

--- a/myotis-api/src/main/java/io/myotis/api/EnsContenthashResult.java
+++ b/myotis-api/src/main/java/io/myotis/api/EnsContenthashResult.java
@@ -1,0 +1,18 @@
+package io.myotis.api;
+
+/**
+ * An ENS contenthash lookup (ENSIP-7).
+ *
+ * @param name           the ENS name
+ * @param contenthashHex the raw contenthash bytes (0x-hex), null when absent
+ * @param blockNumber    block the resolution state anchors to; -1 when none
+ * @param verified       true iff resolved against beacon-finalized state
+ * @param error          null on success
+ */
+public record EnsContenthashResult(
+        String name,
+        String contenthashHex,
+        long blockNumber,
+        boolean verified,
+        String error) {
+}

--- a/myotis-api/src/main/java/io/myotis/api/EnsDnsRecordResult.java
+++ b/myotis-api/src/main/java/io/myotis/api/EnsDnsRecordResult.java
@@ -1,0 +1,22 @@
+package io.myotis.api;
+
+/**
+ * An ENS-stored DNS record lookup (ENSIP-6).
+ *
+ * @param name        the ENS name
+ * @param dnsName     the DNS name queried
+ * @param recordType  the DNS record type (e.g. 1 = A, 16 = TXT)
+ * @param dataHex     the raw DNS record bytes (0x-hex), null when absent
+ * @param blockNumber block the resolution state anchors to; -1 when none
+ * @param verified    true iff resolved against beacon-finalized state
+ * @param error       null on success
+ */
+public record EnsDnsRecordResult(
+        String name,
+        String dnsName,
+        int recordType,
+        String dataHex,
+        long blockNumber,
+        boolean verified,
+        String error) {
+}

--- a/myotis-api/src/main/java/io/myotis/api/EnsInterfaceResult.java
+++ b/myotis-api/src/main/java/io/myotis/api/EnsInterfaceResult.java
@@ -1,0 +1,20 @@
+package io.myotis.api;
+
+/**
+ * An ENS interface-implementer record lookup (ERC-165).
+ *
+ * @param name           the ENS name
+ * @param interfaceIdHex the queried 4-byte interface id (0x-hex)
+ * @param implementerHex the implementer address (0x-hex), null when absent
+ * @param blockNumber    block the resolution state anchors to; -1 when none
+ * @param verified       true iff resolved against beacon-finalized state
+ * @param error          null on success
+ */
+public record EnsInterfaceResult(
+        String name,
+        String interfaceIdHex,
+        String implementerHex,
+        long blockNumber,
+        boolean verified,
+        String error) {
+}

--- a/myotis-api/src/main/java/io/myotis/api/EnsMultiCoinResult.java
+++ b/myotis-api/src/main/java/io/myotis/api/EnsMultiCoinResult.java
@@ -1,0 +1,20 @@
+package io.myotis.api;
+
+/**
+ * An ENS multi-coin address lookup (ENSIP-9 / SLIP-44).
+ *
+ * @param name        the ENS name
+ * @param coinType    the SLIP-44 coin type queried
+ * @param addressHex  the coin address bytes (0x-hex), null when absent
+ * @param blockNumber block the resolution state anchors to; -1 when none
+ * @param verified    true iff resolved against beacon-finalized state
+ * @param error       null on success
+ */
+public record EnsMultiCoinResult(
+        String name,
+        long coinType,
+        String addressHex,
+        long blockNumber,
+        boolean verified,
+        String error) {
+}

--- a/myotis-api/src/main/java/io/myotis/api/EnsPubkeyResult.java
+++ b/myotis-api/src/main/java/io/myotis/api/EnsPubkeyResult.java
@@ -1,0 +1,20 @@
+package io.myotis.api;
+
+/**
+ * An ENS pubkey record lookup.
+ *
+ * @param name        the ENS name
+ * @param pubkeyXHex  the secp256k1 x coordinate (0x-hex), null when absent
+ * @param pubkeyYHex  the secp256k1 y coordinate (0x-hex), null when absent
+ * @param blockNumber block the resolution state anchors to; -1 when none
+ * @param verified    true iff resolved against beacon-finalized state
+ * @param error       null on success
+ */
+public record EnsPubkeyResult(
+        String name,
+        String pubkeyXHex,
+        String pubkeyYHex,
+        long blockNumber,
+        boolean verified,
+        String error) {
+}

--- a/myotis-api/src/main/java/io/myotis/api/EnsResolutionResult.java
+++ b/myotis-api/src/main/java/io/myotis/api/EnsResolutionResult.java
@@ -1,0 +1,18 @@
+package io.myotis.api;
+
+/**
+ * Result of a forward or reverse ENS name↔address resolution.
+ *
+ * @param name        the ENS name (queried, or reverse-resolved)
+ * @param addressHex  the resolved / queried address (0x-hex), null when unresolved
+ * @param blockNumber block the resolution state anchors to; -1 when none
+ * @param verified    true iff resolved against beacon-finalized state
+ * @param error       null on success; otherwise why resolution failed
+ */
+public record EnsResolutionResult(
+        String name,
+        String addressHex,
+        long blockNumber,
+        boolean verified,
+        String error) {
+}

--- a/myotis-api/src/main/java/io/myotis/api/EnsRoot.java
+++ b/myotis-api/src/main/java/io/myotis/api/EnsRoot.java
@@ -1,0 +1,13 @@
+package io.myotis.api;
+
+/**
+ * Which state root ENS resolution runs against.
+ * <ul>
+ *   <li>{@code FINALIZED} — beacon-finalized state (fully verified; ~2 epochs
+ *       stale; needs a snap peer retaining that state).</li>
+ *   <li>{@code PEER_HEAD} — the peer's latest head (freshest; peer-claimed for
+ *       the resolution itself).</li>
+ *   <li>{@code AUTO} — try FINALIZED, fall back to PEER_HEAD on no-record/error.</li>
+ * </ul>
+ */
+public enum EnsRoot { FINALIZED, PEER_HEAD, AUTO }

--- a/myotis-api/src/main/java/io/myotis/api/EnsTextResult.java
+++ b/myotis-api/src/main/java/io/myotis/api/EnsTextResult.java
@@ -1,0 +1,20 @@
+package io.myotis.api;
+
+/**
+ * An ENS text-record lookup.
+ *
+ * @param name        the ENS name
+ * @param key         the queried text key
+ * @param value       the record value, null when absent
+ * @param blockNumber block the resolution state anchors to; -1 when none
+ * @param verified    true iff resolved against beacon-finalized state
+ * @param error       null on success
+ */
+public record EnsTextResult(
+        String name,
+        String key,
+        String value,
+        long blockNumber,
+        boolean verified,
+        String error) {
+}

--- a/myotis-api/src/main/java/io/myotis/api/HeaderInfo.java
+++ b/myotis-api/src/main/java/io/myotis/api/HeaderInfo.java
@@ -1,0 +1,27 @@
+package io.myotis.api;
+
+/**
+ * One fetched block header (integrity-checked: {@code hash} is the recomputed
+ * keccak256 of the header RLP, not peer-claimed).
+ *
+ * @param number           block number
+ * @param hashHex          recomputed block hash (0x-hex)
+ * @param parentHashHex    parent hash (0x-hex)
+ * @param stateRootHex     state root (0x-hex)
+ * @param transactionsRootHex transactions root (0x-hex)
+ * @param timestamp        block timestamp (unix seconds)
+ * @param gasUsed          gas used
+ * @param gasLimit         gas limit
+ * @param baseFeePerGasWei base fee in decimal wei, or null pre-London
+ */
+public record HeaderInfo(
+        long number,
+        String hashHex,
+        String parentHashHex,
+        String stateRootHex,
+        String transactionsRootHex,
+        long timestamp,
+        long gasUsed,
+        long gasLimit,
+        String baseFeePerGasWei) {
+}

--- a/myotis-api/src/main/java/io/myotis/api/HeadersResult.java
+++ b/myotis-api/src/main/java/io/myotis/api/HeadersResult.java
@@ -1,0 +1,13 @@
+package io.myotis.api;
+
+import java.util.List;
+
+/**
+ * Result of a header-range fetch. A fetch failure (no peer, timeout) sets
+ * {@link #error} and leaves {@link #headers} empty.
+ *
+ * @param headers the fetched headers, in ascending block order
+ * @param error   null on success; otherwise a human-readable failure message
+ */
+public record HeadersResult(List<HeaderInfo> headers, String error) {
+}

--- a/myotis-api/src/main/java/io/myotis/api/MyotisEngine.java
+++ b/myotis-api/src/main/java/io/myotis/api/MyotisEngine.java
@@ -1,0 +1,50 @@
+package io.myotis.api;
+
+import io.myotis.api.ports.EnginePorts;
+
+import java.util.List;
+
+/**
+ * The engine's root object: knows the embedded network catalog and hosts one
+ * {@link ChainHandle} per enabled network. One process can host several networks
+ * side by side (mainnet + Gnosis + …), each on its own ports; a failure in one is
+ * isolated to that network.
+ *
+ * <p>Hosts construct exactly one implementation at their composition root (the
+ * single line naming a concrete engine class) and use only this API from there on.
+ */
+public interface MyotisEngine {
+
+    /** The networks compiled into this engine, in display order. */
+    List<NetworkInfo> availableNetworks();
+
+    /**
+     * Resolve a user-supplied network name or alias (case-insensitive; e.g.
+     * {@code xdai}/{@code gbc} → {@code gnosis}) to the canonical name used
+     * everywhere else in this API.
+     *
+     * @throws EngineException on an unknown network
+     */
+    String canonicalNetworkName(String nameOrAlias);
+
+    /**
+     * Construct and register one network's stack with the host's injected ports.
+     * Does NOT start it — call {@link ChainHandle#start()}. Creating a network
+     * that is already hosted throws.
+     *
+     * @throws EngineException on an unknown network or one already hosted
+     */
+    ChainHandle create(EngineConfig config, EnginePorts ports);
+
+    /** The handle for {@code networkName}, or {@code null} if not hosted. */
+    ChainHandle get(String networkName);
+
+    /** Canonical names of the networks currently hosted. */
+    List<String> hostedNetworks();
+
+    /** Stop and unregister one network (no-op if absent). */
+    void stop(String networkName);
+
+    /** Stop and unregister every hosted network. */
+    void shutdownAll();
+}

--- a/myotis-api/src/main/java/io/myotis/api/NetworkInfo.java
+++ b/myotis-api/src/main/java/io/myotis/api/NetworkInfo.java
@@ -1,0 +1,27 @@
+package io.myotis.api;
+
+/**
+ * Static metadata for one embedded network — what a host needs to render network
+ * pickers and settings without reaching into engine internals.
+ *
+ * @param name              canonical lowercase name ({@code mainnet}, {@code gnosis}, …)
+ * @param displayName       human-facing name ("Ethereum Mainnet", "Gnosis Chain", …)
+ * @param chainId           the EVM chain id
+ * @param hasEns            whether ENS resolution is available on this chain
+ * @param defaultElPort     default RLPx TCP + discv4 UDP port
+ * @param defaultDiscv5Port default CL discv5 UDP port
+ * @param defaultRpcPort    default verified JSON-RPC HTTP port
+ * @param clGenesisTime     beacon-chain genesis time (unix seconds)
+ * @param secondsPerSlot    beacon slot time (mainnet preset 12, Gnosis 5)
+ */
+public record NetworkInfo(
+        String name,
+        String displayName,
+        long chainId,
+        boolean hasEns,
+        int defaultElPort,
+        int defaultDiscv5Port,
+        int defaultRpcPort,
+        long clGenesisTime,
+        int secondsPerSlot) {
+}

--- a/myotis-api/src/main/java/io/myotis/api/PeerInfo.java
+++ b/myotis-api/src/main/java/io/myotis/api/PeerInfo.java
@@ -1,0 +1,11 @@
+package io.myotis.api;
+
+/**
+ * One connected READY peer (past the eth handshake), for status peer lists.
+ *
+ * @param remoteAddress "host:port" display string
+ * @param snapSupported whether the peer negotiated snap/1
+ * @param clientId      the peer's Hello client id, or null until received
+ */
+public record PeerInfo(String remoteAddress, boolean snapSupported, String clientId) {
+}

--- a/myotis-api/src/main/java/io/myotis/api/StatusSnapshot.java
+++ b/myotis-api/src/main/java/io/myotis/api/StatusSnapshot.java
@@ -1,0 +1,60 @@
+package io.myotis.api;
+
+import java.util.List;
+
+/**
+ * One coherent point-in-time view of a network's stack — the superset of what the
+ * hosts' status surfaces render (UI status tabs, the daemon's {@code status} /
+ * {@code beacon-status} / {@code peers} IPC commands).
+ *
+ * @param running               whether the stack is running
+ * @param network               canonical network name
+ * @param beaconState           beacon light-client state (STARTING before first state)
+ * @param connectedPeers        EL peers with an open RLPx session (incl. still handshaking)
+ * @param readyPeers            EL peers past the eth handshake
+ * @param snapPeers             peers that negotiated snap/1
+ * @param snapServingPeers      peers currently in the snap serving pool (drives readiness)
+ * @param discoveredPeers       discv4 Kademlia table size
+ * @param backedOffPeers        active (non-expired) dial-backoff entries, pruned on read
+ * @param blacklistedPeers      peers blacklisted this session (wrong chain)
+ * @param attemptedDials        in-flight / recently-attempted dials
+ * @param discv5TableSize       live nodes in the CL discv5 routing table
+ * @param executionBlockNumber  finalized execution block number (0 if none yet)
+ * @param optimisticBlockNumber optimistic-head execution block number (0 if none yet)
+ * @param finalizedSlot         finalized beacon slot (0 if none yet)
+ * @param finalizedBlockNumber  execution block number of the finalized payload (0 if none)
+ * @param syncStartPeriod       sync-committee catch-up start period (-1 if unknown)
+ * @param syncCurrentPeriod     current sync-committee period the client holds
+ * @param syncTargetPeriod      wall-clock sync-committee period (catch-up target)
+ * @param finalizedPeriod       period of the finalized slot
+ * @param wallClockPeriod       wall-clock period (== syncTargetPeriod; kept for
+ *                              diagnostics parity with the daemon's beacon-status)
+ * @param verifiedHeadAgeMs     age of the last verified RPC head context;
+ *                              {@code Long.MAX_VALUE} = none built yet
+ * @param readyPeerList         per-peer detail for the READY peers, snap-capable first
+ */
+public record StatusSnapshot(
+        boolean running,
+        String network,
+        BeaconState beaconState,
+        int connectedPeers,
+        int readyPeers,
+        int snapPeers,
+        int snapServingPeers,
+        int discoveredPeers,
+        int backedOffPeers,
+        int blacklistedPeers,
+        int attemptedDials,
+        int discv5TableSize,
+        long executionBlockNumber,
+        long optimisticBlockNumber,
+        long finalizedSlot,
+        long finalizedBlockNumber,
+        long syncStartPeriod,
+        long syncCurrentPeriod,
+        long syncTargetPeriod,
+        long finalizedPeriod,
+        long wallClockPeriod,
+        long verifiedHeadAgeMs,
+        List<PeerInfo> readyPeerList) {
+}

--- a/myotis-api/src/main/java/io/myotis/api/StorageProofResult.java
+++ b/myotis-api/src/main/java/io/myotis/api/StorageProofResult.java
@@ -1,0 +1,62 @@
+package io.myotis.api;
+
+import java.util.List;
+
+/**
+ * A verified storage-slot query's full result. The storage proof is verified
+ * against the account's proof-verified {@code storageRoot} (never the world state
+ * root directly), and the anchoring account state root is then tied to the beacon
+ * chain exactly like {@link AccountProofResult}.
+ *
+ * @param addressHex            the contract address queried (0x-hex)
+ * @param slot                  the requested slot number
+ * @param holderHex             the mapping holder address, or null for a plain slot
+ * @param storageKeyHex         the actual storage key queried (0x-hex; for a holder,
+ *                              keccak256(holder ‖ slot))
+ * @param storageKeyHashHex     keccak256(storageKey) — the snap trie key
+ * @param exists                whether the slot was present in the peer's response
+ * @param valueHex              slot value (0x-hex), or null when {@code !exists}
+ * @param valueDecimal          slot value as a decimal string, or null
+ * @param slotsReturned         slots the peer returned (diagnostic when {@code !exists})
+ * @param storageRootHex        the account's proof-verified storage root
+ * @param proofNodesHex         the storage MPT proof nodes (0x-hex)
+ * @param storageProofValid     the storage proof verifies against {@code storageRoot}
+ * @param beaconSynced          beacon client was SYNCED at query time
+ * @param beaconChainVerified   the anchoring state root ties to a beacon-attested root
+ * @param blsVerified           the beacon match was BLS-signed
+ * @param matchedBeaconSlot     slot of the matching beacon attestation; -1 if none
+ * @param verifyMethod          "stateRootMatch" / "headerChain" / null
+ * @param failReason            null when verified; otherwise a stable reason token
+ * @param peerBlockNumber       peer-reported block the account proof anchors to
+ * @param finalizedBlockNumber  finalized execution block number (0 if none)
+ * @param optimisticBlockNumber optimistic-head execution block number (0 if none)
+ * @param finalizedSlot         finalized beacon slot (0 if none)
+ * @param optimisticSlot        optimistic beacon slot (0 if none)
+ * @param maxHeaderChainGap     the engine's header-chain walk bound (currently 8192)
+ */
+public record StorageProofResult(
+        String addressHex,
+        long slot,
+        String holderHex,
+        String storageKeyHex,
+        String storageKeyHashHex,
+        boolean exists,
+        String valueHex,
+        String valueDecimal,
+        int slotsReturned,
+        String storageRootHex,
+        List<String> proofNodesHex,
+        boolean storageProofValid,
+        boolean beaconSynced,
+        boolean beaconChainVerified,
+        boolean blsVerified,
+        long matchedBeaconSlot,
+        String verifyMethod,
+        String failReason,
+        long peerBlockNumber,
+        long finalizedBlockNumber,
+        long optimisticBlockNumber,
+        long finalizedSlot,
+        long optimisticSlot,
+        int maxHeaderChainGap) {
+}

--- a/myotis-api/src/main/java/io/myotis/api/SyncState.java
+++ b/myotis-api/src/main/java/io/myotis/api/SyncState.java
@@ -1,0 +1,7 @@
+package io.myotis.api;
+
+/**
+ * The beacon light client's sync state. Not latched — a node can regress from
+ * {@code SYNCED} (e.g. losing CL peers).
+ */
+public enum SyncState { SYNCING, CATCHING_UP, SYNCED }

--- a/myotis-api/src/main/java/io/myotis/api/VerifiedReads.java
+++ b/myotis-api/src/main/java/io/myotis/api/VerifiedReads.java
@@ -1,0 +1,82 @@
+package io.myotis.api;
+
+/**
+ * The verified eth_* read surface — every method is answered ONLY from
+ * cryptographically verified data. {@code null} means "cannot answer verified
+ * right now" (not synced / no peer / head not anchored); the host maps that to a
+ * JSON-RPC error in strict mode. The engine never proxies an unverified answer.
+ *
+ * <p>Methods returning JSON strings ({@code getTransactionReceipt},
+ * {@code getBlockByNumber}, …) use the tri-state convention: a JSON object, the
+ * literal {@code "null"} (a <em>verified</em> "not found" — e.g. an unknown tx on
+ * a synced chain), or {@code null} (no verified answer).
+ *
+ * <p>All methods are blocking; call from a worker thread. Block selectors are
+ * strings: {@code "latest"}, {@code "pending"}, or a 0x-hex block number.
+ */
+public interface VerifiedReads {
+
+    /** The chain id (static config; never null). */
+    long chainId();
+
+    /** Beacon optimistic-head block number, or null when not synced enough. */
+    Long headBlockNumber();
+
+    /** The beacon light client's sync state. */
+    SyncState syncState();
+
+    /**
+     * eth_call against proof-served state in the local EVM. {@code from} may be
+     * null (zero sender — reverts {@code msg.sender}-gated contracts, as geth
+     * does); {@code valueWei} decimal or null for zero.
+     *
+     * @return ABI return bytes, or null when unanswerable verified
+     */
+    byte[] call(byte[] from, byte[] to, byte[] data, String valueWei, String block);
+
+    /** Balance in decimal wei, or null. */
+    String getBalance(byte[] address, String block);
+
+    /** Account nonce (with the own-tx pending overlay for "pending"), or null. */
+    Long getTransactionCount(byte[] address, String block);
+
+    /** Contract bytecode (verified against the proven codeHash), or null. */
+    byte[] getCode(byte[] address, String block);
+
+    /** One 32-byte storage word (proof-verified), or null. */
+    byte[] getStorageAt(byte[] address, byte[] slot32, String block);
+
+    /**
+     * Gossip a signed raw transaction to peers (the engine never signs).
+     *
+     * @return keccak256(rawTx) — the tx hash — or null when no peer accepted it
+     */
+    byte[] sendRawTransaction(byte[] rawTx);
+
+    /** Receipt JSON (verified vs receiptsRoot) | "null" literal | null. */
+    String getTransactionReceipt(byte[] txHash);
+
+    /** Transaction JSON (verified vs transactionsRoot) | "null" literal | null. */
+    String getTransactionByHash(byte[] txHash);
+
+    /** Block JSON (beacon-anchored header) | "null" literal | null. */
+    String getBlockByNumber(String block, boolean fullTransactions);
+
+    /** Block JSON | "null" literal | null. */
+    String getBlockByHash(byte[] blockHash32, boolean fullTransactions);
+
+    /** Legacy gas price in decimal wei (base fee + tip heuristics), or null. */
+    String gasPrice();
+
+    /** Suggested priority fee in decimal wei (from verified bodies), or null. */
+    String maxPriorityFeePerGas();
+
+    /** eth_feeHistory result JSON, or null. */
+    String feeHistory(long blockCount, String newestBlock, double[] rewardPercentiles);
+
+    /**
+     * Gas estimate via the local EVM (intrinsic + metered + safety buffer), or
+     * null. A reverting call yields null (the engine won't estimate a doomed tx).
+     */
+    Long estimateGas(byte[] from, byte[] to, byte[] data, String valueWei);
+}

--- a/myotis-api/src/main/java/io/myotis/api/package-info.java
+++ b/myotis-api/src/main/java/io/myotis/api/package-info.java
@@ -1,0 +1,53 @@
+/**
+ * The Myotis engine API — the formal, language-neutral boundary between hosts
+ * (daemon / desktop / Android / iOS) and the engine (P2P networking, the beacon
+ * light client, verification, the EVM, verified reads).
+ *
+ * <p>The engine is one replaceable unit: the reference implementation is the JVM
+ * engine ({@code node-core} + friends); a Rust/Go engine later replaces everything
+ * behind this API via an FFI binding implementing the same interfaces. Hosts must
+ * consume ONLY the types in this package and {@code io.myotis.api.ports}.
+ *
+ * <h2>Type conventions (binding-portability rules)</h2>
+ * <ol>
+ *   <li>Binary values in {@link io.myotis.api.VerifiedReads} (addresses, slots,
+ *       hashes, code, calldata, raw txs): {@code byte[]}.</li>
+ *   <li>Display/result-record fields: 0x-prefixed lowercase hex {@code String}.</li>
+ *   <li>uint256 amounts (wei): decimal {@code String}; {@code BigInteger} never
+ *       crosses the boundary.</li>
+ *   <li>Gas / nonces / block numbers / slots / periods: {@code long}; boxed
+ *       {@code Long} only where {@code null} means "unanswerable".</li>
+ *   <li>Endpoints: {@code (String host, int port)} pairs in ports; a single
+ *       {@code "host:port"} string only for display.</li>
+ *   <li>File locations: {@code String} paths.</li>
+ *   <li>No {@code Optional}, no {@code CompletableFuture}, no checked exceptions,
+ *       no third-party types. Nullability is documented per method.</li>
+ *   <li>Composite JSON-RPC objects (blocks, txs, receipts, feeHistory): pre-built
+ *       JSON {@code String} with the tri-state convention — a JSON object, the
+ *       literal {@code "null"} (a <em>verified</em> "not found"), or {@code null}
+ *       (no verified answer).</li>
+ *   <li>Collections: {@code java.util.List} of flat records.</li>
+ *   <li>Block selector: {@code String} — {@code "latest"}, {@code "pending"}, or
+ *       a 0x-hex block number.</li>
+ * </ol>
+ *
+ * <h2>Threading model</h2>
+ * All engine methods are <b>blocking</b> and must be called from a worker thread,
+ * never a UI or I/O event-loop thread. Long-running verification queries are
+ * internally timeout-bounded (documented per method). Port implementations
+ * ({@code io.myotis.api.ports}) are invoked by the engine from its own worker
+ * threads and must be thread-safe.
+ *
+ * <h2>Error model</h2>
+ * <ul>
+ *   <li>{@link io.myotis.api.VerifiedReads}: {@code null} = "cannot answer
+ *       verified right now" (host maps to a JSON-RPC error in strict mode).</li>
+ *   <li>Verification queries ({@code requestAccount}, {@code getStorageProof},
+ *       ENS, …): always return a flat result record; verification failures set
+ *       {@code failReason}/{@code error}, never throw.</li>
+ *   <li>Programmer/state errors (unknown network, bad address, not running):
+ *       unchecked {@link io.myotis.api.EngineException} — the only exception type
+ *       this API throws.</li>
+ * </ul>
+ */
+package io.myotis.api;

--- a/myotis-api/src/main/java/io/myotis/api/ports/BootstrapPeer.java
+++ b/myotis-api/src/main/java/io/myotis/api/ports/BootstrapPeer.java
@@ -1,0 +1,8 @@
+package io.myotis.api.ports;
+
+/**
+ * A CL peer that served a light-client bootstrap, and for which period —
+ * front-loads proven bootstrap servers on restart.
+ */
+public record BootstrapPeer(String multiaddr, long period) {
+}

--- a/myotis-api/src/main/java/io/myotis/api/ports/CachedPeerInfo.java
+++ b/myotis-api/src/main/java/io/myotis/api/ports/CachedPeerInfo.java
@@ -1,0 +1,18 @@
+package io.myotis.api.ports;
+
+/**
+ * One cached EL peer.
+ *
+ * @param host         IP literal or hostname
+ * @param port         RLPx TCP port
+ * @param publicKeyHex the peer's uncompressed secp256k1 public key (hex, no 0x04 prefix)
+ * @param snap         whether the peer advertised snap/1
+ * @param snapQuality  the learned snap-serving verdict
+ */
+public record CachedPeerInfo(
+        String host,
+        int port,
+        String publicKeyHex,
+        boolean snap,
+        SnapQuality snapQuality) {
+}

--- a/myotis-api/src/main/java/io/myotis/api/ports/DnsServers.java
+++ b/myotis-api/src/main/java/io/myotis/api/ports/DnsServers.java
@@ -1,0 +1,13 @@
+package io.myotis.api.ports;
+
+import java.util.List;
+
+/**
+ * DNS server IPs for EIP-1459 enrtree TXT lookups. Mobile hosts supply the
+ * active network's DNS servers (their resolvers have no system config); an empty
+ * list falls back to the resolver's default.
+ */
+public interface DnsServers {
+
+    List<String> dnsServerIps();
+}

--- a/myotis-api/src/main/java/io/myotis/api/ports/EngineClPeerCache.java
+++ b/myotis-api/src/main/java/io/myotis/api/ports/EngineClPeerCache.java
@@ -1,0 +1,44 @@
+package io.myotis.api.ports;
+
+import java.util.List;
+
+/**
+ * The CL (beacon libp2p) peer cache — multiaddrs, failure counts, and the
+ * proven-capability records that let the light client front-load peers that have
+ * actually served bootstraps / catch-up ranges / light-client protocols before.
+ */
+public interface EngineClPeerCache {
+
+    /** Cached CL peer multiaddrs to seed the light client, in stored order. */
+    List<String> load();
+
+    /** Record a responsive CL peer multiaddr (idempotent). */
+    void add(String multiaddr);
+
+    /** Record that a CL peer failed (for deprioritization). */
+    void markFailure(String multiaddr);
+
+    /** Proven catch-up service ranges. */
+    List<ServedRange> servedRanges();
+
+    /** Record that {@code multiaddr} served catch-up across [low, high]. */
+    void recordServed(String multiaddr, long low, long high);
+
+    /** Peers that have served bootstraps, with the period served. */
+    List<BootstrapPeer> bootstrapPeers();
+
+    /** Record that {@code multiaddr} served a bootstrap for {@code period}. */
+    void recordBootstrap(String multiaddr, long period);
+
+    /** Peers confirmed to serve the light_client req/resp protocols. */
+    List<String> lightClientConfirmed();
+
+    /** Peers proven NOT to serve the light_client protocols. */
+    List<String> lightClientDenied();
+
+    /** Persist a batch of light-client capability verdicts. */
+    void markLightClientBatch(List<String> confirmed, List<String> denied);
+
+    /** Flush queued writes and release resources. */
+    void close();
+}

--- a/myotis-api/src/main/java/io/myotis/api/ports/EngineClock.java
+++ b/myotis-api/src/main/java/io/myotis/api/ports/EngineClock.java
@@ -1,0 +1,11 @@
+package io.myotis.api.ports;
+
+/**
+ * A monotonic clock (never wall-clock) for the engine's elapsed-time decisions —
+ * head-context TTLs, cache expiry. Android supplies elapsedRealtime(); the JVM
+ * default is System.nanoTime()/1e6.
+ */
+public interface EngineClock {
+
+    long elapsedMillis();
+}

--- a/myotis-api/src/main/java/io/myotis/api/ports/EngineLogger.java
+++ b/myotis-api/src/main/java/io/myotis/api/ports/EngineLogger.java
@@ -1,0 +1,11 @@
+package io.myotis.api.ports;
+
+/** The engine's log sink (Android routes to its in-app buffer, desktop to slf4j). */
+public interface EngineLogger {
+
+    void info(String message);
+
+    void warn(String message);
+
+    void error(String message);
+}

--- a/myotis-api/src/main/java/io/myotis/api/ports/EnginePeerCache.java
+++ b/myotis-api/src/main/java/io/myotis/api/ports/EnginePeerCache.java
@@ -1,0 +1,25 @@
+package io.myotis.api.ports;
+
+import java.util.List;
+
+/**
+ * The EL peer cache — remembers dialable peers (and their snap-serving quality)
+ * across restarts so the engine re-dials proven peers first.
+ */
+public interface EnginePeerCache {
+
+    /** Record a freshly-handshaked peer (idempotent). */
+    void add(String host, int port, String publicKeyHex, boolean snap);
+
+    /** {@code host:port} served a snap proof (promote toward CONFIRMED). */
+    void recordSnapServed(String host, int port);
+
+    /** {@code host:port} failed to serve snap (demote toward DENIED). */
+    void recordSnapFailure(String host, int port);
+
+    /** Cached peers to re-dial on startup, in stored order. */
+    List<CachedPeerInfo> load();
+
+    /** Flush queued writes and release resources. */
+    void close();
+}

--- a/myotis-api/src/main/java/io/myotis/api/ports/EnginePorts.java
+++ b/myotis-api/src/main/java/io/myotis/api/ports/EnginePorts.java
@@ -1,0 +1,25 @@
+package io.myotis.api.ports;
+
+/**
+ * The bundle of host-implemented seams injected into one network's stack.
+ *
+ * @param keyStore    node-identity storage (required)
+ * @param peerCache   EL peer cache (required)
+ * @param clPeerCache CL (beacon libp2p) peer cache (required)
+ * @param dnsServers  DNS servers for EIP-1459 lookups; null → the resolver's
+ *                    default (mobile hosts must supply the active network's DNS —
+ *                    their resolvers have no system config)
+ * @param httpGateway CCIP-Read (ERC-3668) HTTP transport (required where ENS/EVM
+ *                    features are used; null disables off-chain resolution)
+ * @param logger      engine log sink; null → the engine's default logger
+ * @param clock       monotonic clock; null → the engine's monotonic default
+ */
+public record EnginePorts(
+        NodeKeyStore keyStore,
+        EnginePeerCache peerCache,
+        EngineClPeerCache clPeerCache,
+        DnsServers dnsServers,
+        HttpGateway httpGateway,
+        EngineLogger logger,
+        EngineClock clock) {
+}

--- a/myotis-api/src/main/java/io/myotis/api/ports/HttpGateway.java
+++ b/myotis-api/src/main/java/io/myotis/api/ports/HttpGateway.java
@@ -1,0 +1,26 @@
+package io.myotis.api.ports;
+
+/**
+ * The CCIP-Read (ERC-3668) HTTP transport — the single place the engine performs
+ * HTTP, implemented per platform. The gateway is an untrusted data carrier: trust
+ * comes from the resolver contract validating the response on-chain against
+ * proof-verified state, so this port needs no TLS pinning or response validation
+ * beyond size/timeout hygiene.
+ *
+ * <p>Blocking; called from engine worker threads. Implementations should apply
+ * ~10–15 s timeouts and bound the response size (~1 MiB).
+ */
+public interface HttpGateway {
+
+    enum Method { GET, POST }
+
+    /**
+     * Perform one request and return the response body as a string.
+     * {@code bodyOrNull} is the POST payload (null for GET).
+     *
+     * @throws RuntimeException on any transport failure (timeout, non-2xx,
+     *                          oversized response) — the engine treats a throw as
+     *                          "this gateway failed" and reports/falls back
+     */
+    String request(Method method, String url, String bodyOrNull);
+}

--- a/myotis-api/src/main/java/io/myotis/api/ports/NodeKeyStore.java
+++ b/myotis-api/src/main/java/io/myotis/api/ports/NodeKeyStore.java
@@ -1,0 +1,16 @@
+package io.myotis.api.ports;
+
+/**
+ * Where the node's secp256k1 identity lives (a P2P identity, not a wallet key).
+ * The engine calls {@link #load}; when it returns null the engine generates a
+ * fresh key and persists it via {@link #store} so the enode/PeerId stays stable
+ * across restarts.
+ */
+public interface NodeKeyStore {
+
+    /** The 32-byte secret for {@code networkName}, or null when none stored. */
+    byte[] load(String networkName);
+
+    /** Persist a freshly generated 32-byte secret for {@code networkName}. */
+    void store(String networkName, byte[] secret32);
+}

--- a/myotis-api/src/main/java/io/myotis/api/ports/ServedRange.java
+++ b/myotis-api/src/main/java/io/myotis/api/ports/ServedRange.java
@@ -1,0 +1,8 @@
+package io.myotis.api.ports;
+
+/**
+ * A CL peer's proven catch-up service range: it has served sync-committee
+ * updates for periods [{@code low}, {@code high}].
+ */
+public record ServedRange(String multiaddr, long low, long high) {
+}

--- a/myotis-api/src/main/java/io/myotis/api/ports/SnapQuality.java
+++ b/myotis-api/src/main/java/io/myotis/api/ports/SnapQuality.java
@@ -1,0 +1,7 @@
+package io.myotis.api.ports;
+
+/**
+ * A cached EL peer's learned snap-serving verdict — drives dial priority
+ * (CONFIRMED first).
+ */
+public enum SnapQuality { CONFIRMED, UNKNOWN, DENIED }

--- a/myotis-api/src/main/java/io/myotis/api/ports/package-info.java
+++ b/myotis-api/src/main/java/io/myotis/api/ports/package-info.java
@@ -1,0 +1,16 @@
+/**
+ * The host-implemented seams the engine calls OUT through — persistence, HTTP,
+ * DNS, key storage, logging, time. Hosts implement these against their platform
+ * (files + java.net.http on desktop, app-private storage + ConnectivityManager on
+ * Android) and hand them to {@link io.myotis.api.MyotisEngine#create}.
+ *
+ * <p>All port methods are invoked by the engine from its own worker threads:
+ * implementations must be thread-safe and should not block excessively (a slow
+ * cache write stalls engine progress). {@link io.myotis.api.ports.HttpGateway} is
+ * the deliberate exception — it is called for its blocking transport and the
+ * engine budgets its timeout.
+ *
+ * <p>The same type rules as {@code io.myotis.api} apply: byte[], String,
+ * long/int/boolean, enums, flat records, java.util.List only.
+ */
+package io.myotis.api.ports;

--- a/node-core/build.gradle.kts
+++ b/node-core/build.gradle.kts
@@ -15,6 +15,12 @@
 // default yields when a transitive forces 21). AGP 8.7's D8 dexes 21 class files
 // for :android-app.
 
+plugins {
+    // On top of the root `java` plugin: adds the `api` configuration so the
+    // :myotis-api contract types flow transitively to hosts.
+    `java-library`
+}
+
 configurations.all {
     // Mirror :app / :android-app: strip upstream io.netty so the JitPack
     // netty-kotlin fork (republished under the same io.netty.* names, supplied by
@@ -28,6 +34,9 @@ java {
 }
 
 dependencies {
+    // The formal engine boundary this module implements (io.myotis.node.api adapters).
+    // `api` (not `implementation`): hosts consume the interface types transitively.
+    api(project(":myotis-api"))
     implementation(project(":core"))
     implementation(project(":networking"))
     implementation(project(":consensus"))
@@ -53,6 +62,8 @@ dependencies {
 
     testImplementation(platform(libs.junit.bom))
     testImplementation(libs.junit.jupiter)
+    // Tuweni's keccak256 needs the BC provider registered in tests.
+    testImplementation(libs.bouncycastle)
     testRuntimeOnly(libs.logback.classic)
 }
 

--- a/node-core/src/main/java/io/myotis/node/VerifiedAccountQuery.java
+++ b/node-core/src/main/java/io/myotis/node/VerifiedAccountQuery.java
@@ -101,19 +101,48 @@ public final class VerifiedAccountQuery {
     }
 
     /**
-     * Mutable verification scratchpad. Keeps the two verification methods (headerChain +
-     * stateRootMatch) from threading several separate parameters through the async chain.
+     * The immutable verification verdict. {@code verifiedStorageRootHex}/{@code verifiedCodeHashHex}
+     * come from the proof-verified leaf (authoritative — a peer can't forge them while keeping
+     * nonce/balance honest) and are null when the leaf proof didn't verify; callers needing the
+     * peer-claimed slim values must fall back explicitly.
+     *
+     * @param peerProofValid        proof verifies against the peer's own stateRoot (necessary,
+     *                              not sufficient for trust)
+     * @param verifiedStorageRootHex storage root from the proof-verified leaf, or null
+     * @param verifiedCodeHashHex   code hash from the proof-verified leaf, or null
+     * @param beaconChainVerified   the peer's stateRoot ties to a beacon-attested root
+     * @param blsVerified           the beacon match was BLS-signed
+     * @param matchedSlot           slot of the matching attestation; -1 when none
+     * @param verifyMethod          "stateRootMatch" / "headerChain" / null
+     * @param failReason            null when verified
      */
-    public static final class Verification {
-        /** Proof verifies against the peer's own stateRoot (necessary, not sufficient for trust). */
-        public boolean peerProofValid;
-        /** The proof-verified leaf (authoritative storageRoot/codeHash); null when the proof didn't verify. */
-        public MerklePatriciaVerifier.VerifiedAccount verifiedAcct;
-        public boolean beaconChainVerified;
-        public boolean blsVerified;
-        public long matchedSlot = -1;
-        public String verifyMethod;
-        public String failReason;
+    public record Verification(
+            boolean peerProofValid,
+            String verifiedStorageRootHex,
+            String verifiedCodeHashHex,
+            boolean beaconChainVerified,
+            boolean blsVerified,
+            long matchedSlot,
+            String verifyMethod,
+            String failReason) {}
+
+    /** Mutable scratchpad the async verify chain fills before freezing into a {@link Verification}. */
+    private static final class Scratch {
+        boolean peerProofValid;
+        MerklePatriciaVerifier.VerifiedAccount verifiedAcct;
+        boolean beaconChainVerified;
+        boolean blsVerified;
+        long matchedSlot = -1;
+        String verifyMethod;
+        String failReason;
+
+        Verification freeze() {
+            return new Verification(
+                    peerProofValid,
+                    verifiedAcct != null ? Bytes.wrap(verifiedAcct.storageRoot()).toHexString() : null,
+                    verifiedAcct != null ? Bytes.wrap(verifiedAcct.codeHash()).toHexString() : null,
+                    beaconChainVerified, blsVerified, matchedSlot, verifyMethod, failReason);
+        }
     }
 
     private static CompletableFuture<Result> buildAccountResult(
@@ -131,8 +160,91 @@ public final class VerifiedAccountQuery {
             }
         }
         final AccountRangeMessage.AccountData foundFinal = found;
-        return verify(result, address, bss, connector)
+        return verify(result, address, foundFinal, bss, connector)
                 .thenApply(v -> finalizeResult(addr, foundFinal, result, v));
+    }
+
+    /**
+     * Like {@link #query} but returning the full {@link io.myotis.api.AccountProofResult} —
+     * account data + proof material + verdict + beacon diagnostics — so an IPC/API host can
+     * reproduce its complete response from this record alone. Same validation and the same
+     * single verification ladder.
+     */
+    public static CompletableFuture<io.myotis.api.AccountProofResult> queryProof(
+            ChainStack stack, String hexAddress) {
+        RLPxConnector connector = stack != null ? stack.connector() : null;
+        BeaconSyncState bss = stack != null ? stack.beaconSyncState() : null;
+        if (stack == null || !stack.isRunning() || connector == null) {
+            return CompletableFuture.failedFuture(new IllegalStateException("Node is not running"));
+        }
+        if (hexAddress == null) {
+            return CompletableFuture.failedFuture(new IllegalArgumentException("Address is required"));
+        }
+        String hex = hexAddress.strip();
+        if (hex.startsWith("0x") || hex.startsWith("0X")) hex = hex.substring(2);
+        if (hex.length() != 40) {
+            return CompletableFuture.failedFuture(
+                    new IllegalArgumentException("Address must be 20 bytes (40 hex chars)"));
+        }
+        Bytes address;
+        try {
+            address = Bytes.fromHexString(hex);
+        } catch (Exception e) {
+            return CompletableFuture.failedFuture(
+                    new IllegalArgumentException("Invalid hex address: " + e.getMessage()));
+        }
+        final String addr = "0x" + hex;
+        final Bytes32 accountHash = Hash.keccak256(address);
+        final long clGenesisTime = stack.network().clGenesisTime();
+        final int secondsPerSlot = stack.network().secondsPerSlot();
+        final BeaconSyncState bssFinal = bss;
+        final RLPxConnector conn = connector;
+        return connector.requestAccount(address).thenCompose(result -> {
+            AccountRangeMessage.AccountData found = null;
+            for (AccountRangeMessage.AccountData a : result.accounts()) {
+                if (a.accountHash().equals(accountHash)) { found = a; break; }
+            }
+            final AccountRangeMessage.AccountData foundFinal = found;
+            return verify(result, address, foundFinal, bssFinal, conn).thenApply(v -> {
+                List<String> proofHex = new ArrayList<>(result.proof().size());
+                for (Bytes b : result.proof()) proofHex.add(b.toHexString());
+                String storageRootHex = v.verifiedStorageRootHex() != null
+                        ? v.verifiedStorageRootHex()
+                        : (foundFinal != null ? foundFinal.storageRoot().toHexString() : null);
+                String codeHashHex = v.verifiedCodeHashHex() != null
+                        ? v.verifiedCodeHashHex()
+                        : (foundFinal != null ? foundFinal.codeHash().toHexString() : null);
+                boolean synced = bssFinal != null && bssFinal.isSynced();
+                long finalizedPeriod = bssFinal != null ? bssFinal.getFinalizedPeriod() : 0;
+                long wallClockPeriod = com.jaeckel.ethp2p.consensus.lightclient.BeaconChainSpec
+                        .currentPeriod(clGenesisTime, secondsPerSlot);
+                long finalizedBlockNumber = bssFinal != null
+                        ? bssFinal.getFinalizedExecution().blockNumber() : 0;
+                long optimisticBlockNumber = bssFinal != null ? bssFinal.getOptimisticBlockNumber() : 0;
+                return new io.myotis.api.AccountProofResult(
+                        addr,
+                        foundFinal != null,
+                        foundFinal != null ? foundFinal.nonce() : -1,
+                        foundFinal != null ? foundFinal.balance().toString() : null,
+                        storageRootHex,
+                        codeHashHex,
+                        result.blockNumber(),
+                        result.stateRoot() != null ? result.stateRoot().toHexString() : null,
+                        v.peerProofValid(),
+                        v.beaconChainVerified(),
+                        v.blsVerified(),
+                        v.matchedSlot(),
+                        v.verifyMethod(),
+                        v.failReason(),
+                        accountHash.toHexString(),
+                        proofHex,
+                        synced,
+                        finalizedPeriod,
+                        wallClockPeriod,
+                        finalizedBlockNumber,
+                        optimisticBlockNumber);
+            });
+        });
     }
 
     /**
@@ -158,10 +270,24 @@ public final class VerifiedAccountQuery {
                 break;
             }
         }
+        return verify(result, address, found, bss, connector);
+    }
+
+    /**
+     * Same as {@link #verify(AccountRangeMessage.DecodeResult, Bytes, BeaconSyncState,
+     * RLPxConnector)} but accepting the already-located {@code found} account, so callers that
+     * scanned {@code result.accounts()} themselves don't pay a second scan.
+     */
+    public static CompletableFuture<Verification> verify(
+            AccountRangeMessage.DecodeResult result,
+            Bytes address,
+            AccountRangeMessage.AccountData found,
+            BeaconSyncState bss,
+            RLPxConnector connector) {
         long nonce = found != null ? found.nonce() : -1;
         String balance = found != null ? found.balance().toString() : null;
 
-        Verification v = new Verification();
+        Scratch v = new Scratch();
         if (result.stateRoot() != null && !result.proof().isEmpty()) {
             List<byte[]> proofBytes = new ArrayList<>(result.proof().size());
             for (Bytes b : result.proof()) proofBytes.add(b.toArrayUnsafe());
@@ -185,7 +311,7 @@ public final class VerifiedAccountQuery {
                 v.matchedSlot = match.slot();
                 v.blsVerified = match.blsVerified();
                 v.verifyMethod = "stateRootMatch";
-                return CompletableFuture.completedFuture(v);
+                return CompletableFuture.completedFuture(v.freeze());
             }
         }
 
@@ -236,12 +362,12 @@ public final class VerifiedAccountQuery {
                             } else {
                                 v.failReason = "headerChainInvalid";
                             }
-                            return v;
+                            return v.freeze();
                         });
             }
         }
 
-        return CompletableFuture.completedFuture(v);
+        return CompletableFuture.completedFuture(v.freeze());
     }
 
     private static Result finalizeResult(String addr,
@@ -252,15 +378,15 @@ public final class VerifiedAccountQuery {
         String balance = found != null ? found.balance().toString() : null;
         // storageRoot/codeHash come from the proof-verified leaf when we have it, so they're
         // cryptographically anchored rather than peer-claimed. Fall back to the slim (peer-claimed)
-        // body only when the leaf proof didn't verify (v.verifiedAcct == null). Note this is gated
-        // on peerProofValid, NOT beaconChainVerified: the beacon stateRootMatch fast-path can set
-        // beaconChainVerified=true even when the leaf proof didn't verify, so it is not a proxy for
-        // "we have a proof-verified leaf".
-        String storageRootHex = v.verifiedAcct != null
-                ? Bytes.wrap(v.verifiedAcct.storageRoot()).toHexString()
+        // body only when the leaf proof didn't verify (verifiedStorageRootHex == null). Note this
+        // is gated on peerProofValid, NOT beaconChainVerified: the beacon stateRootMatch fast-path
+        // can set beaconChainVerified=true even when the leaf proof didn't verify, so it is not a
+        // proxy for "we have a proof-verified leaf".
+        String storageRootHex = v.verifiedStorageRootHex() != null
+                ? v.verifiedStorageRootHex()
                 : (found != null ? found.storageRoot().toHexString() : null);
-        String codeHashHex = v.verifiedAcct != null
-                ? Bytes.wrap(v.verifiedAcct.codeHash()).toHexString()
+        String codeHashHex = v.verifiedCodeHashHex() != null
+                ? v.verifiedCodeHashHex()
                 : (found != null ? found.codeHash().toHexString() : null);
         return new Result(
                 addr,
@@ -271,12 +397,12 @@ public final class VerifiedAccountQuery {
                 codeHashHex,
                 result.blockNumber(),
                 result.stateRoot() != null ? result.stateRoot().toHexString() : null,
-                v.peerProofValid,
-                v.beaconChainVerified,
-                v.blsVerified,
-                v.matchedSlot,
-                v.verifyMethod,
-                v.failReason);
+                v.peerProofValid(),
+                v.beaconChainVerified(),
+                v.blsVerified(),
+                v.matchedSlot(),
+                v.verifyMethod(),
+                v.failReason());
     }
 
     /**

--- a/node-core/src/main/java/io/myotis/node/api/JavaChainHandle.java
+++ b/node-core/src/main/java/io/myotis/node/api/JavaChainHandle.java
@@ -1,0 +1,224 @@
+package io.myotis.node.api;
+
+import com.jaeckel.ethp2p.consensus.BeaconSyncState;
+import com.jaeckel.ethp2p.consensus.lightclient.BeaconChainSpec;
+import com.jaeckel.ethp2p.networking.NetworkConfig;
+import com.jaeckel.ethp2p.networking.eth.messages.BlockHeadersMessage;
+import com.jaeckel.ethp2p.networking.rlpx.RLPxConnector;
+import io.myotis.api.AccountProofResult;
+import io.myotis.api.BeaconState;
+import io.myotis.api.BlockResult;
+import io.myotis.api.ChainHandle;
+import io.myotis.api.DialResult;
+import io.myotis.api.EngineException;
+import io.myotis.api.EnsApi;
+import io.myotis.api.HeaderInfo;
+import io.myotis.api.HeadersResult;
+import io.myotis.api.PeerInfo;
+import io.myotis.api.StatusSnapshot;
+import io.myotis.api.StorageProofResult;
+import io.myotis.api.VerifiedReads;
+import io.myotis.node.ChainStack;
+import io.myotis.node.VerifiedAccountQuery;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.crypto.SECP256K1;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * The JVM implementation of {@link ChainHandle}: wraps one {@link ChainStack} and assembles
+ * the API shapes from the stack's internal accessors. This is the single place the host-facing
+ * status snapshot is built (previously duplicated across the desktop, Android, and daemon
+ * status paths).
+ */
+public final class JavaChainHandle implements ChainHandle {
+
+    private final ChainStack stack;
+    private final boolean strictStateFreshness;
+
+    JavaChainHandle(ChainStack stack, boolean strictStateFreshness) {
+        this.stack = stack;
+        this.strictStateFreshness = strictStateFreshness;
+    }
+
+    @Override public String networkName() { return stack.network().name(); }
+
+    @Override public long chainId() { return stack.network().networkId(); }
+
+    @Override
+    public boolean start() {
+        // The freshness knob is a process-global system property in the reference engine
+        // (VerifiedRpcBackend reads it once, during this start()); set it here — not at
+        // create() — so interleaved create()/start() across networks can't cross-apply.
+        // Per-network divergence within one process is not supported yet.
+        System.setProperty(io.myotis.rpc.VerifiedRpcBackend.STRICT_STATE_FRESHNESS_PROP,
+                String.valueOf(strictStateFreshness));
+        return stack.start();
+    }
+
+    @Override public void stop() { stack.shutdown(); }
+
+    @Override public boolean isRunning() { return stack.isRunning(); }
+
+    @Override public void setTargetSnapPeers(int target) { stack.setTargetSnapPeers(target); }
+
+    @Override
+    public void clearPeerState() {
+        stack.backoff().clear();
+        stack.blacklistedNodeIds().clear();
+    }
+
+    @Override
+    public StatusSnapshot status() {
+        NetworkConfig net = stack.network();
+        RLPxConnector conn = stack.connector();
+        BeaconSyncState bss = stack.beaconSyncState();
+
+        BeaconState beaconState = bss == null
+                ? BeaconState.STARTING
+                : BeaconState.valueOf(bss.getSyncState(net.clGenesisTime(), net.secondsPerSlot()).name());
+
+        List<RLPxConnector.PeerInfo> active = conn != null ? conn.getActivePeers() : List.of();
+        List<RLPxConnector.PeerInfo> ready = new ArrayList<>();
+        for (RLPxConnector.PeerInfo p : active) {
+            // "ready" = past the eth handshake; the raw active list also includes peers
+            // still negotiating Hello/Status.
+            if ("READY".equals(p.state())) ready.add(p);
+        }
+        // Snap-capable peers first (clientId tiebreak), matching the established UI ordering.
+        ready.sort(Comparator.comparing(RLPxConnector.PeerInfo::snapSupported).reversed()
+                .thenComparing(p -> p.clientId() != null ? p.clientId() : ""));
+        List<PeerInfo> readyRows = new ArrayList<>(ready.size());
+        int snapNegotiated = 0;
+        for (RLPxConnector.PeerInfo p : ready) {
+            if (p.snapSupported()) snapNegotiated++;
+            readyRows.add(new PeerInfo(p.remoteAddress(), p.snapSupported(), p.clientId()));
+        }
+
+        // Two DISTINCT counts: peers that negotiated snap/1 vs peers currently in the
+        // serving pool (activeSnapHandlers filters out serving-failed peers). Surfacing
+        // both makes a serving-pool collapse visible — the live operational issue on
+        // peer-scarce chains — so never feed one into the other.
+        int snapServing = conn != null ? conn.activeSnapHandlers().size() : 0;
+        long wallClockPeriod = BeaconChainSpec.currentPeriod(net.clGenesisTime(), net.secondsPerSlot());
+        io.myotis.rpc.VerifiedRpcBackend backend = stack.rpcBackend();
+
+        return new StatusSnapshot(
+                stack.isRunning(),
+                net.name(),
+                beaconState,
+                active.size(),
+                ready.size(),
+                snapNegotiated,
+                snapServing,
+                stack.discV4() != null ? stack.discV4().table().size() : 0,
+                stack.pruneAndCountActiveBackoff(),
+                stack.blacklistedNodeIds().size(),
+                stack.attemptedCount(),
+                stack.discV5() != null ? stack.discV5().liveNodeCount() : 0,
+                bss != null ? bss.getExecutionBlockNumber() : 0L,
+                bss != null ? bss.getOptimisticBlockNumber() : 0L,
+                bss != null ? bss.getFinalizedSlot() : 0L,
+                bss != null ? bss.getFinalizedExecution().blockNumber() : 0L,
+                bss != null ? bss.getCatchUpStartPeriod() : -1L,
+                bss != null ? bss.getCurrentSyncCommitteePeriod() : 0L,
+                wallClockPeriod,
+                bss != null ? bss.getFinalizedPeriod() : 0L,
+                wallClockPeriod,
+                backend != null ? backend.verifiedHeadAgeMs() : Long.MAX_VALUE,
+                readyRows);
+    }
+
+    @Override
+    public VerifiedReads reads() {
+        io.myotis.rpc.VerifiedRpcBackend backend = stack.rpcBackend();
+        return backend == null ? null : new VerifiedReadsAdapter(backend);
+    }
+
+    @Override
+    public EnsApi ens() {
+        if (!stack.network().hasEns()) return null;
+        return new JavaEnsApi(stack);
+    }
+
+    @Override
+    public AccountProofResult requestAccount(String hexAddress) {
+        try {
+            // queryProof internally bounds the header fetch (60 s); the outer bound covers
+            // the snap fetch + verification end to end.
+            return VerifiedAccountQuery.queryProof(stack, hexAddress).get(120, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new EngineException("interrupted while querying account", e);
+        } catch (Exception e) {
+            Throwable cause = e.getCause() != null ? e.getCause() : e;
+            throw new EngineException(cause.getMessage() != null
+                    ? cause.getMessage() : cause.getClass().getSimpleName(), cause);
+        }
+    }
+
+    @Override
+    public StorageProofResult getStorageProof(String hexAddress, long slot, String holderHexOrNull) {
+        // Wired when the daemon's storage-proof ladder moves into node-core
+        // (plan step PR2: engine-logic motion); nothing calls this until the hosts
+        // are rewired in PR3.
+        throw new EngineException("getStorageProof: not yet wired (lands with the engine-logic motion PR)");
+    }
+
+    @Override
+    public HeadersResult getHeaders(long startBlock, int count) {
+        RLPxConnector conn = stack.connector();
+        if (!stack.isRunning() || conn == null) throw new EngineException("Node is not running");
+        try {
+            List<BlockHeadersMessage.VerifiedHeader> headers =
+                    conn.requestBlockHeaders(startBlock, count).get(30, TimeUnit.SECONDS);
+            List<HeaderInfo> out = new ArrayList<>(headers.size());
+            for (BlockHeadersMessage.VerifiedHeader vh : headers) {
+                var h = vh.header();
+                out.add(new HeaderInfo(
+                        h.number,
+                        vh.hash().toHexString(),
+                        h.parentHash.toHexString(),
+                        h.stateRoot.toHexString(),
+                        h.transactionsRoot.toHexString(),
+                        h.timestamp,
+                        h.gasUsed,
+                        h.gasLimit,
+                        h.baseFeePerGas != null ? h.baseFeePerGas.toString() : null));
+            }
+            return new HeadersResult(out, null);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return new HeadersResult(List.of(), "interrupted");
+        } catch (Exception e) {
+            Throwable cause = e.getCause() != null ? e.getCause() : e;
+            return new HeadersResult(List.of(), cause.getMessage() != null
+                    ? cause.getMessage() : cause.getClass().getSimpleName());
+        }
+    }
+
+    @Override
+    public BlockResult getBlockVerified(long blockNumber) {
+        // Wired when the daemon's block verification moves into node-core (plan step PR2).
+        throw new EngineException("getBlockVerified: not yet wired (lands with the engine-logic motion PR)");
+    }
+
+    @Override
+    public DialResult dialPeer(String host, int port, String pubkeyHex) {
+        RLPxConnector conn = stack.connector();
+        if (!stack.isRunning() || conn == null) throw new EngineException("Node is not running");
+        try {
+            SECP256K1.PublicKey pubKey =
+                    SECP256K1.PublicKey.fromBytes(Bytes.fromHexString(pubkeyHex));
+            conn.connect(new InetSocketAddress(host, port), pubKey);
+            return new DialResult(true, null);
+        } catch (Exception e) {
+            return new DialResult(false, e.getMessage() != null
+                    ? e.getMessage() : e.getClass().getSimpleName());
+        }
+    }
+}

--- a/node-core/src/main/java/io/myotis/node/api/JavaEnsApi.java
+++ b/node-core/src/main/java/io/myotis/node/api/JavaEnsApi.java
@@ -1,0 +1,104 @@
+package io.myotis.node.api;
+
+import io.myotis.api.EngineException;
+import io.myotis.api.EnsAbiResult;
+import io.myotis.api.EnsApi;
+import io.myotis.api.EnsContenthashResult;
+import io.myotis.api.EnsDnsRecordResult;
+import io.myotis.api.EnsInterfaceResult;
+import io.myotis.api.EnsMultiCoinResult;
+import io.myotis.api.EnsPubkeyResult;
+import io.myotis.api.EnsResolutionResult;
+import io.myotis.api.EnsRoot;
+import io.myotis.api.EnsTextResult;
+import io.myotis.node.ChainStack;
+import io.myotis.rpc.EnsResolution;
+import io.myotis.rpc.VerifiedRpcBackend;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * The JVM {@link EnsApi}: forward resolution delegates to the backend's shared resolution
+ * policy ({@link VerifiedRpcBackend#resolveEns}). The record-type lookups (text, contenthash,
+ * multi-coin, …) are wired when the ENS record service moves out of the daemon's
+ * CommandHandler into node-core (plan step PR2); nothing calls them until the hosts are
+ * rewired in PR3.
+ */
+final class JavaEnsApi implements EnsApi {
+
+    /** Worst-case forward resolution: peer probing + EVM + CCIP gateway round-trips. */
+    private static final long RESOLVE_TIMEOUT_SEC = 150;
+
+    private final ChainStack stack;
+
+    JavaEnsApi(ChainStack stack) {
+        this.stack = stack;
+    }
+
+    @Override
+    public EnsResolutionResult resolveAddress(String name, EnsRoot root) {
+        VerifiedRpcBackend backend = stack.rpcBackend();
+        if (backend == null) {
+            return new EnsResolutionResult(name, null, -1, false, "node not running");
+        }
+        try {
+            EnsResolution r = backend.resolveEns(
+                            name, io.myotis.ens.EnsResolutionRoot.valueOf(root.name()))
+                    .get(RESOLVE_TIMEOUT_SEC, TimeUnit.SECONDS);
+            return new EnsResolutionResult(r.name(), r.addressHex(), r.blockNumber(),
+                    r.verified(), r.error());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return new EnsResolutionResult(name, null, -1, false, "interrupted");
+        } catch (Exception e) {
+            Throwable cause = e.getCause() != null ? e.getCause() : e;
+            return new EnsResolutionResult(name, null, -1, false,
+                    cause.getMessage() != null ? cause.getMessage() : cause.getClass().getSimpleName());
+        }
+    }
+
+    @Override
+    public EnsResolutionResult reverseResolve(String hexAddress) {
+        throw notYetWired("reverseResolve");
+    }
+
+    @Override
+    public EnsTextResult resolveText(String name, String key) {
+        throw notYetWired("resolveText");
+    }
+
+    @Override
+    public EnsContenthashResult resolveContenthash(String name) {
+        throw notYetWired("resolveContenthash");
+    }
+
+    @Override
+    public EnsMultiCoinResult resolveMultiCoinAddr(String name, long coinType) {
+        throw notYetWired("resolveMultiCoinAddr");
+    }
+
+    @Override
+    public EnsPubkeyResult resolvePubkey(String name) {
+        throw notYetWired("resolvePubkey");
+    }
+
+    @Override
+    public EnsAbiResult resolveAbi(String name, long contentTypes) {
+        throw notYetWired("resolveAbi");
+    }
+
+    @Override
+    public EnsDnsRecordResult resolveDnsRecord(String name, String dnsName, int recordType) {
+        throw notYetWired("resolveDnsRecord");
+    }
+
+    @Override
+    public EnsInterfaceResult resolveInterfaceImplementer(String name, byte[] interfaceId4) {
+        throw notYetWired("resolveInterfaceImplementer");
+    }
+
+    private static EngineException notYetWired(String method) {
+        return new EngineException(method
+                + ": not yet wired (lands with the engine-logic motion PR)");
+    }
+}

--- a/node-core/src/main/java/io/myotis/node/api/JavaMyotisEngine.java
+++ b/node-core/src/main/java/io/myotis/node/api/JavaMyotisEngine.java
@@ -1,0 +1,170 @@
+package io.myotis.node.api;
+
+import com.jaeckel.ethp2p.core.crypto.NodeKey;
+import com.jaeckel.ethp2p.networking.NetworkConfig;
+import io.myotis.api.ChainHandle;
+import io.myotis.api.EngineConfig;
+import io.myotis.api.EngineException;
+import io.myotis.api.MyotisEngine;
+import io.myotis.api.NetworkInfo;
+import io.myotis.api.ports.EnginePorts;
+import io.myotis.node.ChainPorts;
+import io.myotis.node.ChainStack;
+import io.myotis.node.NodeRegistry;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.crypto.SECP256K1;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * The JVM reference implementation of {@link MyotisEngine}: wraps {@link NodeRegistry} +
+ * {@link ChainStack} behind the language-neutral API. This class is the single line a host
+ * writes that names a concrete engine ({@code new JavaMyotisEngine()}); everything else the
+ * host touches is {@code io.myotis.api}.
+ */
+public final class JavaMyotisEngine implements MyotisEngine {
+
+    private final NodeRegistry registry = new NodeRegistry();
+    private final Map<String, JavaChainHandle> handles = new ConcurrentHashMap<>();
+    /**
+     * Runs the blocking {@code HttpGateway} port when the engine's CCIP executor needs a
+     * future (see {@link PortBridges#toCcipGateway}). Unbounded cached pool: CCIP calls are
+     * rare, short (~10–15 s timeout in the port), and must never queue behind each other.
+     */
+    private final ExecutorService httpExecutor = Executors.newCachedThreadPool(r -> {
+        Thread t = new Thread(r, "engine-http-gateway");
+        t.setDaemon(true);
+        return t;
+    });
+
+    @Override
+    public List<NetworkInfo> availableNetworks() {
+        List<NetworkInfo> out = new ArrayList<>();
+        for (NetworkConfig net : NetworkConfig.allNetworks()) {
+            out.add(toInfo(net));
+        }
+        return out;
+    }
+
+    @Override
+    public String canonicalNetworkName(String nameOrAlias) {
+        if (nameOrAlias == null) throw new EngineException("network name is required");
+        try {
+            return NetworkConfig.byName(nameOrAlias).name();
+        } catch (IllegalArgumentException e) {
+            throw new EngineException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public ChainHandle create(EngineConfig config, EnginePorts ports) {
+        String name = canonicalNetworkName(config.networkName());
+        NetworkConfig net;
+        try {
+            net = NetworkConfig.byName(name);
+        } catch (IllegalArgumentException e) {
+            throw new EngineException(e.getMessage(), e);
+        }
+        if (handles.containsKey(name)) {
+            throw new EngineException("network already hosted: " + name);
+        }
+        // Fail here with a named error rather than letting a null port surface as an
+        // undiagnosable NPE swallowed by ChainStack.start()'s fault isolation.
+        if (ports.peerCache() == null) throw new EngineException("peerCache port is required");
+        if (ports.clPeerCache() == null) throw new EngineException("clPeerCache port is required");
+
+        ChainPorts defaults = ChainPorts.defaultsFor(net);
+        ChainPorts chainPorts = new ChainPorts(
+                config.elPort() > 0 ? config.elPort() : defaults.elPort(),
+                config.discv5Port() > 0 ? config.discv5Port() : defaults.discv5Port(),
+                config.rpcPort() > 0 ? config.rpcPort() : defaults.rpcPort());
+
+        NodeKey nodeKey = loadOrCreateKey(name, ports);
+
+        ChainStack stack = new ChainStack(
+                net,
+                chainPorts,
+                nodeKey,
+                PortBridges.toPeerCachePort(ports.peerCache()),
+                PortBridges.toClPeerCachePort(ports.clPeerCache()),
+                ports.httpGateway() != null
+                        ? PortBridges.toCcipGateway(ports.httpGateway(), httpExecutor)
+                        : null,
+                config.syncSnapshotPath() != null ? Path.of(config.syncSnapshotPath()) : null,
+                config.gossipsubEnabled());
+        if (config.targetSnapPeers() > 0) {
+            stack.configureSnapMaintainer(config.targetSnapPeers(),
+                    PortBridges.toDnsServerProvider(ports.dnsServers()));
+        }
+
+        JavaChainHandle handle = new JavaChainHandle(stack, config.strictStateFreshness());
+        // Atomic claim: two concurrent create()s for the same network must not both
+        // register (the check above is only a fast fail).
+        if (handles.putIfAbsent(name, handle) != null) {
+            throw new EngineException("network already hosted: " + name);
+        }
+        registry.add(stack);
+        return handle;
+    }
+
+    @Override
+    public ChainHandle get(String networkName) {
+        return handles.get(networkName);
+    }
+
+    @Override
+    public List<String> hostedNetworks() {
+        return List.copyOf(handles.keySet());
+    }
+
+    @Override
+    public void stop(String networkName) {
+        handles.remove(networkName);
+        registry.remove(networkName);
+    }
+
+    @Override
+    public void shutdownAll() {
+        handles.clear();
+        registry.shutdownAll();
+    }
+
+    private NodeKey loadOrCreateKey(String networkName, EnginePorts ports) {
+        if (ports.keyStore() == null) throw new EngineException("keyStore port is required");
+        byte[] secret = ports.keyStore().load(networkName);
+        if (secret == null) {
+            NodeKey fresh = NodeKey.generate();
+            ports.keyStore().store(networkName, fresh.secretKey().bytes().toArrayUnsafe());
+            return fresh;
+        }
+        if (secret.length != 32) {
+            throw new EngineException("stored node key for " + networkName
+                    + " must be 32 bytes, got " + secret.length);
+        }
+        try {
+            return NodeKey.fromSecretKey(SECP256K1.SecretKey.fromBytes(Bytes32.wrap(secret)));
+        } catch (Exception e) {
+            throw new EngineException("stored node key for " + networkName + " is invalid: "
+                    + e.getMessage(), e);
+        }
+    }
+
+    private static NetworkInfo toInfo(NetworkConfig net) {
+        return new NetworkInfo(
+                net.name(),
+                net.displayName(),
+                net.networkId(),
+                net.hasEns(),
+                net.defaultElPort(),
+                net.defaultDiscv5Port(),
+                net.defaultRpcPort(),
+                net.clGenesisTime(),
+                net.secondsPerSlot());
+    }
+}

--- a/node-core/src/main/java/io/myotis/node/api/PortBridges.java
+++ b/node-core/src/main/java/io/myotis/node/api/PortBridges.java
@@ -1,0 +1,117 @@
+package io.myotis.node.api;
+
+import io.myotis.api.ports.BootstrapPeer;
+import io.myotis.api.ports.CachedPeerInfo;
+import io.myotis.api.ports.DnsServers;
+import io.myotis.api.ports.EngineClPeerCache;
+import io.myotis.api.ports.EnginePeerCache;
+import io.myotis.api.ports.HttpGateway;
+import io.myotis.api.ports.ServedRange;
+import io.myotis.node.CachedPeer;
+import io.myotis.node.ClPeerCachePort;
+import io.myotis.node.DnsServerProvider;
+import io.myotis.node.PeerCachePort;
+import io.myotis.node.SnapQuality;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+/**
+ * Bridges between the language-neutral {@code io.myotis.api.ports} interfaces the host
+ * implements and the engine-internal port shapes {@code ChainStack} consumes
+ * (InetSocketAddress, Map/Set collections, CompletableFuture). All conversions are
+ * mechanical; no behavior lives here.
+ */
+final class PortBridges {
+
+    private PortBridges() {}
+
+    static PeerCachePort toPeerCachePort(EnginePeerCache cache) {
+        return new PeerCachePort() {
+            @Override public void add(InetSocketAddress address, String publicKeyHex, boolean snap) {
+                cache.add(address.getHostString(), address.getPort(), publicKeyHex, snap);
+            }
+            @Override public void recordSnapServed(InetSocketAddress address) {
+                cache.recordSnapServed(address.getHostString(), address.getPort());
+            }
+            @Override public void recordSnapFailure(InetSocketAddress address) {
+                cache.recordSnapFailure(address.getHostString(), address.getPort());
+            }
+            @Override public List<CachedPeer> load() {
+                List<CachedPeerInfo> cached = cache.load();
+                List<CachedPeer> out = new ArrayList<>(cached.size());
+                for (CachedPeerInfo p : cached) {
+                    out.add(new CachedPeer(
+                            new InetSocketAddress(p.host(), p.port()),
+                            p.publicKeyHex(), p.snap(),
+                            SnapQuality.valueOf(p.snapQuality().name())));
+                }
+                return out;
+            }
+            @Override public void close() { cache.close(); }
+        };
+    }
+
+    static ClPeerCachePort toClPeerCachePort(EngineClPeerCache cache) {
+        return new ClPeerCachePort() {
+            @Override public List<String> load() { return cache.load(); }
+            @Override public void add(String multiaddr) { cache.add(multiaddr); }
+            @Override public void markFailure(String multiaddr) { cache.markFailure(multiaddr); }
+            @Override public Map<String, long[]> servedRanges() {
+                Map<String, long[]> out = new HashMap<>();
+                for (ServedRange r : cache.servedRanges()) {
+                    out.put(r.multiaddr(), new long[]{r.low(), r.high()});
+                }
+                return out;
+            }
+            @Override public void recordServed(String multiaddr, long low, long high) {
+                cache.recordServed(multiaddr, low, high);
+            }
+            @Override public Map<String, Long> bootstrapPeers() {
+                Map<String, Long> out = new HashMap<>();
+                for (BootstrapPeer p : cache.bootstrapPeers()) {
+                    out.put(p.multiaddr(), p.period());
+                }
+                return out;
+            }
+            @Override public void recordBootstrap(String multiaddr, long period) {
+                cache.recordBootstrap(multiaddr, period);
+            }
+            @Override public Set<String> lightClientConfirmed() {
+                return new HashSet<>(cache.lightClientConfirmed());
+            }
+            @Override public Set<String> lightClientDenied() {
+                return new HashSet<>(cache.lightClientDenied());
+            }
+            @Override public void markLightClientBatch(Collection<String> confirmed, Collection<String> denied) {
+                cache.markLightClientBatch(List.copyOf(confirmed), List.copyOf(denied));
+            }
+            @Override public void close() { cache.close(); }
+        };
+    }
+
+    /**
+     * The api gateway is blocking (the FFI-portable shape); the engine's CCIP executor wants a
+     * future. Run the blocking call on {@code executor} — never an engine I/O thread.
+     */
+    static io.myotis.evm.ccipread.CcipGateway toCcipGateway(HttpGateway gateway, Executor executor) {
+        return (method, url, body) -> CompletableFuture.supplyAsync(() ->
+                gateway.request(
+                        method == io.myotis.evm.ccipread.CcipGateway.Method.GET
+                                ? HttpGateway.Method.GET : HttpGateway.Method.POST,
+                        url, body),
+                executor);
+    }
+
+    static DnsServerProvider toDnsServerProvider(DnsServers servers) {
+        return servers == null ? null : servers::dnsServerIps;
+    }
+}

--- a/node-core/src/main/java/io/myotis/node/api/VerifiedReadsAdapter.java
+++ b/node-core/src/main/java/io/myotis/node/api/VerifiedReadsAdapter.java
@@ -1,0 +1,116 @@
+package io.myotis.node.api;
+
+import io.myotis.api.SyncState;
+import io.myotis.api.VerifiedReads;
+import io.myotis.rpc.VerifiedRpcBackend;
+
+import java.math.BigInteger;
+
+/**
+ * Maps {@link VerifiedRpcBackend} onto the language-neutral {@link VerifiedReads} shape:
+ * BigInteger ⇄ decimal String, hash bytes ⇄ hex, enum for the sync state. Pure conversion —
+ * every verification decision stays in the backend. Interim adapter: the SPI-retirement step
+ * (plan PR4) makes the backend implement {@link VerifiedReads} directly and deletes this.
+ */
+final class VerifiedReadsAdapter implements VerifiedReads {
+
+    private final VerifiedRpcBackend backend;
+
+    VerifiedReadsAdapter(VerifiedRpcBackend backend) {
+        this.backend = backend;
+    }
+
+    @Override public long chainId() { return backend.chainId(); }
+
+    @Override public Long headBlockNumber() { return backend.headBlockNumber(); }
+
+    @Override public SyncState syncState() { return SyncState.valueOf(backend.syncState()); }
+
+    @Override
+    public byte[] call(byte[] from, byte[] to, byte[] data, String valueWei, String block) {
+        return backend.call(from, to, data, toBigInt(valueWei), block);
+    }
+
+    @Override
+    public String getBalance(byte[] address, String block) {
+        BigInteger b = backend.getBalance(address, block);
+        return b == null ? null : b.toString();
+    }
+
+    @Override
+    public Long getTransactionCount(byte[] address, String block) {
+        return backend.getTransactionCount(address, block);
+    }
+
+    @Override
+    public byte[] getCode(byte[] address, String block) {
+        return backend.getCode(address, block);
+    }
+
+    @Override
+    public byte[] getStorageAt(byte[] address, byte[] slot32, String block) {
+        return backend.getStorageAt(address, slot32, block);
+    }
+
+    @Override
+    public byte[] sendRawTransaction(byte[] rawTx) {
+        return backend.sendRawTransaction(rawTx);
+    }
+
+    @Override
+    public String getTransactionReceipt(byte[] txHash) {
+        return backend.getTransactionReceipt(txHash);
+    }
+
+    @Override
+    public String getTransactionByHash(byte[] txHash) {
+        return backend.getTransactionByHash(txHash);
+    }
+
+    @Override
+    public String getBlockByNumber(String block, boolean fullTransactions) {
+        return backend.getBlockByNumber(block, fullTransactions);
+    }
+
+    @Override
+    public String getBlockByHash(byte[] blockHash32, boolean fullTransactions) {
+        return backend.getBlockByHash(toHex(blockHash32), fullTransactions);
+    }
+
+    @Override
+    public String gasPrice() {
+        BigInteger p = backend.gasPrice();
+        return p == null ? null : p.toString();
+    }
+
+    @Override
+    public String maxPriorityFeePerGas() {
+        BigInteger p = backend.maxPriorityFeePerGas();
+        return p == null ? null : p.toString();
+    }
+
+    @Override
+    public String feeHistory(long blockCount, String newestBlock, double[] rewardPercentiles) {
+        return backend.feeHistory(blockCount, newestBlock, rewardPercentiles);
+    }
+
+    @Override
+    public Long estimateGas(byte[] from, byte[] to, byte[] data, String valueWei) {
+        BigInteger gas = backend.estimateGas(from, to, data, toBigInt(valueWei));
+        return gas == null ? null : gas.longValue();
+    }
+
+    private static BigInteger toBigInt(String decimal) {
+        return decimal == null ? null : new BigInteger(decimal);
+    }
+
+    private static String toHex(byte[] bytes) {
+        if (bytes == null) return null;
+        StringBuilder sb = new StringBuilder(2 + bytes.length * 2);
+        sb.append("0x");
+        for (byte b : bytes) {
+            sb.append(Character.forDigit((b >> 4) & 0xF, 16)).append(Character.forDigit(b & 0xF, 16));
+        }
+        return sb.toString();
+    }
+}

--- a/node-core/src/test/java/io/myotis/node/VerifiedAccountQueryVerifyTest.java
+++ b/node-core/src/test/java/io/myotis/node/VerifiedAccountQueryVerifyTest.java
@@ -1,0 +1,105 @@
+package io.myotis.node;
+
+import com.jaeckel.ethp2p.consensus.BeaconSyncState;
+import com.jaeckel.ethp2p.networking.snap.messages.AccountRangeMessage;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Locks the {@link VerifiedAccountQuery.Verification} contract for the paths constructible
+ * without a live peer: the failure ladder must set the exact {@code failReason} tokens the
+ * daemon's IPC JSON exposes, and the stateRootMatch fast-path must carry the beacon match
+ * through to the verdict. (The headerChain path needs a peer round-trip and is covered by
+ * the integration contract instead.)
+ */
+class VerifiedAccountQueryVerifyTest {
+
+    @org.junit.jupiter.api.BeforeAll
+    static void setUpProvider() {
+        // Tuweni's keccak256 needs the BouncyCastle provider (same setup as the
+        // networking module's message tests).
+        java.security.Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
+    }
+
+    private static final Bytes ADDRESS =
+            Bytes.fromHexString("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
+
+    @Test
+    void noStateRootFailsWithNoPeerStateRoot() throws Exception {
+        AccountRangeMessage.DecodeResult result =
+                new AccountRangeMessage.DecodeResult(1, List.of(), List.of());
+        VerifiedAccountQuery.Verification v =
+                VerifiedAccountQuery.verify(result, ADDRESS, new BeaconSyncState(), null).get();
+
+        assertEquals("noPeerStateRoot", v.failReason());
+        assertFalse(v.peerProofValid());
+        assertFalse(v.beaconChainVerified());
+        assertFalse(v.blsVerified());
+        assertEquals(-1, v.matchedSlot());
+        assertNull(v.verifyMethod());
+        // No proof-verified leaf → no authoritative storageRoot/codeHash.
+        assertNull(v.verifiedStorageRootHex());
+        assertNull(v.verifiedCodeHashHex());
+    }
+
+    @Test
+    void invalidProofFailsWithPeerProofInvalid() throws Exception {
+        Bytes32 stateRoot = Bytes32.fromHexString(
+                "0x1111111111111111111111111111111111111111111111111111111111111111");
+        // A garbage proof node: proof verification must fail, never throw.
+        AccountRangeMessage.DecodeResult result = new AccountRangeMessage.DecodeResult(
+                1, List.of(), List.of(Bytes.fromHexString("0xdeadbeef")), stateRoot, 100);
+        VerifiedAccountQuery.Verification v =
+                VerifiedAccountQuery.verify(result, ADDRESS, new BeaconSyncState(), null).get();
+
+        assertEquals("peerProofInvalid", v.failReason());
+        assertFalse(v.peerProofValid());
+        assertNull(v.verifiedStorageRootHex());
+        assertFalse(v.beaconChainVerified());
+    }
+
+    @Test
+    void stateRootMatchFastPathCarriesBeaconMatch() throws Exception {
+        Bytes32 stateRoot = Bytes32.fromHexString(
+                "0x2222222222222222222222222222222222222222222222222222222222222222");
+        BeaconSyncState bss = new BeaconSyncState();
+        bss.recordStateRoot(12345L, stateRoot.toArrayUnsafe(), true);
+
+        // Empty proof: the fast-path fires on the beacon match alone; peerProofValid stays
+        // false — the verdict must expose BOTH truthfully (beaconChainVerified is not a
+        // proxy for leaf-proof validity).
+        AccountRangeMessage.DecodeResult result = new AccountRangeMessage.DecodeResult(
+                1, List.of(), List.of(), stateRoot, 100);
+        VerifiedAccountQuery.Verification v =
+                VerifiedAccountQuery.verify(result, ADDRESS, bss, null).get();
+
+        assertTrue(v.beaconChainVerified());
+        assertTrue(v.blsVerified());
+        assertEquals(12345L, v.matchedSlot());
+        assertEquals("stateRootMatch", v.verifyMethod());
+        assertNull(v.failReason());
+        assertFalse(v.peerProofValid());
+        assertNull(v.verifiedStorageRootHex());
+    }
+
+    @Test
+    void beaconNotSyncedFailsAfterValidStructureChecks() throws Exception {
+        Bytes32 stateRoot = Bytes32.fromHexString(
+                "0x3333333333333333333333333333333333333333333333333333333333333333");
+        // Proof present but bogus → the ladder stops at peerProofInvalid before the beacon
+        // check; with NO proof it must stop at peerProofInvalid too (no leaf was verified).
+        AccountRangeMessage.DecodeResult noProof = new AccountRangeMessage.DecodeResult(
+                1, List.of(), List.of(), stateRoot, 100);
+        VerifiedAccountQuery.Verification v =
+                VerifiedAccountQuery.verify(noProof, ADDRESS, new BeaconSyncState(), null).get();
+        assertEquals("peerProofInvalid", v.failReason());
+    }
+}

--- a/node-core/src/test/java/io/myotis/node/api/JavaMyotisEngineTest.java
+++ b/node-core/src/test/java/io/myotis/node/api/JavaMyotisEngineTest.java
@@ -1,0 +1,115 @@
+package io.myotis.node.api;
+
+import io.myotis.api.ChainHandle;
+import io.myotis.api.EngineConfig;
+import io.myotis.api.EngineException;
+import io.myotis.api.NetworkInfo;
+import io.myotis.api.ports.EngineClPeerCache;
+import io.myotis.api.ports.EnginePeerCache;
+import io.myotis.api.ports.EnginePorts;
+import io.myotis.api.ports.NodeKeyStore;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JavaMyotisEngineTest {
+
+    static final class MemoryKeyStore implements NodeKeyStore {
+        final Map<String, byte[]> keys = new HashMap<>();
+        @Override public byte[] load(String networkName) { return keys.get(networkName); }
+        @Override public void store(String networkName, byte[] secret32) { keys.put(networkName, secret32); }
+    }
+
+    private static EnginePorts testPorts(NodeKeyStore keyStore) {
+        EnginePeerCache peerCache = new PortBridgesTest.FakePeerCache();
+        EngineClPeerCache clCache = new PortBridgesTest.FakeClCache();
+        return new EnginePorts(keyStore, peerCache, clCache, null, null, null, null);
+    }
+
+    @Test
+    void canonicalNameResolvesAliases() {
+        JavaMyotisEngine engine = new JavaMyotisEngine();
+        assertEquals("gnosis", engine.canonicalNetworkName("xdai"));
+        assertEquals("gnosis", engine.canonicalNetworkName("GBC"));
+        assertEquals("mainnet", engine.canonicalNetworkName("Mainnet"));
+        assertThrows(EngineException.class, () -> engine.canonicalNetworkName("holesky"));
+        assertThrows(EngineException.class, () -> engine.canonicalNetworkName(null));
+    }
+
+    @Test
+    void availableNetworksCarriesMetadata() {
+        JavaMyotisEngine engine = new JavaMyotisEngine();
+        List<NetworkInfo> nets = engine.availableNetworks();
+        assertEquals(3, nets.size());
+        NetworkInfo mainnet = nets.stream().filter(n -> n.name().equals("mainnet")).findFirst().orElseThrow();
+        assertEquals(1L, mainnet.chainId());
+        assertTrue(mainnet.hasEns());
+        assertEquals(30303, mainnet.defaultElPort());
+        assertEquals(8545, mainnet.defaultRpcPort());
+        assertEquals(12, mainnet.secondsPerSlot());
+        NetworkInfo gnosis = nets.stream().filter(n -> n.name().equals("gnosis")).findFirst().orElseThrow();
+        assertEquals(100L, gnosis.chainId());
+        assertFalse(gnosis.hasEns());
+        assertEquals(5, gnosis.secondsPerSlot());
+    }
+
+    @Test
+    void createDefaultsPortsGeneratesKeyAndRegisters() {
+        JavaMyotisEngine engine = new JavaMyotisEngine();
+        MemoryKeyStore keyStore = new MemoryKeyStore();
+        EngineConfig config = new EngineConfig("gnosis", 0, 0, 0, null, false, 0, true);
+
+        ChainHandle handle = engine.create(config, testPorts(keyStore));
+        assertNotNull(handle);
+        assertEquals("gnosis", handle.networkName());
+        assertEquals(100L, handle.chainId());
+        assertFalse(handle.isRunning());
+
+        // A fresh 32-byte identity was generated and persisted through the port.
+        assertEquals(32, keyStore.keys.get("gnosis").length);
+
+        assertEquals(List.of("gnosis"), engine.hostedNetworks());
+        assertEquals(handle, engine.get("gnosis"));
+        assertNull(engine.get("mainnet"));
+
+        // Same network twice is a programmer error.
+        assertThrows(EngineException.class, () -> engine.create(config, testPorts(keyStore)));
+
+        engine.stop("gnosis");
+        assertTrue(engine.hostedNetworks().isEmpty());
+    }
+
+    @Test
+    void createReusesStoredKey() {
+        JavaMyotisEngine engine = new JavaMyotisEngine();
+        MemoryKeyStore keyStore = new MemoryKeyStore();
+        byte[] secret = new byte[32];
+        secret[31] = 1; // valid non-zero scalar
+        keyStore.keys.put("sepolia", secret.clone());
+
+        engine.create(new EngineConfig("sepolia", 0, 0, 0, null, false, 0, true),
+                testPorts(keyStore));
+        // The stored key was used, not overwritten.
+        assertEquals(1, keyStore.keys.get("sepolia")[31]);
+        engine.shutdownAll();
+    }
+
+    @Test
+    void createRejectsBadStoredKey() {
+        JavaMyotisEngine engine = new JavaMyotisEngine();
+        MemoryKeyStore keyStore = new MemoryKeyStore();
+        keyStore.keys.put("mainnet", new byte[16]); // wrong length
+        assertThrows(EngineException.class, () ->
+                engine.create(new EngineConfig("mainnet", 0, 0, 0, null, false, 0, true),
+                        testPorts(keyStore)));
+    }
+}

--- a/node-core/src/test/java/io/myotis/node/api/PortBridgesTest.java
+++ b/node-core/src/test/java/io/myotis/node/api/PortBridgesTest.java
@@ -1,0 +1,127 @@
+package io.myotis.node.api;
+
+import io.myotis.api.ports.BootstrapPeer;
+import io.myotis.api.ports.CachedPeerInfo;
+import io.myotis.api.ports.EngineClPeerCache;
+import io.myotis.api.ports.EnginePeerCache;
+import io.myotis.api.ports.ServedRange;
+import io.myotis.node.CachedPeer;
+import io.myotis.node.ClPeerCachePort;
+import io.myotis.node.PeerCachePort;
+import io.myotis.node.SnapQuality;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PortBridgesTest {
+
+    /** Minimal recording fake for the EL side. */
+    static final class FakePeerCache implements EnginePeerCache {
+        final List<String> added = new ArrayList<>();
+        final List<String> served = new ArrayList<>();
+        boolean closed;
+        List<CachedPeerInfo> toLoad = List.of();
+
+        @Override public void add(String host, int port, String publicKeyHex, boolean snap) {
+            added.add(host + ":" + port + "/" + publicKeyHex + "/" + snap);
+        }
+        @Override public void recordSnapServed(String host, int port) { served.add(host + ":" + port); }
+        @Override public void recordSnapFailure(String host, int port) { }
+        @Override public List<CachedPeerInfo> load() { return toLoad; }
+        @Override public void close() { closed = true; }
+    }
+
+    @Test
+    void elPeerCacheRoundTrip() {
+        FakePeerCache fake = new FakePeerCache();
+        fake.toLoad = List.of(
+                new CachedPeerInfo("10.0.0.1", 30303, "aa", true,
+                        io.myotis.api.ports.SnapQuality.CONFIRMED),
+                new CachedPeerInfo("10.0.0.2", 30304, "bb", false,
+                        io.myotis.api.ports.SnapQuality.DENIED));
+        PeerCachePort port = PortBridges.toPeerCachePort(fake);
+
+        port.add(new InetSocketAddress("10.0.0.3", 30305), "cc", true);
+        assertEquals(List.of("10.0.0.3:30305/cc/true"), fake.added);
+
+        port.recordSnapServed(InetSocketAddress.createUnresolved("10.0.0.4", 30306));
+        assertEquals(List.of("10.0.0.4:30306"), fake.served);
+
+        List<CachedPeer> loaded = port.load();
+        assertEquals(2, loaded.size());
+        assertEquals("10.0.0.1", loaded.get(0).address().getHostString());
+        assertEquals(30303, loaded.get(0).address().getPort());
+        assertEquals("aa", loaded.get(0).publicKeyHex());
+        assertTrue(loaded.get(0).snap());
+        assertEquals(SnapQuality.CONFIRMED, loaded.get(0).snapQuality());
+        assertEquals(SnapQuality.DENIED, loaded.get(1).snapQuality());
+
+        port.close();
+        assertTrue(fake.closed);
+    }
+
+    /** Minimal fake for the CL side, returning fixed flat records. */
+    static final class FakeClCache implements EngineClPeerCache {
+        List<String> confirmedBatch;
+        List<String> deniedBatch;
+
+        @Override public List<String> load() { return List.of("/ip4/1.2.3.4/tcp/9000/p2p/x"); }
+        @Override public void add(String multiaddr) { }
+        @Override public void markFailure(String multiaddr) { }
+        @Override public List<ServedRange> servedRanges() {
+            return List.of(new ServedRange("peerA", 100, 120));
+        }
+        @Override public void recordServed(String multiaddr, long low, long high) { }
+        @Override public List<BootstrapPeer> bootstrapPeers() {
+            return List.of(new BootstrapPeer("peerB", 1400));
+        }
+        @Override public void recordBootstrap(String multiaddr, long period) { }
+        @Override public List<String> lightClientConfirmed() { return List.of("lc1", "lc2"); }
+        @Override public List<String> lightClientDenied() { return List.of("bad1"); }
+        @Override public void markLightClientBatch(List<String> confirmed, List<String> denied) {
+            this.confirmedBatch = confirmed;
+            this.deniedBatch = denied;
+        }
+        @Override public void close() { }
+    }
+
+    @Test
+    void clPeerCacheListToMapConversions() {
+        FakeClCache fake = new FakeClCache();
+        ClPeerCachePort port = PortBridges.toClPeerCachePort(fake);
+
+        Map<String, long[]> ranges = port.servedRanges();
+        assertEquals(1, ranges.size());
+        assertEquals(100, ranges.get("peerA")[0]);
+        assertEquals(120, ranges.get("peerA")[1]);
+
+        Map<String, Long> bootstraps = port.bootstrapPeers();
+        assertEquals(1400L, bootstraps.get("peerB"));
+
+        assertEquals(2, port.lightClientConfirmed().size());
+        assertTrue(port.lightClientConfirmed().contains("lc1"));
+        assertEquals(1, port.lightClientDenied().size());
+
+        port.markLightClientBatch(List.of("a"), List.of("b"));
+        assertEquals(List.of("a"), fake.confirmedBatch);
+        assertEquals(List.of("b"), fake.deniedBatch);
+    }
+
+    @Test
+    void nullDnsServersBridgesToNullProvider() {
+        assertNull(PortBridges.toDnsServerProvider(null));
+    }
+
+    @Test
+    void dnsServersBridge() {
+        assertEquals(List.of("8.8.8.8"),
+                PortBridges.toDnsServerProvider(() -> List.of("8.8.8.8")).get());
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -38,4 +38,4 @@ dependencyResolutionManagement {
     }
 }
 
-include("core", "networking", "consensus", "app", "android-app", "myotis-evm", "myotis-ens", "jsonrpc-server", "rpc-backend", "node-core", "ui", "app-desktop")
+include("core", "networking", "consensus", "app", "android-app", "myotis-evm", "myotis-ens", "jsonrpc-server", "rpc-backend", "node-core", "ui", "app-desktop", "myotis-api")


### PR DESCRIPTION
First of six PRs extracting a formal, language-neutral engine API so the whole Java engine can later be swapped for a Rust/Go implementation behind the same contract (per `docs/reimplementation/`). Plan phases: (1) define the API, (2) make the Java engine implement it + rewire hosts, (3) document. This PR is phase 1 plus the node-core half of phase 2. **No host is rewired yet** — nothing behavioral changes for the daemon, desktop, or Android.

## New module `:myotis-api`
Zero-dependency, Java 17 (`options.release=17`), enforced by a `checkZeroDependencies` task on both the runtime and compile classpaths. FFI-portable types only — `byte[]`, `String`, `long`, enums, flat records, `List`; no Tuweni, no `CompletableFuture`, no `BigInteger`. All methods blocking (documented worker-thread contract) — the cleanest shape for a future UniFFI/JNI binding, and both Kotlin hosts already wrap calls in `Dispatchers.IO`.

Surface:
- `MyotisEngine` — network catalog, `create(EngineConfig, EnginePorts)`, per-network lifecycle
- `ChainHandle` — start/stop, `status()` (consolidated `StatusSnapshot` superset of all three hosts' status paths), `reads()`, `ens()`, verified operator queries (`requestAccount`, `getStorageProof`, `getHeaders`, `getBlockVerified`, `dialPeer`)
- `VerifiedReads` — the eth_* contract (template: the jsonrpc-server SPI; wei as decimal strings)
- `EnsApi` + per-record result types
- `io.myotis.api.ports` — the host-implemented seams (`NodeKeyStore`, `EnginePeerCache`, `EngineClPeerCache`, `DnsServers`, `HttpGateway`, `EngineLogger`, `EngineClock`)
- 3-tier error model: `VerifiedReads` → `null` = no verified answer; verification queries → result records with `failReason`; programmer/state errors → `EngineException` (the only exception type)

## node-core implements it (`io.myotis.node.api`)
- `JavaMyotisEngine` wraps `NodeRegistry`: key load/generate via the `NodeKeyStore` port, port bridges, `ChainPorts` defaulting (0 → network default), atomic duplicate-create guard, named errors for missing required ports.
- `JavaChainHandle` wraps `ChainStack`: single home for status assembly (incl. the **distinct** `snapPeers` vs `snapServingPeers` counts — serving-pool collapse stays visible), `requestAccount` via the new `queryProof`, `getHeaders`, `dialPeer`. `getStorageProof`/`getBlockVerified`/ENS-record lookups throw a named `EngineException` until PR 2/6 moves that logic out of `CommandHandler` — nothing calls them until the hosts are rewired in PR 3/6.
- `VerifiedReadsAdapter` maps `VerifiedRpcBackend` (interim until PR 4/6 makes the backend implement `VerifiedReads` directly).

## VerifiedAccountQuery hardening (the #115 review follow-up)
- `Verification` is now an **immutable record** and no longer leaks `MerklePatriciaVerifier.VerifiedAccount` — it exposes `verifiedStorageRootHex`/`verifiedCodeHashHex` from the proof-verified leaf instead.
- `verify()` gains an overload accepting the already-located `AccountData` (no second scan).
- New `queryProof()` returns the full `AccountProofResult` (proof nodes, accountHash, beacon diagnostics) so an API host can reproduce the daemon's `get-account` JSON from the record alone.
- **Daemon JSON stays byte-identical**: `CommandHandler` only switched to record accessors and the pre-found overload; the independent review compared the serialization line-by-line.

## Tests
- `VerifiedAccountQueryVerifyTest` — locks the verify() failure-ladder tokens (`noPeerStateRoot`, `peerProofInvalid`) and the stateRootMatch fast-path semantics (incl. that `beaconChainVerified` is not a proxy for leaf-proof validity).
- `JavaMyotisEngineTest` — alias resolution, network metadata, port defaulting, key roundtrip/reuse/rejection, duplicate-create, stop/shutdown bookkeeping.
- `PortBridgesTest` — EL/CL cache bridge conversions, DNS bridge.
- `checkZeroDependencies` wired into `check`.

## Verification
- `./gradlew build` green across all modules (incl. `:android-app:assembleDebug` — the API module is minSdk-29-safe by construction).
- Independent pre-PR review (no implementation knowledge) ran against the full branch diff; its one MUST-FIX (the `snapPeers`/`snapServingPeers` conflation) and the SHOULD-FIXes (compile-classpath guard, required-port validation, verify() contract tests, atomic create, freshness-property ordering) are all incorporated.

Next: PR 2/6 moves the daemon's ENS-record/storage/header/block engine logic into node-core behind these interfaces (with golden tests locking the IPC JSON first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)