### PR TITLE
refactor: daemon consumes only the engine API (API extraction 3/6)

### DIFF
--- a/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
@@ -37,6 +37,12 @@ import kotlin.io.path.createDirectories
 class DesktopNodeController(private val dataDir: Path, private val settings: Settings) : NodeController {
 
     private val registry = NodeRegistry()
+
+    // Runs the blocking HttpGateway port when the CCIP bridge needs a future (interim,
+    // like the PortBridges use below — gone once desktop constructs via MyotisEngine).
+    private val httpGatewayExecutor = java.util.concurrent.Executors.newCachedThreadPool { r ->
+        Thread(r, "desktop-http-gateway").apply { isDaemon = true }
+    }
     // nanoTime, not currentTimeMillis: wall-clock / NTP steps must not skew uptime.
     private val startNs = System.nanoTime()
     // Per-network boot locks keyed by CANONICAL name, mirroring Android's NodeService.bootLocks:
@@ -86,10 +92,15 @@ class DesktopNodeController(private val dataDir: Path, private val settings: Set
                 // Retain the live instances so clearCaches can wipe their in-memory state.
                 peerCaches[canonical] = peerCache
                 clPeerCaches[canonical] = clPeerCache
+                // Interim bridging (removed when desktop constructs via MyotisEngine in the
+                // host-rewiring PR): the daemon's cache adapters + HTTP gateway now implement
+                // the api port shapes; PortBridges maps them back to what ChainStack takes.
                 val stack = ChainStack(
                     network, ports, nodeKey,
-                    PeerCacheAdapter(peerCache), ClPeerCacheAdapter(clPeerCache),
-                    JavaHttpCcipGateway(),
+                    io.myotis.node.api.PortBridges.toPeerCachePort(PeerCacheAdapter(peerCache)),
+                    io.myotis.node.api.PortBridges.toClPeerCachePort(ClPeerCacheAdapter(clPeerCache)),
+                    io.myotis.node.api.PortBridges.toCcipGateway(
+                        JavaHttpCcipGateway(), httpGatewayExecutor),
                     dataDir.resolve("sync-state$suffix.snapshot"),
                     false,
                 )
@@ -133,6 +144,7 @@ class DesktopNodeController(private val dataDir: Path, private val settings: Set
         // close tears every stack down promptly without waiting behind an in-progress boot of an
         // unrelated network.
         registry.shutdownAll()
+        httpGatewayExecutor.shutdown()
         // Forget the (now-closed) cache instances so a stray post-shutdown clearCaches takes the
         // stopped-chain purge path rather than clear()ing a closed instance.
         peerCaches.clear()

--- a/app/src/main/java/com/jaeckel/ethp2p/app/ClPeerCacheAdapter.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/ClPeerCacheAdapter.java
@@ -1,18 +1,20 @@
 package com.jaeckel.ethp2p.app;
 
-import io.myotis.node.ClPeerCachePort;
+import io.myotis.api.ports.BootstrapPeer;
+import io.myotis.api.ports.EngineClPeerCache;
+import io.myotis.api.ports.ServedRange;
 
-import java.util.Collection;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
- * Adapts the daemon's file-backed {@link CLPeerCache} to the {@link ClPeerCachePort}
- * that {@code ChainStack} consumes. Pure delegation. {@code CLPeerCache} flushes its
- * writes inline (no {@code close()}), so {@link #close()} is a no-op.
+ * Adapts the daemon's file-backed {@link CLPeerCache} to the engine API's
+ * {@link EngineClPeerCache} port. Pure delegation plus Map/Set → flat-record-List
+ * conversions. {@code CLPeerCache} flushes its writes inline (no {@code close()}),
+ * so {@link #close()} is a no-op.
  */
-public final class ClPeerCacheAdapter implements ClPeerCachePort {
+public final class ClPeerCacheAdapter implements EngineClPeerCache {
 
     private final CLPeerCache delegate;
 
@@ -21,16 +23,46 @@ public final class ClPeerCacheAdapter implements ClPeerCachePort {
     }
 
     @Override public List<String> load() { return delegate.load(); }
+
     @Override public void add(String multiaddr) { delegate.add(multiaddr); }
+
     @Override public void markFailure(String multiaddr) { delegate.markFailure(multiaddr); }
-    @Override public Map<String, long[]> servedRanges() { return delegate.servedRanges(); }
-    @Override public void recordServed(String multiaddr, long low, long high) { delegate.recordServed(multiaddr, low, high); }
-    @Override public Map<String, Long> bootstrapPeers() { return delegate.bootstrapPeers(); }
-    @Override public void recordBootstrap(String multiaddr, long period) { delegate.recordBootstrap(multiaddr, period); }
-    @Override public Set<String> lightClientConfirmed() { return delegate.lightClientConfirmed(); }
-    @Override public Set<String> lightClientDenied() { return delegate.lightClientDenied(); }
-    @Override public void markLightClientBatch(Collection<String> confirmed, Collection<String> denied) {
+
+    @Override public List<ServedRange> servedRanges() {
+        List<ServedRange> out = new ArrayList<>();
+        for (Map.Entry<String, long[]> e : delegate.servedRanges().entrySet()) {
+            out.add(new ServedRange(e.getKey(), e.getValue()[0], e.getValue()[1]));
+        }
+        return out;
+    }
+
+    @Override public void recordServed(String multiaddr, long low, long high) {
+        delegate.recordServed(multiaddr, low, high);
+    }
+
+    @Override public List<BootstrapPeer> bootstrapPeers() {
+        List<BootstrapPeer> out = new ArrayList<>();
+        for (Map.Entry<String, Long> e : delegate.bootstrapPeers().entrySet()) {
+            out.add(new BootstrapPeer(e.getKey(), e.getValue()));
+        }
+        return out;
+    }
+
+    @Override public void recordBootstrap(String multiaddr, long period) {
+        delegate.recordBootstrap(multiaddr, period);
+    }
+
+    @Override public List<String> lightClientConfirmed() {
+        return List.copyOf(delegate.lightClientConfirmed());
+    }
+
+    @Override public List<String> lightClientDenied() {
+        return List.copyOf(delegate.lightClientDenied());
+    }
+
+    @Override public void markLightClientBatch(List<String> confirmed, List<String> denied) {
         delegate.markLightClientBatch(confirmed, denied);
     }
+
     @Override public void close() { /* CLPeerCache flushes writes inline; nothing to close */ }
 }

--- a/app/src/main/java/com/jaeckel/ethp2p/app/CommandHandler.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/CommandHandler.java
@@ -1,122 +1,58 @@
 package com.jaeckel.ethp2p.app;
 
-import com.jaeckel.ethp2p.consensus.BeaconLightClient;
-import com.jaeckel.ethp2p.consensus.BeaconSyncState;
-import com.jaeckel.ethp2p.consensus.libp2p.BeaconP2PService;
-import com.jaeckel.ethp2p.consensus.lightclient.BeaconChainSpec;
-import io.myotis.node.VerifiedAccountQuery;
-import com.jaeckel.ethp2p.core.types.BlockHeader;
-import com.jaeckel.ethp2p.networking.discv4.DiscV4Service;
-import com.jaeckel.ethp2p.networking.discv4.KademliaTable;
-import com.jaeckel.ethp2p.networking.discv5.DiscV5Service;
-import com.jaeckel.ethp2p.networking.eth.messages.BlockBodiesMessage;
-import com.jaeckel.ethp2p.networking.eth.messages.BlockHeadersMessage;
-import com.jaeckel.ethp2p.networking.rlpx.RLPxConnector;
-import com.jaeckel.ethp2p.networking.snap.messages.AccountRangeMessage;
-import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.bytes.Bytes32;
-import org.apache.tuweni.rlp.RLP;
+import io.myotis.api.AccountProofResult;
+import io.myotis.api.BeaconState;
+import io.myotis.api.BeaconStatus;
+import io.myotis.api.BlockResult;
+import io.myotis.api.ChainHandle;
+import io.myotis.api.ClPeerInfo;
+import io.myotis.api.ConnectedPeer;
+import io.myotis.api.DialResult;
+import io.myotis.api.DiscoveredPeer;
+import io.myotis.api.EngineException;
+import io.myotis.api.EnsAbiResult;
+import io.myotis.api.EnsApi;
+import io.myotis.api.EnsContenthashResult;
+import io.myotis.api.EnsDnsRecordResult;
+import io.myotis.api.EnsInterfaceResult;
+import io.myotis.api.EnsMultiCoinResult;
+import io.myotis.api.EnsPubkeyResult;
+import io.myotis.api.EnsResolutionResult;
+import io.myotis.api.EnsRoot;
+import io.myotis.api.EnsTextResult;
+import io.myotis.api.HeadersResult;
+import io.myotis.api.StatusSnapshot;
+import io.myotis.api.StorageProofResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.jaeckel.trueblocks.AppearanceRecord;
-import com.jaeckel.trueblocks.Bloom;
-import com.jaeckel.trueblocks.Chunk;
-import com.jaeckel.trueblocks.IndexParser;
-import com.jaeckel.trueblocks.IpfsHttpClient;
-import com.jaeckel.trueblocks.ManifestResponse;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 /**
  * Handles JSON-Lines IPC commands dispatched by DaemonServer.
- * Holds references to live P2P services and produces JSON responses.
+ *
+ * <p>Consumes ONLY the engine API ({@code io.myotis.api.ChainHandle}) — the daemon is a
+ * thin host: argument parsing and JSON serialization live here, every fetch and every
+ * verification decision lives behind the API. The single exception is the
+ * {@code get-transactions} debug stream ({@link DebugCommands}), a documented exemption
+ * wired at the composition root.
  */
 public class CommandHandler {
 
     private static final Logger log = LoggerFactory.getLogger(CommandHandler.class);
 
-    private final DiscV4Service discV4;
-    private final DiscV5Service discV5; // nullable
-    private final RLPxConnector connector;
-    private final long startTimeMs;
+    private final ChainHandle handle;
     private final CountDownLatch stopLatch;
-    private final Map<String, Long> backoff;
-    private final Set<String> blacklistedNodeIds;
-    private final BeaconSyncState beaconSyncState;
-    private final BeaconLightClient beaconLightClient; // nullable
-    private final long clGenesisTime; // beacon chain genesis time (seconds since epoch)
-    private final int secondsPerSlot; // network slot time (mainnet 12, Gnosis 5)
+    private final DebugCommands debugCommands; // nullable: streaming debug commands disabled
+    private final long startTimeMs;
 
-    // Shared across every ENS resolution: a single bytecode cache amortizes
-    // Registry + Universal Resolver fetches across requests and between the
-    // oracle and executor in the same request. (Peer selection is done
-    // per-call by prepareEnsCall, which pins one peer for the whole call.)
-    private final io.myotis.evm.world.BytecodeCache ensBytecodeCache =
-            io.myotis.evm.world.BytecodeCache.inMemory();
-
-    public CommandHandler(DiscV4Service discV4, RLPxConnector connector,
-                          CountDownLatch stopLatch, Map<String, Long> backoff,
-                          Set<String> blacklistedNodeIds, BeaconSyncState beaconSyncState) {
-        this(discV4, null, connector, stopLatch, backoff, blacklistedNodeIds, beaconSyncState,
-                null, BeaconChainSpec.MAINNET_GENESIS_TIME);
-    }
-
-    public CommandHandler(DiscV4Service discV4, RLPxConnector connector,
-                          CountDownLatch stopLatch, Map<String, Long> backoff,
-                          Set<String> blacklistedNodeIds, BeaconSyncState beaconSyncState,
-                          BeaconLightClient beaconLightClient) {
-        this(discV4, null, connector, stopLatch, backoff, blacklistedNodeIds, beaconSyncState,
-                beaconLightClient, BeaconChainSpec.MAINNET_GENESIS_TIME);
-    }
-
-    public CommandHandler(DiscV4Service discV4, RLPxConnector connector,
-                          CountDownLatch stopLatch, Map<String, Long> backoff,
-                          Set<String> blacklistedNodeIds, BeaconSyncState beaconSyncState,
-                          BeaconLightClient beaconLightClient, long clGenesisTime) {
-        this(discV4, null, connector, stopLatch, backoff, blacklistedNodeIds, beaconSyncState,
-                beaconLightClient, clGenesisTime);
-    }
-
-    public CommandHandler(DiscV4Service discV4, DiscV5Service discV5,
-                          RLPxConnector connector,
-                          CountDownLatch stopLatch, Map<String, Long> backoff,
-                          Set<String> blacklistedNodeIds, BeaconSyncState beaconSyncState,
-                          BeaconLightClient beaconLightClient, long clGenesisTime) {
-        this(discV4, discV5, connector, stopLatch, backoff, blacklistedNodeIds,
-                beaconSyncState, beaconLightClient, clGenesisTime,
-                BeaconChainSpec.SECONDS_PER_SLOT);
-    }
-
-    public CommandHandler(DiscV4Service discV4, DiscV5Service discV5,
-                          RLPxConnector connector,
-                          CountDownLatch stopLatch, Map<String, Long> backoff,
-                          Set<String> blacklistedNodeIds, BeaconSyncState beaconSyncState,
-                          BeaconLightClient beaconLightClient, long clGenesisTime,
-                          int secondsPerSlot) {
-        this.discV4 = discV4;
-        this.discV5 = discV5;
-        this.connector = connector;
-        this.startTimeMs = System.currentTimeMillis();
+    public CommandHandler(ChainHandle handle, CountDownLatch stopLatch, DebugCommands debugCommands) {
+        this.handle = handle;
         this.stopLatch = stopLatch;
-        this.backoff = backoff;
-        this.blacklistedNodeIds = blacklistedNodeIds;
-        this.beaconSyncState = beaconSyncState;
-        this.beaconLightClient = beaconLightClient;
-        this.clGenesisTime = clGenesisTime;
-        this.secondsPerSlot = secondsPerSlot;
+        this.debugCommands = debugCommands;
+        this.startTimeMs = System.currentTimeMillis();
     }
 
     /** Parse and dispatch one JSON-Lines request; returns a JSON-Lines response. */
@@ -151,13 +87,20 @@ public class CommandHandler {
 
     /**
      * Try to handle a command that streams multiple JSON lines back to the client.
-     * Returns true if the command was handled (streaming), false if it should fall back to single-response.
+     * Returns true if the command was handled (streaming), false if it should fall back
+     * to single-response.
      */
     public boolean handleStreaming(String jsonLine, BufferedWriter writer) {
         try {
             String cmd = extractString(jsonLine, "cmd");
             if ("get-transactions".equals(cmd)) {
-                handleGetTransactions(jsonLine, writer);
+                if (debugCommands == null) {
+                    writer.write(jsonError("get-transactions is not available"));
+                    writer.newLine();
+                    writer.flush();
+                    return true;
+                }
+                debugCommands.handleGetTransactions(jsonLine, writer);
                 return true;
             }
         } catch (Exception e) {
@@ -171,212 +114,42 @@ public class CommandHandler {
         return false;
     }
 
-    /** Reflective access to Kotlin UInt-typed getters on AppearanceRecord. */
-    private static final Method GET_BLOCK_NUMBER;
-    private static final Method GET_TX_INDEX;
-    static {
-        try {
-            GET_BLOCK_NUMBER = AppearanceRecord.class.getMethod("getBlockNumber-pVg5ArA");
-            GET_TX_INDEX = AppearanceRecord.class.getMethod("getTxIndex-pVg5ArA");
-        } catch (NoSuchMethodException e) {
-            throw new ExceptionInInitializerError(e);
-        }
-    }
-
-    private static int appearanceBlockNumber(AppearanceRecord rec) {
-        try { return (int) GET_BLOCK_NUMBER.invoke(rec); }
-        catch (Exception e) { throw new RuntimeException(e); }
-    }
-
-    private static int appearanceTxIndex(AppearanceRecord rec) {
-        try { return (int) GET_TX_INDEX.invoke(rec); }
-        catch (Exception e) { throw new RuntimeException(e); }
-    }
-
-    private void handleGetTransactions(String jsonLine, BufferedWriter writer) throws IOException {
-        String addr = extractString(jsonLine, "address");
-        String hex = (addr.startsWith("0x") || addr.startsWith("0X")) ? addr.substring(2) : addr;
-        if (hex.length() != 40) {
-            writer.write(jsonError("address must be a 20-byte hex string (40 hex chars)"));
-            writer.newLine();
-            writer.flush();
-            return;
-        }
-        String checksumAddr = "0x" + hex.toLowerCase();
-
-        try {
-            IpfsHttpClient ipfs = new IpfsHttpClient();
-            String manifestCID = "QmUBS83qjRmXmSgEvZADVv2ch47137jkgNbqfVVxQep5Y1";
-
-            log.info("[get-transactions] Fetching manifest for address {}", checksumAddr);
-            ManifestResponse manifest = ipfs.fetchAndParseManifestUrl(manifestCID);
-
-            // Construct kethereum Address via reflection (avoids compile-time dependency
-            // on kethereum multiplatform module)
-            Class<?> addressClass = Class.forName("org.kethereum.model.Address");
-            Constructor<?> addressCtor = addressClass.getConstructor(String.class);
-            Object tbAddress = addressCtor.newInstance(checksumAddr);
-            Method isMemberBytes = Bloom.class.getMethod("isMemberBytes", addressClass);
-            List<Chunk> chunks = manifest.getChunks();
-            int totalChunks = chunks.size();
-            int successCount = 0;
-
-            // Scan from highest block number to lowest so recent txs appear first.
-            // Stream results per-chunk: fetch tx data immediately when appearances are found.
-            for (int ci = totalChunks - 1; ci >= 0; ci--) {
-                Chunk chunk = chunks.get(ci);
-                try {
-                    Bloom bloom = ipfs.fetchBloom(chunk.getBloomHash(), chunk.getRange());
-                    if ((boolean) isMemberBytes.invoke(bloom, tbAddress)) {
-                        log.debug("[get-transactions] Bloom hit for chunk {} ({}/{})",
-                                chunk.getRange(), totalChunks - ci, totalChunks);
-                        IndexParser index = ipfs.fetchIndex(chunk.getIndexHash(), false);
-                        List<AppearanceRecord> appearances = index.findAppearances(checksumAddr);
-                        if (appearances.isEmpty()) continue;
-
-                        log.info("[get-transactions] Found {} appearances in chunk {}",
-                                appearances.size(), chunk.getRange());
-
-                        // Sort appearances within chunk descending by block number
-                        appearances.sort(Comparator.comparingInt(
-                                CommandHandler::appearanceBlockNumber).reversed());
-
-                        // Fetch and stream each transaction immediately
-                        for (AppearanceRecord appearance : appearances) {
-                            long blockNumber = Integer.toUnsignedLong(appearanceBlockNumber(appearance));
-                            int txIndex = appearanceTxIndex(appearance);
-                            try {
-                                List<BlockHeadersMessage.VerifiedHeader> headers =
-                                        connector.requestBlockHeadersBatched(blockNumber, 1)
-                                                .get(30, TimeUnit.SECONDS);
-                                if (headers.isEmpty()) {
-                                    writer.write("{\"ok\":false,\"blockNumber\":" + blockNumber
-                                            + ",\"error\":\"No header returned\"}");
-                                    writer.newLine();
-                                    writer.flush();
-                                    continue;
-                                }
-                                BlockHeadersMessage.VerifiedHeader vh = headers.get(0);
-                                Bytes32 blockHash = vh.hash();
-
-                                List<BlockBodiesMessage.BlockBody> bodies =
-                                        connector.requestBlockBodies(blockHash)
-                                                .get(30, TimeUnit.SECONDS);
-                                if (bodies.isEmpty()) {
-                                    writer.write("{\"ok\":false,\"blockNumber\":" + blockNumber
-                                            + ",\"error\":\"No body returned\"}");
-                                    writer.newLine();
-                                    writer.flush();
-                                    continue;
-                                }
-                                BlockBodiesMessage.BlockBody body = bodies.get(0);
-
-                                List<Bytes> txList = body.transactions();
-                                if (txIndex >= txList.size()) {
-                                    writer.write("{\"ok\":false,\"blockNumber\":" + blockNumber
-                                            + ",\"transactionIndex\":" + txIndex
-                                            + ",\"error\":\"Transaction index out of range\"}");
-                                    writer.newLine();
-                                    writer.flush();
-                                    continue;
-                                }
-                                Bytes rawTx = txList.get(txIndex);
-                                String parsedFields = parseTxToJson(rawTx);
-
-                                StringBuilder txJson = new StringBuilder();
-                                txJson.append("{\"ok\":true,\"blockNumber\":").append(blockNumber);
-                                txJson.append(",\"transactionIndex\":").append(txIndex);
-                                if (!parsedFields.isEmpty()) {
-                                    txJson.append(",").append(parsedFields);
-                                }
-                                txJson.append(",\"rawTx\":\"0x").append(rawTx.toUnprefixedHexString()).append("\"");
-                                txJson.append(",\"verified\":false}");
-                                writer.write(txJson.toString());
-                                writer.newLine();
-                                writer.flush();
-                                successCount++;
-
-                            } catch (Exception e) {
-                                Throwable cause = e.getCause() != null ? e.getCause() : e;
-                                String msg = cause.getMessage() != null ? cause.getMessage() : cause.getClass().getSimpleName();
-                                writer.write("{\"ok\":false,\"blockNumber\":" + blockNumber
-                                        + ",\"transactionIndex\":" + txIndex
-                                        + ",\"error\":\"" + escapeJson(msg) + "\"}");
-                                writer.newLine();
-                                writer.flush();
-                            }
-                        }
-                    }
-                } catch (Exception e) {
-                    log.warn("[get-transactions] Error processing chunk {}: {}",
-                            chunk.getRange(), e.getMessage());
-                }
-            }
-
-            log.info("[get-transactions] Scan complete. {} transactions streamed for {}",
-                    successCount, checksumAddr);
-            writer.write("{\"ok\":true,\"done\":true,\"totalTransactions\":" + successCount + "}");
-            writer.newLine();
-            writer.flush();
-
-        } catch (Exception e) {
-            Throwable cause = e.getCause() != null ? e.getCause() : e;
-            String msg = cause.getMessage() != null ? cause.getMessage() : cause.getClass().getSimpleName();
-            writer.write(jsonError("get-transactions failed: " + msg));
-            writer.newLine();
-            writer.flush();
-        }
-    }
-
     // -------------------------------------------------------------------------
-    // Command implementations
+    // Status / peers
     // -------------------------------------------------------------------------
 
     private String handleStatus() {
         long uptimeSec = (System.currentTimeMillis() - startTimeMs) / 1000;
-        int discovered = discV4.table().size();
-        List<RLPxConnector.PeerInfo> peers = connector.getActivePeers();
-        int connectedPeers = peers.size();
-        long readyPeers = peers.stream()
-                .filter(p -> "READY".equals(p.state()))
-                .count();
-        long snapPeers = peers.stream()
-                .filter(p -> "READY".equals(p.state()) && p.snapSupported())
-                .count();
-        long now = System.currentTimeMillis();
-        backoff.values().removeIf(exp -> now >= exp);
-        long backedOffPeers = backoff.size();
-        long blacklistedPeers = blacklistedNodeIds.size();
+        StatusSnapshot s = handle.status();
         return "{\"ok\":true,\"state\":\"RUNNING\",\"uptimeSeconds\":" + uptimeSec
-                + ",\"discoveredPeers\":" + discovered
-                + ",\"connectedPeers\":" + connectedPeers
-                + ",\"readyPeers\":" + readyPeers
-                + ",\"snapPeers\":" + snapPeers
-                + ",\"backedOffPeers\":" + backedOffPeers
-                + ",\"blacklistedPeers\":" + blacklistedPeers + "}";
+                + ",\"discoveredPeers\":" + s.discoveredPeers()
+                + ",\"connectedPeers\":" + s.connectedPeers()
+                + ",\"readyPeers\":" + s.readyPeers()
+                + ",\"snapPeers\":" + s.snapPeers()
+                + ",\"backedOffPeers\":" + s.backedOffPeers()
+                + ",\"blacklistedPeers\":" + s.blacklistedPeers() + "}";
     }
 
     private String handlePeers() {
-        List<KademliaTable.Entry> peers = discV4.table().allPeers();
+        java.util.List<DiscoveredPeer> discovered = handle.discoveredPeers();
         StringBuilder sb = new StringBuilder();
-        sb.append("{\"ok\":true,\"count\":").append(peers.size()).append(",\"peers\":[");
+        sb.append("{\"ok\":true,\"count\":").append(discovered.size()).append(",\"peers\":[");
         boolean first = true;
-        for (KademliaTable.Entry e : peers) {
+        for (DiscoveredPeer e : discovered) {
             if (!first) sb.append(",");
             first = false;
-            String shortId = e.nodeId().size() >= 8
-                    ? e.nodeId().slice(0, 8).toHexString() + "..."
-                    : e.nodeId().toHexString();
-            sb.append("{\"ip\":\"").append(e.udpAddr().getAddress().getHostAddress()).append("\"")
-              .append(",\"udpPort\":").append(e.udpAddr().getPort())
+            // Same 8-byte truncation the daemon has always shown ("0x" + 16 hex + "...").
+            String id = e.nodeIdHex();
+            String shortId = id != null && id.length() >= 18 ? id.substring(0, 18) + "..." : id;
+            sb.append("{\"ip\":\"").append(e.host()).append("\"")
+              .append(",\"udpPort\":").append(e.udpPort())
               .append(",\"tcpPort\":").append(e.tcpPort())
               .append(",\"nodeId\":\"").append(shortId).append("\"")
               .append("}");
         }
         sb.append("],\"connected\":[");
-        List<RLPxConnector.PeerInfo> connected = connector.getActivePeers();
         first = true;
-        for (RLPxConnector.PeerInfo p : connected) {
+        for (ConnectedPeer p : handle.connectedPeers()) {
             if (!first) sb.append(",");
             first = false;
             sb.append("{\"remoteAddress\":\"").append(escapeJson(p.remoteAddress())).append("\"")
@@ -391,15 +164,354 @@ public class CommandHandler {
         return sb.toString();
     }
 
+    private String handleBeaconStatus() {
+        long uptimeSec = (System.currentTimeMillis() - startTimeMs) / 1000;
+        BeaconStatus bs = handle.beaconStatus();
+        String peerStats = "\"uptimeSeconds\":" + uptimeSec
+                + ",\"discoveredPeers\":" + bs.discv5TableSize()
+                + ",\"connectedPeers\":" + bs.connectedPeers()
+                + ",\"lightClientPeers\":" + bs.lightClientPeers();
+        String peersJson = buildBeaconPeersJson(bs.peers());
+        String periodProgress = "\"currentPeriod\":" + bs.currentPeriod()
+                + ",\"targetPeriod\":" + bs.targetPeriod();
+        if (bs.state() == BeaconState.SYNCING || bs.state() == BeaconState.STARTING) {
+            return "{\"ok\":true,\"state\":\"SYNCING\","
+                    + periodProgress + ","
+                    + peerStats
+                    + ",\"finalizedSlot\":0,\"optimisticSlot\":0"
+                    + ",\"executionStateRoot\":null"
+                    + ",\"knownStateRoots\":" + bs.knownStateRoots()
+                    + ",\"peers\":" + peersJson + "}";
+        }
+        String stateRootHex = bs.executionStateRootHex() != null
+                ? "\"" + bs.executionStateRootHex() + "\"" : "null";
+        return "{\"ok\":true,\"state\":\"" + bs.state().name() + "\","
+                + periodProgress + ","
+                + peerStats
+                + ",\"finalizedSlot\":" + bs.finalizedSlot()
+                + ",\"optimisticSlot\":" + bs.optimisticSlot()
+                + ",\"finalizedPeriod\":" + bs.finalizedPeriod()
+                + ",\"syncCommitteePeriod\":" + bs.currentPeriod()
+                + ",\"wallClockPeriod\":" + bs.targetPeriod()
+                + ",\"executionStateRoot\":" + stateRootHex
+                + ",\"executionBlockNumber\":" + bs.executionBlockNumber()
+                + ",\"knownStateRoots\":" + bs.knownStateRoots()
+                + ",\"fillThreshold\":" + bs.fillThreshold()
+                + ",\"peers\":" + peersJson + "}";
+    }
+
+    private static String buildBeaconPeersJson(java.util.List<ClPeerInfo> peers) {
+        StringBuilder sb = new StringBuilder("[");
+        boolean first = true;
+        for (ClPeerInfo p : peers) {
+            if (!first) sb.append(",");
+            first = false;
+            sb.append("{\"peerId\":\"").append(escapeJson(truncatePeerId(p.peerId()))).append("\"");
+            sb.append(",\"remoteAddress\":\"").append(escapeJson(p.remoteAddress())).append("\"");
+            if (p.clientId() != null) {
+                sb.append(",\"clientId\":\"").append(escapeJson(p.clientId())).append("\"");
+            }
+            sb.append(",\"lightClient\":").append(p.lightClient());
+            sb.append(",\"protocols\":").append(p.protocols());
+            sb.append("}");
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+    private static String truncatePeerId(String peerId) {
+        return peerId != null && peerId.length() > 16
+                ? peerId.substring(0, 16) + "..." : peerId;
+    }
+
+    // -------------------------------------------------------------------------
+    // Verified queries (fetch + verification live behind the engine API;
+    // these handlers parse arguments and serialize)
+    // -------------------------------------------------------------------------
+
     private String handleGetHeaders(String jsonLine) {
         long blockNumber = extractLong(jsonLine, "blockNumber");
         int count = (int) extractLong(jsonLine, "count");
-        // The fetch lives in node-core (io.myotis.node.HeaderQuery, shared with the
-        // engine API); this handler only serializes.
-        io.myotis.api.HeadersResult result = io.myotis.node.HeaderQuery.fetch(connector, blockNumber, count);
+        HeadersResult result = handle.getHeaders(blockNumber, count);
         if (result.error() != null) return jsonError(result.error());
         return buildHeadersJson(result);
     }
+
+    private String handleGetBlock(String jsonLine) {
+        long blockNumber = extractLong(jsonLine, "blockNumber");
+        BlockResult r = handle.getBlockVerified(blockNumber);
+        if (r.error() != null) return jsonError(r.error());
+        return buildBlockJson(r);
+    }
+
+    private String handleGetAccount(String jsonLine) {
+        String addr = extractString(jsonLine, "address");
+        String hex = (addr.startsWith("0x") || addr.startsWith("0X")) ? addr.substring(2) : addr;
+        if (hex.length() != 40) {
+            return jsonError("address must be a 20-byte hex string (40 hex chars)");
+        }
+        try {
+            AccountProofResult r = handle.requestAccount(addr);
+            return buildAccountJson(addr, r);
+        } catch (EngineException e) {
+            return jsonError(e.getMessage());
+        }
+    }
+
+    private String handleGetStorage(String jsonLine) {
+        String addr = extractString(jsonLine, "address");
+        String slotStr = extractString(jsonLine, "slot");
+
+        // Validate the address FIRST — historical error precedence: a request with a bad
+        // address and a bad slot reports the address problem.
+        String addrHex = (addr.startsWith("0x") || addr.startsWith("0X")) ? addr.substring(2) : addr;
+        if (addrHex.length() != 40) {
+            return jsonError("address must be a 20-byte hex string (40 hex chars)");
+        }
+
+        long slotNumber;
+        try {
+            slotNumber = Long.parseLong(slotStr);
+        } catch (NumberFormatException e) {
+            return jsonError("slot must be a number");
+        }
+
+        String holderAddr = null;
+        try { holderAddr = extractString(jsonLine, "holder"); } catch (Exception ignored) {}
+
+        try {
+            StorageProofResult r = handle.getStorageProof(addr, slotNumber, holderAddr);
+            return buildStorageJson(r);
+        } catch (EngineException e) {
+            return jsonError(e.getMessage());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // ENS (resolution policy + EVM stack live behind the engine API)
+    // -------------------------------------------------------------------------
+
+    private EnsApi ens() {
+        EnsApi ens = handle.ens();
+        if (ens == null) {
+            throw new IllegalStateException("ENS is not available on " + handle.networkName());
+        }
+        return ens;
+    }
+
+    private String handleResolveEns(String jsonLine) {
+        String name = extractString(jsonLine, "name");
+        try {
+            EnsResolutionResult r = ens().resolveAddress(name, EnsRoot.AUTO);
+            if (r.addressHex() != null) {
+                return "{\"ok\":true,\"resolved\":true"
+                        + ",\"name\":\"" + escapeJson(name) + "\""
+                        + ",\"address\":\"" + r.addressHex() + "\""
+                        + ",\"beaconVerified\":" + r.verified()
+                        + ",\"blockNumber\":" + r.blockNumber() + "}";
+            }
+            // API convention: addressHex==null && error==null = successful "no record".
+            if (r.error() == null) {
+                return "{\"ok\":true,\"resolved\":false"
+                        + ",\"name\":\"" + escapeJson(name) + "\""
+                        + ",\"beaconVerified\":false"
+                        + ",\"blockNumber\":" + r.blockNumber() + "}";
+            }
+            return jsonError(r.error());
+        } catch (EngineException | IllegalStateException e) {
+            return jsonError(e.getMessage());
+        }
+    }
+
+    private String handleResolveEnsText(String jsonLine) {
+        String name = extractString(jsonLine, "name");
+        String key = extractString(jsonLine, "key");
+        try {
+            EnsTextResult r = ens().resolveText(name, key);
+            if (r.error() != null) return jsonError(r.error());
+            String head = "{\"ok\":true"
+                    + ",\"name\":\"" + escapeJson(name) + "\""
+                    + ",\"key\":\"" + escapeJson(key) + "\""
+                    + ",\"blockNumber\":" + r.blockNumber();
+            if (r.value() == null) return head + ",\"resolved\":false}";
+            return head + ",\"resolved\":true,\"value\":\"" + escapeJson(r.value()) + "\"}";
+        } catch (EngineException | IllegalStateException e) {
+            return jsonError(e.getMessage());
+        }
+    }
+
+    private String handleResolveEnsContenthash(String jsonLine) {
+        String name = extractString(jsonLine, "name");
+        try {
+            EnsContenthashResult r = ens().resolveContenthash(name);
+            if (r.error() != null) return jsonError(r.error());
+            String head = "{\"ok\":true"
+                    + ",\"name\":\"" + escapeJson(name) + "\""
+                    + ",\"blockNumber\":" + r.blockNumber();
+            if (r.contenthashHex() == null) return head + ",\"resolved\":false}";
+            return head + ",\"resolved\":true,\"contenthash\":\"" + r.contenthashHex() + "\"}";
+        } catch (EngineException | IllegalStateException e) {
+            return jsonError(e.getMessage());
+        }
+    }
+
+    private String handleResolveEnsAddrCoin(String jsonLine) {
+        String name = extractString(jsonLine, "name");
+        long coinType = extractLong(jsonLine, "coinType");
+        try {
+            EnsMultiCoinResult r = ens().resolveMultiCoinAddr(name, coinType);
+            if (r.error() != null) return jsonError(r.error());
+            String head = "{\"ok\":true"
+                    + ",\"name\":\"" + escapeJson(name) + "\""
+                    + ",\"coinType\":" + coinType
+                    + ",\"blockNumber\":" + r.blockNumber();
+            if (r.addressHex() == null) return head + ",\"resolved\":false}";
+            return head + ",\"resolved\":true,\"address\":\"" + r.addressHex() + "\"}";
+        } catch (EngineException | IllegalStateException e) {
+            return jsonError(e.getMessage());
+        }
+    }
+
+    private String handleResolveEnsPubkey(String jsonLine) {
+        String name = extractString(jsonLine, "name");
+        try {
+            EnsPubkeyResult r = ens().resolvePubkey(name);
+            if (r.error() != null) return jsonError(r.error());
+            String head = "{\"ok\":true"
+                    + ",\"name\":\"" + escapeJson(name) + "\""
+                    + ",\"blockNumber\":" + r.blockNumber();
+            if (r.pubkeyXHex() == null) return head + ",\"resolved\":false}";
+            return head + ",\"resolved\":true"
+                    + ",\"pubkeyX\":\"" + r.pubkeyXHex() + "\""
+                    + ",\"pubkeyY\":\"" + r.pubkeyYHex() + "\"}";
+        } catch (EngineException | IllegalStateException e) {
+            return jsonError(e.getMessage());
+        }
+    }
+
+    private String handleResolveEnsAbi(String jsonLine) {
+        String name = extractString(jsonLine, "name");
+        long contentTypes;
+        // Default to "any encoding the resolver supports" (1|2|4|8 = 0xF) only when the
+        // field is absent. If present but malformed, surface the parse error — silently
+        // defaulting on bad input would hide user typos like {"contentTypes": "two"}.
+        if (jsonLine.contains("\"contentTypes\"")) {
+            try {
+                contentTypes = extractLong(jsonLine, "contentTypes");
+            } catch (Exception e) {
+                return jsonError("contentTypes: " + (e.getMessage() != null ? e.getMessage() : "malformed"));
+            }
+        } else {
+            contentTypes = 0xFL;
+        }
+        try {
+            EnsAbiResult r = ens().resolveAbi(name, contentTypes);
+            if (r.error() != null) return jsonError(r.error());
+            String head = "{\"ok\":true"
+                    + ",\"name\":\"" + escapeJson(name) + "\""
+                    + ",\"contentTypes\":" + contentTypes
+                    + ",\"blockNumber\":" + r.blockNumber();
+            if (r.dataHex() == null) return head + ",\"resolved\":false}";
+            return head + ",\"resolved\":true"
+                    + ",\"contentType\":" + r.contentType()
+                    + ",\"data\":\"" + r.dataHex() + "\"}";
+        } catch (EngineException | IllegalStateException e) {
+            return jsonError(e.getMessage());
+        }
+    }
+
+    private String handleResolveEnsDns(String jsonLine) {
+        String name = extractString(jsonLine, "name");
+        String dnsName = extractString(jsonLine, "dnsName");
+        long resource = extractLong(jsonLine, "resource");
+        if (resource < 0 || resource > 0xFFFFL) {
+            return jsonError("resource must fit in uint16");
+        }
+        try {
+            EnsDnsRecordResult r = ens().resolveDnsRecord(name, dnsName, (int) resource);
+            if (r.error() != null) return jsonError(r.error());
+            String head = "{\"ok\":true"
+                    + ",\"name\":\"" + escapeJson(name) + "\""
+                    + ",\"dnsName\":\"" + escapeJson(dnsName) + "\""
+                    + ",\"resource\":" + resource
+                    + ",\"blockNumber\":" + r.blockNumber();
+            if (r.dataHex() == null) return head + ",\"resolved\":false}";
+            return head + ",\"resolved\":true,\"data\":\"" + r.dataHex() + "\"}";
+        } catch (EngineException | IllegalStateException e) {
+            return jsonError(e.getMessage());
+        }
+    }
+
+    private String handleResolveEnsInterface(String jsonLine) {
+        String name = extractString(jsonLine, "name");
+        String interfaceIdStr = extractString(jsonLine, "interfaceId");
+        String hex = (interfaceIdStr.startsWith("0x") || interfaceIdStr.startsWith("0X"))
+                ? interfaceIdStr.substring(2) : interfaceIdStr;
+        if (hex.length() != 8) {
+            return jsonError("interfaceId must be a 4-byte hex string (8 hex chars)");
+        }
+        byte[] interfaceId;
+        try {
+            interfaceId = java.util.HexFormat.of().parseHex(hex);
+        } catch (IllegalArgumentException e) {
+            return jsonError("interfaceId must be a 4-byte hex string (8 hex chars)");
+        }
+        try {
+            EnsInterfaceResult r = ens().resolveInterfaceImplementer(name, interfaceId);
+            if (r.error() != null) return jsonError(r.error());
+            String head = "{\"ok\":true"
+                    + ",\"name\":\"" + escapeJson(name) + "\""
+                    + ",\"interfaceId\":\"0x" + hex.toLowerCase() + "\""
+                    + ",\"blockNumber\":" + r.blockNumber();
+            if (r.implementerHex() == null) return head + ",\"resolved\":false}";
+            return head + ",\"resolved\":true,\"implementer\":\"" + r.implementerHex() + "\"}";
+        } catch (EngineException | IllegalStateException e) {
+            return jsonError(e.getMessage());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Dial / stop
+    // -------------------------------------------------------------------------
+
+    private String handleDial(String jsonLine) {
+        // Parse enode URL: enode://<pubkey>@<host>:<port>
+        String enode = extractString(jsonLine, "enode");
+        try {
+            if (!enode.startsWith("enode://")) {
+                return jsonError("enode must start with enode://");
+            }
+            String rest = enode.substring("enode://".length());
+            int atIdx = rest.indexOf('@');
+            if (atIdx < 0) return jsonError("Invalid enode format: missing @");
+            String pubKeyHex = rest.substring(0, atIdx);
+            String hostPort = rest.substring(atIdx + 1).split("\\?")[0]; // strip query params
+            int colonIdx = hostPort.lastIndexOf(':');
+            if (colonIdx < 0) return jsonError("Invalid enode format: missing port");
+            String host = hostPort.substring(0, colonIdx);
+            int port = Integer.parseInt(hostPort.substring(colonIdx + 1));
+
+            log.info("[ipc] Dialing enode {} at {}:{}",
+                    pubKeyHex.substring(0, Math.min(16, pubKeyHex.length())) + "...", host, port);
+            DialResult r = handle.dialPeer(host, port, pubKeyHex);
+            if (!r.accepted()) {
+                return jsonError("Failed to dial: " + r.error());
+            }
+            return "{\"ok\":true,\"message\":\"Dialing " + host + ":" + port + "\"}";
+        } catch (Exception e) {
+            return jsonError("Failed to dial: " + e.getMessage());
+        }
+    }
+
+    private String handleStop() {
+        log.info("[ipc] Stop command received — initiating graceful shutdown");
+        stopLatch.countDown();
+        return "{\"ok\":true,\"message\":\"Daemon shutting down\"}";
+    }
+
+    // -------------------------------------------------------------------------
+    // Pure serializers (golden-tested; field order matches the historical output)
+    // -------------------------------------------------------------------------
 
     /** Pure serializer for get-headers (golden-tested); field order matches the historical output. */
     static String buildHeadersJson(io.myotis.api.HeadersResult result) {
@@ -424,16 +536,6 @@ public class CommandHandler {
         }
         sb.append("]}");
         return sb.toString();
-    }
-
-    private String handleGetBlock(String jsonLine) {
-        long blockNumber = extractLong(jsonLine, "blockNumber");
-        // The fetch + beacon verification live in node-core (io.myotis.node.VerifiedBlockQuery,
-        // shared with the engine API); this handler only serializes.
-        io.myotis.api.BlockResult r = io.myotis.node.VerifiedBlockQuery.query(
-                connector, beaconSyncState, blockNumber);
-        if (r.error() != null) return jsonError(r.error());
-        return buildBlockJson(r);
     }
 
     /** Pure serializer for get-block (golden-tested); field order matches the historical output. */
@@ -472,32 +574,6 @@ public class CommandHandler {
         return sb.toString();
     }
 
-    private String handleGetAccount(String jsonLine) {
-        String addr = extractString(jsonLine, "address");
-        String hex = (addr.startsWith("0x") || addr.startsWith("0X")) ? addr.substring(2) : addr;
-        if (hex.length() != 40) {
-            return jsonError("address must be a 20-byte hex string (40 hex chars)");
-        }
-        // The fetch + verification ladder + diagnostics live in node-core
-        // (VerifiedAccountQuery.queryProof, shared with the engine API); this handler
-        // only serializes. The raw input is echoed back unchanged (queryProof
-        // normalizes its own copy).
-        try {
-            io.myotis.api.AccountProofResult r =
-                    VerifiedAccountQuery.queryProof(connector, beaconSyncState,
-                                    clGenesisTime, secondsPerSlot, addr)
-                            .get(120, TimeUnit.SECONDS);
-            return buildAccountJson(addr, r);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            return jsonError("interrupted");
-        } catch (Exception e) {
-            Throwable cause = e.getCause() != null ? e.getCause() : e;
-            String msg = cause.getMessage() != null ? cause.getMessage() : cause.getClass().getSimpleName();
-            return jsonError(msg);
-        }
-    }
-
     /** Pure serializer for get-account (golden-tested); field order and conditional
      *  emissions match the historical output byte-for-byte. {@code echoAddr} is the raw
      *  request address, echoed exactly as the daemon always has. */
@@ -509,8 +585,8 @@ public class CommandHandler {
         }
         proofSb.append("]");
 
-        // The verification sub-object (formerly buildVerificationJson) — the ladder lives
-        // in VerifiedAccountQuery; this is serialization plus the derived periodLag.
+        // The verification sub-object — the ladder lives in the engine; this is
+        // serialization plus the derived periodLag.
         StringBuilder v = new StringBuilder("{");
         v.append("\"peerProofValid\":").append(r.peerProofValid());
         if (r.peerStateRootHex() != null && !r.proofNodesHex().isEmpty()) {
@@ -559,47 +635,6 @@ public class CommandHandler {
             + ",\"codeHash\":\"" + r.codeHashHex() + "\""
             + ",\"proof\":" + proofSb
             + ",\"verification\":" + v + "}";
-    }
-
-
-    private String handleGetStorage(String jsonLine) {
-        String addr = extractString(jsonLine, "address");
-        String slotStr = extractString(jsonLine, "slot");
-
-        // Validate the address FIRST — historical error precedence: a request with a bad
-        // address and a bad slot reports the address problem.
-        String addrHex = (addr.startsWith("0x") || addr.startsWith("0X")) ? addr.substring(2) : addr;
-        if (addrHex.length() != 40) {
-            return jsonError("address must be a 20-byte hex string (40 hex chars)");
-        }
-
-        // Parse slot number (host-side argument parsing; everything after is engine logic).
-        long slotNumber;
-        try {
-            slotNumber = Long.parseLong(slotStr);
-        } catch (NumberFormatException e) {
-            return jsonError("slot must be a number");
-        }
-
-        // Optional holder address (ERC-20 mapping lookups).
-        String holderAddr = null;
-        try { holderAddr = extractString(jsonLine, "holder"); } catch (Exception ignored) {}
-
-        // The fetch + proof + beacon ladder lives in node-core
-        // (io.myotis.node.VerifiedStorageQuery, shared with the engine API);
-        // this handler only parses arguments and serializes the result.
-        try {
-            io.myotis.api.StorageProofResult r = io.myotis.node.VerifiedStorageQuery.query(
-                    connector, beaconSyncState, addr, slotNumber, holderAddr);
-            return buildStorageJson(r);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            return jsonError("interrupted");
-        } catch (Exception e) {
-            Throwable cause = e.getCause() != null ? e.getCause() : e;
-            String msg = cause.getMessage() != null ? cause.getMessage() : cause.getClass().getSimpleName();
-            return jsonError(msg);
-        }
     }
 
     /** Pure serializer for get-storage (golden-tested); field order and conditional
@@ -665,868 +700,6 @@ public class CommandHandler {
         return sb.toString();
     }
 
-
-    /**
-     * Shared single-thread pool that drives the EVM for the {@code resolve-ens}
-     * command (and any future EVM-backed commands). Created lazily on first
-     * use; survives for the daemon's lifetime. Daemon thread, so it doesn't
-     * keep the JVM alive on shutdown.
-     *
-     * <p>Reusing one pool across requests avoids the per-request
-     * {@code Executors.newSingleThreadExecutor} / {@code shutdown} churn
-     * that an earlier draft of {@code handleResolveEns} did. The thread is
-     * single because Besu's EVM is sequential per-call; concurrent
-     * resolutions would either need separate pools or a bounded
-     * {@code newFixedThreadPool}, but the daemon serializes commands
-     * anyway.
-     */
-    private static final java.util.concurrent.ExecutorService EVM_POOL =
-            java.util.concurrent.Executors.newSingleThreadExecutor(r -> {
-                Thread t = new Thread(r, "myotis-evm-cmd");
-                t.setDaemon(true);
-                return t;
-            });
-
-    /**
-     * Resolve {@code name → address} via ENSIP-1 + ENSIP-10 (Universal Resolver),
-     * with ERC-3668 CCIP-Read transparently handled for off-chain names
-     * (Coinbase IDs, Uniswap names, Base subdomains, …).
-     *
-     * <p>Builds the full executor stack on demand:
-     * <pre>
-     *   CcipReadEvmExecutor
-     *     └─ PrefetchingEvmExecutor
-     *         └─ DefaultEvmExecutor
-     *             └─ SnapBackedStateOracle
-     *                 └─ EthHandlerSnapPeer (over a snap-capable peer)
-     * </pre>
-     *
-     * <p>{@link BlockContext} fields come from a freshly-fetched header — the
-     * peer's chain head — rather than the beacon-finalized header. Peers prune
-     * state beyond ~128 blocks, so a 6-minute-old finalized root is usually
-     * stale; the chain-head root is recent enough to serve. Acceptable here
-     * because resolver contracts inspect block.timestamp / block.number for
-     * deadline-style guards, not for trust decisions, and the headers we read
-     * came from peers we already trust to serve snap data.
-     *
-     * <p>The CCIP-Read gateway transport is
-     * {@link com.jaeckel.ethp2p.app.rpc.JavaHttpCcipGateway}, backed by
-     * {@code java.net.http.HttpClient}. That's JVM-only and so not
-     * suitable for the Android wallet — but {@code :app} is the daemon, not
-     * the Android consumer, and the daemon already runs on JVM 21. The
-     * Android module supplies a Ktor-backed {@link CcipGateway} per the
-     * {@code CLAUDE.md} platform direction.
-     */
-    private String handleResolveEns(String jsonLine) {
-        String name = extractString(jsonLine, "name");
-        // Pause acquiring new peers for the duration of the resolution so its
-        // snap round-trips aren't starved by outbound-dial bursts on the shared
-        // event loop. See RLPxConnector.isSnapHeavy().
-        connector.enterSnapHeavy();
-        try {
-        // AUTO: resolve against the beacon-verified finalized state first; only if
-        // it yields no address (record not yet finalized) or can't be served do we
-        // fall back to the peer head (returned with beaconVerified=false).
-        EnsCallContext fin = null;
-        Exception finErr = null;
-        try {
-            fin = prepareEnsCall(io.myotis.ens.EnsResolutionRoot.FINALIZED);
-            java.util.Optional<io.myotis.evm.Address> resolved =
-                fin.resolver.resolveAddress(name, fin.blockCtx).get(60, TimeUnit.SECONDS);
-            if (resolved.isPresent()) {
-                return resolveEnsJson(name, resolved.get().toHex(), true, fin.blockNumber);
-            }
-            // No record at the finalized block — fall through to the head.
-        } catch (Exception e) {
-            finErr = e;
-            log.debug("[ens] finalized resolution failed for {} ({}); falling back to head",
-                name, unwrapMessage(e));
-        }
-        // If the finalized attempt already consumed an ERC-3668 offchain (CCIP)
-        // answer, the result is determined by the gateway, not by which EL state
-        // root we ran against — re-resolving at the peer head would just repeat
-        // the same (slow, multi-round-trip) gateway calls for the same answer.
-        // (If finalized had produced an address we'd have returned above.)
-        if (fin != null && fin.offchainExecutor().usedOffchain()) {
-            if (finErr != null) {
-                // The offchain gateway FAILED (e.g. HTTP 429 rate-limit) rather than
-                // returning a valid empty record. Surface that as a transient error
-                // — reporting "does not resolve" here would wrongly imply the name
-                // has no address.
-                return jsonError("ENS gateway error (try again): " + unwrapMessage(finErr));
-            }
-            log.debug("[ens] {} used an offchain gateway at finalized; skipping head fallback", name);
-            return "{\"ok\":true,\"resolved\":false"
-                + ",\"name\":\"" + escapeJson(name) + "\""
-                + ",\"beaconVerified\":false"
-                + ",\"blockNumber\":" + fin.blockNumber + "}";
-        }
-        try {
-            EnsCallContext head = prepareEnsCall(io.myotis.ens.EnsResolutionRoot.PEER_HEAD);
-            java.util.Optional<io.myotis.evm.Address> resolved =
-                head.resolver.resolveAddress(name, head.blockCtx).get(60, TimeUnit.SECONDS);
-            if (resolved.isEmpty()) {
-                return "{\"ok\":true,\"resolved\":false"
-                    + ",\"name\":\"" + escapeJson(name) + "\""
-                    + ",\"beaconVerified\":false"
-                    + ",\"blockNumber\":" + head.blockNumber + "}";
-            }
-            return resolveEnsJson(name, resolved.get().toHex(), false, head.blockNumber);
-        } catch (Exception e) {
-            return jsonError(unwrapMessage(e));
-        }
-        } finally {
-            connector.exitSnapHeavy();
-        }
-    }
-
-    private static String resolveEnsJson(String name, String addressHex, boolean beaconVerified, long blockNumber) {
-        return "{\"ok\":true,\"resolved\":true"
-            + ",\"name\":\"" + escapeJson(name) + "\""
-            + ",\"address\":\"" + addressHex + "\""
-            + ",\"beaconVerified\":" + beaconVerified
-            + ",\"blockNumber\":" + blockNumber + "}";
-    }
-
-    // -----------------------------------------------------------------------
-    // ENS shared call setup
-    // -----------------------------------------------------------------------
-
-    /**
-     * Aggregate of the per-call EVM context every ENS handler needs:
-     * the peer-servable header (for the response's blockNumber), the
-     * BlockContext built from it, and a network-aware
-     * {@link io.myotis.ens.EnsResolver}. Constructed via
-     * {@link #prepareEnsCall()} so the snap-peer probe + EVM stack
-     * boilerplate isn't duplicated across the eight ENS commands.
-     */
-    private record EnsCallContext(
-            long blockNumber,
-            boolean beaconVerified,
-            io.myotis.evm.BlockContext blockCtx,
-            io.myotis.ens.EnsResolver resolver,
-            io.myotis.evm.CcipReadEvmExecutor offchainExecutor) {}
-
-    /**
-     * Probe every active snap peer in parallel for a fresh head, pick the
-     * first one with a sensible block number, and pin <em>that</em> peer
-     * for every state read of the resolution. We MUST take the stateRoot
-     * from the same peer that will serve the SNAP requests: peers prune
-     * trie state outside a ~128-block window and the snapshot is anchored
-     * at the peer's own current head. A stateRoot from peer A used against
-     * peer B reliably surfaces as
-     * {@code InvalidProof[... missing node ... (path idx=0)]} — peer B has
-     * no node hashing to A's root.
-     *
-     * <p>Wraps the result in {@link EnsCallContext} so every ENS handler
-     * shares the same peer-probe + EVM-stack boilerplate. Throws on any
-     * failure; callers fold the throw into a {@code jsonError} response.
-     */
-    private EnsCallContext prepareEnsCall() throws Exception {
-        return prepareEnsCall(io.myotis.ens.EnsResolutionRoot.FINALIZED);
-    }
-
-    private EnsCallContext prepareEnsCall(io.myotis.ens.EnsResolutionRoot root) throws Exception {
-        List<com.jaeckel.ethp2p.networking.eth.EthHandler> snapPeers =
-            connector.activeSnapHandlers();
-        if (snapPeers.isEmpty()) {
-            throw new IllegalStateException("No active peer with snap/1 support");
-        }
-
-        // FINALIZED (default): resolve against the light client's beacon-verified
-        // finalized execution header — the name→address mapping is then anchored to
-        // a beacon-attested root. ~12 min stale (finality lag); a snap peer must
-        // still retain that block's state, which they often DON'T (Geth prunes
-        // trie state beyond ~128 blocks and serves snap from a flat layer that
-        // lags the head). So we don't blindly pin a peer here — we probe each one
-        // for the finalized root and pin the first that actually serves it. If
-        // none do, we throw and AUTO falls back to the head.
-        if (root == io.myotis.ens.EnsResolutionRoot.FINALIZED) {
-            if (beaconLightClient == null) {
-                throw new IllegalStateException("beacon light client not running (needed for verified ENS)");
-            }
-            com.jaeckel.ethp2p.consensus.types.LightClientHeader fin =
-                beaconLightClient.getStore().getFinalizedHeader();
-            if (fin == null) {
-                throw new IllegalStateException("no beacon-verified finalized header yet");
-            }
-            com.jaeckel.ethp2p.consensus.types.ExecutionPayloadHeader exec = fin.execution();
-            org.apache.tuweni.bytes.Bytes32 finRoot =
-                org.apache.tuweni.bytes.Bytes32.wrap(exec.stateRoot());
-            com.jaeckel.ethp2p.networking.eth.EthHandler finPeer =
-                firstPeerServing(snapPeers, finRoot);
-            if (finPeer == null) {
-                throw new IllegalStateException(
-                    "no snap peer retains the beacon-finalized state (block #"
-                    + exec.blockNumber() + ")");
-            }
-            io.myotis.evm.BlockContext finCtx = new io.myotis.evm.BlockContext(
-                exec.stateRoot(),
-                exec.blockNumber(),
-                exec.timestamp(),
-                leUint256ToBigInteger(exec.baseFeePerGas()),
-                io.myotis.evm.Address.of(exec.feeRecipient()),
-                exec.prevRandao(),
-                java.math.BigInteger.valueOf(connector.getNetwork().networkId()),
-                exec.gasLimit());
-            io.myotis.evm.CcipReadEvmExecutor finExec = buildEnsResolver(finPeer, finCtx);
-            return new EnsCallContext(exec.blockNumber(), true, finCtx,
-                io.myotis.ens.EnsResolver.forChainId(finExec, connector.getNetwork().networkId()), finExec);
-        }
-
-        // PEER_HEAD: each snap peer has its own chain head, and the bleeding-edge
-        // head root is frequently NOT yet snap-servable (the flat state lags the
-        // head by a few blocks). The previous implementation pinned the first peer
-        // that returned a fresh header and gave up if that one peer couldn't serve
-        // its own head root — which is exactly the failure get-account avoids by
-        // retrying across peers. So here we walk every peer: fetch its fresh head,
-        // then PROBE that the peer actually serves a snap account at that root
-        // before pinning it. The first peer that passes both is pinned for the
-        // whole resolution (all reads anchor to one consistent root).
-        long minSensibleHead = connector.getNetwork().minSensibleHeadBlock();
-        // Live staleness floor: a peer whose head is behind the beacon-finalized exec
-        // block can never anchor to the beacon chain (finality already passed it), yet
-        // it still snap-serves its frozen root and would be pinned here — forcing the
-        // finalized fallback while fresh-headed peers sit connected.
-        long finalizedNum = -1;
-        long optimisticHead = -1;
-        if (beaconLightClient != null) {
-            com.jaeckel.ethp2p.consensus.types.LightClientHeader finHdr =
-                    beaconLightClient.getStore().getFinalizedHeader();
-            if (finHdr != null) {
-                finalizedNum = finHdr.execution().blockNumber();
-                minSensibleHead = Math.max(minSensibleHead, finalizedNum);
-            }
-            com.jaeckel.ethp2p.consensus.types.LightClientHeader optHdr =
-                    beaconLightClient.getStore().getOptimisticHeader();
-            if (optHdr != null) optimisticHead = optHdr.execution().blockNumber();
-        }
-        // Probe each peer's LIVE head by NUMBER (forward window from the finalized block,
-        // which every fresh peer holds) rather than its frozen connect-time Status hash —
-        // the Status hash never advances and drifts below the floor as the chain moves.
-        // See EthHandler#requestFreshHeadHeaderAsync(long,int).
-        final boolean byNumberProbe = finalizedNum > 0;
-        final long probeFrom = finalizedNum;
-        final int probeWindow = byNumberProbe
-                ? (int) Math.max(16, Math.min(256,
-                    (optimisticHead > finalizedNum ? optimisticHead - finalizedNum : 0) + 16))
-                : 0;
-        String lastError = null;
-        for (com.jaeckel.ethp2p.networking.eth.EthHandler peer : snapPeers) {
-            if (!peer.isReady() || peer.isSnapServingFailed()) {
-                continue;
-            }
-            try {
-                BlockHeader head = (byNumberProbe
-                        ? peer.requestFreshHeadHeaderAsync(probeFrom, probeWindow)
-                        : peer.requestFreshHeadHeaderAsync()).get(6, TimeUnit.SECONDS);
-                if (head.number < minSensibleHead) {
-                    lastError = "peer " + peer.getRemoteAddress()
-                        + " returned stale head #" + head.number
-                        + " (< floor #" + minSensibleHead + ")";
-                    continue;
-                }
-                if (!servesRoot(peer, head.stateRoot)) {
-                    lastError = "peer " + peer.getRemoteAddress()
-                        + " does not snap-serve its head root (block #" + head.number + ")";
-                    continue;
-                }
-                io.myotis.evm.BlockContext blockCtx = new io.myotis.evm.BlockContext(
-                    head.stateRoot.toArrayUnsafe(),
-                    head.number,
-                    head.timestamp,
-                    head.baseFeePerGas,
-                    io.myotis.evm.Address.of(head.beneficiary.toArrayUnsafe()),
-                    head.mixHashOrPrevRandao.toArrayUnsafe(),
-                    java.math.BigInteger.valueOf(connector.getNetwork().networkId()),
-                    head.gasLimit);
-                io.myotis.evm.CcipReadEvmExecutor headExec = buildEnsResolver(peer, blockCtx);
-                return new EnsCallContext(head.number, false, blockCtx,
-                    io.myotis.ens.EnsResolver.forChainId(headExec, connector.getNetwork().networkId()), headExec);
-            } catch (Exception e) {
-                lastError = "peer " + peer.getRemoteAddress() + " probe failed: " + unwrapMessage(e);
-            }
-        }
-        throw new IllegalStateException("No snap peer served a fresh head root for ENS"
-            + (lastError != null ? " (" + lastError + ")" : ""));
-    }
-
-    /**
-     * Probe account used only to confirm a peer can actually serve snap state at a
-     * given root before we pin it for a whole ENS resolution. The beacon deposit
-     * contract is present in every post-Merge state and is a high-traffic account,
-     * so a non-empty proof for it means the peer retains that root's trie. Any
-     * always-present account would do; this one is canonical and stable.
-     */
-    private static final org.apache.tuweni.bytes.Bytes32 SNAP_PROBE_ACCOUNT_HASH =
-        org.apache.tuweni.crypto.Hash.keccak256(
-            org.apache.tuweni.bytes.Bytes.fromHexString("0x00000000219ab540356cBB839Cbe05303d7705Fa"));
-
-    /** First ready snap peer that returns a non-empty account proof at {@code root}, or null. */
-    private com.jaeckel.ethp2p.networking.eth.EthHandler firstPeerServing(
-            List<com.jaeckel.ethp2p.networking.eth.EthHandler> peers,
-            org.apache.tuweni.bytes.Bytes32 root) {
-        for (com.jaeckel.ethp2p.networking.eth.EthHandler peer : peers) {
-            if (peer.isReady() && !peer.isSnapServingFailed() && servesRoot(peer, root)) {
-                return peer;
-            }
-        }
-        return null;
-    }
-
-    /** True if this peer returns a non-empty account proof for the probe account at {@code root}. */
-    private boolean servesRoot(com.jaeckel.ethp2p.networking.eth.EthHandler peer,
-                               org.apache.tuweni.bytes.Bytes32 root) {
-        try {
-            AccountRangeMessage.DecodeResult r =
-                peer.requestAccountByHashAsync(SNAP_PROBE_ACCOUNT_HASH, root).get(10, TimeUnit.SECONDS);
-            return r.proof() != null && !r.proof().isEmpty();
-        } catch (Exception e) {
-            return false;
-        }
-    }
-
-    /**
-     * Build the EVM/ENS stack pinned to one snap peer for the given block context.
-     * Shared by the FINALIZED and PEER_HEAD paths of {@link #prepareEnsCall}.
-     * Retries inside the oracle still engage on transient failures (timeouts,
-     * channel close), but every retry targets this one peer — the one expected to
-     * have {@code blockCtx}'s stateRoot in its snapshot.
-     */
-    /** Snap-oracle per-fetch retry budget; each attempt rotates to a different ready
-     *  snap peer so a slow/dead peer fails over instead of eating the whole budget. */
-    private static final int SNAP_ORACLE_MAX_ATTEMPTS = 8;
-
-    private io.myotis.evm.CcipReadEvmExecutor buildEnsResolver(
-            com.jaeckel.ethp2p.networking.eth.EthHandler pinnedPeer,
-            io.myotis.evm.BlockContext blockCtx) {
-        // Snap requests carry the stateRoot explicitly, so ANY connected snap peer that
-        // retains blockCtx's trie can serve them. Rotate the oracle's supplier (probed
-        // peer first, then round-robin the ready set) so a peer that stalls on
-        // GetAccountRange fails over instead of funnelling every retry into one dead
-        // peer — the single-peer pin made each eth_call against a stalled peer eat the
-        // full timeout while other peers held the same state.
-        final com.jaeckel.ethp2p.networking.eth.EthHandler probedPeer = pinnedPeer;
-        final java.util.concurrent.atomic.AtomicInteger rotation =
-            new java.util.concurrent.atomic.AtomicInteger();
-        // Peers that returned an empty proof / no-state for this head's stateRoot — deny
-        // them for this context so the rotation converges on peers that actually serve
-        // the root (see NodeService for the rationale). Per-context.
-        final java.util.Set<com.jaeckel.ethp2p.networking.eth.EthHandler> rootDenied =
-            java.util.concurrent.ConcurrentHashMap.newKeySet();
-        io.myotis.evm.world.SnapBackedStateOracle oracle =
-            new io.myotis.evm.world.SnapBackedStateOracle(
-                () -> {
-                    int n = rotation.getAndIncrement();
-                    if (n == 0 && probedPeer.isReady() && !probedPeer.isSnapServingFailed()
-                            && !rootDenied.contains(probedPeer)) {
-                        final com.jaeckel.ethp2p.networking.eth.EthHandler pp = probedPeer;
-                        return new com.jaeckel.ethp2p.app.snap.EthHandlerSnapPeer(
-                            pp, () -> rootDenied.add(pp));
-                    }
-                    // activeSnapHandlers() already filters to ready, snap-negotiated,
-                    // non-failed peers; drop the ones denied for this root.
-                    java.util.List<com.jaeckel.ethp2p.networking.eth.EthHandler> ready =
-                        new java.util.ArrayList<>();
-                    for (com.jaeckel.ethp2p.networking.eth.EthHandler p : connector.activeSnapHandlers()) {
-                        if (!rootDenied.contains(p)) ready.add(p);
-                    }
-                    if (ready.isEmpty()) return null;
-                    final com.jaeckel.ethp2p.networking.eth.EthHandler chosen =
-                        ready.get(Math.floorMod(n, ready.size()));
-                    return new com.jaeckel.ethp2p.app.snap.EthHandlerSnapPeer(
-                        chosen, () -> rootDenied.add(chosen));
-                },
-                ensBytecodeCache,
-                SNAP_ORACLE_MAX_ATTEMPTS);
-        io.myotis.evm.DefaultEvmExecutor base = new io.myotis.evm.DefaultEvmExecutor(
-            oracle, ensBytecodeCache, EVM_POOL);
-        io.myotis.evm.PrefetchingEvmExecutor prefetching =
-            new io.myotis.evm.PrefetchingEvmExecutor(base);
-        io.myotis.evm.ccipread.CcipReadHandler ccipHandler =
-            new io.myotis.evm.ccipread.CcipReadHandler(
-                new com.jaeckel.ethp2p.app.rpc.JavaHttpCcipGateway());
-        // Returned (not just wrapped) so the caller can later read usedOffchain()
-        // to decide whether an AUTO head-fallback is worthwhile.
-        return new io.myotis.evm.CcipReadEvmExecutor(prefetching, ccipHandler);
-    }
-
-    /** Convert an SSZ uint256 (32-byte little-endian) to a non-negative BigInteger. */
-    private static java.math.BigInteger leUint256ToBigInteger(byte[] le) {
-        byte[] be = new byte[le.length];
-        for (int i = 0; i < le.length; i++) be[i] = le[le.length - 1 - i];
-        return new java.math.BigInteger(1, be);
-    }
-
-    private static String unwrapMessage(Exception e) {
-        Throwable cause = e.getCause() != null ? e.getCause() : e;
-        return cause.getMessage() != null ? cause.getMessage() : cause.getClass().getSimpleName();
-    }
-
-    // -----------------------------------------------------------------------
-    // Extended ENS record-type IPC handlers
-    // -----------------------------------------------------------------------
-
-    private String handleResolveEnsText(String jsonLine) {
-        String name = extractString(jsonLine, "name");
-        String key  = extractString(jsonLine, "key");
-        try {
-            EnsCallContext ctx = prepareEnsCall();
-            java.util.Optional<String> value =
-                ctx.resolver.resolveText(name, key, ctx.blockCtx).get(60, TimeUnit.SECONDS);
-            String head = "{\"ok\":true"
-                + ",\"name\":\"" + escapeJson(name) + "\""
-                + ",\"key\":\"" + escapeJson(key) + "\""
-                + ",\"blockNumber\":" + ctx.blockNumber;
-            if (value.isEmpty()) {
-                return head + ",\"resolved\":false}";
-            }
-            return head + ",\"resolved\":true,\"value\":\"" + escapeJson(value.get()) + "\"}";
-        } catch (Exception e) {
-            return jsonError(unwrapMessage(e));
-        }
-    }
-
-    private String handleResolveEnsContenthash(String jsonLine) {
-        String name = extractString(jsonLine, "name");
-        try {
-            EnsCallContext ctx = prepareEnsCall();
-            java.util.Optional<byte[]> value =
-                ctx.resolver.resolveContenthash(name, ctx.blockCtx).get(60, TimeUnit.SECONDS);
-            String head = "{\"ok\":true"
-                + ",\"name\":\"" + escapeJson(name) + "\""
-                + ",\"blockNumber\":" + ctx.blockNumber;
-            if (value.isEmpty()) {
-                return head + ",\"resolved\":false}";
-            }
-            return head + ",\"resolved\":true,\"contenthash\":\""
-                + Bytes.wrap(value.get()).toHexString() + "\"}";
-        } catch (Exception e) {
-            return jsonError(unwrapMessage(e));
-        }
-    }
-
-    private String handleResolveEnsAddrCoin(String jsonLine) {
-        String name = extractString(jsonLine, "name");
-        long coinType = extractLong(jsonLine, "coinType");
-        try {
-            EnsCallContext ctx = prepareEnsCall();
-            java.util.Optional<byte[]> value =
-                ctx.resolver.resolveMultiCoinAddress(name, coinType, ctx.blockCtx)
-                    .get(60, TimeUnit.SECONDS);
-            String head = "{\"ok\":true"
-                + ",\"name\":\"" + escapeJson(name) + "\""
-                + ",\"coinType\":" + coinType
-                + ",\"blockNumber\":" + ctx.blockNumber;
-            if (value.isEmpty()) {
-                return head + ",\"resolved\":false}";
-            }
-            return head + ",\"resolved\":true,\"address\":\""
-                + Bytes.wrap(value.get()).toHexString() + "\"}";
-        } catch (Exception e) {
-            return jsonError(unwrapMessage(e));
-        }
-    }
-
-    private String handleResolveEnsPubkey(String jsonLine) {
-        String name = extractString(jsonLine, "name");
-        try {
-            EnsCallContext ctx = prepareEnsCall();
-            java.util.Optional<io.myotis.ens.EnsResolver.Pubkey> value =
-                ctx.resolver.resolvePubkey(name, ctx.blockCtx).get(60, TimeUnit.SECONDS);
-            String head = "{\"ok\":true"
-                + ",\"name\":\"" + escapeJson(name) + "\""
-                + ",\"blockNumber\":" + ctx.blockNumber;
-            if (value.isEmpty()) {
-                return head + ",\"resolved\":false}";
-            }
-            io.myotis.ens.EnsResolver.Pubkey pk = value.get();
-            return head + ",\"resolved\":true"
-                + ",\"pubkeyX\":\"" + Bytes.wrap(pk.x()).toHexString() + "\""
-                + ",\"pubkeyY\":\"" + Bytes.wrap(pk.y()).toHexString() + "\"}";
-        } catch (Exception e) {
-            return jsonError(unwrapMessage(e));
-        }
-    }
-
-    private String handleResolveEnsAbi(String jsonLine) {
-        String name = extractString(jsonLine, "name");
-        long contentTypes;
-        // Default to "any encoding the resolver supports" (1|2|4|8 = 0xF) only
-        // when the field is absent. If it's present but malformed, let the
-        // parse error surface — silently defaulting on bad input would hide
-        // user typos like {"contentTypes": "two"}.
-        if (jsonLine.contains("\"contentTypes\"")) {
-            try {
-                contentTypes = extractLong(jsonLine, "contentTypes");
-            } catch (Exception e) {
-                return jsonError("contentTypes: " + (e.getMessage() != null ? e.getMessage() : "malformed"));
-            }
-        } else {
-            contentTypes = 0xFL;
-        }
-        try {
-            EnsCallContext ctx = prepareEnsCall();
-            java.util.Optional<io.myotis.ens.EnsResolver.AbiRecord> value =
-                ctx.resolver.resolveAbi(name, contentTypes, ctx.blockCtx)
-                    .get(60, TimeUnit.SECONDS);
-            String head = "{\"ok\":true"
-                + ",\"name\":\"" + escapeJson(name) + "\""
-                + ",\"contentTypes\":" + contentTypes
-                + ",\"blockNumber\":" + ctx.blockNumber;
-            if (value.isEmpty()) {
-                return head + ",\"resolved\":false}";
-            }
-            io.myotis.ens.EnsResolver.AbiRecord r = value.get();
-            return head + ",\"resolved\":true"
-                + ",\"contentType\":" + r.contentType()
-                + ",\"data\":\"" + Bytes.wrap(r.data()).toHexString() + "\"}";
-        } catch (Exception e) {
-            return jsonError(unwrapMessage(e));
-        }
-    }
-
-    private String handleResolveEnsDns(String jsonLine) {
-        String name = extractString(jsonLine, "name");
-        String dnsName = extractString(jsonLine, "dnsName");
-        long resource = extractLong(jsonLine, "resource");
-        if (resource < 0 || resource > 0xFFFFL) {
-            return jsonError("resource must fit in uint16");
-        }
-        try {
-            EnsCallContext ctx = prepareEnsCall();
-            byte[] dnsNameWire = io.myotis.ens.DnsEncoder.encode(dnsName);
-            java.util.Optional<byte[]> value =
-                ctx.resolver.resolveDnsRecord(name, dnsNameWire, (int) resource, ctx.blockCtx)
-                    .get(60, TimeUnit.SECONDS);
-            String head = "{\"ok\":true"
-                + ",\"name\":\"" + escapeJson(name) + "\""
-                + ",\"dnsName\":\"" + escapeJson(dnsName) + "\""
-                + ",\"resource\":" + resource
-                + ",\"blockNumber\":" + ctx.blockNumber;
-            if (value.isEmpty()) {
-                return head + ",\"resolved\":false}";
-            }
-            return head + ",\"resolved\":true,\"data\":\""
-                + Bytes.wrap(value.get()).toHexString() + "\"}";
-        } catch (Exception e) {
-            return jsonError(unwrapMessage(e));
-        }
-    }
-
-    private String handleResolveEnsInterface(String jsonLine) {
-        String name = extractString(jsonLine, "name");
-        String interfaceIdStr = extractString(jsonLine, "interfaceId");
-        String hex = (interfaceIdStr.startsWith("0x") || interfaceIdStr.startsWith("0X"))
-            ? interfaceIdStr.substring(2) : interfaceIdStr;
-        if (hex.length() != 8) {
-            return jsonError("interfaceId must be a 4-byte hex string (8 hex chars)");
-        }
-        byte[] interfaceId = Bytes.fromHexString(hex).toArrayUnsafe();
-        try {
-            EnsCallContext ctx = prepareEnsCall();
-            java.util.Optional<io.myotis.evm.Address> value =
-                ctx.resolver.resolveInterfaceImplementer(name, interfaceId, ctx.blockCtx)
-                    .get(60, TimeUnit.SECONDS);
-            String head = "{\"ok\":true"
-                + ",\"name\":\"" + escapeJson(name) + "\""
-                + ",\"interfaceId\":\"0x" + hex.toLowerCase() + "\""
-                + ",\"blockNumber\":" + ctx.blockNumber;
-            if (value.isEmpty()) {
-                return head + ",\"resolved\":false}";
-            }
-            return head + ",\"resolved\":true,\"implementer\":\"" + value.get().toHex() + "\"}";
-        } catch (Exception e) {
-            return jsonError(unwrapMessage(e));
-        }
-    }
-
-    private String handleBeaconStatus() {
-        // Peer / discovery counters — same shape as `status` for the EL side so
-        // the two outputs compare apples-to-apples.
-        long uptimeSec = (System.currentTimeMillis() - startTimeMs) / 1000;
-        int discv5Live = discV5 != null ? discV5.liveNodeCount() : 0;
-        List<BeaconP2PService.PeerInfo> peers = beaconLightClient != null
-                ? beaconLightClient.getConnectedPeers()
-                : List.of();
-        int connectedPeers = peers.size();
-        long lightClientPeers = peers.stream()
-                .filter(BeaconP2PService.PeerInfo::supportsLightClient)
-                .count();
-        String peerStats = "\"uptimeSeconds\":" + uptimeSec
-                + ",\"discoveredPeers\":" + discv5Live
-                + ",\"connectedPeers\":" + connectedPeers
-                + ",\"lightClientPeers\":" + lightClientPeers;
-
-        String peersJson = buildBeaconPeersJson();
-        BeaconSyncState.State state = beaconSyncState.getSyncState(clGenesisTime, secondsPerSlot);
-        // Sync-committee period progress, surfaced next to `state` so catch-up
-        // progress is visible at a glance: currentPeriod / targetPeriod.
-        // currentPeriod is the committee we hold (0 before bootstrap); targetPeriod
-        // is the wall-clock period we're catching up to.
-        long currentPeriod = beaconSyncState.getCurrentSyncCommitteePeriod();
-        long targetPeriod = BeaconChainSpec.currentPeriod(clGenesisTime, secondsPerSlot);
-        String periodProgress = "\"currentPeriod\":" + currentPeriod
-                + ",\"targetPeriod\":" + targetPeriod;
-        if (state == BeaconSyncState.State.SYNCING) {
-            return "{\"ok\":true,\"state\":\"SYNCING\","
-                    + periodProgress + ","
-                    + peerStats
-                    + ",\"finalizedSlot\":0,\"optimisticSlot\":0"
-                    + ",\"executionStateRoot\":null"
-                    + ",\"knownStateRoots\":" + beaconSyncState.getKnownStateRootCount()
-                    + ",\"peers\":" + peersJson + "}";
-        }
-        byte[] stateRoot = beaconSyncState.getVerifiedExecutionStateRoot();
-        String stateRootHex = stateRoot != null ? "\"0x" + bytesToHex(stateRoot) + "\"" : "null";
-        long finalizedSlot = beaconSyncState.getFinalizedSlot();
-        long optimisticSlot = beaconSyncState.getOptimisticSlot();
-        long finalizedPeriod = finalizedSlot / BeaconChainSpec.SLOTS_PER_SYNC_COMMITTEE_PERIOD; // 8192 (32*256 == 16*512)
-        return "{\"ok\":true,\"state\":\"" + state.name() + "\","
-                + periodProgress + ","
-                + peerStats
-                + ",\"finalizedSlot\":" + finalizedSlot
-                + ",\"optimisticSlot\":" + optimisticSlot
-                + ",\"finalizedPeriod\":" + finalizedPeriod
-                + ",\"syncCommitteePeriod\":" + currentPeriod
-                + ",\"wallClockPeriod\":" + targetPeriod
-                + ",\"executionStateRoot\":" + stateRootHex
-                + ",\"executionBlockNumber\":" + beaconSyncState.getExecutionBlockNumber()
-                + ",\"knownStateRoots\":" + beaconSyncState.getKnownStateRootCount()
-                + ",\"fillThreshold\":" + BeaconSyncState.FILL_THRESHOLD
-                + ",\"peers\":" + peersJson + "}";
-    }
-
-    private String buildBeaconPeersJson() {
-        if (beaconLightClient == null) return "[]";
-        List<BeaconP2PService.PeerInfo> peers = beaconLightClient.getConnectedPeers();
-        StringBuilder sb = new StringBuilder("[");
-        boolean first = true;
-        for (BeaconP2PService.PeerInfo p : peers) {
-            if (!first) sb.append(",");
-            first = false;
-            sb.append("{\"peerId\":\"").append(escapeJson(truncatePeerId(p.peerId()))).append("\"");
-            sb.append(",\"remoteAddress\":\"").append(escapeJson(p.remoteAddress())).append("\"");
-            if (p.agentVersion() != null) {
-                sb.append(",\"clientId\":\"").append(escapeJson(p.agentVersion())).append("\"");
-            }
-            sb.append(",\"lightClient\":").append(p.supportsLightClient());
-            sb.append(",\"protocols\":").append(p.protocols().size());
-            sb.append("}");
-        }
-        sb.append("]");
-        return sb.toString();
-    }
-
-    private static String truncatePeerId(String peerId) {
-        return peerId != null && peerId.length() > 16
-                ? peerId.substring(0, 16) + "..." : peerId;
-    }
-
-    private String handleDial(String jsonLine) {
-        // Parse enode URL: enode://<pubkey>@<host>:<port>
-        String enode = extractString(jsonLine, "enode");
-        try {
-            if (!enode.startsWith("enode://")) {
-                return jsonError("enode must start with enode://");
-            }
-            String rest = enode.substring("enode://".length());
-            int atIdx = rest.indexOf('@');
-            if (atIdx < 0) return jsonError("Invalid enode format: missing @");
-            String pubKeyHex = rest.substring(0, atIdx);
-            String hostPort = rest.substring(atIdx + 1).split("\\?")[0]; // strip query params
-            int colonIdx = hostPort.lastIndexOf(':');
-            if (colonIdx < 0) return jsonError("Invalid enode format: missing port");
-            String host = hostPort.substring(0, colonIdx);
-            int port = Integer.parseInt(hostPort.substring(colonIdx + 1));
-
-            org.apache.tuweni.crypto.SECP256K1.PublicKey pubKey =
-                org.apache.tuweni.crypto.SECP256K1.PublicKey.fromBytes(
-                    org.apache.tuweni.bytes.Bytes.fromHexString(pubKeyHex));
-            java.net.InetSocketAddress addr = new java.net.InetSocketAddress(host, port);
-            log.info("[ipc] Dialing enode {} at {}", pubKeyHex.substring(0, 16) + "...", addr);
-            connector.connect(addr, pubKey);
-            return "{\"ok\":true,\"message\":\"Dialing " + host + ":" + port + "\"}";
-        } catch (Exception e) {
-            return jsonError("Failed to dial: " + e.getMessage());
-        }
-    }
-
-    private String handleStop() {
-        log.info("[ipc] Stop command received — initiating graceful shutdown");
-        stopLatch.countDown();
-        return "{\"ok\":true,\"message\":\"Daemon shutting down\"}";
-    }
-
-
-    private static String bytesToHex(byte[] bytes) {
-        StringBuilder sb = new StringBuilder(bytes.length * 2);
-        for (byte b : bytes) sb.append(String.format("%02x", b));
-        return sb.toString();
-    }
-
-    // -------------------------------------------------------------------------
-    // Transaction parsing
-    // -------------------------------------------------------------------------
-
-    /**
-     * Parse raw transaction bytes into JSON fields.
-     * Supports legacy, EIP-2930 (type 1), EIP-1559 (type 2), and EIP-4844 (type 3).
-     */
-    private static String parseTxToJson(Bytes rawTx) {
-        if (rawTx == null || rawTx.isEmpty()) return "";
-        try {
-            int firstByte = rawTx.get(0) & 0xFF;
-            if (firstByte >= 0xc0) {
-                // Legacy transaction (RLP list)
-                return parseLegacyTx(rawTx);
-            } else if (firstByte <= 0x03) {
-                // Typed transaction (EIP-2718): type byte + RLP payload
-                int type = firstByte;
-                Bytes payload = rawTx.slice(1);
-                return switch (type) {
-                    case 1 -> parseEip2930Tx(payload);
-                    case 2 -> parseEip1559Tx(payload);
-                    case 3 -> parseEip4844Tx(payload);
-                    default -> "\"type\":" + type;
-                };
-            }
-            return "";
-        } catch (Exception e) {
-            return "\"parseError\":\"" + escapeJson(e.getMessage()) + "\"";
-        }
-    }
-
-    /** Legacy tx: [nonce, gasPrice, gasLimit, to, value, data, v, r, s] */
-    private static String parseLegacyTx(Bytes rlp) {
-        StringBuilder sb = new StringBuilder();
-        RLP.decodeList(rlp, reader -> {
-            Bytes nonce = reader.readValue();
-            Bytes gasPrice = reader.readValue();
-            Bytes gasLimit = reader.readValue();
-            Bytes to = reader.readValue();
-            Bytes value = reader.readValue();
-            Bytes data = reader.readValue();
-            sb.append("\"type\":0");
-            sb.append(",\"nonce\":").append(toLong(nonce));
-            sb.append(",\"gasPrice\":\"0x").append(toMinHex(gasPrice)).append("\"");
-            sb.append(",\"gasLimit\":").append(toLong(gasLimit));
-            if (!to.isEmpty()) {
-                sb.append(",\"to\":\"0x").append(to.toUnprefixedHexString()).append("\"");
-            }
-            sb.append(",\"value\":\"0x").append(toMinHex(value)).append("\"");
-            if (!data.isEmpty()) {
-                sb.append(",\"data\":\"0x").append(data.toUnprefixedHexString()).append("\"");
-            }
-            return null;
-        });
-        return sb.toString();
-    }
-
-    /** EIP-2930 tx: [chainId, nonce, gasPrice, gasLimit, to, value, data, accessList, yParity, r, s] */
-    private static String parseEip2930Tx(Bytes rlp) {
-        StringBuilder sb = new StringBuilder();
-        RLP.decodeList(rlp, reader -> {
-            Bytes chainId = reader.readValue();
-            Bytes nonce = reader.readValue();
-            Bytes gasPrice = reader.readValue();
-            Bytes gasLimit = reader.readValue();
-            Bytes to = reader.readValue();
-            Bytes value = reader.readValue();
-            Bytes data = reader.readValue();
-            sb.append("\"type\":1");
-            sb.append(",\"chainId\":").append(toLong(chainId));
-            sb.append(",\"nonce\":").append(toLong(nonce));
-            sb.append(",\"gasPrice\":\"0x").append(toMinHex(gasPrice)).append("\"");
-            sb.append(",\"gasLimit\":").append(toLong(gasLimit));
-            if (!to.isEmpty()) {
-                sb.append(",\"to\":\"0x").append(to.toUnprefixedHexString()).append("\"");
-            }
-            sb.append(",\"value\":\"0x").append(toMinHex(value)).append("\"");
-            if (!data.isEmpty()) {
-                sb.append(",\"data\":\"0x").append(data.toUnprefixedHexString()).append("\"");
-            }
-            return null;
-        });
-        return sb.toString();
-    }
-
-    /** EIP-1559 tx: [chainId, nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit, to, value, data, accessList, yParity, r, s] */
-    private static String parseEip1559Tx(Bytes rlp) {
-        StringBuilder sb = new StringBuilder();
-        RLP.decodeList(rlp, reader -> {
-            Bytes chainId = reader.readValue();
-            Bytes nonce = reader.readValue();
-            Bytes maxPriorityFee = reader.readValue();
-            Bytes maxFee = reader.readValue();
-            Bytes gasLimit = reader.readValue();
-            Bytes to = reader.readValue();
-            Bytes value = reader.readValue();
-            Bytes data = reader.readValue();
-            sb.append("\"type\":2");
-            sb.append(",\"chainId\":").append(toLong(chainId));
-            sb.append(",\"nonce\":").append(toLong(nonce));
-            sb.append(",\"maxPriorityFeePerGas\":\"0x").append(toMinHex(maxPriorityFee)).append("\"");
-            sb.append(",\"maxFeePerGas\":\"0x").append(toMinHex(maxFee)).append("\"");
-            sb.append(",\"gasLimit\":").append(toLong(gasLimit));
-            if (!to.isEmpty()) {
-                sb.append(",\"to\":\"0x").append(to.toUnprefixedHexString()).append("\"");
-            }
-            sb.append(",\"value\":\"0x").append(toMinHex(value)).append("\"");
-            if (!data.isEmpty()) {
-                sb.append(",\"data\":\"0x").append(data.toUnprefixedHexString()).append("\"");
-            }
-            return null;
-        });
-        return sb.toString();
-    }
-
-    /** EIP-4844 tx: [chainId, nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit, to, value, data, accessList, maxFeePerBlobGas, blobVersionedHashes, yParity, r, s] */
-    private static String parseEip4844Tx(Bytes rlp) {
-        StringBuilder sb = new StringBuilder();
-        RLP.decodeList(rlp, reader -> {
-            Bytes chainId = reader.readValue();
-            Bytes nonce = reader.readValue();
-            Bytes maxPriorityFee = reader.readValue();
-            Bytes maxFee = reader.readValue();
-            Bytes gasLimit = reader.readValue();
-            Bytes to = reader.readValue();
-            Bytes value = reader.readValue();
-            Bytes data = reader.readValue();
-            reader.readList(r -> { r.readRemaining(); return null; }); // accessList
-            Bytes maxFeePerBlobGas = reader.readValue();
-            sb.append("\"type\":3");
-            sb.append(",\"chainId\":").append(toLong(chainId));
-            sb.append(",\"nonce\":").append(toLong(nonce));
-            sb.append(",\"maxPriorityFeePerGas\":\"0x").append(toMinHex(maxPriorityFee)).append("\"");
-            sb.append(",\"maxFeePerGas\":\"0x").append(toMinHex(maxFee)).append("\"");
-            sb.append(",\"gasLimit\":").append(toLong(gasLimit));
-            if (!to.isEmpty()) {
-                sb.append(",\"to\":\"0x").append(to.toUnprefixedHexString()).append("\"");
-            }
-            sb.append(",\"value\":\"0x").append(toMinHex(value)).append("\"");
-            sb.append(",\"maxFeePerBlobGas\":\"0x").append(toMinHex(maxFeePerBlobGas)).append("\"");
-            if (!data.isEmpty()) {
-                sb.append(",\"data\":\"0x").append(data.toUnprefixedHexString()).append("\"");
-            }
-            return null;
-        });
-        return sb.toString();
-    }
-
-    /** Convert RLP-encoded integer bytes to long. Empty bytes = 0. */
-    private static long toLong(Bytes b) {
-        if (b.isEmpty()) return 0;
-        return b.toLong();
-    }
-
-    /** Minimal hex representation (no leading zeros), or "0" for empty/zero. */
-    private static String toMinHex(Bytes b) {
-        if (b.isEmpty()) return "0";
-        String hex = b.toUnprefixedHexString().replaceFirst("^0+", "");
-        return hex.isEmpty() ? "0" : hex;
-    }
-
     // -------------------------------------------------------------------------
     // JSON helpers (no external library needed for simple commands)
     // -------------------------------------------------------------------------
@@ -1543,7 +716,6 @@ public class CommandHandler {
                 .replace("\r", "\\r");
     }
 
-    /** Minimal field extractor for string values: finds {@code "field":"value"} in flat JSON. */
     static String extractString(String json, String field) {
         String key = "\"" + field + "\"";
         int keyIdx = json.indexOf(key);
@@ -1557,7 +729,6 @@ public class CommandHandler {
         return json.substring(open + 1, close);
     }
 
-    /** Minimal field extractor for long/integer values. */
     static long extractLong(String json, String field) {
         String key = "\"" + field + "\"";
         int keyIdx = json.indexOf(key);

--- a/app/src/main/java/com/jaeckel/ethp2p/app/DebugCommands.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/DebugCommands.java
@@ -1,0 +1,381 @@
+package com.jaeckel.ethp2p.app;
+
+import com.jaeckel.ethp2p.networking.eth.messages.BlockBodiesMessage;
+import com.jaeckel.ethp2p.networking.eth.messages.BlockHeadersMessage;
+import com.jaeckel.ethp2p.networking.rlpx.RLPxConnector;
+import com.jaeckel.trueblocks.AppearanceRecord;
+import com.jaeckel.trueblocks.Bloom;
+import com.jaeckel.trueblocks.Chunk;
+import com.jaeckel.trueblocks.IndexParser;
+import com.jaeckel.trueblocks.IpfsHttpClient;
+import com.jaeckel.trueblocks.ManifestResponse;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.rlp.RLP;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * DEBUG-ONLY IPC commands that deliberately sit OUTSIDE the engine API boundary.
+ *
+ * <p>{@code get-transactions} streams address appearances from the TrueBlocks/IPFS
+ * index — an explorer/debugging aid that is UNVERIFIED on this path (each returned
+ * tx says {@code "verified":false}) and depends on engine internals
+ * ({@link RLPxConnector} header/body fetches). It is a documented exemption from the
+ * "hosts consume only {@code io.myotis.api}" rule (see docs/reimplementation): not
+ * part of the engine contract, not required of a re-implementation, and constructed
+ * at the composition root where the internals are still in reach.
+ */
+final class DebugCommands {
+
+    private static final Logger log = LoggerFactory.getLogger(DebugCommands.class);
+
+    private final RLPxConnector connector;
+
+    DebugCommands(RLPxConnector connector) {
+        this.connector = connector;
+    }
+
+    private static String jsonError(String message) {
+        return "{\"ok\":false,\"error\":\"" + escapeJson(message) + "\"}";
+    }
+
+    private static String escapeJson(String s) {
+        if (s == null) return "";
+        return s.replace("\\", "\\\\")
+                .replace("\"", "\\\"")
+                .replace("\n", "\\n")
+                .replace("\r", "\\r");
+    }
+
+    /** Reflective access to Kotlin UInt-typed getters on AppearanceRecord. */
+    private static final Method GET_BLOCK_NUMBER;
+    private static final Method GET_TX_INDEX;
+    static {
+        try {
+            GET_BLOCK_NUMBER = AppearanceRecord.class.getMethod("getBlockNumber-pVg5ArA");
+            GET_TX_INDEX = AppearanceRecord.class.getMethod("getTxIndex-pVg5ArA");
+        } catch (NoSuchMethodException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    private static int appearanceBlockNumber(AppearanceRecord rec) {
+        try { return (int) GET_BLOCK_NUMBER.invoke(rec); }
+        catch (Exception e) { throw new RuntimeException(e); }
+    }
+
+    private static int appearanceTxIndex(AppearanceRecord rec) {
+        try { return (int) GET_TX_INDEX.invoke(rec); }
+        catch (Exception e) { throw new RuntimeException(e); }
+    }
+
+    void handleGetTransactions(String jsonLine, BufferedWriter writer) throws IOException {
+        String addr = CommandHandler.extractString(jsonLine, "address");
+        String hex = (addr.startsWith("0x") || addr.startsWith("0X")) ? addr.substring(2) : addr;
+        if (hex.length() != 40) {
+            writer.write(jsonError("address must be a 20-byte hex string (40 hex chars)"));
+            writer.newLine();
+            writer.flush();
+            return;
+        }
+        String checksumAddr = "0x" + hex.toLowerCase();
+
+        try {
+            IpfsHttpClient ipfs = new IpfsHttpClient();
+            String manifestCID = "QmUBS83qjRmXmSgEvZADVv2ch47137jkgNbqfVVxQep5Y1";
+
+            log.info("[get-transactions] Fetching manifest for address {}", checksumAddr);
+            ManifestResponse manifest = ipfs.fetchAndParseManifestUrl(manifestCID);
+
+            // Construct kethereum Address via reflection (avoids compile-time dependency
+            // on kethereum multiplatform module)
+            Class<?> addressClass = Class.forName("org.kethereum.model.Address");
+            Constructor<?> addressCtor = addressClass.getConstructor(String.class);
+            Object tbAddress = addressCtor.newInstance(checksumAddr);
+            Method isMemberBytes = Bloom.class.getMethod("isMemberBytes", addressClass);
+            List<Chunk> chunks = manifest.getChunks();
+            int totalChunks = chunks.size();
+            int successCount = 0;
+
+            // Scan from highest block number to lowest so recent txs appear first.
+            // Stream results per-chunk: fetch tx data immediately when appearances are found.
+            for (int ci = totalChunks - 1; ci >= 0; ci--) {
+                Chunk chunk = chunks.get(ci);
+                try {
+                    Bloom bloom = ipfs.fetchBloom(chunk.getBloomHash(), chunk.getRange());
+                    if ((boolean) isMemberBytes.invoke(bloom, tbAddress)) {
+                        log.debug("[get-transactions] Bloom hit for chunk {} ({}/{})",
+                                chunk.getRange(), totalChunks - ci, totalChunks);
+                        IndexParser index = ipfs.fetchIndex(chunk.getIndexHash(), false);
+                        List<AppearanceRecord> appearances = index.findAppearances(checksumAddr);
+                        if (appearances.isEmpty()) continue;
+
+                        log.info("[get-transactions] Found {} appearances in chunk {}",
+                                appearances.size(), chunk.getRange());
+
+                        // Sort appearances within chunk descending by block number
+                        appearances.sort(Comparator.comparingInt(
+                                DebugCommands::appearanceBlockNumber).reversed());
+
+                        // Fetch and stream each transaction immediately
+                        for (AppearanceRecord appearance : appearances) {
+                            long blockNumber = Integer.toUnsignedLong(appearanceBlockNumber(appearance));
+                            int txIndex = appearanceTxIndex(appearance);
+                            try {
+                                List<BlockHeadersMessage.VerifiedHeader> headers =
+                                        connector.requestBlockHeadersBatched(blockNumber, 1)
+                                                .get(30, TimeUnit.SECONDS);
+                                if (headers.isEmpty()) {
+                                    writer.write("{\"ok\":false,\"blockNumber\":" + blockNumber
+                                            + ",\"error\":\"No header returned\"}");
+                                    writer.newLine();
+                                    writer.flush();
+                                    continue;
+                                }
+                                BlockHeadersMessage.VerifiedHeader vh = headers.get(0);
+                                Bytes32 blockHash = vh.hash();
+
+                                List<BlockBodiesMessage.BlockBody> bodies =
+                                        connector.requestBlockBodies(blockHash)
+                                                .get(30, TimeUnit.SECONDS);
+                                if (bodies.isEmpty()) {
+                                    writer.write("{\"ok\":false,\"blockNumber\":" + blockNumber
+                                            + ",\"error\":\"No body returned\"}");
+                                    writer.newLine();
+                                    writer.flush();
+                                    continue;
+                                }
+                                BlockBodiesMessage.BlockBody body = bodies.get(0);
+
+                                List<Bytes> txList = body.transactions();
+                                if (txIndex >= txList.size()) {
+                                    writer.write("{\"ok\":false,\"blockNumber\":" + blockNumber
+                                            + ",\"transactionIndex\":" + txIndex
+                                            + ",\"error\":\"Transaction index out of range\"}");
+                                    writer.newLine();
+                                    writer.flush();
+                                    continue;
+                                }
+                                Bytes rawTx = txList.get(txIndex);
+                                String parsedFields = parseTxToJson(rawTx);
+
+                                StringBuilder txJson = new StringBuilder();
+                                txJson.append("{\"ok\":true,\"blockNumber\":").append(blockNumber);
+                                txJson.append(",\"transactionIndex\":").append(txIndex);
+                                if (!parsedFields.isEmpty()) {
+                                    txJson.append(",").append(parsedFields);
+                                }
+                                txJson.append(",\"rawTx\":\"0x").append(rawTx.toUnprefixedHexString()).append("\"");
+                                txJson.append(",\"verified\":false}");
+                                writer.write(txJson.toString());
+                                writer.newLine();
+                                writer.flush();
+                                successCount++;
+
+                            } catch (Exception e) {
+                                // The blocking .get() calls above can throw InterruptedException
+                                // directly (not wrapped) — restore the flag so a cancelled stream
+                                // stops promptly instead of swallowing the interrupt per-tx.
+                                if (e instanceof InterruptedException) Thread.currentThread().interrupt();
+                                Throwable cause = e.getCause() != null ? e.getCause() : e;
+                                String msg = cause.getMessage() != null ? cause.getMessage() : cause.getClass().getSimpleName();
+                                writer.write("{\"ok\":false,\"blockNumber\":" + blockNumber
+                                        + ",\"transactionIndex\":" + txIndex
+                                        + ",\"error\":\"" + escapeJson(msg) + "\"}");
+                                writer.newLine();
+                                writer.flush();
+                            }
+                        }
+                    }
+                } catch (Exception e) {
+                    log.warn("[get-transactions] Error processing chunk {}: {}",
+                            chunk.getRange(), e.getMessage());
+                }
+            }
+
+            log.info("[get-transactions] Scan complete. {} transactions streamed for {}",
+                    successCount, checksumAddr);
+            writer.write("{\"ok\":true,\"done\":true,\"totalTransactions\":" + successCount + "}");
+            writer.newLine();
+            writer.flush();
+
+        } catch (Exception e) {
+            Throwable cause = e.getCause() != null ? e.getCause() : e;
+            String msg = cause.getMessage() != null ? cause.getMessage() : cause.getClass().getSimpleName();
+            writer.write(jsonError("get-transactions failed: " + msg));
+            writer.newLine();
+            writer.flush();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Transaction parsing
+    // -------------------------------------------------------------------------
+
+    /**
+     * Parse raw transaction bytes into JSON fields.
+     * Supports legacy, EIP-2930 (type 1), EIP-1559 (type 2), and EIP-4844 (type 3).
+     */
+    private static String parseTxToJson(Bytes rawTx) {
+        if (rawTx == null || rawTx.isEmpty()) return "";
+        try {
+            int firstByte = rawTx.get(0) & 0xFF;
+            if (firstByte >= 0xc0) {
+                // Legacy transaction (RLP list)
+                return parseLegacyTx(rawTx);
+            } else if (firstByte <= 0x03) {
+                // Typed transaction (EIP-2718): type byte + RLP payload
+                int type = firstByte;
+                Bytes payload = rawTx.slice(1);
+                return switch (type) {
+                    case 1 -> parseEip2930Tx(payload);
+                    case 2 -> parseEip1559Tx(payload);
+                    case 3 -> parseEip4844Tx(payload);
+                    default -> "\"type\":" + type;
+                };
+            }
+            return "";
+        } catch (Exception e) {
+            return "\"parseError\":\"" + escapeJson(e.getMessage()) + "\"";
+        }
+    }
+
+    /** Legacy tx: [nonce, gasPrice, gasLimit, to, value, data, v, r, s] */
+    private static String parseLegacyTx(Bytes rlp) {
+        StringBuilder sb = new StringBuilder();
+        RLP.decodeList(rlp, reader -> {
+            Bytes nonce = reader.readValue();
+            Bytes gasPrice = reader.readValue();
+            Bytes gasLimit = reader.readValue();
+            Bytes to = reader.readValue();
+            Bytes value = reader.readValue();
+            Bytes data = reader.readValue();
+            sb.append("\"type\":0");
+            sb.append(",\"nonce\":").append(toLong(nonce));
+            sb.append(",\"gasPrice\":\"0x").append(toMinHex(gasPrice)).append("\"");
+            sb.append(",\"gasLimit\":").append(toLong(gasLimit));
+            if (!to.isEmpty()) {
+                sb.append(",\"to\":\"0x").append(to.toUnprefixedHexString()).append("\"");
+            }
+            sb.append(",\"value\":\"0x").append(toMinHex(value)).append("\"");
+            if (!data.isEmpty()) {
+                sb.append(",\"data\":\"0x").append(data.toUnprefixedHexString()).append("\"");
+            }
+            return null;
+        });
+        return sb.toString();
+    }
+
+    /** EIP-2930 tx: [chainId, nonce, gasPrice, gasLimit, to, value, data, accessList, yParity, r, s] */
+    private static String parseEip2930Tx(Bytes rlp) {
+        StringBuilder sb = new StringBuilder();
+        RLP.decodeList(rlp, reader -> {
+            Bytes chainId = reader.readValue();
+            Bytes nonce = reader.readValue();
+            Bytes gasPrice = reader.readValue();
+            Bytes gasLimit = reader.readValue();
+            Bytes to = reader.readValue();
+            Bytes value = reader.readValue();
+            Bytes data = reader.readValue();
+            sb.append("\"type\":1");
+            sb.append(",\"chainId\":").append(toLong(chainId));
+            sb.append(",\"nonce\":").append(toLong(nonce));
+            sb.append(",\"gasPrice\":\"0x").append(toMinHex(gasPrice)).append("\"");
+            sb.append(",\"gasLimit\":").append(toLong(gasLimit));
+            if (!to.isEmpty()) {
+                sb.append(",\"to\":\"0x").append(to.toUnprefixedHexString()).append("\"");
+            }
+            sb.append(",\"value\":\"0x").append(toMinHex(value)).append("\"");
+            if (!data.isEmpty()) {
+                sb.append(",\"data\":\"0x").append(data.toUnprefixedHexString()).append("\"");
+            }
+            return null;
+        });
+        return sb.toString();
+    }
+
+    /** EIP-1559 tx: [chainId, nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit, to, value, data, accessList, yParity, r, s] */
+    private static String parseEip1559Tx(Bytes rlp) {
+        StringBuilder sb = new StringBuilder();
+        RLP.decodeList(rlp, reader -> {
+            Bytes chainId = reader.readValue();
+            Bytes nonce = reader.readValue();
+            Bytes maxPriorityFee = reader.readValue();
+            Bytes maxFee = reader.readValue();
+            Bytes gasLimit = reader.readValue();
+            Bytes to = reader.readValue();
+            Bytes value = reader.readValue();
+            Bytes data = reader.readValue();
+            sb.append("\"type\":2");
+            sb.append(",\"chainId\":").append(toLong(chainId));
+            sb.append(",\"nonce\":").append(toLong(nonce));
+            sb.append(",\"maxPriorityFeePerGas\":\"0x").append(toMinHex(maxPriorityFee)).append("\"");
+            sb.append(",\"maxFeePerGas\":\"0x").append(toMinHex(maxFee)).append("\"");
+            sb.append(",\"gasLimit\":").append(toLong(gasLimit));
+            if (!to.isEmpty()) {
+                sb.append(",\"to\":\"0x").append(to.toUnprefixedHexString()).append("\"");
+            }
+            sb.append(",\"value\":\"0x").append(toMinHex(value)).append("\"");
+            if (!data.isEmpty()) {
+                sb.append(",\"data\":\"0x").append(data.toUnprefixedHexString()).append("\"");
+            }
+            return null;
+        });
+        return sb.toString();
+    }
+
+    /** EIP-4844 tx: [chainId, nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit, to, value, data, accessList, maxFeePerBlobGas, blobVersionedHashes, yParity, r, s] */
+    private static String parseEip4844Tx(Bytes rlp) {
+        StringBuilder sb = new StringBuilder();
+        RLP.decodeList(rlp, reader -> {
+            Bytes chainId = reader.readValue();
+            Bytes nonce = reader.readValue();
+            Bytes maxPriorityFee = reader.readValue();
+            Bytes maxFee = reader.readValue();
+            Bytes gasLimit = reader.readValue();
+            Bytes to = reader.readValue();
+            Bytes value = reader.readValue();
+            Bytes data = reader.readValue();
+            reader.readList(r -> { r.readRemaining(); return null; }); // accessList
+            Bytes maxFeePerBlobGas = reader.readValue();
+            sb.append("\"type\":3");
+            sb.append(",\"chainId\":").append(toLong(chainId));
+            sb.append(",\"nonce\":").append(toLong(nonce));
+            sb.append(",\"maxPriorityFeePerGas\":\"0x").append(toMinHex(maxPriorityFee)).append("\"");
+            sb.append(",\"maxFeePerGas\":\"0x").append(toMinHex(maxFee)).append("\"");
+            sb.append(",\"gasLimit\":").append(toLong(gasLimit));
+            if (!to.isEmpty()) {
+                sb.append(",\"to\":\"0x").append(to.toUnprefixedHexString()).append("\"");
+            }
+            sb.append(",\"value\":\"0x").append(toMinHex(value)).append("\"");
+            sb.append(",\"maxFeePerBlobGas\":\"0x").append(toMinHex(maxFeePerBlobGas)).append("\"");
+            if (!data.isEmpty()) {
+                sb.append(",\"data\":\"0x").append(data.toUnprefixedHexString()).append("\"");
+            }
+            return null;
+        });
+        return sb.toString();
+    }
+
+    /** Convert RLP-encoded integer bytes to long. Empty bytes = 0. */
+    private static long toLong(Bytes b) {
+        if (b.isEmpty()) return 0;
+        return b.toLong();
+    }
+
+    /** Minimal hex representation (no leading zeros), or "0" for empty/zero. */
+    private static String toMinHex(Bytes b) {
+        if (b.isEmpty()) return "0";
+        String hex = b.toUnprefixedHexString().replaceFirst("^0+", "");
+        return hex.isEmpty() ? "0" : hex;
+    }
+}

--- a/app/src/main/java/com/jaeckel/ethp2p/app/FileNodeKeyStore.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/FileNodeKeyStore.java
@@ -1,0 +1,48 @@
+package com.jaeckel.ethp2p.app;
+
+import io.myotis.api.ports.NodeKeyStore;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HexFormat;
+import java.util.function.Function;
+
+/**
+ * The daemon's node-identity storage: one hex file per network (mainnet keeps the legacy
+ * {@code nodekey.hex}), byte-compatible with the files {@code NodeKey.loadOrGenerate} has
+ * always written, so existing identities carry over unchanged.
+ */
+public final class FileNodeKeyStore implements NodeKeyStore {
+
+    private final Function<String, Path> fileFor;
+
+    public FileNodeKeyStore(Function<String, Path> fileFor) {
+        this.fileFor = fileFor;
+    }
+
+    @Override
+    public byte[] load(String networkName) {
+        Path file = fileFor.apply(networkName);
+        if (!Files.exists(file)) return null;
+        try {
+            String hex = new String(Files.readAllBytes(file), StandardCharsets.UTF_8).strip();
+            if (hex.startsWith("0x") || hex.startsWith("0X")) hex = hex.substring(2);
+            return HexFormat.of().parseHex(hex);
+        } catch (Exception e) {
+            throw new RuntimeException("failed to read node key " + file + ": " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void store(String networkName, byte[] secret32) {
+        Path file = fileFor.apply(networkName);
+        try {
+            // Same format loadOrGenerate wrote: 0x-prefixed lowercase hex, no newline.
+            Files.write(file, ("0x" + HexFormat.of().formatHex(secret32))
+                    .getBytes(StandardCharsets.UTF_8));
+        } catch (Exception e) {
+            throw new RuntimeException("failed to write node key " + file + ": " + e.getMessage(), e);
+        }
+    }
+}

--- a/app/src/main/java/com/jaeckel/ethp2p/app/Main.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/Main.java
@@ -1,10 +1,10 @@
 package com.jaeckel.ethp2p.app;
 
-import com.jaeckel.ethp2p.core.crypto.NodeKey;
-import com.jaeckel.ethp2p.networking.NetworkConfig;
-import io.myotis.node.ChainPorts;
-import io.myotis.node.ChainStack;
-import io.myotis.node.NodeRegistry;
+import io.myotis.api.ChainHandle;
+import io.myotis.api.EngineConfig;
+import io.myotis.api.MyotisEngine;
+import io.myotis.api.ports.EnginePorts;
+import io.myotis.node.api.JavaMyotisEngine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,9 +49,11 @@ import java.util.concurrent.CountDownLatch;
  * </ul>
  *
  * <p>Each network's node stack (EL + discv4 + discv5 + beacon light client + verified
- * JSON-RPC) lives in {@link ChainStack} (module {@code :node-core}), shared with the
- * Android app, and is held by a {@link NodeRegistry}. This class owns the daemon shell:
- * the per-network lock files + Unix-socket IPC servers, and the shutdown latch.
+ * JSON-RPC) lives behind the engine API ({@link MyotisEngine}/{@link ChainHandle}) —
+ * {@code new JavaMyotisEngine()} below is the single line naming a concrete engine.
+ * This class owns the daemon shell: the host-implemented ports (file caches, node-key
+ * files, the JVM HTTP CCIP gateway), the per-network lock files + Unix-socket IPC
+ * servers, and the shutdown latch.
  */
 public final class Main {
 
@@ -134,8 +136,17 @@ public final class Main {
         }
         String[] cmdArgs = remaining.toArray(new String[0]);
 
-        // Client commands / purge target a single network — the first listed.
+        MyotisEngine engine = new JavaMyotisEngine();
+
+        // Client commands / purge target a single network — the first listed. Canonicalize
+        // aliases (xdai/gbc → gnosis) so the client targets the SAME socket the daemon
+        // creates; an unknown name keeps the raw form (old behavior: "daemon not running").
         String primary = networkNames.get(0);
+        try {
+            primary = engine.canonicalNetworkName(primary);
+        } catch (io.myotis.api.EngineException ignored) {
+            // keep the raw name; client mode will report the socket as absent
+        }
         Path primarySocket = socketPath(primary);
         Path primaryLock = lockPath(primary);
 
@@ -165,13 +176,16 @@ public final class Main {
         }
 
         // ── Daemon mode (one or more networks in this process) ───────────────
-        List<NetworkConfig> networks = new ArrayList<>();
-        for (String n : networkNames) networks.add(NetworkConfig.byName(n));
-        for (NetworkConfig net : networks) {
-            if (isDaemonRunning(socketPath(net.name()), lockPath(net.name()))) {
-                System.err.println("Daemon already running for " + net.name()
-                        + " (socket: " + socketPath(net.name()) + ")");
-                if (networks.size() == 1) {
+        List<String> canonical = new ArrayList<>();
+        for (String n : networkNames) {
+            String name = engine.canonicalNetworkName(n);
+            if (!canonical.contains(name)) canonical.add(name);
+        }
+        for (String name : canonical) {
+            if (isDaemonRunning(socketPath(name), lockPath(name))) {
+                System.err.println("Daemon already running for " + name
+                        + " (socket: " + socketPath(name) + ")");
+                if (canonical.size() == 1) {
                     System.err.println("Commands:");
                     System.err.println("  ./gradlew :app:run -Pargs=status");
                     System.err.println("  ./gradlew :app:run -Pargs=peers");
@@ -180,29 +194,28 @@ public final class Main {
                 System.exit(1);
             }
         }
-        runDaemon(networks, port, gossipsubEnabled);
+        runDaemon(engine, canonical, port, gossipsubEnabled);
     }
 
     // -------------------------------------------------------------------------
     // Daemon
     // -------------------------------------------------------------------------
 
-    private static void runDaemon(List<NetworkConfig> networks, int portOverride,
+    private static void runDaemon(MyotisEngine engine, List<String> networks, int portOverride,
                                   boolean gossipsubEnabled) throws Exception {
         boolean multi = networks.size() > 1;
-        log.info("=== ethp2p Daemon ({}) ===",
-                String.join(", ", networks.stream().map(NetworkConfig::name).toList()));
+        log.info("=== ethp2p Daemon ({}) ===", String.join(", ", networks));
 
         // 0. Acquire every target network's exclusive lock up front; release all and
         //    abort if any is held (another daemon already owns that network).
         List<FileChannel> lockChannels = new ArrayList<>();
         List<FileLock> fileLocks = new ArrayList<>();
-        for (NetworkConfig network : networks) {
-            FileChannel ch = FileChannel.open(lockPath(network.name()),
+        for (String network : networks) {
+            FileChannel ch = FileChannel.open(lockPath(network),
                     StandardOpenOption.CREATE, StandardOpenOption.WRITE);
             FileLock lk = ch.tryLock();
             if (lk == null) {
-                System.err.println("Daemon already running (lock held: " + lockPath(network.name()) + ")");
+                System.err.println("Daemon already running (lock held: " + lockPath(network) + ")");
                 ch.close();
                 releaseAll(fileLocks, lockChannels);
                 System.exit(1);
@@ -213,57 +226,64 @@ public final class Main {
         }
 
         CountDownLatch stopLatch = new CountDownLatch(1);
-        NodeRegistry registry = new NodeRegistry();
         List<DaemonServer> servers = new ArrayList<>();
 
-        // 1. Build, start, and IPC-wire each network's stack.
-        for (NetworkConfig network : networks) {
-            log.info("IPC socket ({}): {}", network.name(), socketPath(network.name()));
+        // 1. Build, start, and IPC-wire each network's stack — everything through the
+        //    engine API; the host supplies its ports (file caches, key files, HTTP).
+        for (String network : networks) {
+            log.info("IPC socket ({}): {}", network, socketPath(network));
 
             // Ports: single-network stays byte-identical (legacy --port/30303 + discv5 9000 +
-            // RPC 8545); multi-network uses pinned per-network ports so the stacks don't collide.
-            // Identity is always per-network (nodeKeyFile below), independent of this.
-            ChainPorts ports = multi
-                    ? ChainPorts.defaultsFor(network)
-                    : new ChainPorts(portOverride, 9000, 8545);
-            NodeKey nodeKey = NodeKey.loadOrGenerate(nodeKeyFile(network.name()));
-
-            PeerCache peerCache = new PeerCache(cacheFile(network.name()));
-            CLPeerCache clPeerCache = new CLPeerCache(clCacheFile(network.name()));
-            ChainStack stack = new ChainStack(
-                    network, ports, nodeKey,
-                    new PeerCacheAdapter(peerCache),
-                    new ClPeerCacheAdapter(clPeerCache),
+            // RPC 8545); multi-network uses the engine's pinned per-network defaults (0 = default)
+            // so the stacks don't collide. Identity is always per-network (nodeKeyFile).
+            // Strict state freshness keeps honoring the documented operator knob
+            // (-Dmyotis.rpc.strictStateFreshness=false — see OPTIMISATIONS_AND_LIMITATIONS.md).
+            boolean strict = Boolean.parseBoolean(
+                    System.getProperty("myotis.rpc.strictStateFreshness", "true"));
+            EngineConfig config = multi
+                    ? new EngineConfig(network, 0, 0, 0,
+                            syncSnapshotFile(network).toString(), gossipsubEnabled,
+                            SNAP_PEER_TARGET, strict)
+                    : new EngineConfig(network, portOverride, 9000, 8545,
+                            syncSnapshotFile(network).toString(), gossipsubEnabled,
+                            SNAP_PEER_TARGET, strict);
+            // dnsServers=null → resolver's default DNS (the daemon, unlike Android, has
+            // system DNS config). The snap maintainer (SNAP_PEER_TARGET) keeps snap peers
+            // topped up from the cache + a refreshing EIP-1459 DNS pool — helps networks
+            // with scarce snap peers (Gnosis) retain a snap/1 peer for verified reads.
+            EnginePorts ports = new EnginePorts(
+                    new FileNodeKeyStore(Main::nodeKeyFile),
+                    new PeerCacheAdapter(new PeerCache(cacheFile(network))),
+                    new ClPeerCacheAdapter(new CLPeerCache(clCacheFile(network))),
+                    null,
                     new com.jaeckel.ethp2p.app.rpc.JavaHttpCcipGateway(),
-                    syncSnapshotFile(network.name()),
-                    gossipsubEnabled);
-            // Keep snap peers topped up from the cache + a refreshing EIP-1459 DNS pool —
-            // the discv4-independent path. Helps networks with scarce snap peers (Gnosis)
-            // retain a snap/1 peer for verified state reads. dnsServers=null → resolver's
-            // default DNS (the daemon, unlike Android, has system DNS config).
-            stack.configureSnapMaintainer(SNAP_PEER_TARGET, null);
+                    null,
+                    null);
 
-            if (!stack.start()) {
-                System.err.println("Failed to start " + network.name() + " node stack");
-                registry.shutdownAll();
+            ChainHandle handle = engine.create(config, ports);
+            if (!handle.start()) {
+                System.err.println("Failed to start " + network + " node stack");
+                engine.shutdownAll();
                 closeAll(servers);
                 releaseAll(fileLocks, lockChannels);
                 System.exit(1);
                 return;
             }
-            registry.add(stack);
 
-            CommandHandler commandHandler = new CommandHandler(
-                    stack.discV4(), stack.discV5(), stack.connector(), stopLatch,
-                    stack.backoff(), stack.blacklistedNodeIds(),
-                    stack.beaconSyncState(), stack.beaconLightClient(),
-                    network.clGenesisTime(), network.secondsPerSlot());
-            DaemonServer server = new DaemonServer(socketPath(network.name()), commandHandler);
+            // get-transactions (TrueBlocks debug stream) is the documented exemption from
+            // the API boundary — it takes the raw connector via the CONCRETE engine's
+            // debug accessor, wired only here at the composition root.
+            DebugCommands debugCommands = engine instanceof JavaMyotisEngine je
+                    ? new DebugCommands(je.debugStack(network).connector())
+                    : null;
+
+            CommandHandler commandHandler = new CommandHandler(handle, stopLatch, debugCommands);
+            DaemonServer server = new DaemonServer(socketPath(network), commandHandler);
             try {
                 server.start();
             } catch (Exception e) {
-                System.err.println("Failed to start IPC server for " + network.name() + ": " + e.getMessage());
-                registry.shutdownAll();
+                System.err.println("Failed to start IPC server for " + network + ": " + e.getMessage());
+                engine.shutdownAll();
                 closeAll(servers);
                 releaseAll(fileLocks, lockChannels);
                 System.exit(1);
@@ -277,7 +297,7 @@ public final class Main {
         java.util.concurrent.atomic.AtomicBoolean cleaned = new java.util.concurrent.atomic.AtomicBoolean(false);
         Runnable cleanup = () -> {
             if (!cleaned.compareAndSet(false, true)) return;
-            registry.shutdownAll();
+            engine.shutdownAll();
             closeAll(servers);
             releaseAll(fileLocks, lockChannels);
         };

--- a/app/src/main/java/com/jaeckel/ethp2p/app/PeerCacheAdapter.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/PeerCacheAdapter.java
@@ -1,20 +1,21 @@
 package com.jaeckel.ethp2p.app;
 
-import io.myotis.node.CachedPeer;
-import io.myotis.node.PeerCachePort;
-import io.myotis.node.SnapQuality;
+import io.myotis.api.ports.CachedPeerInfo;
+import io.myotis.api.ports.EnginePeerCache;
+import io.myotis.api.ports.SnapQuality;
 
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Adapts the daemon's file-backed {@link PeerCache} to the {@link PeerCachePort}
- * that {@code ChainStack} consumes, so {@code node-core} stays independent of the
- * daemon module. Pure delegation plus a {@link PeerCache.SnapQuality} → shared
- * {@link SnapQuality} mapping.
+ * Adapts the daemon's file-backed {@link PeerCache} to the engine API's
+ * {@link EnginePeerCache} port. Pure delegation plus the host/port ⇄
+ * InetSocketAddress and {@link PeerCache.SnapQuality} → api {@link SnapQuality}
+ * mappings. Addresses are constructed unresolved — {@code PeerCache} keys by
+ * {@code getHostString()}, so no DNS lookup is needed (or wanted) here.
  */
-public final class PeerCacheAdapter implements PeerCachePort {
+public final class PeerCacheAdapter implements EnginePeerCache {
 
     private final PeerCache delegate;
 
@@ -22,23 +23,25 @@ public final class PeerCacheAdapter implements PeerCachePort {
         this.delegate = java.util.Objects.requireNonNull(delegate, "delegate");
     }
 
-    @Override public void add(InetSocketAddress address, String publicKeyHex, boolean snap) {
-        delegate.add(address, publicKeyHex, snap);
+    @Override public void add(String host, int port, String publicKeyHex, boolean snap) {
+        delegate.add(InetSocketAddress.createUnresolved(host, port), publicKeyHex, snap);
     }
 
-    @Override public void recordSnapServed(InetSocketAddress address) {
-        delegate.recordSnapServed(address);
+    @Override public void recordSnapServed(String host, int port) {
+        delegate.recordSnapServed(InetSocketAddress.createUnresolved(host, port));
     }
 
-    @Override public void recordSnapFailure(InetSocketAddress address) {
-        delegate.recordSnapFailure(address);
+    @Override public void recordSnapFailure(String host, int port) {
+        delegate.recordSnapFailure(InetSocketAddress.createUnresolved(host, port));
     }
 
-    @Override public List<CachedPeer> load() {
+    @Override public List<CachedPeerInfo> load() {
         List<PeerCache.CachedPeer> src = delegate.load();
-        List<CachedPeer> out = new ArrayList<>(src.size());
+        List<CachedPeerInfo> out = new ArrayList<>(src.size());
         for (PeerCache.CachedPeer p : src) {
-            out.add(new CachedPeer(p.address(), p.publicKeyHex(), p.snap(), map(p.snapQuality())));
+            out.add(new CachedPeerInfo(
+                    p.address().getHostString(), p.address().getPort(),
+                    p.publicKeyHex(), p.snap(), map(p.snapQuality())));
         }
         return out;
     }

--- a/app/src/main/java/com/jaeckel/ethp2p/app/rpc/JavaHttpCcipGateway.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/rpc/JavaHttpCcipGateway.java
@@ -1,58 +1,54 @@
 package com.jaeckel.ethp2p.app.rpc;
 
+import io.myotis.api.ports.HttpGateway;
+
 /**
- * JVM-only {@link io.myotis.evm.ccipread.CcipGateway} backed by
- * {@code java.net.http.HttpClient}. Used by the daemon, where JVM 21 is
- * guaranteed. Android consumers must supply a Ktor-backed gateway per
- * {@code CLAUDE.md} (java.net.http isn't covered by Android core library
- * desugaring below API 33) — which is also why this class lives in {@code :app}
- * and not in the Android-consumed {@code :rpc-backend}.
+ * JVM-only {@link HttpGateway} (the engine API's CCIP-Read transport) backed by
+ * {@code java.net.http.HttpClient}. Used by the daemon, where JVM 21 is guaranteed.
+ * Android consumers must supply a Ktor-backed gateway per {@code CLAUDE.md}
+ * (java.net.http isn't covered by Android core library desugaring below API 33) —
+ * which is also why this class lives in {@code :app}.
  *
- * <p>Per ERC-3668 §6.1, any non-2xx HTTP status code must be treated as
- * an error so {@link io.myotis.evm.ccipread.CcipReadHandler} can fall
- * through to the next URL in the gateway list. We surface non-2xx as a
- * failed future carrying an {@link java.io.IOException} with the status
- * code and URL, which the handler's {@code exceptionallyCompose} catches
- * and folds into the per-URL diagnostic list.
+ * <p>Blocking, per the port contract: the engine calls it from its own workers and
+ * bridges to its internal async shape. Per ERC-3668 §6.1, any non-2xx HTTP status
+ * must be treated as an error so the CCIP handler can fall through to the next URL
+ * in the gateway list — surfaced here as a thrown {@link RuntimeException} carrying
+ * the status code and URL.
  */
-public final class JavaHttpCcipGateway implements io.myotis.evm.ccipread.CcipGateway {
+public final class JavaHttpCcipGateway implements HttpGateway {
 
     private static final java.net.http.HttpClient CLIENT = java.net.http.HttpClient.newBuilder()
             .connectTimeout(java.time.Duration.ofSeconds(10))
             .build();
 
     @Override
-    public java.util.concurrent.CompletableFuture<String> request(Method method, String url, String body) {
-        // Build the request inside the try: URI.create() throws
-        // IllegalArgumentException on a malformed gateway URL (CCIP gateway URLs
-        // are contract-supplied, so untrusted), and a synchronous throw here would
-        // bypass CcipReadHandler's .thenApply failover and propagate to the caller.
-        // Always hand back a (possibly failed) future so the failover chain holds.
-        java.net.http.HttpRequest request;
-        try {
-            java.net.http.HttpRequest.Builder rb = java.net.http.HttpRequest.newBuilder()
-                    .uri(java.net.URI.create(url))
-                    .timeout(java.time.Duration.ofSeconds(15));
-            if (method == Method.POST) {
-                rb.header("Content-Type", "application/json");
-                rb.POST(java.net.http.HttpRequest.BodyPublishers.ofString(
-                        body == null ? "" : body));
-            } else {
-                rb.GET();
-            }
-            request = rb.build();
-        } catch (RuntimeException e) {
-            return java.util.concurrent.CompletableFuture.failedFuture(e);
+    public String request(Method method, String url, String bodyOrNull) {
+        // URI.create() throws IllegalArgumentException on a malformed gateway URL
+        // (CCIP gateway URLs are contract-supplied, so untrusted) — that's a valid
+        // "this gateway failed" signal under the port's throw-on-failure contract.
+        java.net.http.HttpRequest.Builder rb = java.net.http.HttpRequest.newBuilder()
+                .uri(java.net.URI.create(url))
+                .timeout(java.time.Duration.ofSeconds(15));
+        if (method == Method.POST) {
+            rb.header("Content-Type", "application/json");
+            rb.POST(java.net.http.HttpRequest.BodyPublishers.ofString(
+                    bodyOrNull == null ? "" : bodyOrNull));
+        } else {
+            rb.GET();
         }
-        return CLIENT.sendAsync(request,
-                java.net.http.HttpResponse.BodyHandlers.ofString())
-                .thenCompose(resp -> {
-                    int status = resp.statusCode();
-                    if (status >= 200 && status < 300) {
-                        return java.util.concurrent.CompletableFuture.completedFuture(resp.body());
-                    }
-                    return java.util.concurrent.CompletableFuture.failedFuture(
-                            new java.io.IOException("HTTP " + status + " from " + url));
-                });
+        try {
+            java.net.http.HttpResponse<String> resp = CLIENT.send(
+                    rb.build(), java.net.http.HttpResponse.BodyHandlers.ofString());
+            int status = resp.statusCode();
+            if (status >= 200 && status < 300) {
+                return resp.body();
+            }
+            throw new RuntimeException("HTTP " + status + " from " + url);
+        } catch (java.io.IOException e) {
+            throw new RuntimeException("HTTP transport failure for " + url + ": " + e.getMessage(), e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("interrupted during gateway request to " + url, e);
+        }
     }
 }

--- a/myotis-api/src/main/java/io/myotis/api/BeaconStatus.java
+++ b/myotis-api/src/main/java/io/myotis/api/BeaconStatus.java
@@ -1,0 +1,39 @@
+package io.myotis.api;
+
+import java.util.List;
+
+/**
+ * Deep beacon/CL status — the superset behind operator surfaces like the daemon's
+ * {@code beacon-status} command (the EL-side counterpart lives in {@link StatusSnapshot}).
+ *
+ * @param state                 beacon light-client state
+ * @param currentPeriod         sync-committee period the client holds (0 before bootstrap)
+ * @param targetPeriod          wall-clock period being caught up to
+ * @param discv5TableSize       live nodes in the CL discv5 routing table
+ * @param connectedPeers        connected CL libp2p peers
+ * @param lightClientPeers      of those, peers serving the light_client protocols
+ * @param finalizedSlot         finalized beacon slot (0 while SYNCING)
+ * @param optimisticSlot        optimistic beacon slot (0 while SYNCING)
+ * @param finalizedPeriod       period of the finalized slot
+ * @param executionStateRootHex latest verified execution state root (0x-hex), null while SYNCING
+ * @param executionBlockNumber  finalized execution block number
+ * @param knownStateRoots       beacon-attested state roots currently held
+ * @param fillThreshold         the engine's known-roots threshold for serving verified reads
+ * @param peers                 per-peer CL detail
+ */
+public record BeaconStatus(
+        BeaconState state,
+        long currentPeriod,
+        long targetPeriod,
+        int discv5TableSize,
+        int connectedPeers,
+        long lightClientPeers,
+        long finalizedSlot,
+        long optimisticSlot,
+        long finalizedPeriod,
+        String executionStateRootHex,
+        long executionBlockNumber,
+        int knownStateRoots,
+        int fillThreshold,
+        List<ClPeerInfo> peers) {
+}

--- a/myotis-api/src/main/java/io/myotis/api/ChainHandle.java
+++ b/myotis-api/src/main/java/io/myotis/api/ChainHandle.java
@@ -47,6 +47,15 @@ public interface ChainHandle {
      */
     StatusSnapshot status();
 
+    /** EL discovery's routing-table entries (operator diagnostics). Cheap. */
+    java.util.List<DiscoveredPeer> discoveredPeers();
+
+    /** All EL peers with an open RLPx session, including those still handshaking. Cheap. */
+    java.util.List<ConnectedPeer> connectedPeers();
+
+    /** Deep beacon/CL status including per-peer detail. Cheap. */
+    BeaconStatus beaconStatus();
+
     /**
      * The verified eth_* read surface, or {@code null} while the RPC backend
      * isn't started (e.g. the RPC port was unavailable at {@link #start()}).

--- a/myotis-api/src/main/java/io/myotis/api/ClPeerInfo.java
+++ b/myotis-api/src/main/java/io/myotis/api/ClPeerInfo.java
@@ -1,0 +1,14 @@
+package io.myotis.api;
+
+/**
+ * One connected CL (beacon libp2p) peer.
+ *
+ * @param peerId        the libp2p peer id (full)
+ * @param remoteAddress remote multiaddr/endpoint display string
+ * @param clientId      the peer's agent version, or null when unknown
+ * @param lightClient   whether the peer serves the light_client req/resp protocols
+ * @param protocols     number of protocols the peer advertised
+ */
+public record ClPeerInfo(String peerId, String remoteAddress, String clientId,
+                         boolean lightClient, int protocols) {
+}

--- a/myotis-api/src/main/java/io/myotis/api/ConnectedPeer.java
+++ b/myotis-api/src/main/java/io/myotis/api/ConnectedPeer.java
@@ -1,0 +1,13 @@
+package io.myotis.api;
+
+/**
+ * One EL peer with an open RLPx session, including those still handshaking
+ * (unlike {@link PeerInfo}, which covers only READY peers).
+ *
+ * @param remoteAddress "host:port" display string
+ * @param state         connection state name (e.g. "AWAITING_STATUS", "READY")
+ * @param snapSupported whether the peer negotiated snap/1
+ * @param clientId      the peer's Hello client id, or null until received
+ */
+public record ConnectedPeer(String remoteAddress, String state, boolean snapSupported, String clientId) {
+}

--- a/myotis-api/src/main/java/io/myotis/api/DiscoveredPeer.java
+++ b/myotis-api/src/main/java/io/myotis/api/DiscoveredPeer.java
@@ -1,0 +1,12 @@
+package io.myotis.api;
+
+/**
+ * One entry from EL discovery's routing table (operator diagnostics).
+ *
+ * @param host      IP literal
+ * @param udpPort   discv4 UDP port
+ * @param tcpPort   advertised RLPx TCP port (0 when unknown)
+ * @param nodeIdHex the peer's full 64-byte node id (0x-hex)
+ */
+public record DiscoveredPeer(String host, int udpPort, int tcpPort, String nodeIdHex) {
+}

--- a/myotis-api/src/main/java/io/myotis/api/EnsResolutionResult.java
+++ b/myotis-api/src/main/java/io/myotis/api/EnsResolutionResult.java
@@ -3,11 +3,15 @@ package io.myotis.api;
 /**
  * Result of a forward or reverse ENS name↔address resolution.
  *
+ * <p>Convention (same as every ENS record lookup): {@code addressHex == null} with
+ * {@code error == null} is a <em>successful</em> "name has no record";
+ * {@code error != null} is a resolution failure.
+ *
  * @param name        the ENS name (queried, or reverse-resolved)
  * @param addressHex  the resolved / queried address (0x-hex), null when unresolved
  * @param blockNumber block the resolution state anchors to; -1 when none
  * @param verified    true iff resolved against beacon-finalized state
- * @param error       null on success; otherwise why resolution failed
+ * @param error       null on success or no-record; otherwise why resolution failed
  */
 public record EnsResolutionResult(
         String name,

--- a/node-core/src/main/java/io/myotis/node/api/JavaChainHandle.java
+++ b/node-core/src/main/java/io/myotis/node/api/JavaChainHandle.java
@@ -43,6 +43,11 @@ public final class JavaChainHandle implements ChainHandle {
         this.strictStateFreshness = strictStateFreshness;
     }
 
+    /** Package-private: {@link JavaMyotisEngine#debugStack} only. */
+    ChainStack stack() {
+        return stack;
+    }
+
     @Override public String networkName() { return stack.network().name(); }
 
     @Override public long chainId() { return stack.network().networkId(); }
@@ -129,6 +134,72 @@ public final class JavaChainHandle implements ChainHandle {
                 wallClockPeriod,
                 backend != null ? backend.verifiedHeadAgeMs() : Long.MAX_VALUE,
                 readyRows);
+    }
+
+    @Override
+    public java.util.List<io.myotis.api.DiscoveredPeer> discoveredPeers() {
+        var disc = stack.discV4();
+        if (disc == null) return List.of();
+        List<io.myotis.api.DiscoveredPeer> out = new ArrayList<>();
+        for (var e : disc.table().allPeers()) {
+            out.add(new io.myotis.api.DiscoveredPeer(
+                    e.udpAddr().getAddress().getHostAddress(),
+                    e.udpAddr().getPort(),
+                    e.tcpPort(),
+                    e.nodeId().toHexString()));
+        }
+        return out;
+    }
+
+    @Override
+    public java.util.List<io.myotis.api.ConnectedPeer> connectedPeers() {
+        RLPxConnector conn = stack.connector();
+        if (conn == null) return List.of();
+        List<io.myotis.api.ConnectedPeer> out = new ArrayList<>();
+        for (RLPxConnector.PeerInfo p : conn.getActivePeers()) {
+            out.add(new io.myotis.api.ConnectedPeer(
+                    p.remoteAddress(), p.state(), p.snapSupported(), p.clientId()));
+        }
+        return out;
+    }
+
+    @Override
+    public io.myotis.api.BeaconStatus beaconStatus() {
+        NetworkConfig net = stack.network();
+        BeaconSyncState bss = stack.beaconSyncState();
+        var blc = stack.beaconLightClient();
+
+        List<io.myotis.api.ClPeerInfo> peers = new ArrayList<>();
+        int lightClientPeers = 0;
+        if (blc != null) {
+            for (var p : blc.getConnectedPeers()) {
+                boolean lc = p.supportsLightClient();
+                if (lc) lightClientPeers++;
+                peers.add(new io.myotis.api.ClPeerInfo(
+                        p.peerId(), p.remoteAddress(), p.agentVersion(), lc, p.protocols().size()));
+            }
+        }
+        io.myotis.api.BeaconState state = bss == null
+                ? io.myotis.api.BeaconState.STARTING
+                : io.myotis.api.BeaconState.valueOf(
+                        bss.getSyncState(net.clGenesisTime(), net.secondsPerSlot()).name());
+        byte[] stateRoot = bss != null ? bss.getVerifiedExecutionStateRoot() : null;
+        long finalizedSlot = bss != null ? bss.getFinalizedSlot() : 0L;
+        return new io.myotis.api.BeaconStatus(
+                state,
+                bss != null ? bss.getCurrentSyncCommitteePeriod() : 0L,
+                BeaconChainSpec.currentPeriod(net.clGenesisTime(), net.secondsPerSlot()),
+                stack.discV5() != null ? stack.discV5().liveNodeCount() : 0,
+                peers.size(),
+                lightClientPeers,
+                finalizedSlot,
+                bss != null ? bss.getOptimisticSlot() : 0L,
+                finalizedSlot / BeaconChainSpec.SLOTS_PER_SYNC_COMMITTEE_PERIOD,
+                stateRoot != null ? org.apache.tuweni.bytes.Bytes.wrap(stateRoot).toHexString() : null,
+                bss != null ? bss.getExecutionBlockNumber() : 0L,
+                bss != null ? bss.getKnownStateRootCount() : 0,
+                BeaconSyncState.FILL_THRESHOLD,
+                peers);
     }
 
     @Override

--- a/node-core/src/main/java/io/myotis/node/api/JavaEnsApi.java
+++ b/node-core/src/main/java/io/myotis/node/api/JavaEnsApi.java
@@ -42,6 +42,9 @@ final class JavaEnsApi implements EnsApi {
         return backend;
     }
 
+    /** The backend's internal marker for a successful empty forward resolution. */
+    private static final String BACKEND_NO_RECORD = "name does not resolve";
+
     @Override
     public EnsResolutionResult resolveAddress(String name, EnsRoot root) {
         // backend() throws EngineException when not running — the same state-error
@@ -50,8 +53,13 @@ final class JavaEnsApi implements EnsApi {
         try {
             EnsResolution r = backend.resolveEns(name, toEngineRoot(root))
                     .get(RESOLVE_TIMEOUT_SEC, TimeUnit.SECONDS);
+            // Normalize to the API's record convention (same as every EnsApi record
+            // lookup): a successful "no such record" is value==null && error==null.
+            // The backend folds that case into an error string; unfold it HERE so no
+            // consumer ever has to match the magic text.
+            String error = BACKEND_NO_RECORD.equals(r.error()) ? null : r.error();
             return new EnsResolutionResult(r.name(), r.addressHex(), r.blockNumber(),
-                    r.verified(), r.error());
+                    r.verified(), error);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             return new EnsResolutionResult(name, null, -1, false, "interrupted");

--- a/node-core/src/main/java/io/myotis/node/api/JavaMyotisEngine.java
+++ b/node-core/src/main/java/io/myotis/node/api/JavaMyotisEngine.java
@@ -118,6 +118,17 @@ public final class JavaMyotisEngine implements MyotisEngine {
         return handles.get(networkName);
     }
 
+    /**
+     * DEBUG-ONLY escape hatch: the underlying {@link ChainStack} for hosts' documented
+     * exemptions (the daemon's TrueBlocks {@code get-transactions} stream). Deliberately
+     * NOT on the {@link MyotisEngine} interface — a host that wants the engine to stay
+     * replaceable must not build features on this.
+     */
+    public ChainStack debugStack(String networkName) {
+        JavaChainHandle handle = handles.get(networkName);
+        return handle != null ? handle.stack() : null;
+    }
+
     @Override
     public List<String> hostedNetworks() {
         return List.copyOf(handles.keySet());

--- a/node-core/src/main/java/io/myotis/node/api/PortBridges.java
+++ b/node-core/src/main/java/io/myotis/node/api/PortBridges.java
@@ -30,11 +30,13 @@ import java.util.concurrent.Executor;
  * (InetSocketAddress, Map/Set collections, CompletableFuture). All conversions are
  * mechanical; no behavior lives here.
  */
-final class PortBridges {
+public final class PortBridges {
 
     private PortBridges() {}
 
-    static PeerCachePort toPeerCachePort(EnginePeerCache cache) {
+    /** Public interim: hosts mid-migration (desktop until its engine-API rewiring PR)
+     *  bridge their api-shaped port implementations back to the ChainStack shapes. */
+    public static PeerCachePort toPeerCachePort(EnginePeerCache cache) {
         return new PeerCachePort() {
             @Override public void add(InetSocketAddress address, String publicKeyHex, boolean snap) {
                 cache.add(address.getHostString(), address.getPort(), publicKeyHex, snap);
@@ -60,7 +62,8 @@ final class PortBridges {
         };
     }
 
-    static ClPeerCachePort toClPeerCachePort(EngineClPeerCache cache) {
+    /** Public interim — see {@link #toPeerCachePort}. */
+    public static ClPeerCachePort toClPeerCachePort(EngineClPeerCache cache) {
         return new ClPeerCachePort() {
             @Override public List<String> load() { return cache.load(); }
             @Override public void add(String multiaddr) { cache.add(multiaddr); }
@@ -102,7 +105,7 @@ final class PortBridges {
      * The api gateway is blocking (the FFI-portable shape); the engine's CCIP executor wants a
      * future. Run the blocking call on {@code executor} — never an engine I/O thread.
      */
-    static io.myotis.evm.ccipread.CcipGateway toCcipGateway(HttpGateway gateway, Executor executor) {
+    public static io.myotis.evm.ccipread.CcipGateway toCcipGateway(HttpGateway gateway, Executor executor) {
         return (method, url, body) -> CompletableFuture.supplyAsync(() ->
                 gateway.request(
                         method == io.myotis.evm.ccipread.CcipGateway.Method.GET


### PR DESCRIPTION
PR 3/6 of the engine-API extraction. After #117 (the `:myotis-api` contract) and #118 (engine-logic motion), this rewires the daemon: **`Main` + `CommandHandler` now consume only `io.myotis.api`** — the daemon is a thin host (argument parsing, JSON serialization, files/sockets); every fetch and verification decision is behind `MyotisEngine`/`ChainHandle`. `new JavaMyotisEngine()` is the single concrete-engine line.

## API additions
The daemon's operator surfaces needed more than `StatusSnapshot`:
- `ChainHandle.discoveredPeers()` → `List<DiscoveredPeer>` (discv4 table detail)
- `ChainHandle.connectedPeers()` → `List<ConnectedPeer>` (all RLPx sessions incl. handshaking, with state)
- `ChainHandle.beaconStatus()` → `BeaconStatus` + `ClPeerInfo` rows, `knownStateRoots`, `fillThreshold` — this is also exactly what the desktop deep-CL-stats follow-up (task #37) needs in PR 5/6.

## Daemon rewiring
- **CommandHandler**: one `(ChainHandle, stopLatch, DebugCommands)` constructor; every handler on the handle. The ~600 lines of daemon-local ENS engine logic (peer probing, pinned-root EVM stack, `EnsCallContext`) are **deleted** — ENS commands ride the backend's shared machinery via `handle.ens()`.
- **Main**: hosts networks via `engine.create(EngineConfig, EnginePorts)` / `start()` / `shutdownAll()`. New `FileNodeKeyStore` is byte-compatible both directions with the old `nodekey*.hex` files; the peer-cache adapters retargeted to the api ports; `JavaHttpCcipGateway` rewritten as the blocking `HttpGateway` port (same timeouts/non-2xx semantics; the sync throw stays inside the bridge's future). Single-network port legacy (`--port`/9000/8545) preserved.
- **`get-transactions`** (TrueBlocks stream) moved **verbatim** to `DebugCommands` — the documented API-boundary exemption, wired at the composition root via `JavaMyotisEngine.debugStack()` (deliberately NOT on the `MyotisEngine` interface).
- **Desktop** keeps compiling via now-public `PortBridges` (documented interim; removed when PR 5/6 rewires it).
- Client-mode socket targeting now canonicalizes aliases (`xdai` → `gnosis`), closing a pre-existing hole where `-Pnetwork=xdai -Pargs=status` targeted a socket the daemon never creates.
- The `EnsResolutionResult` no-record convention is now uniform with every record lookup (`addressHex==null && error==null` = successful "no record") — no consumer matches the backend's magic error string anymore.

## Behavioral deltas (shapes unchanged; per the independent review)
- The seven ENS record-type commands switch from FINALIZED-only to the same AUTO ladder as `resolve-ens` (finalized first, peer-head fallback) — they can now answer where they previously errored with "no snap peer retains the beacon-finalized state".
- `resolve-ens` gateway failures surface the backend's error text (the old `"ENS gateway error (try again): "` prefix is gone).
- get-account/get-storage interruption reports `"interrupted while querying …"`.
- `beacon-status` folds the pre-start STARTING state into `"SYNCING"` (previously unreachable — the old code would have NPE'd).
- The `-Dmyotis.rpc.strictStateFreshness` operator knob keeps working (seeded into `EngineConfig`).

## Verification
- `./gradlew build` green (all modules incl. android + desktop); golden JSON tests unchanged and passing.
- **Live daemon smoke on mainnet (SYNCED)**: `status`/`peers`/`beacon-status`/`get-headers` shapes unchanged; `get-account 0xd8dA…6045` → `exists:true`, verified nonce/balance, `beaconChainVerified:true, blsVerified:true`; the CLAUDE.md `get-storage` contract → `storageProofValid:true, beaconChainVerified:true`; `resolve-ens vitalik.eth` → resolved, `beaconVerified:true`; `stop` cleanly shuts down.
- Independent no-context review verified IPC shape parity field-by-field (incl. nodeId/peerId truncations, conditional emissions, the golden builders byte-identical vs main), the FileNodeKeyStore round-trip, and the verbatim DebugCommands move. Its findings (strict-freshness knob clobbered, no-record magic string, alias socket hole) are all incorporated.

Next: PR 4/6 retires the jsonrpc-server SPI (`VerifiedRpcBackend implements VerifiedReads` directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)