### PR TITLE
ci: fix release jobs — set GH_REPO so gh works without a checkout

### DIFF
--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -102,6 +102,10 @@ jobs:
       - name: Publish to GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # No checkout in this job — gh must be told the repo explicitly or it
+          # dies with "fatal: not a git repository" (which sank the first v0.1.0
+          # attempt: every gh release call failed, so no release was created).
+          GH_REPO: ${{ github.repository }}
         run: |
           set -eu
           tag="${GITHUB_REF_NAME}"

--- a/.github/workflows/desktop-dmg.yml
+++ b/.github/workflows/desktop-dmg.yml
@@ -181,6 +181,10 @@ jobs:
       - name: Publish to GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # No checkout in this job — gh must be told the repo explicitly or it
+          # dies with "fatal: not a git repository" (which sank the first v0.1.0
+          # attempt: every gh release call failed, so no release was created).
+          GH_REPO: ${{ github.repository }}
         run: |
           set -eu
           tag="${GITHUB_REF_NAME}"


### PR DESCRIPTION
## What

The v0.1.0 tag run (#28750448315 / #28750448295) built all four artifacts successfully, but **both `release` jobs failed on every `gh` call** with:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

The release jobs intentionally skip checkout (they only download build artifacts), so `gh` had no repo context. Fix: `GH_REPO: ${{ github.repository }}` on the publish step in both workflows.

## Verification

Reproduced locally from a non-git directory: `gh release view v0.1.0` fails with the identical error; with `GH_REPO` set it returns `release not found` (clean exit 1), which correctly routes the script into `gh release create`.

After merge, re-pointing the `v0.1.0` tag at the merge commit re-triggers both workflows and publishes the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)