### PR TITLE
docs: declare :myotis-api the canonical engine contract (API extraction 6/6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,8 +38,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Architecture
 
-Five Gradle modules:
+Key Gradle modules:
 
+- **myotis-api** — THE ENGINE CONTRACT: zero-dependency Java-17 interfaces
+  (`io.myotis.api` + `io.myotis.api.ports`) every host consumes exclusively.
+  FFI-portable types only (byte[], String, long, double[], enums, flat records;
+  blocking methods). Implemented by **node-core**'s `io.myotis.node.api` adapters
+  (`JavaMyotisEngine`/`JavaChainHandle` over `ChainStack`/`NodeRegistry`). Designed so a Rust engine can replace the Java one behind the same
+  surface — see docs/reimplementation/05-engine-api-bindings.md.
 - **core** — Cryptographic identity (`NodeKey`), data types (`BlockHeader`), ENR decoding
 - **networking** — Three protocol layers, all Netty-based:
   - `discv4` — UDP peer discovery using Kademlia DHT (ping/pong/findnode/neighbors)
@@ -66,6 +72,13 @@ Five Gradle modules:
 - Concurrent collections (`ConcurrentHashMap.newKeySet()`) for shared mutable state
 - IPC uses JSON-Lines over Unix domain sockets with Java 21 virtual threads
 - Network configs (genesis hash, fork ID, bootnodes) live in `NetworkConfig`
+- **Hosts talk ONLY to `:myotis-api`** (`MyotisEngine`/`ChainHandle`): host runtime
+  paths in the daemon, desktop, and Android don't import engine internals
+  (node-core/networking/consensus types). Documented exemptions: the single
+  `new JavaMyotisEngine()` at each composition root; the daemon's `get-transactions`
+  debug stream (`DebugCommands` via `JavaMyotisEngine.debugStack`); Android's
+  BLS-backend toggle (`BlsBackends` — an internal engine seam, deliberately not on
+  the API); and `:app`'s `testing/MainnetPeerBootstrap` (an integration-test fixture).
 
 ## Platform & language direction
 

--- a/docs/reimplementation/04-engine-and-hosts.md
+++ b/docs/reimplementation/04-engine-and-hosts.md
@@ -101,20 +101,26 @@ enabled. `withRpcPort(n)` overrides just the RPC port (hosts may let users pick 
 ### 1.4 Platform ports (the injection seams)
 
 See [README §5.2](README.md#52-platform-ports-iomyotisapiports--implement-per-host) for the
-table. The shapes (re-create as traits/interfaces):
+table. The CANONICAL shapes are the `io.myotis.api.ports` interfaces (re-create as
+traits/callback interfaces exactly as written there):
 
-- `PeerCache`: `add(addr, pubkeyHex, snap)`, `recordSnapServed(addr)`, `recordSnapFailure(addr)`,
-  `load() -> [CachedPeer]`, `close()`.
-- `ClPeerCache`: `load() -> [multiaddr]`, `add`, `markFailure`, `servedRanges() ->
-  map<multiaddr,[low,high]>`, `recordServed`, `bootstrapPeers() -> map<multiaddr,period>`,
-  `recordBootstrap`, `lightClientConfirmed()`, `lightClientDenied()`, `markLightClientBatch`,
-  `close()`. (Method shapes mirror the light client's seed/listener setters so they wire as direct
-  callbacks.)
-- `DnsServerProvider`: `get() -> [dnsServerIp]` (null/empty → resolver's default).
-- `CcipGateway`: `request(method, url, body) -> bytes`.
-- `SnapQualitySink`: `recordSnapServed/Failure(addr)` (persist EL peer quality).
-- `RpcLogger`: `info/warn`. `RpcClock`: `elapsedMillis()` (monotonic).
-- `CachedPeer = (address, publicKeyHex, snap, snapQuality ∈ {CONFIRMED, UNKNOWN, DENIED})`.
+- `NodeKeyStore`: `load(networkName) -> bytes32?`, `store(networkName, bytes32)`.
+- `EnginePeerCache`: `add(host, port, pubkeyHex, snap)`, `recordSnapServed(host, port)`,
+  `recordSnapFailure(host, port)`, `load() -> [CachedPeerInfo]`, `close()`.
+- `EngineClPeerCache`: `load() -> [multiaddr]`, `add`, `markFailure`,
+  `servedRanges() -> [ServedRange(multiaddr, low, high)]`, `recordServed`,
+  `bootstrapPeers() -> [BootstrapPeer(multiaddr, period)]`, `recordBootstrap`,
+  `lightClientConfirmed()/Denied() -> [multiaddr]`, `markLightClientBatch(confirmed, denied)`,
+  `close()`. (Flat record lists, not maps — the engine converts to the light client's
+  seed/listener shapes internally.)
+- `DnsServers`: `dnsServerIps() -> [String]` (null port / empty list → resolver's default).
+- `HttpGateway`: `request(method, url, body?) -> String` — **BLOCKING**, throws on any
+  transport failure; the engine wraps it into its internal async shape and budgets the
+  timeout. (The engine-internal `CcipGateway` future-shape is an implementation detail.)
+- `EngineLogger`: `info/warn/error`. `EngineClock`: `elapsedMillis()` (monotonic).
+- `CachedPeerInfo = (host, port, publicKeyHex, snap, snapQuality ∈ {CONFIRMED, UNKNOWN, DENIED})`.
+- (The old `SnapQualitySink` is engine-internal now — snap-quality persistence rides
+  `EnginePeerCache.recordSnapServed/Failure`.)
 
 ---
 

--- a/docs/reimplementation/04-engine-and-hosts.md
+++ b/docs/reimplementation/04-engine-and-hosts.md
@@ -1,5 +1,30 @@
 # 04 — The Engine and Its Hosts
 
+> **UPDATE — the engine API is now formalized in code.** Since this document was first
+> written, the engine boundary described here has been extracted into the
+> **`:myotis-api`** module (`io.myotis.api` + `io.myotis.api.ports`): a zero-dependency
+> Java-17 contract that every host consumes exclusively (verified across the daemon,
+> desktop, and Android in PRs #117–#121). Where this document says `ChainStack` /
+> `NodeRegistry` / `MyotisRpcBackend` / `PeerCachePort` etc., the CANONICAL public names
+> are now:
+>
+> | This document (internal) | Canonical API (`io.myotis.api`) |
+> |---|---|
+> | `NodeRegistry` | `MyotisEngine` (catalog + `create`/`get`/`stop`/`shutdownAll`) |
+> | `ChainStack` (ctor + accessors) | `ChainHandle` (+ `EngineConfig`/`EnginePorts` at `create`) |
+> | *host status assembly (was 3× duplicated)* | `status()` → `StatusSnapshot`, `beaconStatus()` → `BeaconStatus`, `discoveredPeers()`, `connectedPeers()` |
+> | `MyotisRpcBackend` (jsonrpc-server SPI, deleted) | `VerifiedReads` (implemented by `VerifiedRpcBackend`) |
+> | `PeerCachePort` / `ClPeerCachePort` / `DnsServerProvider` / `CcipGateway` / `RpcLogger` / `RpcClock` | `ports.EnginePeerCache` / `ports.EngineClPeerCache` / `ports.DnsServers` / `ports.HttpGateway` (blocking) / `ports.EngineLogger` / `ports.EngineClock` (+ `ports.NodeKeyStore`) |
+> | `VerifiedAccountQuery` / storage / block / header queries | `ChainHandle.requestAccount/getStorageProof/getBlockVerified/getHeaders` |
+> | ENS via daemon-local EVM stack (deleted) | `ChainHandle.ens()` → `EnsApi` |
+>
+> The internal machinery this document details (`ChainStack` internals, `RpcCallContext`,
+> caching tiers, the prefetch loop) is still accurate as an implementation guide — it
+> simply now lives BEHIND the API. Re-implementers: match the **`:myotis-api`
+> signatures** (see [README §5](README.md#5-the-engine-api--the-framework-surface-the-deliverable)
+> and [`05-engine-api-bindings.md`](05-engine-api-bindings.md)); use the rest of this
+> document for the wire/verification/concurrency behavior behind them.
+
 > Companion to the [re-implementation spec](README.md). Covers the **reusable engine**
 > (`ChainStack` / `NodeRegistry` + platform ports), the **verified-read backend** (the eth_*
 > pipeline), and the two **host surfaces** — the desktop daemon (Unix-domain-socket IPC) and the
@@ -75,7 +100,7 @@ enabled. `withRpcPort(n)` overrides just the RPC port (hosts may let users pick 
 
 ### 1.4 Platform ports (the injection seams)
 
-See [README §5.2](README.md#52-platform-ports-the-injection-seams--implement-per-host) for the
+See [README §5.2](README.md#52-platform-ports-iomyotisapiports--implement-per-host) for the
 table. The shapes (re-create as traits/interfaces):
 
 - `PeerCache`: `add(addr, pubkeyHex, snap)`, `recordSnapServed(addr)`, `recordSnapFailure(addr)`,
@@ -124,7 +149,7 @@ tighter** (it's what the wallet signs against); block-number tolerances for "nea
 
 ### 2.2 Method catalog
 
-The full list is in [README §5.3](README.md#53-the-verified-read-backend-the-eth_-contract). Notable
+The full list is in [README §5.3](README.md#53-the-verified-read-backend-verifiedreads-the-eth_-contract). Notable
 behaviors to replicate:
 
 - **Null-return contract** (central): a method returns "no verified answer" (host maps to a JSON-RPC

--- a/docs/reimplementation/05-engine-api-bindings.md
+++ b/docs/reimplementation/05-engine-api-bindings.md
@@ -1,0 +1,106 @@
+# 05 — The Engine API: Binding Strategy for a Rust (or Go) Engine
+
+> Companion to the [re-implementation spec](README.md). The engine contract is the
+> **`:myotis-api`** module (`io.myotis.api` + `io.myotis.api.ports`) — this document maps
+> every interface in it to a concrete Rust/UniFFI (or JNI) binding strategy, so a Rust
+> engine can slot in behind the exact surface the JVM hosts already consume.
+
+## 1. Why the API is shaped the way it is
+
+`:myotis-api` was designed binding-first (see the module's `package-info`):
+
+- **Blocking methods everywhere.** UniFFI translates a blocking Rust fn to a blocking
+  Kotlin/Swift call 1:1, or lifts it to `async` in the generated bindings. The hosts
+  already call the API from worker threads (`Dispatchers.IO`, a query pool, virtual
+  threads), so nothing about the JVM side changes when the implementation becomes Rust.
+  Callbacks exist only in the ports (engine → host), which UniFFI models as *foreign
+  traits* / callback interfaces.
+- **Only FFI-trivial types cross**: `byte[]` ⇄ `Vec<u8>`, `String` ⇄ `String`,
+  `long` ⇄ `i64`/`u64`, enums ⇄ enums, flat records ⇄ UniFFI *dictionaries* (Rust
+  structs), `List<record>` ⇄ `Vec<struct>`. No `BigInteger` (wei = decimal strings),
+  no `CompletableFuture`, no `InetSocketAddress`/`Path` (host:port pairs / path strings).
+- **Three-tier error model** that needs no exception marshalling:
+  1. `VerifiedReads` returns `null` (`Option::None`) = "cannot answer verified";
+  2. verification queries return flat records with `failReason`/`error` strings;
+  3. only programmer/state errors throw — one type, `EngineException`, which UniFFI
+     models as a single flat `Error` enum.
+
+## 2. Interface → binding map
+
+| `io.myotis.api` | UniFFI construct | Rust shape |
+|---|---|---|
+| `MyotisEngine` | `interface` (object) | `struct RustEngine` behind `Arc`, constructor exported as the factory the host names once |
+| `ChainHandle` | `interface` (object) | per-network handle owning the tokio runtime pieces |
+| `EngineConfig`, `NetworkInfo`, `StatusSnapshot`, `BeaconStatus`, `PeerInfo`, `ConnectedPeer`, `DiscoveredPeer`, `ClPeerInfo`, `AccountProofResult`, `StorageProofResult`, `HeaderInfo`, `HeadersResult`, `BlockResult`, `DialResult`, `EnsResolutionResult` + the `Ens*Result` family, `ports.CachedPeerInfo`, `ports.ServedRange`, `ports.BootstrapPeer` | `dictionary` | plain `struct`s (all fields by value) |
+| `SyncState`, `BeaconState`, `EnsRoot`, `ports.SnapQuality`, `ports.HttpGateway.Method` | `enum` | fieldless enums |
+| `VerifiedReads`, `EnsApi` | `interface` (object returned by the handle) | sub-objects borrowing the handle's internals |
+| `ports.NodeKeyStore`, `ports.EnginePeerCache`, `ports.EngineClPeerCache`, `ports.DnsServers`, `ports.HttpGateway`, `ports.EngineLogger`, `ports.EngineClock` | **callback interface** (foreign trait) | `Box<dyn Trait + Send + Sync>` handed into the engine at `create()` |
+| `EngineException` | `[Error]` enum (single `Message(String)` variant) | `thiserror` enum |
+| `EnginePorts` (the bundle record) | `dictionary` of callback-interface handles | struct of trait objects |
+
+Threading contract carried over: the engine invokes port callbacks from its own worker
+threads (tokio blocking pool for `HttpGateway`, never an I/O driver thread); port
+implementations must be thread-safe. `HttpGateway` stays deliberately blocking — the
+Rust side wraps it in `spawn_blocking`, exactly mirroring today's
+`PortBridges.toCcipGateway` bridge.
+
+## 3. Packaging (proven pattern)
+
+`rust/myotis-bls` already proves the one-crate → desktop `.so` + Android ABIs pipeline
+(cargo-ndk, `rust/build-android.sh`, loaded through the `BlsBackend` JNI seam — see
+[bls-rust-acceleration.md](../bls-rust-acceleration.md)). A full engine generalizes it:
+
+- **Android**: cdylib (`arm64-v8a`, `armeabi-v7a`, `x86_64`) + UniFFI-generated Kotlin
+  in an `.aar`. The Kotlin bindings implement... nothing: they ARE the engine; a thin
+  adapter maps them onto `io.myotis.api` so `NodeService` keeps compiling unchanged —
+  or, once the JVM engine retires, hosts consume the UniFFI Kotlin types directly.
+- **iOS**: staticlib + UniFFI Swift bindings as an `.xcframework`. The shared Compose
+  UI (`:ui` commonMain — already pure Kotlin, no JVM types) gains `iosArm64`/
+  `iosSimulatorArm64` targets; an iOS actual of the `NodeController`/`Settings`/
+  `LogSource`/`QueryHistory` seams maps UniFFI types → the ui models (template:
+  `AndroidNodeBridge.kt`, ~200 lines). iOS-native ports: `NodeKeyStore` → Keychain,
+  `HttpGateway` → URLSession/Ktor-Darwin, `DnsServers` → resolver config.
+- **Desktop**: use the crate directly from the JVM via JNI/UniFFI-Kotlin, or ship the
+  Rust daemon binary with the same UDS JSON-lines IPC.
+
+**No Java→Kotlin conversion debt exists**: everything currently Java is either the
+engine (replaced by Rust), a platform-specific host shell (stays on its platform), or a
+port implementation (rewritten natively per platform by design).
+
+## 4. Recommended API simplification for the Rust port
+
+The two peer-cache ports (`EnginePeerCache`, `EngineClPeerCache`) exist because the JVM
+hosts historically owned the cache **files**. They are pure persistence with no
+platform semantics beyond a directory. A Rust engine should **own peer-cache
+persistence internally** (sled/flat files under a data dir) and replace both ports with
+a single `dataDir` string in `EngineConfig`:
+
+- Hosts shrink to three small native ports: `NodeKeyStore`, `HttpGateway`, `DnsServers`
+  (+ optional logger/clock).
+- The "Clear caches" host feature becomes an engine method (e.g.
+  `ChainHandle.clearPeerCaches()`), removing today's host-side live-instance juggling.
+- Keep the on-disk formats readable (documented in [README §9](README.md#9-persistence--storage))
+  or migrate once at first run — they are reconstructible caches, not trust anchors.
+
+`NodeKeyStore` should stay a port (key custody is a genuine platform concern —
+Keychain/keystore vs files), as should `HttpGateway` (TLS stacks are platform-owned)
+and `DnsServers` (mobile resolver quirk).
+
+## 5. Conformance checklist for a replacement engine
+
+1. Implement every `io.myotis.api` signature with the exact null/`failReason`
+   semantics (the JVM hosts' behavior is pinned by: the daemon's golden JSON tests over
+   the operator queries, `RpcRouterTest` over `VerifiedReads` wire shapes, and the
+   `verify()`-ladder unit tests over `failReason` tokens).
+2. Honor the threading contract: blocking API, thread-safe reentrant handles, port
+   callbacks off I/O threads.
+3. Preserve the security invariants of [README §11](README.md#11-security-critical-invariants-consolidated-checklist)
+   — the API cannot express an unverified answer, and a port must not be able to inject
+   one (ports carry availability data only: peers, DNS, HTTP bytes that are re-verified
+   on-chain).
+4. Match the stable `failReason`/`verifyMethod` tokens (`stateRootMatch`,
+   `headerChain`, `beaconNotSynced`, `headerChainGapTooLarge`, `preMergeBlock`, …) —
+   operator tooling and the integration tests grep them.
+5. Wire the integration gate: with a SYNCED node, `ChainHandle.requestAccount` must
+   yield `beaconChainVerified=true` with `verifyMethod` `stateRootMatch` or
+   `headerChain`, and the CLAUDE.md `get-storage` contract must hold end-to-end.

--- a/docs/reimplementation/05-engine-api-bindings.md
+++ b/docs/reimplementation/05-engine-api-bindings.md
@@ -57,7 +57,7 @@ Rust side wraps it in `spawn_blocking`, exactly mirroring today's
 - **iOS**: staticlib + UniFFI Swift bindings as an `.xcframework`. The shared Compose
   UI (`:ui` commonMain — already pure Kotlin, no JVM types) gains `iosArm64`/
   `iosSimulatorArm64` targets; an iOS actual of the `NodeController`/`Settings`/
-  `LogSource`/`QueryHistory` seams maps UniFFI types → the ui models (template:
+  `LogSource`/`QueryHistory` seams, mapping UniFFI types → the ui models (template:
   `AndroidNodeBridge.kt`, ~200 lines). iOS-native ports: `NodeKeyStore` → Keychain,
   `HttpGateway` → URLSession/Ktor-Darwin, `DnsServers` → resolver config.
 - **Desktop**: use the crate directly from the JVM via JNI/UniFFI-Kotlin, or ship the

--- a/docs/reimplementation/README.md
+++ b/docs/reimplementation/README.md
@@ -345,7 +345,7 @@ not-found) / `null`. Wei values are decimal strings; addresses/hashes/calldata a
 |---|---|---|
 | `chainId()` | long | config |
 | `headBlockNumber()` | Long? | beacon optimistic head |
-| `syncState()` | `SYNCING \| CATCHING_UP \| SYNCED` | beacon light client |
+| `syncState()` | `SYNCING` \| `CATCHING_UP` \| `SYNCED` | beacon light client |
 | `getBalance(bytes, block)` | decimal-wei String? | MPT account proof vs anchored stateRoot |
 | `getTransactionCount(bytes, block)` | Long? | MPT account proof (+pending overlay for own txs) |
 | `getCode(bytes, block)` | bytes? | bytecode vs proven `codeHash` |

--- a/docs/reimplementation/README.md
+++ b/docs/reimplementation/README.md
@@ -7,7 +7,7 @@
 This is the **master document**. It gives the whole picture: what Myotis is, its trust
 model, its architecture, the engine API surface to expose, the dependency mapping from
 the JVM reference implementation to Go/Rust, and how to package the result as a
-multi-platform library. Wire-level protocol detail lives in four companion documents:
+multi-platform library. Wire-level protocol detail lives in five companion documents:
 
 | Companion | Covers |
 |---|---|
@@ -15,6 +15,7 @@ multi-platform library. Wire-level protocol detail lives in four companion docum
 | [`02-execution-networking.md`](02-execution-networking.md) | devp2p: discv4, discv5, EIP-1459 DNS discovery, RLPx (ECIES + framing), the `eth` and `snap` sub-protocols |
 | [`03-state-verification-and-evm.md`](03-state-verification-and-evm.md) | Merkle-Patricia proof verification, the SNAP state oracle, the local EVM stack, gas estimation, ABI, CCIP-Read, ENS |
 | [`04-engine-and-hosts.md`](04-engine-and-hosts.md) | The reusable engine (`ChainStack`/`NodeRegistry`), platform ports, the verified backend, IPC + JSON-RPC host surfaces, persistence, concurrency |
+| [`05-engine-api-bindings.md`](05-engine-api-bindings.md) | The formal engine contract (`:myotis-api`) → Rust/UniFFI binding strategy, packaging (Android `.aar` / iOS `.xcframework`), conformance checklist |
 
 > **Scope note.** The request is to re-implement *everything except the Android-specific
 > parts*. Concretely: re-implement the **engine** (all protocols + verification + the
@@ -279,77 +280,100 @@ desktop + Android + iOS.
 
 ## 5. The Engine API — the framework surface (the deliverable)
 
-This is what apps consume. Keep it **library-neutral and FFI-friendly**: bytes, strings,
-integers, enums, and simple records — **no framework-specific async types leaking across
-the boundary** (the reference explicitly forbids leaking `CompletableFuture` into shared
-APIs; for Rust expose `async fn` or blocking + callbacks, for Go expose blocking methods +
-goroutine-safe handles).
+> **This section is now CODE, not prose.** The engine API is formalized as the
+> `:myotis-api` Gradle module (`io.myotis.api` + `io.myotis.api.ports`) — a
+> zero-dependency, Java-17 contract that the JVM reference engine implements and that
+> ALL hosts (JVM daemon, Compose desktop, Android) consume exclusively. **The module's
+> interfaces are the canonical specification**; re-implement to those signatures. This
+> section summarizes the shape; [`05-engine-api-bindings.md`](05-engine-api-bindings.md)
+> maps every interface to a Rust/UniFFI binding strategy.
 
-### 5.1 Lifecycle: `NodeRegistry` + `ChainStack`
+The design rules the module enforces (and a port must keep): **library-neutral and
+FFI-friendly** — `byte[]`, `String`, `long`/`int`/`boolean`, `double[]`, enums, flat records,
+`List`; **no** `CompletableFuture`/`BigInteger`/`Optional`/`InetSocketAddress`/`Path`;
+**all methods blocking** (call from a worker thread; hosts wrap in their own async),
+with callbacks only in the host-implemented ports. Wei crosses as decimal strings;
+hashes/addresses as bytes on the read API and 0x-hex strings in result records.
 
-- **`ChainStack`** — one network's full node on its own ports & identity. Constructed with:
-  `(NetworkConfig, ChainPorts, NodeKey, PeerCache, ClPeerCache, CcipGateway,
-  syncSnapshotPath, gossipsubEnabled)`. Lifecycle: `start() -> bool` (fault-isolated: any
-  failure tears down only this stack and returns false), `shutdown()`. Optional:
-  `configureSnapMaintainer(targetSnapPeers, dnsServerProvider)` (call before `start()`).
-  Accessors expose the live connector, discovery services, beacon sync state/light client,
-  and the verified backend.
-- **`NodeRegistry`** — `Map<networkName, ChainStack>`; `add/get/all/remove/shutdownAll`.
+### 5.1 Lifecycle: `MyotisEngine` + `ChainHandle`
+
+- **`MyotisEngine`** — the root object: `availableNetworks() -> [NetworkInfo]` (the
+  embedded catalog), `canonicalNetworkName(alias)`, `create(EngineConfig, EnginePorts)
+  -> ChainHandle` (registers, does not start), `get/hostedNetworks/stop/shutdownAll`.
   One process hosts mainnet + Gnosis + Sepolia simultaneously, each on its own ports.
-- **`ChainPorts`** — `(elPort, discv5Port, rpcPort)`, defaulted per network so several
-  stacks never collide (see §6).
+  Hosts name a concrete engine exactly once (`new JavaMyotisEngine()` today; the Rust
+  binding's factory later).
+- **`ChainHandle`** — one network: `start() -> bool` (fault-isolated), `stop()`,
+  `isRunning()`, `setTargetSnapPeers(n)`, `clearPeerState()`, plus the read surfaces
+  below and the verified operator queries (`requestAccount`, `getStorageProof`,
+  `getHeaders`, `getBlockVerified`, `dialPeer`) returning flat result records whose
+  `failReason`/`error` fields carry verification failures (never exceptions).
+- **`EngineConfig`** — `(networkName, elPort, discv5Port, rpcPort [0 = per-network
+  default], syncSnapshotPath, gossipsubEnabled, targetSnapPeers [0 = maintainer off],
+  strictStateFreshness)`.
+- **Status**: `status() -> StatusSnapshot` (EL + beacon counts, per-peer rows),
+  `discoveredPeers()`, `connectedPeers()`, `beaconStatus() -> BeaconStatus` (deep CL
+  view incl. per-peer detail, bootstrapped flag, execution block hash).
 
-### 5.2 Platform ports (the injection seams — implement per host)
+### 5.2 Platform ports (`io.myotis.api.ports` — implement per host)
 
-| Port | Purpose | Desktop impl | Mobile impl |
+| Port | Purpose | Desktop/daemon impl | Mobile impl |
 |---|---|---|---|
-| `PeerCache` | EL peer cache: `add(addr, pubkeyHex, snap)`, `recordSnapServed/Failure`, `load() -> [CachedPeer]`, `close()` | file (`peers-<net>.cache`) | app-private file |
-| `ClPeerCache` | CL libp2p peer cache: load/add/markFailure + served-period ranges, bootstrap peers, light-client confirmed/denied verdicts | file (`cl-peers-<net>.cache`) | app-private file |
-| `DnsServerProvider` | DNS server IPs for EIP-1459 TXT lookups (mobile DNS has no system resolver config) | null → system DNS | active-network DNS IPs |
-| `CcipGateway` | CCIP-Read HTTP transport: `request(method, url, body) -> bytes` (GET+POST, ~10–15 s timeouts, bounded response size) | native HTTP client | platform HTTP client |
-| `SnapQualitySink` | persist EL peer snap-serving quality across restarts | file-backed | file-backed |
-| `RpcLogger`, `RpcClock` | logging seam + monotonic clock | stdlib | platform clock/log |
-| key storage | where `NodeKey` (secp256k1) is stored | `nodekey-<net>.hex` | secure storage/keystore |
+| `NodeKeyStore` | 32-byte secp256k1 identity: `load(net) -> bytes?`, `store(net, bytes)` | hex file (`nodekey-<net>.hex`) | app-private file / keystore |
+| `EnginePeerCache` | EL peer cache: `add(host, port, pubkeyHex, snap)`, `recordSnapServed/Failure`, `load() -> [CachedPeerInfo]`, `close()` | file (`peers-<net>.cache`) | app-private file |
+| `EngineClPeerCache` | CL peer cache: multiaddrs + failure counts + `ServedRange`/`BootstrapPeer` records + light-client verdicts | file (`cl-peers-<net>.cache`) | app-private file |
+| `DnsServers` | DNS IPs for EIP-1459 TXT lookups | null → system DNS | active-network DNS IPs |
+| `HttpGateway` | CCIP-Read transport: `request(method, url, body) -> String`, BLOCKING, throw on failure | java.net.http | HttpURLConnection / URLSession |
+| `EngineLogger`, `EngineClock` | log sink + monotonic clock | null → engine defaults | platform log/clock |
 
-`CachedPeer = (address, publicKeyHex, snap: bool, snapQuality: CONFIRMED|UNKNOWN|DENIED)`;
+`CachedPeerInfo = (host, port, publicKeyHex, snap, snapQuality: CONFIRMED|UNKNOWN|DENIED)`;
 quality drives dial priority (CONFIRMED first).
 
-### 5.3 The verified-read backend (the eth_* contract)
+> **Rust-port simplification (recommended):** the peer-cache file formats are pure
+> persistence — a Rust engine should own them internally and shrink both cache ports to
+> plain directory-path strings in `EngineConfig`, leaving hosts only key storage + HTTP
+> + DNS. See [`05-engine-api-bindings.md`](05-engine-api-bindings.md).
 
-The engine's verified surface mirrors the Ethereum JSON-RPC API. This is the single most
-useful API to expose to apps (every method answered **only** from verified data; a method
-returns "absent/unanswerable" rather than guessing — the host maps that to an error):
+### 5.3 The verified-read backend: `VerifiedReads` (the eth_* contract)
+
+`ChainHandle.reads()` (null until the RPC backend is up). Every method answers **only**
+from verified data; `null` = "cannot answer verified right now" (the host maps that to
+an error); JSON-string methods use the tri-state `JSON` / literal `"null"` (verified
+not-found) / `null`. Wei values are decimal strings; addresses/hashes/calldata are bytes.
 
 | Method | Returns | Verification basis |
 |---|---|---|
-| `chainId()` | chain id | config |
-| `headBlockNumber()` | beacon optimistic head, or none | beacon light client |
-| `syncState()` | `SYNCING` \| `CATCHING_UP` \| `SYNCED` | beacon light client |
-| `getBalance(addr, block)` | wei | MPT account proof vs anchored stateRoot |
-| `getTransactionCount(addr, block)` | nonce | MPT account proof (+pending overlay for own txs) |
-| `getCode(addr, block)` | bytecode | bytecode vs proven `codeHash` |
-| `getStorageAt(addr, slot, block)` | 32 bytes | MPT storage proof vs proven `storageRoot` |
-| `call(from, to, data, value, block)` | ABI return bytes | local EVM over proof-served state (threads real `from`/`value` — a zero sender reverts `msg.sender`-gated contracts) |
-| `estimateGas(from, to, data, value)` | gas | local EVM, intrinsic + metered + 15% buffer |
-| `gasPrice()` / `maxPriorityFeePerGas()` / `feeHistory(...)` | fees | base fee from headers, tips from verified bodies |
-| `getBlockByNumber/Hash(...)` | block JSON | beacon-anchored header (no snap needed) |
-| `getTransactionByHash(hash)` | tx JSON | beacon-anchored block vs `transactionsRoot` (+ own sent-tx cache) |
-| `getTransactionReceipt(hash)` | receipt JSON | vs `receiptsRoot` (handles eth/69 bloomless receipts) |
-| `sendRawTransaction(rawTx)` | keccak256(rawTx) | devp2p gossip (engine never signs — relays only) |
+| `chainId()` | long | config |
+| `headBlockNumber()` | Long? | beacon optimistic head |
+| `syncState()` | `SYNCING \| CATCHING_UP \| SYNCED` | beacon light client |
+| `getBalance(bytes, block)` | decimal-wei String? | MPT account proof vs anchored stateRoot |
+| `getTransactionCount(bytes, block)` | Long? | MPT account proof (+pending overlay for own txs) |
+| `getCode(bytes, block)` | bytes? | bytecode vs proven `codeHash` |
+| `getStorageAt(bytes, slot32, block)` | bytes? | MPT storage proof vs proven `storageRoot` |
+| `call(from?, to, data, valueWei?, block)` | bytes? | local EVM over proof-served state |
+| `estimateGas(from?, to, data, valueWei?)` | Long? | local EVM, intrinsic + metered + 15% buffer |
+| `gasPrice()` / `maxPriorityFeePerGas()` | decimal-wei String? | verified headers/bodies |
+| `feeHistory(count, newest, percentiles)` | JSON String? | beacon-verified headers (+bodies) |
+| `getBlockByNumber/Hash(...)` | JSON String? | beacon-anchored header |
+| `getTransactionByHash(bytes32)` | JSON String? | vs `transactionsRoot` (+ own sent-tx cache) |
+| `getTransactionReceipt(bytes32)` | JSON String? | vs `receiptsRoot` (eth/69 bloomless handled) |
+| `sendRawTransaction(bytes)` | bytes? (tx hash) | devp2p gossip (engine never signs) |
 
-Plus **ENS**: `resolve(name)` / `resolveText/Contenthash/MultiCoinAddr/Pubkey/Abi/DnsRecord/
-InterfaceImplementer` and reverse `resolveName(addr)` (with mandatory forward-verification).
+Plus **ENS** via `ChainHandle.ens()` (null on chains without ENS): `resolveAddress(name,
+root)` / `reverseResolve(addr)` (mandatory forward-verification) and the record lookups
+(`text`, `contenthash`, multi-coin, pubkey, ABI, DNS, interface-implementer), each
+returning a flat record with `(value…, blockNumber, verified, error)`. Convention:
+value `null` with error `null` = a *successful* "no such record".
 
 ### 5.4 Host surfaces (pick per platform)
 
-- **Desktop**: a CLI that talks to a long-running daemon over a **Unix-domain socket** with
-  a line-delimited JSON protocol (operator/debug commands incl. proof/verification metadata).
-- **Wallet integration**: an **Ethereum JSON-RPC HTTP server bound to loopback**
-  (`127.0.0.1`), strict mode, so stock wallets work unmodified.
-- **Mobile**: **direct FFI calls** into the engine's verified-read API (no socket needed),
-  or an in-process loopback JSON-RPC server the platform WebView/wallet points at.
+- **Desktop**: a CLI talking to a daemon over a Unix-domain socket, line-delimited JSON
+  (the daemon serializes API records; shapes are host-owned).
+- **Wallet integration**: the Ethereum JSON-RPC HTTP server on loopback, strict mode —
+  the router consumes `VerifiedReads` directly.
+- **Mobile**: direct calls into the engine API (no socket), or the in-process loopback
+  JSON-RPC server the platform wallet points at.
 
----
 
 ## 6. Network Configuration
 

--- a/docs/reimplementation/README.md
+++ b/docs/reimplementation/README.md
@@ -307,7 +307,9 @@ hashes/addresses as bytes on the read API and 0x-hex strings in result records.
   `isRunning()`, `setTargetSnapPeers(n)`, `clearPeerState()`, plus the read surfaces
   below and the verified operator queries (`requestAccount`, `getStorageProof`,
   `getHeaders`, `getBlockVerified`, `dialPeer`) returning flat result records whose
-  `failReason`/`error` fields carry verification failures (never exceptions).
+  `failReason`/`error` fields carry verification failures. Verification failures never
+  throw; programmer/state errors (malformed address, network not running) DO throw the
+  API's single `EngineException`.
 - **`EngineConfig`** — `(networkName, elPort, discv5Port, rpcPort [0 = per-network
   default], syncSnapshotPath, gossipsubEnabled, targetSnapPeers [0 = maintainer off],
   strictStateFreshness)`.


### PR DESCRIPTION
Final PR of the engine-API extraction — Phase 3 (documentation). Docs-only; the reimplementation spec now points at the code as the specification.

## Changes
- **README §5 rewritten**: the engine API *is* the `:myotis-api` module — canonical `MyotisEngine`/`ChainHandle` lifecycle, the enforced FFI type rules, the `io.myotis.api.ports` catalog (with per-platform impl columns), and the `VerifiedReads` eth_* table in its final shapes (decimal-string wei, byte[] hashes, tri-state JSON). Companion table gains doc 05.
- **04-engine-and-hosts.md**: banner mapping every internal name the doc uses (`ChainStack`/`NodeRegistry`/`MyotisRpcBackend`/`PeerCachePort`/…) to its canonical API counterpart — the doc's internals remain the behavior guide *behind* the API signatures. Its own §5.2/§5.3 anchors updated for the renamed headings.
- **NEW `05-engine-api-bindings.md`**: the Rust-port playbook — interface→UniFFI construct map (objects/dictionaries/enums/callback-interface ports/single Error enum), threading + error-model contract, per-platform packaging on the proven `rust/myotis-bls` pipeline (`.aar`/`.xcframework`/desktop), the **recommended Rust-port simplification** (engine-owned peer-cache persistence, shrinking hosts to keystore+HTTP+DNS ports — from the iOS discussion), and a conformance checklist wired to the golden JSON tests, `RpcRouterTest`, the verify()-ladder tests, and the CLAUDE.md integration gate.
- **CLAUDE.md**: `:myotis-api` added to the module list; new convention line — hosts talk only to `:myotis-api`, with the documented exemptions spelled out precisely (composition-root `JavaMyotisEngine`, the `get-transactions` debug stream, Android's `BlsBackends` seam, the `MainnetPeerBootstrap` test fixture).

## Verification
Independent no-context review cross-checked **every signature/type/field claim against the `myotis-api` source (~40 types) — zero misstatements found** — plus link/anchor integrity, markdown table escaping, the PR-series claims (#117–#121 all merged), and the convention statement against actual host imports. Its two MUST-FIXes (the doc's own renamed anchors breaking two §5.x links in doc 04; the CLAUDE.md "never" that Android's BLS wiring falsified) and NITs (`close()` in the port table, `double[]` in the type rules, node-core mention, mapping-table row label) are all incorporated.

Follow-up candidates noted by the review (not for this docs-only PR): delete the two dead `EthHandlerSnapPeer` copies in `:app`/`:android-app` (superseded by `io.myotis.rpc.snap`).

This closes the 3-phase plan: (1) define the API → #117; (2) make the Java engine implement it + rewire every host → #118–#121; (3) document → this PR. A Rust engine now has a precise, code-anchored contract to implement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)