### PR TITLE
refactor: desktop + Android hosts consume only the engine API (API extraction 5/6)

### DIFF
--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/AndroidClPeerCacheAdapter.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/AndroidClPeerCacheAdapter.java
@@ -1,19 +1,20 @@
 package com.jaeckel.ethp2p.android;
 
-import io.myotis.node.ClPeerCachePort;
+import io.myotis.api.ports.BootstrapPeer;
+import io.myotis.api.ports.EngineClPeerCache;
+import io.myotis.api.ports.ServedRange;
 
-import java.util.Collection;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
- * Adapts {@link AndroidCLPeerCache} to the {@link ClPeerCachePort} that {@code ChainStack}
- * consumes. Pure delegation. {@code AndroidCLPeerCache} flushes writes inline (no
- * {@code close()}), so {@link #close()} is a no-op. Mirrors the daemon's
- * {@code ClPeerCacheAdapter}.
+ * Adapts {@link AndroidCLPeerCache} to the engine API's {@link EngineClPeerCache} port.
+ * Pure delegation plus Map/Set → flat-record-List conversions. {@code AndroidCLPeerCache}
+ * flushes writes inline (no {@code close()}), so {@link #close()} is a no-op. Mirrors the
+ * daemon's {@code ClPeerCacheAdapter}.
  */
-public final class AndroidClPeerCacheAdapter implements ClPeerCachePort {
+public final class AndroidClPeerCacheAdapter implements EngineClPeerCache {
 
     private final AndroidCLPeerCache delegate;
 
@@ -22,16 +23,46 @@ public final class AndroidClPeerCacheAdapter implements ClPeerCachePort {
     }
 
     @Override public List<String> load() { return delegate.load(); }
+
     @Override public void add(String multiaddr) { delegate.add(multiaddr); }
+
     @Override public void markFailure(String multiaddr) { delegate.markFailure(multiaddr); }
-    @Override public Map<String, long[]> servedRanges() { return delegate.servedRanges(); }
-    @Override public void recordServed(String multiaddr, long low, long high) { delegate.recordServed(multiaddr, low, high); }
-    @Override public Map<String, Long> bootstrapPeers() { return delegate.bootstrapPeers(); }
-    @Override public void recordBootstrap(String multiaddr, long period) { delegate.recordBootstrap(multiaddr, period); }
-    @Override public Set<String> lightClientConfirmed() { return delegate.lightClientConfirmed(); }
-    @Override public Set<String> lightClientDenied() { return delegate.lightClientDenied(); }
-    @Override public void markLightClientBatch(Collection<String> confirmed, Collection<String> denied) {
+
+    @Override public List<ServedRange> servedRanges() {
+        List<ServedRange> out = new ArrayList<>();
+        for (Map.Entry<String, long[]> e : delegate.servedRanges().entrySet()) {
+            out.add(new ServedRange(e.getKey(), e.getValue()[0], e.getValue()[1]));
+        }
+        return out;
+    }
+
+    @Override public void recordServed(String multiaddr, long low, long high) {
+        delegate.recordServed(multiaddr, low, high);
+    }
+
+    @Override public List<BootstrapPeer> bootstrapPeers() {
+        List<BootstrapPeer> out = new ArrayList<>();
+        for (Map.Entry<String, Long> e : delegate.bootstrapPeers().entrySet()) {
+            out.add(new BootstrapPeer(e.getKey(), e.getValue()));
+        }
+        return out;
+    }
+
+    @Override public void recordBootstrap(String multiaddr, long period) {
+        delegate.recordBootstrap(multiaddr, period);
+    }
+
+    @Override public List<String> lightClientConfirmed() {
+        return List.copyOf(delegate.lightClientConfirmed());
+    }
+
+    @Override public List<String> lightClientDenied() {
+        return List.copyOf(delegate.lightClientDenied());
+    }
+
+    @Override public void markLightClientBatch(List<String> confirmed, List<String> denied) {
         delegate.markLightClientBatch(confirmed, denied);
     }
+
     @Override public void close() { /* AndroidCLPeerCache flushes writes inline; nothing to close */ }
 }

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/AndroidPeerCacheAdapter.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/AndroidPeerCacheAdapter.java
@@ -1,20 +1,21 @@
 package com.jaeckel.ethp2p.android;
 
-import io.myotis.node.CachedPeer;
-import io.myotis.node.PeerCachePort;
-import io.myotis.node.SnapQuality;
+import io.myotis.api.ports.CachedPeerInfo;
+import io.myotis.api.ports.EnginePeerCache;
+import io.myotis.api.ports.SnapQuality;
 
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Adapts {@link AndroidPeerCache} to the {@link PeerCachePort} that {@code ChainStack}
- * consumes, so {@code node-core} stays independent of the Android module. Pure
- * delegation plus an {@link AndroidPeerCache.SnapQuality} → shared {@link SnapQuality}
- * mapping. Mirrors the daemon's {@code PeerCacheAdapter}.
+ * Adapts {@link AndroidPeerCache} to the engine API's {@link EnginePeerCache} port.
+ * Pure delegation plus the host/port ⇄ InetSocketAddress and
+ * {@link AndroidPeerCache.SnapQuality} → api {@link SnapQuality} mappings. Mirrors the
+ * daemon's {@code PeerCacheAdapter}; addresses are constructed unresolved (the cache
+ * keys by host string, no DNS lookup wanted here).
  */
-public final class AndroidPeerCacheAdapter implements PeerCachePort {
+public final class AndroidPeerCacheAdapter implements EnginePeerCache {
 
     private final AndroidPeerCache delegate;
 
@@ -22,23 +23,25 @@ public final class AndroidPeerCacheAdapter implements PeerCachePort {
         this.delegate = java.util.Objects.requireNonNull(delegate, "delegate");
     }
 
-    @Override public void add(InetSocketAddress address, String publicKeyHex, boolean snap) {
-        delegate.add(address, publicKeyHex, snap);
+    @Override public void add(String host, int port, String publicKeyHex, boolean snap) {
+        delegate.add(InetSocketAddress.createUnresolved(host, port), publicKeyHex, snap);
     }
 
-    @Override public void recordSnapServed(InetSocketAddress address) {
-        delegate.recordSnapServed(address);
+    @Override public void recordSnapServed(String host, int port) {
+        delegate.recordSnapServed(InetSocketAddress.createUnresolved(host, port));
     }
 
-    @Override public void recordSnapFailure(InetSocketAddress address) {
-        delegate.recordSnapFailure(address);
+    @Override public void recordSnapFailure(String host, int port) {
+        delegate.recordSnapFailure(InetSocketAddress.createUnresolved(host, port));
     }
 
-    @Override public List<CachedPeer> load() {
+    @Override public List<CachedPeerInfo> load() {
         List<AndroidPeerCache.CachedPeer> src = delegate.load();
-        List<CachedPeer> out = new ArrayList<>(src.size());
+        List<CachedPeerInfo> out = new ArrayList<>(src.size());
         for (AndroidPeerCache.CachedPeer p : src) {
-            out.add(new CachedPeer(p.address(), p.publicKeyHex(), p.snap(), map(p.snapQuality())));
+            out.add(new CachedPeerInfo(
+                    p.address().getHostString(), p.address().getPort(),
+                    p.publicKeyHex(), p.snap(), map(p.snapQuality())));
         }
         return out;
     }

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -31,7 +31,6 @@ import java.net.InetAddress;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -560,6 +559,8 @@ public final class NodeService extends Service {
         return requestAccount(primaryNetwork(this), hexAddress);
     }
 
+    @SuppressLint("NewApi") // CompletableFuture.failedFuture (API 31) is backported to
+                            // minSdk 29 via desugar_jdk_libs — see the comment block above.
     public CompletableFuture<AccountQueryResult> requestAccount(String network, String hexAddress) {
         ChainHandle handle = handles.get(canonicalNetwork(network));
         if (handle == null) {
@@ -770,35 +771,6 @@ public final class NodeService extends Service {
                     + ", state-freshness " + (strictStateFreshness(this) ? "strict" : "relaxed")
                     + ", bls " + blsChoice + ")");
 
-            // Reconstructible network state lives in getCacheDir() so "Clear cache" wipes the
-            // peer caches + sync snapshot while identity / query history in getFilesDir() survive.
-            AndroidPeerCache pc = new AndroidPeerCache(netCacheFor(n, "peers", ".cache").toPath());
-            AndroidCLPeerCache cl = new AndroidCLPeerCache(netCacheFor(n, "cl-peers", ".cache").toPath());
-            cachedElCounts.put(n, pc.load().size());
-            cachedClCounts.put(n, cl.load().size());
-            elCaches.put(n, pc);
-            clCaches.put(n, cl);
-
-            // EL/discv5 ports use the engine's per-network defaults (0); the RPC port is the
-            // user-configurable one. The snap maintainer keeps snap peers topped up (the
-            // discv4-independent path NAT'd mobile needs); Android supplies the active
-            // network's DNS servers for EIP-1459 resolution.
-            EngineConfig config = new EngineConfig(
-                    n, 0, 0, rpcPort,
-                    netCacheFor(n, "sync-state", ".snapshot").getAbsolutePath(),
-                    /*gossipsub*/ false,
-                    snapTarget(this),
-                    strictStateFreshness(this));
-            EnginePorts ports = new EnginePorts(
-                    // Identity: legacy mainnet keeps nodekey.hex; other chains get a
-                    // per-network key so two chains never share an identity.
-                    new AndroidNodeKeyStore(getFilesDir()),
-                    new AndroidPeerCacheAdapter(pc),
-                    new AndroidClPeerCacheAdapter(cl),
-                    this::activeNetworkDnsServers,
-                    new com.jaeckel.ethp2p.android.ens.AndroidCcipGateway(),
-                    null, null); // engine default logger/clock
-
             // create() + start() under the per-network bootLock: a Stop→Start / disable→enable
             // has this boot wait for the old instance's teardown (which holds the same lock) to
             // free the ports AND unregister from the engine (create() throws on a still-hosted
@@ -823,6 +795,41 @@ public final class NodeService extends Service {
                     if (existing != null) handles.putIfAbsent(n, existing);
                     return;
                 }
+
+                // Build the caches HERE — inside the lock, after every bail check — so an
+                // early bail can never orphan a freshly-started cache writer thread, and the
+                // maps can never be clobbered while a live stack still uses the previous
+                // instances (the engine owns these via the port adapters from create() on).
+                // Reconstructible network state lives in getCacheDir() so "Clear cache" wipes
+                // the peer caches + sync snapshot while identity / query history in
+                // getFilesDir() survive.
+                AndroidPeerCache pc = new AndroidPeerCache(netCacheFor(n, "peers", ".cache").toPath());
+                AndroidCLPeerCache cl = new AndroidCLPeerCache(netCacheFor(n, "cl-peers", ".cache").toPath());
+                cachedElCounts.put(n, pc.load().size());
+                cachedClCounts.put(n, cl.load().size());
+                elCaches.put(n, pc);
+                clCaches.put(n, cl);
+
+                // EL/discv5 ports use the engine's per-network defaults (0); the RPC port is
+                // the user-configurable one. The snap maintainer keeps snap peers topped up
+                // (the discv4-independent path NAT'd mobile needs); Android supplies the
+                // active network's DNS servers for EIP-1459 resolution.
+                EngineConfig config = new EngineConfig(
+                        n, 0, 0, rpcPort,
+                        netCacheFor(n, "sync-state", ".snapshot").getAbsolutePath(),
+                        /*gossipsub*/ false,
+                        snapTarget(this),
+                        strictStateFreshness(this));
+                EnginePorts ports = new EnginePorts(
+                        // Identity: legacy mainnet keeps nodekey.hex; other chains get a
+                        // per-network key so two chains never share an identity.
+                        new AndroidNodeKeyStore(getFilesDir()),
+                        new AndroidPeerCacheAdapter(pc),
+                        new AndroidClPeerCacheAdapter(cl),
+                        this::activeNetworkDnsServers,
+                        new com.jaeckel.ethp2p.android.ens.AndroidCcipGateway(),
+                        null, null); // engine default logger/clock
+
                 ChainHandle handle = ENGINE.create(config, ports);
                 created = handle;
                 handles.put(n, handle);
@@ -876,7 +883,17 @@ public final class NodeService extends Service {
                 String hex = new String(Files.readAllBytes(file),
                         java.nio.charset.StandardCharsets.UTF_8).strip();
                 if (hex.startsWith("0x") || hex.startsWith("0X")) hex = hex.substring(2);
-                return HexFormat.of().parseHex(hex);
+                // Hand-rolled hex: java.util.HexFormat is API 34 and NOT covered by
+                // core-library desugaring, so it would crash at runtime on minSdk 29.
+                if (hex.length() % 2 != 0) throw new IllegalArgumentException("odd-length hex");
+                byte[] out = new byte[hex.length() / 2];
+                for (int i = 0; i < out.length; i++) {
+                    int hi = Character.digit(hex.charAt(i * 2), 16);
+                    int lo = Character.digit(hex.charAt(i * 2 + 1), 16);
+                    if (hi < 0 || lo < 0) throw new IllegalArgumentException("non-hex character");
+                    out[i] = (byte) ((hi << 4) | lo);
+                }
+                return out;
             } catch (Exception e) {
                 throw new RuntimeException("failed to read node key " + file + ": " + e.getMessage(), e);
             }
@@ -884,8 +901,13 @@ public final class NodeService extends Service {
         @Override public void store(String networkName, byte[] secret32) {
             Path file = fileFor(networkName);
             try {
-                Files.write(file, ("0x" + HexFormat.of().formatHex(secret32))
-                        .getBytes(java.nio.charset.StandardCharsets.UTF_8));
+                StringBuilder sb = new StringBuilder(2 + secret32.length * 2);
+                sb.append("0x");
+                for (byte b : secret32) {
+                    sb.append(Character.forDigit((b >> 4) & 0xF, 16))
+                      .append(Character.forDigit(b & 0xF, 16));
+                }
+                Files.write(file, sb.toString().getBytes(java.nio.charset.StandardCharsets.UTF_8));
             } catch (Exception e) {
                 throw new RuntimeException("failed to write node key " + file + ": " + e.getMessage(), e);
             }

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -14,34 +14,30 @@ import android.os.Binder;
 import android.os.IBinder;
 import com.jaeckel.ethp2p.android.log.LogBuffer;
 
-import com.jaeckel.ethp2p.consensus.BeaconLightClient;
-import com.jaeckel.ethp2p.consensus.BeaconSyncState;
-import com.jaeckel.ethp2p.consensus.libp2p.BeaconP2PService;
-import com.jaeckel.ethp2p.consensus.proof.OrderedTrieRoot;
-import com.jaeckel.ethp2p.core.crypto.NodeKey;
-import com.jaeckel.ethp2p.core.types.BlockHeader;
-import com.jaeckel.ethp2p.networking.NetworkConfig;
-import com.jaeckel.ethp2p.networking.discv4.DiscV4Service;
-import com.jaeckel.ethp2p.networking.discv5.DiscV5Service;
-import com.jaeckel.ethp2p.networking.eth.messages.BlockBodiesMessage;
-import com.jaeckel.ethp2p.networking.eth.messages.Receipt;
-import com.jaeckel.ethp2p.networking.eth.messages.TxFeeFields;
-import com.jaeckel.ethp2p.networking.rlpx.RLPxConnector;
-
-import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.crypto.SECP256K1;
+import io.myotis.api.AccountProofResult;
+import io.myotis.api.BeaconState;
+import io.myotis.api.BeaconStatus;
+import io.myotis.api.ChainHandle;
+import io.myotis.api.EngineConfig;
+import io.myotis.api.EnsResolutionResult;
+import io.myotis.api.EnsRoot;
+import io.myotis.api.MyotisEngine;
+import io.myotis.api.NetworkInfo;
+import io.myotis.api.StatusSnapshot;
+import io.myotis.api.ports.EnginePorts;
+import io.myotis.api.ports.NodeKeyStore;
 
 import java.net.InetAddress;
-import java.net.InetSocketAddress;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Comparator;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -127,11 +123,29 @@ public final class NodeService extends Service {
         return c.getSharedPreferences(PREFS_NAME, android.content.Context.MODE_PRIVATE);
     }
     /**
-     * Canonicalize a network name to one {@link NetworkConfig#byName} accepts AND that
-     * the per-network helpers (which test {@code "gnosis".equals(network)}) handle
-     * consistently. Unknown/corrupt/empty values fall back to mainnet so a bad pref can
-     * never crash node startup (byName throws on unknown names) or silently desync the
-     * RPC-port/preset selection from the resolved chain.
+     * The engine, and its static network catalog for the pref helpers below (they're
+     * static — callable from Activities without a bound service). One process-global
+     * engine mirrors the process-global RUNNING flag: service instances come and go,
+     * the hosted-network registry persists across them. The single line naming a
+     * concrete engine class.
+     */
+    private static final MyotisEngine ENGINE = new io.myotis.node.api.JavaMyotisEngine();
+    private static final List<NetworkInfo> NETWORKS = ENGINE.availableNetworks();
+
+    private static NetworkInfo networkInfo(String canonical) {
+        for (NetworkInfo n : NETWORKS) {
+            if (n.name().equals(canonical)) return n;
+        }
+        return NETWORKS.get(0); // mainnet — canonicalNetwork() already fell back
+    }
+
+    /**
+     * Canonicalize a network name to one the engine hosts AND that the per-network
+     * helpers (which test {@code "gnosis".equals(network)}) handle consistently.
+     * Unknown/corrupt/empty values fall back to mainnet so a bad pref can never crash
+     * node startup or silently desync the RPC-port/preset selection from the resolved
+     * chain (which is why this doesn't use {@code ENGINE.canonicalNetworkName} — that
+     * throws on unknown names).
      */
     private static String canonicalNetwork(String n) {
         if (n == null) return "mainnet";
@@ -168,11 +182,11 @@ public final class NodeService extends Service {
     public static void setNetworkEnabled(android.content.Context c, String network, boolean on) {
         prefs(c).edit().putBoolean(enabledKey(canonicalNetwork(network)), on).apply();
     }
-    /** The set of enabled networks (in {@link NetworkConfig#allNetworks} display order). Never
+    /** The set of enabled networks (in the engine catalog's display order). Never
      *  empty — falls back to mainnet so the service always has something to run. */
     public static List<String> enabledNetworks(android.content.Context c) {
         List<String> out = new ArrayList<>();
-        for (NetworkConfig nc : NetworkConfig.allNetworks()) {
+        for (NetworkInfo nc : NETWORKS) {
             if (isNetworkEnabled(c, nc.name())) out.add(nc.name());
         }
         if (out.isEmpty()) out.add("mainnet");
@@ -182,12 +196,26 @@ public final class NodeService extends Service {
     public static String primaryNetwork(android.content.Context c) {
         return enabledNetworks(c).get(0);
     }
-    /** Per-network default RPC port — delegate to {@link NetworkConfig#defaultRpcPort()} so the
-     *  defaults stay collision-free and consistent with {@code ChainPorts.defaultsFor()} (mainnet
-     *  8545, Gnosis 8546, Sepolia 8547). A NodeService-local table would silently put Sepolia on
+    /** Per-network default RPC port — from the engine's catalog so the defaults stay
+     *  collision-free and consistent with the engine's own port defaulting (mainnet 8545,
+     *  Gnosis 8546, Sepolia 8547). A NodeService-local table would silently put Sepolia on
      *  8545 and collide with mainnet's RPC bind when both run. */
     public static int defaultRpcPort(String network) {
-        return NetworkConfig.byName(canonicalNetwork(network)).defaultRpcPort();
+        return networkInfo(canonicalNetwork(network)).defaultRpcPort();
+    }
+    /** All supported networks in display order, from the engine's catalog. */
+    public static List<String> allNetworkNames() {
+        List<String> out = new ArrayList<>(NETWORKS.size());
+        for (NetworkInfo n : NETWORKS) out.add(n.name());
+        return out;
+    }
+    /** Human-facing chain name, from the engine's catalog. */
+    public static String displayName(String network) {
+        return networkInfo(canonicalNetwork(network)).displayName();
+    }
+    /** Whether ENS resolution is available on {@code network}, from the engine's catalog. */
+    public static boolean hasEns(String network) {
+        return networkInfo(canonicalNetwork(network)).hasEns();
     }
     // The RPC port is stored per network so each chain keeps an independent port — a shared key
     // would force the same URL on multiple chains, which MetaMask rejects and which collides on
@@ -279,14 +307,14 @@ public final class NodeService extends Service {
         int c = clampInt(v, 1, 128, DEFAULT_SNAP_TARGET);
         this.targetSnapPeers = c;
         setSnapTargetPref(this, c);
-        for (io.myotis.node.ChainStack s : stacks.values()) s.setTargetSnapPeers(c);
+        for (ChainHandle h : handles.values()) h.setTargetSnapPeers(c);
     }
 
     /** Currently live networks (a chip per entry), in display order. */
     public List<String> liveNetworks() {
         List<String> out = new ArrayList<>();
-        for (NetworkConfig nc : NetworkConfig.allNetworks()) {
-            if (stacks.containsKey(nc.name())) out.add(nc.name());
+        for (NetworkInfo nc : NETWORKS) {
+            if (handles.containsKey(nc.name())) out.add(nc.name());
         }
         return out;
     }
@@ -303,7 +331,7 @@ public final class NodeService extends Service {
             startForegroundService(new Intent(this, NodeService.class));
             return;
         }
-        if (stacks.containsKey(n)) return;
+        if (handles.containsKey(n)) return;
         new Thread(() -> buildAndStart(n), "ethp2p-boot-" + n).start();
     }
 
@@ -314,11 +342,10 @@ public final class NodeService extends Service {
     public void disableNetwork(String name) {
         String n = canonicalNetwork(name);
         setNetworkEnabled(this, n, false);
-        io.myotis.node.ChainStack s = stacks.get(n);
-        forgetStack(n);
+        forgetStack(n);   // drop from the UI's live map immediately
         new Thread(() -> {
             synchronized (bootLock(n)) {
-                if (s != null) { try { s.shutdown(); } catch (Throwable ignored) {} }
+                try { ENGINE.stop(n); } catch (Throwable ignored) {}
             }
             stopIfNoStacksLeft();
         }, "ethp2p-disable-" + n).start();
@@ -332,22 +359,21 @@ public final class NodeService extends Service {
     public void rebootNetwork(String name) {
         String n = canonicalNetwork(name);
         if (!RUNNING.get()) return;
-        io.myotis.node.ChainStack old = stacks.remove(n);
         // Only reboot a chain that's actually live. If it isn't (disabled / not yet built), do
         // nothing — the new port is already persisted and applies on the next enable. Without this,
         // saving settings would start a chain the user has turned off.
-        if (old == null) return;
+        if (handles.remove(n) == null) return;
         new Thread(() -> {
             synchronized (bootLock(n)) {
-                try { old.shutdown(); } catch (Throwable ignored) {}
+                try { ENGINE.stop(n); } catch (Throwable ignored) {}
             }
             buildAndStart(n);   // re-acquires bootLock(n) for its start() — frees ports first
         }, "ethp2p-reboot-" + n).start();
     }
 
-    /** Drop all NodeService-side bookkeeping for a network (the stack itself is shut down separately). */
+    /** Drop all NodeService-side bookkeeping for a network (the engine-side stop happens separately). */
     private void forgetStack(String n) {
-        stacks.remove(n);
+        handles.remove(n);
         cachedElCounts.remove(n);
         cachedClCounts.remove(n);
         elCaches.remove(n);
@@ -356,7 +382,7 @@ public final class NodeService extends Service {
 
     /** True if any network is still enabled (incl. the seeded default). */
     private boolean anyNetworkEnabled() {
-        for (NetworkConfig nc : NetworkConfig.allNetworks()) {
+        for (NetworkInfo nc : NETWORKS) {
             if (isNetworkEnabled(this, nc.name())) return true;
         }
         return false;
@@ -369,7 +395,7 @@ public final class NodeService extends Service {
      * up; without it, disabling one chain mid-boot could wrongly stop the whole service.
      */
     private void stopIfNoStacksLeft() {
-        if (stacks.isEmpty() && !anyNetworkEnabled() && RUNNING.compareAndSet(true, false)) {
+        if (handles.isEmpty() && !anyNetworkEnabled() && RUNNING.compareAndSet(true, false)) {
             LogBuffer.i(TAG, "no networks left enabled; stopping service");
             stopForeground(STOP_FOREGROUND_REMOVE);
             stopSelf();
@@ -385,38 +411,43 @@ public final class NodeService extends Service {
     }
 
 
-    // One per-network node stack (EL + discv4/5 + beacon LC + verified RPC + the snap-peer
-    // maintainer), shared with the :app daemon via :node-core. Step 9: NodeService hosts a
-    // registry of stacks so several chains run concurrently; the UI views one at a time via
-    // a chip selector. The map is the single source of truth for "what's live" — snapshot,
-    // query routing and shutdown all iterate it. Keyed by canonical network name.
-    private final Map<String, io.myotis.node.ChainStack> stacks = new ConcurrentHashMap<>();
+    // One per-network engine handle (EL + discv4/5 + beacon LC + verified RPC + the
+    // snap-peer maintainer), shared with the :app daemon via the engine API. The map is
+    // the UI's source of truth for "what's live" — snapshot, query routing and shutdown
+    // all iterate it; the engine's own registry parallels it (entries are added/removed
+    // together under the per-network bootLock). Keyed by canonical network name.
+    private final Map<String, ChainHandle> handles = new ConcurrentHashMap<>();
     // Per-network "peers loaded from cache at boot" counts, captured when a stack is built
     // (ChainStack owns the live caches via the adapters, so we read the size once here).
     private final Map<String, Integer> cachedElCounts = new ConcurrentHashMap<>();
     private final Map<String, Integer> cachedClCounts = new ConcurrentHashMap<>();
-    // The live cache instances per network (also passed into the ChainStack adapters), kept so
-    // "Clear caches" can wipe the in-memory + on-disk cache of a running chain. Removed on shutdown.
+    // The live cache instances per network (also handed to the engine via the port
+    // adapters), kept so "Clear caches" can wipe the in-memory + on-disk cache of a
+    // running chain. Removed on shutdown.
     private final Map<String, AndroidPeerCache> elCaches = new ConcurrentHashMap<>();
     private final Map<String, AndroidCLPeerCache> clCaches = new ConcurrentHashMap<>();
-    // Per-network lifecycle lock: a network's start() and shutdown() (across DIFFERENT ChainStack
-    // instances) serialize on this, so a fast Stop→Start or disable→enable of the same chain has
-    // the new instance's start() wait for the old instance's shutdown() to free its ports instead
-    // of racing into a BindException. (Per-instance synchronization inside ChainStack can't cover
-    // two different instances — this is the cross-instance equivalent of the old single bootLock.)
-    private final Map<String, Object> bootLocks = new ConcurrentHashMap<>();
-    private Object bootLock(String network) {
-        return bootLocks.computeIfAbsent(canonicalNetwork(network), k -> new Object());
+    // Per-network lifecycle lock: a network's start() and stop() serialize on this, so a
+    // fast Stop→Start or disable→enable of the same chain has the new boot wait for the old
+    // teardown to free its ports AND unregister from the engine (create() throws on a
+    // still-hosted network). STATIC, matching ENGINE and RUNNING: the engine registry
+    // outlives a service instance, so a recreated service's boot must serialize against the
+    // PREVIOUS instance's teardown thread — instance-scoped locks would let them interleave.
+    private static final Map<String, Object> BOOT_LOCKS = new ConcurrentHashMap<>();
+    private static Object bootLock(String network) {
+        return BOOT_LOCKS.computeIfAbsent(canonicalNetwork(network), k -> new Object());
     }
 
     // Service-global uptime stamp (the whole service, not a single chain). Owned by the
     // next start; never cleared in doShutdown — see the PR #82 note there.
     private volatile long startTimeMs;
 
-    // CCIP-Read gateway HTTP is blocking; keep it off the single EVM thread.
-    private final java.util.concurrent.ExecutorService ccipPool =
-            java.util.concurrent.Executors.newCachedThreadPool(r -> {
-                Thread t = new Thread(r, "android-ccip");
+    // Runs the BLOCKING engine-API calls (requestAccount, ens().resolveAddress) off the
+    // caller's thread — the service's public surface stays CompletableFuture-based for
+    // the Kotlin bridge, so the blocking API call is wrapped here. Static daemon pool:
+    // queries may outlive a service instance teardown harmlessly.
+    private static final ExecutorService QUERY_POOL =
+            Executors.newCachedThreadPool(r -> {
+                Thread t = new Thread(r, "android-engine-query");
                 t.setDaemon(true);
                 return t;
             });
@@ -467,7 +498,7 @@ public final class NodeService extends Service {
             // The readiness traffic-light's green gate: a recent head means wallet
             // calls serve instead of hitting "no verified head".
             long verifiedHeadAgeMs,
-            List<RLPxConnector.PeerInfo> readyPeerList,
+            List<io.myotis.api.PeerInfo> readyPeerList,
             String network) {}            // active chain ("mainnet"/"gnosis")
 
     /** Result of a get-account query. Mirrors the JVM daemon's JSON response shape. */
@@ -511,7 +542,7 @@ public final class NodeService extends Service {
      *       trails finalized + a few recent optimistic slots.</li>
      *   <li><b>stateRootMatch</b> (fast-path shortcut) — if the peer's
      *       reported stateRoot happens to be one the BLC has already
-     *       attested ({@link BeaconSyncState#findStateRoot}), skip the
+     *       attested ({@code BeaconSyncState.findStateRoot}), skip the
      *       header fetch entirely. Rare in practice: only fires when the
      *       peer's head briefly aligns with a slot the BLC has just seen.</li>
      * </ul>
@@ -530,12 +561,17 @@ public final class NodeService extends Service {
     }
 
     public CompletableFuture<AccountQueryResult> requestAccount(String network, String hexAddress) {
-        io.myotis.node.ChainStack stack = stacks.get(canonicalNetwork(network));
-        return io.myotis.node.VerifiedAccountQuery.query(stack, hexAddress)
-                .thenApply(NodeService::toAccountQueryResult);
+        ChainHandle handle = handles.get(canonicalNetwork(network));
+        if (handle == null) {
+            return CompletableFuture.failedFuture(new IllegalStateException("Node is not running"));
+        }
+        // The engine call is blocking (snap fetch + verification ladder, internally
+        // timeout-bounded) — run it on the query pool and expose the future the UI expects.
+        return CompletableFuture.supplyAsync(
+                () -> toAccountQueryResult(handle.requestAccount(hexAddress)), QUERY_POOL);
     }
 
-    private static AccountQueryResult toAccountQueryResult(io.myotis.node.VerifiedAccountQuery.Result r) {
+    private static AccountQueryResult toAccountQueryResult(AccountProofResult r) {
         return new AccountQueryResult(
                 r.address(), r.exists(), r.nonce(), r.balanceWei(),
                 r.storageRootHex(), r.codeHashHex(), r.blockNumber(),
@@ -586,19 +622,18 @@ public final class NodeService extends Service {
                                 boolean beaconVerified, String error) {}
 
     /**
-     * Which state ENS resolution runs against. Defaults to the beacon-verified
-     * finalized root so resolved mappings are verified end-to-end; switch to
-     * {@link io.myotis.ens.EnsResolutionRoot#PEER_HEAD} for freshest (unverified)
-     * data. Library consumers can override via {@link #setEnsResolutionRoot}.
+     * Which state ENS resolution runs against. Defaults to AUTO (beacon-verified
+     * finalized root first, peer-head fallback); switch to {@link EnsRoot#PEER_HEAD}
+     * for freshest (unverified) data. Library consumers can override via
+     * {@link #setEnsResolutionRoot}.
      */
-    private volatile io.myotis.ens.EnsResolutionRoot ensResolutionRoot =
-            io.myotis.ens.EnsResolutionRoot.AUTO;
+    private volatile EnsRoot ensResolutionRoot = EnsRoot.AUTO;
 
-    public void setEnsResolutionRoot(io.myotis.ens.EnsResolutionRoot root) {
+    public void setEnsResolutionRoot(EnsRoot root) {
         if (root != null) this.ensResolutionRoot = root;
     }
 
-    public io.myotis.ens.EnsResolutionRoot getEnsResolutionRoot() {
+    public EnsRoot getEnsResolutionRoot() {
         return ensResolutionRoot;
     }
 
@@ -618,30 +653,32 @@ public final class NodeService extends Service {
         return resolveEns(primaryNetwork(this), name);
     }
 
-    @SuppressLint("NewApi") // CompletableFuture.orTimeout — see requestAccount
+    @SuppressLint("NewApi") // CompletableFuture.failedFuture — see requestAccount
     public CompletableFuture<EnsResolution> resolveEns(String network, String name) {
         final String trimmed = name == null ? "" : name.trim();
         final String n = canonicalNetwork(network);
-        // ENS is mainnet/Sepolia-only — Gnosis has no canonical registry (EnsResolver
-        // .forChainId throws for chainId 100). Refuse early so we never run ENS contracts
-        // against a chain that can't have them; the UI also hides the ENS path there.
-        if (!NetworkConfig.byName(n).hasEns()) {
+        // ENS is mainnet/Sepolia-only — refuse early so we never run ENS contracts against
+        // a chain that can't have them; the UI also hides the ENS path there.
+        if (!networkInfo(n).hasEns()) {
             return CompletableFuture.completedFuture(new EnsResolution(
                     trimmed, null, -1, false, "ENS is not available on " + n));
         }
-        // Delegate to the shared backend — the AUTO → FINALIZED → PEER_HEAD policy,
-        // snap-heavy pause, and CCIP handling all live there now (one impl for daemon
-        // + Android). Map its neutral io.myotis.rpc.EnsResolution back to the public
-        // NodeService.EnsResolution the UI (MainActivity) consumes.
-        io.myotis.node.ChainStack stack = stacks.get(n);
-        io.myotis.rpc.VerifiedRpcBackend b = stack != null ? stack.rpcBackend() : null;
-        if (!RUNNING.get() || b == null) {
+        ChainHandle handle = handles.get(n);
+        io.myotis.api.EnsApi ens = handle != null ? handle.ens() : null;
+        if (!RUNNING.get() || ens == null) {
             return CompletableFuture.completedFuture(
                     new EnsResolution(trimmed, null, -1, false, "node not running on " + n));
         }
-        return b.resolveEns(trimmed, ensResolutionRoot)
-                .thenApply(r -> new EnsResolution(
-                        r.name(), r.addressHex(), r.blockNumber(), r.verified(), r.error()));
+        // Delegate to the engine's shared resolution machinery (one AUTO → FINALIZED →
+        // PEER_HEAD policy for daemon + desktop + Android). The engine call is blocking —
+        // run on the query pool; NOTE the API's no-record convention: addressHex==null
+        // with error==null is a successful "name has no record".
+        final EnsRoot root = ensResolutionRoot;
+        return CompletableFuture.supplyAsync(() -> {
+            EnsResolutionResult r = ens.resolveAddress(trimmed, root);
+            return new EnsResolution(r.name(), r.addressHex(), r.blockNumber(),
+                    r.verified(), r.error());
+        }, QUERY_POOL);
     }
 
 
@@ -712,38 +749,25 @@ public final class NodeService extends Service {
     }
 
     /**
-     * Build and start one network's {@link io.myotis.node.ChainStack}, register it in
-     * {@link #stacks}, and capture its boot-time cached-peer counts. ChainStack owns
+     * Build and start one network's engine stack, register its handle in
+     * {@link #handles}, and capture its boot-time cached-peer counts. The engine owns
      * discv4/discv5/beacon/RPC + the snap-peer maintainer and serializes start()/shutdown()
      * internally, so a fast disable→enable (or rebootNetwork) of the same chain waits for
      * its own ports to free. Stops the service only if the very last stack fails to come up.
      */
     private void buildAndStart(String netName) {
         String n = canonicalNetwork(netName);
-        io.myotis.node.ChainStack s = null;
         try {
-            NetworkConfig network = NetworkConfig.byName(n);
             int rpcPort = rpcPortFor(this, n);
-            // VerifiedRpcBackend (built inside ChainStack.start() below) reads its state-read
-            // freshness mode from this process-wide property; mirror the user's Settings choice
-            // into it before the stack builds. Process-global, shared across all stacks.
-            System.setProperty(io.myotis.rpc.VerifiedRpcBackend.STRICT_STATE_FRESHNESS_PROP,
-                    String.valueOf(strictStateFreshness(this)));
             // Mirror the native-BLS toggle into the process-wide BlsBackends selection (set the
             // property + select() the backend). The Settings switch also applies it live on
-            // toggle; re-applying here keeps a freshly (re)started stack consistent.
+            // toggle; re-applying here keeps a freshly (re)started stack consistent. (This is
+            // an internal engine seam, not part of the api — deliberate.)
             String blsChoice = applyBlsBackend(this);
             LogBuffer.i(TAG, "[" + n + "] booting (snap target " + snapTarget(this)
                     + ", rpc port " + rpcPort
                     + ", state-freshness " + (strictStateFreshness(this) ? "strict" : "relaxed")
                     + ", bls " + blsChoice + ")");
-
-            // Identity: legacy mainnet keeps nodekey.hex; other chains get a per-network key
-            // so two chains in one process never share an identity.
-            Path keyFile = new java.io.File(getFilesDir(),
-                    n.equals("mainnet") ? "nodekey.hex" : "nodekey-" + n + ".hex").toPath();
-            NodeKey nodeKey = NodeKey.loadOrGenerate(keyFile);
-            LogBuffer.i(TAG, "[" + n + "] node ID " + nodeKey.nodeId().toHexString());
 
             // Reconstructible network state lives in getCacheDir() so "Clear cache" wipes the
             // peer caches + sync snapshot while identity / query history in getFilesDir() survive.
@@ -754,60 +778,105 @@ public final class NodeService extends Service {
             elCaches.put(n, pc);
             clCaches.put(n, cl);
 
-            // Per-network default EL/discv5 ports (gnosis 30304/9001, sepolia 30305/9002) keep
-            // stacks from colliding; the RPC port is the user-configurable one. ChainStack owns
-            // discv4/discv5/beacon/RPC and the snap-peer maintainer (shared :node-core lifecycle).
-            io.myotis.node.ChainPorts ports =
-                    io.myotis.node.ChainPorts.defaultsFor(network).withRpcPort(rpcPort);
-            s = new io.myotis.node.ChainStack(
-                    network, ports, nodeKey,
+            // EL/discv5 ports use the engine's per-network defaults (0); the RPC port is the
+            // user-configurable one. The snap maintainer keeps snap peers topped up (the
+            // discv4-independent path NAT'd mobile needs); Android supplies the active
+            // network's DNS servers for EIP-1459 resolution.
+            EngineConfig config = new EngineConfig(
+                    n, 0, 0, rpcPort,
+                    netCacheFor(n, "sync-state", ".snapshot").getAbsolutePath(),
+                    /*gossipsub*/ false,
+                    snapTarget(this),
+                    strictStateFreshness(this));
+            EnginePorts ports = new EnginePorts(
+                    // Identity: legacy mainnet keeps nodekey.hex; other chains get a
+                    // per-network key so two chains never share an identity.
+                    new AndroidNodeKeyStore(getFilesDir()),
                     new AndroidPeerCacheAdapter(pc),
                     new AndroidClPeerCacheAdapter(cl),
-                    new com.jaeckel.ethp2p.android.ens.AndroidCcipGateway(ccipPool),
-                    netCacheFor(n, "sync-state", ".snapshot").toPath(),
-                    /*gossipsub*/ false);
-            // Keep snap peers topped up (the discv4-independent path NAT'd mobile needs);
-            // Android supplies the active network's DNS servers for EIP-1459 resolution.
-            s.configureSnapMaintainer(snapTarget(this), this::activeNetworkDnsServers);
-            // Publish into the registry before start() so a concurrent shutdown()/disable can
-            // find and tear it down.
-            stacks.put(n, s);
+                    this::activeNetworkDnsServers,
+                    new com.jaeckel.ethp2p.android.ens.AndroidCcipGateway(),
+                    null, null); // engine default logger/clock
 
-            // Serialize start() against this network's teardown (bootLock) so a Stop→Start /
-            // disable→enable has this new instance's start() wait for the old instance's
-            // shutdown() to free the ports. A whole-service Stop (RUNNING=false) or a per-network
-            // disableNetwork(n) (sets enabled_<n>=false before tearing down) could race this boot,
-            // so bail if either says the chain is no longer wanted — re-checked after start() too,
+            // create() + start() under the per-network bootLock: a Stop→Start / disable→enable
+            // has this boot wait for the old instance's teardown (which holds the same lock) to
+            // free the ports AND unregister from the engine (create() throws on a still-hosted
+            // network). A whole-service Stop or a per-network disable could race this boot, so
+            // bail if either says the chain is no longer wanted — re-checked after start() too,
             // since start() blocks and the race window spans it.
             synchronized (bootLock(n)) {
                 if (!RUNNING.get() || !isNetworkEnabled(this, n)) {
-                    LogBuffer.i(TAG, "[" + n + "] stop/disable raced boot; tearing down constructed stack");
+                    LogBuffer.i(TAG, "[" + n + "] stop/disable raced boot; skipping");
                     forgetStack(n);
-                    s.shutdown();
                     stopIfNoStacksLeft();
                     return;
                 }
-                if (!s.start()) {
+                if (ENGINE.get(n) != null) {
+                    // Already hosted: a genuine double-enable, or a teardown we raced won the
+                    // lock first and hasn't unregistered yet (it holds this lock, so by the
+                    // time we're here it HAS — this branch is then a plain double-enable).
+                    // Log it so an enabled-but-dead chain is diagnosable, and make the UI map
+                    // consistent with the engine either way.
+                    LogBuffer.i(TAG, "[" + n + "] boot skipped: already hosted by the engine");
+                    ChainHandle existing = ENGINE.get(n);
+                    if (existing != null) handles.putIfAbsent(n, existing);
+                    return;
+                }
+                ChainHandle handle = ENGINE.create(config, ports);
+                handles.put(n, handle);
+                if (!handle.start()) {
                     LogBuffer.e(TAG, "[" + n + "] node stack failed to start");
                     forgetStack(n);
+                    try { ENGINE.stop(n); } catch (Throwable ignored) {}
                     stopIfNoStacksLeft();
                     return;
                 }
                 if (!RUNNING.get() || !isNetworkEnabled(this, n)) {
                     LogBuffer.i(TAG, "[" + n + "] stop/disable raced start; tearing down");
                     forgetStack(n);
-                    s.shutdown();
+                    try { ENGINE.stop(n); } catch (Throwable ignored) {}
                     stopIfNoStacksLeft();
                     return;
                 }
             }
-            LogBuffer.i(TAG, "[" + n + "] node stack started (EL " + ports.elPort()
-                    + ", RPC " + ports.rpcPort() + ")");
+            LogBuffer.i(TAG, "[" + n + "] node stack started (RPC " + rpcPort + ")");
         } catch (Exception e) {
             LogBuffer.e(TAG, "[" + n + "] node boot failed", e);
-            if (s != null) { try { s.shutdown(); } catch (Throwable ignored) {} }
             forgetStack(n);
+            try { ENGINE.stop(n); } catch (Throwable ignored) {}
             stopIfNoStacksLeft();
+        }
+    }
+
+    /** Node-identity storage over getFilesDir(): one hex file per network, byte-compatible
+     *  with the files NodeKey.loadOrGenerate has always written (identities carry over). */
+    private static final class AndroidNodeKeyStore implements NodeKeyStore {
+        private final java.io.File filesDir;
+        AndroidNodeKeyStore(java.io.File filesDir) { this.filesDir = filesDir; }
+        private Path fileFor(String network) {
+            return new java.io.File(filesDir,
+                    network.equals("mainnet") ? "nodekey.hex" : "nodekey-" + network + ".hex").toPath();
+        }
+        @Override public byte[] load(String networkName) {
+            Path file = fileFor(networkName);
+            if (!Files.exists(file)) return null;
+            try {
+                String hex = new String(Files.readAllBytes(file),
+                        java.nio.charset.StandardCharsets.UTF_8).strip();
+                if (hex.startsWith("0x") || hex.startsWith("0X")) hex = hex.substring(2);
+                return HexFormat.of().parseHex(hex);
+            } catch (Exception e) {
+                throw new RuntimeException("failed to read node key " + file + ": " + e.getMessage(), e);
+            }
+        }
+        @Override public void store(String networkName, byte[] secret32) {
+            Path file = fileFor(networkName);
+            try {
+                Files.write(file, ("0x" + HexFormat.of().formatHex(secret32))
+                        .getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            } catch (Exception e) {
+                throw new RuntimeException("failed to write node key " + file + ": " + e.getMessage(), e);
+            }
         }
     }
 
@@ -843,18 +912,17 @@ public final class NodeService extends Service {
      * with bind-in-use.
      */
     private synchronized void doShutdown() {
-        // Shut down and drop every stack. Each ChainStack owns its own close order
-        // (RPC server + backend, beacon LC, connector, discv4/5, peer caches) and
-        // serializes start()/shutdown() internally, so the next start() of the same
-        // chain waits for its ports to free.
-        for (Map.Entry<String, io.myotis.node.ChainStack> e : stacks.entrySet()) {
+        // Stop and drop every network. Iterate the ENGINE's registry (not this instance's
+        // mirror map): with a process-global engine, "stop everything" must be scoped to
+        // what the engine actually hosts, or a handles/engine divergence would leak a stack.
+        for (String n : ENGINE.hostedNetworks()) {
             // Hold the per-network lock so a racing buildAndStart for the same chain can't start a
             // new instance while we're tearing the old one down (would race for the same ports).
-            synchronized (bootLock(e.getKey())) {
-                try { e.getValue().shutdown(); } catch (Throwable ignored) {}
+            synchronized (bootLock(n)) {
+                try { ENGINE.stop(n); } catch (Throwable ignored) {}
             }
         }
-        stacks.clear();
+        handles.clear();
         cachedElCounts.clear();
         cachedClCounts.clear();
         elCaches.clear();
@@ -887,10 +955,10 @@ public final class NodeService extends Service {
     }
 
     private void doClearCaches(String n) {
-        // Backoff/blacklist live in the stack; clear them there so "Clear caches" gives
-        // discovery a fresh slate (the on-disk peer caches are wiped below).
-        io.myotis.node.ChainStack s = stacks.get(n);
-        if (s != null) { s.backoff().clear(); s.blacklistedNodeIds().clear(); }
+        // Backoff/blacklist live in the engine; clear them through the API so "Clear caches"
+        // gives discovery a fresh slate (the on-disk peer caches are wiped below).
+        ChainHandle h = handles.get(n);
+        if (h != null) { try { h.clearPeerState(); } catch (Throwable ignored) {} }
         cachedElCounts.put(n, 0);
         cachedClCounts.put(n, 0);
         // Clear the live cache instance when the chain is up (also wipes the file); when it's
@@ -938,8 +1006,8 @@ public final class NodeService extends Service {
     public Map<String, Snapshot> snapshots() {
         Map<String, Snapshot> out = new java.util.LinkedHashMap<>();
         for (String n : liveNetworks()) {
-            io.myotis.node.ChainStack s = stacks.get(n);
-            if (s != null) out.put(n, snapshotOf(n, s));
+            ChainHandle h = handles.get(n);
+            if (h != null) out.put(n, snapshotOf(n, h));
         }
         return out;
     }
@@ -947,105 +1015,43 @@ public final class NodeService extends Service {
     /** Back-compat: snapshot of the primary enabled network (null when nothing is live). */
     public Snapshot snapshot() {
         String n = primaryNetwork(this);
-        io.myotis.node.ChainStack s = stacks.get(n);
-        return s != null ? snapshotOf(n, s) : null;
+        ChainHandle h = handles.get(n);
+        return h != null ? snapshotOf(n, h) : null;
     }
 
-    /** Build the UI snapshot for one network from its stack's getters. Tolerates a stack
-     *  mid-boot (null connector/discv5/beacon) — those read as zeros / STOPPED. */
-    private Snapshot snapshotOf(String network, io.myotis.node.ChainStack s) {
+    /** Build the UI snapshot for one network from the engine's status surfaces. Tolerates a
+     *  stack mid-boot — the engine reads those as zeros / STARTING (mapped to STOPPED here,
+     *  the string this UI has always shown pre-beacon). */
+    private Snapshot snapshotOf(String network, ChainHandle h) {
         boolean running = RUNNING.get();
-        int attemptedN = s.attemptedCount();
-        // Active backoff count, pruning expired entries as we go — backoff().size() alone would
-        // count stale (expired) entries and let the map grow unbounded over long uptimes, since
-        // the dial path only drops an entry when that peer is re-encountered.
-        int backoffN = s.pruneAndCountActiveBackoff();
-        int blacklistedN = s.blacklistedNodeIds().size();
-        DiscV5Service discV5 = s.discV5();
-        int discv5Live = discV5 != null ? discV5.liveNodeCount() : 0;
+        StatusSnapshot s = h.status();
+        BeaconStatus bs = h.beaconStatus();
         int cachedEl = cachedElCounts.getOrDefault(network, 0);
         int cachedCl = cachedClCounts.getOrDefault(network, 0);
-        BeaconStats bs = beaconStatsSnapshot(s);
-        RLPxConnector connector = s.connector();
-        if (!running || connector == null) {
+        String beaconState = bs.state() == BeaconState.STARTING ? "STOPPED" : bs.state().name();
+        // Catch-up progress: preserve the historical -1-until-known convention (the engine
+        // API defaults these to 0 pre-beacon) for the UI's determinate progress bar.
+        boolean preBeacon = bs.state() == BeaconState.STARTING;
+        long syncCurrent = preBeacon ? -1 : s.syncCurrentPeriod();
+        long syncTarget = preBeacon ? -1 : s.syncTargetPeriod();
+        if (!running || !s.running()) {
             return new Snapshot(running, startTimeMs, 0, 0, 0, 0, /*snapServing*/0,
-                    cachedEl, attemptedN, backoffN,
-                    blacklistedN, discv5Live, 0,
-                    bs.state, bs.bootstrapped, bs.connected, bs.lc,
-                    cachedCl, bs.finalizedSlot, bs.execBlockNum, bs.execBlockHashHex,
-                    bs.syncStartPeriod, bs.syncCurrentPeriod, bs.syncTargetPeriod,
+                    cachedEl, s.attemptedDials(), s.backedOffPeers(),
+                    s.blacklistedPeers(), s.discv5TableSize(), 0,
+                    beaconState, bs.bootstrapped(), bs.connectedPeers(), (int) bs.lightClientPeers(),
+                    cachedCl, bs.finalizedSlot(), bs.executionBlockNumber(), bs.executionBlockHashHex(),
+                    s.syncStartPeriod(), syncCurrent, syncTarget,
                     Long.MAX_VALUE, List.of(), network);
         }
-        List<RLPxConnector.PeerInfo> active = connector.getActivePeers();
-        List<RLPxConnector.PeerInfo> ready = new ArrayList<>();
-        int snapCount = 0;
-        for (RLPxConnector.PeerInfo p : active) {
-            if ("READY".equals(p.state())) {
-                ready.add(p);
-                if (p.snapSupported()) snapCount++;
-            }
-        }
-        // snap peers first, then by clientId. Mirrors peers.sh.
-        ready.sort(Comparator
-                .comparing(RLPxConnector.PeerInfo::snapSupported).reversed()
-                .thenComparing(p -> p.clientId() == null ? "" : p.clientId()));
-        DiscV4Service discV4 = s.discV4();
-        int tableSize = discV4 != null ? discV4.table().size() : 0;
-        io.myotis.rpc.VerifiedRpcBackend backend = s.rpcBackend();
-        long headAge = backend != null ? backend.verifiedHeadAgeMs() : Long.MAX_VALUE;
-        // Serving pool = what head builds / heavy confirm screens actually use (filters out
-        // peers benched by snapServingFailed). Distinct from snapCount (negotiated) — surfacing
-        // it makes a serving-pool collapse visible instead of hidden behind the headline count.
-        int snapServing = connector.activeSnapHandlers().size();
-        return new Snapshot(true, startTimeMs, tableSize, active.size(), ready.size(), snapCount, snapServing,
-                cachedEl, attemptedN, backoffN,
-                blacklistedN, discv5Live, 0,
-                bs.state, bs.bootstrapped, bs.connected, bs.lc,
-                cachedCl, bs.finalizedSlot, bs.execBlockNum, bs.execBlockHashHex,
-                bs.syncStartPeriod, bs.syncCurrentPeriod, bs.syncTargetPeriod,
-                headAge, ready, network);
-    }
-
-    /** Per-snapshot beacon view, computed once so the record fields stay consistent. */
-    private record BeaconStats(String state, boolean bootstrapped, int connected, int lc,
-                               long finalizedSlot, long execBlockNum, String execBlockHashHex,
-                               // Sync-committee-period catch-up progress (all -1 until known):
-                               // start = period catch-up began from, current = period the store
-                               // holds now, target = wall-clock period. Lets the UI draw a
-                               // determinate progress bar during CATCHING_UP.
-                               long syncStartPeriod, long syncCurrentPeriod, long syncTargetPeriod) {}
-
-    private BeaconStats beaconStatsSnapshot(io.myotis.node.ChainStack s) {
-        BeaconLightClient blc = s.beaconLightClient();
-        BeaconSyncState bss = s.beaconSyncState();
-        // Genesis time is a constant of the network config (no async publish to race), so the
-        // STARTING guard the single-stack code needed no longer applies; still treat blc/bss
-        // not-yet-wired as STOPPED. Network slot time (Gnosis is 5s, not 12) drives the
-        // wall-clock period; without it the CATCHING_UP/SYNCED classification is wrong.
-        long genesis = s.network().clGenesisTime();
-        int secondsPerSlot = s.network().secondsPerSlot();
-        if (blc == null || bss == null || genesis <= 0L) {
-            return new BeaconStats("STOPPED", false, 0, 0, 0L, 0L, null, -1, -1, -1);
-        }
-        List<BeaconP2PService.PeerInfo> peers = blc.getConnectedPeers();
-        int lc = 0;
-        for (BeaconP2PService.PeerInfo p : peers) {
-            if (p.supportsLightClient()) lc++;
-        }
-        byte[] execHash = bss.getExecutionBlockHash();
-        String execHashHex = execHash == null ? null
-                : org.apache.tuweni.bytes.Bytes.wrap(execHash).toHexString();
-        return new BeaconStats(
-                bss.getSyncState(genesis, secondsPerSlot).name(),
-                blc.isBootstrapped(),
-                peers.size(),
-                lc,
-                bss.getFinalizedSlot(),
-                bss.getExecutionBlockNumber(),
-                execHashHex,
-                bss.getCatchUpStartPeriod(),
-                bss.getCurrentSyncCommitteePeriod(),
-                com.jaeckel.ethp2p.consensus.lightclient.BeaconChainSpec.currentPeriod(genesis, secondsPerSlot));
+        return new Snapshot(true, startTimeMs,
+                s.discoveredPeers(), s.connectedPeers(), s.readyPeers(),
+                s.snapPeers(), s.snapServingPeers(),
+                cachedEl, s.attemptedDials(), s.backedOffPeers(),
+                s.blacklistedPeers(), s.discv5TableSize(), 0,
+                beaconState, bs.bootstrapped(), bs.connectedPeers(), (int) bs.lightClientPeers(),
+                cachedCl, bs.finalizedSlot(), bs.executionBlockNumber(), bs.executionBlockHashHex(),
+                s.syncStartPeriod(), syncCurrent, syncTarget,
+                s.verifiedHeadAgeMs(), s.readyPeerList(), network);
     }
 
     @Override
@@ -1057,7 +1063,6 @@ public final class NodeService extends Service {
         // tears every stack down under each network's bootLock, so a subsequent
         // service start can't race with a half-finished close.
         RUNNING.set(false);
-        ccipPool.shutdownNow();
         new Thread(this::doShutdown, "ethp2p-shutdown").start();
         super.onDestroy();
     }

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -757,6 +757,7 @@ public final class NodeService extends Service {
      */
     private void buildAndStart(String netName) {
         String n = canonicalNetwork(netName);
+        ChainHandle created = null;
         try {
             int rpcPort = rpcPortFor(this, n);
             // Mirror the native-BLS toggle into the process-wide BlsBackends selection (set the
@@ -823,6 +824,7 @@ public final class NodeService extends Service {
                     return;
                 }
                 ChainHandle handle = ENGINE.create(config, ports);
+                created = handle;
                 handles.put(n, handle);
                 if (!handle.start()) {
                     LogBuffer.e(TAG, "[" + n + "] node stack failed to start");
@@ -843,7 +845,17 @@ public final class NodeService extends Service {
         } catch (Exception e) {
             LogBuffer.e(TAG, "[" + n + "] node boot failed", e);
             forgetStack(n);
-            try { ENGINE.stop(n); } catch (Throwable ignored) {}
+            // Tear down only the instance THIS boot created, under the lock, and only
+            // while it is still the registered one — after we dropped the lock a racing
+            // enable may have registered a fresh healthy instance that must not be
+            // stopped by our failure cleanup.
+            if (created != null) {
+                synchronized (bootLock(n)) {
+                    if (ENGINE.get(n) == created) {
+                        try { ENGINE.stop(n); } catch (Throwable ignored) {}
+                    }
+                }
+            }
             stopIfNoStacksLeft();
         }
     }

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/cmp/AndroidNodeBridge.kt
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/cmp/AndroidNodeBridge.kt
@@ -6,7 +6,6 @@ import android.net.Network
 import android.net.NetworkCapabilities
 import com.jaeckel.ethp2p.android.AndroidQueryHistory
 import com.jaeckel.ethp2p.android.NodeService
-import com.jaeckel.ethp2p.networking.NetworkConfig
 import io.myotis.ui.AccountResult
 import io.myotis.ui.EnsResult
 import io.myotis.ui.NetworkStatus
@@ -152,7 +151,7 @@ private fun NodeService.Snapshot.toModel(): NodeSnapshot = NodeSnapshot(
 class AndroidSettings(private val ctx: Context) : Settings {
     override fun enabledNetworks(): List<String> = NodeService.enabledNetworks(ctx)
     override fun primaryNetwork(): String = NodeService.primaryNetwork(ctx)
-    override fun allNetworks(): List<String> = NetworkConfig.allNetworks().map { it.name() }
+    override fun allNetworks(): List<String> = NodeService.allNetworkNames()
     override fun isNetworkEnabled(name: String): Boolean = NodeService.isNetworkEnabled(ctx, name)
     override fun setNetworkEnabled(name: String, on: Boolean) = NodeService.setNetworkEnabled(ctx, name, on)
     override fun rpcPortFor(network: String): Int = NodeService.rpcPortFor(ctx, network)
@@ -160,9 +159,9 @@ class AndroidSettings(private val ctx: Context) : Settings {
     override fun snapTarget(): Int = NodeService.snapTarget(ctx)
     override fun setSnapTarget(v: Int) = NodeService.setSnapTargetPref(ctx, v)
 
-    override fun displayName(network: String): String = NetworkConfig.byName(network).displayName()
-    override fun defaultRpcPort(network: String): Int = NetworkConfig.byName(network).defaultRpcPort()
-    override fun hasEns(network: String): Boolean = NetworkConfig.byName(network).hasEns()
+    override fun displayName(network: String): String = NodeService.displayName(network)
+    override fun defaultRpcPort(network: String): Int = NodeService.defaultRpcPort(network)
+    override fun hasEns(network: String): Boolean = NodeService.hasEns(network)
 
     override fun deepPoolThreshold(): Int = NodeService.deepPoolThreshold(ctx)
     override fun setDeepPool(v: Int) = NodeService.setDeepPoolThreshold(ctx, v)

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/ens/AndroidCcipGateway.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/ens/AndroidCcipGateway.java
@@ -1,6 +1,6 @@
 package com.jaeckel.ethp2p.android.ens;
 
-import io.myotis.evm.ccipread.CcipGateway;
+import io.myotis.api.ports.HttpGateway;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -9,90 +9,64 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
 
 /**
- * CCIP-Read ({@link CcipGateway}) transport for Android, backed by
- * {@link HttpURLConnection}.
+ * CCIP-Read transport for Android — the engine API's {@link HttpGateway} port, backed
+ * by {@link HttpURLConnection}.
  *
- * <p>The JVM daemon uses a {@code java.net.http.HttpClient} gateway, but that
- * API is unavailable on Android below API 33 and is not covered by
- * {@code coreLibraryDesugaring} — at minSdk 29 it would {@code NoClassDefFound}
- * at runtime. {@link HttpURLConnection} has been present since API 1.
+ * <p>The JVM daemon uses a {@code java.net.http.HttpClient} gateway, but that API is
+ * unavailable on Android below API 33 and not covered by {@code coreLibraryDesugaring} —
+ * at minSdk 29 it would {@code NoClassDefFound} at runtime. {@link HttpURLConnection}
+ * has been present since API 1.
  *
- * <p>This is a legitimate outbound HTTP call, not a "data source": ERC-3668
- * gateway responses are not trusted — the resolver re-validates them via the
- * on-chain callback. So it does not violate the devp2p/libp2p-only data-source
- * rule. Calls run on the supplied {@link Executor} (off the UI thread).
+ * <p>Blocking, per the port contract: the engine calls it from its own worker threads
+ * and bridges to its internal async shape. This is a legitimate outbound HTTP call, not
+ * a "data source": ERC-3668 gateway responses are not trusted — the resolver
+ * re-validates them via the on-chain callback, so the devp2p/libp2p-only rule holds.
  */
-public final class AndroidCcipGateway implements CcipGateway {
+public final class AndroidCcipGateway implements HttpGateway {
 
     private static final int CONNECT_TIMEOUT_MS = 10_000;
     private static final int READ_TIMEOUT_MS = 15_000;
     /**
-     * Hard cap on the response body. ERC-3668 gateway responses are JSON
-     * wrapping a small ABI blob (well under 1 MB); without a cap, a malicious or
-     * misconfigured gateway could stream unbounded data into memory and OOM the
-     * app. Read defensively and abort past the limit.
+     * Hard cap on the response body. ERC-3668 gateway responses are JSON wrapping a
+     * small ABI blob (well under 1 MB); without a cap, a malicious or misconfigured
+     * gateway could stream unbounded data into memory and OOM the app.
      */
     private static final int MAX_RESPONSE_BYTES = 1_048_576; // 1 MiB
 
-    private final Executor executor;
-
-    public AndroidCcipGateway(Executor executor) {
-        this.executor = executor;
-    }
-
     @Override
-    public CompletableFuture<String> request(Method method, String url, String body) {
-        CompletableFuture<String> result = new CompletableFuture<>();
-        // executor.execute can throw RejectedExecutionException synchronously if
-        // the pool was shut down (service onDestroy). Complete the future
-        // exceptionally rather than letting it propagate and leave the caller's
-        // future hanging until the ENS timeout.
+    public String request(Method method, String url, String bodyOrNull) {
+        HttpURLConnection conn = null;
         try {
-            executor.execute(() -> requestBlocking(method, url, body, result));
-        } catch (RuntimeException e) {
-            result.completeExceptionally(e);
-        }
-        return result;
-    }
-
-    private static void requestBlocking(
-            Method method, String url, String body, CompletableFuture<String> result) {
-            HttpURLConnection conn = null;
-            try {
-                conn = (HttpURLConnection) new URL(url).openConnection();
-                conn.setConnectTimeout(CONNECT_TIMEOUT_MS);
-                conn.setReadTimeout(READ_TIMEOUT_MS);
-                if (method == Method.POST) {
-                    conn.setRequestMethod("POST");
-                    conn.setDoOutput(true);
-                    conn.setRequestProperty("Content-Type", "application/json");
-                    byte[] payload = (body == null ? "" : body).getBytes(StandardCharsets.UTF_8);
-                    try (OutputStream os = conn.getOutputStream()) {
-                        os.write(payload);
-                    }
-                } else {
-                    conn.setRequestMethod("GET");
+            conn = (HttpURLConnection) new URL(url).openConnection();
+            conn.setConnectTimeout(CONNECT_TIMEOUT_MS);
+            conn.setReadTimeout(READ_TIMEOUT_MS);
+            if (method == Method.POST) {
+                conn.setRequestMethod("POST");
+                conn.setDoOutput(true);
+                conn.setRequestProperty("Content-Type", "application/json");
+                byte[] payload = (bodyOrNull == null ? "" : bodyOrNull).getBytes(StandardCharsets.UTF_8);
+                try (OutputStream os = conn.getOutputStream()) {
+                    os.write(payload);
                 }
-                int status = conn.getResponseCode();
-                if (status >= 200 && status < 300) {
-                    // Close the stream explicitly (don't rely on disconnect()) so the
-                    // underlying socket can be released back for connection reuse.
-                    try (InputStream in = conn.getInputStream()) {
-                        result.complete(readAll(in));
-                    }
-                } else {
-                    result.completeExceptionally(
-                            new IOException("HTTP " + status + " from " + url));
-                }
-            } catch (Exception e) {
-                result.completeExceptionally(e);
-            } finally {
-                if (conn != null) conn.disconnect();
+            } else {
+                conn.setRequestMethod("GET");
             }
+            int status = conn.getResponseCode();
+            if (status >= 200 && status < 300) {
+                // Close the stream explicitly (don't rely on disconnect()) so the
+                // underlying socket can be released back for connection reuse.
+                try (InputStream in = conn.getInputStream()) {
+                    return readAll(in);
+                }
+            }
+            throw new RuntimeException("HTTP " + status + " from " + url);
+        } catch (IOException e) {
+            throw new RuntimeException("HTTP transport failure for " + url + ": " + e.getMessage(), e);
+        } finally {
+            if (conn != null) conn.disconnect();
+        }
     }
 
     private static String readAll(InputStream in) throws IOException {

--- a/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
@@ -2,17 +2,17 @@ package io.myotis.desktop
 
 import com.jaeckel.ethp2p.app.CLPeerCache
 import com.jaeckel.ethp2p.app.ClPeerCacheAdapter
+import com.jaeckel.ethp2p.app.FileNodeKeyStore
 import com.jaeckel.ethp2p.app.PeerCache
 import com.jaeckel.ethp2p.app.PeerCacheAdapter
 import com.jaeckel.ethp2p.app.rpc.JavaHttpCcipGateway
-import com.jaeckel.ethp2p.consensus.lightclient.BeaconChainSpec
-import com.jaeckel.ethp2p.core.crypto.NodeKey
-import com.jaeckel.ethp2p.networking.NetworkConfig
-import io.myotis.ens.EnsResolutionRoot
-import io.myotis.node.ChainPorts
-import io.myotis.node.ChainStack
-import io.myotis.node.NodeRegistry
-import io.myotis.node.VerifiedAccountQuery
+import io.myotis.api.ChainHandle
+import io.myotis.api.EngineConfig
+import io.myotis.api.EnsRoot
+import io.myotis.api.MyotisEngine
+import io.myotis.api.NetworkInfo
+import io.myotis.api.ports.EnginePorts
+import io.myotis.node.api.JavaMyotisEngine
 import io.myotis.ui.AccountResult
 import io.myotis.ui.EnsResult
 import io.myotis.ui.NetworkStatus
@@ -20,36 +20,35 @@ import io.myotis.ui.NodeController
 import io.myotis.ui.NodeSnapshot
 import io.myotis.ui.PeerRow
 import io.myotis.ui.Settings
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.future.await
+import kotlinx.coroutines.withContext
 import java.nio.file.Path
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.io.path.createDirectories
 
 /**
- * The Desktop actual of [NodeController]: drives the SAME Java backend (`node-core`
- * `ChainStack`/`NodeRegistry`) the daemon and Android use, in-process — no Android Service,
- * no IPC. Reuses the daemon's file-backed caches + CCIP gateway from `:app`.
+ * The Desktop actual of [NodeController]: drives the SAME engine the daemon and Android
+ * use — through the engine API ([MyotisEngine]/[ChainHandle]) only. The single concrete
+ * engine reference is the [JavaMyotisEngine] default in the constructor; everything else
+ * this host touches is `io.myotis.api`. Reuses the daemon's file-backed caches + CCIP
+ * gateway from `:app` as its port implementations.
  */
-class DesktopNodeController(private val dataDir: Path, private val settings: Settings) : NodeController {
+class DesktopNodeController(
+    private val dataDir: Path,
+    private val settings: Settings,
+    private val engine: MyotisEngine = JavaMyotisEngine(),
+) : NodeController {
 
-    private val registry = NodeRegistry()
-
-    // Runs the blocking HttpGateway port when the CCIP bridge needs a future (interim,
-    // like the PortBridges use below — gone once desktop constructs via MyotisEngine).
-    private val httpGatewayExecutor = java.util.concurrent.Executors.newCachedThreadPool { r ->
-        Thread(r, "desktop-http-gateway").apply { isDaemon = true }
-    }
     // nanoTime, not currentTimeMillis: wall-clock / NTP steps must not skew uptime.
     private val startNs = System.nanoTime()
     // Per-network boot locks keyed by CANONICAL name, mirroring Android's NodeService.bootLocks:
     // serialize enable/disable for one network without a global lock, so a slow boot of network
-    // A never blocks shutdown or lifecycle ops on B. NodeRegistry is ConcurrentHashMap-backed
-    // (each add/get/remove is already thread-safe), so these locks only guard the per-network
-    // check-then-build so two boots of the same network can't race.
+    // A never blocks shutdown or lifecycle ops on B. The engine's registry is thread-safe, so
+    // these locks only guard the per-network check-then-build so two boots can't race.
     private val bootLocks = ConcurrentHashMap<String, Any>()
     // Live per-network cache instances (keyed by canonical name), retained so clearCaches can wipe
     // the authoritative in-memory state — not just the file, which a running stack would rewrite.
@@ -61,77 +60,71 @@ class DesktopNodeController(private val dataDir: Path, private val settings: Set
         dataDir.createDirectories()
     }
 
-    // A registered stack may still be booting (or have failed start()); report running only
-    // when at least one stack is actually up, not merely present in the registry.
     override val running: Boolean
-        get() = registry.all().any { it.isRunning }
+        get() = engine.hostedNetworks().any { engine.get(it)?.isRunning == true }
 
     override fun enableNetwork(name: String) {
-        // Resolve the canonical name up front: NetworkConfig.byName aliases (xdai/gbc → gnosis,
-        // case-folds, etc.). Everything below — registry keys, the boot lock, and the key/cache
-        // filenames — must use the canonical form, or an alias would double-boot and leak (the
-        // registry keys stacks by network().name(), so a raw-alias remove() would miss).
-        val network = NetworkConfig.byName(name)
-        val canonical = network.name()
-        // All of this (key load/generate, cache init, stack.start()) does blocking disk I/O
-        // and network setup — never run it on the UI thread. Boot on a daemon thread; the
-        // per-network lock (not a global one) keeps two boots of the SAME network from racing
-        // while leaving shutdown / other networks free to proceed.
+        // Resolve the canonical name up front (xdai/gbc → gnosis, case-folds): the boot lock
+        // and the key/cache filenames must use the canonical form, or an alias would
+        // double-boot and leak.
+        val canonical = engine.canonicalNetworkName(name)
+        // All of this (key load/generate, cache init, start()) does blocking disk I/O and
+        // network setup — never on the UI thread. Boot on a daemon thread; the per-network
+        // lock keeps two boots of the SAME network from racing while leaving shutdown /
+        // other networks free to proceed.
         Thread({
             synchronized(bootLock(canonical)) {
-                if (registry.get(canonical) != null) return@synchronized
-                // Honor the configured JSON-RPC port from Settings (the Settings tab's port field),
-                // falling back to the network default — otherwise editing the port on desktop would
-                // be inert. A reboot (disable+enable) after a port change re-reads this.
-                val ports = ChainPorts.defaultsFor(network).withRpcPort(settings.rpcPortFor(canonical))
-                val keyFile = if (canonical == "mainnet") "nodekey.hex" else "nodekey-$canonical.hex"
-                val nodeKey = NodeKey.loadOrGenerate(dataDir.resolve(keyFile))
+                if (engine.get(canonical) != null) return@synchronized
                 val suffix = if (canonical == "mainnet") "" else "-$canonical"
                 val peerCache = PeerCache(dataDir.resolve("peers$suffix.cache"))
                 val clPeerCache = CLPeerCache(dataDir.resolve("cl-peers$suffix.cache"))
                 // Retain the live instances so clearCaches can wipe their in-memory state.
                 peerCaches[canonical] = peerCache
                 clPeerCaches[canonical] = clPeerCache
-                // Interim bridging (removed when desktop constructs via MyotisEngine in the
-                // host-rewiring PR): the daemon's cache adapters + HTTP gateway now implement
-                // the api port shapes; PortBridges maps them back to what ChainStack takes.
-                val stack = ChainStack(
-                    network, ports, nodeKey,
-                    io.myotis.node.api.PortBridges.toPeerCachePort(PeerCacheAdapter(peerCache)),
-                    io.myotis.node.api.PortBridges.toClPeerCachePort(ClPeerCacheAdapter(clPeerCache)),
-                    io.myotis.node.api.PortBridges.toCcipGateway(
-                        JavaHttpCcipGateway(), httpGatewayExecutor),
-                    dataDir.resolve("sync-state$suffix.snapshot"),
+                // Honor the Settings tab's JSON-RPC port + snap target + freshness toggle;
+                // EL/discv5 ports use the engine's per-network defaults (0).
+                val config = EngineConfig(
+                    canonical, 0, 0, settings.rpcPortFor(canonical),
+                    dataDir.resolve("sync-state$suffix.snapshot").toString(),
                     false,
+                    settings.snapTarget(),
+                    settings.strictStateFreshness(),
                 )
-                // Configured snap-peer target (Settings tab), not a hardcoded 32. system DNS → null.
-                stack.configureSnapMaintainer(settings.snapTarget(), null)
-                registry.add(stack)
-                // ChainStack.start() is fault-isolated: it returns false (and closes its own
-                // resources) on failure rather than throwing. Either way — false return or a
-                // stray throwable — drop the stack from the registry so a later enable can
-                // retry; leaving a dead entry would report "running" forever and block retries.
+                val ports = EnginePorts(
+                    FileNodeKeyStore { n ->
+                        dataDir.resolve(if (n == "mainnet") "nodekey.hex" else "nodekey-$n.hex")
+                    },
+                    PeerCacheAdapter(peerCache),
+                    ClPeerCacheAdapter(clPeerCache),
+                    null,                    // system DNS
+                    JavaHttpCcipGateway(),
+                    null, null,              // engine default logger/clock
+                )
+                val handle = engine.create(config, ports)
+                // start() is fault-isolated: false (resources closed) on failure rather than a
+                // throw. Either way, drop the network so a later enable can retry — leaving a
+                // dead entry would report "running" forever and block retries.
                 val ok = try {
-                    stack.start()
+                    handle.start()
                 } catch (t: Throwable) {
-                    dropStack(canonical)
+                    dropNetwork(canonical)
                     throw t
                 }
-                if (!ok) dropStack(canonical)
+                if (!ok) dropNetwork(canonical)
             }
         }, "desktop-boot-$canonical").apply { isDaemon = true }.start()
     }
 
-    /** Drop a network's registry entry and forget its retained cache instances. */
-    private fun dropStack(canonical: String) {
-        registry.remove(canonical)
+    /** Stop + unregister a network and forget its retained cache instances. */
+    private fun dropNetwork(canonical: String) {
+        engine.stop(canonical)
         peerCaches.remove(canonical)
         clPeerCaches.remove(canonical)
     }
 
     override fun disableNetwork(name: String) {
-        val canonical = NetworkConfig.byName(name).name()
-        synchronized(bootLock(canonical)) { dropStack(canonical) }
+        val canonical = engine.canonicalNetworkName(name)
+        synchronized(bootLock(canonical)) { dropNetwork(canonical) }
     }
 
     override fun rebootNetwork(name: String) {
@@ -140,47 +133,44 @@ class DesktopNodeController(private val dataDir: Path, private val settings: Set
     }
 
     override fun shutdown() {
-        // No global lock: NodeRegistry and ChainStack.shutdown() are each thread-safe, so window
-        // close tears every stack down promptly without waiting behind an in-progress boot of an
-        // unrelated network.
-        registry.shutdownAll()
-        httpGatewayExecutor.shutdown()
-        // Forget the (now-closed) cache instances so a stray post-shutdown clearCaches takes the
-        // stopped-chain purge path rather than clear()ing a closed instance.
+        // No global lock: the engine's shutdown is thread-safe, so window close tears every
+        // network down promptly without waiting behind an in-progress boot of another one.
+        engine.shutdownAll()
+        // Forget the (now-closed) cache instances so a stray post-shutdown clearCaches takes
+        // the stopped-chain purge path rather than clear()ing a closed instance.
         peerCaches.clear()
         clPeerCaches.clear()
     }
 
     override fun setTargetSnapPeers(target: Int) {
-        registry.all().forEach { it.setTargetSnapPeers(target) }
+        engine.hostedNetworks().forEach { engine.get(it)?.setTargetSnapPeers(target) }
     }
 
     override fun applyBlsBackend() {
         // No-op on desktop: there's no bundled native blst library yet (the macOS dylib is a
-        // follow-up — see the CMP plan), so desktop always runs the pure-Java Milagro backend and
-        // the Settings toggle has nothing to swap. Wire this to BlsBackends.set(...) once the
-        // native library ships for desktop.
+        // follow-up — see the CMP plan), so desktop always runs the pure-Java Milagro backend
+        // and the Settings toggle has nothing to swap.
     }
 
     override fun clearCaches(network: String) {
-        val canonical = NetworkConfig.byName(network).name()
-        // File deletes are IO — never on the Compose UI thread. Run on a daemon thread (mirrors
-        // Android's NodeService.doClearCaches offloading). Serialize with enable/disable via the
-        // per-network boot lock so "is the stack live?" and the clear/purge can't race a teardown.
+        val canonical = engine.canonicalNetworkName(network)
+        // File deletes are IO — never on the Compose UI thread. Serialize with enable/disable
+        // via the per-network boot lock so "is the chain live?" and the clear can't race a
+        // teardown.
         Thread({
             synchronized(bootLock(canonical)) {
                 val suffix = if (canonical == "mainnet") "" else "-$canonical"
-                val stack = registry.get(canonical)
-                if (stack != null) {
-                    // Chain is up: clear the LIVE instances (memory + file) so the running stack
-                    // can't rewrite the old peers back, plus the backoff/blacklist.
-                    stack.backoff().clear(); stack.blacklistedNodeIds().clear()
+                val handle = engine.get(canonical)
+                if (handle != null) {
+                    // Chain is up: clear the live dial state (backoff + session blacklist)
+                    // through the API, and the LIVE cache instances (memory + file) so the
+                    // running stack can't rewrite the old peers back.
+                    handle.clearPeerState()
                     peerCaches[canonical]?.clear() ?: PeerCache.purge(dataDir.resolve("peers$suffix.cache"))
                     clPeerCaches[canonical]?.clear() ?: CLPeerCache.purge(dataDir.resolve("cl-peers$suffix.cache"))
                 } else {
-                    // Chain stopped: any retained instance is CLOSED (its diskWriter is shut down, so
-                    // clear() would silently drop the file delete on RejectedExecutionException).
-                    // Forget the stale references and purge the on-disk files directly.
+                    // Chain stopped: any retained instance is CLOSED (clear() would silently drop
+                    // the file delete). Forget the stale references and purge the files directly.
                     peerCaches.remove(canonical)
                     clPeerCaches.remove(canonical)
                     PeerCache.purge(dataDir.resolve("peers$suffix.cache"))
@@ -191,13 +181,12 @@ class DesktopNodeController(private val dataDir: Path, private val settings: Set
     }
 
     override fun resetSyncState(network: String) {
-        val canonical = NetworkConfig.byName(network).name()
+        val canonical = engine.canonicalNetworkName(network)
         // Off the UI thread — directory scan + deletes are blocking IO.
         Thread({
             val suffix = if (canonical == "mainnet") "" else "-$canonical"
-            // Delete the persisted snapshot and any sibling parts (e.g. the ".roots" accumulator)
-            // so the next start re-bootstraps from the embedded checkpoint. A running stack keeps
-            // its in-memory state; this only affects the next start.
+            // Delete the persisted snapshot and any sibling parts (e.g. the ".roots"
+            // accumulator) so the next start re-bootstraps from the embedded checkpoint.
             java.nio.file.Files.newDirectoryStream(dataDir, "sync-state$suffix.snapshot*").use { s ->
                 s.forEach { java.nio.file.Files.deleteIfExists(it) }
             }
@@ -205,9 +194,10 @@ class DesktopNodeController(private val dataDir: Path, private val settings: Set
     }
 
     override suspend fun requestAccount(network: String, address: String): AccountResult {
-        // VerifiedAccountQuery handles a null/!running stack itself (failed future → throws).
-        val stack = registry.get(NetworkConfig.byName(network).name())
-        val r = VerifiedAccountQuery.query(stack, address).await()
+        val handle = engine.get(engine.canonicalNetworkName(network))
+            ?: throw IllegalStateException("Node is not running on $network")
+        // Blocking engine call (snap fetch + verification ladder) — worker thread.
+        val r = withContext(Dispatchers.IO) { handle.requestAccount(address) }
         return AccountResult(
             r.address(), r.exists(), r.nonce(), r.balanceWei(),
             r.storageRootHex(), r.codeHashHex(), r.blockNumber(), r.peerStateRootHex(),
@@ -217,72 +207,59 @@ class DesktopNodeController(private val dataDir: Path, private val settings: Set
     }
 
     override suspend fun resolveEns(network: String, name: String): EnsResult {
-        val stack = registry.get(NetworkConfig.byName(network).name())
+        val handle = engine.get(engine.canonicalNetworkName(network))
             ?: throw IllegalStateException("Node is not running on $network")
-        val backend = stack.rpcBackend()
-            ?: throw IllegalStateException("RPC backend not started on $network")
-        val r = backend.resolveEns(name.trim(), EnsResolutionRoot.AUTO).await()
+        val ens = handle.ens()
+            ?: throw IllegalStateException("ENS is not available on $network")
+        val r = withContext(Dispatchers.IO) { ens.resolveAddress(name.trim(), EnsRoot.AUTO) }
         return EnsResult(r.name(), r.addressHex(), r.blockNumber(), r.verified(), r.error())
     }
 
-    /** Poll the live stacks every 2s and emit a per-network snapshot map for the UI. */
+    /** Poll the hosted networks every 2s and emit a per-network snapshot map for the UI. */
     override fun snapshots(): Flow<Map<String, NodeSnapshot>> = flow {
         while (true) {
-            emit(registry.all().associate { it.network().name() to snapshotOf(it) })
+            emit(engine.hostedNetworks().mapNotNull { name ->
+                engine.get(name)?.let { name to snapshotOf(it) }
+            }.toMap())
             delay(2000)
         }
     }
 
-    private fun snapshotOf(stack: ChainStack): NodeSnapshot {
-        val net = stack.network()
-        val conn = stack.connector()
-        val bss = stack.beaconSyncState()
-        val disc4 = stack.discV4()
-        val state = if (bss != null)
-            bss.getSyncState(net.clGenesisTime(), net.secondsPerSlot()).name
-        else "STARTING"
-        val active = conn?.activePeers ?: emptyList()
-        // "ready" = peers past the eth handshake, matching Android's filtered count (the raw
-        // active list also includes peers still negotiating Hello/Status).
-        val readyList = active.filter { "READY" == it.state() }
-        val backend = stack.rpcBackend()
+    private fun snapshotOf(handle: ChainHandle): NodeSnapshot {
+        val s = handle.status()
         return NodeSnapshot(
-            running = stack.isRunning,
-            network = net.name(),
-            beaconState = state,
-            connectedPeers = active.size,
-            readyPeers = readyList.size,
-            snapPeers = conn?.activeSnapHandlers()?.size ?: 0,
-            // Desktop's connector exposes only the serving handlers, so serving == negotiated here.
-            snapServingPeers = conn?.activeSnapHandlers()?.size ?: 0,
-            discoveredPeers = disc4?.table()?.size() ?: 0,
-            // Prune expired entries before counting (backoff() leaks expired entries until a peer
-            // is re-encountered) — matches Android's NodeService, which uses this same accessor.
-            backedOffPeers = stack.pruneAndCountActiveBackoff(),
-            blacklistedPeers = stack.blacklistedNodeIds().size,
-            discv5Peers = stack.discV5()?.liveNodeCount() ?: 0,
-            executionBlockNumber = bss?.executionBlockNumber ?: 0L,
-            finalizedSlot = bss?.finalizedSlot ?: 0L,
-            syncStartPeriod = bss?.catchUpStartPeriod ?: -1L,
-            syncCurrentPeriod = bss?.currentSyncCommitteePeriod ?: 0L,
-            syncTargetPeriod = BeaconChainSpec.currentPeriod(net.clGenesisTime(), net.secondsPerSlot()),
-            // Real age of the last verified RPC head, or MAX_VALUE if RPC hasn't built one yet
-            // (same sentinel Android's NodeService uses; the UI renders it as "—").
-            verifiedHeadAgeMs = backend?.verifiedHeadAgeMs() ?: Long.MAX_VALUE,
+            running = s.running(),
+            network = s.network(),
+            beaconState = s.beaconState().name,
+            connectedPeers = s.connectedPeers(),
+            readyPeers = s.readyPeers(),
+            snapPeers = s.snapPeers(),
+            snapServingPeers = s.snapServingPeers(),
+            discoveredPeers = s.discoveredPeers(),
+            backedOffPeers = s.backedOffPeers(),
+            blacklistedPeers = s.blacklistedPeers(),
+            discv5Peers = s.discv5TableSize(),
+            executionBlockNumber = s.executionBlockNumber(),
+            finalizedSlot = s.finalizedSlot(),
+            syncStartPeriod = s.syncStartPeriod(),
+            syncCurrentPeriod = s.syncCurrentPeriod(),
+            syncTargetPeriod = s.syncTargetPeriod(),
+            verifiedHeadAgeMs = s.verifiedHeadAgeMs(),
             uptimeSeconds = (System.nanoTime() - startNs) / 1_000_000_000L,
-            // snap-capable peers first (matches Android's ordering).
-            readyPeerList = readyList.sortedByDescending { it.snapSupported() }
-                .map { PeerRow(it.remoteAddress(), it.snapSupported(), it.clientId()) },
+            readyPeerList = s.readyPeerList().map { PeerRow(it.remoteAddress(), it.snapSupported(), it.clientId()) },
         )
     }
 }
 
 /**
  * Minimal in-memory desktop settings (Step 1). File-backed persistence is a follow-up.
- * Read/written from both the UI thread and the boot threads, so every access is guarded by
- * `synchronized(this)` over the non-thread-safe backing collections.
+ * Network metadata comes from the engine's [NetworkInfo] catalog — no engine-internal
+ * config types. Read/written from both the UI thread and the boot threads, so every
+ * access is guarded by `synchronized(this)` over the non-thread-safe backing collections.
  */
-class DesktopSettings : Settings {
+class DesktopSettings(
+    private val networks: List<NetworkInfo> = JavaMyotisEngine().availableNetworks(),
+) : Settings {
     private val enabled = linkedSetOf("mainnet")
     private val ports = HashMap<String, Int>()
     private var snap = 32
@@ -292,29 +269,31 @@ class DesktopSettings : Settings {
     // toggle persists but DesktopNodeController.applyBlsBackend() is a no-op until the dylib ships.
     private var nativeBls = false
 
+    private fun info(network: String): NetworkInfo? = networks.firstOrNull { it.name() == network }
+
     override fun enabledNetworks(): List<String> = synchronized(this) { enabled.toList() }
     override fun primaryNetwork(): String = synchronized(this) { enabled.firstOrNull() ?: "mainnet" }
-    override fun allNetworks(): List<String> = NetworkConfig.allNetworks().map { it.name() }
+    override fun allNetworks(): List<String> = networks.map { it.name() }
     override fun isNetworkEnabled(name: String): Boolean = synchronized(this) { name in enabled }
     override fun setNetworkEnabled(name: String, on: Boolean) = synchronized(this) {
         if (on) enabled.add(name) else enabled.remove(name)
         Unit
     }
     override fun rpcPortFor(network: String): Int = synchronized(this) {
-        ports[network] ?: NetworkConfig.byName(network).defaultRpcPort()
+        ports[network] ?: defaultRpcPort(network)
     }
     override fun setRpcPort(network: String, port: Int) = synchronized(this) {
-        // Clamp to the valid TCP range, falling back to the network default on out-of-range input
-        // (parity with Android's NodeService.setRpcPort) so we never try to bind an unusable port.
-        ports[network] = if (port in 1024..65535) port else NetworkConfig.byName(network).defaultRpcPort()
+        // Clamp to the valid TCP range, falling back to the network default on out-of-range
+        // input (parity with Android's NodeService.setRpcPort).
+        ports[network] = if (port in 1024..65535) port else defaultRpcPort(network)
         Unit
     }
     override fun snapTarget(): Int = synchronized(this) { snap }
     override fun setSnapTarget(v: Int) = synchronized(this) { snap = v }
 
-    override fun displayName(network: String): String = NetworkConfig.byName(network).displayName()
-    override fun defaultRpcPort(network: String): Int = NetworkConfig.byName(network).defaultRpcPort()
-    override fun hasEns(network: String): Boolean = NetworkConfig.byName(network).hasEns()
+    override fun displayName(network: String): String = info(network)?.displayName() ?: network
+    override fun defaultRpcPort(network: String): Int = info(network)?.defaultRpcPort() ?: 8545
+    override fun hasEns(network: String): Boolean = info(network)?.hasEns() ?: false
 
     override fun deepPoolThreshold(): Int = synchronized(this) { deep }
     override fun setDeepPool(v: Int) = synchronized(this) { deep = v }

--- a/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.withContext
 import java.nio.file.Path
 import java.util.concurrent.ConcurrentHashMap
@@ -215,7 +216,9 @@ class DesktopNodeController(
         return EnsResult(r.name(), r.addressHex(), r.blockNumber(), r.verified(), r.error())
     }
 
-    /** Poll the hosted networks every 2s and emit a per-network snapshot map for the UI. */
+    /** Poll the hosted networks every 2s and emit a per-network snapshot map for the UI.
+     *  flowOn(Default): status() walks/sorts peer lists and prunes the backoff map — keep
+     *  that off the Compose UI thread (parity with Android's bridge, which does the same). */
     override fun snapshots(): Flow<Map<String, NodeSnapshot>> = flow {
         while (true) {
             emit(engine.hostedNetworks().mapNotNull { name ->
@@ -223,7 +226,7 @@ class DesktopNodeController(
             }.toMap())
             delay(2000)
         }
-    }
+    }.flowOn(Dispatchers.Default)
 
     private fun snapshotOf(handle: ChainHandle): NodeSnapshot {
         val s = handle.status()

--- a/myotis-api/src/main/java/io/myotis/api/BeaconStatus.java
+++ b/myotis-api/src/main/java/io/myotis/api/BeaconStatus.java
@@ -7,6 +7,7 @@ import java.util.List;
  * {@code beacon-status} command (the EL-side counterpart lives in {@link StatusSnapshot}).
  *
  * @param state                 beacon light-client state
+ * @param bootstrapped          whether the light client completed its checkpoint bootstrap
  * @param currentPeriod         sync-committee period the client holds (0 before bootstrap)
  * @param targetPeriod          wall-clock period being caught up to
  * @param discv5TableSize       live nodes in the CL discv5 routing table
@@ -16,6 +17,7 @@ import java.util.List;
  * @param optimisticSlot        optimistic beacon slot (0 while SYNCING)
  * @param finalizedPeriod       period of the finalized slot
  * @param executionStateRootHex latest verified execution state root (0x-hex), null while SYNCING
+ * @param executionBlockHashHex finalized execution block hash (0x-hex), null until first finality
  * @param executionBlockNumber  finalized execution block number
  * @param knownStateRoots       beacon-attested state roots currently held
  * @param fillThreshold         the engine's known-roots threshold for serving verified reads
@@ -23,6 +25,7 @@ import java.util.List;
  */
 public record BeaconStatus(
         BeaconState state,
+        boolean bootstrapped,
         long currentPeriod,
         long targetPeriod,
         int discv5TableSize,
@@ -32,6 +35,7 @@ public record BeaconStatus(
         long optimisticSlot,
         long finalizedPeriod,
         String executionStateRootHex,
+        String executionBlockHashHex,
         long executionBlockNumber,
         int knownStateRoots,
         int fillThreshold,

--- a/node-core/src/main/java/io/myotis/node/api/JavaChainHandle.java
+++ b/node-core/src/main/java/io/myotis/node/api/JavaChainHandle.java
@@ -184,9 +184,11 @@ public final class JavaChainHandle implements ChainHandle {
                 : io.myotis.api.BeaconState.valueOf(
                         bss.getSyncState(net.clGenesisTime(), net.secondsPerSlot()).name());
         byte[] stateRoot = bss != null ? bss.getVerifiedExecutionStateRoot() : null;
+        byte[] blockHash = bss != null ? bss.getExecutionBlockHash() : null;
         long finalizedSlot = bss != null ? bss.getFinalizedSlot() : 0L;
         return new io.myotis.api.BeaconStatus(
                 state,
+                blc != null && blc.isBootstrapped(),
                 bss != null ? bss.getCurrentSyncCommitteePeriod() : 0L,
                 BeaconChainSpec.currentPeriod(net.clGenesisTime(), net.secondsPerSlot()),
                 stack.discV5() != null ? stack.discV5().liveNodeCount() : 0,
@@ -196,6 +198,7 @@ public final class JavaChainHandle implements ChainHandle {
                 bss != null ? bss.getOptimisticSlot() : 0L,
                 finalizedSlot / BeaconChainSpec.SLOTS_PER_SYNC_COMMITTEE_PERIOD,
                 stateRoot != null ? org.apache.tuweni.bytes.Bytes.wrap(stateRoot).toHexString() : null,
+                blockHash != null ? org.apache.tuweni.bytes.Bytes.wrap(blockHash).toHexString() : null,
                 bss != null ? bss.getExecutionBlockNumber() : 0L,
                 bss != null ? bss.getKnownStateRootCount() : 0,
                 BeaconSyncState.FILL_THRESHOLD,


### PR DESCRIPTION
PR 5/6 of the engine-API extraction: the last two hosts — `:app-desktop` and `:android-app` — now talk exclusively to `MyotisEngine`/`ChainHandle`. Combined with #119 (daemon) and #120 (JSON-RPC server), **every host consumes only `io.myotis.api`**; the Java engine is one replaceable unit.

## Desktop (`DesktopNodeController`)
- All lifecycle/status/query paths via the engine; PR 3's interim `PortBridges` glue and the bridging executor are **gone**.
- `requestAccount`/`resolveEns` wrap the blocking engine calls in `Dispatchers.IO` (replacing future-await).
- `DesktopSettings` network metadata comes from the engine's `NetworkInfo` catalog (no `NetworkConfig`).
- Desktop's status now carries the **distinct** `snapPeers` vs `snapServingPeers` counts it previously conflated — serving-pool collapse is visible on desktop too.

## Android (`NodeService`)
- One **process-global** `JavaMyotisEngine` (the single concrete-engine line), with process-global boot locks to match — a recreated service's boot now genuinely serializes against the previous instance's teardown (the old instance-scoped locks couldn't guarantee that).
- `buildAndStart` via `EngineConfig`/`EnginePorts`: `create()`+`start()` both under the boot lock (create throws on a still-hosted network, so it must wait out the old teardown); new `AndroidNodeKeyStore` over `getFilesDir()` (byte-compatible both directions with the existing `nodekey*.hex` files); the cache adapters retargeted to the api ports; `AndroidCcipGateway` rewritten as the blocking `HttpGateway` port (same timeouts/1 MiB cap); DNS from ConnectivityManager; `strictStateFreshness` via `EngineConfig`.
- `requestAccount`/`resolveEns` keep their `CompletableFuture` surface for the Kotlin bridge, wrapping the blocking engine calls on a static query pool. ENS rides `handle.ens()` (the engine's one AUTO policy) with the API's no-record convention.
- `snapshotOf` rebuilt from `StatusSnapshot` + `BeaconStatus` (which gained `bootstrapped` + `executionBlockHashHex`); `Snapshot.readyPeerList` retyped to `io.myotis.api.PeerInfo` — the Kotlin bridge compiles unchanged. Historical `-1`-until-known and `"STOPPED"`-pre-beacon conventions preserved.
- `AndroidSettings` (bridge) now uses `NodeService`'s catalog-backed statics — the last `NetworkConfig` reference in host code is gone.
- `doShutdown` iterates the **engine's** registry (not the instance mirror map), so "stop everything" is robust to any divergence by construction.

## Verification
- `./gradlew build` green across all modules (JVM + desktop Kotlin + Android incl. the CMP bridge).
- **Desktop visually QA'd** via the Xvfb harness: Status tab SYNCED with live mainnet data (EL block 25467363; peers 51 / ready 14 / snap 11 / serving 11; discv5 642; sync period 1794/1794; verified head age ~8 s) — entirely through the API path. Screenshot attached in the session.
- Independent no-context review traced lifecycle races (desktop enable/disable/reboot, Android Stop→Start / disable→enable interleavings), snapshot field parity arg-by-arg on both hosts, the key-store round-trip, and CCIP semantics. Its findings — static boot locks, the silent double-enable swallow (now logged + map-repaired), engine-registry-scoped shutdown, and the bridge's leftover `NetworkConfig` uses — are all incorporated, plus its NITs (sync-period `-1` parity, stale javadocs, unused import).
- On-device smoke remains for a phone/emulator session (can't run here); `assembleDebug`/`assembleRelease` both build.

Notes for follow-ups (PR 6/6 or later): `android-app/.../snap/EthHandlerSnapPeer.java` is now dead host code; Android no longer logs the node ID at boot (derivable from the key store if wanted); `Main.kt` constructs two engine instances (Settings' throwaway catalog + the controller's — harmless, lazily-threaded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)