### PR TITLE
Rust PR4: myotis-consensus verification core — SSZ, merkleization, sync-committee verify

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "blst"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,10 +62,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "glob"
@@ -151,6 +199,7 @@ name = "myotis-consensus"
 version = "0.1.0"
 dependencies = [
  "myotis-bls",
+ "sha2",
 ]
 
 [[package]]
@@ -244,6 +293,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,10 +350,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/rust/myotis-consensus/Cargo.toml
+++ b/rust/myotis-consensus/Cargo.toml
@@ -8,3 +8,6 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 # The pure BLS verify core (no JNI — this crate is a plain lib).
 myotis-bls = { path = "../myotis-bls", default-features = false }
+# SSZ merkleization is SHA-256 only; the containers themselves are hand-decoded
+# (fork-polymorphic layouts — see src/ssz.rs for why not ssz_derive).
+sha2 = "0.10"

--- a/rust/myotis-consensus/src/lib.rs
+++ b/rust/myotis-consensus/src/lib.rs
@@ -1,14 +1,24 @@
 //! The Myotis sync-committee light client, in Rust.
 //!
-//! Grows through the Rust-engine PR series (see docs/reimplementation/05 and the
-//! phase-1 plan): SSZ types + tree_hash merkleization, checkpoint-pinned bootstrap,
-//! sync-committee verification (over [`myotis_bls::fast_aggregate_verify`]),
-//! catch-up via libp2p req/resp, discv5 CL discovery.
+//! Grown through the Rust-engine PR series (see docs/reimplementation/05 and the
+//! phase-1 plan). This stage (plan PR 4) is the VERIFICATION CORE: SSZ decoding of
+//! the light-client wire containers, hash_tree_root merkleization, Merkle-branch /
+//! gindex checks, and sync-committee signature verification over
+//! [`myotis_bls::fast_aggregate_verify`] — proven equivalent to the Java
+//! implementation by replaying `rust/testdata/lc/mainnet` to the verdicts recorded
+//! in `expected.txt` (see `tests/lc_conformance.rs`). Networking (discv5 + libp2p
+//! req/resp) is the next stage; no I/O lives in this crate yet.
 //!
 //! This is a pure-Rust library crate — no JNI here; the JVM boundary lives in
 //! `myotis-engine`.
 
-/// Placeholder proving the workspace wiring (myotis-bls rlib reuse without JNI).
+pub mod spec;
+pub mod ssz;
+pub mod store;
+pub mod types;
+pub mod verify;
+
+/// The production BLS DST (re-exported for callers that log/compare it).
 pub fn bls_dst() -> &'static [u8] {
     myotis_bls::DST
 }

--- a/rust/myotis-consensus/src/spec.rs
+++ b/rust/myotis-consensus/src/spec.rs
@@ -15,19 +15,32 @@ const CURRENT_SYNC_COMMITTEE_FIELD_INDEX: u64 = 22;
 const NEXT_SYNC_COMMITTEE_FIELD_INDEX: u64 = 23;
 const FINALIZED_CHECKPOINT_FIELD_INDEX: u64 = 20;
 
+// Depths reaching these helpers come from decode-validated branch lengths (4..=7),
+// but a shift-overflow panic on a wild depth would be a DoS foothold — guard and
+// return gindex 0, which can never satisfy verify_merkle_branch (safe rejection).
+
 /// Generalized index of current_sync_committee for a fork-dependent branch depth.
 pub fn sync_committee_gindex(branch_depth: usize) -> u64 {
+    if branch_depth >= 64 {
+        return 0;
+    }
     (1u64 << branch_depth) + CURRENT_SYNC_COMMITTEE_FIELD_INDEX
 }
 
 /// Generalized index of next_sync_committee for a fork-dependent branch depth.
 pub fn next_sync_committee_gindex(branch_depth: usize) -> u64 {
+    if branch_depth >= 64 {
+        return 0;
+    }
     (1u64 << branch_depth) + NEXT_SYNC_COMMITTEE_FIELD_INDEX
 }
 
 /// Generalized index of finalized_checkpoint.root — the branch depth includes the
 /// extra level into the Checkpoint container (root = field 1).
 pub fn finalized_root_gindex(branch_depth: usize) -> u64 {
+    if branch_depth == 0 || branch_depth >= 64 {
+        return 0;
+    }
     let checkpoint_gindex = (1u64 << (branch_depth - 1)) + FINALIZED_CHECKPOINT_FIELD_INDEX;
     checkpoint_gindex * 2 + 1
 }

--- a/rust/myotis-consensus/src/spec.rs
+++ b/rust/myotis-consensus/src/spec.rs
@@ -1,0 +1,54 @@
+//! Chain constants + gindex helpers — Rust twin of the Java `BeaconChainSpec`.
+
+pub const SLOTS_PER_EPOCH: u64 = 32;
+pub const EPOCHS_PER_SYNC_COMMITTEE_PERIOD: u64 = 256;
+pub const SLOTS_PER_SYNC_COMMITTEE_PERIOD: u64 =
+    SLOTS_PER_EPOCH * EPOCHS_PER_SYNC_COMMITTEE_PERIOD; // 8192
+pub const SYNC_COMMITTEE_SIZE: usize = 512;
+
+pub const DOMAIN_SYNC_COMMITTEE: [u8; 4] = [0x07, 0x00, 0x00, 0x00];
+
+pub const EXECUTION_PAYLOAD_GINDEX: u64 = 25;
+pub const EXECUTION_PAYLOAD_DEPTH: usize = 4;
+
+const CURRENT_SYNC_COMMITTEE_FIELD_INDEX: u64 = 22;
+const NEXT_SYNC_COMMITTEE_FIELD_INDEX: u64 = 23;
+const FINALIZED_CHECKPOINT_FIELD_INDEX: u64 = 20;
+
+/// Generalized index of current_sync_committee for a fork-dependent branch depth.
+pub fn sync_committee_gindex(branch_depth: usize) -> u64 {
+    (1u64 << branch_depth) + CURRENT_SYNC_COMMITTEE_FIELD_INDEX
+}
+
+/// Generalized index of next_sync_committee for a fork-dependent branch depth.
+pub fn next_sync_committee_gindex(branch_depth: usize) -> u64 {
+    (1u64 << branch_depth) + NEXT_SYNC_COMMITTEE_FIELD_INDEX
+}
+
+/// Generalized index of finalized_checkpoint.root — the branch depth includes the
+/// extra level into the Checkpoint container (root = field 1).
+pub fn finalized_root_gindex(branch_depth: usize) -> u64 {
+    let checkpoint_gindex = (1u64 << (branch_depth - 1)) + FINALIZED_CHECKPOINT_FIELD_INDEX;
+    checkpoint_gindex * 2 + 1
+}
+
+pub fn compute_sync_committee_period(slot: u64) -> u64 {
+    slot / SLOTS_PER_SYNC_COMMITTEE_PERIOD
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Same expectations the Java BeaconChainSpec constants encode.
+    #[test]
+    fn gindices_match_java_spec_constants() {
+        assert_eq!(sync_committee_gindex(5), 54);
+        assert_eq!(next_sync_committee_gindex(5), 55);
+        assert_eq!(finalized_root_gindex(6), 105);
+        // Electra depths
+        assert_eq!(sync_committee_gindex(6), 86);
+        assert_eq!(next_sync_committee_gindex(6), 87);
+        assert_eq!(finalized_root_gindex(7), 169);
+    }
+}

--- a/rust/myotis-consensus/src/ssz.rs
+++ b/rust/myotis-consensus/src/ssz.rs
@@ -1,0 +1,179 @@
+//! SSZ hashing/merkleization primitives — the Rust twin of the Java `SszUtil`.
+//!
+//! Hand-rolled (sha2 only) rather than the `ethereum_ssz`/`tree_hash` derive stack:
+//! the wire types this crate decodes are fork-POLYMORPHIC (branch lengths and fixed
+//! sizes are sniffed from offsets at runtime, exactly like the Java decoders), which
+//! static ssz_derive containers cannot express. Conformance to the spec is pinned by
+//! the shared corpus (`rust/testdata/lc/mainnet`) instead of by a library.
+
+use sha2::{Digest, Sha256};
+
+pub const ROOT_LEN: usize = 32;
+pub type Root = [u8; ROOT_LEN];
+
+/// SHA-256 of `a || b` (the only hash SSZ merkleization needs).
+pub fn sha256_pair(a: &[u8], b: &[u8]) -> Root {
+    let mut h = Sha256::new();
+    h.update(a);
+    h.update(b);
+    h.finalize().into()
+}
+
+/// zero_hashes[0] = 32 zero bytes; zero_hashes[n] = H(zh[n-1] || zh[n-1]).
+fn zero_hash(depth: usize) -> Root {
+    // Depth is tiny (<32) on every path here; recompute instead of a lazy static.
+    let mut z = [0u8; 32];
+    for _ in 0..depth {
+        z = sha256_pair(&z, &z);
+    }
+    z
+}
+
+fn next_power_of_two(n: usize) -> usize {
+    n.max(1).next_power_of_two()
+}
+
+/// Merkleize chunks, padding with zero hashes to `max(next_pow2(len), limit)` leaves.
+///
+/// Pads the BOTTOM layer with zero leaves and hashes upward — equivalent to the
+/// Java `merkleizeWithSize(chunks, size, depthOffset=0)`; Java's sparse variant
+/// (which pads with `ZERO_HASHES[depth]`) serves huge-limit lists these light
+/// client containers never contain, so it's deliberately absent here.
+pub fn merkleize_with_limit(chunks: &[Root], limit: usize) -> Root {
+    let size = next_power_of_two(chunks.len()).max(next_power_of_two(limit));
+    let mut layer: Vec<Root> = Vec::with_capacity(size);
+    layer.extend_from_slice(chunks);
+    layer.resize(size, zero_hash(0));
+    while layer.len() > 1 {
+        layer = layer
+            .chunks_exact(2)
+            .map(|p| sha256_pair(&p[0], &p[1]))
+            .collect();
+    }
+    layer[0]
+}
+
+pub fn merkleize(chunks: &[Root]) -> Root {
+    merkleize_with_limit(chunks, 0)
+}
+
+/// hash_tree_root of a container = merkleize of its field roots.
+pub fn container_root(field_roots: &[Root]) -> Root {
+    merkleize(field_roots)
+}
+
+/// mix_in_length: H(root || LE64(length) zero-padded to 32).
+pub fn mix_in_length(root: &Root, length: u64) -> Root {
+    let mut chunk = [0u8; 32];
+    chunk[..8].copy_from_slice(&length.to_le_bytes());
+    sha256_pair(root, &chunk)
+}
+
+pub fn uint64_root(v: u64) -> Root {
+    let mut chunk = [0u8; 32];
+    chunk[..8].copy_from_slice(&v.to_le_bytes());
+    chunk
+}
+
+pub fn bytes32_root(b: &[u8; 32]) -> Root {
+    *b
+}
+
+/// Zero-pad a short fixed byte value (bytes4 / bytes20) into one chunk.
+pub fn padded_root(b: &[u8]) -> Root {
+    debug_assert!(b.len() <= 32);
+    let mut chunk = [0u8; 32];
+    chunk[..b.len()].copy_from_slice(b);
+    chunk
+}
+
+/// hash_tree_root of a fixed-length byte vector of any size (chunked, zero-padded).
+pub fn byte_vector_root(data: &[u8]) -> Root {
+    let chunks: Vec<Root> = data
+        .chunks(32)
+        .map(|c| {
+            let mut chunk = [0u8; 32];
+            chunk[..c.len()].copy_from_slice(c);
+            chunk
+        })
+        .collect();
+    merkleize(&chunks)
+}
+
+/// hash_tree_root of a variable byte list with a chunk limit (extraData).
+pub fn byte_list_root(data: &[u8], chunk_limit: usize) -> Root {
+    let chunks: Vec<Root> = if data.is_empty() {
+        vec![[0u8; 32]]
+    } else {
+        data.chunks(32)
+            .map(|c| {
+                let mut chunk = [0u8; 32];
+                chunk[..c.len()].copy_from_slice(c);
+                chunk
+            })
+            .collect()
+    };
+    let root = merkleize_with_limit(&chunks, chunk_limit);
+    mix_in_length(&root, data.len() as u64)
+}
+
+/// Verify an SSZ Merkle inclusion proof (mirrors `SszUtil.verifyMerkleBranch`).
+pub fn verify_merkle_branch(
+    leaf: &Root,
+    branch: &[Root],
+    depth: usize,
+    index: u64,
+    root: &Root,
+) -> bool {
+    if branch.len() != depth {
+        return false;
+    }
+    let mut value = *leaf;
+    for (i, node) in branch.iter().enumerate() {
+        value = if (index >> i) & 1 == 1 {
+            sha256_pair(node, &value)
+        } else {
+            sha256_pair(&value, node)
+        };
+    }
+    value == *root
+}
+
+// ---- little-endian readers over untrusted input (checked) ----
+
+pub fn read_u32(data: &[u8], offset: usize) -> Option<u32> {
+    data.get(offset..offset + 4)
+        .map(|b| u32::from_le_bytes(b.try_into().unwrap()))
+}
+
+pub fn read_u64(data: &[u8], offset: usize) -> Option<u64> {
+    data.get(offset..offset + 8)
+        .map(|b| u64::from_le_bytes(b.try_into().unwrap()))
+}
+
+pub fn read_root(data: &[u8], offset: usize) -> Option<Root> {
+    data.get(offset..offset + 32).map(|b| b.try_into().unwrap())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_hash_chain_matches_definition() {
+        assert_eq!(zero_hash(0), [0u8; 32]);
+        assert_eq!(zero_hash(1), sha256_pair(&[0u8; 32], &[0u8; 32]));
+        let z1 = zero_hash(1);
+        assert_eq!(zero_hash(2), sha256_pair(&z1, &z1));
+    }
+
+    #[test]
+    fn merkle_branch_roundtrip() {
+        // Build a 4-leaf tree by hand and prove leaf 2 (gindex 4+2=6).
+        let leaves: Vec<Root> = (0u8..4).map(|i| [i; 32]).collect();
+        let root = merkleize(&leaves);
+        let branch = [leaves[3], sha256_pair(&leaves[0], &leaves[1])];
+        assert!(verify_merkle_branch(&leaves[2], &branch, 2, 6, &root));
+        assert!(!verify_merkle_branch(&leaves[2], &branch, 2, 7, &root));
+    }
+}

--- a/rust/myotis-consensus/src/ssz.rs
+++ b/rust/myotis-consensus/src/ssz.rs
@@ -44,11 +44,13 @@ pub fn merkleize_with_limit(chunks: &[Root], limit: usize) -> Root {
     let mut layer: Vec<Root> = Vec::with_capacity(size);
     layer.extend_from_slice(chunks);
     layer.resize(size, zero_hash(0));
-    while layer.len() > 1 {
-        layer = layer
-            .chunks_exact(2)
-            .map(|p| sha256_pair(&p[0], &p[1]))
-            .collect();
+    // In-place pairwise reduction: no per-level reallocation.
+    let mut len = size;
+    while len > 1 {
+        for i in 0..len / 2 {
+            layer[i] = sha256_pair(&layer[2 * i], &layer[2 * i + 1]);
+        }
+        len /= 2;
     }
     layer[0]
 }
@@ -102,17 +104,17 @@ pub fn byte_vector_root(data: &[u8]) -> Root {
 
 /// hash_tree_root of a variable byte list with a chunk limit (extraData).
 pub fn byte_list_root(data: &[u8], chunk_limit: usize) -> Root {
-    let chunks: Vec<Root> = if data.is_empty() {
-        vec![[0u8; 32]]
-    } else {
-        data.chunks(32)
-            .map(|c| {
-                let mut chunk = [0u8; 32];
-                chunk[..c.len()].copy_from_slice(c);
-                chunk
-            })
-            .collect()
-    };
+    // No empty-data special case needed: merkleize_with_limit pads an empty chunk
+    // list with zero leaves up to the limit, which equals the Java one-zero-chunk
+    // path's root exactly.
+    let chunks: Vec<Root> = data
+        .chunks(32)
+        .map(|c| {
+            let mut chunk = [0u8; 32];
+            chunk[..c.len()].copy_from_slice(c);
+            chunk
+        })
+        .collect();
     let root = merkleize_with_limit(&chunks, chunk_limit);
     mix_in_length(&root, data.len() as u64)
 }

--- a/rust/myotis-consensus/src/store.rs
+++ b/rust/myotis-consensus/src/store.rs
@@ -1,0 +1,247 @@
+//! Light-client store + processor — Rust twins of the Java `LightClientStore` /
+//! `LightClientProcessor`. Wall-clock-free by construction: the one live-loop
+//! clock input (the slot estimate behind `force_rotate_if_past_period`) is a
+//! plain parameter, exactly as the conformance corpus records it.
+
+use crate::spec;
+use crate::ssz::{self, Root};
+use crate::types::{
+    LightClientFinalityUpdate, LightClientHeader, LightClientUpdate, SyncCommittee,
+};
+use crate::verify;
+
+#[derive(Default)]
+pub struct LightClientStore {
+    finalized_header: Option<LightClientHeader>,
+    optimistic_header: Option<LightClientHeader>,
+    current_sync_committee: Option<SyncCommittee>,
+    next_sync_committee: Option<SyncCommittee>,
+    finalized_slot: u64,
+    optimistic_slot: u64,
+    current_sync_committee_period: u64,
+}
+
+impl LightClientStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn initialize(&mut self, header: LightClientHeader, committee: SyncCommittee) {
+        self.finalized_slot = header.beacon.slot;
+        self.optimistic_slot = header.beacon.slot;
+        self.current_sync_committee_period =
+            spec::compute_sync_committee_period(self.finalized_slot);
+        self.finalized_header = Some(header.clone());
+        self.optimistic_header = Some(header);
+        self.current_sync_committee = Some(committee);
+        self.next_sync_committee = None;
+    }
+
+    pub fn is_initialized(&self) -> bool {
+        self.current_sync_committee.is_some()
+    }
+
+    pub fn update_finalized(&mut self, header: &LightClientHeader, slot: u64) {
+        if slot > self.finalized_slot {
+            self.finalized_header = Some(header.clone());
+            self.finalized_slot = slot;
+        }
+    }
+
+    pub fn update_optimistic(&mut self, header: &LightClientHeader, slot: u64) {
+        if slot > self.optimistic_slot {
+            self.optimistic_header = Some(header.clone());
+            self.optimistic_slot = slot;
+        }
+    }
+
+    pub fn update_next_sync_committee(&mut self, next: SyncCommittee) {
+        self.next_sync_committee = Some(next);
+    }
+
+    pub fn apply_next_when_period_changes(&mut self, old_finalized_slot: u64, new_finalized_slot: u64) {
+        if self.next_sync_committee.is_none() {
+            return;
+        }
+        let old_period = spec::compute_sync_committee_period(old_finalized_slot);
+        let new_period = spec::compute_sync_committee_period(new_finalized_slot);
+        if new_period > old_period {
+            self.current_sync_committee = self.next_sync_committee.take();
+            self.current_sync_committee_period += 1;
+        }
+    }
+
+    /// Mirrors `LightClientStore.forceRotateIfPastPeriod` (the live loop's — and the
+    /// conformance corpus's — recorded-slot-estimate rotation between updates).
+    pub fn force_rotate_if_past_period(&mut self, current_slot_estimate: u64) {
+        if self.next_sync_committee.is_none() {
+            return;
+        }
+        let wall_period = spec::compute_sync_committee_period(current_slot_estimate);
+        if wall_period > self.current_sync_committee_period {
+            self.current_sync_committee = self.next_sync_committee.take();
+            self.current_sync_committee_period += 1;
+        }
+    }
+
+    pub fn finalized_header(&self) -> Option<&LightClientHeader> {
+        self.finalized_header.as_ref()
+    }
+    pub fn optimistic_header(&self) -> Option<&LightClientHeader> {
+        self.optimistic_header.as_ref()
+    }
+    pub fn current_sync_committee(&self) -> Option<&SyncCommittee> {
+        self.current_sync_committee.as_ref()
+    }
+    pub fn next_sync_committee(&self) -> Option<&SyncCommittee> {
+        self.next_sync_committee.as_ref()
+    }
+    pub fn finalized_slot(&self) -> u64 {
+        self.finalized_slot
+    }
+    pub fn optimistic_slot(&self) -> u64 {
+        self.optimistic_slot
+    }
+    pub fn current_period(&self) -> u64 {
+        self.current_sync_committee_period
+    }
+}
+
+/// Processes updates against a store — Rust twin of `LightClientProcessor` (minus
+/// the duplicate-signature fast path, which is a perf memo, not a verdict change:
+/// re-verifying a duplicate reaches the same `true`).
+pub struct LightClientProcessor {
+    pub store: LightClientStore,
+    fork_version: [u8; 4],
+    genesis_validators_root: Root,
+}
+
+impl LightClientProcessor {
+    pub fn new(store: LightClientStore, fork_version: [u8; 4], genesis_validators_root: Root) -> Self {
+        Self { store, fork_version, genesis_validators_root }
+    }
+
+    /// `is_valid_light_client_header` (Capella+): the execution payload header is
+    /// bound to the beacon body solely through this branch — the sync-committee
+    /// signature does NOT cover it.
+    pub fn verify_execution_branch(header: &LightClientHeader) -> bool {
+        ssz::verify_merkle_branch(
+            &header.execution.hash_tree_root(),
+            &header.execution_branch,
+            spec::EXECUTION_PAYLOAD_DEPTH,
+            spec::EXECUTION_PAYLOAD_GINDEX,
+            &header.beacon.body_root,
+        )
+    }
+
+    pub fn process_update(&mut self, update: &LightClientUpdate) -> bool {
+        let Some(committee) = self.store.current_sync_committee() else {
+            return false;
+        };
+
+        // Applicability gate BEFORE the expensive BLS verify (per spec
+        // validate_light_client_update; mirrors the Java gate exactly).
+        let store_period = self.store.current_period();
+        let sig_period = spec::compute_sync_committee_period(update.signature_slot);
+        let have_next = self.store.next_sync_committee().is_some();
+        let applicable = if have_next {
+            sig_period == store_period || sig_period == store_period + 1
+        } else {
+            sig_period == store_period
+        };
+        if !applicable {
+            return false;
+        }
+
+        if !verify::verify_sync_aggregate(
+            &update.sync_aggregate,
+            committee,
+            &update.attested_header.beacon,
+            &self.fork_version,
+            &self.genesis_validators_root,
+        ) {
+            return false;
+        }
+
+        // Finality branch: finalizedHeader is finalized in the attested state.
+        let depth = update.finality_branch.len();
+        if !ssz::verify_merkle_branch(
+            &update.finalized_header.beacon.hash_tree_root(),
+            &update.finality_branch,
+            depth,
+            spec::finalized_root_gindex(depth),
+            &update.attested_header.beacon.state_root,
+        ) {
+            return false;
+        }
+
+        if !Self::verify_execution_branch(&update.attested_header)
+            || !Self::verify_execution_branch(&update.finalized_header)
+        {
+            return false;
+        }
+
+        // Next sync committee: verify + store when we don't already hold one.
+        if self.store.next_sync_committee().is_none() {
+            let depth = update.next_sync_committee_branch.len();
+            if !ssz::verify_merkle_branch(
+                &update.next_sync_committee.hash_tree_root(),
+                &update.next_sync_committee_branch,
+                depth,
+                spec::next_sync_committee_gindex(depth),
+                &update.attested_header.beacon.state_root,
+            ) {
+                return false;
+            }
+            self.store
+                .update_next_sync_committee(update.next_sync_committee.clone());
+        }
+
+        let old_finalized = self.store.finalized_slot();
+        let finalized_slot = update.finalized_header.beacon.slot;
+        self.store.update_finalized(&update.finalized_header, finalized_slot);
+        self.store.update_optimistic(&update.attested_header, update.signature_slot);
+        self.store.apply_next_when_period_changes(old_finalized, finalized_slot);
+        true
+    }
+
+    pub fn process_finality_update(&mut self, update: &LightClientFinalityUpdate) -> bool {
+        let Some(committee) = self.store.current_sync_committee() else {
+            return false;
+        };
+
+        if !verify::verify_sync_aggregate(
+            &update.sync_aggregate,
+            committee,
+            &update.attested_header.beacon,
+            &self.fork_version,
+            &self.genesis_validators_root,
+        ) {
+            return false;
+        }
+
+        let depth = update.finality_branch.len();
+        if !ssz::verify_merkle_branch(
+            &update.finalized_header.beacon.hash_tree_root(),
+            &update.finality_branch,
+            depth,
+            spec::finalized_root_gindex(depth),
+            &update.attested_header.beacon.state_root,
+        ) {
+            return false;
+        }
+
+        if !Self::verify_execution_branch(&update.attested_header)
+            || !Self::verify_execution_branch(&update.finalized_header)
+        {
+            return false;
+        }
+
+        let old_finalized = self.store.finalized_slot();
+        let finalized_slot = update.finalized_header.beacon.slot;
+        self.store.update_finalized(&update.finalized_header, finalized_slot);
+        self.store.update_optimistic(&update.attested_header, update.signature_slot);
+        self.store.apply_next_when_period_changes(old_finalized, finalized_slot);
+        true
+    }
+}

--- a/rust/myotis-consensus/src/types.rs
+++ b/rust/myotis-consensus/src/types.rs
@@ -1,0 +1,604 @@
+//! Light-client wire types with SSZ decoding + hash_tree_root — Rust twins of the
+//! Java `com.jaeckel.ethp2p.consensus.types` decoders, INCLUDING their runtime
+//! fork sniffing (branch lengths / fixed sizes derived from the leading offsets,
+//! pre-Electra vs Electra+). Decoding never panics: every malformed input returns
+//! `Err(SszError)` with a message shaped like the Java exceptions.
+
+use crate::ssz::{self, Root};
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct SszError(pub String);
+
+impl std::fmt::Display for SszError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+impl std::error::Error for SszError {}
+
+fn err<T>(msg: impl Into<String>) -> Result<T, SszError> {
+    Err(SszError(msg.into()))
+}
+
+// -------------------------------------------------------------------------
+// BeaconBlockHeader — 112 bytes fixed
+// -------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BeaconBlockHeader {
+    pub slot: u64,
+    pub proposer_index: u64,
+    pub parent_root: Root,
+    pub state_root: Root,
+    pub body_root: Root,
+}
+
+impl BeaconBlockHeader {
+    pub const ENCODED_SIZE: usize = 112;
+
+    pub fn decode(ssz_bytes: &[u8]) -> Result<Self, SszError> {
+        if ssz_bytes.len() < Self::ENCODED_SIZE {
+            return err(format!(
+                "BeaconBlockHeader requires 112 bytes, got {}",
+                ssz_bytes.len()
+            ));
+        }
+        Ok(Self {
+            slot: ssz::read_u64(ssz_bytes, 0).unwrap(),
+            proposer_index: ssz::read_u64(ssz_bytes, 8).unwrap(),
+            parent_root: ssz::read_root(ssz_bytes, 16).unwrap(),
+            state_root: ssz::read_root(ssz_bytes, 48).unwrap(),
+            body_root: ssz::read_root(ssz_bytes, 80).unwrap(),
+        })
+    }
+
+    pub fn hash_tree_root(&self) -> Root {
+        ssz::container_root(&[
+            ssz::uint64_root(self.slot),
+            ssz::uint64_root(self.proposer_index),
+            self.parent_root,
+            self.state_root,
+            self.body_root,
+        ])
+    }
+}
+
+// -------------------------------------------------------------------------
+// SyncCommittee — 512 * 48 + 48 = 24624 bytes fixed
+// -------------------------------------------------------------------------
+
+pub const SYNC_COMMITTEE_SIZE: usize = 512;
+pub const PUBKEY_SIZE: usize = 48;
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct SyncCommittee {
+    /// The 512 pubkeys flattened (512 * 48 bytes) — the layout myotis-bls consumes.
+    pub pubkeys: Vec<u8>,
+    pub aggregate_pubkey: [u8; PUBKEY_SIZE],
+}
+
+impl SyncCommittee {
+    pub const ENCODED_SIZE: usize = SYNC_COMMITTEE_SIZE * PUBKEY_SIZE + PUBKEY_SIZE; // 24624
+
+    pub fn decode(ssz_bytes: &[u8]) -> Result<Self, SszError> {
+        if ssz_bytes.len() < Self::ENCODED_SIZE {
+            return err(format!(
+                "SyncCommittee requires {} bytes, got {}",
+                Self::ENCODED_SIZE,
+                ssz_bytes.len()
+            ));
+        }
+        let pubkeys = ssz_bytes[..SYNC_COMMITTEE_SIZE * PUBKEY_SIZE].to_vec();
+        let aggregate_pubkey = ssz_bytes
+            [SYNC_COMMITTEE_SIZE * PUBKEY_SIZE..Self::ENCODED_SIZE]
+            .try_into()
+            .unwrap();
+        Ok(Self { pubkeys, aggregate_pubkey })
+    }
+
+    pub fn pubkey(&self, i: usize) -> &[u8] {
+        &self.pubkeys[i * PUBKEY_SIZE..(i + 1) * PUBKEY_SIZE]
+    }
+
+    /// 48-byte pubkey → root: zero-pad to 64, merkleize the two chunks.
+    fn pubkey_root(pk: &[u8]) -> Root {
+        let mut c0 = [0u8; 32];
+        c0.copy_from_slice(&pk[..32]);
+        let mut c1 = [0u8; 32];
+        c1[..16].copy_from_slice(&pk[32..48]);
+        ssz::merkleize(&[c0, c1])
+    }
+
+    pub fn hash_tree_root(&self) -> Root {
+        let pubkey_roots: Vec<Root> = (0..SYNC_COMMITTEE_SIZE)
+            .map(|i| Self::pubkey_root(self.pubkey(i)))
+            .collect();
+        let pubkeys_vector_root = ssz::merkleize(&pubkey_roots);
+        let aggregate_root = Self::pubkey_root(&self.aggregate_pubkey);
+        ssz::container_root(&[pubkeys_vector_root, aggregate_root])
+    }
+}
+
+impl std::fmt::Debug for SyncCommittee {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SyncCommittee(512 pubkeys)")
+    }
+}
+
+// -------------------------------------------------------------------------
+// SyncAggregate — 64 + 96 = 160 bytes fixed
+// -------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SyncAggregate {
+    pub sync_committee_bits: [u8; 64],
+    pub sync_committee_signature: [u8; 96],
+}
+
+impl SyncAggregate {
+    pub const ENCODED_SIZE: usize = 160;
+
+    pub fn decode(ssz_bytes: &[u8]) -> Result<Self, SszError> {
+        if ssz_bytes.len() < Self::ENCODED_SIZE {
+            return err(format!(
+                "SyncAggregate requires 160 bytes, got {}",
+                ssz_bytes.len()
+            ));
+        }
+        Ok(Self {
+            sync_committee_bits: ssz_bytes[..64].try_into().unwrap(),
+            sync_committee_signature: ssz_bytes[64..160].try_into().unwrap(),
+        })
+    }
+
+    pub fn count_participants(&self) -> usize {
+        self.sync_committee_bits
+            .iter()
+            .map(|b| b.count_ones() as usize)
+            .sum()
+    }
+
+    pub fn get_bit(&self, i: usize) -> bool {
+        (self.sync_committee_bits[i / 8] >> (i % 8)) & 1 == 1
+    }
+}
+
+// -------------------------------------------------------------------------
+// ExecutionPayloadHeader — Deneb (584B fixed) / Electra+ (680B fixed), sniffed
+// from the extraData offset, exactly like the Java decoder.
+// -------------------------------------------------------------------------
+
+pub const DENEB_FIXED_SIZE: usize = 584;
+pub const ELECTRA_FIXED_SIZE: usize = 680;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecutionPayloadHeader {
+    pub parent_hash: Root,
+    pub fee_recipient: [u8; 20],
+    pub state_root: Root,
+    pub receipts_root: Root,
+    pub logs_bloom: Vec<u8>, // 256
+    pub prev_randao: Root,
+    pub block_number: u64,
+    pub gas_limit: u64,
+    pub gas_used: u64,
+    pub timestamp: u64,
+    pub extra_data: Vec<u8>,
+    pub base_fee_per_gas: Root, // uint256 LE
+    pub block_hash: Root,
+    pub transactions_root: Root,
+    pub withdrawals_root: Root,
+    pub blob_gas_used: u64,
+    pub excess_blob_gas: u64,
+    // Electra+ request roots are parsed but — mirroring the Java hashTreeRoot,
+    // which merkleizes only the 17 Deneb fields — excluded from the root.
+    pub deposit_requests_root: Option<Root>,
+    pub withdrawal_requests_root: Option<Root>,
+    pub consolidation_requests_root: Option<Root>,
+}
+
+impl ExecutionPayloadHeader {
+    pub fn decode(ssz_bytes: &[u8]) -> Result<Self, SszError> {
+        if ssz_bytes.len() < DENEB_FIXED_SIZE {
+            return err(format!(
+                "ExecutionPayloadHeader requires at least {} bytes, got {}",
+                DENEB_FIXED_SIZE,
+                ssz_bytes.len()
+            ));
+        }
+        let g = |o: usize| ssz::read_root(ssz_bytes, o).unwrap();
+        let extra_data_offset = ssz::read_u32(ssz_bytes, 436).unwrap() as usize;
+        let is_electra = extra_data_offset >= ELECTRA_FIXED_SIZE;
+        if is_electra && ssz_bytes.len() < ELECTRA_FIXED_SIZE {
+            // Same observable outcome as the Java decoder, which reads the three
+            // request roots via buf.get and throws BufferUnderflowException here —
+            // a decode REJECTION either way, just a clean Err instead of an
+            // exception. (Pinned by eph_electra_offset_short_buffer_rejected.)
+            return err("ExecutionPayloadHeader: Electra offset but short buffer");
+        }
+        let fixed = if is_electra { ELECTRA_FIXED_SIZE } else { DENEB_FIXED_SIZE };
+        let extra_data = if extra_data_offset >= fixed && extra_data_offset <= ssz_bytes.len() {
+            ssz_bytes[extra_data_offset..].to_vec()
+        } else {
+            Vec::new()
+        };
+        Ok(Self {
+            parent_hash: g(0),
+            fee_recipient: ssz_bytes[32..52].try_into().unwrap(),
+            state_root: g(52),
+            receipts_root: g(84),
+            logs_bloom: ssz_bytes[116..372].to_vec(),
+            prev_randao: g(372),
+            block_number: ssz::read_u64(ssz_bytes, 404).unwrap(),
+            gas_limit: ssz::read_u64(ssz_bytes, 412).unwrap(),
+            gas_used: ssz::read_u64(ssz_bytes, 420).unwrap(),
+            timestamp: ssz::read_u64(ssz_bytes, 428).unwrap(),
+            extra_data,
+            base_fee_per_gas: g(440),
+            block_hash: g(472),
+            transactions_root: g(504),
+            withdrawals_root: g(536),
+            blob_gas_used: ssz::read_u64(ssz_bytes, 568).unwrap(),
+            excess_blob_gas: ssz::read_u64(ssz_bytes, 576).unwrap(),
+            deposit_requests_root: is_electra.then(|| g(584)),
+            withdrawal_requests_root: is_electra.then(|| g(616)),
+            consolidation_requests_root: is_electra.then(|| g(648)),
+        })
+    }
+
+    /// 17 Deneb fields, padded to 32 leaves — matches the Java hashTreeRoot (and
+    /// beacon nodes' ExecutionPayloadHeader root for Deneb/Electra/Fulu).
+    pub fn hash_tree_root(&self) -> Root {
+        const MAX_EXTRA_DATA_CHUNKS: usize = 1;
+        ssz::container_root(&[
+            self.parent_hash,
+            ssz::padded_root(&self.fee_recipient),
+            self.state_root,
+            self.receipts_root,
+            ssz::byte_vector_root(&self.logs_bloom),
+            self.prev_randao,
+            ssz::uint64_root(self.block_number),
+            ssz::uint64_root(self.gas_limit),
+            ssz::uint64_root(self.gas_used),
+            ssz::uint64_root(self.timestamp),
+            ssz::byte_list_root(&self.extra_data, MAX_EXTRA_DATA_CHUNKS),
+            self.base_fee_per_gas,
+            self.block_hash,
+            self.transactions_root,
+            self.withdrawals_root,
+            ssz::uint64_root(self.blob_gas_used),
+            ssz::uint64_root(self.excess_blob_gas),
+        ])
+    }
+}
+
+// -------------------------------------------------------------------------
+// LightClientHeader — beacon(112) + execution offset(4) + executionBranch(128)
+// -------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LightClientHeader {
+    pub beacon: BeaconBlockHeader,
+    pub execution: ExecutionPayloadHeader,
+    pub execution_branch: Vec<Root>, // 4 nodes
+}
+
+impl LightClientHeader {
+    pub const FIXED_SIZE: usize = 244;
+
+    pub fn decode(ssz_bytes: &[u8]) -> Result<Self, SszError> {
+        if ssz_bytes.len() < Self::FIXED_SIZE {
+            return err(format!(
+                "LightClientHeader requires at least {} bytes, got {}",
+                Self::FIXED_SIZE,
+                ssz_bytes.len()
+            ));
+        }
+        let beacon = BeaconBlockHeader::decode(&ssz_bytes[..112])?;
+        let execution_offset = ssz::read_u32(ssz_bytes, 112).unwrap() as usize;
+        let execution_branch: Vec<Root> = (0..4)
+            .map(|i| ssz::read_root(ssz_bytes, 116 + i * 32).unwrap())
+            .collect();
+        if execution_offset < Self::FIXED_SIZE || execution_offset > ssz_bytes.len() {
+            return err(format!(
+                "Invalid execution offset {execution_offset} in LightClientHeader"
+            ));
+        }
+        let execution = ExecutionPayloadHeader::decode(&ssz_bytes[execution_offset..])?;
+        Ok(Self { beacon, execution, execution_branch })
+    }
+}
+
+// -------------------------------------------------------------------------
+// LightClientBootstrap
+// -------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub struct LightClientBootstrap {
+    pub header: LightClientHeader,
+    pub current_sync_committee: SyncCommittee,
+    pub current_sync_committee_branch: Vec<Root>, // 5 or 6, fork-sniffed
+}
+
+impl LightClientBootstrap {
+    pub const MIN_FIXED_SIZE: usize = 4 + SyncCommittee::ENCODED_SIZE + 5 * 32; // 24788
+
+    pub fn decode(ssz_bytes: &[u8]) -> Result<Self, SszError> {
+        if ssz_bytes.len() < Self::MIN_FIXED_SIZE {
+            return err(format!(
+                "LightClientBootstrap requires at least {} bytes, got {}",
+                Self::MIN_FIXED_SIZE,
+                ssz_bytes.len()
+            ));
+        }
+        let header_offset = ssz::read_u32(ssz_bytes, 0).unwrap() as usize;
+        // The header offset IS the fixed size; derive the fork-dependent branch len.
+        let branch_bytes = header_offset
+            .checked_sub(4 + SyncCommittee::ENCODED_SIZE)
+            .unwrap_or(0);
+        let branch_nodes = branch_bytes / 32;
+        if !(5..=6).contains(&branch_nodes) || branch_bytes % 32 != 0 {
+            return err(format!(
+                "Invalid branch size: {branch_bytes} bytes (expected 160 or 192) in LightClientBootstrap"
+            ));
+        }
+        let current_sync_committee =
+            SyncCommittee::decode(&ssz_bytes[4..4 + SyncCommittee::ENCODED_SIZE])?;
+        let branch_start = 4 + SyncCommittee::ENCODED_SIZE;
+        // branch_nodes was sniffed from the ATTACKER-CONTROLLED offset: a 6-node
+        // claim on a 5-node-sized buffer must reject, not panic (checked reads).
+        let current_sync_committee_branch: Vec<Root> = (0..branch_nodes)
+            .map(|i| ssz::read_root(ssz_bytes, branch_start + i * 32))
+            .collect::<Option<_>>()
+            .ok_or_else(|| SszError("LightClientBootstrap: truncated branch".into()))?;
+        if header_offset > ssz_bytes.len() {
+            return err(format!(
+                "Invalid header offset {header_offset} in LightClientBootstrap"
+            ));
+        }
+        let header = LightClientHeader::decode(&ssz_bytes[header_offset..])?;
+        Ok(Self { header, current_sync_committee, current_sync_committee_branch })
+    }
+}
+
+// -------------------------------------------------------------------------
+// LightClientUpdate
+// -------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub struct LightClientUpdate {
+    pub attested_header: LightClientHeader,
+    pub next_sync_committee: SyncCommittee,
+    pub next_sync_committee_branch: Vec<Root>, // 5 or 6
+    pub finalized_header: LightClientHeader,
+    pub finality_branch: Vec<Root>, // 6 or 7
+    pub sync_aggregate: SyncAggregate,
+    pub signature_slot: u64,
+}
+
+impl LightClientUpdate {
+    pub const MIN_FIXED_SIZE: usize =
+        4 + SyncCommittee::ENCODED_SIZE + 5 * 32 + 4 + 6 * 32 + 160 + 8;
+
+    pub fn decode(ssz_bytes: &[u8]) -> Result<Self, SszError> {
+        if ssz_bytes.len() < Self::MIN_FIXED_SIZE {
+            return err(format!(
+                "LightClientUpdate requires at least {} bytes, got {}",
+                Self::MIN_FIXED_SIZE,
+                ssz_bytes.len()
+            ));
+        }
+        let attested_offset = ssz::read_u32(ssz_bytes, 0).unwrap() as usize;
+        // Fork sniff (same tolerance as Java: unknown sizes fall back to pre-Electra).
+        let total_branch_bytes = attested_offset
+            .checked_sub(4 + SyncCommittee::ENCODED_SIZE + 4 + 160 + 8)
+            .unwrap_or(0);
+        let (sc_nodes, fin_nodes) = if total_branch_bytes == 6 * 32 + 7 * 32 {
+            (6usize, 7usize) // Electra+
+        } else {
+            (5usize, 6usize) // pre-Electra (and the Java fallback)
+        };
+
+        let mut pos = 4usize;
+        let next_sync_committee =
+            SyncCommittee::decode(&ssz_bytes[pos..pos + SyncCommittee::ENCODED_SIZE])?;
+        pos += SyncCommittee::ENCODED_SIZE;
+        let next_sync_committee_branch: Vec<Root> = (0..sc_nodes)
+            .map(|i| ssz::read_root(ssz_bytes, pos + i * 32).unwrap())
+            .collect();
+        pos += sc_nodes * 32;
+        let finalized_offset = ssz::read_u32(ssz_bytes, pos)
+            .ok_or_else(|| SszError("LightClientUpdate: truncated".into()))? as usize;
+        pos += 4;
+        let finality_branch: Vec<Root> = (0..fin_nodes)
+            .map(|i| ssz::read_root(ssz_bytes, pos + i * 32))
+            .collect::<Option<_>>()
+            .ok_or_else(|| SszError("LightClientUpdate: truncated finality branch".into()))?;
+        pos += fin_nodes * 32;
+        let sync_aggregate = SyncAggregate::decode(
+            ssz_bytes
+                .get(pos..pos + SyncAggregate::ENCODED_SIZE)
+                .ok_or_else(|| SszError("LightClientUpdate: truncated syncAggregate".into()))?,
+        )?;
+        pos += SyncAggregate::ENCODED_SIZE;
+        let signature_slot = ssz::read_u64(ssz_bytes, pos)
+            .ok_or_else(|| SszError("LightClientUpdate: truncated signatureSlot".into()))?;
+
+        if attested_offset > ssz_bytes.len() {
+            return err(format!("Invalid attestedHeader offset: {attested_offset}"));
+        }
+        let attested_end = if finalized_offset > attested_offset && finalized_offset <= ssz_bytes.len() {
+            finalized_offset
+        } else {
+            ssz_bytes.len()
+        };
+        let attested_header = LightClientHeader::decode(&ssz_bytes[attested_offset..attested_end])?;
+        if finalized_offset > ssz_bytes.len() {
+            return err(format!("Invalid finalizedHeader offset: {finalized_offset}"));
+        }
+        let finalized_header = LightClientHeader::decode(&ssz_bytes[finalized_offset..])?;
+
+        Ok(Self {
+            attested_header,
+            next_sync_committee,
+            next_sync_committee_branch,
+            finalized_header,
+            finality_branch,
+            sync_aggregate,
+            signature_slot,
+        })
+    }
+}
+
+// -------------------------------------------------------------------------
+// LightClientFinalityUpdate
+// -------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub struct LightClientFinalityUpdate {
+    pub attested_header: LightClientHeader,
+    pub finalized_header: LightClientHeader,
+    pub finality_branch: Vec<Root>, // 6 or 7
+    pub sync_aggregate: SyncAggregate,
+    pub signature_slot: u64,
+}
+
+impl LightClientFinalityUpdate {
+    pub const MIN_FIXED_SIZE: usize = 4 + 4 + 6 * 32 + 160 + 8; // 368
+
+    pub fn decode(ssz_bytes: &[u8]) -> Result<Self, SszError> {
+        if ssz_bytes.len() < Self::MIN_FIXED_SIZE {
+            return err(format!(
+                "LightClientFinalityUpdate requires at least {} bytes, got {}",
+                Self::MIN_FIXED_SIZE,
+                ssz_bytes.len()
+            ));
+        }
+        let attested_offset = ssz::read_u32(ssz_bytes, 0).unwrap() as usize;
+        let finalized_offset = ssz::read_u32(ssz_bytes, 4).unwrap() as usize;
+
+        let branch_bytes = attested_offset.checked_sub(4 + 4 + 160 + 8).unwrap_or(0);
+        if branch_bytes % 32 != 0 {
+            return err(format!(
+                "Finality branch region is not a multiple of 32 bytes: {branch_bytes}"
+            ));
+        }
+        let branch_nodes = branch_bytes / 32;
+        if branch_nodes != 6 && branch_nodes != 7 {
+            return err(format!(
+                "Unexpected finality branch node count: {branch_nodes} (expected 6 or 7)"
+            ));
+        }
+        // branch_nodes came from the ATTACKER-CONTROLLED attested offset: a 7-node
+        // claim on a 6-node-sized buffer must reject, not panic (checked reads for
+        // everything positioned after the sniffed branch).
+        let finality_branch: Vec<Root> = (0..branch_nodes)
+            .map(|i| ssz::read_root(ssz_bytes, 8 + i * 32))
+            .collect::<Option<_>>()
+            .ok_or_else(|| SszError("LightClientFinalityUpdate: truncated branch".into()))?;
+        let mut pos = 8 + branch_nodes * 32;
+        let sync_aggregate = SyncAggregate::decode(
+            ssz_bytes
+                .get(pos..pos + 160)
+                .ok_or_else(|| SszError("LightClientFinalityUpdate: truncated syncAggregate".into()))?,
+        )?;
+        pos += 160;
+        let signature_slot = ssz::read_u64(ssz_bytes, pos)
+            .ok_or_else(|| SszError("LightClientFinalityUpdate: truncated signatureSlot".into()))?;
+
+        let actual_fixed = 4 + 4 + branch_nodes * 32 + 160 + 8;
+        if attested_offset < actual_fixed || attested_offset > ssz_bytes.len() {
+            return err(format!("Invalid attestedHeader offset: {attested_offset}"));
+        }
+        if finalized_offset < actual_fixed || finalized_offset > ssz_bytes.len() {
+            return err(format!("Invalid finalizedHeader offset: {finalized_offset}"));
+        }
+        let (attested_end, finalized_end) = if attested_offset < finalized_offset {
+            (finalized_offset, ssz_bytes.len())
+        } else {
+            (ssz_bytes.len(), attested_offset)
+        };
+        let attested_header = LightClientHeader::decode(&ssz_bytes[attested_offset..attested_end])?;
+        let finalized_header =
+            LightClientHeader::decode(&ssz_bytes[finalized_offset..finalized_end])?;
+
+        Ok(Self {
+            attested_header,
+            finalized_header,
+            finality_branch,
+            sync_aggregate,
+            signature_slot,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Malformed/truncated inputs must come back as Err, never panic — these
+    /// decoders face untrusted peer bytes.
+    #[test]
+    fn truncated_inputs_error_cleanly() {
+        assert!(BeaconBlockHeader::decode(&[0u8; 111]).is_err());
+        assert!(SyncCommittee::decode(&[0u8; 100]).is_err());
+        assert!(SyncAggregate::decode(&[0u8; 159]).is_err());
+        assert!(ExecutionPayloadHeader::decode(&[0u8; 583]).is_err());
+        assert!(LightClientHeader::decode(&[0u8; 243]).is_err());
+        assert!(LightClientBootstrap::decode(&[0u8; 100]).is_err());
+        assert!(LightClientUpdate::decode(&[0u8; 100]).is_err());
+        assert!(LightClientFinalityUpdate::decode(&[0u8; 100]).is_err());
+    }
+
+    /// All-zero buffers of plausible sizes carry nonsense offsets — still Err/Ok
+    /// without panicking (offset arithmetic is checked, not trusted).
+    #[test]
+    fn zeroed_buffers_never_panic() {
+        let _ = LightClientBootstrap::decode(&[0u8; LightClientBootstrap::MIN_FIXED_SIZE]);
+        let _ = LightClientUpdate::decode(&[0u8; LightClientUpdate::MIN_FIXED_SIZE]);
+        let _ = LightClientFinalityUpdate::decode(&[0u8; LightClientFinalityUpdate::MIN_FIXED_SIZE]);
+        let _ = LightClientHeader::decode(&[0u8; LightClientHeader::FIXED_SIZE]);
+        let _ = ExecutionPayloadHeader::decode(&[0u8; DENEB_FIXED_SIZE]);
+    }
+
+    /// The review's exact reproducers: fork-sniff offsets claiming the LARGER
+    /// (Electra) shape over a minimum-size buffer must reject, never panic.
+    #[test]
+    fn forged_fork_sniff_offsets_reject_cleanly() {
+        // Bootstrap: 6-node claim (offset 24820) over a 5-node-sized buffer.
+        let mut b = vec![0u8; LightClientBootstrap::MIN_FIXED_SIZE];
+        b[..4].copy_from_slice(&24820u32.to_le_bytes());
+        assert!(LightClientBootstrap::decode(&b).is_err());
+
+        // FinalityUpdate: 7-node claim (offset 400) over a 368-byte buffer —
+        // panicked at the syncAggregate slice before the fix.
+        let mut f = vec![0u8; LightClientFinalityUpdate::MIN_FIXED_SIZE];
+        f[..4].copy_from_slice(&400u32.to_le_bytes());
+        assert!(LightClientFinalityUpdate::decode(&f).is_err());
+
+        // FinalityUpdate: 399-byte buffer — the aggregate slice fits but the
+        // signatureSlot read runs off the end.
+        let mut f = vec![0u8; 399];
+        f[..4].copy_from_slice(&400u32.to_le_bytes());
+        assert!(LightClientFinalityUpdate::decode(&f).is_err());
+    }
+
+    /// Electra extraData offset over a Deneb-sized buffer: clean Err (the Java
+    /// twin throws BufferUnderflowException — a rejection on both engines).
+    #[test]
+    fn eph_electra_offset_short_buffer_rejected() {
+        let mut e = vec![0u8; DENEB_FIXED_SIZE];
+        e[436..440].copy_from_slice(&(ELECTRA_FIXED_SIZE as u32).to_le_bytes());
+        assert!(ExecutionPayloadHeader::decode(&e).is_err());
+    }
+
+    /// Bootstrap with a header offset pointing past the buffer must be rejected.
+    #[test]
+    fn bootstrap_bad_offset_rejected() {
+        let mut b = vec![0u8; LightClientBootstrap::MIN_FIXED_SIZE];
+        // offset = fixed size (valid branch len) but buffer ends exactly there → the
+        // embedded LightClientHeader decode fails on the empty tail.
+        b[..4].copy_from_slice(&(LightClientBootstrap::MIN_FIXED_SIZE as u32).to_le_bytes());
+        assert!(LightClientBootstrap::decode(&b).is_err());
+    }
+}

--- a/rust/myotis-consensus/src/types.rs
+++ b/rust/myotis-consensus/src/types.rs
@@ -217,6 +217,12 @@ impl ExecutionPayloadHeader {
             return err("ExecutionPayloadHeader: Electra offset but short buffer");
         }
         let fixed = if is_electra { ELECTRA_FIXED_SIZE } else { DENEB_FIXED_SIZE };
+        // Out-of-range extraData offsets fall back to EMPTY, deliberately NOT Err:
+        // this mirrors the Java reference decoder byte-for-byte (same `>= fixed &&
+        // <= len` guard, same empty fallback), and behavioral parity is the contract
+        // the conformance corpus pins. A forged offset can't smuggle anything —
+        // extraData feeds the EPH hash_tree_root, and a wrong root fails the signed
+        // execution-branch check downstream on BOTH engines identically.
         let extra_data = if extra_data_offset >= fixed && extra_data_offset <= ssz_bytes.len() {
             ssz_bytes[extra_data_offset..].to_vec()
         } else {

--- a/rust/myotis-consensus/src/verify.rs
+++ b/rust/myotis-consensus/src/verify.rs
@@ -1,0 +1,66 @@
+//! Sync-committee signature verification — Rust twin of the Java
+//! `SyncCommitteeVerifier` + `ForkData.computeDomain`, over the shared
+//! [`myotis_bls::fast_aggregate_verify`] core (production POP DST).
+
+use crate::spec;
+use crate::ssz::{self, Root};
+use crate::types::{BeaconBlockHeader, SyncAggregate, SyncCommittee, PUBKEY_SIZE};
+
+/// compute_domain(DOMAIN_SYNC_COMMITTEE, fork_version, genesis_validators_root):
+/// 4 domain-type bytes || first 28 bytes of hash_tree_root(ForkData).
+pub fn compute_domain(
+    domain_type: &[u8; 4],
+    fork_version: &[u8; 4],
+    genesis_validators_root: &Root,
+) -> Root {
+    let fork_data_root = ssz::container_root(&[
+        ssz::padded_root(fork_version),
+        *genesis_validators_root,
+    ]);
+    let mut domain = [0u8; 32];
+    domain[..4].copy_from_slice(domain_type);
+    domain[4..].copy_from_slice(&fork_data_root[..28]);
+    domain
+}
+
+/// compute_signing_root(object_root, domain) — a 2-field container root.
+pub fn compute_signing_root(object_root: &Root, domain: &Root) -> Root {
+    ssz::container_root(&[*object_root, *domain])
+}
+
+/// Verify a sync aggregate over an attested header (mirrors
+/// `SyncCommitteeVerifier.verify`): ≥2/3 participation, then
+/// fast_aggregate_verify of the participating pubkeys over the signing root.
+pub fn verify_sync_aggregate(
+    sync_aggregate: &SyncAggregate,
+    committee: &SyncCommittee,
+    attested_header: &BeaconBlockHeader,
+    fork_version: &[u8; 4],
+    genesis_validators_root: &Root,
+) -> bool {
+    let participants = sync_aggregate.count_participants();
+    if participants * 3 < spec::SYNC_COMMITTEE_SIZE * 2 {
+        return false;
+    }
+
+    let mut pubkeys = Vec::with_capacity(participants * PUBKEY_SIZE);
+    for i in 0..spec::SYNC_COMMITTEE_SIZE {
+        if sync_aggregate.get_bit(i) {
+            pubkeys.extend_from_slice(committee.pubkey(i));
+        }
+    }
+
+    let domain = compute_domain(
+        &spec::DOMAIN_SYNC_COMMITTEE,
+        fork_version,
+        genesis_validators_root,
+    );
+    let signing_root = compute_signing_root(&attested_header.hash_tree_root(), &domain);
+
+    myotis_bls::fast_aggregate_verify(
+        &pubkeys,
+        participants,
+        &signing_root,
+        &sync_aggregate.sync_committee_signature,
+    )
+}

--- a/rust/myotis-consensus/tests/lc_conformance.rs
+++ b/rust/myotis-consensus/tests/lc_conformance.rs
@@ -1,0 +1,154 @@
+//! Replays the committed light-client corpus (`rust/testdata/lc/mainnet` — raw SSZ
+//! captured from live mainnet) through the RUST verify path and asserts the exact
+//! verdicts `expected.txt` records, which the Java `LcVectorConformanceTest`
+//! replays and asserts on every JVM build. Identical bytes in → identical verdicts
+//! out, on both engines — this test is the plan's PR-4 exit criterion.
+//!
+//! The corpus is loaded via `CARGO_MANIFEST_DIR` (not `include_bytes!`) so a corpus
+//! refresh doesn't force a rebuild; the file set is enumerated from expected.txt's
+//! own counts, so a vector added without regenerated verdicts fails loudly here
+//! exactly like it does on the Java side.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::PathBuf;
+
+use myotis_consensus::spec;
+use myotis_consensus::ssz;
+use myotis_consensus::store::{LightClientProcessor, LightClientStore};
+use myotis_consensus::types::{
+    LightClientBootstrap, LightClientFinalityUpdate, LightClientUpdate,
+};
+
+fn corpus_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("testdata")
+        .join("lc")
+        .join("mainnet")
+}
+
+fn parse_kv(text: &str) -> BTreeMap<String, String> {
+    text.lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty() && !l.starts_with('#'))
+        .filter_map(|l| l.split_once('='))
+        .map(|(k, v)| (k.trim().to_string(), v.trim().to_string()))
+        .collect()
+}
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+fn unhex(s: &str) -> Vec<u8> {
+    (0..s.len() / 2)
+        .map(|i| u8::from_str_radix(&s[2 * i..2 * i + 2], 16).expect("bad hex in expected.txt"))
+        .collect()
+}
+
+#[test]
+fn replay_reproduces_recorded_verdicts() {
+    let dir = corpus_dir();
+    let expected = parse_kv(
+        &fs::read_to_string(dir.join("expected.txt"))
+            .expect("expected.txt missing — the corpus ships with recorded verdicts"),
+    );
+
+    // ---- bootstrap: same branch checks the Java replay (and live client) makes ----
+    let bootstrap_ssz = fs::read(dir.join("bootstrap.ssz")).expect("bootstrap.ssz");
+    let bootstrap = LightClientBootstrap::decode(&bootstrap_ssz).expect("bootstrap decodes");
+
+    let sc_depth = bootstrap.current_sync_committee_branch.len();
+    assert!(
+        ssz::verify_merkle_branch(
+            &bootstrap.current_sync_committee.hash_tree_root(),
+            &bootstrap.current_sync_committee_branch,
+            sc_depth,
+            spec::sync_committee_gindex(sc_depth),
+            &bootstrap.header.beacon.state_root,
+        ),
+        "bootstrap sync-committee branch must verify"
+    );
+    assert!(
+        LightClientProcessor::verify_execution_branch(&bootstrap.header),
+        "bootstrap execution branch must verify"
+    );
+
+    let mut actual: BTreeMap<String, String> = BTreeMap::new();
+    actual.insert("bootstrap.slot".into(), bootstrap.header.beacon.slot.to_string());
+    actual.insert(
+        "bootstrap.headerRoot".into(),
+        hex(&bootstrap.header.beacon.hash_tree_root()),
+    );
+
+    // ---- context recorded in expected.txt ----
+    let fork_version: [u8; 4] = unhex(&expected["forkVersion"]).try_into().unwrap();
+    let gvr: [u8; 32] = unhex(&expected["genesisValidatorsRoot"]).try_into().unwrap();
+    let slot_estimate: u64 = expected["input.currentSlotEstimate"].parse().unwrap();
+    actual.insert("forkVersion".into(), expected["forkVersion"].clone());
+    actual.insert("genesisValidatorsRoot".into(), expected["genesisValidatorsRoot"].clone());
+    actual.insert("input.currentSlotEstimate".into(), slot_estimate.to_string());
+
+    let mut store = LightClientStore::new();
+    store.initialize(bootstrap.header.clone(), bootstrap.current_sync_committee.clone());
+    let mut processor = LightClientProcessor::new(store, fork_version, gvr);
+
+    // ---- catch-up updates, filename order (3-digit corpus convention) ----
+    let mut update_files: Vec<_> = fs::read_dir(&dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|n| n.ends_with("-update.ssz")
+            && n.len() == "000-update.ssz".len()
+            && n[..3].chars().all(|c| c.is_ascii_digit()))
+        .collect();
+    update_files.sort();
+    actual.insert("updates.count".into(), update_files.len().to_string());
+    for (i, name) in update_files.iter().enumerate() {
+        let update = LightClientUpdate::decode(&fs::read(dir.join(name)).unwrap())
+            .unwrap_or_else(|e| panic!("{name} decodes: {e}"));
+        let applied = processor.process_update(&update);
+        if applied {
+            // Mirrors the live applyCatchUpResponses loop (and the Java replay).
+            processor.store.force_rotate_if_past_period(slot_estimate);
+        }
+        actual.insert(format!("update.{i}.applied"), applied.to_string());
+        actual.insert(
+            format!("update.{i}.finalizedSlot"),
+            processor.store.finalized_slot().to_string(),
+        );
+    }
+
+    // ---- finality updates, filename order ----
+    let mut finality_files: Vec<_> = fs::read_dir(&dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|n| n.ends_with("-finality.ssz")
+            && n.len() == "000-finality.ssz".len()
+            && n[..3].chars().all(|c| c.is_ascii_digit()))
+        .collect();
+    finality_files.sort();
+    actual.insert("finality.count".into(), finality_files.len().to_string());
+    for (i, name) in finality_files.iter().enumerate() {
+        let update = LightClientFinalityUpdate::decode(&fs::read(dir.join(name)).unwrap())
+            .unwrap_or_else(|e| panic!("{name} decodes: {e}"));
+        let applied = processor.process_finality_update(&update);
+        actual.insert(format!("finality.{i}.applied"), applied.to_string());
+    }
+
+    actual.insert(
+        "final.finalizedSlot".into(),
+        processor.store.finalized_slot().to_string(),
+    );
+    actual.insert(
+        "final.finalizedExecStateRoot".into(),
+        hex(&processor.store.finalized_header().unwrap().execution.state_root),
+    );
+
+    assert_eq!(
+        expected, actual,
+        "Rust replay verdicts diverge from expected.txt (the Java-recorded truth)"
+    );
+}

--- a/rust/myotis-consensus/tests/lc_conformance.rs
+++ b/rust/myotis-consensus/tests/lc_conformance.rs
@@ -32,8 +32,14 @@ fn parse_kv(text: &str) -> BTreeMap<String, String> {
     text.lines()
         .map(str::trim)
         .filter(|l| !l.is_empty() && !l.starts_with('#'))
-        .filter_map(|l| l.split_once('='))
-        .map(|(k, v)| (k.trim().to_string(), v.trim().to_string()))
+        .map(|l| {
+            // expected.txt is the conformance ORACLE: a non-comment line without
+            // '=' means it's corrupted/half-edited — fail loudly, never drop it.
+            let (k, v) = l
+                .split_once('=')
+                .unwrap_or_else(|| panic!("malformed line in expected.txt: {l:?}"));
+            (k.trim().to_string(), v.trim().to_string())
+        })
         .collect()
 }
 
@@ -42,6 +48,7 @@ fn hex(bytes: &[u8]) -> String {
 }
 
 fn unhex(s: &str) -> Vec<u8> {
+    assert!(s.len() % 2 == 0, "odd-length hex in expected.txt: {s:?}");
     (0..s.len() / 2)
         .map(|i| u8::from_str_radix(&s[2 * i..2 * i + 2], 16).expect("bad hex in expected.txt"))
         .collect()

--- a/rust/myotis-consensus/tests/lc_conformance.rs
+++ b/rust/myotis-consensus/tests/lc_conformance.rs
@@ -101,7 +101,7 @@ fn replay_reproduces_recorded_verdicts() {
         .map(|e| e.file_name().to_string_lossy().into_owned())
         .filter(|n| n.ends_with("-update.ssz")
             && n.len() == "000-update.ssz".len()
-            && n[..3].chars().all(|c| c.is_ascii_digit()))
+            && n.chars().take(3).all(|c| c.is_ascii_digit()))
         .collect();
     update_files.sort();
     actual.insert("updates.count".into(), update_files.len().to_string());
@@ -127,7 +127,7 @@ fn replay_reproduces_recorded_verdicts() {
         .map(|e| e.file_name().to_string_lossy().into_owned())
         .filter(|n| n.ends_with("-finality.ssz")
             && n.len() == "000-finality.ssz".len()
-            && n[..3].chars().all(|c| c.is_ascii_digit()))
+            && n.chars().take(3).all(|c| c.is_ascii_digit()))
         .collect();
     finality_files.sort();
     actual.insert("finality.count".into(), finality_files.len().to_string());


### PR DESCRIPTION
Fourth checkpoint PR of the Rust-engine phase (base: `rust-engine`): the Rust light client's **verification core**, proven equivalent to the Java implementation by replaying the committed mainnet corpus to identical verdicts.

## What

- **`ssz.rs`** — SHA-256 merkleization primitives. Hand-rolled over `sha2` rather than the `ethereum_ssz`/`tree_hash` derive stack, because the wire containers are fork-POLYMORPHIC (branch lengths and fixed sizes sniffed from offsets at runtime, exactly like the Java decoders) — static `ssz_derive` containers cannot express that; conformance is pinned by the shared corpus instead. Rationale documented in the module.
- **`types.rs`** — all LC wire types (`BeaconBlockHeader`, `SyncCommittee`, `SyncAggregate`, `ExecutionPayloadHeader` with the Deneb/Electra sniff, `LightClientHeader`/`Bootstrap`/`Update`/`FinalityUpdate`). `decode()` NEVER panics on untrusted peer bytes — every read after an attacker-influenced offset is checked. `hash_tree_root` matches the Java merkleization (17-field EPH root, 48-byte pubkey chunking, byte-list/vector semantics).
- **`spec.rs`** — gindex helpers unit-pinned to the Java `BeaconChainSpec` constants (54/55/105 pre-Electra; 86/87/169 Electra).
- **`verify.rs`** — `compute_domain`/signing root/sync-committee verify over the shared `myotis-bls` POP core, including the exact 2/3-participation boundary.
- **`store.rs`** — store + processor mirroring the Java semantics: applicability gate before BLS, finality/next-committee/execution-branch checks, period rotation with the recorded slot estimate as a plain parameter (wall-clock-free by construction). The Java duplicate-signature fast path is deliberately omitted (perf memo, verdict-neutral).

## The exit criterion

`tests/lc_conformance.rs` replays `rust/testdata/lc/mainnet` and asserts **full verdict parity** with `expected.txt` (the Java-recorded truth, asserted by `LcVectorConformanceTest` on every JVM build): bootstrap branch checks, all 19 updates (18 applied + the stale negative), both finality vectors (incl. the BLS-rejected negative), final head + execution state root. **Passed on the first complete run** — identical bytes in, identical verdicts out, on both engines.

## Independent review (Rust/consensus specialist pass)

Found **two genuine BLOCKERs** — decode panics on crafted fork-sniff offsets (a forged bootstrap claiming a 6-node branch over a 5-node buffer; a forged finality update claiming 7 nodes over a 368/399-byte buffer). Both fixed with checked reads; the reviewer's exact adversarial reproducers are committed as regression tests (`forged_fork_sniff_offsets_reject_cleanly`). Also addressed: the Electra-offset/short-buffer EPH case documented + pinned as rejection-on-both-engines (`eph_electra_offset_short_buffer_rejected`), the merkleize padding-equivalence note, and a digits-only corpus glob for exact parity with the Java test's filter. Everything on the accept path (merkleization, gindices, BLS, rotation) was confirmed equivalent and corpus-pinned.

## Verified

`cargo test --workspace` green (18 tests incl. the corpus replay in 0.26 s); `cargo build --release` clean, zero warnings; full `./gradlew build` green (cargoTest picks the new tests up via `check`); no-cargo build green with one `[rust]` note. Pure Rust — no Gradle/JNI surface changes; jniLibs byte-identical (the new modules aren't reachable from the R0 cdylib surface yet).

## Next

PR 5: `myotis-consensus` networking — sigp/discv5 CL discovery + rust-libp2p req/resp (bootstrap, `light_client_updates_by_range` catch-up, finality polling) driving this verification core against live mainnet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)