### PR TITLE
refactor: move get-storage/get-block/get-headers/ENS engine logic into the engine (API extraction 2/6)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,6 +39,8 @@ dependencies {
 
     testImplementation(platform(libs.junit.bom))
     testImplementation(libs.junit.jupiter)
+    // CommandHandler's static init computes a keccak256 → tests must register the BC provider.
+    testImplementation(libs.bouncycastle)
 }
 
 tasks.test {

--- a/app/src/main/java/com/jaeckel/ethp2p/app/CommandHandler.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/CommandHandler.java
@@ -4,7 +4,6 @@ import com.jaeckel.ethp2p.consensus.BeaconLightClient;
 import com.jaeckel.ethp2p.consensus.BeaconSyncState;
 import com.jaeckel.ethp2p.consensus.libp2p.BeaconP2PService;
 import com.jaeckel.ethp2p.consensus.lightclient.BeaconChainSpec;
-import com.jaeckel.ethp2p.consensus.proof.MerklePatriciaVerifier;
 import io.myotis.node.VerifiedAccountQuery;
 import com.jaeckel.ethp2p.core.types.BlockHeader;
 import com.jaeckel.ethp2p.networking.discv4.DiscV4Service;
@@ -14,10 +13,8 @@ import com.jaeckel.ethp2p.networking.eth.messages.BlockBodiesMessage;
 import com.jaeckel.ethp2p.networking.eth.messages.BlockHeadersMessage;
 import com.jaeckel.ethp2p.networking.rlpx.RLPxConnector;
 import com.jaeckel.ethp2p.networking.snap.messages.AccountRangeMessage;
-import com.jaeckel.ethp2p.networking.snap.messages.StorageRangesMessage;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
-import org.apache.tuweni.crypto.Hash;
 import org.apache.tuweni.rlp.RLP;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -397,266 +394,82 @@ public class CommandHandler {
     private String handleGetHeaders(String jsonLine) {
         long blockNumber = extractLong(jsonLine, "blockNumber");
         int count = (int) extractLong(jsonLine, "count");
+        // The fetch lives in node-core (io.myotis.node.HeaderQuery, shared with the
+        // engine API); this handler only serializes.
+        io.myotis.api.HeadersResult result = io.myotis.node.HeaderQuery.fetch(connector, blockNumber, count);
+        if (result.error() != null) return jsonError(result.error());
+        return buildHeadersJson(result);
+    }
 
-        try {
-            List<BlockHeadersMessage.VerifiedHeader> headers =
-                    connector.requestBlockHeaders(blockNumber, count)
-                             .get(30, TimeUnit.SECONDS);
-
-            StringBuilder sb = new StringBuilder();
-            sb.append("{\"ok\":true,\"count\":").append(headers.size()).append(",\"headers\":[");
-            boolean first = true;
-            for (BlockHeadersMessage.VerifiedHeader vh : headers) {
-                if (!first) sb.append(",");
-                first = false;
-                BlockHeader h = vh.header();
-                sb.append("{\"number\":").append(h.number)
-                  .append(",\"hash\":\"").append(vh.hash().toHexString()).append("\"")
-                  .append(",\"parentHash\":\"").append(h.parentHash.toHexString()).append("\"")
-                  .append(",\"stateRoot\":\"").append(h.stateRoot.toHexString()).append("\"")
-                  .append(",\"transactionsRoot\":\"").append(h.transactionsRoot.toHexString()).append("\"")
-                  .append(",\"timestamp\":").append(h.timestamp)
-                  .append(",\"gasUsed\":").append(h.gasUsed)
-                  .append(",\"gasLimit\":").append(h.gasLimit);
-                if (h.baseFeePerGas != null) {
-                    sb.append(",\"baseFeePerGas\":\"").append(h.baseFeePerGas).append("\"");
-                }
-                sb.append("}");
+    /** Pure serializer for get-headers (golden-tested); field order matches the historical output. */
+    static String buildHeadersJson(io.myotis.api.HeadersResult result) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{\"ok\":true,\"count\":").append(result.headers().size()).append(",\"headers\":[");
+        boolean first = true;
+        for (io.myotis.api.HeaderInfo h : result.headers()) {
+            if (!first) sb.append(",");
+            first = false;
+            sb.append("{\"number\":").append(h.number())
+              .append(",\"hash\":\"").append(h.hashHex()).append("\"")
+              .append(",\"parentHash\":\"").append(h.parentHashHex()).append("\"")
+              .append(",\"stateRoot\":\"").append(h.stateRootHex()).append("\"")
+              .append(",\"transactionsRoot\":\"").append(h.transactionsRootHex()).append("\"")
+              .append(",\"timestamp\":").append(h.timestamp())
+              .append(",\"gasUsed\":").append(h.gasUsed())
+              .append(",\"gasLimit\":").append(h.gasLimit());
+            if (h.baseFeePerGasWei() != null) {
+                sb.append(",\"baseFeePerGas\":\"").append(h.baseFeePerGasWei()).append("\"");
             }
-            sb.append("]}");
-            return sb.toString();
-        } catch (Exception e) {
-            Throwable cause = e.getCause() != null ? e.getCause() : e;
-            String msg = cause.getMessage() != null ? cause.getMessage() : cause.getClass().getSimpleName();
-            return jsonError(msg);
+            sb.append("}");
         }
+        sb.append("]}");
+        return sb.toString();
     }
 
     private String handleGetBlock(String jsonLine) {
         long blockNumber = extractLong(jsonLine, "blockNumber");
-
-        try {
-            // Step 1: fetch the header (use batched path which retries across peers)
-            List<BlockHeadersMessage.VerifiedHeader> headers =
-                    connector.requestBlockHeadersBatched(blockNumber, 1)
-                             .get(30, TimeUnit.SECONDS);
-            if (headers.isEmpty()) {
-                return jsonError("No header returned for block " + blockNumber);
-            }
-            BlockHeadersMessage.VerifiedHeader vh = headers.get(0);
-            BlockHeader h = vh.header();
-
-            // Step 2: fetch the body using the block hash
-            org.apache.tuweni.bytes.Bytes32 blockHash = vh.hash();
-            List<BlockBodiesMessage.BlockBody> bodies =
-                    connector.requestBlockBodies(blockHash)
-                             .get(30, TimeUnit.SECONDS);
-            if (bodies.isEmpty()) {
-                return jsonError("No body returned for block " + blockNumber);
-            }
-            BlockBodiesMessage.BlockBody body = bodies.get(0);
-
-            // Step 3: verify block against beacon chain
-            String verificationJson = buildBlockVerificationJson(h, blockNumber);
-
-            // Step 4: combine into JSON response
-            StringBuilder sb = new StringBuilder();
-            sb.append("{\"ok\":true,\"block\":{");
-            sb.append("\"number\":").append(h.number);
-            sb.append(",\"hash\":\"").append(vh.hash().toHexString()).append("\"");
-            sb.append(",\"parentHash\":\"").append(h.parentHash.toHexString()).append("\"");
-            sb.append(",\"stateRoot\":\"").append(h.stateRoot.toHexString()).append("\"");
-            sb.append(",\"transactionsRoot\":\"").append(h.transactionsRoot.toHexString()).append("\"");
-            sb.append(",\"receiptsRoot\":\"").append(h.receiptsRoot.toHexString()).append("\"");
-            sb.append(",\"timestamp\":").append(h.timestamp);
-            sb.append(",\"gasUsed\":").append(h.gasUsed);
-            sb.append(",\"gasLimit\":").append(h.gasLimit);
-            if (h.baseFeePerGas != null) {
-                sb.append(",\"baseFeePerGas\":\"").append(h.baseFeePerGas).append("\"");
-            }
-            sb.append(",\"transactionCount\":").append(body.transactions().size());
-            sb.append(",\"uncleCount\":").append(body.uncleCount());
-            sb.append(",\"withdrawalCount\":").append(body.withdrawalCount());
-            sb.append("},\"verification\":").append(verificationJson).append("}");
-            return sb.toString();
-        } catch (Exception e) {
-            Throwable cause = e.getCause() != null ? e.getCause() : e;
-            String msg = cause.getMessage() != null ? cause.getMessage() : cause.getClass().getSimpleName();
-            return jsonError(msg);
-        }
+        // The fetch + beacon verification live in node-core (io.myotis.node.VerifiedBlockQuery,
+        // shared with the engine API); this handler only serializes.
+        io.myotis.api.BlockResult r = io.myotis.node.VerifiedBlockQuery.query(
+                connector, beaconSyncState, blockNumber);
+        if (r.error() != null) return jsonError(r.error());
+        return buildBlockJson(r);
     }
 
-    /**
-     * Build beacon chain verification JSON for a block header.
-     *
-     * Verification strategy:
-     * 1. State root match — check if the block's stateRoot matches a beacon-attested root
-     * 2. Header chain anchored to beacon block hash — the beacon chain's ExecutionPayloadHeader
-     *    contains a block_hash field verified by sync committee BLS signatures. We fetch the
-     *    finalized block header from the peer, verify its keccak256(RLP) matches the beacon-
-     *    attested block hash, then walk the parent-hash chain to/from the requested block.
-     *    Each link in the chain is pinned by the previous header's keccak256 hash, so forging
-     *    any header would require a keccak256 preimage attack.
-     */
-    /** The Merge block — first PoS block on mainnet (Sep 15 2022). */
-    private static final long MERGE_BLOCK = 15_537_394L;
-    private static final int MAX_HEADER_CHAIN_GAP = 8192;
-
-    private String buildBlockVerificationJson(BlockHeader header, long blockNumber) {
-        boolean beaconChainVerified = false;
-        boolean blsVerified = false;
-        long matchedSlot = -1;
-        String verifyMethod = null;
-        String failReason = null;
-
-        // Pre-merge blocks cannot be verified via beacon chain
-        if (blockNumber < MERGE_BLOCK) {
-            failReason = "preMergeBlock";
-        } else {
-            // Strategy 1: direct state root match against beacon-attested roots
-            byte[] blockStateRoot = header.stateRoot.toArrayUnsafe();
-            BeaconSyncState.SlottedStateRoot match = beaconSyncState.findStateRoot(blockStateRoot);
-            if (match != null) {
-                beaconChainVerified = true;
-                matchedSlot = match.slot();
-                blsVerified = match.blsVerified();
-                verifyMethod = "stateRootMatch";
-            }
-
-            // Strategy 2: header chain anchored to beacon-attested block hash
-            if (!beaconChainVerified && beaconSyncState.isSynced()) {
-                long finalizedBlockNum = beaconSyncState.getExecutionBlockNumber();
-                byte[] beaconBlockHash = beaconSyncState.getExecutionBlockHash();
-                long gap = Math.abs(blockNumber - finalizedBlockNum);
-                log.info("[verify-block] headerChain: block={}, finalizedBlock={}, gap={}",
-                        blockNumber, finalizedBlockNum, gap);
-                if (finalizedBlockNum <= 0 || beaconBlockHash == null || beaconBlockHash.length != 32) {
-                    failReason = "beaconBlockHashUnavailable";
-                } else if (gap > MAX_HEADER_CHAIN_GAP && blockNumber != finalizedBlockNum) {
-                    failReason = "headerChainGapTooLarge";
-                } else {
-                    try {
-                        boolean chainValid;
-                        if (blockNumber == finalizedBlockNum) {
-                            chainValid = verifyBlockHashAgainstBeacon(
-                                    finalizedBlockNum, beaconBlockHash, blockStateRoot);
-                        } else if (blockNumber > finalizedBlockNum) {
-                            chainValid = verifyBlockChainFromBeacon(
-                                    finalizedBlockNum, blockNumber, beaconBlockHash);
-                        } else {
-                            chainValid = verifyBlockChainFromBeacon(
-                                    blockNumber, finalizedBlockNum, beaconBlockHash);
-                        }
-                        if (chainValid) {
-                            beaconChainVerified = true;
-                            matchedSlot = beaconSyncState.getFinalizedSlot();
-                            blsVerified = true;
-                            verifyMethod = "headerChain";
-                        } else {
-                            failReason = "headerChainInvalid";
-                        }
-                    } catch (Exception e) {
-                        log.info("[verify-block] Header chain verification failed: {}", e.getMessage());
-                        failReason = "headerChainError";
-                    }
-                }
-            } else if (!beaconChainVerified && !beaconSyncState.isSynced()) {
-                failReason = "beaconNotSynced";
+    /** Pure serializer for get-block (golden-tested); field order matches the historical output. */
+    static String buildBlockJson(io.myotis.api.BlockResult r) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{\"ok\":true,\"block\":{");
+        sb.append("\"number\":").append(r.number());
+        sb.append(",\"hash\":\"").append(r.hashHex()).append("\"");
+        sb.append(",\"parentHash\":\"").append(r.parentHashHex()).append("\"");
+        sb.append(",\"stateRoot\":\"").append(r.stateRootHex()).append("\"");
+        sb.append(",\"transactionsRoot\":\"").append(r.transactionsRootHex()).append("\"");
+        sb.append(",\"receiptsRoot\":\"").append(r.receiptsRootHex()).append("\"");
+        sb.append(",\"timestamp\":").append(r.timestamp());
+        sb.append(",\"gasUsed\":").append(r.gasUsed());
+        sb.append(",\"gasLimit\":").append(r.gasLimit());
+        if (r.baseFeePerGasWei() != null) {
+            sb.append(",\"baseFeePerGas\":\"").append(r.baseFeePerGasWei()).append("\"");
+        }
+        sb.append(",\"transactionCount\":").append(r.transactionCount());
+        sb.append(",\"uncleCount\":").append(r.uncleCount());
+        sb.append(",\"withdrawalCount\":").append(r.withdrawalCount());
+        sb.append("},\"verification\":{");
+        sb.append("\"beaconSynced\":").append(r.beaconSynced());
+        sb.append(",\"beaconChainVerified\":").append(r.beaconChainVerified());
+        if (r.beaconChainVerified()) {
+            sb.append(",\"matchedBeaconSlot\":").append(r.matchedBeaconSlot());
+            sb.append(",\"blsVerified\":").append(r.blsVerified());
+            if (r.verifyMethod() != null) {
+                sb.append(",\"verifyMethod\":\"").append(r.verifyMethod()).append("\"");
             }
         }
-
-        StringBuilder sb = new StringBuilder("{");
-        sb.append("\"beaconSynced\":").append(beaconSyncState.isSynced());
-        sb.append(",\"beaconChainVerified\":").append(beaconChainVerified);
-        if (beaconChainVerified) {
-            sb.append(",\"matchedBeaconSlot\":").append(matchedSlot);
-            sb.append(",\"blsVerified\":").append(blsVerified);
-            if (verifyMethod != null) {
-                sb.append(",\"verifyMethod\":\"").append(verifyMethod).append("\"");
-            }
+        if (!r.beaconChainVerified() && r.failReason() != null) {
+            sb.append(",\"failReason\":\"").append(r.failReason()).append("\"");
         }
-        if (!beaconChainVerified && failReason != null) {
-            sb.append(",\"failReason\":\"").append(failReason).append("\"");
-        }
-        sb.append("}");
+        sb.append("}}");
         return sb.toString();
-    }
-
-    /**
-     * Verify a single block by checking its hash against the beacon-attested block hash.
-     * Used when the requested block IS the finalized block.
-     */
-    private boolean verifyBlockHashAgainstBeacon(long blockNumber, byte[] beaconBlockHash,
-                                                  byte[] expectedStateRoot) throws Exception {
-        List<BlockHeadersMessage.VerifiedHeader> headers =
-                connector.requestBlockHeaders(blockNumber, 1).get(30, TimeUnit.SECONDS);
-        if (headers.isEmpty()) return false;
-        BlockHeadersMessage.VerifiedHeader vh = headers.get(0);
-        // VerifiedHeader.hash() is keccak256(rawRLP) computed locally — compare to beacon anchor
-        if (!java.util.Arrays.equals(vh.hash().toArrayUnsafe(), beaconBlockHash)) {
-            log.info("[verify-block] Finalized block hash mismatch: peer={} beacon={}",
-                    vh.hash().toShortHexString(), Bytes32.wrap(beaconBlockHash).toShortHexString());
-            return false;
-        }
-        // Also confirm stateRoot matches what the requested block header has
-        return java.util.Arrays.equals(vh.header().stateRoot.toArrayUnsafe(), expectedStateRoot);
-    }
-
-    /**
-     * Verify a chain of blocks anchored to the beacon-attested block hash.
-     *
-     * Fetches headers from startBlock to endBlock. The header at finalizedBlockNum
-     * must have keccak256(RLP) == beaconBlockHash (the sync-committee-verified anchor).
-     * All other headers are verified via parent-hash chaining from that anchor.
-     */
-    private boolean verifyBlockChainFromBeacon(long startBlock, long endBlock,
-                                                byte[] beaconBlockHash) throws Exception {
-        long finalizedBlockNum = beaconSyncState.getExecutionBlockNumber();
-        int total = (int) (endBlock - startBlock + 1);
-        if (total < 2 || total > MAX_HEADER_CHAIN_GAP) {
-            log.info("[verify-block] Block chain gap {} — out of range [2, {}]", total, MAX_HEADER_CHAIN_GAP);
-            return false;
-        }
-
-        log.info("[verify-block] Fetching {} headers from block #{} to #{}", total, startBlock, endBlock);
-        List<BlockHeadersMessage.VerifiedHeader> allHeaders =
-                connector.requestBlockHeadersBatched(startBlock, total)
-                        .get(120, TimeUnit.SECONDS);
-        if (allHeaders.size() != total) {
-            log.info("[verify-block] Expected {} headers, got {}", total, allHeaders.size());
-            return false;
-        }
-
-        // Find the finalized block within the chain and verify its hash against beacon
-        int anchorIndex = (int) (finalizedBlockNum - startBlock);
-        if (anchorIndex < 0 || anchorIndex >= allHeaders.size()) {
-            log.info("[verify-block] Finalized block #{} not in range [{}, {}]",
-                    finalizedBlockNum, startBlock, endBlock);
-            return false;
-        }
-        BlockHeadersMessage.VerifiedHeader anchorHeader = allHeaders.get(anchorIndex);
-        if (!java.util.Arrays.equals(anchorHeader.hash().toArrayUnsafe(), beaconBlockHash)) {
-            log.info("[verify-block] Anchor block hash mismatch at #{}: peer={} beacon={}",
-                    finalizedBlockNum, anchorHeader.hash().toShortHexString(),
-                    Bytes32.wrap(beaconBlockHash).toShortHexString());
-            return false;
-        }
-
-        // Verify parent-hash chain continuity across all headers
-        for (int i = 0; i < allHeaders.size() - 1; i++) {
-            Bytes32 currentHash = allHeaders.get(i).hash();
-            Bytes32 nextParent = allHeaders.get(i + 1).header().parentHash;
-            if (!currentHash.equals(nextParent)) {
-                log.info("[verify-block] Hash chain break at index {}: block #{} hash={} != block #{} parentHash={}",
-                        i, allHeaders.get(i).header().number, currentHash.toShortHexString(),
-                        allHeaders.get(i + 1).header().number, nextParent.toShortHexString());
-                return false;
-            }
-        }
-
-        log.info("[verify-block] Block chain verified: {} headers anchored at finalized block #{}",
-                total, finalizedBlockNum);
-        return true;
     }
 
     private String handleGetAccount(String jsonLine) {
@@ -665,79 +478,102 @@ public class CommandHandler {
         if (hex.length() != 40) {
             return jsonError("address must be a 20-byte hex string (40 hex chars)");
         }
-        Bytes address = Bytes.fromHexString(hex);
-        Bytes32 accountHash = Hash.keccak256(address);
+        // The fetch + verification ladder + diagnostics live in node-core
+        // (VerifiedAccountQuery.queryProof, shared with the engine API); this handler
+        // only serializes. The raw input is echoed back unchanged (queryProof
+        // normalizes its own copy).
         try {
-            // Use peer's fresh state root to avoid pruning issues —
-            // peers prune state beyond ~128 blocks, so a beacon-finalized root
-            // (6+ min old) is usually too stale for them to serve.
-            AccountRangeMessage.DecodeResult result =
-                connector.requestAccount(address).get(30, TimeUnit.SECONDS);
-            AccountRangeMessage.AccountData found = result.accounts().stream()
-                .filter(a -> a.accountHash().equals(accountHash))
-                .findFirst().orElse(null);
-            // Build proof array
-            StringBuilder proofSb = new StringBuilder("[");
-            for (int i = 0; i < result.proof().size(); i++) {
-                if (i > 0) proofSb.append(",");
-                proofSb.append("\"").append(result.proof().get(i).toHexString()).append("\"");
-            }
-            proofSb.append("]");
-            String proofJson = proofSb.toString();
-
-            // Run the SHARED verification ladder (io.myotis.node.VerifiedAccountQuery.verify) —
-            // the single home of the trust anchor — instead of a daemon-local copy. One pass
-            // yields both the beacon verdict AND the proof-verified leaf. Pass the account we
-            // already located so verify() doesn't re-scan the response.
-            VerifiedAccountQuery.Verification v =
-                    VerifiedAccountQuery.verify(result, address, found, beaconSyncState, connector)
-                            .get(90, TimeUnit.SECONDS);
-            String verificationJson = buildVerificationJson(
-                    v, result.stateRoot(), !result.proof().isEmpty(), result.blockNumber());
-
-            if (found == null) {
-                return "{\"ok\":true,\"exists\":false"
-                    + ",\"address\":\"" + addr + "\""
-                    + ",\"accountHash\":\"" + accountHash.toHexString() + "\""
-                    + ",\"proof\":" + proofJson
-                    + ",\"verification\":" + verificationJson + "}";
-            }
-            // storageRoot/codeHash from the proof-verified leaf when available, not the peer's
-            // slim body — a peer can forge those two while keeping nonce/balance honest, and the
-            // slim values would otherwise ride along as "verified".
-            return "{\"ok\":true,\"exists\":true"
-                + ",\"address\":\"" + addr + "\""
-                + ",\"accountHash\":\"" + found.accountHash().toHexString() + "\""
-                + ",\"nonce\":" + found.nonce()
-                + ",\"balance\":\"" + found.balance() + "\""
-                + ",\"storageRoot\":\"" + (v.verifiedStorageRootHex() != null
-                        ? v.verifiedStorageRootHex()
-                        : found.storageRoot().toHexString()) + "\""
-                + ",\"codeHash\":\"" + (v.verifiedCodeHashHex() != null
-                        ? v.verifiedCodeHashHex()
-                        : found.codeHash().toHexString()) + "\""
-                + ",\"proof\":" + proofJson
-                + ",\"verification\":" + verificationJson + "}";
+            io.myotis.api.AccountProofResult r =
+                    VerifiedAccountQuery.queryProof(connector, beaconSyncState,
+                                    clGenesisTime, secondsPerSlot, addr)
+                            .get(120, TimeUnit.SECONDS);
+            return buildAccountJson(addr, r);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return jsonError("interrupted");
         } catch (Exception e) {
-            // The blocking .get() calls above (requestAccount, verify) can throw
-            // InterruptedException; restore the interrupt status so cancellation propagates.
-            if (e instanceof InterruptedException) Thread.currentThread().interrupt();
             Throwable cause = e.getCause() != null ? e.getCause() : e;
             String msg = cause.getMessage() != null ? cause.getMessage() : cause.getClass().getSimpleName();
             return jsonError(msg);
         }
     }
 
+    /** Pure serializer for get-account (golden-tested); field order and conditional
+     *  emissions match the historical output byte-for-byte. {@code echoAddr} is the raw
+     *  request address, echoed exactly as the daemon always has. */
+    static String buildAccountJson(String echoAddr, io.myotis.api.AccountProofResult r) {
+        StringBuilder proofSb = new StringBuilder("[");
+        for (int i = 0; i < r.proofNodesHex().size(); i++) {
+            if (i > 0) proofSb.append(",");
+            proofSb.append("\"").append(r.proofNodesHex().get(i)).append("\"");
+        }
+        proofSb.append("]");
+
+        // The verification sub-object (formerly buildVerificationJson) — the ladder lives
+        // in VerifiedAccountQuery; this is serialization plus the derived periodLag.
+        StringBuilder v = new StringBuilder("{");
+        v.append("\"peerProofValid\":").append(r.peerProofValid());
+        if (r.peerStateRootHex() != null && !r.proofNodesHex().isEmpty()) {
+            v.append(",\"peerStateRoot\":\"").append(r.peerStateRootHex()).append("\"");
+        }
+        v.append(",\"beaconSynced\":").append(r.beaconSynced());
+        v.append(",\"beaconChainVerified\":").append(r.beaconChainVerified());
+        if (r.beaconChainVerified()) {
+            v.append(",\"matchedBeaconSlot\":").append(r.matchedBeaconSlot());
+            v.append(",\"blsVerified\":").append(r.blsVerified());
+            if (r.verifyMethod() != null) {
+                v.append(",\"verifyMethod\":\"").append(r.verifyMethod()).append("\"");
+            }
+        } else {
+            if (r.failReason() != null) {
+                v.append(",\"failReason\":\"").append(r.failReason()).append("\"");
+            }
+            v.append(",\"finalizedPeriod\":").append(r.finalizedPeriod());
+            v.append(",\"wallClockPeriod\":").append(r.wallClockPeriod());
+            v.append(",\"periodLag\":").append(r.wallClockPeriod() - r.finalizedPeriod());
+            if (r.blockNumber() > 0) {
+                v.append(",\"peerBlockNumber\":").append(r.blockNumber());
+            }
+            if (r.finalizedBlockNumber() > 0) {
+                v.append(",\"finalizedBlockNumber\":").append(r.finalizedBlockNumber());
+            }
+            if (r.optimisticBlockNumber() > 0) {
+                v.append(",\"optimisticBlockNumber\":").append(r.optimisticBlockNumber());
+            }
+        }
+        v.append("}");
+
+        if (!r.exists()) {
+            return "{\"ok\":true,\"exists\":false"
+                + ",\"address\":\"" + echoAddr + "\""
+                + ",\"accountHash\":\"" + r.accountHashHex() + "\""
+                + ",\"proof\":" + proofSb
+                + ",\"verification\":" + v + "}";
+        }
+        return "{\"ok\":true,\"exists\":true"
+            + ",\"address\":\"" + echoAddr + "\""
+            + ",\"accountHash\":\"" + r.accountHashHex() + "\""
+            + ",\"nonce\":" + r.nonce()
+            + ",\"balance\":\"" + r.balanceWei() + "\""
+            + ",\"storageRoot\":\"" + r.storageRootHex() + "\""
+            + ",\"codeHash\":\"" + r.codeHashHex() + "\""
+            + ",\"proof\":" + proofSb
+            + ",\"verification\":" + v + "}";
+    }
+
+
     private String handleGetStorage(String jsonLine) {
         String addr = extractString(jsonLine, "address");
         String slotStr = extractString(jsonLine, "slot");
-        String hex = (addr.startsWith("0x") || addr.startsWith("0X")) ? addr.substring(2) : addr;
-        if (hex.length() != 40) {
+
+        // Validate the address FIRST — historical error precedence: a request with a bad
+        // address and a bad slot reports the address problem.
+        String addrHex = (addr.startsWith("0x") || addr.startsWith("0X")) ? addr.substring(2) : addr;
+        if (addrHex.length() != 40) {
             return jsonError("address must be a 20-byte hex string (40 hex chars)");
         }
-        Bytes contractAddress = Bytes.fromHexString(hex);
 
-        // Parse slot number
+        // Parse slot number (host-side argument parsing; everything after is engine logic).
         long slotNumber;
         try {
             slotNumber = Long.parseLong(slotStr);
@@ -745,245 +581,90 @@ public class CommandHandler {
             return jsonError("slot must be a number");
         }
 
-        // Check if a holder address is provided (for ERC-20 mapping lookups)
+        // Optional holder address (ERC-20 mapping lookups).
         String holderAddr = null;
         try { holderAddr = extractString(jsonLine, "holder"); } catch (Exception ignored) {}
 
-        // Compute the storage key
-        byte[] storageSlotKey;
-        if (holderAddr != null) {
-            // ERC-20 mapping: keccak256(abi.encode(holderAddress, uint256(slot)))
-            String holderHex = (holderAddr.startsWith("0x") || holderAddr.startsWith("0X"))
-                    ? holderAddr.substring(2) : holderAddr;
-            if (holderHex.length() != 40) {
-                return jsonError("holder must be a 20-byte hex string (40 hex chars)");
-            }
-            byte[] holderBytes = Bytes.fromHexString(holderHex).toArrayUnsafe();
-            byte[] encoded = new byte[64];
-            // Left-pad holder address to 32 bytes
-            System.arraycopy(holderBytes, 0, encoded, 12, 20);
-            // uint256(slot) as 32 bytes big-endian
-            encoded[63] = (byte) (slotNumber);
-            encoded[62] = (byte) (slotNumber >>> 8);
-            encoded[61] = (byte) (slotNumber >>> 16);
-            encoded[60] = (byte) (slotNumber >>> 24);
-            encoded[59] = (byte) (slotNumber >>> 32);
-            encoded[58] = (byte) (slotNumber >>> 40);
-            encoded[57] = (byte) (slotNumber >>> 48);
-            encoded[56] = (byte) (slotNumber >>> 56);
-            storageSlotKey = Hash.keccak256(Bytes.wrap(encoded)).toArrayUnsafe();
-        } else {
-            // Direct slot access: key = uint256(slot) as 32 bytes big-endian
-            byte[] slotBytes = new byte[32];
-            slotBytes[31] = (byte) (slotNumber);
-            slotBytes[30] = (byte) (slotNumber >>> 8);
-            slotBytes[29] = (byte) (slotNumber >>> 16);
-            slotBytes[28] = (byte) (slotNumber >>> 24);
-            slotBytes[27] = (byte) (slotNumber >>> 32);
-            slotBytes[26] = (byte) (slotNumber >>> 40);
-            slotBytes[25] = (byte) (slotNumber >>> 48);
-            slotBytes[24] = (byte) (slotNumber >>> 56);
-            storageSlotKey = slotBytes;
-        }
-
-        Bytes32 storageKeyHash = Hash.keccak256(Bytes.wrap(storageSlotKey));
-
+        // The fetch + proof + beacon ladder lives in node-core
+        // (io.myotis.node.VerifiedStorageQuery, shared with the engine API);
+        // this handler only parses arguments and serializes the result.
         try {
-            // Step 1: fetch the account to get storageRoot
-            // Use peer's fresh state root to avoid pruning issues —
-            // peers prune state beyond ~128 blocks, so a beacon-finalized root
-            // (6+ min old) is usually too stale for them to serve.
-            Bytes32 accountHash = Hash.keccak256(contractAddress);
-            AccountRangeMessage.DecodeResult accountResult =
-                connector.requestAccount(contractAddress).get(30, TimeUnit.SECONDS);
-            AccountRangeMessage.AccountData account = accountResult.accounts().stream()
-                .filter(a -> a.accountHash().equals(accountHash))
-                .findFirst().orElse(null);
-            if (account == null) {
-                return jsonError("Contract account not found");
-            }
-
-            // Step 2: fetch storage slot using the same peer state root for consistency
-            Bytes32 snapStateRoot = accountResult.stateRoot();
-
-            // Take storageRoot from the PROOF-VERIFIED account leaf, not the peer's
-            // slim body. Otherwise a peer could forge storageRoot (keeping nonce/
-            // balance honest) plus a matching storage proof and fabricate a
-            // "verified" slot value. snapStateRoot is anchored to the beacon below.
-            List<byte[]> accountProofBytes = accountResult.proof().stream()
-                    .map(Bytes::toArrayUnsafe).toList();
-            MerklePatriciaVerifier.VerifiedAccount verifiedAccount =
-                    snapStateRoot == null ? null
-                            : MerklePatriciaVerifier.verifyAndExtractAccount(
-                                    snapStateRoot.toArrayUnsafe(),
-                                    contractAddress.toArrayUnsafe(), accountProofBytes,
-                                    account.nonce(), account.balance().toString());
-            if (verifiedAccount == null) {
-                return jsonError("Contract account proof did not verify against peer state root");
-            }
-            Bytes32 storageRoot = Bytes32.wrap(verifiedAccount.storageRoot());
-            StorageRangesMessage.DecodeResult storageResult =
-                connector.requestStorage(contractAddress, storageKeyHash, snapStateRoot)
-                    .get(30, TimeUnit.SECONDS);
-
-            // Find matching slot
-            StorageRangesMessage.StorageData found = storageResult.slots().stream()
-                .filter(s -> s.slotHash().equals(storageKeyHash))
-                .findFirst().orElse(null);
-
-            // Build proof array
-            StringBuilder proofSb = new StringBuilder("[");
-            for (int i = 0; i < storageResult.proof().size(); i++) {
-                if (i > 0) proofSb.append(",");
-                proofSb.append("\"").append(storageResult.proof().get(i).toHexString()).append("\"");
-            }
-            proofSb.append("]");
-
-            // Verify storage proof against storageRoot
-            boolean storageProofValid = false;
-            if (!storageResult.proof().isEmpty()) {
-                List<byte[]> proofBytes = storageResult.proof().stream()
-                    .map(Bytes::toArrayUnsafe).toList();
-                byte[] leafValue = MerklePatriciaVerifier.verifyStorageProof(
-                    storageRoot.toArrayUnsafe(), storageSlotKey, proofBytes);
-                storageProofValid = (leafValue != null);
-            }
-
-            // Verify account's state root against beacon state
-            boolean beaconChainVerified = false;
-            boolean blsVerified = false;
-            long matchedSlot = -1;
-            String verifyMethod = null;
-            String failReason = null;
-            Bytes32 usedStateRoot = accountResult.stateRoot();
-            if (usedStateRoot != null) {
-                BeaconSyncState.SlottedStateRoot match =
-                    beaconSyncState.findStateRoot(usedStateRoot.toArrayUnsafe());
-                if (match != null) {
-                    beaconChainVerified = true;
-                    matchedSlot = match.slot();
-                    blsVerified = match.blsVerified();
-                    verifyMethod = "stateRootMatch";
-                }
-            }
-
-            // Header chain verification fallback. Mirror get-account's
-            // buildVerificationJson flow so that a "beaconChainVerified:false"
-            // response always comes with a named failReason — silent nopes
-            // used to turn into a 3-boolean blob that was impossible to debug.
-            long peerBlockNumber = accountResult.blockNumber();
-            if (!beaconChainVerified) {
-                // Atomic snapshot: block number + state root must come from the same
-                // finalized payload, since the header chain is anchored at the block
-                // number and required to terminate at the state root.
-                BeaconSyncState.FinalizedExecution fin = beaconSyncState.getFinalizedExecution();
-                long finalizedBlockNum = fin.blockNumber();
-                byte[] beaconRoot = fin.stateRoot();
-                if (usedStateRoot == null) {
-                    failReason = "noPeerStateRoot";
-                } else if (!storageProofValid) {
-                    failReason = "peerProofInvalid";
-                } else if (!beaconSyncState.isSynced()) {
-                    failReason = "beaconNotSynced";
-                } else if (peerBlockNumber <= 0) {
-                    failReason = "noPeerBlockNumber";
-                } else if (finalizedBlockNum <= 0 || beaconRoot == null) {
-                    failReason = "beaconBlockUnavailable";
-                } else if (peerBlockNumber <= finalizedBlockNum) {
-                    failReason = "peerBlockBehindFinalized";
-                } else if (peerBlockNumber - finalizedBlockNum > MAX_HEADER_CHAIN_GAP) {
-                    failReason = "headerChainGapTooLarge";
-                } else {
-                    log.info("[verify] headerChain: peerBlock={}, finalizedBlock={}, gap={}",
-                            peerBlockNumber, finalizedBlockNum, peerBlockNumber - finalizedBlockNum);
-                    try {
-                        boolean chainValid = verifyHeaderChainBatched(
-                                finalizedBlockNum, peerBlockNumber, beaconRoot,
-                                usedStateRoot.toArrayUnsafe());
-                        if (chainValid) {
-                            beaconChainVerified = true;
-                            matchedSlot = beaconSyncState.getFinalizedSlot();
-                            blsVerified = true;
-                            verifyMethod = "headerChain";
-                        } else {
-                            failReason = "headerChainInvalid";
-                        }
-                    } catch (Exception e) {
-                        log.info("[verify] Header chain verification failed: {}", e.getMessage());
-                        failReason = "headerChainError";
-                    }
-                }
-            }
-
-            String valueHex = found != null ? found.slotValue().toHexString() : null;
-            java.math.BigInteger valueInt = null;
-            if (found != null && !found.slotValue().isEmpty()) {
-                valueInt = new java.math.BigInteger(1, found.slotValue().toArrayUnsafe());
-            }
-
-            StringBuilder sb = new StringBuilder("{\"ok\":true");
-            sb.append(",\"address\":\"").append(addr).append("\"");
-            sb.append(",\"slot\":").append(slotNumber);
-            if (holderAddr != null) {
-                sb.append(",\"holder\":\"").append(holderAddr).append("\"");
-            }
-            sb.append(",\"storageKey\":\"0x").append(bytesToHex(storageSlotKey)).append("\"");
-            sb.append(",\"storageKeyHash\":\"").append(storageKeyHash.toHexString()).append("\"");
-            if (found != null) {
-                sb.append(",\"exists\":true");
-                sb.append(",\"value\":\"").append(valueHex).append("\"");
-                if (valueInt != null) {
-                    sb.append(",\"valueDecimal\":\"").append(valueInt).append("\"");
-                }
-            } else {
-                sb.append(",\"exists\":false");
-                sb.append(",\"slotsReturned\":").append(storageResult.slots().size());
-            }
-            sb.append(",\"storageRoot\":\"").append(storageRoot.toHexString()).append("\"");
-            sb.append(",\"proof\":").append(proofSb);
-            sb.append(",\"verification\":{");
-            sb.append("\"storageProofValid\":").append(storageProofValid);
-            sb.append(",\"beaconSynced\":").append(beaconSyncState.isSynced());
-            sb.append(",\"beaconChainVerified\":").append(beaconChainVerified);
-            if (beaconChainVerified) {
-                sb.append(",\"matchedBeaconSlot\":").append(matchedSlot);
-                sb.append(",\"blsVerified\":").append(blsVerified);
-                if (verifyMethod != null) {
-                    sb.append(",\"verifyMethod\":\"").append(verifyMethod).append("\"");
-                }
-            } else {
-                if (failReason != null) {
-                    sb.append(",\"failReason\":\"").append(failReason).append("\"");
-                }
-                // Always surface the numbers so the operator can see *how far*
-                // off we are, not just that we're off. Emit both finalized and
-                // optimistic anchors — headerChainGapTooLarge is meaningful only
-                // after you see which anchor was considered.
-                long finalizedBlockNum = beaconSyncState.getExecutionBlockNumber();
-                long finalizedSlot = beaconSyncState.getFinalizedSlot();
-                long optBlockNum = beaconSyncState.getOptimisticBlockNumber();
-                long optSlot = beaconSyncState.getOptimisticSlot();
-                sb.append(",\"peerBlockNumber\":").append(peerBlockNumber);
-                sb.append(",\"finalizedBlockNumber\":").append(finalizedBlockNum);
-                sb.append(",\"optimisticBlockNumber\":").append(optBlockNum);
-                if (peerBlockNumber > 0 && finalizedBlockNum > 0) {
-                    sb.append(",\"blockGap\":").append(peerBlockNumber - finalizedBlockNum);
-                }
-                if (peerBlockNumber > 0 && optBlockNum > 0) {
-                    sb.append(",\"optimisticBlockGap\":").append(peerBlockNumber - optBlockNum);
-                }
-                sb.append(",\"maxHeaderChainGap\":").append(MAX_HEADER_CHAIN_GAP);
-                sb.append(",\"finalizedSlot\":").append(finalizedSlot);
-                sb.append(",\"optimisticSlot\":").append(optSlot);
-            }
-            sb.append("}}");
-            return sb.toString();
+            io.myotis.api.StorageProofResult r = io.myotis.node.VerifiedStorageQuery.query(
+                    connector, beaconSyncState, addr, slotNumber, holderAddr);
+            return buildStorageJson(r);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return jsonError("interrupted");
         } catch (Exception e) {
             Throwable cause = e.getCause() != null ? e.getCause() : e;
             String msg = cause.getMessage() != null ? cause.getMessage() : cause.getClass().getSimpleName();
             return jsonError(msg);
         }
     }
+
+    /** Pure serializer for get-storage (golden-tested); field order and conditional
+     *  emissions match the historical output byte-for-byte. */
+    static String buildStorageJson(io.myotis.api.StorageProofResult r) {
+        StringBuilder proofSb = new StringBuilder("[");
+        for (int i = 0; i < r.proofNodesHex().size(); i++) {
+            if (i > 0) proofSb.append(",");
+            proofSb.append("\"").append(r.proofNodesHex().get(i)).append("\"");
+        }
+        proofSb.append("]");
+
+        StringBuilder sb = new StringBuilder("{\"ok\":true");
+        sb.append(",\"address\":\"").append(r.addressHex()).append("\"");
+        sb.append(",\"slot\":").append(r.slot());
+        if (r.holderHex() != null) {
+            sb.append(",\"holder\":\"").append(r.holderHex()).append("\"");
+        }
+        sb.append(",\"storageKey\":\"").append(r.storageKeyHex()).append("\"");
+        sb.append(",\"storageKeyHash\":\"").append(r.storageKeyHashHex()).append("\"");
+        if (r.exists()) {
+            sb.append(",\"exists\":true");
+            sb.append(",\"value\":\"").append(r.valueHex()).append("\"");
+            if (r.valueDecimal() != null) {
+                sb.append(",\"valueDecimal\":\"").append(r.valueDecimal()).append("\"");
+            }
+        } else {
+            sb.append(",\"exists\":false");
+            sb.append(",\"slotsReturned\":").append(r.slotsReturned());
+        }
+        sb.append(",\"storageRoot\":\"").append(r.storageRootHex()).append("\"");
+        sb.append(",\"proof\":").append(proofSb);
+        sb.append(",\"verification\":{");
+        sb.append("\"storageProofValid\":").append(r.storageProofValid());
+        sb.append(",\"beaconSynced\":").append(r.beaconSynced());
+        sb.append(",\"beaconChainVerified\":").append(r.beaconChainVerified());
+        if (r.beaconChainVerified()) {
+            sb.append(",\"matchedBeaconSlot\":").append(r.matchedBeaconSlot());
+            sb.append(",\"blsVerified\":").append(r.blsVerified());
+            if (r.verifyMethod() != null) {
+                sb.append(",\"verifyMethod\":\"").append(r.verifyMethod()).append("\"");
+            }
+        } else {
+            if (r.failReason() != null) {
+                sb.append(",\"failReason\":\"").append(r.failReason()).append("\"");
+            }
+            // Always surface the numbers so the operator can see *how far* off we
+            // are, not just that we're off — both finalized and optimistic anchors.
+            sb.append(",\"peerBlockNumber\":").append(r.peerBlockNumber());
+            sb.append(",\"finalizedBlockNumber\":").append(r.finalizedBlockNumber());
+            sb.append(",\"optimisticBlockNumber\":").append(r.optimisticBlockNumber());
+            if (r.peerBlockNumber() > 0 && r.finalizedBlockNumber() > 0) {
+                sb.append(",\"blockGap\":").append(r.peerBlockNumber() - r.finalizedBlockNumber());
+            }
+            if (r.peerBlockNumber() > 0 && r.optimisticBlockNumber() > 0) {
+                sb.append(",\"optimisticBlockGap\":").append(r.peerBlockNumber() - r.optimisticBlockNumber());
+            }
+            sb.append(",\"maxHeaderChainGap\":").append(r.maxHeaderChainGap());
+            sb.append(",\"finalizedSlot\":").append(r.finalizedSlot());
+            sb.append(",\"optimisticSlot\":").append(r.optimisticSlot());
+        }
+        sb.append("}}");
+        return sb.toString();
+    }
+
 
     /**
      * Shared single-thread pool that drives the EVM for the {@code resolve-ens}
@@ -1677,126 +1358,6 @@ public class CommandHandler {
         return "{\"ok\":true,\"message\":\"Daemon shutting down\"}";
     }
 
-    // -------------------------------------------------------------------------
-    // Beacon proof verification helpers
-    // -------------------------------------------------------------------------
-
-    /**
-     * Serialize the shared {@link VerifiedAccountQuery.Verification} verdict into the daemon's
-     * get-account "verification" JSON, plus the daemon-only diagnostics (finalized / wall-clock
-     * period lag, block numbers). The verification LADDER now lives ONLY in VerifiedAccountQuery;
-     * this method is pure serialization (the daemon used to re-implement the ladder here).
-     */
-    private String buildVerificationJson(VerifiedAccountQuery.Verification v,
-                                          Bytes32 peerStateRoot, boolean proofPresent,
-                                          long peerBlockNumber) {
-        String peerStateRootHex = (peerStateRoot != null && proofPresent) ? peerStateRoot.toHexString() : null;
-
-        // Daemon-only diagnostics (not carried by the shared Verification).
-        long finalizedBlockNum = beaconSyncState.getFinalizedExecution().blockNumber();
-        long finalizedPeriod = beaconSyncState.getFinalizedPeriod();
-        long wallClockPeriod = BeaconChainSpec.currentPeriod(clGenesisTime, secondsPerSlot);
-        long periodLag = wallClockPeriod - finalizedPeriod;
-
-        StringBuilder sb = new StringBuilder("{");
-        sb.append("\"peerProofValid\":").append(v.peerProofValid());
-        if (peerStateRootHex != null) {
-            sb.append(",\"peerStateRoot\":\"").append(peerStateRootHex).append("\"");
-        }
-        sb.append(",\"beaconSynced\":").append(beaconSyncState.isSynced());
-        sb.append(",\"beaconChainVerified\":").append(v.beaconChainVerified());
-        if (v.beaconChainVerified()) {
-            sb.append(",\"matchedBeaconSlot\":").append(v.matchedSlot());
-            sb.append(",\"blsVerified\":").append(v.blsVerified());
-            if (v.verifyMethod() != null) {
-                sb.append(",\"verifyMethod\":\"").append(v.verifyMethod()).append("\"");
-            }
-        } else {
-            if (v.failReason() != null) {
-                sb.append(",\"failReason\":\"").append(v.failReason()).append("\"");
-            }
-            sb.append(",\"finalizedPeriod\":").append(finalizedPeriod);
-            sb.append(",\"wallClockPeriod\":").append(wallClockPeriod);
-            sb.append(",\"periodLag\":").append(periodLag);
-            if (peerBlockNumber > 0) {
-                sb.append(",\"peerBlockNumber\":").append(peerBlockNumber);
-            }
-            if (finalizedBlockNum > 0) {
-                sb.append(",\"finalizedBlockNumber\":").append(finalizedBlockNum);
-            }
-            long optBlockNum = beaconSyncState.getOptimisticBlockNumber();
-            if (optBlockNum > 0) {
-                sb.append(",\"optimisticBlockNumber\":").append(optBlockNum);
-            }
-        }
-        sb.append("}");
-        return sb.toString();
-    }
-
-    /**
-     * Verify a chain of consecutive block headers.
-     * Checks that:
-     * 1. The first header's state root matches the beacon-finalized root
-     * 2. Each header's hash equals the next header's parentHash
-     * 3. The last header's state root matches the peer's state root
-     */
-    private static boolean verifyHeaderChain(List<BlockHeadersMessage.VerifiedHeader> headers,
-                                              byte[] expectedFirstStateRoot,
-                                              byte[] expectedLastStateRoot) {
-        if (headers.isEmpty()) return false;
-
-        // Check first header's state root matches beacon-finalized root
-        byte[] firstStateRoot = headers.get(0).header().stateRoot.toArrayUnsafe();
-        if (!java.util.Arrays.equals(firstStateRoot, expectedFirstStateRoot)) return false;
-
-        // Check last header's state root matches peer's state root
-        byte[] lastStateRoot = headers.get(headers.size() - 1).header().stateRoot.toArrayUnsafe();
-        if (!java.util.Arrays.equals(lastStateRoot, expectedLastStateRoot)) return false;
-
-        // Verify hash chain: each header's hash must equal the next header's parentHash
-        for (int i = 0; i < headers.size() - 1; i++) {
-            Bytes32 currentHash = headers.get(i).hash();
-            Bytes32 nextParent = headers.get(i + 1).header().parentHash;
-            if (!currentHash.equals(nextParent)) {
-                log.info("[verify] Hash chain break at index {}: block #{} hash={} != block #{} parentHash={}",
-                        i, headers.get(i).header().number, currentHash.toShortHexString(),
-                        headers.get(i + 1).header().number, nextParent.toShortHexString());
-                return false;
-            }
-        }
-        return true;
-    }
-
-    /**
-     * Fetch headers in batches from a single peer and verify the full chain.
-     * Uses RLPxConnector.requestBlockHeadersBatched to ensure all batches
-     * come from the same peer, preventing cross-peer discontinuities.
-     */
-    private boolean verifyHeaderChainBatched(long finalizedBlock, long peerBlock,
-                                              byte[] beaconStateRoot, byte[] peerStateRoot)
-            throws Exception {
-        int total = (int) (peerBlock - finalizedBlock + 1);
-        if (total < 2 || total > 8192) {
-            log.info("[verify] Header chain gap {} blocks — out of range [2, 8192]", total);
-            return false;
-        }
-
-        log.info("[verify] Fetching {} headers from block #{} to #{}", total, finalizedBlock, peerBlock);
-        List<BlockHeadersMessage.VerifiedHeader> allHeaders =
-                connector.requestBlockHeadersBatched(finalizedBlock, total)
-                        .get(60, TimeUnit.SECONDS);
-
-        boolean valid = verifyHeaderChain(allHeaders, beaconStateRoot, peerStateRoot);
-        log.info("[verify] Full header chain ({} blocks) valid: {}", total, valid);
-        if (!valid && !allHeaders.isEmpty()) {
-            byte[] firstSR = allHeaders.get(0).header().stateRoot.toArrayUnsafe();
-            byte[] lastSR = allHeaders.get(allHeaders.size() - 1).header().stateRoot.toArrayUnsafe();
-            log.info("[verify] firstStateRoot match={}, lastStateRoot match={}",
-                    java.util.Arrays.equals(firstSR, beaconStateRoot),
-                    java.util.Arrays.equals(lastSR, peerStateRoot));
-        }
-        return valid;
-    }
 
     private static String bytesToHex(byte[] bytes) {
         StringBuilder sb = new StringBuilder(bytes.length * 2);

--- a/app/src/test/java/com/jaeckel/ethp2p/app/CommandHandlerJsonGoldenTest.java
+++ b/app/src/test/java/com/jaeckel/ethp2p/app/CommandHandlerJsonGoldenTest.java
@@ -1,0 +1,340 @@
+package com.jaeckel.ethp2p.app;
+
+import io.myotis.api.AccountProofResult;
+import io.myotis.api.BlockResult;
+import io.myotis.api.HeaderInfo;
+import io.myotis.api.HeadersResult;
+import io.myotis.api.StorageProofResult;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * GOLDEN TESTS for the daemon's IPC JSON serializers. These lock the exact byte shape of
+ * the {@code get-account} / {@code get-storage} / {@code get-block} / {@code get-headers}
+ * responses across the engine-API refactor: the fetch/verification logic moved into
+ * node-core, and these strings are the contract that move must not disturb (the
+ * integration test additionally greps {@code "verifyMethod":"headerChain"} on a synced
+ * daemon). Do not "fix" an expected string here without treating it as an IPC contract
+ * change.
+ */
+class CommandHandlerJsonGoldenTest {
+
+    @org.junit.jupiter.api.BeforeAll
+    static void setUpProvider() {
+        // CommandHandler's static init computes a keccak256 (the ENS snap-probe hash),
+        // which needs the BC provider registered.
+        java.security.Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
+    }
+
+    // -- get-account ---------------------------------------------------------
+
+    private static AccountProofResult account(boolean exists, boolean verified, String failReason) {
+        return new AccountProofResult(
+                "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+                exists,
+                exists ? 42 : -1,
+                exists ? "123450000000000000000" : null,
+                exists ? "0x1111111111111111111111111111111111111111111111111111111111111111" : null,
+                exists ? "0x2222222222222222222222222222222222222222222222222222222222222222" : null,
+                21000123,
+                "0x3333333333333333333333333333333333333333333333333333333333333333",
+                true,
+                verified,
+                verified,
+                verified ? 12345678 : -1,
+                verified ? "headerChain" : null,
+                failReason,
+                "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                List.of("0xf90211a0dead", "0xf90211a0beef"),
+                true,
+                1490,
+                1492,
+                21000100,
+                21000130);
+    }
+
+    @Test
+    void accountExistsVerified() {
+        assertEquals(
+                "{\"ok\":true,\"exists\":true"
+                + ",\"address\":\"0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045\""
+                + ",\"accountHash\":\"0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\""
+                + ",\"nonce\":42"
+                + ",\"balance\":\"123450000000000000000\""
+                + ",\"storageRoot\":\"0x1111111111111111111111111111111111111111111111111111111111111111\""
+                + ",\"codeHash\":\"0x2222222222222222222222222222222222222222222222222222222222222222\""
+                + ",\"proof\":[\"0xf90211a0dead\",\"0xf90211a0beef\"]"
+                + ",\"verification\":{\"peerProofValid\":true"
+                + ",\"peerStateRoot\":\"0x3333333333333333333333333333333333333333333333333333333333333333\""
+                + ",\"beaconSynced\":true"
+                + ",\"beaconChainVerified\":true"
+                + ",\"matchedBeaconSlot\":12345678"
+                + ",\"blsVerified\":true"
+                + ",\"verifyMethod\":\"headerChain\"}}",
+                // The raw request address is echoed verbatim (mixed case preserved).
+                CommandHandler.buildAccountJson(
+                        "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+                        account(true, true, null)));
+    }
+
+    @Test
+    void accountExistsUnverifiedCarriesDiagnostics() {
+        assertEquals(
+                "{\"ok\":true,\"exists\":true"
+                + ",\"address\":\"0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045\""
+                + ",\"accountHash\":\"0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\""
+                + ",\"nonce\":42"
+                + ",\"balance\":\"123450000000000000000\""
+                + ",\"storageRoot\":\"0x1111111111111111111111111111111111111111111111111111111111111111\""
+                + ",\"codeHash\":\"0x2222222222222222222222222222222222222222222222222222222222222222\""
+                + ",\"proof\":[\"0xf90211a0dead\",\"0xf90211a0beef\"]"
+                + ",\"verification\":{\"peerProofValid\":true"
+                + ",\"peerStateRoot\":\"0x3333333333333333333333333333333333333333333333333333333333333333\""
+                + ",\"beaconSynced\":true"
+                + ",\"beaconChainVerified\":false"
+                + ",\"failReason\":\"headerChainGapTooLarge\""
+                + ",\"finalizedPeriod\":1490"
+                + ",\"wallClockPeriod\":1492"
+                + ",\"periodLag\":2"
+                + ",\"peerBlockNumber\":21000123"
+                + ",\"finalizedBlockNumber\":21000100"
+                + ",\"optimisticBlockNumber\":21000130}}",
+                CommandHandler.buildAccountJson(
+                        "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+                        account(true, false, "headerChainGapTooLarge")));
+    }
+
+    @Test
+    void accountAbsent() {
+        assertEquals(
+                "{\"ok\":true,\"exists\":false"
+                + ",\"address\":\"0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045\""
+                + ",\"accountHash\":\"0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\""
+                + ",\"proof\":[\"0xf90211a0dead\",\"0xf90211a0beef\"]"
+                + ",\"verification\":{\"peerProofValid\":true"
+                + ",\"peerStateRoot\":\"0x3333333333333333333333333333333333333333333333333333333333333333\""
+                + ",\"beaconSynced\":true"
+                + ",\"beaconChainVerified\":true"
+                + ",\"matchedBeaconSlot\":12345678"
+                + ",\"blsVerified\":true"
+                + ",\"verifyMethod\":\"headerChain\"}}",
+                CommandHandler.buildAccountJson(
+                        "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+                        account(false, true, null)));
+    }
+
+    // -- get-storage ---------------------------------------------------------
+
+    @Test
+    void storageExistsVerifiedWithHolder() {
+        StorageProofResult r = new StorageProofResult(
+                "0x1A5F9352Af8aF974bFC03399e3767DF6370d82e4",
+                1,
+                "0x308686553a1EAC2fE721Ac8B814De638975a276e",
+                "0x4444444444444444444444444444444444444444444444444444444444444444",
+                "0x5555555555555555555555555555555555555555555555555555555555555555",
+                true,
+                "0x0de0b6b3a7640000",
+                "1000000000000000000",
+                1,
+                "0x6666666666666666666666666666666666666666666666666666666666666666",
+                List.of("0xf90211a0cafe"),
+                true, true, true, true,
+                12345678,
+                "stateRootMatch",
+                null,
+                21000123, 21000100, 21000130, 9876543, 9876575, 8192);
+        assertEquals(
+                "{\"ok\":true"
+                + ",\"address\":\"0x1A5F9352Af8aF974bFC03399e3767DF6370d82e4\""
+                + ",\"slot\":1"
+                + ",\"holder\":\"0x308686553a1EAC2fE721Ac8B814De638975a276e\""
+                + ",\"storageKey\":\"0x4444444444444444444444444444444444444444444444444444444444444444\""
+                + ",\"storageKeyHash\":\"0x5555555555555555555555555555555555555555555555555555555555555555\""
+                + ",\"exists\":true"
+                + ",\"value\":\"0x0de0b6b3a7640000\""
+                + ",\"valueDecimal\":\"1000000000000000000\""
+                + ",\"storageRoot\":\"0x6666666666666666666666666666666666666666666666666666666666666666\""
+                + ",\"proof\":[\"0xf90211a0cafe\"]"
+                + ",\"verification\":{\"storageProofValid\":true"
+                + ",\"beaconSynced\":true"
+                + ",\"beaconChainVerified\":true"
+                + ",\"matchedBeaconSlot\":12345678"
+                + ",\"blsVerified\":true"
+                + ",\"verifyMethod\":\"stateRootMatch\"}}",
+                CommandHandler.buildStorageJson(r));
+    }
+
+    @Test
+    void storageAbsentUnverifiedCarriesAnchors() {
+        StorageProofResult r = new StorageProofResult(
+                "0x1A5F9352Af8aF974bFC03399e3767DF6370d82e4",
+                7,
+                null,
+                "0x0000000000000000000000000000000000000000000000000000000000000007",
+                "0x5555555555555555555555555555555555555555555555555555555555555555",
+                false,
+                null,
+                null,
+                3,
+                "0x6666666666666666666666666666666666666666666666666666666666666666",
+                List.of("0xf90211a0feed"),
+                true, true, false, false,
+                -1,
+                null,
+                "beaconNotSynced",
+                21000123, 21000100, 21000130, 9876543, 9876575, 8192);
+        assertEquals(
+                "{\"ok\":true"
+                + ",\"address\":\"0x1A5F9352Af8aF974bFC03399e3767DF6370d82e4\""
+                + ",\"slot\":7"
+                + ",\"storageKey\":\"0x0000000000000000000000000000000000000000000000000000000000000007\""
+                + ",\"storageKeyHash\":\"0x5555555555555555555555555555555555555555555555555555555555555555\""
+                + ",\"exists\":false"
+                + ",\"slotsReturned\":3"
+                + ",\"storageRoot\":\"0x6666666666666666666666666666666666666666666666666666666666666666\""
+                + ",\"proof\":[\"0xf90211a0feed\"]"
+                + ",\"verification\":{\"storageProofValid\":true"
+                + ",\"beaconSynced\":true"
+                + ",\"beaconChainVerified\":false"
+                + ",\"failReason\":\"beaconNotSynced\""
+                + ",\"peerBlockNumber\":21000123"
+                + ",\"finalizedBlockNumber\":21000100"
+                + ",\"optimisticBlockNumber\":21000130"
+                + ",\"blockGap\":23"
+                + ",\"optimisticBlockGap\":-7"
+                + ",\"maxHeaderChainGap\":8192"
+                + ",\"finalizedSlot\":9876543"
+                + ",\"optimisticSlot\":9876575}}",
+                CommandHandler.buildStorageJson(r));
+    }
+
+    // -- get-block -----------------------------------------------------------
+
+    @Test
+    void blockVerified() {
+        BlockResult r = new BlockResult(
+                21000123,
+                "0x7777777777777777777777777777777777777777777777777777777777777777",
+                "0x8888888888888888888888888888888888888888888888888888888888888888",
+                "0x9999999999999999999999999999999999999999999999999999999999999999",
+                "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                1734567890,
+                12500000,
+                30000000,
+                "7000000000",
+                142, 0, 16,
+                true, true, true,
+                12345678,
+                "headerChain",
+                null,
+                null);
+        assertEquals(
+                "{\"ok\":true,\"block\":{"
+                + "\"number\":21000123"
+                + ",\"hash\":\"0x7777777777777777777777777777777777777777777777777777777777777777\""
+                + ",\"parentHash\":\"0x8888888888888888888888888888888888888888888888888888888888888888\""
+                + ",\"stateRoot\":\"0x9999999999999999999999999999999999999999999999999999999999999999\""
+                + ",\"transactionsRoot\":\"0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\""
+                + ",\"receiptsRoot\":\"0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\""
+                + ",\"timestamp\":1734567890"
+                + ",\"gasUsed\":12500000"
+                + ",\"gasLimit\":30000000"
+                + ",\"baseFeePerGas\":\"7000000000\""
+                + ",\"transactionCount\":142"
+                + ",\"uncleCount\":0"
+                + ",\"withdrawalCount\":16"
+                + "},\"verification\":{"
+                + "\"beaconSynced\":true"
+                + ",\"beaconChainVerified\":true"
+                + ",\"matchedBeaconSlot\":12345678"
+                + ",\"blsVerified\":true"
+                + ",\"verifyMethod\":\"headerChain\"}}",
+                CommandHandler.buildBlockJson(r));
+    }
+
+    @Test
+    void blockPreMerge() {
+        BlockResult r = new BlockResult(
+                15000000,
+                "0x7777777777777777777777777777777777777777777777777777777777777777",
+                "0x8888888888888888888888888888888888888888888888888888888888888888",
+                "0x9999999999999999999999999999999999999999999999999999999999999999",
+                "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                1658000000,
+                12000000,
+                30000000,
+                null,
+                97, 0, 0,
+                true, false, false,
+                -1,
+                null,
+                "preMergeBlock",
+                null);
+        assertEquals(
+                "{\"ok\":true,\"block\":{"
+                + "\"number\":15000000"
+                + ",\"hash\":\"0x7777777777777777777777777777777777777777777777777777777777777777\""
+                + ",\"parentHash\":\"0x8888888888888888888888888888888888888888888888888888888888888888\""
+                + ",\"stateRoot\":\"0x9999999999999999999999999999999999999999999999999999999999999999\""
+                + ",\"transactionsRoot\":\"0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\""
+                + ",\"receiptsRoot\":\"0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\""
+                + ",\"timestamp\":1658000000"
+                + ",\"gasUsed\":12000000"
+                + ",\"gasLimit\":30000000"
+                + ",\"transactionCount\":97"
+                + ",\"uncleCount\":0"
+                + ",\"withdrawalCount\":0"
+                + "},\"verification\":{"
+                + "\"beaconSynced\":true"
+                + ",\"beaconChainVerified\":false"
+                + ",\"failReason\":\"preMergeBlock\"}}",
+                CommandHandler.buildBlockJson(r));
+    }
+
+    // -- get-headers ---------------------------------------------------------
+
+    @Test
+    void headersWithAndWithoutBaseFee() {
+        HeadersResult r = new HeadersResult(List.of(
+                new HeaderInfo(21000000,
+                        "0x1111111111111111111111111111111111111111111111111111111111111111",
+                        "0x2222222222222222222222222222222222222222222222222222222222222222",
+                        "0x3333333333333333333333333333333333333333333333333333333333333333",
+                        "0x4444444444444444444444444444444444444444444444444444444444444444",
+                        1734567890, 12500000, 30000000, "7000000000"),
+                new HeaderInfo(12000000,
+                        "0x5555555555555555555555555555555555555555555555555555555555555555",
+                        "0x6666666666666666666666666666666666666666666666666666666666666666",
+                        "0x7777777777777777777777777777777777777777777777777777777777777777",
+                        "0x8888888888888888888888888888888888888888888888888888888888888888",
+                        1610000000, 12000000, 12500000, null)),
+                null);
+        assertEquals(
+                "{\"ok\":true,\"count\":2,\"headers\":["
+                + "{\"number\":21000000"
+                + ",\"hash\":\"0x1111111111111111111111111111111111111111111111111111111111111111\""
+                + ",\"parentHash\":\"0x2222222222222222222222222222222222222222222222222222222222222222\""
+                + ",\"stateRoot\":\"0x3333333333333333333333333333333333333333333333333333333333333333\""
+                + ",\"transactionsRoot\":\"0x4444444444444444444444444444444444444444444444444444444444444444\""
+                + ",\"timestamp\":1734567890"
+                + ",\"gasUsed\":12500000"
+                + ",\"gasLimit\":30000000"
+                + ",\"baseFeePerGas\":\"7000000000\"}"
+                + ",{\"number\":12000000"
+                + ",\"hash\":\"0x5555555555555555555555555555555555555555555555555555555555555555\""
+                + ",\"parentHash\":\"0x6666666666666666666666666666666666666666666666666666666666666666\""
+                + ",\"stateRoot\":\"0x7777777777777777777777777777777777777777777777777777777777777777\""
+                + ",\"transactionsRoot\":\"0x8888888888888888888888888888888888888888888888888888888888888888\""
+                + ",\"timestamp\":1610000000"
+                + ",\"gasUsed\":12000000"
+                + ",\"gasLimit\":12500000}"
+                + "]}",
+                CommandHandler.buildHeadersJson(r));
+    }
+}

--- a/myotis-api/src/main/java/io/myotis/api/BlockResult.java
+++ b/myotis-api/src/main/java/io/myotis/api/BlockResult.java
@@ -19,6 +19,7 @@ package io.myotis.api;
  * @param transactionCount    transactions in the body
  * @param uncleCount          uncles in the body
  * @param withdrawalCount     withdrawals in the body
+ * @param beaconSynced        beacon client was SYNCED at query time
  * @param beaconChainVerified the block ties to a beacon-attested root/hash
  * @param blsVerified         the beacon match was BLS-signed
  * @param matchedBeaconSlot   slot of the matching attestation; -1 if none
@@ -41,6 +42,7 @@ public record BlockResult(
         int transactionCount,
         int uncleCount,
         int withdrawalCount,
+        boolean beaconSynced,
         boolean beaconChainVerified,
         boolean blsVerified,
         long matchedBeaconSlot,

--- a/node-core/src/main/java/io/myotis/node/HeaderQuery.java
+++ b/node-core/src/main/java/io/myotis/node/HeaderQuery.java
@@ -1,0 +1,52 @@
+package io.myotis.node;
+
+import com.jaeckel.ethp2p.networking.eth.messages.BlockHeadersMessage;
+import com.jaeckel.ethp2p.networking.rlpx.RLPxConnector;
+import io.myotis.api.HeaderInfo;
+import io.myotis.api.HeadersResult;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Shared header-range fetch (the daemon's {@code get-headers}): integrity-checked headers
+ * ({@code hash} is the locally recomputed keccak256 of the RLP) mapped into the API shape.
+ * Chain-of-custody verification against the beacon anchor is {@link VerifiedBlockQuery}'s
+ * job; this is the raw fetch surface.
+ */
+public final class HeaderQuery {
+
+    private HeaderQuery() {}
+
+    /** Blocking (worker thread; single 30 s fetch). Failures come back in
+     *  {@link HeadersResult#error()} with an empty list. */
+    public static HeadersResult fetch(RLPxConnector connector, long startBlock, int count) {
+        try {
+            List<BlockHeadersMessage.VerifiedHeader> headers =
+                    connector.requestBlockHeaders(startBlock, count).get(30, TimeUnit.SECONDS);
+            List<HeaderInfo> out = new ArrayList<>(headers.size());
+            for (BlockHeadersMessage.VerifiedHeader vh : headers) {
+                var h = vh.header();
+                out.add(new HeaderInfo(
+                        h.number,
+                        vh.hash().toHexString(),
+                        h.parentHash.toHexString(),
+                        h.stateRoot.toHexString(),
+                        h.transactionsRoot.toHexString(),
+                        h.timestamp,
+                        h.gasUsed,
+                        h.gasLimit,
+                        h.baseFeePerGas != null ? h.baseFeePerGas.toString() : null));
+            }
+            return new HeadersResult(out, null);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return new HeadersResult(List.of(), "interrupted");
+        } catch (Exception e) {
+            Throwable cause = e.getCause() != null ? e.getCause() : e;
+            return new HeadersResult(List.of(), cause.getMessage() != null
+                    ? cause.getMessage() : cause.getClass().getSimpleName());
+        }
+    }
+}

--- a/node-core/src/main/java/io/myotis/node/VerifiedAccountQuery.java
+++ b/node-core/src/main/java/io/myotis/node/VerifiedAccountQuery.java
@@ -172,9 +172,21 @@ public final class VerifiedAccountQuery {
      */
     public static CompletableFuture<io.myotis.api.AccountProofResult> queryProof(
             ChainStack stack, String hexAddress) {
-        RLPxConnector connector = stack != null ? stack.connector() : null;
-        BeaconSyncState bss = stack != null ? stack.beaconSyncState() : null;
-        if (stack == null || !stack.isRunning() || connector == null) {
+        if (stack == null || !stack.isRunning()) {
+            return CompletableFuture.failedFuture(new IllegalStateException("Node is not running"));
+        }
+        return queryProof(stack.connector(), stack.beaconSyncState(),
+                stack.network().clGenesisTime(), stack.network().secondsPerSlot(), hexAddress);
+    }
+
+    /**
+     * {@link #queryProof(ChainStack, String)} for callers holding the parts rather than a
+     * stack (the JVM daemon's CommandHandler until the hosts are rewired onto the API).
+     */
+    public static CompletableFuture<io.myotis.api.AccountProofResult> queryProof(
+            RLPxConnector connector, BeaconSyncState bss,
+            long clGenesisTime, int secondsPerSlot, String hexAddress) {
+        if (connector == null) {
             return CompletableFuture.failedFuture(new IllegalStateException("Node is not running"));
         }
         if (hexAddress == null) {
@@ -195,8 +207,6 @@ public final class VerifiedAccountQuery {
         }
         final String addr = "0x" + hex;
         final Bytes32 accountHash = Hash.keccak256(address);
-        final long clGenesisTime = stack.network().clGenesisTime();
-        final int secondsPerSlot = stack.network().secondsPerSlot();
         final BeaconSyncState bssFinal = bss;
         final RLPxConnector conn = connector;
         return connector.requestAccount(address).thenCompose(result -> {
@@ -411,7 +421,9 @@ public final class VerifiedAccountQuery {
      * header's stateRoot equals the peer's reported root, and every header's hash equals the
      * next header's parentHash.
      */
-    private static CompletableFuture<Boolean> verifyHeaderChainBatched(
+    /** Package-private: {@link VerifiedStorageQuery} anchors its account root with the
+     *  same walk, so the headerChain fetch+verify lives once. */
+    static CompletableFuture<Boolean> verifyHeaderChainBatched(
             RLPxConnector connector, long finalizedBlock, long peerBlock,
             byte[] beaconStateRoot, byte[] peerStateRoot) {
         long totalLong = peerBlock - finalizedBlock + 1;

--- a/node-core/src/main/java/io/myotis/node/VerifiedBlockQuery.java
+++ b/node-core/src/main/java/io/myotis/node/VerifiedBlockQuery.java
@@ -1,0 +1,241 @@
+package io.myotis.node;
+
+import com.jaeckel.ethp2p.consensus.BeaconSyncState;
+import com.jaeckel.ethp2p.core.types.BlockHeader;
+import com.jaeckel.ethp2p.networking.eth.messages.BlockBodiesMessage;
+import com.jaeckel.ethp2p.networking.eth.messages.BlockHeadersMessage;
+import com.jaeckel.ethp2p.networking.rlpx.RLPxConnector;
+import io.myotis.api.BlockResult;
+import org.apache.tuweni.bytes.Bytes32;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Shared, host-agnostic verified single-block query — the engine home of the daemon's
+ * {@code get-block} verification (moved out of the JVM {@code CommandHandler} verbatim).
+ *
+ * <p>Verification strategy:
+ * <ol>
+ *   <li><b>stateRootMatch</b> — the block's stateRoot matches a beacon-attested root.</li>
+ *   <li><b>headerChain</b> — the beacon's ExecutionPayloadHeader carries a BLS-verified
+ *       block_hash; fetch the header range between the finalized block and the target,
+ *       require the finalized header's keccak256(RLP) to equal that anchor, then walk the
+ *       parent-hash chain. Forging any header would need a keccak preimage.</li>
+ * </ol>
+ * Pre-Merge blocks can't tie to the beacon chain → {@code failReason:"preMergeBlock"}.
+ */
+public final class VerifiedBlockQuery {
+
+    private static final Logger log = LoggerFactory.getLogger(VerifiedBlockQuery.class);
+
+    /** The Merge block — first PoS block on mainnet (Sep 15 2022). */
+    private static final long MERGE_BLOCK = 15_537_394L;
+    private static final int MAX_HEADER_CHAIN_GAP = VerifiedAccountQuery.MAX_HEADER_CHAIN_GAP;
+
+    private VerifiedBlockQuery() {}
+
+    /**
+     * Blocking (worker thread; bounded by the internal fetch timeouts, ~180 s worst case).
+     * Fetch failures come back as {@link BlockResult#error()}; verification failures as
+     * {@link BlockResult#failReason()}.
+     */
+    public static BlockResult query(RLPxConnector connector,
+                                    BeaconSyncState beaconSyncState,
+                                    long blockNumber) {
+        try {
+            // Step 1: header (batched path — retries across peers).
+            List<BlockHeadersMessage.VerifiedHeader> headers =
+                    connector.requestBlockHeadersBatched(blockNumber, 1)
+                            .get(30, TimeUnit.SECONDS);
+            if (headers.isEmpty()) {
+                return errorResult("No header returned for block " + blockNumber);
+            }
+            BlockHeadersMessage.VerifiedHeader vh = headers.get(0);
+            BlockHeader h = vh.header();
+
+            // Step 2: body by the recomputed block hash.
+            List<BlockBodiesMessage.BlockBody> bodies =
+                    connector.requestBlockBodies(vh.hash()).get(30, TimeUnit.SECONDS);
+            if (bodies.isEmpty()) {
+                return errorResult("No body returned for block " + blockNumber);
+            }
+            BlockBodiesMessage.BlockBody body = bodies.get(0);
+
+            // Step 3: beacon verification.
+            Verdict v = verifyAgainstBeacon(connector, beaconSyncState, h, blockNumber);
+
+            return new BlockResult(
+                    h.number,
+                    vh.hash().toHexString(),
+                    h.parentHash.toHexString(),
+                    h.stateRoot.toHexString(),
+                    h.transactionsRoot.toHexString(),
+                    h.receiptsRoot.toHexString(),
+                    h.timestamp,
+                    h.gasUsed,
+                    h.gasLimit,
+                    h.baseFeePerGas != null ? h.baseFeePerGas.toString() : null,
+                    body.transactions().size(),
+                    body.uncleCount(),
+                    body.withdrawalCount(),
+                    beaconSyncState.isSynced(),
+                    v.beaconChainVerified,
+                    v.blsVerified,
+                    v.matchedSlot,
+                    v.verifyMethod,
+                    v.failReason,
+                    null);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return errorResult("interrupted");
+        } catch (Exception e) {
+            Throwable cause = e.getCause() != null ? e.getCause() : e;
+            return errorResult(cause.getMessage() != null
+                    ? cause.getMessage() : cause.getClass().getSimpleName());
+        }
+    }
+
+    private static final class Verdict {
+        boolean beaconChainVerified;
+        boolean blsVerified;
+        long matchedSlot = -1;
+        String verifyMethod;
+        String failReason;
+    }
+
+    private static Verdict verifyAgainstBeacon(RLPxConnector connector,
+                                               BeaconSyncState beaconSyncState,
+                                               BlockHeader header, long blockNumber) {
+        Verdict v = new Verdict();
+        if (blockNumber < MERGE_BLOCK) {
+            // Pre-merge blocks cannot be verified via the beacon chain (the embedded
+            // pre-Merge accumulator is designed but not built yet).
+            v.failReason = "preMergeBlock";
+            return v;
+        }
+        byte[] blockStateRoot = header.stateRoot.toArrayUnsafe();
+        BeaconSyncState.SlottedStateRoot match = beaconSyncState.findStateRoot(blockStateRoot);
+        if (match != null) {
+            v.beaconChainVerified = true;
+            v.matchedSlot = match.slot();
+            v.blsVerified = match.blsVerified();
+            v.verifyMethod = "stateRootMatch";
+            return v;
+        }
+        if (!beaconSyncState.isSynced()) {
+            v.failReason = "beaconNotSynced";
+            return v;
+        }
+        long finalizedBlockNum = beaconSyncState.getExecutionBlockNumber();
+        byte[] beaconBlockHash = beaconSyncState.getExecutionBlockHash();
+        long gap = Math.abs(blockNumber - finalizedBlockNum);
+        log.info("[verify-block] headerChain: block={}, finalizedBlock={}, gap={}",
+                blockNumber, finalizedBlockNum, gap);
+        if (finalizedBlockNum <= 0 || beaconBlockHash == null || beaconBlockHash.length != 32) {
+            v.failReason = "beaconBlockHashUnavailable";
+            return v;
+        }
+        if (gap > MAX_HEADER_CHAIN_GAP && blockNumber != finalizedBlockNum) {
+            v.failReason = "headerChainGapTooLarge";
+            return v;
+        }
+        try {
+            boolean chainValid;
+            if (blockNumber == finalizedBlockNum) {
+                chainValid = verifyBlockHashAgainstBeacon(
+                        connector, finalizedBlockNum, beaconBlockHash, blockStateRoot);
+            } else if (blockNumber > finalizedBlockNum) {
+                chainValid = verifyBlockChainFromBeacon(
+                        connector, beaconSyncState, finalizedBlockNum, blockNumber, beaconBlockHash);
+            } else {
+                chainValid = verifyBlockChainFromBeacon(
+                        connector, beaconSyncState, blockNumber, finalizedBlockNum, beaconBlockHash);
+            }
+            if (chainValid) {
+                v.beaconChainVerified = true;
+                v.matchedSlot = beaconSyncState.getFinalizedSlot();
+                v.blsVerified = true;
+                v.verifyMethod = "headerChain";
+            } else {
+                v.failReason = "headerChainInvalid";
+            }
+        } catch (Exception e) {
+            log.info("[verify-block] Header chain verification failed: {}", e.getMessage());
+            v.failReason = "headerChainError";
+        }
+        return v;
+    }
+
+    /** The requested block IS the finalized block: compare its recomputed hash to the
+     *  beacon-attested block hash and its stateRoot to the header's. */
+    private static boolean verifyBlockHashAgainstBeacon(RLPxConnector connector,
+                                                        long blockNumber, byte[] beaconBlockHash,
+                                                        byte[] expectedStateRoot) throws Exception {
+        List<BlockHeadersMessage.VerifiedHeader> headers =
+                connector.requestBlockHeaders(blockNumber, 1).get(30, TimeUnit.SECONDS);
+        if (headers.isEmpty()) return false;
+        BlockHeadersMessage.VerifiedHeader vh = headers.get(0);
+        // VerifiedHeader.hash() is keccak256(rawRLP) computed locally — compare to the anchor.
+        if (!java.util.Arrays.equals(vh.hash().toArrayUnsafe(), beaconBlockHash)) {
+            log.info("[verify-block] Finalized block hash mismatch: peer={} beacon={}",
+                    vh.hash().toShortHexString(), Bytes32.wrap(beaconBlockHash).toShortHexString());
+            return false;
+        }
+        return java.util.Arrays.equals(vh.header().stateRoot.toArrayUnsafe(), expectedStateRoot);
+    }
+
+    /** Fetch [startBlock..endBlock], require the finalized header's hash to equal the
+     *  beacon anchor, and verify parent-hash continuity across the whole range. */
+    private static boolean verifyBlockChainFromBeacon(RLPxConnector connector,
+                                                      BeaconSyncState beaconSyncState,
+                                                      long startBlock, long endBlock,
+                                                      byte[] beaconBlockHash) throws Exception {
+        long finalizedBlockNum = beaconSyncState.getExecutionBlockNumber();
+        int total = (int) (endBlock - startBlock + 1);
+        if (total < 2 || total > MAX_HEADER_CHAIN_GAP) {
+            log.info("[verify-block] Block chain gap {} — out of range [2, {}]", total, MAX_HEADER_CHAIN_GAP);
+            return false;
+        }
+        log.info("[verify-block] Fetching {} headers from block #{} to #{}", total, startBlock, endBlock);
+        List<BlockHeadersMessage.VerifiedHeader> allHeaders =
+                connector.requestBlockHeadersBatched(startBlock, total).get(120, TimeUnit.SECONDS);
+        if (allHeaders.size() != total) {
+            log.info("[verify-block] Expected {} headers, got {}", total, allHeaders.size());
+            return false;
+        }
+        int anchorIndex = (int) (finalizedBlockNum - startBlock);
+        if (anchorIndex < 0 || anchorIndex >= allHeaders.size()) {
+            log.info("[verify-block] Finalized block #{} not in range [{}, {}]",
+                    finalizedBlockNum, startBlock, endBlock);
+            return false;
+        }
+        BlockHeadersMessage.VerifiedHeader anchorHeader = allHeaders.get(anchorIndex);
+        if (!java.util.Arrays.equals(anchorHeader.hash().toArrayUnsafe(), beaconBlockHash)) {
+            log.info("[verify-block] Anchor block hash mismatch at #{}: peer={} beacon={}",
+                    finalizedBlockNum, anchorHeader.hash().toShortHexString(),
+                    Bytes32.wrap(beaconBlockHash).toShortHexString());
+            return false;
+        }
+        for (int i = 0; i < allHeaders.size() - 1; i++) {
+            Bytes32 currentHash = allHeaders.get(i).hash();
+            Bytes32 nextParent = allHeaders.get(i + 1).header().parentHash;
+            if (!currentHash.equals(nextParent)) {
+                log.info("[verify-block] Hash chain break at index {}: block #{} hash={} != block #{} parentHash={}",
+                        i, allHeaders.get(i).header().number, currentHash.toShortHexString(),
+                        allHeaders.get(i + 1).header().number, nextParent.toShortHexString());
+                return false;
+            }
+        }
+        log.info("[verify-block] Block chain verified: {} headers anchored at finalized block #{}",
+                total, finalizedBlockNum);
+        return true;
+    }
+
+    private static BlockResult errorResult(String message) {
+        return new BlockResult(0, null, null, null, null, null, 0, 0, 0, null,
+                0, 0, 0, false, false, false, -1, null, null, message);
+    }
+}

--- a/node-core/src/main/java/io/myotis/node/VerifiedStorageQuery.java
+++ b/node-core/src/main/java/io/myotis/node/VerifiedStorageQuery.java
@@ -1,0 +1,239 @@
+package io.myotis.node;
+
+import com.jaeckel.ethp2p.consensus.BeaconSyncState;
+import com.jaeckel.ethp2p.consensus.proof.MerklePatriciaVerifier;
+import com.jaeckel.ethp2p.networking.rlpx.RLPxConnector;
+import com.jaeckel.ethp2p.networking.snap.messages.AccountRangeMessage;
+import com.jaeckel.ethp2p.networking.snap.messages.StorageRangesMessage;
+import io.myotis.api.StorageProofResult;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.crypto.Hash;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Shared, host-agnostic verified storage-slot query — the engine home of the daemon's
+ * {@code get-storage} ladder (moved out of the JVM {@code CommandHandler} verbatim):
+ *
+ * <ol>
+ *   <li>Fetch the contract account at the peer's fresh state root (peers prune beyond
+ *       ~128 blocks, so a beacon-finalized root is usually too stale for them to serve).</li>
+ *   <li>Take {@code storageRoot} from the PROOF-VERIFIED account leaf, never the peer's
+ *       slim body — a peer could otherwise forge storageRoot (keeping nonce/balance
+ *       honest) plus a matching storage proof and fabricate a "verified" slot value.</li>
+ *   <li>Fetch + MPT-verify the slot against that storageRoot.</li>
+ *   <li>Anchor the account's state root to the beacon chain: stateRootMatch fast-path,
+ *       else the BLS-attested headerChain walk (shared with {@link VerifiedAccountQuery}).</li>
+ * </ol>
+ *
+ * <p>Verification failures surface in the result's {@code failReason}; malformed input and
+ * unservable fetches throw ({@link IllegalArgumentException}/{@link IllegalStateException}
+ * with the daemon's established messages, which hosts fold into their error responses).
+ */
+public final class VerifiedStorageQuery {
+
+    private static final Logger log = LoggerFactory.getLogger(VerifiedStorageQuery.class);
+
+    private VerifiedStorageQuery() {}
+
+    /**
+     * Blocking query (call from a worker thread; internally bounded — two 30 s fetches plus
+     * the 60 s header walk worst-case). {@code holderHexOrNull} switches the queried key to
+     * the Solidity mapping slot {@code keccak256(pad32(holder) ‖ uint256(slot))} (ERC-20
+     * balance lookups).
+     */
+    public static StorageProofResult query(RLPxConnector connector,
+                                           BeaconSyncState beaconSyncState,
+                                           String hexAddress,
+                                           long slotNumber,
+                                           String holderHexOrNull) throws Exception {
+        String addr = hexAddress == null ? "" : hexAddress;
+        String hex = (addr.startsWith("0x") || addr.startsWith("0X")) ? addr.substring(2) : addr;
+        if (hex.length() != 40) {
+            throw new IllegalArgumentException("address must be a 20-byte hex string (40 hex chars)");
+        }
+        Bytes contractAddress = Bytes.fromHexString(hex);
+
+        // Compute the storage key: plain uint256(slot), or the ERC-20 mapping key
+        // keccak256(abi.encode(holderAddress, uint256(slot))).
+        String holderEcho = null;
+        byte[] storageSlotKey;
+        if (holderHexOrNull != null) {
+            holderEcho = holderHexOrNull;
+            String holderHex = (holderHexOrNull.startsWith("0x") || holderHexOrNull.startsWith("0X"))
+                    ? holderHexOrNull.substring(2) : holderHexOrNull;
+            if (holderHex.length() != 40) {
+                throw new IllegalArgumentException("holder must be a 20-byte hex string (40 hex chars)");
+            }
+            byte[] holderBytes = Bytes.fromHexString(holderHex).toArrayUnsafe();
+            byte[] encoded = new byte[64];
+            System.arraycopy(holderBytes, 0, encoded, 12, 20); // left-pad holder to 32 bytes
+            writeSlotBe(encoded, 56, slotNumber);
+            storageSlotKey = Hash.keccak256(Bytes.wrap(encoded)).toArrayUnsafe();
+        } else {
+            byte[] slotBytes = new byte[32];
+            writeSlotBe(slotBytes, 24, slotNumber);
+            storageSlotKey = slotBytes;
+        }
+        Bytes32 storageKeyHash = Hash.keccak256(Bytes.wrap(storageSlotKey));
+
+        // Step 1: fetch the account to get the proof-verified storageRoot.
+        Bytes32 accountHash = Hash.keccak256(contractAddress);
+        AccountRangeMessage.DecodeResult accountResult =
+                connector.requestAccount(contractAddress).get(30, TimeUnit.SECONDS);
+        AccountRangeMessage.AccountData account = accountResult.accounts().stream()
+                .filter(a -> a.accountHash().equals(accountHash))
+                .findFirst().orElse(null);
+        if (account == null) {
+            throw new IllegalStateException("Contract account not found");
+        }
+
+        Bytes32 snapStateRoot = accountResult.stateRoot();
+        List<byte[]> accountProofBytes = accountResult.proof().stream()
+                .map(Bytes::toArrayUnsafe).toList();
+        MerklePatriciaVerifier.VerifiedAccount verifiedAccount =
+                snapStateRoot == null ? null
+                        : MerklePatriciaVerifier.verifyAndExtractAccount(
+                                snapStateRoot.toArrayUnsafe(),
+                                contractAddress.toArrayUnsafe(), accountProofBytes,
+                                account.nonce(), account.balance().toString());
+        if (verifiedAccount == null) {
+            throw new IllegalStateException("Contract account proof did not verify against peer state root");
+        }
+        Bytes32 storageRoot = Bytes32.wrap(verifiedAccount.storageRoot());
+
+        // Step 2: fetch the slot at the SAME peer state root for consistency.
+        StorageRangesMessage.DecodeResult storageResult =
+                connector.requestStorage(contractAddress, storageKeyHash, snapStateRoot)
+                        .get(30, TimeUnit.SECONDS);
+        StorageRangesMessage.StorageData found = storageResult.slots().stream()
+                .filter(s -> s.slotHash().equals(storageKeyHash))
+                .findFirst().orElse(null);
+
+        List<String> proofHex = storageResult.proof().stream().map(Bytes::toHexString).toList();
+
+        // Step 3: verify the storage proof against the proof-verified storageRoot.
+        boolean storageProofValid = false;
+        if (!storageResult.proof().isEmpty()) {
+            List<byte[]> proofBytes = storageResult.proof().stream()
+                    .map(Bytes::toArrayUnsafe).toList();
+            byte[] leafValue = MerklePatriciaVerifier.verifyStorageProof(
+                    storageRoot.toArrayUnsafe(), storageSlotKey, proofBytes);
+            storageProofValid = (leafValue != null);
+        }
+
+        // Step 4: anchor the account's state root to the beacon chain — stateRootMatch
+        // fast-path, then the same failure ladder + headerChain walk as get-account.
+        boolean beaconChainVerified = false;
+        boolean blsVerified = false;
+        long matchedSlot = -1;
+        String verifyMethod = null;
+        String failReason = null;
+        Bytes32 usedStateRoot = accountResult.stateRoot();
+        if (usedStateRoot != null) {
+            BeaconSyncState.SlottedStateRoot match =
+                    beaconSyncState.findStateRoot(usedStateRoot.toArrayUnsafe());
+            if (match != null) {
+                beaconChainVerified = true;
+                matchedSlot = match.slot();
+                blsVerified = match.blsVerified();
+                verifyMethod = "stateRootMatch";
+            }
+        }
+        long peerBlockNumber = accountResult.blockNumber();
+        if (!beaconChainVerified) {
+            // Atomic snapshot: block number + state root must come from the same finalized
+            // payload — the header chain is anchored at the number and must terminate at
+            // the root.
+            BeaconSyncState.FinalizedExecution fin = beaconSyncState.getFinalizedExecution();
+            long finalizedBlockNum = fin.blockNumber();
+            byte[] beaconRoot = fin.stateRoot();
+            if (usedStateRoot == null) {
+                failReason = "noPeerStateRoot";
+            } else if (!storageProofValid) {
+                failReason = "peerProofInvalid";
+            } else if (!beaconSyncState.isSynced()) {
+                failReason = "beaconNotSynced";
+            } else if (peerBlockNumber <= 0) {
+                failReason = "noPeerBlockNumber";
+            } else if (finalizedBlockNum <= 0 || beaconRoot == null) {
+                failReason = "beaconBlockUnavailable";
+            } else if (peerBlockNumber <= finalizedBlockNum) {
+                failReason = "peerBlockBehindFinalized";
+            } else if (peerBlockNumber - finalizedBlockNum > VerifiedAccountQuery.MAX_HEADER_CHAIN_GAP) {
+                failReason = "headerChainGapTooLarge";
+            } else {
+                log.info("[verify] headerChain: peerBlock={}, finalizedBlock={}, gap={}",
+                        peerBlockNumber, finalizedBlockNum, peerBlockNumber - finalizedBlockNum);
+                try {
+                    boolean chainValid = VerifiedAccountQuery.verifyHeaderChainBatched(
+                                    connector, finalizedBlockNum, peerBlockNumber,
+                                    beaconRoot, usedStateRoot.toArrayUnsafe())
+                            .get(VerifiedAccountQuery.HEADER_CHAIN_TIMEOUT_SEC + 10, TimeUnit.SECONDS);
+                    if (chainValid) {
+                        beaconChainVerified = true;
+                        matchedSlot = beaconSyncState.getFinalizedSlot();
+                        blsVerified = true;
+                        verifyMethod = "headerChain";
+                    } else {
+                        failReason = "headerChainInvalid";
+                    }
+                } catch (Exception e) {
+                    log.info("[verify] Header chain verification failed: {}", e.getMessage());
+                    failReason = "headerChainError";
+                }
+            }
+        }
+
+        String valueHex = found != null ? found.slotValue().toHexString() : null;
+        String valueDecimal = null;
+        if (found != null && !found.slotValue().isEmpty()) {
+            valueDecimal = new java.math.BigInteger(1, found.slotValue().toArrayUnsafe()).toString();
+        }
+
+        return new StorageProofResult(
+                addr,
+                slotNumber,
+                holderEcho,
+                "0x" + Bytes.wrap(storageSlotKey).toUnprefixedHexString(),
+                storageKeyHash.toHexString(),
+                found != null,
+                valueHex,
+                valueDecimal,
+                storageResult.slots().size(),
+                storageRoot.toHexString(),
+                proofHex,
+                storageProofValid,
+                beaconSyncState.isSynced(),
+                beaconChainVerified,
+                blsVerified,
+                matchedSlot,
+                verifyMethod,
+                failReason,
+                peerBlockNumber,
+                // Diagnostics mirror the daemon's historical output: the finalized anchor
+                // here reads getExecutionBlockNumber() (not the atomic pair used for the
+                // walk above) — keep it so the emitted numbers don't shift.
+                beaconSyncState.getExecutionBlockNumber(),
+                beaconSyncState.getOptimisticBlockNumber(),
+                beaconSyncState.getFinalizedSlot(),
+                beaconSyncState.getOptimisticSlot(),
+                VerifiedAccountQuery.MAX_HEADER_CHAIN_GAP);
+    }
+
+    /** uint64 → 8 big-endian bytes at {@code offset}..{@code offset+7}. */
+    private static void writeSlotBe(byte[] out, int offset, long slot) {
+        out[offset + 7] = (byte) (slot);
+        out[offset + 6] = (byte) (slot >>> 8);
+        out[offset + 5] = (byte) (slot >>> 16);
+        out[offset + 4] = (byte) (slot >>> 24);
+        out[offset + 3] = (byte) (slot >>> 32);
+        out[offset + 2] = (byte) (slot >>> 40);
+        out[offset + 1] = (byte) (slot >>> 48);
+        out[offset]     = (byte) (slot >>> 56);
+    }
+}

--- a/node-core/src/main/java/io/myotis/node/api/JavaChainHandle.java
+++ b/node-core/src/main/java/io/myotis/node/api/JavaChainHandle.java
@@ -3,7 +3,6 @@ package io.myotis.node.api;
 import com.jaeckel.ethp2p.consensus.BeaconSyncState;
 import com.jaeckel.ethp2p.consensus.lightclient.BeaconChainSpec;
 import com.jaeckel.ethp2p.networking.NetworkConfig;
-import com.jaeckel.ethp2p.networking.eth.messages.BlockHeadersMessage;
 import com.jaeckel.ethp2p.networking.rlpx.RLPxConnector;
 import io.myotis.api.AccountProofResult;
 import io.myotis.api.BeaconState;
@@ -12,7 +11,6 @@ import io.myotis.api.ChainHandle;
 import io.myotis.api.DialResult;
 import io.myotis.api.EngineException;
 import io.myotis.api.EnsApi;
-import io.myotis.api.HeaderInfo;
 import io.myotis.api.HeadersResult;
 import io.myotis.api.PeerInfo;
 import io.myotis.api.StatusSnapshot;
@@ -163,48 +161,33 @@ public final class JavaChainHandle implements ChainHandle {
 
     @Override
     public StorageProofResult getStorageProof(String hexAddress, long slot, String holderHexOrNull) {
-        // Wired when the daemon's storage-proof ladder moves into node-core
-        // (plan step PR2: engine-logic motion); nothing calls this until the hosts
-        // are rewired in PR3.
-        throw new EngineException("getStorageProof: not yet wired (lands with the engine-logic motion PR)");
+        RLPxConnector conn = stack.connector();
+        if (!stack.isRunning() || conn == null) throw new EngineException("Node is not running");
+        try {
+            return io.myotis.node.VerifiedStorageQuery.query(
+                    conn, stack.beaconSyncState(), hexAddress, slot, holderHexOrNull);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new EngineException("interrupted while querying storage", e);
+        } catch (Exception e) {
+            Throwable cause = e.getCause() != null ? e.getCause() : e;
+            throw new EngineException(cause.getMessage() != null
+                    ? cause.getMessage() : cause.getClass().getSimpleName(), cause);
+        }
     }
 
     @Override
     public HeadersResult getHeaders(long startBlock, int count) {
         RLPxConnector conn = stack.connector();
         if (!stack.isRunning() || conn == null) throw new EngineException("Node is not running");
-        try {
-            List<BlockHeadersMessage.VerifiedHeader> headers =
-                    conn.requestBlockHeaders(startBlock, count).get(30, TimeUnit.SECONDS);
-            List<HeaderInfo> out = new ArrayList<>(headers.size());
-            for (BlockHeadersMessage.VerifiedHeader vh : headers) {
-                var h = vh.header();
-                out.add(new HeaderInfo(
-                        h.number,
-                        vh.hash().toHexString(),
-                        h.parentHash.toHexString(),
-                        h.stateRoot.toHexString(),
-                        h.transactionsRoot.toHexString(),
-                        h.timestamp,
-                        h.gasUsed,
-                        h.gasLimit,
-                        h.baseFeePerGas != null ? h.baseFeePerGas.toString() : null));
-            }
-            return new HeadersResult(out, null);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            return new HeadersResult(List.of(), "interrupted");
-        } catch (Exception e) {
-            Throwable cause = e.getCause() != null ? e.getCause() : e;
-            return new HeadersResult(List.of(), cause.getMessage() != null
-                    ? cause.getMessage() : cause.getClass().getSimpleName());
-        }
+        return io.myotis.node.HeaderQuery.fetch(conn, startBlock, count);
     }
 
     @Override
     public BlockResult getBlockVerified(long blockNumber) {
-        // Wired when the daemon's block verification moves into node-core (plan step PR2).
-        throw new EngineException("getBlockVerified: not yet wired (lands with the engine-logic motion PR)");
+        RLPxConnector conn = stack.connector();
+        if (!stack.isRunning() || conn == null) throw new EngineException("Node is not running");
+        return io.myotis.node.VerifiedBlockQuery.query(conn, stack.beaconSyncState(), blockNumber);
     }
 
     @Override

--- a/node-core/src/main/java/io/myotis/node/api/JavaEnsApi.java
+++ b/node-core/src/main/java/io/myotis/node/api/JavaEnsApi.java
@@ -14,19 +14,20 @@ import io.myotis.api.EnsTextResult;
 import io.myotis.node.ChainStack;
 import io.myotis.rpc.EnsResolution;
 import io.myotis.rpc.VerifiedRpcBackend;
+import org.apache.tuweni.bytes.Bytes;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 /**
- * The JVM {@link EnsApi}: forward resolution delegates to the backend's shared resolution
- * policy ({@link VerifiedRpcBackend#resolveEns}). The record-type lookups (text, contenthash,
- * multi-coin, …) are wired when the ENS record service moves out of the daemon's
- * CommandHandler into node-core (plan step PR2); nothing calls them until the hosts are
- * rewired in PR3.
+ * The JVM {@link EnsApi}: every lookup delegates to {@link VerifiedRpcBackend}'s shared
+ * resolution machinery (peer probe + pinned-root EVM stack + AUTO ladder), so the policy
+ * lives once in the engine. This class only blocks on the futures and maps the backend
+ * records onto the flat API result shapes.
  */
 final class JavaEnsApi implements EnsApi {
 
-    /** Worst-case forward resolution: peer probing + EVM + CCIP gateway round-trips. */
+    /** Worst-case resolution: peer probing + EVM + CCIP gateway round-trips. */
     private static final long RESOLVE_TIMEOUT_SEC = 150;
 
     private final ChainStack stack;
@@ -35,15 +36,19 @@ final class JavaEnsApi implements EnsApi {
         this.stack = stack;
     }
 
+    private VerifiedRpcBackend backend() {
+        VerifiedRpcBackend backend = stack.rpcBackend();
+        if (backend == null) throw new EngineException("node not running (RPC backend not started)");
+        return backend;
+    }
+
     @Override
     public EnsResolutionResult resolveAddress(String name, EnsRoot root) {
-        VerifiedRpcBackend backend = stack.rpcBackend();
-        if (backend == null) {
-            return new EnsResolutionResult(name, null, -1, false, "node not running");
-        }
+        // backend() throws EngineException when not running — the same state-error
+        // convention as every other method here (per the EnsApi contract).
+        VerifiedRpcBackend backend = backend();
         try {
-            EnsResolution r = backend.resolveEns(
-                            name, io.myotis.ens.EnsResolutionRoot.valueOf(root.name()))
+            EnsResolution r = backend.resolveEns(name, toEngineRoot(root))
                     .get(RESOLVE_TIMEOUT_SEC, TimeUnit.SECONDS);
             return new EnsResolutionResult(r.name(), r.addressHex(), r.blockNumber(),
                     r.verified(), r.error());
@@ -59,46 +64,118 @@ final class JavaEnsApi implements EnsApi {
 
     @Override
     public EnsResolutionResult reverseResolve(String hexAddress) {
-        throw notYetWired("reverseResolve");
+        byte[] addr20;
+        try {
+            String hex = hexAddress != null && (hexAddress.startsWith("0x") || hexAddress.startsWith("0X"))
+                    ? hexAddress.substring(2) : hexAddress;
+            if (hex == null || hex.length() != 40) {
+                throw new IllegalArgumentException("address must be a 20-byte hex string (40 hex chars)");
+            }
+            addr20 = Bytes.fromHexString(hex).toArrayUnsafe();
+        } catch (Exception e) {
+            throw new EngineException(e.getMessage() != null ? e.getMessage() : "invalid address", e);
+        }
+        VerifiedRpcBackend.EnsRecord<String> r = await(
+                backend().reverseResolveEns(addr20, io.myotis.ens.EnsResolutionRoot.AUTO));
+        // value = the forward-verified primary name (resolveName enforces ENSIP-3).
+        return new EnsResolutionResult(r.value(), hexAddress, r.blockNumber(), r.verified(), r.error());
     }
 
     @Override
     public EnsTextResult resolveText(String name, String key) {
-        throw notYetWired("resolveText");
+        VerifiedRpcBackend.EnsRecord<String> r = await(
+                backend().resolveEnsText(name, key, io.myotis.ens.EnsResolutionRoot.AUTO));
+        return new EnsTextResult(name, key, r.value(), r.blockNumber(), r.verified(), r.error());
     }
 
     @Override
     public EnsContenthashResult resolveContenthash(String name) {
-        throw notYetWired("resolveContenthash");
+        VerifiedRpcBackend.EnsRecord<byte[]> r = await(
+                backend().resolveEnsContenthash(name, io.myotis.ens.EnsResolutionRoot.AUTO));
+        return new EnsContenthashResult(name, hexOrNull(r.value()),
+                r.blockNumber(), r.verified(), r.error());
     }
 
     @Override
     public EnsMultiCoinResult resolveMultiCoinAddr(String name, long coinType) {
-        throw notYetWired("resolveMultiCoinAddr");
+        VerifiedRpcBackend.EnsRecord<byte[]> r = await(
+                backend().resolveEnsMultiCoinAddr(name, coinType, io.myotis.ens.EnsResolutionRoot.AUTO));
+        return new EnsMultiCoinResult(name, coinType, hexOrNull(r.value()),
+                r.blockNumber(), r.verified(), r.error());
     }
 
     @Override
     public EnsPubkeyResult resolvePubkey(String name) {
-        throw notYetWired("resolvePubkey");
+        VerifiedRpcBackend.EnsRecord<io.myotis.ens.EnsResolver.Pubkey> r = await(
+                backend().resolveEnsPubkey(name, io.myotis.ens.EnsResolutionRoot.AUTO));
+        io.myotis.ens.EnsResolver.Pubkey pk = r.value();
+        return new EnsPubkeyResult(name,
+                pk != null ? Bytes.wrap(pk.x()).toHexString() : null,
+                pk != null ? Bytes.wrap(pk.y()).toHexString() : null,
+                r.blockNumber(), r.verified(), r.error());
     }
 
     @Override
     public EnsAbiResult resolveAbi(String name, long contentTypes) {
-        throw notYetWired("resolveAbi");
+        VerifiedRpcBackend.EnsRecord<io.myotis.ens.EnsResolver.AbiRecord> r = await(
+                backend().resolveEnsAbi(name, contentTypes, io.myotis.ens.EnsResolutionRoot.AUTO));
+        io.myotis.ens.EnsResolver.AbiRecord rec = r.value();
+        return new EnsAbiResult(name,
+                rec != null ? rec.contentType() : 0,
+                rec != null ? Bytes.wrap(rec.data()).toHexString() : null,
+                r.blockNumber(), r.verified(), r.error());
     }
 
     @Override
     public EnsDnsRecordResult resolveDnsRecord(String name, String dnsName, int recordType) {
-        throw notYetWired("resolveDnsRecord");
+        byte[] dnsNameWire;
+        try {
+            dnsNameWire = io.myotis.ens.DnsEncoder.encode(dnsName);
+        } catch (Exception e) {
+            throw new EngineException("invalid DNS name: " + e.getMessage(), e);
+        }
+        VerifiedRpcBackend.EnsRecord<byte[]> r = await(
+                backend().resolveEnsDnsRecord(name, dnsNameWire, recordType,
+                        io.myotis.ens.EnsResolutionRoot.AUTO));
+        return new EnsDnsRecordResult(name, dnsName, recordType, hexOrNull(r.value()),
+                r.blockNumber(), r.verified(), r.error());
     }
 
     @Override
     public EnsInterfaceResult resolveInterfaceImplementer(String name, byte[] interfaceId4) {
-        throw notYetWired("resolveInterfaceImplementer");
+        if (interfaceId4 == null || interfaceId4.length != 4) {
+            throw new EngineException("interfaceId must be exactly 4 bytes");
+        }
+        VerifiedRpcBackend.EnsRecord<io.myotis.evm.Address> r = await(
+                backend().resolveEnsInterfaceImplementer(name, interfaceId4,
+                        io.myotis.ens.EnsResolutionRoot.AUTO));
+        return new EnsInterfaceResult(name, Bytes.wrap(interfaceId4).toHexString(),
+                r.value() != null ? r.value().toHex() : null,
+                r.blockNumber(), r.verified(), r.error());
     }
 
-    private static EngineException notYetWired(String method) {
-        return new EngineException(method
-                + ": not yet wired (lands with the engine-logic motion PR)");
+    /** Block on a backend record future, folding interruption/timeouts into the record's
+     *  error convention (never throwing for resolution failures). */
+    private static <T> VerifiedRpcBackend.EnsRecord<T> await(
+            CompletableFuture<VerifiedRpcBackend.EnsRecord<T>> future) {
+        try {
+            return future.get(RESOLVE_TIMEOUT_SEC, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return new VerifiedRpcBackend.EnsRecord<>(null, -1, false, "interrupted");
+        } catch (Exception e) {
+            Throwable cause = e.getCause() != null ? e.getCause() : e;
+            return new VerifiedRpcBackend.EnsRecord<>(null, -1, false,
+                    cause.getMessage() != null ? cause.getMessage() : cause.getClass().getSimpleName());
+        }
+    }
+
+    private static String hexOrNull(byte[] value) {
+        return value == null ? null : Bytes.wrap(value).toHexString();
+    }
+
+    private static io.myotis.ens.EnsResolutionRoot toEngineRoot(EnsRoot root) {
+        return io.myotis.ens.EnsResolutionRoot.valueOf(
+                (root == null ? EnsRoot.AUTO : root).name());
     }
 }

--- a/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
+++ b/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
@@ -984,6 +984,172 @@ public final class VerifiedRpcBackend implements io.myotis.jsonrpc.MyotisRpcBack
     }
 
     // ---------------------------------------------------------------------
+    // ENS record-type lookups (text / contenthash / multi-coin / pubkey / abi /
+    // DNS / interface-implementer / reverse) — the engine home of what the
+    // daemon's IPC handlers used to build ad hoc. Same RpcCallContext machinery,
+    // same AUTO ladder as resolveEns.
+    // ---------------------------------------------------------------------
+
+    /**
+     * One record-type lookup outcome. {@code value == null} with {@code error == null}
+     * is a <em>successful</em> "no such record"; {@code error != null} is a failure.
+     * {@code verified} is true iff the lookup ran against beacon-finalized state.
+     */
+    public record EnsRecord<T>(T value, long blockNumber, boolean verified, String error) {}
+
+    private record RecordAttempt<T>(EnsRecord<T> record, boolean usedOffchain) {}
+
+    /** ENSIP-5 text record. */
+    public CompletableFuture<EnsRecord<String>> resolveEnsText(
+            String name, String key, io.myotis.ens.EnsResolutionRoot mode) {
+        return resolveRecordWithMode("resolveText", mode,
+                (r, ctx) -> r.resolveText(name, key, ctx));
+    }
+
+    /** ENSIP-7 contenthash. */
+    public CompletableFuture<EnsRecord<byte[]>> resolveEnsContenthash(
+            String name, io.myotis.ens.EnsResolutionRoot mode) {
+        return resolveRecordWithMode("resolveContenthash", mode,
+                (r, ctx) -> r.resolveContenthash(name, ctx));
+    }
+
+    /** ENSIP-9 multi-coin address (SLIP-44 coin type). */
+    public CompletableFuture<EnsRecord<byte[]>> resolveEnsMultiCoinAddr(
+            String name, long coinType, io.myotis.ens.EnsResolutionRoot mode) {
+        return resolveRecordWithMode("resolveMultiCoinAddress", mode,
+                (r, ctx) -> r.resolveMultiCoinAddress(name, coinType, ctx));
+    }
+
+    /** Pubkey record (secp256k1 x/y). */
+    public CompletableFuture<EnsRecord<io.myotis.ens.EnsResolver.Pubkey>> resolveEnsPubkey(
+            String name, io.myotis.ens.EnsResolutionRoot mode) {
+        return resolveRecordWithMode("resolvePubkey", mode,
+                (r, ctx) -> r.resolvePubkey(name, ctx));
+    }
+
+    /** ABI record (ENSIP-4); {@code contentTypes} is the accepted-encodings bitmask. */
+    public CompletableFuture<EnsRecord<io.myotis.ens.EnsResolver.AbiRecord>> resolveEnsAbi(
+            String name, long contentTypes, io.myotis.ens.EnsResolutionRoot mode) {
+        return resolveRecordWithMode("resolveAbi", mode,
+                (r, ctx) -> r.resolveAbi(name, contentTypes, ctx));
+    }
+
+    /** DNS record stored in ENS (ENSIP-6); {@code dnsNameWire} is the wire-encoded name. */
+    public CompletableFuture<EnsRecord<byte[]>> resolveEnsDnsRecord(
+            String name, byte[] dnsNameWire, int resource, io.myotis.ens.EnsResolutionRoot mode) {
+        return resolveRecordWithMode("resolveDnsRecord", mode,
+                (r, ctx) -> r.resolveDnsRecord(name, dnsNameWire, resource, ctx));
+    }
+
+    /** ERC-165 interface-implementer record. */
+    public CompletableFuture<EnsRecord<io.myotis.evm.Address>> resolveEnsInterfaceImplementer(
+            String name, byte[] interfaceId4, io.myotis.ens.EnsResolutionRoot mode) {
+        return resolveRecordWithMode("resolveInterfaceImplementer", mode,
+                (r, ctx) -> r.resolveInterfaceImplementer(name, interfaceId4, ctx));
+    }
+
+    /**
+     * Reverse resolution (address → primary name) with the resolver's mandatory ENSIP-3
+     * forward-verification. The returned record's value is the verified name.
+     */
+    public CompletableFuture<EnsRecord<String>> reverseResolveEns(
+            byte[] address20, io.myotis.ens.EnsResolutionRoot mode) {
+        final io.myotis.evm.Address addr;
+        try {
+            addr = io.myotis.evm.Address.of(address20);
+        } catch (RuntimeException e) {
+            // Keep the family's never-throws contract even for a bad-length array.
+            return CompletableFuture.completedFuture(
+                    new EnsRecord<>(null, -1, false, unwrap(e)));
+        }
+        return resolveRecordWithMode("resolveName", mode,
+                (r, ctx) -> r.resolveName(addr, ctx));
+    }
+
+    /**
+     * Shared mode dispatch + snap-heavy guard for the record lookups — mirrors
+     * {@link #resolveEns}: AUTO tries FINALIZED and falls back to PEER_HEAD only when the
+     * record was absent AND no CCIP gateway already determined the answer. Never throws.
+     */
+    private <T> CompletableFuture<EnsRecord<T>> resolveRecordWithMode(
+            String label, io.myotis.ens.EnsResolutionRoot mode,
+            java.util.function.BiFunction<io.myotis.ens.EnsResolver, io.myotis.evm.BlockContext,
+                    CompletableFuture<java.util.Optional<T>>> call) {
+        RLPxConnector conn = connector;
+        if (conn == null) {
+            return CompletableFuture.completedFuture(
+                    new EnsRecord<>(null, -1, false, "node not running"));
+        }
+        final io.myotis.ens.EnsResolutionRoot m =
+                (mode == null) ? io.myotis.ens.EnsResolutionRoot.AUTO : mode;
+        conn.enterSnapHeavy();
+        // Same synchronous-throw guard as resolveEns: supplyAsync can reject before any
+        // future exists; don't leak the snap-heavy state on that path.
+        try {
+            final CompletableFuture<EnsRecord<T>> result;
+            if (m == io.myotis.ens.EnsResolutionRoot.AUTO) {
+                result = attemptResolveRecord(label, io.myotis.ens.EnsResolutionRoot.FINALIZED, call)
+                        .thenCompose(fin -> {
+                            if (fin.record().value() != null || fin.usedOffchain()) {
+                                return CompletableFuture.completedFuture(fin.record());
+                            }
+                            return attemptResolveRecord(label,
+                                    io.myotis.ens.EnsResolutionRoot.PEER_HEAD, call)
+                                    .thenApply(RecordAttempt::record);
+                        });
+            } else {
+                result = attemptResolveRecord(label, m, call).thenApply(RecordAttempt::record);
+            }
+            return result.whenComplete((r, ex) -> conn.exitSnapHeavy());
+        } catch (Throwable t) {
+            conn.exitSnapHeavy();
+            return CompletableFuture.completedFuture(
+                    new EnsRecord<>(null, -1, false, unwrap(t)));
+        }
+    }
+
+    /** One record-lookup attempt against {@code root}. Never throws (mirrors
+     *  {@link #attemptResolveEns}); an absent record is value=null with error=null. */
+    private <T> CompletableFuture<RecordAttempt<T>> attemptResolveRecord(
+            String label, io.myotis.ens.EnsResolutionRoot root,
+            java.util.function.BiFunction<io.myotis.ens.EnsResolver, io.myotis.evm.BlockContext,
+                    CompletableFuture<java.util.Optional<T>>> call) {
+        return CompletableFuture.<RpcCallContext>supplyAsync(() -> {
+            try {
+                return prepareEnsCall(root);
+            } catch (Exception e) {
+                throw new java.util.concurrent.CompletionException(e);
+            }
+        }, evmPool).thenCompose(ctx -> {
+            final boolean verified = ctx.beaconVerified();
+            if (ctx.resolver() == null) {
+                return CompletableFuture.completedFuture(new RecordAttempt<T>(new EnsRecord<>(
+                        null, ctx.blockNumber(), verified,
+                        "ENS not available on chain id " + connector.getNetwork().networkId()),
+                        false));
+            }
+            return call.apply(ctx.resolver(), ctx.blockCtx())
+                    .orTimeout(ENS_TIMEOUT_SEC, TimeUnit.SECONDS)
+                    .handle((opt, ex) -> {
+                        final boolean usedOffchain = ctx.offchainExecutor().usedOffchain();
+                        if (ex != null) {
+                            log.info("[ens] " + label + " failed: " + unwrap(ex));
+                            return new RecordAttempt<T>(new EnsRecord<>(
+                                    null, ctx.blockNumber(), verified, unwrap(ex)), usedOffchain);
+                        }
+                        T value = (opt == null || opt.isEmpty()) ? null : opt.get();
+                        return new RecordAttempt<T>(new EnsRecord<>(
+                                value, ctx.blockNumber(), verified, null), usedOffchain);
+                    });
+        }).exceptionally(ex -> {
+            Throwable cause = (ex instanceof java.util.concurrent.CompletionException
+                    && ex.getCause() != null) ? ex.getCause() : ex;
+            return new RecordAttempt<T>(new EnsRecord<>(null, -1,
+                    root == io.myotis.ens.EnsResolutionRoot.FINALIZED, unwrap(cause)), false);
+        });
+    }
+
+    // ---------------------------------------------------------------------
     // Shared anchored-head context resolution
     // ---------------------------------------------------------------------
 


### PR DESCRIPTION
PR 2/6 of the engine-API extraction (plan: define the API → make the Java engine implement it → document). PR 1/6 (#117) added `:myotis-api` and the node-core adapters; this PR moves the engine logic that still lived in the daemon's `CommandHandler` into the engine modules — **verbatim, no behavior change** — and locks the daemon's IPC JSON with golden tests before the hosts are rewired in PR 3/6.

## What moved where

**node-core** (the daemon's verification ladders, line-for-line):
- `VerifiedStorageQuery` — the `get-storage` ladder: account proof → proof-verified-leaf `storageRoot` (never the peer's slim body) → storage proof → beacon anchor (stateRootMatch fast-path, else the headerChain walk). Includes the `keccak256(pad32(holder)‖uint256(slot))` ERC-20 mapping-key derivation. Reuses `VerifiedAccountQuery.verifyHeaderChainBatched` (now package-private) so the walk lives once. Two historical quirks are deliberately preserved and commented: the diagnostics read `getExecutionBlockNumber()` while the walk uses the atomic `getFinalizedExecution()` pair.
- `VerifiedBlockQuery` — the `get-block` header+body fetch and beacon verification (`stateRootMatch` / headerChain anchored at the BLS-verified execution block hash / `preMergeBlock`).
- `HeaderQuery` — the `get-headers` fetch (shared with `JavaChainHandle`).
- `VerifiedAccountQuery.queryProof` gained a parts-based overload for the daemon (which holds `connector`/`beaconSyncState` rather than a `ChainStack` until PR 3/6).

**rpc-backend**: `VerifiedRpcBackend` gains the ENS **record-type** lookups (text, contenthash, multi-coin, pubkey, ABI, DNS, interface-implementer, and ENSIP-3 forward-verified reverse) built on its existing `RpcCallContext` machinery — same AUTO ladder (finalized-first, head fallback unless a CCIP gateway already answered), same snap-heavy guard, same never-throws contract as `resolveEns`. The engine now has **one** peer-probe/EVM-stack home for ENS instead of the daemon duplicating ~600 lines of it. (The daemon's ENS IPC handlers are deliberately untouched until PR 3/6.)

**node-core adapters completed**: `JavaChainHandle.getStorageProof`/`getBlockVerified`/`getHeaders` and all `JavaEnsApi` methods are now wired — no "not yet wired" stubs remain on the engine API.

**Daemon**: `handleGetAccount`/`handleGetStorage`/`handleGetBlock`/`handleGetHeaders` now delegate to the node-core queries and only serialize, via pure static builders (`buildAccountJson`/`buildStorageJson`/`buildBlockJson`/`buildHeadersJson`). The dead daemon-local ladder copies (~350 lines) are deleted.

## The byte-identical contract
`CommandHandlerJsonGoldenTest` — 8 golden tests locking the exact response bytes for get-account/get-storage/get-block/get-headers across exists/absent × verified/unverified, every conditional emission (`peerStateRoot`, `baseFeePerGas`, `valueDecimal`, block-gap diagnostics, `>0` gates), and the raw-address echo. The independent pre-PR review additionally reconstructed the old serialization from `main` and compared field-by-field: **byte-identical**, including the diagnostic-source quirks.

Minor IPC-visible notes (error paths only, shapes unchanged): interruption now reports `"interrupted"` with the interrupt status properly restored; a 40-char non-hex get-account address reports `"Invalid hex address: …"`; get-account's timeout is one 120 s gate instead of 30 s + 90 s staged (same worst case).

## Verification
- `./gradlew build` green across all modules; golden tests + PR-1's verify()-ladder tests pass.
- Independent no-context review (constraints: byte-identical JSON, verbatim ladders, ENS-machinery parity, golden-test adequacy) found no MUST-FIX; its findings (unused imports, get-storage error precedence, `reverseResolveEns` never-throws guard, `JavaEnsApi.resolveAddress` state-error consistency, golden-test field realism) are all incorporated.
- Live-daemon integration check (`"verifyMethod":"headerChain"` on a synced node) still applies as the end-to-end gate and is unchanged by this PR's serializers.

Next: PR 3/6 rewires `Main`/`CommandHandler` to consume only `myotis-api` (except the documented `get-transactions` debug exemption).

🤖 Generated with [Claude Code](https://claude.com/claude-code)