### PR TITLE
ci: publish GitHub Release with dmgs + apk on v* tags

### DIFF
--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -91,8 +91,13 @@ jobs:
       - name: Rename APK to a stable, versioned asset name
         run: |
           set -eu
-          apk=$(ls apk/*.apk | head -n1)
-          mv "$apk" "apk/Myotis-${GITHUB_REF_NAME}-android-debug.apk"
+          # Glob into an array and assert exactly one apk — a stray second file
+          # (or zero) should fail here, not silently ship an arbitrary pick.
+          shopt -s nullglob
+          apks=(apk/*.apk)
+          [ "${#apks[@]}" -eq 1 ] \
+            || { echo "::error::expected exactly 1 apk, found ${#apks[@]}: ${apks[*]}"; exit 1; }
+          mv "${apks[0]}" "apk/Myotis-${GITHUB_REF_NAME}-android-debug.apk"
 
       - name: Publish to GitHub Release
         env:
@@ -100,6 +105,19 @@ jobs:
         run: |
           set -eu
           tag="${GITHUB_REF_NAME}"
+          # Notes via a quoted heredoc + --notes-file: markdown stays literal
+          # (no shell escaping of backticks/quotes) and renders as intended.
+          notes=$(mktemp)
+          cat > "$notes" <<'NOTES'
+          First public build of the Myotis wallet apps (pre-release).
+
+          **Android (`*-android-debug.apk`)** — unsigned *debug* build. Install via
+          "Install unknown apps". Not a signed release build.
+
+          **Desktop (`Myotis-<arch>.dmg`)** — unsigned; download the dmg matching
+          your Mac (arm64 for Apple Silicon, x64 for Intel). First launch:
+          right-click → Open to get past Gatekeeper (not notarized yet).
+          NOTES
           # Create the release if it doesn't exist yet. The desktop workflow may
           # win this race for the same tag: if `create` fails, re-check with
           # `view` — success there means the other job already created it (fine),
@@ -108,14 +126,7 @@ jobs:
             gh release create "$tag" \
               --prerelease \
               --title "Myotis $tag" \
-              --notes "First public build of the Myotis wallet apps (pre-release).
-
-          **Android (\`*-android-debug.apk\`)** — unsigned *debug* build. Install via
-          \"Install unknown apps\". Not a signed release build.
-
-          **Desktop (\`Myotis-<arch>.dmg\`)** — unsigned; download the dmg matching
-          your Mac (arm64 for Apple Silicon, x64 for Intel). First launch:
-          right-click → Open to get past Gatekeeper (not notarized yet)." \
+              --notes-file "$notes" \
               --target "${GITHUB_SHA}" \
             || gh release view "$tag" >/dev/null 2>&1
           fi

--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -67,3 +67,56 @@ jobs:
           path: android-app/build/outputs/apk/debug/*.apk
           if-no-files-found: error
           retention-days: 30
+
+  # Attach the built APK to the GitHub Release for the pushed tag. Runs ONLY on
+  # `v*` tags (never on branch/PR builds), and reuses the build job's artifact
+  # rather than rebuilding. The desktop-dmg workflow publishes to the SAME
+  # release for the same tag; whichever job runs first creates it and the other
+  # just uploads its asset — the create step below tolerates that race.
+  release:
+    name: Publish APK to release
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      # gh release create/upload needs write access to Releases (repo contents).
+      contents: write
+    steps:
+      - name: Download APK artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: android-app-debug-${{ github.sha }}
+          path: apk
+
+      - name: Rename APK to a stable, versioned asset name
+        run: |
+          set -eu
+          apk=$(ls apk/*.apk | head -n1)
+          mv "$apk" "apk/Myotis-${GITHUB_REF_NAME}-android-debug.apk"
+
+      - name: Publish to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -eu
+          tag="${GITHUB_REF_NAME}"
+          # Create the release if it doesn't exist yet. The desktop workflow may
+          # win this race for the same tag: if `create` fails, re-check with
+          # `view` — success there means the other job already created it (fine),
+          # while a genuine failure still surfaces because `view` also fails.
+          if ! gh release view "$tag" >/dev/null 2>&1; then
+            gh release create "$tag" \
+              --prerelease \
+              --title "Myotis $tag" \
+              --notes "First public build of the Myotis wallet apps (pre-release).
+
+          **Android (\`*-android-debug.apk\`)** — unsigned *debug* build. Install via
+          \"Install unknown apps\". Not a signed release build.
+
+          **Desktop (\`Myotis-<arch>.dmg\`)** — unsigned; download the dmg matching
+          your Mac (arm64 for Apple Silicon, x64 for Intel). First launch:
+          right-click → Open to get past Gatekeeper (not notarized yet)." \
+              --target "${GITHUB_SHA}" \
+            || gh release view "$tag" >/dev/null 2>&1
+          fi
+          gh release upload "$tag" apk/Myotis-*.apk --clobber

--- a/.github/workflows/desktop-dmg.yml
+++ b/.github/workflows/desktop-dmg.yml
@@ -154,3 +154,59 @@ jobs:
           path: app-desktop/build/compose/binaries/main/dmg/*.dmg
           if-no-files-found: error
           retention-days: 30
+
+  # Attach both arch dmgs to the GitHub Release for the pushed tag. Runs ONLY on
+  # `v*` tags, ONCE (not per-arch), after BOTH matrix build jobs finish, and
+  # reuses their artifacts rather than rebuilding. The android-apk workflow
+  # publishes to the SAME release for the same tag; whichever job runs first
+  # creates it and the other just uploads — the create step tolerates that race.
+  release:
+    name: Publish dmgs to release
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      # gh release create/upload needs write access to Releases (repo contents).
+      contents: write
+    steps:
+      # Both matrix jobs' artifacts (Myotis-arm64.dmg, Myotis-x64.dmg) land under
+      # dmg/ — they were already arch-tagged and verified in the build job.
+      - name: Download dmg artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: myotis-desktop-dmg-*-${{ github.sha }}
+          path: dmg
+          merge-multiple: true
+
+      - name: Publish to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -eu
+          tag="${GITHUB_REF_NAME}"
+          # Fail loudly if either arch dmg is missing rather than shipping a
+          # half release (e.g. one matrix job was cancelled).
+          for arch in arm64 x64; do
+            test -f "dmg/Myotis-${arch}.dmg" \
+              || { echo "::error::missing dmg/Myotis-${arch}.dmg"; exit 1; }
+          done
+          # Create the release if it doesn't exist yet. The android workflow may
+          # win this race for the same tag: if `create` fails, re-check with
+          # `view` — success there means the other job already created it (fine),
+          # while a genuine failure still surfaces because `view` also fails.
+          if ! gh release view "$tag" >/dev/null 2>&1; then
+            gh release create "$tag" \
+              --prerelease \
+              --title "Myotis $tag" \
+              --notes "First public build of the Myotis wallet apps (pre-release).
+
+          **Android (\`*-android-debug.apk\`)** — unsigned *debug* build. Install via
+          \"Install unknown apps\". Not a signed release build.
+
+          **Desktop (\`Myotis-<arch>.dmg\`)** — unsigned; download the dmg matching
+          your Mac (arm64 for Apple Silicon, x64 for Intel). First launch:
+          right-click → Open to get past Gatekeeper (not notarized yet)." \
+              --target "${GITHUB_SHA}" \
+            || gh release view "$tag" >/dev/null 2>&1
+          fi
+          gh release upload "$tag" dmg/Myotis-arm64.dmg dmg/Myotis-x64.dmg --clobber

--- a/.github/workflows/desktop-dmg.yml
+++ b/.github/workflows/desktop-dmg.yml
@@ -190,6 +190,19 @@ jobs:
             test -f "dmg/Myotis-${arch}.dmg" \
               || { echo "::error::missing dmg/Myotis-${arch}.dmg"; exit 1; }
           done
+          # Notes via a quoted heredoc + --notes-file: markdown stays literal
+          # (no shell escaping of backticks/quotes) and renders as intended.
+          notes=$(mktemp)
+          cat > "$notes" <<'NOTES'
+          First public build of the Myotis wallet apps (pre-release).
+
+          **Android (`*-android-debug.apk`)** — unsigned *debug* build. Install via
+          "Install unknown apps". Not a signed release build.
+
+          **Desktop (`Myotis-<arch>.dmg`)** — unsigned; download the dmg matching
+          your Mac (arm64 for Apple Silicon, x64 for Intel). First launch:
+          right-click → Open to get past Gatekeeper (not notarized yet).
+          NOTES
           # Create the release if it doesn't exist yet. The android workflow may
           # win this race for the same tag: if `create` fails, re-check with
           # `view` — success there means the other job already created it (fine),
@@ -198,14 +211,7 @@ jobs:
             gh release create "$tag" \
               --prerelease \
               --title "Myotis $tag" \
-              --notes "First public build of the Myotis wallet apps (pre-release).
-
-          **Android (\`*-android-debug.apk\`)** — unsigned *debug* build. Install via
-          \"Install unknown apps\". Not a signed release build.
-
-          **Desktop (\`Myotis-<arch>.dmg\`)** — unsigned; download the dmg matching
-          your Mac (arm64 for Apple Silicon, x64 for Intel). First launch:
-          right-click → Open to get past Gatekeeper (not notarized yet)." \
+              --notes-file "$notes" \
               --target "${GITHUB_SHA}" \
             || gh release view "$tag" >/dev/null 2>&1
           fi


### PR DESCRIPTION
## What

Both `android-apk` and `desktop-dmg` workflows already build on `v*` tags but only stored their output as 30-day workflow artifacts — nothing created a downloadable GitHub Release. This adds a tag-gated `release` job to each so a `v*` tag publishes a single GitHub **pre-release** with the binaries attached:

- `Myotis-arm64.dmg` + `Myotis-x64.dmg` (desktop, both arches)
- `Myotis-<tag>-android-debug.apk` (unsigned debug build)

## How

- **desktop**: a `release` job (`needs: build`) runs once after both matrix arch jobs, downloads the arch-tagged dmg artifacts, and uploads them. Fails loudly if either arch dmg is missing.
- **android**: a `release` job downloads the debug apk and renames it to a versioned asset name.
- Both use the runner's built-in `GITHUB_TOKEN` (`contents: write`) via the `gh` CLI — no third-party action.
- The two workflows publish to the **same** release for a tag; the create step is race-tolerant (create-then-re-check-`view`), so whichever runs first creates the pre-release and the other just uploads.
- Release is `--prerelease` (early, unsigned/debug builds).

## Notes

- Only runs on `refs/tags/v*` — branch/PR builds are unaffected.
- Desktop dmg internal version stays `1.0.0` because macOS `jpackage` requires major > 0 (see `app-desktop/build.gradle.kts:94`); the git tag / Release is `v0.1.0`, and dmg filenames are arch-only so no version leaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)