### PR TITLE
Rust PR5: myotis-net — discv5 + libp2p req/resp networking; full live mainnet sync

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -203,6 +203,27 @@ val cargoTest = tasks.register<Exec>("cargoTest") {
 }
 tasks.named("check") { dependsOn(cargoTest) }
 
+// wasm32 canary: `cargo check --target wasm32-unknown-unknown -p myotis-consensus`
+// PROVES the verification core stayed sans-I/O — tokio/libp2p/discv5 (and any
+// sockets/fs dependency someone accidentally adds) don't build for plain wasm32,
+// so the check failing is the tripwire. Needs BOTH the rustup target installed
+// AND clang on PATH (blst compiles its C sources with clang for wasm); self-skips
+// otherwise with one lifecycle note, like every other cargo* task.
+val wasmTargetInstalled = rustAvailable &&
+    probeTool("rustup", "target", "list", "--installed")
+        .lineSequence().any { it.trim() == "wasm32-unknown-unknown" }
+val clangAvailable = rustAvailable && probeTool("clang", "--version").isNotEmpty()
+val cargoCheckWasm = tasks.register<Exec>("cargoCheckWasm") {
+    group = "rust"
+    description = "cargo check -p myotis-consensus for wasm32-unknown-unknown — the sans-I/O canary (self-skips without cargo + the rustup wasm32 target + clang)"
+    onlyIf { rustAvailable && wasmTargetInstalled && clangAvailable }
+    workingDir = file("rust")
+    commandLine("cargo", "check", "--target", "wasm32-unknown-unknown", "-p", "myotis-consensus")
+    // No declared outputs, same rationale as cargoTest: cargo's own
+    // incrementalism makes a no-change rerun cheap.
+}
+tasks.named("check") { dependsOn(cargoCheckWasm) }
+
 tasks.register<Exec>("cargoNdkAndroid") {
     group = "rust"
     description = "Cross-compile the Android jniLibs via rust/build-android.sh (self-skips without cargo + cargo-ndk + NDK; the committed jniLibs are the fallback)"
@@ -250,6 +271,10 @@ gradle.taskGraph.whenReady {
         (cargoNdkVersion.isEmpty() || androidNdkDir == null)
     ) {
         logger.lifecycle("[rust] cargo-ndk or Android NDK not found — Android keeps the committed jniLibs")
+    } else if (allTasks.any { it.name == "cargoCheckWasm" } &&
+        (!wasmTargetInstalled || !clangAvailable)
+    ) {
+        logger.lifecycle("[rust] wasm32 canary skipped — needs rustup target wasm32-unknown-unknown + clang")
     }
 }
 

--- a/docs/myotis-rust-engine-guidelines.md
+++ b/docs/myotis-rust-engine-guidelines.md
@@ -1,0 +1,178 @@
+# Myotis Rust Engine — Design Guidelines for Embeddability
+
+> Companion to `docs/myotis-integration.md`. These are constraints to bake into the Myotis
+> Rust reimplementation **now, while the code is young**, so that one core serves every
+> Kohaku target: desktop daemon / native-messaging host (browser extension), in-process
+> Android/iOS (React Native app), and optionally WASM. Retrofitting any of these later is
+> far more expensive than respecting them from the first commit.
+
+## Target matrix the engine must serve
+
+| Target | Packaging | Sockets | Threads | Filesystem | Lifecycle |
+|---|---|---|---|---|---|
+| Desktop daemon / CLI | binary | ✅ raw TCP/UDP | ✅ tokio multi-thread | ✅ | long-running, user-managed |
+| Native-messaging host (Chrome/Firefox) | binary, spawned by browser | ✅ raw TCP/UDP | ✅ | ✅ | **spawned/killed on demand** — cold start matters |
+| Android (in-process) | `.aar` via UniFFI | ✅ | ✅ (thermal/battery limits) | ✅ app storage | foreground service; OS may kill/restore |
+| iOS (in-process) | `.xcframework` via UniFFI | ✅ | ✅ (stricter background limits) | ✅ app storage | aggressive suspension |
+| WASM (optional, degraded) | wasm-bindgen pkg | ❌ WebSocket/fetch only | ❌ single-threaded | ❌ IndexedDB via port | MV3 service worker killed after ~30 s idle |
+
+The common denominator drives the architecture: **the core must not assume sockets,
+threads, filesystem, or wall-clock time. All of these are host-provided.**
+
+## 1. Sans-I/O core: everything through port traits
+
+The reimplementation spec already injects host ports (keystore, peer cache, DNS, HTTP
+gateway, logger, clock). Extend that to the two things currently *not* behind ports:
+
+- **`StreamTransport`** — async open/read/write/close of ordered byte streams. RLPx
+  crypto and framing stay in the core; only the byte pipe is host-provided (native: TCP;
+  wasm: WebSocket bridge; tests: in-memory duplex).
+- **`PacketTransport`** — datagram send/recv for discv4/discv5.
+
+Plus, promote to explicit ports:
+
+- **`Storage`** — atomic key→blob store (node identity, peer caches, LCSS light-client
+  snapshot). Native: files; Android/iOS: app storage; wasm: IndexedDB/`chrome.storage`.
+  Design snapshots as *small, atomic, versioned blobs* — `chrome.storage` has quotas and
+  no partial writes.
+- **`Clock`** — both wall time and monotonic time. Never call
+  `std::time::Instant::now()` / `SystemTime::now()` in core crates (they panic or lie on
+  `wasm32-unknown-unknown`; injected time also enables deterministic tests).
+- **`Spawner` + timers** — no direct `tokio::spawn`, `std::thread::spawn`, or
+  `tokio::time::sleep` in core crates. The host decides: multi-threaded tokio natively,
+  `wasm_bindgen_futures::spawn_local` + `setTimeout` timers in the browser.
+- **`Entropy`** — route randomness through `getrandom` (works everywhere with the right
+  backend) or an injected source; never seed from time.
+
+**Rule of thumb: `myotis-core`, `myotis-consensus`, `myotis-evm`, `myotis-ens`, and
+`myotis-engine` must compile with no dependency on `tokio` (beyond `tokio::sync` if
+needed), `mio`, `socket2`, `std::net`, `std::fs`, `std::thread`, or `std::time`
+constructors.** Shells own all of those.
+
+## 2. Suggested crate layout
+
+```
+myotis-core        # crypto, RLP/SSZ, MPT proof verification        — sans-I/O, no_std-friendly where cheap
+myotis-consensus   # beacon light client, BLS gate, LCSS snapshots  — sans-I/O
+myotis-evm         # revm over proof-served state                   — sans-I/O
+myotis-ens         # ENSIP-10, CCIP-Read (via HttpGateway port)     — sans-I/O
+myotis-engine      # orchestration: sync loops, peer mgmt, VerifiedReads — only port traits
+myotis-shell-native  # tokio + real sockets + fs + threads → daemon, NM host
+myotis-shell-mobile  # UniFFI bindings (.aar / .xcframework), reuses shell-native internals
+myotis-shell-wasm    # wasm-bindgen + WebSocket transport + IndexedDB storage (optional)
+myotis-jsonrpc     # transport-independent RPC dispatch (see §5)
+myotis-cli         # native only
+```
+
+## 3. Async & threading discipline
+
+- **Executor-agnostic futures.** Core async code must run on a single-threaded executor.
+  Avoid gratuitous `Send + 'static` bounds in core traits; where the native shell needs
+  `Send`, use the `cfg(target_arch = "wasm32")` conditional-bound pattern (as reqwest and
+  libp2p do) rather than forcing `Send` everywhere or nowhere.
+- **No rayon / worker pools in core.** Heavy operations — BLS aggregate verification over
+  512-validator committees, EVM runs with proof round-trips — must be structured as
+  **chunked, yieldable async tasks** so a single-threaded host stays responsive. The
+  native shell may parallelize them via `Spawner`; the wasm shell runs them cooperatively
+  (or in a dedicated Web Worker — but never assume `SharedArrayBuffer`/wasm-threads;
+  cross-origin isolation in MV3 extensions is not realistically available).
+- **Cancellation safety.** Any await point may be the last one (service worker killed,
+  phone suspended, NM host SIGKILLed). Persist at explicit checkpoints; never require a
+  clean shutdown to avoid corruption. Restart must be idempotent.
+
+## 4. Crypto choices
+
+- **BLS: `blst` with the `portable` feature as the guaranteed-everywhere baseline**, asm
+  paths where available. blst compiles for wasm32; benchmark before assuming browser
+  performance is a problem (the 76× Android-ART slowdown that motivated the JNI crate was
+  a JVM artifact, not intrinsic).
+- Prefer pure-Rust RustCrypto crates (`k256`, `sha2`, `sha3`) for everything else — they
+  are portable to all targets by construction. Avoid `ring` and anything with mandatory
+  platform assembly or a C build that breaks cross-compilation (cargo-ndk, wasm32).
+- Keccak/secp256k1 hot paths: measure first; only take native-only accelerations behind
+  feature flags with a portable fallback.
+
+## 5. One RPC dispatch layer, many fronts
+
+Implement method dispatch (`eth_*`, `myotis_*`) once, against the engine handle,
+transport-independent. Then wrap it in thin fronts:
+
+- **HTTP/WS server** on loopback (daemon mode) — with an auth token or `Origin` check,
+  since localhost is reachable by any local process and any webpage.
+- **Native-messaging stdio** (Chrome framing: 4-byte LE length + JSON, **≤1 MB per
+  host→browser message** — build response chunking into the front, not the dispatch).
+- **In-process calls** (UniFFI for mobile, wasm-bindgen for wasm) — same dispatch, no
+  serialization detour where avoidable.
+
+Include a `myotis_status` method from day one: version, network, sync state, verified
+head, finality lag. Kohaku's provider uses it for detection, the verification badge, and
+degraded-mode UX.
+
+## 6. FFI-friendly API boundary
+
+The engine boundary (`MyotisEngine` → `ChainHandle` → `VerifiedReads`) must be expressible
+in **both UniFFI and wasm-bindgen** without a redesign:
+
+- DTOs are plain owned `serde` structs — no lifetimes, no generics, no trait objects
+  crossing the boundary.
+- Methods are `async fn(...) -> Result<T, MyotisError>` with a flat, enumerated error
+  type (FFI can't do rich error hierarchies).
+- Events/subscriptions (new verified head, sync progress, peer count) via a registered
+  callback interface — the one pattern that works over UniFFI callbacks, JS callbacks,
+  and channels alike. Avoid returning streams/iterators across the boundary.
+- Strict mode semantics preserved at the boundary: unverifiable → typed error, never a
+  silently proxied answer.
+
+## 7. Lifecycle: assume the host kills you
+
+This is the single most important behavioral requirement across MV3 service workers,
+native-messaging hosts, and mobile OSes:
+
+- **Fast warm start is a feature, not an optimization.** Persist the LCSS snapshot + peer
+  caches aggressively (the JVM implementation's ~10 s warm re-sync is the bar; the NM
+  host should aim lower since the browser spawns it per session).
+- Cold start (weak-subjectivity checkpoint) must be possible headlessly, with progress
+  events, and interruptible/resumable.
+- Embedded weak-subjectivity checkpoints must be updatable by the host without a binary
+  release (host passes a newer checkpoint via config).
+
+## 8. CI gates (cheap now, priceless later)
+
+Add from the first commit of the port traits:
+
+```
+cargo check --target wasm32-unknown-unknown -p myotis-core -p myotis-consensus -p myotis-evm -p myotis-ens -p myotis-engine
+cargo ndk -t arm64-v8a check          # Android cross-compile of shell-mobile deps
+cargo deny check                      # lockfile hygiene; ban wasm-hostile deps from core crates
+```
+
+The wasm32 check is the canary: it fails the moment someone adds `std::net`, `tokio/rt`,
+`SystemTime::now()`, or a C-asm dependency to a core crate — even if a browser build is
+never shipped, this check keeps the core honest about §1.
+
+## 9. Miscellaneous portability traps
+
+- **Logging/metrics:** `tracing` with host-installed subscriber only; no
+  `env_logger`/`tracing_subscriber::fmt` init inside core or engine crates.
+- **Binary size:** mobile and wasm care; keep `opt-level = "z"` / `lto = true` release
+  profiles measured in CI, and avoid mega-deps in core (e.g. full `alloy` when only
+  `alloy-rlp`/`alloy-primitives` are needed).
+- **DNS:** already a port in the spec — keep it that way (browsers and Android have no
+  `/etc/resolv.conf`).
+- **No global mutable state / no `lazy_static` singletons holding I/O** — multiple engine
+  instances per process must work (tests, multi-network, mobile app restarts).
+- **Determinism as a test strategy:** with time, entropy, transport, and storage all
+  injected, the whole engine can run under deterministic simulation (fake clock,
+  scripted peers) — this is the payoff of sans-I/O beyond portability.
+
+## What this buys Kohaku specifically
+
+- **Desktop extension:** the daemon and native-messaging host are two thin `shell-native`
+  fronts over the same dispatch — the Kohaku `MyotisProvider` talks to either without
+  caring which.
+- **Kohaku mobile apps:** the identical engine ships *in-process* via `shell-mobile`
+  (UniFFI), so `rpcProvider: 'myotis'` means the same thing on every platform.
+- **Optional in-extension WASM:** ruled out for real P2P (no raw sockets), but a
+  wasm-clean core leaves the door open for verified consensus-over-HTTPS light-client
+  reads inside the extension as a degraded fallback when no native engine is installed —
+  at essentially zero extra engine cost.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3,6 +3,244 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "alloy-rlp"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24671b1f62edcf0f9b62994c7bf72cd621a04a4b99f5020ece1a647b40e2f103"
+dependencies = [
+ "arrayvec",
+ "bytes",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "asn1_der"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4858a9d740c5007a9069007c3b4e91152d0506f13c1b31dd49051fd537656156"
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "asynchronous-codec"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a860072022177f903e59730004fb5dc13db9275b79bb2aef7ba8ce831956c233"
+dependencies = [
+ "bytes",
+ "futures-sink",
+ "futures-util",
+ "memchr",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "attohttpc"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e2cdb6d5ed835199484bb92bb8b3edd526effe995c61732580439c1a67e2e9"
+dependencies = [
+ "base64",
+ "http",
+ "log",
+ "url",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "base-x"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
+
+[[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base256emoji"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e9430d9a245a77c92176e649af6e275f20839a48389859d1661e9a128d077c"
+dependencies = [
+ "const-str",
+ "match-lookup",
+]
+
+[[package]]
+name = "base45"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240e56f4d3c453c36faacb695c535a4d5f8c7d23dac175014f32eb0a71012a03"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22,6 +260,27 @@ dependencies = [
  "threadpool",
  "zeroize",
 ]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -52,6 +311,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20 0.9.1",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -60,6 +371,43 @@ dependencies = [
  "bytes",
  "memchr",
 ]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-str"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f421161cb492475f1661ddc9815a745a1c894592070661180fdec3d4872e9c3"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -71,14 +419,175 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "data-encoding-macro"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3259c913752a86488b501ed8680446a5ed2d5aeac6e596cb23ba3800768ea32c"
+dependencies = [
+ "data-encoding",
+ "data-encoding-macro-internal",
+]
+
+[[package]]
+name = "data-encoding-macro-internal"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
+dependencies = [
+ "data-encoding",
+ "syn",
+]
+
+[[package]]
+name = "delay_map"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88e365f083a5cb5972d50ce8b1b2c9f125dc5ec0f50c0248cfb568ae59efcf0b"
+dependencies = [
+ "futures",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "digest"
@@ -87,14 +596,354 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "subtle",
 ]
+
+[[package]]
+name = "discv5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470ad731fddfc5b184e8bd2e3e24ddc6c7b006212af2b3989fd37a3de1217b4b"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "alloy-rlp",
+ "arrayvec",
+ "ctr",
+ "delay_map",
+ "enr",
+ "fnv",
+ "futures",
+ "hashlink 0.11.1",
+ "hex",
+ "hkdf",
+ "lazy_static",
+ "more-asserts",
+ "parking_lot",
+ "rand 0.8.6",
+ "smallvec",
+ "socket2 0.6.4",
+ "tokio",
+ "tracing",
+ "uint",
+ "zeroize",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dtoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "enr"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "851bd664a3d3a3c175cff92b2f0df02df3c541b4895d0ae307611827aae46152"
+dependencies = [
+ "alloy-rlp",
+ "base64",
+ "bytes",
+ "ed25519-dalek",
+ "hex",
+ "k256",
+ "log",
+ "rand 0.8.6",
+ "serde",
+ "sha3",
+ "zeroize",
+]
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fastbloom"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef975e30683b2d965054bb0a836f8973857c4ebf6acf274fe46617cd285060d8"
+dependencies = [
+ "foldhash 0.2.0",
+ "libm",
+ "portable-atomic",
+ "siphasher",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-bounded"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91f328e7fb845fc832912fb6a34f40cf6d1888c92f974d1893a54e97b5ff542e"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f2f12607f92c69b12ed746fabf9ca4f5c482cba46679c1a75b874ed7c26adb"
+dependencies = [
+ "futures-io",
+ "rustls",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "generic-array"
@@ -104,6 +953,56 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -113,10 +1012,443 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hickory-proto"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "once_cell",
+ "rand 0.9.4",
+ "ring",
+ "socket2 0.5.10",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "moka",
+ "once_cell",
+ "parking_lot",
+ "rand 0.9.4",
+ "resolv-conf",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "libc",
+ "pin-project-lite",
+ "socket2 0.6.4",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "if-addrs"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0a05c691e1fae256cf7013d99dad472dc52d5543322761f83ec8d47eab40d2b"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "if-watch"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71c02a5161c313f0cbdbadc511611893584a10a7b6153cb554bdf83ddce99ec2"
+dependencies = [
+ "async-io",
+ "core-foundation",
+ "fnv",
+ "futures",
+ "if-addrs",
+ "ipnet",
+ "log",
+ "netlink-packet-core",
+ "netlink-packet-route",
+ "netlink-proto",
+ "netlink-sys",
+ "rtnetlink",
+ "system-configuration",
+ "tokio",
+ "windows",
+]
+
+[[package]]
+name = "igd-next"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516893339c97f6011282d5825ac94fc1c7aad5cad26bdc2d0cee068c0bf97f97"
+dependencies = [
+ "async-trait",
+ "attohttpc",
+ "bytes",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "rand 0.9.4",
+ "tokio",
+ "url",
+ "xmltree",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "ipconfig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+dependencies = [
+ "socket2 0.6.4",
+ "widestring",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -135,7 +1467,7 @@ dependencies = [
  "combine",
  "jni-sys 0.3.1",
  "log",
- "thiserror",
+ "thiserror 1.0.69",
  "walkdir",
  "windows-sys 0.45.0",
 ]
@@ -169,10 +1501,409 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "k256"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+dependencies = [
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "once_cell",
+ "sha2",
+ "signature",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libp2p"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce71348bf5838e46449ae240631117b487073d5f347c06d434caddcb91dceb5a"
+dependencies = [
+ "bytes",
+ "either",
+ "futures",
+ "futures-timer",
+ "getrandom 0.2.17",
+ "libp2p-allow-block-list",
+ "libp2p-connection-limits",
+ "libp2p-core",
+ "libp2p-dns",
+ "libp2p-identify",
+ "libp2p-identity",
+ "libp2p-mdns",
+ "libp2p-metrics",
+ "libp2p-noise",
+ "libp2p-quic",
+ "libp2p-request-response",
+ "libp2p-swarm",
+ "libp2p-tcp",
+ "libp2p-upnp",
+ "libp2p-yamux",
+ "multiaddr",
+ "pin-project",
+ "rw-stream-sink",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "libp2p-allow-block-list"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16ccf824ee859ca83df301e1c0205270206223fd4b1f2e512a693e1912a8f4a"
+dependencies = [
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+]
+
+[[package]]
+name = "libp2p-connection-limits"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18b8b607cf3bfa2f8c57db9c7d8569a315d5cc0a282e6bfd5ebfc0a9840b2a0"
+dependencies = [
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+]
+
+[[package]]
+name = "libp2p-core"
+version = "0.43.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "249128cd37a2199aff30a7675dffa51caf073b51aa612d2f544b19932b9aebca"
+dependencies = [
+ "either",
+ "fnv",
+ "futures",
+ "futures-timer",
+ "libp2p-identity",
+ "multiaddr",
+ "multihash",
+ "multistream-select",
+ "parking_lot",
+ "pin-project",
+ "quick-protobuf",
+ "rand 0.8.6",
+ "rw-stream-sink",
+ "thiserror 2.0.18",
+ "tracing",
+ "unsigned-varint 0.8.0",
+ "web-time",
+]
+
+[[package]]
+name = "libp2p-dns"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b770c1c8476736ca98c578cba4b505104ff8e842c2876b528925f9766379f9a"
+dependencies = [
+ "async-trait",
+ "futures",
+ "hickory-resolver",
+ "libp2p-core",
+ "libp2p-identity",
+ "parking_lot",
+ "smallvec",
+ "tracing",
+]
+
+[[package]]
+name = "libp2p-identify"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ab792a8b68fdef443a62155b01970c81c3aadab5e659621b063ef252a8e65e8"
+dependencies = [
+ "asynchronous-codec",
+ "either",
+ "futures",
+ "futures-bounded",
+ "futures-timer",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "quick-protobuf",
+ "quick-protobuf-codec",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "libp2p-identity"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9525f3831544f7ae497bde79adf114ef127b0fbbb97edbbf692a80408636421c"
+dependencies = [
+ "asn1_der",
+ "bs58",
+ "ed25519-dalek",
+ "hkdf",
+ "k256",
+ "multihash",
+ "prost",
+ "rand 0.8.6",
+ "sha2",
+ "thiserror 2.0.18",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "libp2p-mdns"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66872d0f1ffcded2788683f76931be1c52e27f343edb93bc6d0bcd8887be443"
+dependencies = [
+ "futures",
+ "hickory-proto",
+ "if-watch",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "rand 0.8.6",
+ "smallvec",
+ "socket2 0.5.10",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "libp2p-metrics"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "805a555148522cb3414493a5153451910cb1a146c53ffbf4385708349baf62b7"
+dependencies = [
+ "futures",
+ "libp2p-core",
+ "libp2p-identify",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "pin-project",
+ "prometheus-client",
+ "web-time",
+]
+
+[[package]]
+name = "libp2p-noise"
+version = "0.46.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc73eacbe6462a0eb92a6527cac6e63f02026e5407f8831bde8293f19217bfbf"
+dependencies = [
+ "asynchronous-codec",
+ "bytes",
+ "futures",
+ "libp2p-core",
+ "libp2p-identity",
+ "multiaddr",
+ "multihash",
+ "quick-protobuf",
+ "rand 0.8.6",
+ "snow",
+ "static_assertions",
+ "thiserror 2.0.18",
+ "tracing",
+ "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
+name = "libp2p-quic"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dcc597d70bf7f6f30cbe07081802c836184e48416e89e9ce73a0ba2c56a319e"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "if-watch",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-tls",
+ "quinn",
+ "quinn-proto",
+ "rand 0.8.6",
+ "ring",
+ "rustls",
+ "socket2 0.5.10",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "libp2p-request-response"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9f1cca83488b90102abac7b67d5c36fc65bc02ed47620228af7ed002e6a1478"
+dependencies = [
+ "async-trait",
+ "futures",
+ "futures-bounded",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "rand 0.8.6",
+ "smallvec",
+ "tracing",
+]
+
+[[package]]
+name = "libp2p-swarm"
+version = "0.47.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce88c6c4bf746c8482480345ea3edfd08301f49e026889d1cbccfa1808a9ed9e"
+dependencies = [
+ "either",
+ "fnv",
+ "futures",
+ "futures-timer",
+ "hashlink 0.10.0",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm-derive",
+ "multistream-select",
+ "rand 0.8.6",
+ "smallvec",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "libp2p-swarm-derive"
+version = "0.35.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd297cf53f0cb3dee4d2620bb319ae47ef27c702684309f682bdb7e55a18ae9c"
+dependencies = [
+ "heck",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "libp2p-tcp"
+version = "0.44.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb6585b9309699f58704ec9ab0bb102eca7a3777170fa91a8678d73ca9cafa93"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "if-watch",
+ "libc",
+ "libp2p-core",
+ "socket2 0.6.4",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "libp2p-tls"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96ff65a82e35375cbc31ebb99cacbbf28cb6c4fefe26bf13756ddcf708d40080"
+dependencies = [
+ "futures",
+ "futures-rustls",
+ "libp2p-core",
+ "libp2p-identity",
+ "rcgen",
+ "ring",
+ "rustls",
+ "rustls-webpki",
+ "thiserror 2.0.18",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
+name = "libp2p-upnp"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4757e65fe69399c1a243bbb90ec1ae5a2114b907467bf09f3575e899815bb8d3"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "igd-next",
+ "libp2p-core",
+ "libp2p-swarm",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "libp2p-yamux"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f15df094914eb4af272acf9adaa9e287baa269943f32ea348ba29cfb9bfc60d8"
+dependencies = [
+ "either",
+ "futures",
+ "libp2p-core",
+ "thiserror 2.0.18",
+ "tracing",
+ "yamux 0.12.1",
+ "yamux 0.13.10",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -181,10 +1912,131 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "match-lookup"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "757aee279b8bdbb9f9e676796fd459e4207a1f986e87886700abf589f5abf771"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "mio"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
+name = "more-asserts"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
+
+[[package]]
+name = "multiaddr"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe6351f60b488e04c1d21bc69e56b89cb3f5e8f5d22557d6e8031bdfd79b6961"
+dependencies = [
+ "arrayref",
+ "byteorder",
+ "data-encoding",
+ "libp2p-identity",
+ "multibase",
+ "multihash",
+ "percent-encoding",
+ "serde",
+ "static_assertions",
+ "unsigned-varint 0.8.0",
+ "url",
+]
+
+[[package]]
+name = "multibase"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e0e4a371cbf1dfd666b658ba137763edb23c45beb43cfe369b5593cd6b437b6"
+dependencies = [
+ "base-x",
+ "base256emoji",
+ "base45",
+ "data-encoding",
+ "data-encoding-macro",
+]
+
+[[package]]
+name = "multihash"
+version = "0.19.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "577c63b00ad74d57e8c9aa870b5fccebf2fd64a308a5aee9f1bb88e4aea19447"
+dependencies = [
+ "unsigned-varint 0.8.0",
+]
+
+[[package]]
+name = "multistream-select"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0df8e5eec2298a62b326ee4f0d7fe1a6b90a09dfcf9df37b38f947a8c42f19"
+dependencies = [
+ "bytes",
+ "futures",
+ "log",
+ "pin-project",
+ "smallvec",
+ "unsigned-varint 0.7.2",
+]
 
 [[package]]
 name = "myotis-bls"
@@ -213,6 +2065,140 @@ dependencies = [
 ]
 
 [[package]]
+name = "myotis-net"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "discv5",
+ "futures",
+ "libp2p",
+ "myotis-consensus",
+ "snap",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "netlink-packet-core"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3463cbb78394cb0141e2c926b93fc2197e473394b761986eca3b9da2c63ae0f4"
+dependencies = [
+ "paste",
+]
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ce3636fa715e988114552619582b530481fd5ef176a1e5c1bf024077c2c9445"
+dependencies = [
+ "bitflags",
+ "libc",
+ "log",
+ "netlink-packet-core",
+]
+
+[[package]]
+name = "netlink-proto"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65d130ee111430e47eed7896ea43ca693c387f097dd97376bffafbf25812128"
+dependencies = [
+ "bytes",
+ "futures",
+ "log",
+ "netlink-packet-core",
+ "netlink-sys",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "netlink-sys"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd6c30ed10fa69cc491d491b85cc971f6bdeb8e7367b7cde2ee6cc878d583fae"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "libc",
+ "log",
+ "tokio",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,6 +2206,185 @@ checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
 ]
 
 [[package]]
@@ -232,12 +2397,411 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus-client"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf41c1a7c32ed72abe5082fb19505b969095c12da9f5732a4bc9878757fd087c"
+dependencies = [
+ "dtoa",
+ "itoa",
+ "parking_lot",
+ "prometheus-client-derive-encode",
+]
+
+[[package]]
+name = "prometheus-client-derive-encode"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "quick-protobuf"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d6da84cc204722a989e01ba2f6e1e276e190f22263d0cb6ce8526fcdb0d2e1f"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "quick-protobuf-codec"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15a0580ab32b169745d7a39db2ba969226ca16738931be152a3209b409de2474"
+dependencies = [
+ "asynchronous-codec",
+ "bytes",
+ "quick-protobuf",
+ "thiserror 1.0.69",
+ "unsigned-varint 0.8.0",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "futures-io",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2 0.6.4",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "bytes",
+ "fastbloom",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.4",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20 0.10.1",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rtnetlink"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b960d5d873a75b5be9761b1e73b146f52dddcd27bac75263f40fba686d4d7b5"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "log",
+ "netlink-packet-core",
+ "netlink-packet-route",
+ "netlink-proto",
+ "netlink-sys",
+ "nix",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rw-stream-sink"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8c9026ff5d2f23da5e45bbc283f156383001bfb09c4e44256d02c1a685fe9a1"
+dependencies = [
+ "futures",
+ "pin-project",
+ "static_assertions",
 ]
 
 [[package]]
@@ -248,6 +2812,32 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -299,8 +2889,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+dependencies = [
+ "digest",
+ "keccak",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -308,6 +2917,115 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "snap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
+
+[[package]]
+name = "snow"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "850948bee068e713b8ab860fe1adc4d109676ab4c3b621fd8147f06b261f2f85"
+dependencies = [
+ "aes-gcm",
+ "blake2",
+ "chacha20poly1305",
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "ring",
+ "rustc_version",
+ "sha2",
+ "subtle",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -321,12 +3039,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -341,6 +3106,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "threadpool"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,16 +3135,261 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2 0.6.4",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "slab",
+ "tokio",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "log",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "uint"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "909988d098b2f738727b161a106cfc7cab00c539c2687a8836f8e565976fb53e"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "unsigned-varint"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6889a77d49f1f013504cec6bf97a2c730394adedaeb1deb5ea08949a50541105"
+
+[[package]]
+name = "unsigned-varint"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "1.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+dependencies = [
+ "getrandom 0.4.3",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"
@@ -378,6 +3408,91 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -387,10 +3502,116 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -398,7 +3619,16 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -416,13 +3646,38 @@ version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -432,10 +3687,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -444,10 +3711,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -456,16 +3741,194 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4569f339c0c402346d4a75a9e39cf8dad310e287eef1ff56d4c68e5067f53460"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+
+[[package]]
+name = "xmltree"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7d8a75eaf6557bb84a65ace8609883db44a29951042ada9b393151532e41fcb"
+dependencies = [
+ "xml-rs",
+]
+
+[[package]]
+name = "yamux"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed0164ae619f2dc144909a9f082187ebb5893693d8c0196e8085283ccd4b776"
+dependencies = [
+ "futures",
+ "log",
+ "nohash-hasher",
+ "parking_lot",
+ "pin-project",
+ "rand 0.8.6",
+ "static_assertions",
+]
+
+[[package]]
+name = "yamux"
+version = "0.13.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1991f6690292030e31b0144d73f5e8368936c58e45e7068254f7138b23b00672"
+dependencies = [
+ "futures",
+ "log",
+ "nohash-hasher",
+ "parking_lot",
+ "pin-project",
+ "rand 0.9.4",
+ "static_assertions",
+ "web-time",
+]
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
 
 [[package]]
 name = "zeroize"
@@ -481,6 +3944,39 @@ name = "zeroize_derive"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -4,9 +4,12 @@
 #   myotis-bls       — BLS12-381 fast-aggregate-verify (blst); cdylib for the JVM's
 #                      NativeBlsBackend AND rlib for in-workspace reuse (jni is a
 #                      default feature the pure-Rust consumers turn off).
-#   myotis-consensus — the sync-committee light client (pure Rust lib, no JNI):
-#                      SSZ types, tree_hash merkleization, sync-committee verify,
-#                      discv5 + libp2p req/resp. Grows through the Rust-engine PRs.
+#   myotis-consensus — the sync-committee light client VERIFICATION CORE (pure
+#                      Rust lib, no JNI, sans-I/O — no tokio/sockets/fs/clock):
+#                      SSZ types, tree_hash merkleization, sync-committee verify.
+#   myotis-net       — ALL consensus-layer I/O: discv5 discovery, libp2p eth2
+#                      req/resp, and the sync loop driving myotis-consensus.
+#                      Depends on myotis-consensus; never the other way around.
 #   myotis-engine    — the Rust implementation of the io.myotis.api engine contract,
 #                      exposed to the JVM via hand-JNI (libmyotis_engine).
 #
@@ -15,7 +18,7 @@
 
 [workspace]
 resolver = "2"
-members = ["myotis-bls", "myotis-consensus", "myotis-engine"]
+members = ["myotis-bls", "myotis-consensus", "myotis-engine", "myotis-net"]
 
 # Release profile is workspace-owned (crate-level [profile.*] is ignored in a
 # workspace): same tuning myotis-bls always shipped with.

--- a/rust/myotis-net/Cargo.toml
+++ b/rust/myotis-net/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "myotis-net"
+version = "0.1.0"
+edition = "2021"
+description = "Myotis consensus-layer networking: discv5 discovery + libp2p eth2 req/resp + the light-client sync loop (ALL I/O lives here; myotis-consensus stays sans-I/O)"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+# The sans-I/O verification core this crate drives. The dependency is strictly
+# one-way: myotis-consensus must never grow a dependency on this crate (or on
+# tokio/libp2p/discv5 through any other path) — that's the wasm32 canary's job
+# to enforce (root build.gradle.kts `cargoCheckWasm`).
+myotis-consensus = { path = "../myotis-consensus" }
+
+# Exact pins: this crate owns the I/O surface and interop with live CL peers
+# depends on wire-level behavior of these exact versions (noise/yamux framing,
+# discv5 packet format). Cargo.lock would pin them anyway; the `=` makes the
+# intent explicit and survives lockfile regeneration.
+tokio = { version = "=1.52.3", features = ["rt-multi-thread", "macros", "time", "sync", "signal"] }
+libp2p = { version = "=0.56.0", features = ["tokio", "tcp", "noise", "yamux", "identify", "request-response", "secp256k1", "macros"] }
+discv5 = "=0.11.0"
+snap = "=1.1.1"
+tracing = "=0.1.44"
+futures = "=0.3.32"
+async-trait = "=0.1.89"
+
+[dev-dependencies]
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[[example]]
+name = "live_sync"

--- a/rust/myotis-net/examples/live_sync.rs
+++ b/rust/myotis-net/examples/live_sync.rs
@@ -1,0 +1,62 @@
+//! Run the Rust light client against live mainnet until SYNCED, then keep
+//! polling finality.
+//!
+//! ```bash
+//! RUST_LOG=info cargo run --release -p myotis-net --example live_sync
+//! RUST_LOG=info cargo run --release -p myotis-net --example live_sync -- --once
+//! ```
+//!
+//! `--once` exits 0 as soon as the store is SYNCED (finalized within a couple
+//! of epochs of wall clock), non-zero after 25 minutes. Catch-up is peer-bound:
+//! live LC servers pace update chunks (~10 s apart under rate limiting), so the
+//! sync staggers disjoint sub-ranges across the fan-out and budgets generous
+//! per-request deadlines; a ~18-period-stale checkpoint measured 2026-07-06 in
+//! the low minutes with cooperative peers, longer under churn.
+
+use std::time::Duration;
+
+use myotis_net::{ChainConfig, SyncHandle, SyncState};
+
+#[tokio::main]
+async fn main() {
+    // The binary installs a subscriber; the library itself only emits tracing.
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info,myotis_net=info".into()),
+        )
+        .init();
+
+    let once = std::env::args().any(|a| a == "--once");
+
+    let handle = match SyncHandle::start(ChainConfig::mainnet()) {
+        Ok(h) => h,
+        Err(e) => {
+            tracing::error!(error = %e, "failed to start sync");
+            std::process::exit(2);
+        }
+    };
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(1500);
+    let mut last_status = None;
+    loop {
+        tokio::time::sleep(Duration::from_secs(3)).await;
+        let s = handle.status();
+        if last_status.as_ref() != Some(&s) {
+            tracing::info!(state = %s.state, finalized_slot = s.finalized_slot,
+                optimistic_slot = s.optimistic_slot, period = s.period,
+                peers = s.peer_count, "status");
+            last_status = Some(s.clone());
+        }
+        if s.state == SyncState::Synced && once {
+            tracing::info!("SYNCED — exiting (--once)");
+            handle.stop().await;
+            std::process::exit(0);
+        }
+        if once && tokio::time::Instant::now() > deadline {
+            tracing::error!("not SYNCED within 15 minutes");
+            handle.stop().await;
+            std::process::exit(1);
+        }
+    }
+}

--- a/rust/myotis-net/examples/probe_updates.rs
+++ b/rust/myotis-net/examples/probe_updates.rs
@@ -1,0 +1,87 @@
+//! Ground-truth probe for updates_by_range chunking: ask each static mainnet
+//! peer for a full 16-update range and report EXACTLY what comes back (wire
+//! bytes, chunk count, per-chunk sizes, wall time). Diagnostic tool for the
+//! "why do we see one chunk per response?" question — not part of the sync.
+//!
+//! ```bash
+//! RUST_LOG=info cargo run --release -p myotis-net --example probe_updates
+//! ```
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use libp2p::Multiaddr;
+use myotis_net::codec;
+use myotis_net::protocols;
+use myotis_net::reqresp::{self, LocalStatus};
+use myotis_net::status::StatusMessage;
+use myotis_net::sync::ChainConfig;
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info".into()),
+        )
+        .init();
+
+    let config = ChainConfig::mainnet();
+    let from_period = config.checkpoint_slot / 8192; // 1777
+    let span: u64 = 16;
+
+    // Same pre-bootstrap Status SyncHandle::start serves (checkpoint anchors).
+    let local = LocalStatus::new(StatusMessage {
+        fork_digest: config.current_fork_digest(),
+        finalized_root: config.checkpoint_root,
+        finalized_epoch: config.checkpoint_slot / config.slots_per_epoch.max(1),
+        head_root: config.checkpoint_root,
+        head_slot: config.checkpoint_slot,
+        earliest_available_slot: 0,
+    });
+    let client = reqresp::start_host(Arc::clone(&local)).expect("host");
+
+    let mut ssz_request = Vec::with_capacity(16);
+    ssz_request.extend_from_slice(&from_period.to_le_bytes());
+    ssz_request.extend_from_slice(&span.to_le_bytes());
+    let wire = codec::encode_request(&ssz_request);
+
+    for peer_str in &config.static_peers {
+        // Split /p2p/<id> off the multiaddr (same as sync's parse_static_peer).
+        let Ok(full) = peer_str.parse::<Multiaddr>() else { continue };
+        let mut addr = Multiaddr::empty();
+        let mut peer = None;
+        for proto in full.iter() {
+            if let libp2p::multiaddr::Protocol::P2p(id) = proto {
+                peer = Some(id);
+            } else {
+                addr.push(proto);
+            }
+        }
+        let Some(peer) = peer else { continue };
+        let t0 = Instant::now();
+        match tokio::time::timeout(
+            Duration::from_secs(60),
+            client.request_raw(peer, addr, protocols::UPDATES_BY_RANGE, wire.clone()),
+        )
+        .await
+        {
+            Ok(Ok(raw)) => {
+                let elapsed = t0.elapsed();
+                match codec::decode_multi_chunk_response(&raw, span as usize) {
+                    Ok(chunks) => {
+                        let sizes: Vec<usize> = chunks.iter().map(|c| c.len()).collect();
+                        tracing::info!(peer = %peer, wire_bytes = raw.len(),
+                            chunks = chunks.len(), ?sizes, ms = elapsed.as_millis() as u64,
+                            "response");
+                    }
+                    Err(e) => tracing::warn!(peer = %peer, wire_bytes = raw.len(),
+                        ms = elapsed.as_millis() as u64, error = %e, "undecodable"),
+                }
+            }
+            Ok(Err(e)) => tracing::warn!(peer = %peer, error = %e, "request failed"),
+            Err(_) => tracing::warn!(peer = %peer, "timed out (60s)"),
+        }
+    }
+    client.shutdown().await;
+}

--- a/rust/myotis-net/src/codec.rs
+++ b/rust/myotis-net/src/codec.rs
@@ -1,0 +1,571 @@
+//! Eth2 req/resp wire framing — the Rust twin of the Java `ReqRespCodec` (plus the
+//! multi-chunk scanner that lives in `BeaconP2PService.decodeMultiChunkResponse` /
+//! `skipSnappyFrames`). Byte-for-byte the same wire format:
+//!
+//! Request:  `unsigned_varint(UNCOMPRESSED ssz len) || snappy_frame_compressed(ssz)`.
+//! An empty request encodes as the single byte `0x00` (varint(0), no snappy data)
+//! — but note the finality/optimistic protocols send NO bytes at all (the Java
+//! `requestFinalityUpdate` passes an empty payload straight to `doReqResp`, which
+//! writes nothing and just half-closes); that choice lives in the transport layer
+//! ([`crate::reqresp`]), not here.
+//!
+//! Response chunk: `result_byte || [context_bytes(4, fork digest)] ||
+//! varint(uncompressed len) || snappy_frames`. Context bytes are present for the
+//! fork-dependent SSZ types (`light_client_*`) and absent for the fixed ones
+//! (status/ping/metadata/goodbye) — see [`crate::protocols`].
+
+use std::io::{Read, Write};
+
+/// Result codes per the eth2 req/resp spec.
+pub const RESULT_SUCCESS: u8 = 0;
+pub const RESULT_INVALID_REQUEST: u8 = 1;
+pub const RESULT_SERVER_ERROR: u8 = 2;
+pub const RESULT_RESOURCE_UNAVAILABLE: u8 = 3;
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct CodecError(pub String);
+
+impl std::fmt::Display for CodecError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+impl std::error::Error for CodecError {}
+
+fn err<T>(msg: impl Into<String>) -> Result<T, CodecError> {
+    Err(CodecError(msg.into()))
+}
+
+// -------------------------------------------------------------------------
+// Varint (protobuf-style unsigned) — mirrors ReqRespCodec.writeVarint/readVarint
+// -------------------------------------------------------------------------
+
+/// Append a protobuf-style unsigned varint. varint(0) is the single byte 0x00.
+pub fn write_varint(out: &mut Vec<u8>, value: u64) {
+    let mut v = value;
+    loop {
+        if v & !0x7F == 0 {
+            out.push(v as u8);
+            return;
+        }
+        out.push(((v & 0x7F) | 0x80) as u8);
+        v >>= 7;
+    }
+}
+
+/// Read a varint at `pos`; returns `(value, next_pos)`. Mirrors the Java reader,
+/// including the 5-byte (shift >= 35) overflow guard — lengths on this wire fit
+/// in an i32 there and the guard is part of the pinned behavior.
+pub fn read_varint(data: &[u8], pos: usize) -> Result<(u64, usize), CodecError> {
+    let mut result: u64 = 0;
+    let mut shift = 0u32;
+    let mut pos = pos;
+    while pos < data.len() {
+        let b = data[pos];
+        pos += 1;
+        result |= u64::from(b & 0x7F) << shift;
+        shift += 7;
+        if b & 0x80 == 0 {
+            return Ok((result, pos));
+        }
+        if shift >= 35 {
+            return err(format!("Varint too long (overflow at shift {shift})"));
+        }
+    }
+    err(format!("Truncated varint at position {pos}"))
+}
+
+// -------------------------------------------------------------------------
+// Snappy framing helpers (the FRAMED format, not raw snappy blocks)
+// -------------------------------------------------------------------------
+
+/// Compress with the snappy FRAMING format (stream identifier + frames) —
+/// the same format the Java side's iq80 `SnappyFramedOutputStream` writes.
+pub fn snappy_compress(input: &[u8]) -> Vec<u8> {
+    let mut enc = snap::write::FrameEncoder::new(Vec::new());
+    // Writing to a Vec cannot fail.
+    enc.write_all(input).expect("Vec write cannot fail");
+    enc.into_inner().expect("Vec flush cannot fail")
+}
+
+/// eth2 RPC ceiling on any single decompressed payload — the spec's MAX_PAYLOAD_SIZE
+/// (10 MiB). Light-client updates are ~27 KB, bootstraps ~25 KB, so this is pure
+/// headroom; the point is to reject an attacker's declared length BEFORE allocating.
+pub const MAX_UNCOMPRESSED_PAYLOAD: usize = 10 * 1024 * 1024;
+
+/// Decompress a snappy framed stream, BOUNDED by the wire's declared uncompressed
+/// length. A malicious peer can otherwise force a multi-hundred-MiB allocation from
+/// a 16 MiB frame of max-ratio copy ops (snappy expands up to ~21x) — an OOM vector
+/// on mobile, amplified by the catch-up fan-out. The eth2 spec REQUIRES the varint
+/// to equal the real uncompressed length, so we cap the reader at `declared` (+1 to
+/// detect overrun) and reject any mismatch.
+pub fn snappy_decompress(input: &[u8], declared_len: usize) -> Result<Vec<u8>, CodecError> {
+    if declared_len == 0 || declared_len > MAX_UNCOMPRESSED_PAYLOAD {
+        return Err(CodecError(format!(
+            "declared uncompressed length {declared_len} outside (0, {MAX_UNCOMPRESSED_PAYLOAD}]"
+        )));
+    }
+    let mut out = Vec::with_capacity(declared_len);
+    // take(declared+1): a well-formed frame yields exactly `declared`; anything
+    // longer trips the mismatch check below instead of allocating unbounded.
+    snap::read::FrameDecoder::new(input)
+        .take(declared_len as u64 + 1)
+        .read_to_end(&mut out)
+        .map_err(|e| CodecError(format!("snappy decompress failed: {e}")))?;
+    if out.len() != declared_len {
+        return Err(CodecError(format!(
+            "snappy output {} bytes != declared {declared_len}",
+            out.len()
+        )));
+    }
+    Ok(out)
+}
+
+// -------------------------------------------------------------------------
+// Request framing
+// -------------------------------------------------------------------------
+
+/// `varint(uncompressed ssz len) || snappy_frame_compressed(ssz)`.
+/// An empty payload returns [`encode_empty_request`] (single 0x00 byte).
+pub fn encode_request(ssz_payload: &[u8]) -> Vec<u8> {
+    if ssz_payload.is_empty() {
+        return encode_empty_request();
+    }
+    let compressed = snappy_compress(ssz_payload);
+    let mut out = Vec::with_capacity(compressed.len() + 5);
+    write_varint(&mut out, ssz_payload.len() as u64);
+    out.extend_from_slice(&compressed);
+    out
+}
+
+/// varint(0) = single byte 0x00, no snappy data follows.
+pub fn encode_empty_request() -> Vec<u8> {
+    vec![0x00]
+}
+
+/// Decode an inbound request body: `varint(len) || snappy_frames` → ssz bytes.
+/// Mirrors the Java responder's `parseRequestSsz` (None on anything unparseable).
+pub fn parse_request_ssz(raw: &[u8]) -> Option<Vec<u8>> {
+    if raw.len() < 2 {
+        return None;
+    }
+    let (uncompressed_len, snappy_start) = read_varint(raw, 0).ok()?;
+    if uncompressed_len == 0 || snappy_start >= raw.len() {
+        return None;
+    }
+    snappy_decompress(&raw[snappy_start..], uncompressed_len as usize).ok()
+}
+
+// -------------------------------------------------------------------------
+// Single-chunk response decode — mirrors ReqRespCodec.decodeResponse
+// -------------------------------------------------------------------------
+
+#[derive(Debug)]
+pub struct DecodeResult {
+    pub result_code: u8,
+    /// 4 bytes when `has_context_bytes`, empty otherwise.
+    pub fork_digest: Vec<u8>,
+    pub ssz_payload: Vec<u8>,
+}
+
+/// Decode a single-chunk response frame. `has_context_bytes` is true for the
+/// fork-dependent protocols (`light_client_*`), false for status/ping/metadata/
+/// goodbye. A non-zero result code returns `Err` carrying the error type and
+/// any trailing UTF-8 message, exactly like the Java decoder throwing.
+pub fn decode_response(raw: &[u8], has_context_bytes: bool) -> Result<DecodeResult, CodecError> {
+    if raw.is_empty() {
+        return err("Response too short: no result byte");
+    }
+    let mut pos = 0usize;
+    let result_code = raw[pos];
+    pos += 1;
+
+    if result_code != 0 {
+        // Best-effort error message from the remaining bytes (raw UTF-8, like Java).
+        let error_msg = if pos + 4 < raw.len() {
+            String::from_utf8_lossy(&raw[pos..]).trim().to_string()
+        } else {
+            String::new()
+        };
+        let error_type = match result_code {
+            1 => "InvalidRequest".to_string(),
+            2 => "ServerError".to_string(),
+            3 => "ResourceUnavailable".to_string(),
+            other => format!("Unknown({other})"),
+        };
+        return err(if error_msg.is_empty() {
+            format!("Peer returned error: {error_type}")
+        } else {
+            format!("Peer returned error: {error_type} — {error_msg}")
+        });
+    }
+
+    let fork_digest = if has_context_bytes {
+        if raw.len() < pos + 4 {
+            return err(format!(
+                "Response too short: missing fork digest (need 4 bytes after result, have {})",
+                raw.len() - pos
+            ));
+        }
+        let fd = raw[pos..pos + 4].to_vec();
+        pos += 4;
+        fd
+    } else {
+        Vec::new()
+    };
+
+    let (uncompressed_len, next) = read_varint(raw, pos)?;
+    pos = next;
+
+    if uncompressed_len == 0 {
+        return Ok(DecodeResult { result_code, fork_digest, ssz_payload: Vec::new() });
+    }
+    if pos >= raw.len() {
+        return err("Response truncated: no compressed data after header");
+    }
+    let ssz_payload = snappy_decompress(&raw[pos..], uncompressed_len as usize)?;
+    Ok(DecodeResult { result_code, fork_digest, ssz_payload })
+}
+
+// -------------------------------------------------------------------------
+// Multi-chunk response decode (updates_by_range) — mirrors
+// BeaconP2PService.decodeMultiChunkResponse + skipSnappyFrames
+// -------------------------------------------------------------------------
+
+/// Decode a multi-chunk response: each chunk is
+/// `result(1) || fork_digest(4) || varint(uncompressed len) || snappy_frames`.
+/// Stops at the first error chunk (logging it) or after `expected_count` items,
+/// returning whatever decoded cleanly — the same salvage behavior as the Java.
+pub fn decode_multi_chunk_response(
+    raw: &[u8],
+    expected_count: usize,
+) -> Result<Vec<Vec<u8>>, CodecError> {
+    let mut items: Vec<Vec<u8>> = Vec::new();
+    let mut pos = 0usize;
+    while pos < raw.len() && items.len() < expected_count {
+        let result_code = raw[pos];
+        if result_code != 0 {
+            // Error chunk: <result><varint(len)><snappy(error_msg)>, no fork digest.
+            let err_body = decode_error_chunk_message(raw, pos + 1);
+            tracing::info!(
+                item = items.len(),
+                code = result_code,
+                raw_len = raw.len(),
+                msg = %err_body,
+                "multi-chunk response item carries an error code"
+            );
+            break;
+        }
+        pos += 1;
+        if pos + 4 > raw.len() {
+            break;
+        }
+        pos += 4; // fork digest (per-chunk; the payload's own fork sniffing governs decode)
+        let (uncompressed_len, next) = read_varint(raw, pos)?;
+        pos = next;
+        let uncompressed_len = uncompressed_len as usize;
+        if uncompressed_len == 0 {
+            tracing::info!(item = items.len(), raw_len = raw.len(),
+                "multi-chunk item has uncompressedLength=0");
+            items.push(Vec::new());
+            continue;
+        }
+        let snappy_start = pos;
+        pos = skip_snappy_frames(raw, pos, uncompressed_len);
+        if pos <= snappy_start {
+            tracing::info!(item = items.len(), raw_len = raw.len(),
+                "multi-chunk skip_snappy_frames returned empty span");
+            break;
+        }
+        let decompressed = snappy_decompress(&raw[snappy_start..pos], uncompressed_len)?;
+        if decompressed.is_empty() {
+            tracing::info!(
+                item = items.len(),
+                varint_len = uncompressed_len,
+                compressed_len = pos - snappy_start,
+                raw_len = raw.len(),
+                "multi-chunk snappy decompress returned 0 bytes"
+            );
+            break;
+        }
+        items.push(decompressed);
+    }
+    Ok(items)
+}
+
+/// Best-effort decode of an error chunk's message: `varint(len) || snappy(msg)`,
+/// falling back to raw UTF-8 when the snappy frame is missing/corrupt.
+fn decode_error_chunk_message(raw: &[u8], err_start: usize) -> String {
+    if err_start >= raw.len() {
+        return String::new();
+    }
+    if let Ok((declared, msg_start)) = read_varint(raw, err_start) {
+        if msg_start < raw.len() {
+            // eth2 caps error strings at 256 bytes; use the declared length as the
+            // bound but never trust it past that ceiling.
+            let cap = (declared as usize).min(256);
+            if cap > 0 {
+                if let Ok(decompressed) = snappy_decompress(&raw[msg_start..], cap) {
+                    return String::from_utf8_lossy(&decompressed).trim().to_string();
+                }
+            }
+            return format!("[raw] {}", String::from_utf8_lossy(&raw[msg_start..]).trim());
+        }
+    }
+    String::new()
+}
+
+/// Skip past one complete snappy framed stream, mirroring the Java
+/// `skipSnappyFrames`: frame types 0xFF (stream identifier), 0x00 (compressed,
+/// CRC32C + snappy block whose leading varint is the decompressed size), 0x01
+/// (uncompressed, CRC32C + raw data). Tracks decompressed output so a following
+/// chunk's 0x00 result byte isn't mistaken for another compressed frame.
+fn skip_snappy_frames(data: &[u8], start: usize, uncompressed_len: usize) -> usize {
+    let mut pos = start;
+    let mut decompressed_so_far = 0usize;
+    while pos < data.len() {
+        let chunk_type = data[pos];
+        if chunk_type != 0xFF && chunk_type != 0x00 && chunk_type != 0x01 {
+            break; // next response chunk's result code
+        }
+        if pos + 4 > data.len() {
+            break;
+        }
+        let frame_len = data[pos + 1] as usize
+            | (data[pos + 2] as usize) << 8
+            | (data[pos + 3] as usize) << 16;
+        if pos + 4 + frame_len > data.len() {
+            // Truncated frame — consume remaining data.
+            pos = data.len();
+            break;
+        }
+        if chunk_type == 0x01 && frame_len > 4 {
+            decompressed_so_far += frame_len - 4;
+        } else if chunk_type == 0x00 && frame_len > 4 {
+            let snappy_block_start = pos + 4 + 4; // frame header (4) + CRC32C (4)
+            match read_varint(data, snappy_block_start) {
+                Ok((block_size, _)) => decompressed_so_far += block_size as usize,
+                Err(_) => break, // not a real snappy frame
+            }
+        }
+        // 0xFF stream identifier contributes 0 decompressed bytes.
+        pos += 4 + frame_len;
+        if decompressed_so_far >= uncompressed_len && uncompressed_len > 0 {
+            break;
+        }
+    }
+    pos
+}
+
+// -------------------------------------------------------------------------
+// Response encoding (responder side) — mirrors ResponderController
+// -------------------------------------------------------------------------
+
+/// `0x00 || [fork_digest] || varint(ssz len) || snappy_frames(ssz)`.
+pub fn encode_success_response(ssz: &[u8], fork_digest: Option<[u8; 4]>) -> Vec<u8> {
+    let compressed = snappy_compress(ssz);
+    let mut out = Vec::with_capacity(compressed.len() + 16);
+    out.push(RESULT_SUCCESS);
+    if let Some(fd) = fork_digest {
+        out.extend_from_slice(&fd);
+    }
+    write_varint(&mut out, ssz.len() as u64);
+    out.extend_from_slice(&compressed);
+    out
+}
+
+/// Error response: `result || varint(msg len) || snappy_frames(msg)` (no fork
+/// digest on error responses, per spec — same as the Java `writeError`).
+pub fn encode_error_response(result_code: u8, msg: &str) -> Vec<u8> {
+    let utf8 = msg.as_bytes();
+    let mut out = Vec::with_capacity(utf8.len() + 16);
+    out.push(result_code);
+    write_varint(&mut out, utf8.len() as u64);
+    out.extend_from_slice(&snappy_compress(utf8));
+    out
+}
+
+// -------------------------------------------------------------------------
+// Tests
+// -------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn varint_zero_is_single_zero_byte() {
+        let mut out = Vec::new();
+        write_varint(&mut out, 0);
+        assert_eq!(out, vec![0x00]);
+        assert_eq!(encode_empty_request(), vec![0x00]);
+        assert_eq!(read_varint(&[0x00], 0).unwrap(), (0, 1));
+    }
+
+    #[test]
+    fn varint_round_trip() {
+        for v in [0u64, 1, 127, 128, 300, 16384, 25_000, u32::MAX as u64] {
+            let mut out = Vec::new();
+            write_varint(&mut out, v);
+            let (decoded, next) = read_varint(&out, 0).unwrap();
+            assert_eq!(decoded, v);
+            assert_eq!(next, out.len());
+        }
+        // Same fixed encodings the protobuf spec defines.
+        let mut out = Vec::new();
+        write_varint(&mut out, 300);
+        assert_eq!(out, vec![0xAC, 0x02]);
+    }
+
+    #[test]
+    fn varint_guards_mirror_java() {
+        assert!(read_varint(&[0x80], 0).is_err()); // truncated
+        assert!(read_varint(&[0x80, 0x80, 0x80, 0x80, 0x80, 0x01], 0).is_err()); // shift >= 35
+    }
+
+    #[test]
+    fn request_round_trip() {
+        let root = [0x11u8; 32];
+        let wire = encode_request(&root);
+        // varint(32) = 0x20, then a snappy framed stream starting with the
+        // stream identifier ff 06 00 00 73 4e 61 50 70 59 ("sNaPpY").
+        assert_eq!(wire[0], 0x20);
+        assert_eq!(&wire[1..11], &[0xFF, 0x06, 0x00, 0x00, 0x73, 0x4E, 0x61, 0x50, 0x70, 0x59]);
+        let parsed = parse_request_ssz(&wire).unwrap();
+        assert_eq!(parsed, root);
+    }
+
+    /// Golden vectors generated by the JAVA `ReqRespCodec.encodeRequest` (jshell
+    /// against the compiled :consensus classes + iq80 snappy 0.4, 2026-07-06):
+    ///
+    /// ```text
+    /// encodeRequest(32 x 0x11)            = 20ff060000734e61507059000a00000eb49f4d2000117a0100
+    /// encodeRequest(LE64(1777)||LE64(16)) = 10ff060000734e6150705901140000de50a893f10600000000000010000000 00000000
+    /// encodeRequest(bytes 0x00..0x5b)     = 5cff060000734e6150705901600000cf4ded1a<92 raw bytes>
+    /// encodeEmptyRequest()                = 00
+    /// ```
+    ///
+    /// Pins that the Rust codec DECODES exactly what the Java encoder emits, and
+    /// asserts full byte equality of the Rust encoder against the Java bytes
+    /// (both sides implement the reference snappy framing; equality verified to
+    /// hold for these inputs — if a future snap version changes its compression
+    /// choices, decode-equality is the interop-critical half).
+    #[test]
+    fn java_golden_request_vectors() {
+        // ReqRespCodec.encodeRequest(32 x 0x11): varint(32) || compressed frame.
+        let java_root_frame = hex("20ff060000734e61507059000a00000eb49f4d2000117a0100");
+        let root = [0x11u8; 32];
+        assert_eq!(parse_request_ssz(&java_root_frame).unwrap(), root);
+        assert_eq!(encode_request(&root), java_root_frame);
+
+        // updates_by_range request body (startPeriod=1777, count=16): varint(16)
+        // || uncompressed frame (16 LE bytes don't compress).
+        let java_range_frame =
+            hex("10ff060000734e6150705901140000de50a893f1060000000000001000000000000000");
+        let mut range_ssz = Vec::new();
+        range_ssz.extend_from_slice(&1777u64.to_le_bytes());
+        range_ssz.extend_from_slice(&16u64.to_le_bytes());
+        assert_eq!(parse_request_ssz(&java_range_frame).unwrap(), range_ssz);
+        assert_eq!(encode_request(&range_ssz), java_range_frame);
+
+        // 92-byte status-shaped payload (bytes 0x00..0x5b): varint(92) ||
+        // uncompressed frame.
+        let mut java_status_frame = hex("5cff060000734e6150705901600000cf4ded1a");
+        let status_ssz: Vec<u8> = (0u8..92).collect();
+        java_status_frame.extend_from_slice(&status_ssz);
+        assert_eq!(parse_request_ssz(&java_status_frame).unwrap(), status_ssz);
+        assert_eq!(encode_request(&status_ssz), java_status_frame);
+
+        // Java encodeEmptyRequest() == 0x00 == our encode_empty_request.
+        assert_eq!(encode_request(&[]), hex("00"));
+    }
+
+    fn hex(s: &str) -> Vec<u8> {
+        (0..s.len()).step_by(2).map(|i| u8::from_str_radix(&s[i..i + 2], 16).unwrap()).collect()
+    }
+
+    #[test]
+    fn single_response_round_trip_with_context() {
+        let ssz = vec![0xABu8; 100];
+        let wire = encode_success_response(&ssz, Some([1, 2, 3, 4]));
+        let decoded = decode_response(&wire, true).unwrap();
+        assert_eq!(decoded.result_code, 0);
+        assert_eq!(decoded.fork_digest, vec![1, 2, 3, 4]);
+        assert_eq!(decoded.ssz_payload, ssz);
+    }
+
+    #[test]
+    fn single_response_round_trip_without_context() {
+        let ssz = vec![0x42u8; 92];
+        let wire = encode_success_response(&ssz, None);
+        let decoded = decode_response(&wire, false).unwrap();
+        assert_eq!(decoded.fork_digest, Vec::<u8>::new());
+        assert_eq!(decoded.ssz_payload, ssz);
+    }
+
+    #[test]
+    fn error_response_surfaces_type_and_message() {
+        let wire = encode_error_response(RESULT_RESOURCE_UNAVAILABLE, "pruned");
+        let e = decode_response(&wire, true).unwrap_err();
+        assert!(e.0.contains("ResourceUnavailable"), "{e}");
+    }
+
+    #[test]
+    fn multi_chunk_round_trip() {
+        // Three chunks of distinct sizes back to back, as updates_by_range returns.
+        let payloads: Vec<Vec<u8>> = vec![vec![0x01; 500], vec![0x02; 25_000], vec![0x03; 7]];
+        let mut wire = Vec::new();
+        for p in &payloads {
+            wire.extend_from_slice(&encode_success_response(p, Some([0xAA, 0xBB, 0xCC, 0xDD])));
+        }
+        let items = decode_multi_chunk_response(&wire, payloads.len()).unwrap();
+        assert_eq!(items, payloads);
+    }
+
+    #[test]
+    fn multi_chunk_stops_at_error_chunk() {
+        let good = vec![0x05u8; 64];
+        let mut wire = encode_success_response(&good, Some([0; 4]));
+        wire.extend_from_slice(&encode_error_response(RESULT_RESOURCE_UNAVAILABLE, "no more"));
+        let items = decode_multi_chunk_response(&wire, 5).unwrap();
+        assert_eq!(items, vec![good]);
+    }
+
+    #[test]
+    fn multi_chunk_respects_expected_count() {
+        let p = vec![0x09u8; 32];
+        let mut wire = Vec::new();
+        for _ in 0..4 {
+            wire.extend_from_slice(&encode_success_response(&p, Some([0; 4])));
+        }
+        let items = decode_multi_chunk_response(&wire, 2).unwrap();
+        assert_eq!(items.len(), 2);
+    }
+
+    #[test]
+    fn malformed_inputs_never_panic() {
+        assert!(decode_response(&[], true).is_err());
+        assert!(decode_response(&[0x00], true).is_err()); // missing digest
+        assert!(decode_response(&[0x00, 1, 2, 3, 4], true).is_err()); // truncated varint region
+        assert!(decode_response(&[0x00, 1, 2, 3, 4, 0x05], true).is_err()); // no snappy data
+        assert!(parse_request_ssz(&[]).is_none());
+        assert!(parse_request_ssz(&[0x00]).is_none());
+        let _ = decode_multi_chunk_response(&[0x00, 0, 0], 3);
+        let _ = decode_multi_chunk_response(&[0xFF; 40], 3);
+    }
+
+    #[test]
+    fn snappy_decompress_enforces_declared_bound() {
+        let payload = vec![0x42u8; 1000];
+        let framed = snappy_compress(&payload);
+        // Correct declared length round-trips.
+        assert_eq!(snappy_decompress(&framed, 1000).unwrap(), payload);
+        // A declared length that disagrees with the real output is rejected —
+        // this is what stops an attacker's inflated varint from mattering.
+        assert!(snappy_decompress(&framed, 999).is_err());
+        assert!(snappy_decompress(&framed, 1001).is_err());
+        // Over-ceiling declared length is rejected BEFORE any decompression work.
+        assert!(snappy_decompress(&framed, MAX_UNCOMPRESSED_PAYLOAD + 1).is_err());
+        assert!(snappy_decompress(&framed, 0).is_err());
+    }
+}

--- a/rust/myotis-net/src/discovery.rs
+++ b/rust/myotis-net/src/discovery.rs
@@ -1,0 +1,201 @@
+//! discv5 peer discovery for the consensus layer — mirrors the Java
+//! `ChainStack` wiring of `DiscV5Service`: seed the routing table from the
+//! network's bootstrap ENRs, run iterative FINDNODE lookups, filter discovered
+//! ENRs by their `eth2` field's fork digest against our accepted set (current
+//! digest plus the prior fork's, when configured), and emit libp2p dial
+//! candidates (TCP multiaddr + PeerId derived from the ENR's secp256k1 key).
+
+use std::collections::HashSet;
+use std::net::IpAddr;
+
+use discv5::enr::{CombinedKey, CombinedPublicKey, EnrPublicKey, NodeId};
+use discv5::{ConfigBuilder, Discv5, Enr, ListenConfig};
+use libp2p::{Multiaddr, PeerId};
+use tokio::sync::mpsc;
+
+/// A dialable CL peer candidate emitted by discovery.
+#[derive(Debug, Clone)]
+pub struct DiscoveredPeer {
+    pub peer_id: PeerId,
+    /// `/ip4/<ip>/tcp/<port>` (no `/p2p` suffix; the peer id travels separately).
+    pub addr: Multiaddr,
+}
+
+pub struct DiscoveryConfig {
+    pub bootstrap_enrs: Vec<String>,
+    /// Accepted `eth2` fork digests: current first, then the prior fork's when
+    /// the chain configures one (`NetworkConfig.acceptedForkDigests`).
+    pub accepted_fork_digests: Vec<[u8; 4]>,
+    /// UDP port to bind. 0 lets the OS pick.
+    pub listen_port: u16,
+}
+
+/// Spawn the discovery task. Discovered, fork-matched peers stream out on the
+/// returned channel until the task is aborted (drop the `JoinHandle` owner) or
+/// the receiver closes. Failure to start is returned, not panicked — the Java
+/// treats discv5 as non-essential the same way.
+pub async fn spawn(
+    config: DiscoveryConfig,
+    tx: mpsc::Sender<DiscoveredPeer>,
+) -> Result<tokio::task::JoinHandle<()>, String> {
+    let enr_key = CombinedKey::generate_secp256k1();
+    let local_enr = Enr::builder()
+        .build(&enr_key)
+        .map_err(|e| format!("local ENR build failed: {e}"))?;
+
+    let listen = ListenConfig::Ipv4 { ip: std::net::Ipv4Addr::UNSPECIFIED, port: config.listen_port };
+    let discv5_config = ConfigBuilder::new(listen).build();
+    let mut discv5 = Discv5::new(local_enr, enr_key, discv5_config)
+        .map_err(|e| format!("discv5 init failed: {e}"))?;
+
+    let mut seeded = 0usize;
+    for enr_str in &config.bootstrap_enrs {
+        match enr_str.parse::<Enr>() {
+            Ok(enr) => {
+                if discv5.add_enr(enr).is_ok() {
+                    seeded += 1;
+                }
+            }
+            Err(e) => tracing::warn!(error = %e, "skipping malformed bootstrap ENR"),
+        }
+    }
+
+    discv5
+        .start()
+        .await
+        .map_err(|e| format!("discv5 start failed: {e}"))?;
+    tracing::info!(bootnodes = seeded, port = config.listen_port, "discv5 started");
+
+    Ok(tokio::spawn(run_lookups(discv5, config.accepted_fork_digests, tx)))
+}
+
+async fn run_lookups(
+    discv5: Discv5,
+    accepted_digests: Vec<[u8; 4]>,
+    tx: mpsc::Sender<DiscoveredPeer>,
+) {
+    let mut seen: HashSet<NodeId> = HashSet::new();
+    loop {
+        match discv5.find_node(NodeId::random()).await {
+            Ok(enrs) => {
+                let mut emitted = 0usize;
+                for enr in enrs {
+                    if !seen.insert(enr.node_id()) {
+                        continue;
+                    }
+                    if let Some(peer) = filter_candidate(&enr, &accepted_digests) {
+                        emitted += 1;
+                        if tx.send(peer).await.is_err() {
+                            return; // receiver gone — sync loop shut down
+                        }
+                    }
+                }
+                tracing::debug!(emitted, known = seen.len(), "discv5 lookup round complete");
+            }
+            Err(e) => tracing::debug!(error = %e, "discv5 lookup failed"),
+        }
+        if tx.is_closed() {
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(15)).await;
+        // Bound the dedup set: discovery on mainnet finds thousands of nodes.
+        if seen.len() > 16_384 {
+            seen.clear();
+        }
+    }
+}
+
+/// ENR → dial candidate, applying the same gates the Java discv5 callback does:
+/// must carry an `eth2` field whose fork digest is in our accepted set, a TCP
+/// endpoint, and a secp256k1 key we can turn into a libp2p PeerId.
+fn filter_candidate(enr: &Enr, accepted_digests: &[[u8; 4]]) -> Option<DiscoveredPeer> {
+    let digest = enr_eth2_fork_digest(enr)?;
+    let match_idx = accepted_digests.iter().position(|d| *d == digest)?;
+
+    let (ip, tcp_port): (IpAddr, u16) = if let (Some(ip4), Some(tcp4)) = (enr.ip4(), enr.tcp4()) {
+        (IpAddr::V4(ip4), tcp4)
+    } else if let (Some(ip6), Some(tcp6)) = (enr.ip6(), enr.tcp6()) {
+        (IpAddr::V6(ip6), tcp6)
+    } else {
+        return None;
+    };
+
+    let peer_id = enr_to_peer_id(enr)?;
+    let addr = Multiaddr::empty()
+        .with(ip.into())
+        .with(libp2p::multiaddr::Protocol::Tcp(tcp_port));
+    tracing::debug!(peer = %peer_id, %addr, prior_fork = match_idx > 0, "CL peer discovered");
+    Some(DiscoveredPeer { peer_id, addr })
+}
+
+/// First 4 bytes of the ENR `eth2` field (SSZ `ENRForkID`: fork_digest(4) ||
+/// next_fork_version(4) || next_fork_epoch(8)). The field value is an
+/// RLP-encoded byte string inside the record; strip the string header by hand
+/// (a 16-byte payload is `0x90 || bytes`, but tolerate any short-string form).
+fn enr_eth2_fork_digest(enr: &Enr) -> Option<[u8; 4]> {
+    let raw = enr.get_raw_rlp(b"eth2")?;
+    let payload = rlp_short_string_payload(raw)?;
+    if payload.len() < 4 {
+        return None;
+    }
+    Some(payload[..4].try_into().expect("length checked"))
+}
+
+/// Decode a single RLP short string (the only shape an `eth2` field takes).
+fn rlp_short_string_payload(raw: &[u8]) -> Option<&[u8]> {
+    let first = *raw.first()?;
+    match first {
+        0x00..=0x7F => Some(&raw[..1]),
+        0x80..=0xB7 => {
+            let len = (first - 0x80) as usize;
+            raw.get(1..1 + len)
+        }
+        _ => None, // long string / list — not a valid eth2 field
+    }
+}
+
+/// Derive the libp2p PeerId from the ENR's secp256k1 public key (compressed
+/// SEC1 bytes → libp2p secp256k1 public key → PeerId).
+fn enr_to_peer_id(enr: &Enr) -> Option<PeerId> {
+    match enr.public_key() {
+        CombinedPublicKey::Secp256k1(pk) => {
+            let compressed = pk.encode(); // 33 bytes compressed
+            let pk = libp2p::identity::secp256k1::PublicKey::try_from_bytes(&compressed).ok()?;
+            Some(PeerId::from(libp2p::identity::PublicKey::from(pk)))
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A live Gnosis bootnode ENR from NetworkConfig — known to carry an eth2
+    /// field (digest 0x824be431), ip4+tcp, and a secp256k1 key.
+    const GNOSIS_BOOT_ENR: &str = "enr:-Ly4QIAhiTHk6JdVhCdiLwT83wAolUFo5J4nI5HrF7-zJO_QEw3cmEGxC1jvqNNUN64Vu-xxqDKSM528vKRNCehZAfEBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpCCS-QxAgAAZP__________gmlkgnY0gmlwhEFtZ5SJc2VjcDI1NmsxoQJwgL5C-30E8RJmW8gCb7sfwWvvfre7wGcCeV4X1G2wJYhzeW5jbmV0cwCDdGNwgiMog3VkcIIjKA";
+
+    #[test]
+    fn parses_eth2_field_and_peer_id_from_real_enr() {
+        let enr: Enr = GNOSIS_BOOT_ENR.parse().unwrap();
+        let digest = enr_eth2_fork_digest(&enr).unwrap();
+        assert_eq!(digest, [0x82, 0x4B, 0xE4, 0x31]);
+        assert!(enr_to_peer_id(&enr).is_some());
+        // Accepted-digest filter: matches its own digest, rejects others.
+        assert!(filter_candidate(&enr, &[[0x82, 0x4B, 0xE4, 0x31]]).is_some());
+        assert!(filter_candidate(&enr, &[[0xDE, 0xAD, 0xBE, 0xEF]]).is_none());
+        // Prior-fork fallback position also matches (index 1).
+        assert!(filter_candidate(&enr, &[[0; 4], [0x82, 0x4B, 0xE4, 0x31]]).is_some());
+    }
+
+    #[test]
+    fn rlp_short_string_forms() {
+        assert_eq!(rlp_short_string_payload(&[0x42]), Some(&[0x42u8][..]));
+        let mut buf = vec![0x90u8];
+        buf.extend_from_slice(&[7u8; 16]);
+        assert_eq!(rlp_short_string_payload(&buf), Some(&[7u8; 16][..]));
+        assert_eq!(rlp_short_string_payload(&[0x90, 1, 2]), None); // truncated
+        assert_eq!(rlp_short_string_payload(&[0xC1, 0x01]), None); // list
+        assert_eq!(rlp_short_string_payload(&[]), None);
+    }
+}

--- a/rust/myotis-net/src/lib.rs
+++ b/rust/myotis-net/src/lib.rs
@@ -1,0 +1,31 @@
+//! Myotis consensus-layer networking — ALL the I/O around the sans-I/O
+//! [`myotis_consensus`] verification core.
+//!
+//! - [`codec`] — eth2 req/resp wire framing (varint + snappy frames), the Rust
+//!   twin of the Java `ReqRespCodec` + the multi-chunk scanner, pinned against
+//!   Java-generated golden vectors.
+//! - [`protocols`] — the protocol IDs the Java `BeaconP2PService` speaks.
+//! - [`status`] — `Status`/`MetaData` SSZ + fork-digest math (incl. EIP-7892 BPO).
+//! - [`reqresp`] — libp2p (TCP + noise + yamux + identify, secp256k1 identity)
+//!   dialer/responder for the eth2 req/resp protocols.
+//! - [`discovery`] — sigp discv5 seeded from the chain's bootstrap ENRs,
+//!   filtering by the `eth2` ENR fork digest.
+//! - [`sync`] — the light-client sync loop ([`sync::SyncHandle`]): bootstrap →
+//!   catch-up → finality polling, driving `myotis_consensus`.
+//!
+//! Dependency direction is one-way by design: `myotis-net` → `myotis-consensus`.
+//! The consensus crate stays free of tokio/sockets/fs/clock (enforced by the
+//! wasm32 canary in the root Gradle build); every clock read happens here and
+//! crosses into the consensus crate as a plain slot number.
+//!
+//! Library hygiene: tracing only (no println), no global mutable state — every
+//! [`sync::SyncHandle`] owns its own libp2p host, discv5 service, and store.
+
+pub mod codec;
+pub mod discovery;
+pub mod protocols;
+pub mod reqresp;
+pub mod status;
+pub mod sync;
+
+pub use sync::{ChainConfig, SyncHandle, SyncState, SyncStatus};

--- a/rust/myotis-net/src/protocols.rs
+++ b/rust/myotis-net/src/protocols.rs
@@ -1,0 +1,59 @@
+//! Eth2 req/resp protocol identifiers — exactly the set (and versions) the Java
+//! `BeaconP2PService` speaks, plus the per-protocol wire attributes the codec
+//! needs (context bytes, expected request size).
+
+pub const STATUS_V2: &str = "/eth2/beacon_chain/req/status/2/ssz_snappy";
+pub const STATUS_V1: &str = "/eth2/beacon_chain/req/status/1/ssz_snappy";
+pub const BOOTSTRAP: &str = "/eth2/beacon_chain/req/light_client_bootstrap/1/ssz_snappy";
+pub const UPDATES_BY_RANGE: &str =
+    "/eth2/beacon_chain/req/light_client_updates_by_range/1/ssz_snappy";
+pub const FINALITY_UPDATE: &str =
+    "/eth2/beacon_chain/req/light_client_finality_update/1/ssz_snappy";
+pub const OPTIMISTIC_UPDATE: &str =
+    "/eth2/beacon_chain/req/light_client_optimistic_update/1/ssz_snappy";
+pub const PING: &str = "/eth2/beacon_chain/req/ping/1/ssz_snappy";
+pub const METADATA_V2: &str = "/eth2/beacon_chain/req/metadata/2/ssz_snappy";
+pub const GOODBYE: &str = "/eth2/beacon_chain/req/goodbye/1/ssz_snappy";
+
+/// Whether the protocol's responses carry 4 context bytes (fork digest) between
+/// the result byte and the length varint. True for fork-dependent SSZ types
+/// (`light_client_*`), false for the fixed ones (status/ping/metadata/goodbye)
+/// — mirrors the Java `registerBinding` flags.
+pub fn has_context_bytes(protocol: &str) -> bool {
+    matches!(
+        protocol,
+        BOOTSTRAP | UPDATES_BY_RANGE | FINALITY_UPDATE | OPTIMISTIC_UPDATE
+    )
+}
+
+/// Expected SSZ size of the request body for the responder role. 0 means the
+/// request has no body (metadata / finality_update / optimistic_update) — same
+/// table the Java `registerBinding` calls pin.
+pub fn expected_request_size(protocol: &str) -> usize {
+    match protocol {
+        STATUS_V2 => 92,
+        STATUS_V1 => 84,
+        PING | GOODBYE => 8,
+        BOOTSTRAP => 32,
+        UPDATES_BY_RANGE => 16,
+        _ => 0, // metadata, finality_update, optimistic_update
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn context_bytes_table_matches_java_bindings() {
+        assert!(!has_context_bytes(STATUS_V2));
+        assert!(!has_context_bytes(STATUS_V1));
+        assert!(!has_context_bytes(PING));
+        assert!(!has_context_bytes(METADATA_V2));
+        assert!(!has_context_bytes(GOODBYE));
+        assert!(has_context_bytes(BOOTSTRAP));
+        assert!(has_context_bytes(UPDATES_BY_RANGE));
+        assert!(has_context_bytes(FINALITY_UPDATE));
+        assert!(has_context_bytes(OPTIMISTIC_UPDATE));
+    }
+}

--- a/rust/myotis-net/src/reqresp.rs
+++ b/rust/myotis-net/src/reqresp.rs
@@ -1,0 +1,785 @@
+//! libp2p transport + eth2 req/resp dialer/responder.
+//!
+//! Mirrors the behavior (not the structure) of the Java `BeaconP2PService`:
+//! TCP + noise XX + yamux with a secp256k1 identity (the CL spec requirement),
+//! per-protocol req/resp streams where the dialer writes the request, half-closes,
+//! and buffers the response until the responder closes, and minimal responder
+//! roles for status/ping/metadata/goodbye (peers drop clients that don't answer
+//! those). The `light_client_*` read protocols answer `ResourceUnavailable` —
+//! the Java relays from a response cache when warm; empty-cache behavior is the
+//! same result code.
+//!
+//! Requests and responses cross this module as RAW WIRE BYTES ([`crate::codec`]
+//! frames); parsing/validation happens in the sync layer. An empty request means
+//! "write nothing, just half-close" (finality/optimistic — see `requestFinalityUpdate`).
+
+use std::collections::{HashMap, HashSet};
+use std::io;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use futures::prelude::*;
+use libp2p::identify;
+use libp2p::request_response::{self, OutboundRequestId, ProtocolSupport};
+use libp2p::connection_limits::{self, ConnectionLimits};
+use libp2p::swarm::{NetworkBehaviour, SwarmEvent};
+use libp2p::{Multiaddr, PeerId, StreamProtocol, Swarm};
+use tokio::sync::{mpsc, oneshot};
+
+use crate::codec;
+use crate::protocols;
+use crate::status::{self, StatusMessage};
+
+/// Response deadline mirroring the Java RESP_TIMEOUT (~10 s) for single-chunk
+/// protocols; updates_by_range gets the Java catch-up deadline (15 s) — live
+/// peers cap those responses at one chunk per request anyway (Lighthouse's
+/// one_every(10s) quota), so waiting longer buys nothing.
+pub const RESP_TIMEOUT: Duration = Duration::from_secs(10);
+/// Live servers PACE multi-chunk responses (observed: single chunks arriving
+/// ~10 s apart under Lighthouse's rate limiter) — a short deadline turns a
+/// 16-chunk response into a 1-chunk one. Budget for a paced full batch.
+pub const UPDATES_TIMEOUT: Duration = Duration::from_secs(45);
+
+/// Complete a response once the stream has gone quiet for this long with data
+/// buffered — the Rust twin of the Java controller's safety/drain timers.
+/// Responders SHOULD close after the last chunk, but some stall the close;
+/// waiting only for EOF would burn the whole request timeout instead.
+const RESPONSE_QUIET_WINDOW: Duration = Duration::from_secs(3);
+/// Multi-chunk (updates_by_range) quiet window: healthy responders stream
+/// chunks back-to-back; observed live behavior is one chunk per request from
+/// rate-limited peers, where waiting longer buys nothing — the sync loop
+/// rotates peers instead.
+/// Must comfortably exceed the observed inter-chunk pacing (~10 s) or the
+/// quiet window truncates paced batches to their first chunk.
+const UPDATES_QUIET_WINDOW: Duration = Duration::from_secs(12);
+
+const MAX_REQUEST_WIRE_BYTES: usize = 1024;
+/// A 16-update batch decompresses to ~16 x ~60 KB SSZ; the compressed wire is
+/// smaller. 16 MiB is a generous DoS ceiling, not a target.
+const MAX_RESPONSE_WIRE_BYTES: usize = 16 * 1024 * 1024;
+
+// -------------------------------------------------------------------------
+// Codec: raw wire bytes in, raw wire bytes out
+// -------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub struct Eth2Protocol(pub StreamProtocol);
+
+impl AsRef<str> for Eth2Protocol {
+    fn as_ref(&self) -> &str {
+        self.0.as_ref()
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct Eth2Codec;
+
+async fn read_capped<T>(io: &mut T, cap: usize) -> io::Result<Vec<u8>>
+where
+    T: AsyncRead + Unpin + Send,
+{
+    let mut buf = Vec::new();
+    io.take(cap as u64 + 1).read_to_end(&mut buf).await?;
+    if buf.len() > cap {
+        return Err(io::Error::new(io::ErrorKind::InvalidData, "response exceeds size cap"));
+    }
+    Ok(buf)
+}
+
+/// Read to EOF, but once at least one byte is buffered treat `quiet` of
+/// silence as end-of-response; also salvage buffered data when the peer
+/// resets the stream instead of half-closing.
+async fn read_until_quiet<T>(io: &mut T, cap: usize, quiet: Duration) -> io::Result<Vec<u8>>
+where
+    T: AsyncRead + Unpin + Send,
+{
+    let mut buf = Vec::new();
+    let mut chunk = [0u8; 16 * 1024];
+    loop {
+        // The quiet window only means anything once bytes are buffered (it
+        // detects "peer finished a paced response without closing"). Before the
+        // first byte, await the read with NO per-iteration timer — the
+        // behaviour-level request timeout is the deadline — instead of respawning
+        // a `quiet`-length timer every window while a slow peer spins up.
+        let read = if buf.is_empty() {
+            io.read(&mut chunk).await.map(Some)
+        } else {
+            match tokio::time::timeout(quiet, io.read(&mut chunk)).await {
+                Ok(r) => r.map(Some),
+                Err(_elapsed) => Ok(None), // quiet with data buffered → complete
+            }
+        };
+        match read {
+            Ok(Some(0)) => break,
+            Ok(Some(n)) => {
+                buf.extend_from_slice(&chunk[..n]);
+                if buf.len() > cap {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "response exceeds size cap",
+                    ));
+                }
+            }
+            Ok(None) => break, // quiet window elapsed with data buffered
+            Err(e) => {
+                if buf.is_empty() {
+                    return Err(e);
+                }
+                tracing::debug!(buffered = buf.len(), error = %e,
+                    "stream errored after data — salvaging buffered response");
+                break;
+            }
+        }
+    }
+    Ok(buf)
+}
+
+#[async_trait]
+impl request_response::Codec for Eth2Codec {
+    type Protocol = Eth2Protocol;
+    type Request = Vec<u8>;
+    type Response = Vec<u8>;
+
+    async fn read_request<T>(&mut self, _p: &Eth2Protocol, io: &mut T) -> io::Result<Vec<u8>>
+    where
+        T: AsyncRead + Unpin + Send,
+    {
+        // The requester half-closes after writing, so EOF delimits the request.
+        read_capped(io, MAX_REQUEST_WIRE_BYTES).await
+    }
+
+    async fn read_response<T>(&mut self, p: &Eth2Protocol, io: &mut T) -> io::Result<Vec<u8>>
+    where
+        T: AsyncRead + Unpin + Send,
+    {
+        // eth2 responders write their chunk(s) then close. Buffer until EOF,
+        // completing early when the stream goes quiet with data on hand —
+        // mirroring the Java controller's drain timers (and salvaging complete
+        // chunks when a peer resets instead of closing; the codec validates
+        // everything downstream).
+        let quiet = if p.as_ref() == protocols::UPDATES_BY_RANGE {
+            UPDATES_QUIET_WINDOW
+        } else {
+            RESPONSE_QUIET_WINDOW
+        };
+        read_until_quiet(io, MAX_RESPONSE_WIRE_BYTES, quiet).await
+    }
+
+    async fn write_request<T>(&mut self, _p: &Eth2Protocol, io: &mut T, req: Vec<u8>) -> io::Result<()>
+    where
+        T: AsyncWrite + Unpin + Send,
+    {
+        // Empty request = write NOTHING (finality/optimistic), then the handler
+        // half-closes — mirroring the Java doReqResp empty-payload path.
+        if !req.is_empty() {
+            io.write_all(&req).await?;
+        }
+        Ok(())
+    }
+
+    async fn write_response<T>(&mut self, _p: &Eth2Protocol, io: &mut T, res: Vec<u8>) -> io::Result<()>
+    where
+        T: AsyncWrite + Unpin + Send,
+    {
+        io.write_all(&res).await
+    }
+}
+
+// -------------------------------------------------------------------------
+// Behaviour: one request_response instance per protocol (each eth2 protocol
+// negotiates independently; a single multi-protocol instance would offer every
+// protocol on every outbound stream)
+// -------------------------------------------------------------------------
+
+type RR = request_response::Behaviour<Eth2Codec>;
+
+fn rr(protocol: &'static str, support: ProtocolSupport, timeout: Duration) -> RR {
+    request_response::Behaviour::with_codec(
+        Eth2Codec,
+        [(Eth2Protocol(StreamProtocol::new(protocol)), support)],
+        request_response::Config::default()
+            .with_request_timeout(timeout)
+            .with_max_concurrent_streams(64),
+    )
+}
+
+#[derive(NetworkBehaviour)]
+pub struct Behaviour {
+    // Defense-in-depth: this client dials but also accepts inbound, and each
+    // protocol behaviour independently permits concurrent streams. Cap total
+    // established connections so a peer flood can't exhaust fds/memory.
+    pub limits: connection_limits::Behaviour,
+    pub identify: identify::Behaviour,
+    pub status_v2: RR,
+    pub status_v1: RR,
+    pub ping: RR,
+    pub metadata: RR,
+    pub goodbye: RR,
+    pub bootstrap: RR,
+    pub updates: RR,
+    pub finality: RR,
+    pub optimistic: RR,
+}
+
+impl Behaviour {
+    fn new(local_public_key: libp2p::identity::PublicKey) -> Self {
+        Self {
+            limits: connection_limits::Behaviour::new(
+                ConnectionLimits::default()
+                    .with_max_established_incoming(Some(64))
+                    .with_max_established_per_peer(Some(2))
+                    .with_max_pending_incoming(Some(16)),
+            ),
+            identify: identify::Behaviour::new(
+                identify::Config::new("eth2/1.0.0".into(), local_public_key)
+                    .with_agent_version("myotis/0.1.0-rs".into()),
+            ),
+            status_v2: rr(protocols::STATUS_V2, ProtocolSupport::Full, RESP_TIMEOUT),
+            status_v1: rr(protocols::STATUS_V1, ProtocolSupport::Full, RESP_TIMEOUT),
+            ping: rr(protocols::PING, ProtocolSupport::Full, RESP_TIMEOUT),
+            metadata: rr(protocols::METADATA_V2, ProtocolSupport::Full, RESP_TIMEOUT),
+            goodbye: rr(protocols::GOODBYE, ProtocolSupport::Full, RESP_TIMEOUT),
+            bootstrap: rr(protocols::BOOTSTRAP, ProtocolSupport::Full, RESP_TIMEOUT),
+            // Never advertised inbound: we can't serve catch-up history, and the
+            // Java learned that advertising unservable protocols gets us
+            // goodbye'd ("durationMs=1 closes in the wild").
+            updates: rr(protocols::UPDATES_BY_RANGE, ProtocolSupport::Outbound, UPDATES_TIMEOUT),
+            finality: rr(protocols::FINALITY_UPDATE, ProtocolSupport::Full, RESP_TIMEOUT),
+            optimistic: rr(protocols::OPTIMISTIC_UPDATE, ProtocolSupport::Full, RESP_TIMEOUT),
+        }
+    }
+}
+
+// -------------------------------------------------------------------------
+// Service handle
+// -------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RequestError {
+    /// Peer doesn't speak the protocol (negotiation failed) — the signal the
+    /// Java uses to blacklist a peer for updates_by_range.
+    UnsupportedProtocol,
+    Timeout,
+    DialFailure,
+    ConnectionClosed,
+    Io(String),
+    /// The service shut down before the request completed.
+    Shutdown,
+}
+
+impl std::fmt::Display for RequestError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnsupportedProtocol => write!(f, "protocol negotiation failed"),
+            Self::Timeout => write!(f, "request timed out"),
+            Self::DialFailure => write!(f, "dial failed"),
+            Self::ConnectionClosed => write!(f, "connection closed"),
+            Self::Io(m) => write!(f, "io: {m}"),
+            Self::Shutdown => write!(f, "service shut down"),
+        }
+    }
+}
+impl std::error::Error for RequestError {}
+
+enum Command {
+    Request {
+        peer: PeerId,
+        addr: Multiaddr,
+        protocol: &'static str,
+        wire: Vec<u8>,
+        reply: oneshot::Sender<Result<Vec<u8>, RequestError>>,
+    },
+    PeerCount {
+        reply: oneshot::Sender<usize>,
+    },
+    /// Peers whose Identify advertised light_client_updates_by_range.
+    LcServers {
+        reply: oneshot::Sender<HashSet<PeerId>>,
+    },
+    Shutdown,
+}
+
+/// Cheap-to-clone client for issuing eth2 req/resp calls against the running
+/// swarm task. Independent instances of the whole stack are independent — no
+/// globals anywhere in this crate.
+#[derive(Clone)]
+pub struct ReqRespClient {
+    tx: mpsc::Sender<Command>,
+}
+
+impl ReqRespClient {
+    /// One request against `peer` (dialing `addr` if not connected): sends the
+    /// pre-encoded wire bytes, returns the raw wire response.
+    pub async fn request_raw(
+        &self,
+        peer: PeerId,
+        addr: Multiaddr,
+        protocol: &'static str,
+        wire: Vec<u8>,
+    ) -> Result<Vec<u8>, RequestError> {
+        let (reply, rx) = oneshot::channel();
+        self.tx
+            .send(Command::Request { peer, addr, protocol, wire, reply })
+            .await
+            .map_err(|_| RequestError::Shutdown)?;
+        rx.await.map_err(|_| RequestError::Shutdown)?
+    }
+
+    pub async fn connected_peer_count(&self) -> usize {
+        let (reply, rx) = oneshot::channel();
+        if self.tx.send(Command::PeerCount { reply }).await.is_err() {
+            return 0;
+        }
+        rx.await.unwrap_or(0)
+    }
+
+    /// Peers whose Identify response advertised `light_client_updates_by_range`.
+    pub async fn lc_update_servers(&self) -> HashSet<PeerId> {
+        let (reply, rx) = oneshot::channel();
+        if self.tx.send(Command::LcServers { reply }).await.is_err() {
+            return HashSet::new();
+        }
+        rx.await.unwrap_or_default()
+    }
+
+    pub async fn shutdown(&self) {
+        let _ = self.tx.send(Command::Shutdown).await;
+    }
+}
+
+/// Shared local view the responder answers from. The sync loop refreshes it as
+/// the store advances so our Status stays honest (Lighthouse's relevance check
+/// requires a real block root — see the Java `buildLocalStatusFor` doc).
+pub struct LocalStatus {
+    inner: Mutex<StatusMessage>,
+}
+
+impl LocalStatus {
+    pub fn new(initial: StatusMessage) -> Arc<Self> {
+        Arc::new(Self { inner: Mutex::new(initial) })
+    }
+    pub fn set(&self, s: StatusMessage) {
+        *self.inner.lock().expect("status lock") = s;
+    }
+    pub fn get(&self) -> StatusMessage {
+        self.inner.lock().expect("status lock").clone()
+    }
+}
+
+/// Start the libp2p host and its event-loop task. Returns the request client;
+/// the task exits on [`ReqRespClient::shutdown`] (or when every client is dropped).
+pub fn start_host(local_status: Arc<LocalStatus>) -> Result<ReqRespClient, String> {
+    // Ethereum CL spec requires secp256k1 identity keys (same as the Java
+    // HostBuilder's KeyType.SECP256K1) — the default ed25519 would make some
+    // peers reject the noise handshake payload.
+    let keypair = libp2p::identity::Keypair::generate_secp256k1();
+    let mut swarm = libp2p::SwarmBuilder::with_existing_identity(keypair)
+        .with_tokio()
+        .with_tcp(
+            libp2p::tcp::Config::default().nodelay(true),
+            libp2p::noise::Config::new,
+            libp2p::yamux::Config::default,
+        )
+        .map_err(|e| format!("tcp/noise/yamux setup failed: {e}"))?
+        .with_behaviour(|key| Behaviour::new(key.public()))
+        .map_err(|e| format!("behaviour setup failed: {e}"))?
+        .with_swarm_config(|c| c.with_idle_connection_timeout(Duration::from_secs(120)))
+        .build();
+
+    // Listen on an ephemeral port: some peers reject dial-only hosts (same
+    // reason the Java host listens on /ip4/0.0.0.0/tcp/0).
+    swarm
+        .listen_on("/ip4/0.0.0.0/tcp/0".parse().expect("static multiaddr"))
+        .map_err(|e| format!("listen failed: {e}"))?;
+
+    tracing::info!(peer_id = %swarm.local_peer_id(), "libp2p host starting");
+
+    let (tx, rx) = mpsc::channel(256);
+    tokio::spawn(run_swarm(swarm, rx, local_status));
+    Ok(ReqRespClient { tx })
+}
+
+/// What a pending outbound request id maps back to.
+enum Pending {
+    External(oneshot::Sender<Result<Vec<u8>, RequestError>>),
+    /// Fire-and-forget auto-Status (v2, falls back to v1 on unsupported protocol).
+    AutoStatusV2(PeerId),
+    AutoStatusV1(PeerId),
+}
+
+/// A request parked until the peer's Status handshake completes.
+struct QueuedRequest {
+    addr: Multiaddr,
+    protocol: &'static str,
+    wire: Vec<u8>,
+    reply: oneshot::Sender<Result<Vec<u8>, RequestError>>,
+}
+
+struct SwarmCtx {
+    pending: HashMap<OutboundRequestId, Pending>,
+    connected: HashSet<PeerId>,
+    /// Peers whose spec-required first Status exchange has completed (either
+    /// way). Requests to peers not in this set are parked in `queued` —
+    /// opening a light_client stream before Status completes gets the whole
+    /// connection dropped by Lighthouse/Teku (see the Java autoStatus doc).
+    status_done: HashSet<PeerId>,
+    queued: HashMap<PeerId, Vec<QueuedRequest>>,
+    lc_servers: HashSet<PeerId>,
+    local_status: Arc<LocalStatus>,
+}
+
+async fn run_swarm(
+    mut swarm: Swarm<Behaviour>,
+    mut rx: mpsc::Receiver<Command>,
+    local_status: Arc<LocalStatus>,
+) {
+    let mut ctx = SwarmCtx {
+        pending: HashMap::new(),
+        connected: HashSet::new(),
+        status_done: HashSet::new(),
+        queued: HashMap::new(),
+        lc_servers: HashSet::new(),
+        local_status,
+    };
+    loop {
+        tokio::select! {
+            cmd = rx.recv() => match cmd {
+                None | Some(Command::Shutdown) => {
+                    for (_, p) in ctx.pending.drain() {
+                        if let Pending::External(reply) = p {
+                            let _ = reply.send(Err(RequestError::Shutdown));
+                        }
+                    }
+                    for (_, queue) in ctx.queued.drain() {
+                        for q in queue {
+                            let _ = q.reply.send(Err(RequestError::Shutdown));
+                        }
+                    }
+                    tracing::info!("libp2p host stopping");
+                    return;
+                }
+                Some(Command::Request { peer, addr, protocol, wire, reply }) => {
+                    submit_request(&mut swarm, &mut ctx, peer, addr, protocol, wire, reply);
+                }
+                Some(Command::PeerCount { reply }) => {
+                    let _ = reply.send(ctx.connected.len());
+                }
+                Some(Command::LcServers { reply }) => {
+                    let _ = reply.send(ctx.lc_servers.clone());
+                }
+            },
+            event = swarm.select_next_some() => handle_swarm_event(&mut swarm, &mut ctx, event),
+        }
+    }
+}
+
+/// Dispatch an external request. Peers that haven't completed the
+/// spec-required first Status exchange get the request PARKED until the
+/// auto-Status settles — Lighthouse/Teku drop connections whose first inbound
+/// stream isn't Status, which is exactly what a raced dial+request produces.
+fn submit_request(
+    swarm: &mut Swarm<Behaviour>,
+    ctx: &mut SwarmCtx,
+    peer: PeerId,
+    addr: Multiaddr,
+    protocol: &'static str,
+    wire: Vec<u8>,
+    reply: oneshot::Sender<Result<Vec<u8>, RequestError>>,
+) {
+    if ctx.status_done.contains(&peer) {
+        let Some(rr) = behaviour_for(swarm, protocol) else {
+            let _ = reply.send(Err(RequestError::Io(format!("unknown protocol {protocol}"))));
+            return;
+        };
+        let id = rr.send_request_with_addresses(&peer, wire, vec![addr]);
+        ctx.pending.insert(id, Pending::External(reply));
+        return;
+    }
+
+    ctx.queued
+        .entry(peer)
+        .or_default()
+        .push(QueuedRequest { addr: addr.clone(), protocol, wire, reply });
+    if !ctx.connected.contains(&peer) {
+        use libp2p::swarm::dial_opts::DialOpts;
+        let opts = DialOpts::peer_id(peer).addresses(vec![addr]).build();
+        match swarm.dial(opts) {
+            Ok(()) => {}
+            // Already dialing / connecting — the queued request rides along.
+            Err(libp2p::swarm::DialError::DialPeerConditionFalse(_)) => {}
+            Err(e) => {
+                tracing::debug!(peer = %peer, error = %e, "dial failed");
+                fail_queued(ctx, &peer, RequestError::DialFailure);
+            }
+        }
+    }
+}
+
+fn behaviour_for<'a>(swarm: &'a mut Swarm<Behaviour>, protocol: &str) -> Option<&'a mut RR> {
+    let behaviour = swarm.behaviour_mut();
+    Some(match protocol {
+        protocols::STATUS_V2 => &mut behaviour.status_v2,
+        protocols::STATUS_V1 => &mut behaviour.status_v1,
+        protocols::PING => &mut behaviour.ping,
+        protocols::METADATA_V2 => &mut behaviour.metadata,
+        protocols::GOODBYE => &mut behaviour.goodbye,
+        protocols::BOOTSTRAP => &mut behaviour.bootstrap,
+        protocols::UPDATES_BY_RANGE => &mut behaviour.updates,
+        protocols::FINALITY_UPDATE => &mut behaviour.finality,
+        protocols::OPTIMISTIC_UPDATE => &mut behaviour.optimistic,
+        _ => return None,
+    })
+}
+
+fn fail_queued(ctx: &mut SwarmCtx, peer: &PeerId, error: RequestError) {
+    if let Some(queue) = ctx.queued.remove(peer) {
+        for q in queue {
+            let _ = q.reply.send(Err(error.clone()));
+        }
+    }
+}
+
+/// The peer's Status handshake settled (either way): release its parked requests.
+fn mark_status_done(swarm: &mut Swarm<Behaviour>, ctx: &mut SwarmCtx, peer: PeerId) {
+    ctx.status_done.insert(peer);
+    let Some(queue) = ctx.queued.remove(&peer) else { return };
+    for q in queue {
+        let Some(rr) = behaviour_for(swarm, q.protocol) else {
+            let _ = q.reply.send(Err(RequestError::Io(format!("unknown protocol {}", q.protocol))));
+            continue;
+        };
+        let id = rr.send_request_with_addresses(&peer, q.wire, vec![q.addr]);
+        ctx.pending.insert(id, Pending::External(q.reply));
+    }
+}
+
+fn handle_swarm_event(swarm: &mut Swarm<Behaviour>, ctx: &mut SwarmCtx, event: SwarmEvent<BehaviourEvent>) {
+    match event {
+        SwarmEvent::ConnectionEstablished { peer_id, endpoint, .. } => {
+            let newly = ctx.connected.insert(peer_id);
+            tracing::debug!(peer = %peer_id, remote = %endpoint.get_remote_address(),
+                "connection established");
+            if newly {
+                // CL p2p spec: Status MUST be the first req/resp on a new
+                // connection; clients drop peers that skip it (see autoStatus
+                // in the Java service). v2 first, v1 fallback on negotiation
+                // failure. Parked requests flush when it settles.
+                let wire = codec::encode_request(&ctx.local_status.get().encode());
+                let id = swarm.behaviour_mut().status_v2.send_request(&peer_id, wire);
+                ctx.pending.insert(id, Pending::AutoStatusV2(peer_id));
+            }
+        }
+        SwarmEvent::ConnectionClosed { peer_id, num_established, .. } => {
+            if num_established == 0 {
+                ctx.connected.remove(&peer_id);
+                // Next connection must redo the Status handshake.
+                ctx.status_done.remove(&peer_id);
+                fail_queued(ctx, &peer_id, RequestError::ConnectionClosed);
+                tracing::debug!(peer = %peer_id, "connection closed");
+            }
+        }
+        SwarmEvent::OutgoingConnectionError { peer_id: Some(peer_id), error, .. } => {
+            tracing::debug!(peer = %peer_id, error = %error, "outgoing connection failed");
+            fail_queued(ctx, &peer_id, RequestError::DialFailure);
+        }
+        SwarmEvent::Behaviour(be) => handle_behaviour_event(swarm, ctx, be),
+        SwarmEvent::NewListenAddr { address, .. } => {
+            tracing::debug!(%address, "listening");
+        }
+        _ => {}
+    }
+}
+
+fn handle_behaviour_event(swarm: &mut Swarm<Behaviour>, ctx: &mut SwarmCtx, event: BehaviourEvent) {
+    use BehaviourEvent as E;
+    match event {
+        E::Identify(identify::Event::Received { peer_id, info, .. }) => {
+            let lc = info
+                .protocols
+                .iter()
+                .any(|p| p.as_ref().contains("light_client_updates_by_range"));
+            if lc {
+                ctx.lc_servers.insert(peer_id);
+            }
+            tracing::debug!(peer = %peer_id, agent = %info.agent_version,
+                protocols = info.protocols.len(), lc_updates = lc, "identify received");
+        }
+        E::Identify(_) => {}
+        E::StatusV2(ev) => on_rr_event(swarm, ctx, protocols::STATUS_V2, ev),
+        E::StatusV1(ev) => on_rr_event(swarm, ctx, protocols::STATUS_V1, ev),
+        E::Ping(ev) => on_rr_event(swarm, ctx, protocols::PING, ev),
+        E::Metadata(ev) => on_rr_event(swarm, ctx, protocols::METADATA_V2, ev),
+        E::Goodbye(ev) => on_rr_event(swarm, ctx, protocols::GOODBYE, ev),
+        E::Bootstrap(ev) => on_rr_event(swarm, ctx, protocols::BOOTSTRAP, ev),
+        E::Updates(ev) => on_rr_event(swarm, ctx, protocols::UPDATES_BY_RANGE, ev),
+        E::Finality(ev) => on_rr_event(swarm, ctx, protocols::FINALITY_UPDATE, ev),
+        E::Optimistic(ev) => on_rr_event(swarm, ctx, protocols::OPTIMISTIC_UPDATE, ev),
+    }
+}
+
+type RrEvent = request_response::Event<Vec<u8>, Vec<u8>>;
+
+fn on_rr_event(swarm: &mut Swarm<Behaviour>, ctx: &mut SwarmCtx, protocol: &'static str, event: RrEvent) {
+    match event {
+        request_response::Event::Message { peer, message, .. } => match message {
+            request_response::Message::Response { request_id, response } => {
+                complete(ctx, swarm, request_id, peer, Ok(response));
+            }
+            request_response::Message::Request { request, channel, .. } => {
+                let response = respond_inbound(ctx, protocol, peer, &request);
+                let behaviour = swarm.behaviour_mut();
+                let rr = match protocol {
+                    protocols::STATUS_V2 => &mut behaviour.status_v2,
+                    protocols::STATUS_V1 => &mut behaviour.status_v1,
+                    protocols::PING => &mut behaviour.ping,
+                    protocols::METADATA_V2 => &mut behaviour.metadata,
+                    protocols::GOODBYE => &mut behaviour.goodbye,
+                    protocols::BOOTSTRAP => &mut behaviour.bootstrap,
+                    protocols::FINALITY_UPDATE => &mut behaviour.finality,
+                    protocols::OPTIMISTIC_UPDATE => &mut behaviour.optimistic,
+                    _ => return, // updates_by_range is outbound-only
+                };
+                if rr.send_response(channel, response).is_err() {
+                    tracing::debug!(peer = %peer, protocol, "inbound response channel closed");
+                }
+            }
+        },
+        request_response::Event::OutboundFailure { peer, request_id, error, .. } => {
+            let mapped = match &error {
+                request_response::OutboundFailure::Timeout => RequestError::Timeout,
+                request_response::OutboundFailure::UnsupportedProtocols => {
+                    RequestError::UnsupportedProtocol
+                }
+                request_response::OutboundFailure::DialFailure => RequestError::DialFailure,
+                request_response::OutboundFailure::ConnectionClosed => {
+                    RequestError::ConnectionClosed
+                }
+                other => RequestError::Io(other.to_string()),
+            };
+            tracing::debug!(peer = %peer, protocol, error = %error, "outbound failure");
+            complete(ctx, swarm, request_id, peer, Err(mapped));
+        }
+        request_response::Event::InboundFailure { peer, error, .. } => {
+            tracing::debug!(peer = %peer, protocol, error = %error, "inbound failure");
+        }
+        request_response::Event::ResponseSent { .. } => {}
+    }
+}
+
+fn complete(
+    ctx: &mut SwarmCtx,
+    swarm: &mut Swarm<Behaviour>,
+    request_id: OutboundRequestId,
+    _peer: PeerId,
+    result: Result<Vec<u8>, RequestError>,
+) {
+    match ctx.pending.remove(&request_id) {
+        Some(Pending::External(reply)) => {
+            let _ = reply.send(result);
+        }
+        Some(Pending::AutoStatusV2(peer_id)) => match result {
+            Ok(raw) => {
+                log_peer_status("v2", peer_id, &raw);
+                mark_status_done(swarm, ctx, peer_id);
+            }
+            Err(RequestError::UnsupportedProtocol) => {
+                // v1-only peer (Nimbus bucket in the Java notes) — fall back.
+                let local = ctx.local_status.get();
+                let wire = codec::encode_request(&local.encode_v1());
+                let id = swarm.behaviour_mut().status_v1.send_request(&peer_id, wire);
+                ctx.pending.insert(id, Pending::AutoStatusV1(peer_id));
+            }
+            Err(e) => {
+                tracing::debug!(peer = %peer_id, error = %e, "auto-status v2 failed");
+                // Settled (failed) — release parked requests rather than
+                // starving them; the peer may still serve other protocols.
+                mark_status_done(swarm, ctx, peer_id);
+            }
+        },
+        Some(Pending::AutoStatusV1(peer_id)) => {
+            match result {
+                Ok(raw) => log_peer_status("v1", peer_id, &raw),
+                Err(e) => tracing::debug!(peer = %peer_id, error = %e, "auto-status v1 failed"),
+            }
+            mark_status_done(swarm, ctx, peer_id);
+        }
+        None => {}
+    }
+}
+
+fn log_peer_status(version: &str, peer: PeerId, raw: &[u8]) {
+    match codec::decode_response(raw, false) {
+        Ok(d) => {
+            let decoded = if version == "v2" {
+                StatusMessage::decode(&d.ssz_payload)
+            } else {
+                StatusMessage::decode_v1(&d.ssz_payload)
+            };
+            match decoded {
+                Ok(s) => tracing::debug!(peer = %peer, version,
+                    fork_digest = %hex4(&s.fork_digest),
+                    finalized_epoch = s.finalized_epoch, head_slot = s.head_slot,
+                    earliest = s.earliest_available_slot, "auto-status ok"),
+                Err(e) => tracing::debug!(peer = %peer, version, error = %e,
+                    "auto-status decode failed"),
+            }
+        }
+        Err(e) => tracing::debug!(peer = %peer, version, error = %e, "auto-status frame invalid"),
+    }
+}
+
+fn hex4(b: &[u8; 4]) -> String {
+    format!("{:02x}{:02x}{:02x}{:02x}", b[0], b[1], b[2], b[3])
+}
+
+/// Serve a peer-initiated request, mirroring the Java responder handlers:
+/// status → our current Status; ping/goodbye → echo; metadata → light-client
+/// zeros; light_client_* → ResourceUnavailable (no relay cache in this stage).
+fn respond_inbound(ctx: &SwarmCtx, protocol: &'static str, peer: PeerId, raw: &[u8]) -> Vec<u8> {
+    let expected = protocols::expected_request_size(protocol);
+    let req_ssz: Vec<u8> = if expected == 0 {
+        Vec::new()
+    } else {
+        match codec::parse_request_ssz(raw) {
+            Some(ssz) => ssz,
+            None => {
+                return codec::encode_error_response(
+                    codec::RESULT_INVALID_REQUEST,
+                    "InvalidRequest: unparseable body",
+                )
+            }
+        }
+    };
+
+    match protocol {
+        protocols::STATUS_V2 => {
+            let local = ctx.local_status.get();
+            codec::encode_success_response(&local.encode(), None)
+        }
+        protocols::STATUS_V1 => {
+            let local = ctx.local_status.get();
+            codec::encode_success_response(&local.encode_v1(), None)
+        }
+        protocols::PING => {
+            let body: &[u8] = if req_ssz.len() == 8 { &req_ssz } else { &[0u8; 8] };
+            codec::encode_success_response(body, None)
+        }
+        protocols::METADATA_V2 => {
+            codec::encode_success_response(&status::metadata_v2_light_client(), None)
+        }
+        protocols::GOODBYE => {
+            let reason = if req_ssz.len() == 8 {
+                u64::from_le_bytes(req_ssz[..8].try_into().expect("length checked"))
+            } else {
+                0
+            };
+            tracing::info!(peer = %peer, reason, "peer sent goodbye");
+            let body: &[u8] = if req_ssz.len() == 8 { &req_ssz } else { &[0u8; 8] };
+            codec::encode_success_response(body, None)
+        }
+        // No relay cache yet: same observable result as the Java handlers on a
+        // cold cache — ResourceUnavailable, "ask someone else".
+        _ => codec::encode_error_response(codec::RESULT_RESOURCE_UNAVAILABLE, "ResourceUnavailable"),
+    }
+}

--- a/rust/myotis-net/src/status.rs
+++ b/rust/myotis-net/src/status.rs
@@ -1,0 +1,172 @@
+//! `Status` / `MetaData` SSZ containers and the fork-digest math — Rust twins of
+//! the Java `StatusMessage` / `MetadataMessage` / `BeaconLightClient.computeForkDigest`.
+
+use myotis_consensus::ssz;
+
+/// `Status` v2 (post-Electra, `/req/status/2`): 92 bytes fixed.
+/// v1 (`/req/status/1`) is the same layout without `earliest_available_slot` (84 bytes).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StatusMessage {
+    pub fork_digest: [u8; 4],
+    pub finalized_root: [u8; 32],
+    pub finalized_epoch: u64,
+    pub head_root: [u8; 32],
+    pub head_slot: u64,
+    pub earliest_available_slot: u64,
+}
+
+impl StatusMessage {
+    pub const SSZ_SIZE_V2: usize = 92;
+    pub const SSZ_SIZE_V1: usize = 84;
+
+    pub fn encode(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(Self::SSZ_SIZE_V2);
+        out.extend_from_slice(&self.fork_digest);
+        out.extend_from_slice(&self.finalized_root);
+        out.extend_from_slice(&self.finalized_epoch.to_le_bytes());
+        out.extend_from_slice(&self.head_root);
+        out.extend_from_slice(&self.head_slot.to_le_bytes());
+        out.extend_from_slice(&self.earliest_available_slot.to_le_bytes());
+        out
+    }
+
+    /// v1: 84 bytes, no `earliest_available_slot`.
+    pub fn encode_v1(&self) -> Vec<u8> {
+        let mut out = self.encode();
+        out.truncate(Self::SSZ_SIZE_V1);
+        out
+    }
+
+    pub fn decode(ssz_bytes: &[u8]) -> Result<Self, String> {
+        if ssz_bytes.len() < Self::SSZ_SIZE_V2 {
+            return Err(format!(
+                "Status requires {} bytes, got {}",
+                Self::SSZ_SIZE_V2,
+                ssz_bytes.len()
+            ));
+        }
+        let mut s = Self::decode_v1(ssz_bytes)?;
+        s.earliest_available_slot =
+            u64::from_le_bytes(ssz_bytes[84..92].try_into().expect("length checked"));
+        Ok(s)
+    }
+
+    /// v1 decode: 84 bytes, `earliest_available_slot` defaulted to 0.
+    pub fn decode_v1(ssz_bytes: &[u8]) -> Result<Self, String> {
+        if ssz_bytes.len() < Self::SSZ_SIZE_V1 {
+            return Err(format!(
+                "Status v1 requires {} bytes, got {}",
+                Self::SSZ_SIZE_V1,
+                ssz_bytes.len()
+            ));
+        }
+        Ok(Self {
+            fork_digest: ssz_bytes[0..4].try_into().expect("length checked"),
+            finalized_root: ssz_bytes[4..36].try_into().expect("length checked"),
+            finalized_epoch: u64::from_le_bytes(ssz_bytes[36..44].try_into().expect("len")),
+            head_root: ssz_bytes[44..76].try_into().expect("length checked"),
+            head_slot: u64::from_le_bytes(ssz_bytes[76..84].try_into().expect("len")),
+            earliest_available_slot: 0,
+        })
+    }
+}
+
+/// `MetaData` v2 (`/req/metadata/2`): seq_number(8) || attnets Bitvector[64](8)
+/// || syncnets Bitvector[4](1) = 17 bytes. A pure light client subscribes to
+/// nothing, so the canonical answer is all zeros.
+pub fn metadata_v2_light_client() -> Vec<u8> {
+    vec![0u8; 17]
+}
+
+// -------------------------------------------------------------------------
+// Fork digest
+// -------------------------------------------------------------------------
+
+/// `compute_fork_data_root(fork_version, genesis_validators_root)` — the full
+/// 32-byte hash_tree_root of ForkData, over the same ssz primitives
+/// `myotis_consensus::verify::compute_domain` uses internally.
+pub fn fork_data_root(fork_version: [u8; 4], genesis_validators_root: [u8; 32]) -> [u8; 32] {
+    ssz::container_root(&[ssz::padded_root(&fork_version), genesis_validators_root])
+}
+
+/// Pre-Fulu `compute_fork_digest`: first 4 bytes of the ForkData root.
+pub fn fork_digest(fork_version: [u8; 4], genesis_validators_root: [u8; 32]) -> [u8; 4] {
+    let root = fork_data_root(fork_version, genesis_validators_root);
+    root[..4].try_into().expect("4 <= 32")
+}
+
+/// Fulu / EIP-7892 `compute_fork_digest`, folding the active BPO blob params in:
+/// `(fork_data_root XOR sha256(u64_le(epoch) || u64_le(max_blobs)))[0..4]`.
+/// `blob_params_epoch == 0` means no BPO is active → the pre-Fulu formula.
+/// Mirrors `BeaconLightClient.computeForkDigest` / `NetworkConfig.currentForkDigest`.
+pub fn fork_digest_bpo(
+    fork_version: [u8; 4],
+    genesis_validators_root: [u8; 32],
+    blob_params_epoch: u64,
+    blob_params_max_blobs: u64,
+) -> [u8; 4] {
+    let base = fork_data_root(fork_version, genesis_validators_root);
+    if blob_params_epoch == 0 {
+        return base[..4].try_into().expect("4 <= 32");
+    }
+    // sha256(epoch_le || max_blobs_le) via the consensus crate's pair hash.
+    let bp_hash = ssz::sha256_pair(&blob_params_epoch.to_le_bytes(), &blob_params_max_blobs.to_le_bytes());
+    let mut out = [0u8; 4];
+    for i in 0..4 {
+        out[i] = base[i] ^ bp_hash[i];
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mainnet_gvr() -> [u8; 32] {
+        let hex = "4b363db94e286120d76eb905340fdd4e54bfe9f06bf33ff6cf5ad27f511bfe95";
+        let mut out = [0u8; 32];
+        for i in 0..32 {
+            out[i] = u8::from_str_radix(&hex[i * 2..i * 2 + 2], 16).unwrap();
+        }
+        out
+    }
+
+    /// The live values the Java side computes for mainnet (Fulu 0x06000000,
+    /// BPO2 epoch=419072 max_blobs=21 — NetworkConfig.MAINNET).
+    #[test]
+    fn mainnet_fork_digest_matches_java() {
+        let base = fork_digest([0x06, 0, 0, 0], mainnet_gvr());
+        assert_eq!(base, [0x82, 0xFA, 0xE5, 0x41]);
+        let bpo = fork_digest_bpo([0x06, 0, 0, 0], mainnet_gvr(), 419_072, 21);
+        assert_eq!(bpo, [0x8C, 0x9F, 0x62, 0xFE]);
+        // epoch == 0 falls back to the base formula.
+        assert_eq!(fork_digest_bpo([0x06, 0, 0, 0], mainnet_gvr(), 0, 0), base);
+    }
+
+    #[test]
+    fn status_round_trips_both_versions() {
+        let s = StatusMessage {
+            fork_digest: [0x8C, 0x9F, 0x62, 0xFE],
+            finalized_root: [7u8; 32],
+            finalized_epoch: 455_000,
+            head_root: [9u8; 32],
+            head_slot: 14_560_000,
+            earliest_available_slot: 42,
+        };
+        let v2 = s.encode();
+        assert_eq!(v2.len(), StatusMessage::SSZ_SIZE_V2);
+        assert_eq!(StatusMessage::decode(&v2).unwrap(), s);
+
+        let v1 = s.encode_v1();
+        assert_eq!(v1.len(), StatusMessage::SSZ_SIZE_V1);
+        let d1 = StatusMessage::decode_v1(&v1).unwrap();
+        assert_eq!(d1.earliest_available_slot, 0);
+        assert_eq!(d1.head_slot, s.head_slot);
+        assert!(StatusMessage::decode(&v1).is_err()); // 84 bytes is not a v2
+    }
+
+    #[test]
+    fn metadata_is_17_zero_bytes() {
+        assert_eq!(metadata_v2_light_client(), vec![0u8; 17]);
+    }
+}

--- a/rust/myotis-net/src/sync.rs
+++ b/rust/myotis-net/src/sync.rs
@@ -1,0 +1,1159 @@
+//! The light-client sync loop — drives `myotis_consensus` (store + processor)
+//! over the req/resp transport, mirroring the behavior of the Java
+//! `BeaconLightClient.syncLoop`: bootstrap from the embedded checkpoint,
+//! catch the sync committee up to the wall-clock period via
+//! `light_client_updates_by_range`, then poll `light_client_finality_update`
+//! every slot.
+//!
+//! CLOCK POLICY: this module is the only place wall-clock time is read. Slot
+//! estimates are computed here and passed into the consensus crate as plain
+//! values (`force_rotate_if_past_period(slot_estimate)`), keeping
+//! `myotis-consensus` clock-free.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use futures::stream::{FuturesUnordered, StreamExt};
+use libp2p::{Multiaddr, PeerId};
+use tokio::sync::{mpsc, watch};
+
+use myotis_consensus::spec;
+use myotis_consensus::store::{LightClientProcessor, LightClientStore};
+use myotis_consensus::types::{LightClientBootstrap, LightClientFinalityUpdate, LightClientUpdate};
+use myotis_consensus::ssz;
+
+use crate::codec;
+use crate::discovery::{self, DiscoveryConfig};
+use crate::protocols;
+use crate::reqresp::{self, LocalStatus, ReqRespClient, RequestError};
+use crate::status::{fork_digest, fork_digest_bpo, StatusMessage};
+
+// -------------------------------------------------------------------------
+// Chain configuration
+// -------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub struct ChainConfig {
+    pub name: &'static str,
+    pub fork_version: [u8; 4],
+    /// Prior fork version, accepted as a discv5 fork-digest fallback (the Java
+    /// `NetworkConfig.acceptedForkDigests`). None for mainnet (on Fulu; stale
+    /// digests wouldn't help us sync).
+    pub prior_fork_version: Option<[u8; 4]>,
+    pub genesis_validators_root: [u8; 32],
+    /// Beacon chain genesis time (seconds since epoch) for wall-clock slot estimates.
+    pub genesis_time: u64,
+    pub seconds_per_slot: u64,
+    pub slots_per_epoch: u64,
+    /// EIP-7892 active BPO entry folded into the fork digest (0 epoch = none).
+    pub blob_params_epoch: u64,
+    pub blob_params_max_blobs: u64,
+    /// Trusted weak-subjectivity checkpoint (block root + slot).
+    pub checkpoint_root: [u8; 32],
+    pub checkpoint_slot: u64,
+    /// Pinned light-client-serving peer multiaddrs (`/ip4/../tcp/../p2p/..`).
+    pub static_peers: Vec<String>,
+    /// discv5 bootstrap ENRs.
+    pub bootstrap_enrs: Vec<String>,
+    /// discv5 UDP listen port (0 = OS-assigned; use when running next to a Java daemon).
+    pub discv5_port: u16,
+}
+
+impl ChainConfig {
+    /// Mainnet — values duplicated verbatim from the Java
+    /// `NetworkConfig.MAINNET` (networking/src/main/java/.../NetworkConfig.java).
+    pub fn mainnet() -> Self {
+        Self {
+            name: "mainnet",
+            // Fulu, activated at slot 13164544 (2025-12-03).
+            fork_version: [0x06, 0x00, 0x00, 0x00],
+            prior_fork_version: None,
+            genesis_validators_root: hex32(
+                "4b363db94e286120d76eb905340fdd4e54bfe9f06bf33ff6cf5ad27f511bfe95",
+            ),
+            genesis_time: 1_606_824_023, // 2020-12-01 12:00:23 UTC
+            seconds_per_slot: 12,
+            slots_per_epoch: 32,
+            // BPO2 (Fusaka) blob schedule entry: epoch 419072, MAX_BLOBS=21.
+            blob_params_epoch: 419_072,
+            blob_params_max_blobs: 21,
+            // Copied verbatim from the @checkpoint:mainnet:begin/end region of
+            // NetworkConfig.java (slot 14560000, 2026-06-15, period 1777).
+            // NOTE: `./gradlew refreshMainnetCheckpoint` rewrites only the Java
+            // region today — it does NOT rewrite this constant yet (plan PR7);
+            // until then a checkpoint refresh must be mirrored here by hand.
+            checkpoint_root: hex32(
+                "58cb432571912a434ab7fb83317bb60d09632cce53839fc2541417710465b42e",
+            ),
+            checkpoint_slot: 14_560_000,
+            static_peers: MAINNET_STATIC_PEERS.iter().map(|s| s.to_string()).collect(),
+            bootstrap_enrs: MAINNET_BOOTSTRAP_ENRS.iter().map(|s| s.to_string()).collect(),
+            discv5_port: 0,
+        }
+    }
+
+    /// Fork digests accepted when filtering discv5 ENRs — current first, then
+    /// the prior fork's when configured (`NetworkConfig.acceptedForkDigests`).
+    pub fn accepted_fork_digests(&self) -> Vec<[u8; 4]> {
+        let mut out = vec![self.current_fork_digest()];
+        if let Some(prior) = self.prior_fork_version {
+            out.push(fork_digest(prior, self.genesis_validators_root));
+        }
+        out
+    }
+
+    pub fn current_fork_digest(&self) -> [u8; 4] {
+        fork_digest_bpo(
+            self.fork_version,
+            self.genesis_validators_root,
+            self.blob_params_epoch,
+            self.blob_params_max_blobs,
+        )
+    }
+
+    /// Wall-clock slot estimate — THE clock read of this crate.
+    fn current_slot_estimate(&self) -> u64 {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or(Duration::ZERO)
+            .as_secs();
+        now.saturating_sub(self.genesis_time) / self.seconds_per_slot.max(1)
+    }
+}
+
+fn hex32(s: &str) -> [u8; 32] {
+    let mut out = [0u8; 32];
+    for (i, byte) in out.iter_mut().enumerate() {
+        *byte = u8::from_str_radix(&s[i * 2..i * 2 + 2], 16).expect("valid hex constant");
+    }
+    out
+}
+
+/// Known light-client-serving mainnet peers — the Java `NetworkConfig.MAINNET`
+/// clPeerMultiaddrs list (nimbus/lodestar/lighthouse, discovered 2026-03-11).
+const MAINNET_STATIC_PEERS: &[&str] = &[
+    "/ip4/176.229.58.1/tcp/9001/p2p/16Uiu2HAmHu1BxzrSWg7sN9JyJenC5unK5ntdk5QFYqQdQyyD7x3a",
+    "/ip4/81.172.166.237/tcp/9001/p2p/16Uiu2HAmRogw5aqM4ZuVEmZoQvFp25sUnnQ9wpGuWXRLFMmXc88j",
+    "/ip4/54.157.213.0/tcp/9000/p2p/16Uiu2HAmQz83bNmMaBFCafuxDasiNdPYZF1B4zhgo3DckByU8bo3",
+    "/ip4/84.229.246.214/tcp/9001/p2p/16Uiu2HAm1UtRynVpuvWUgn3bfNooSUKYSUrbW8oeuBBcwVxbC1c9",
+    "/ip4/73.205.184.197/tcp/9000/p2p/16Uiu2HAm9CKG1x5rJk6sgEnCh9TKRagNEVVJfjR1jC3ruzPQfwzb",
+    "/ip4/172.92.13.157/tcp/9000/p2p/16Uiu2HAm7TEx4DP8iVj1RedeDNK59pw9AskGRwV7x9vgexTQi8CM",
+    "/ip4/77.12.100.127/tcp/9012/p2p/16Uiu2HAmA5VXnNKGu9jmV5yhL3tGy5seiNMnaBMTaV1vBesz84iJ",
+    "/ip4/52.200.203.85/tcp/9000/p2p/16Uiu2HAm6JKuoWTSKP7uTbe1PESUcejo4ffcaADoRMuKmMJQKBeP",
+    "/ip4/82.139.21.242/tcp/9802/p2p/16Uiu2HAm5LSnoe8EdTDhrPEm4M1fnYw34zSo2SYbXLLH4FtfcfnL",
+    "/ip4/217.67.221.74/tcp/9037/p2p/16Uiu2HAmExQubp4XC5KoQwvYxNWJP2M5rpX3VKdtEYgwPnMb5Kn4",
+    "/ip4/135.181.210.123/tcp/9000/p2p/16Uiu2HAmBWXZS9H2ncxgEcVi77GvYtmGUEGpHNyJxsF3Ct25Uidc",
+    "/ip4/195.201.160.183/tcp/9000/p2p/16Uiu2HAm79xzMY5FNnXGo6xcBRxCzYvMNE7CM6NZytrjXoDB5yRQ",
+    "/ip4/45.10.55.78/tcp/9000/p2p/16Uiu2HAmCpe6iMDvcXFmjLVpJ98u1fqNehpDLS2dmMRgxQ8mgMKu",
+    "/ip4/185.107.68.131/tcp/9000/p2p/16Uiu2HAm3sGDmyV3m4tju3SzekGt2EBSnALQNdn9QebPSiQP5NA2",
+    "/ip4/51.161.218.70/tcp/9000/p2p/16Uiu2HAmE6fJp7ZZVMUFxZGgfxAvfVyX3GDU6Wh88GvWv5U6SriT",
+    "/ip4/216.105.170.30/tcp/9000/p2p/16Uiu2HAm86YwyECbBiHTo2imwQJ4UXGgR1NLY2W6dPUfEFDony6d",
+    "/ip4/54.201.148.177/tcp/9000/p2p/16Uiu2HAmNwEsdBC2phX7qU7camNe9Gs21WyrpV5AZDYyjZBMYjWZ",
+    "/ip4/16.63.94.117/tcp/9000/p2p/16Uiu2HAmSd7qzG5joNgvEYYcgVvg1y9MiYjpMHMvzRzaWYqXxkCM",
+];
+
+/// Mainnet CL discv5 bootnodes — the Java `NetworkConfig.MAINNET`
+/// clDiscv5Bootnodes list (sigp/lighthouse bootstrap_nodes.yaml mirror).
+const MAINNET_BOOTSTRAP_ENRS: &[&str] = &[
+    // Teku
+    "enr:-Iu4QLm7bZGdAt9NSeJG0cEnJohWcQTQaI9wFLu3Q7eHIDfrI4cwtzvEW3F3VbG9XdFXlrHyFGeXPn9snTCQJ9bnMRABgmlkgnY0gmlwhAOTJQCJc2VjcDI1NmsxoQIZdZD6tDYpkpEfVo5bgiU8MGRjhcOmHGD2nErK0UKRrIN0Y3CCIyiDdWRwgiMo",
+    "enr:-Iu4QEDJ4Wa_UQNbK8Ay1hFEkXvd8psolVK6OhfTL9irqz3nbXxxWyKwEplPfkju4zduVQj6mMhUCm9R2Lc4YM5jPcIBgmlkgnY0gmlwhANrfESJc2VjcDI1NmsxoQJCYz2-nsqFpeEj6eov9HSi9QssIVIVNr0I89J1vXM9foN0Y3CCIyiDdWRwgiMo",
+    // Prylabs
+    "enr:-Ku4QImhMc1z8yCiNJ1TyUxdcfNucje3BGwEHzodEZUan8PherEo4sF7pPHPSIB1NNuSg5fZy7qFsjmUKs2ea1Whi0EBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpD1pf1CAAAAAP__________gmlkgnY0gmlwhBLf22SJc2VjcDI1NmsxoQOVphkDqal4QzPMksc5wnpuC3gvSC8AfbFOnZY_On34wIN1ZHCCIyg",
+    "enr:-Ku4QP2xDnEtUXIjzJ_DhlCRN9SN99RYQPJL92TMlSv7U5C1YnYLjwOQHgZIUXw6c-BvRg2Yc2QsZxxoS_pPRVe0yK8Bh2F0dG5ldHOIAAAAAAAAAACEZXRoMpD1pf1CAAAAAP__________gmlkgnY0gmlwhBLf22SJc2VjcDI1NmsxoQMeFF5GrS7UZpAH2Ly84aLK-TyvH-dRo0JM1i8yygH50YN1ZHCCJxA",
+    "enr:-Ku4QPp9z1W4tAO8Ber_NQierYaOStqhDqQdOPY3bB3jDgkjcbk6YrEnVYIiCBbTxuar3CzS528d2iE7TdJsrL-dEKoBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpD1pf1CAAAAAP__________gmlkgnY0gmlwhBLf22SJc2VjcDI1NmsxoQMw5fqqkw2hHC4F5HZZDPsNmPdB1Gi8JPQK7pRc9XHh-oN1ZHCCKvg",
+    // Sigma Prime (Lighthouse)
+    "enr:-Le4QPUXJS2BTORXxyx2Ia-9ae4YqA_JWX3ssj4E_J-3z1A-HmFGrU8BpvpqhNabayXeOZ2Nq_sbeDgtzMJpLLnXFgAChGV0aDKQtTA_KgEAAAAAIgEAAAAAAIJpZIJ2NIJpcISsaa0Zg2lwNpAkAIkHAAAAAPA8kv_-awoTiXNlY3AyNTZrMaEDHAD2JKYevx89W0CcFJFiskdcEzkH_Wdv9iW42qLK79ODdWRwgiMohHVkcDaCI4I",
+    "enr:-Le4QLHZDSvkLfqgEo8IWGG96h6mxwe_PsggC20CL3neLBjfXLGAQFOPSltZ7oP6ol54OvaNqO02Rnvb8YmDR274uq8ChGV0aDKQtTA_KgEAAAAAIgEAAAAAAIJpZIJ2NIJpcISLosQxg2lwNpAqAX4AAAAAAPA8kv_-ax65iXNlY3AyNTZrMaEDBJj7_dLFACaxBfaI8KZTh_SSJUjhyAyfshimvSqo22WDdWRwgiMohHVkcDaCI4I",
+    "enr:-Le4QH6LQrusDbAHPjU_HcKOuMeXfdEB5NJyXgHWFadfHgiySqeDyusQMvfphdYWOzuSZO9Uq2AMRJR5O4ip7OvVma8BhGV0aDKQtTA_KgEAAAAAIgEAAAAAAIJpZIJ2NIJpcISLY9ncg2lwNpAkAh8AgQIBAAAAAAAAAAmXiXNlY3AyNTZrMaECDYCZTZEksF-kmgPholqgVt8IXr-8L7Nu7YrZ7HUpgxmDdWRwgiMohHVkcDaCI4I",
+    "enr:-Le4QIqLuWybHNONr933Lk0dcMmAB5WgvGKRyDihy1wHDIVlNuuztX62W51voT4I8qD34GcTEOTmag1bcdZ_8aaT4NUBhGV0aDKQtTA_KgEAAAAAIgEAAAAAAIJpZIJ2NIJpcISLY04ng2lwNpAkAh8AgAIBAAAAAAAAAA-fiXNlY3AyNTZrMaEDscnRV6n1m-D9ID5UsURk0jsoKNXt1TIrj8uKOGW6iluDdWRwgiMohHVkcDaCI4I",
+    // Ethereum Foundation
+    "enr:-Ku4QHqVeJ8PPICcWk1vSn_XcSkjOkNiTg6Fmii5j6vUQgvzMc9L1goFnLKgXqBJspJjIsB91LTOleFmyWWrFVATGngBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpC1MD8qAAAAAP__________gmlkgnY0gmlwhAMRHkWJc2VjcDI1NmsxoQKLVXFOhp2uX6jeT0DvvDpPcU8FWMjQdR4wMuORMhpX24N1ZHCCIyg",
+    "enr:-Ku4QG-2_Md3sZIAUebGYT6g0SMskIml77l6yR-M_JXc-UdNHCmHQeOiMLbylPejyJsdAPsTHJyjJB2sYGDLe0dn8uYBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpC1MD8qAAAAAP__________gmlkgnY0gmlwhBLY-NyJc2VjcDI1NmsxoQORcM6e19T1T9gi7jxEZjk_sjVLGFscUNqAY9obgZaxbIN1ZHCCIyg",
+    "enr:-Ku4QPn5eVhcoF1opaFEvg1b6JNFD2rqVkHQ8HApOKK61OIcIXD127bKWgAtbwI7pnxx6cDyk_nI88TrZKQaGMZj0q0Bh2F0dG5ldHOIAAAAAAAAAACEZXRoMpC1MD8qAAAAAP__________gmlkgnY0gmlwhDayLMaJc2VjcDI1NmsxoQK2sBOLGcUb4AwuYzFuAVCaNHA-dy24UuEKkeFNgCVCsIN1ZHCCIyg",
+    "enr:-Ku4QEWzdnVtXc2Q0ZVigfCGggOVB2Vc1ZCPEc6j21NIFLODSJbvNaef1g4PxhPwl_3kax86YPheFUSLXPRs98vvYsoBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpC1MD8qAAAAAP__________gmlkgnY0gmlwhDZBrP2Jc2VjcDI1NmsxoQM6jr8Rb1ktLEsVcKAPa08wCsKUmvoQ8khiOl_SLozf9IN1ZHCCIyg",
+    // Nimbus
+    "enr:-LK4QA8FfhaAjlb_BXsXxSfiysR7R52Nhi9JBt4F8SPssu8hdE1BXQQEtVDC3qStCW60LSO7hEsVHv5zm8_6Vnjhcn0Bh2F0dG5ldHOIAAAAAAAAAACEZXRoMpC1MD8qAAAAAP__________gmlkgnY0gmlwhAN4aBKJc2VjcDI1NmsxoQJerDhsJ-KxZ8sHySMOCmTO6sHM3iCFQ6VMvLTe948MyYN0Y3CCI4yDdWRwgiOM",
+    "enr:-LK4QKWrXTpV9T78hNG6s8AM6IO4XH9kFT91uZtFg1GcsJ6dKovDOr1jtAAFPnS2lvNltkOGA9k29BUN7lFh_sjuc9QBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpC1MD8qAAAAAP__________gmlkgnY0gmlwhANAdd-Jc2VjcDI1NmsxoQLQa6ai7y9PMN5hpLe5HmiJSlYzMuzP7ZhwRiwHvqNXdoN0Y3CCI4yDdWRwgiOM",
+    // Lodestar
+    "enr:-IS4QPi-onjNsT5xAIAenhCGTDl4z-4UOR25Uq-3TmG4V3kwB9ljLTb_Kp1wdjHNj-H8VVLRBSSWVZo3GUe3z6k0E-IBgmlkgnY0gmlwhKB3_qGJc2VjcDI1NmsxoQMvAfgB4cJXvvXeM6WbCG86CstbSxbQBSGx31FAwVtOTYN1ZHCCIyg",
+    "enr:-KG4QPUf8-g_jU-KrwzG42AGt0wWM1BTnQxgZXlvCEIfTQ5hSmptkmgmMbRkpOqv6kzb33SlhPHJp7x4rLWWiVq5lSECgmlkgnY0gmlwhFPlR9KDaXA2kCoGxcAJAAAVAAAAAAAAABCJc2VjcDI1NmsxoQLdUv9Eo9sxCt0tc_CheLOWnX59yHJtkBSOL7kpxdJ6GYN1ZHCCIyiEdWRwNoIjKA",
+];
+
+// -------------------------------------------------------------------------
+// Status snapshot
+// -------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SyncState {
+    Starting,
+    Bootstrapping,
+    CatchingUp,
+    Synced,
+}
+
+impl std::fmt::Display for SyncState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::Starting => "STARTING",
+            Self::Bootstrapping => "BOOTSTRAPPING",
+            Self::CatchingUp => "CATCHING_UP",
+            Self::Synced => "SYNCED",
+        };
+        write!(f, "{s}")
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SyncStatus {
+    pub state: SyncState,
+    pub finalized_slot: u64,
+    /// hash_tree_root of the finalized beacon header.
+    pub finalized_root: [u8; 32],
+    pub optimistic_slot: u64,
+    /// Sync-committee period the store currently holds a committee for.
+    pub period: u64,
+    pub peer_count: usize,
+}
+
+impl SyncStatus {
+    fn initial() -> Self {
+        Self {
+            state: SyncState::Starting,
+            finalized_slot: 0,
+            finalized_root: [0u8; 32],
+            optimistic_slot: 0,
+            period: 0,
+            peer_count: 0,
+        }
+    }
+}
+
+// -------------------------------------------------------------------------
+// SyncHandle
+// -------------------------------------------------------------------------
+
+/// A running light-client sync. Independent instances are fully independent
+/// (each owns its libp2p host, discv5 service, and store — no globals).
+pub struct SyncHandle {
+    status_rx: watch::Receiver<SyncStatus>,
+    client: ReqRespClient,
+    tasks: Vec<tokio::task::JoinHandle<()>>,
+}
+
+impl SyncHandle {
+    /// Start syncing. Must be called from within a tokio runtime.
+    pub fn start(config: ChainConfig) -> Result<SyncHandle, String> {
+        let (status_tx, status_rx) = watch::channel(SyncStatus::initial());
+
+        // Local Status the responder serves pre-bootstrap: the trusted
+        // checkpoint (a real block root — Lighthouse's relevance check
+        // goodbyes zero roots; see the Java buildLocalStatusFor).
+        let local_status = LocalStatus::new(StatusMessage {
+            fork_digest: config.current_fork_digest(),
+            finalized_root: config.checkpoint_root,
+            finalized_epoch: config.checkpoint_slot / config.slots_per_epoch.max(1),
+            head_root: config.checkpoint_root,
+            head_slot: config.checkpoint_slot,
+            earliest_available_slot: 0,
+        });
+
+        let client = reqresp::start_host(Arc::clone(&local_status))?;
+
+        let discovery_cfg = DiscoveryConfig {
+            bootstrap_enrs: config.bootstrap_enrs.clone(),
+            accepted_fork_digests: config.accepted_fork_digests(),
+            listen_port: config.discv5_port,
+        };
+
+        let sync_task = tokio::spawn(run_sync(
+            config,
+            client.clone(),
+            local_status,
+            status_tx,
+            discovery_cfg,
+        ));
+
+        Ok(SyncHandle { status_rx, client, tasks: vec![sync_task] })
+    }
+
+    pub fn status(&self) -> SyncStatus {
+        self.status_rx.borrow().clone()
+    }
+
+    /// A watch receiver for callers that want to await state changes.
+    pub fn watch(&self) -> watch::Receiver<SyncStatus> {
+        self.status_rx.clone()
+    }
+
+    /// Stop the sync loop, discovery, and the libp2p host.
+    pub async fn stop(self) {
+        self.client.shutdown().await;
+        for task in &self.tasks {
+            task.abort();
+        }
+        for task in self.tasks {
+            let _ = task.await;
+        }
+    }
+}
+
+// -------------------------------------------------------------------------
+// Peer pool
+// -------------------------------------------------------------------------
+
+#[derive(Clone)]
+struct Peer {
+    id: PeerId,
+    addr: Multiaddr,
+}
+
+struct PeerPool {
+    peers: Vec<Peer>,
+    known: HashSet<PeerId>,
+    /// Peers proven NOT to serve light_client_updates_by_range (protocol
+    /// negotiation failed) — mirrors the Java `peersNoLcUpdates`.
+    no_lc_updates: HashSet<PeerId>,
+    /// Peers that actually SERVED light-client data (bootstrap or an applied
+    /// update) — mirrors the Java proven-server tracking; preferred first.
+    proven: HashSet<PeerId>,
+    /// Per-peer "don't re-ask updates_by_range until" marks. Live CL peers
+    /// rate-limit that protocol to ~one served update per request window; an
+    /// immediate re-ask returns an empty stream, so rotate away for a while.
+    cooldown_until: HashMap<PeerId, Instant>,
+    /// Consecutive terminal-failure count per peer, for eviction. Reset on any
+    /// success. Without eviction the MAX_POOL cap fills with dead peers and
+    /// `add` starts rejecting fresh ones — a permanent catch-up wedge.
+    fail_counts: HashMap<PeerId, u32>,
+    /// Rotating offset so retries sweep different peers each cycle.
+    sweep: usize,
+}
+
+/// How long to leave a peer alone after it served (or empty-replied) an
+/// updates_by_range request. Lighthouse's default inbound quota for this
+/// protocol is `Quota::one_every(10s)` (rpc/config.rs) — one update per 10 s
+/// per peer; asking again just after the window refills is both polite and
+/// the fastest legal cadence.
+const UPDATES_SERVE_COOLDOWN: Duration = Duration::from_secs(11);
+
+/// Cap on the discovered pool (Java MAX_CL_PEERS is 1024; we keep it smaller —
+/// the sync loop fans out to a handful at a time anyway).
+const MAX_POOL: usize = 512;
+
+/// Consecutive terminal failures before eviction. Un-proven peers go on the
+/// first (cheap, endlessly rediscoverable); a peer that has actually served
+/// gets slack so one transient blip doesn't drop a scarce LC server.
+const UNPROVEN_EVICT_AT: u32 = 1;
+const PROVEN_EVICT_AT: u32 = 3;
+
+impl PeerPool {
+    fn new() -> Self {
+        Self {
+            peers: Vec::new(),
+            known: HashSet::new(),
+            no_lc_updates: HashSet::new(),
+            proven: HashSet::new(),
+            cooldown_until: HashMap::new(),
+            fail_counts: HashMap::new(),
+            sweep: 0,
+        }
+    }
+
+    fn mark_proven(&mut self, id: PeerId) {
+        self.proven.insert(id);
+        self.fail_counts.remove(&id); // a served peer is demonstrably alive
+    }
+
+    /// Record a terminal request failure (dial/timeout/connection-closed — NOT
+    /// UnsupportedProtocol, which means the peer is alive but doesn't serve LC).
+    /// Evicts once the peer crosses its threshold, freeing a MAX_POOL slot.
+    fn note_failure(&mut self, id: PeerId) {
+        let n = self.fail_counts.entry(id).or_insert(0);
+        *n += 1;
+        let threshold = if self.proven.contains(&id) {
+            PROVEN_EVICT_AT
+        } else {
+            UNPROVEN_EVICT_AT
+        };
+        if *n >= threshold {
+            self.evict(&id);
+        }
+    }
+
+    /// Remove a peer everywhere, including from `known` so discovery may re-add
+    /// it if it comes back (mirrors the Java addPeer/knownPeerAddrs eviction —
+    /// re-discoverable rather than permanently tombstoned; `fail_counts` resets
+    /// with it, so a recovered peer starts clean).
+    fn evict(&mut self, id: &PeerId) {
+        self.peers.retain(|p| &p.id != id);
+        self.known.remove(id);
+        self.no_lc_updates.remove(id);
+        self.proven.remove(id);
+        self.cooldown_until.remove(id);
+        self.fail_counts.remove(id);
+    }
+
+    fn set_updates_cooldown(&mut self, id: PeerId) {
+        self.cooldown_until.insert(id, Instant::now() + UPDATES_SERVE_COOLDOWN);
+    }
+
+    fn cooled_down(&self, id: &PeerId) -> bool {
+        self.cooldown_until.get(id).is_none_or(|until| *until <= Instant::now())
+    }
+
+    fn add(&mut self, id: PeerId, addr: Multiaddr) {
+        if self.peers.len() >= MAX_POOL || !self.known.insert(id) {
+            return;
+        }
+        self.peers.push(Peer { id, addr });
+    }
+
+    fn mark_no_lc_updates(&mut self, id: PeerId) {
+        self.no_lc_updates.insert(id);
+    }
+
+    fn is_empty(&self) -> bool {
+        self.peers.is_empty()
+    }
+
+    fn len(&self) -> usize {
+        self.peers.len()
+    }
+
+    /// Up to `n` candidates starting at a rotating offset. `skip_no_lc`
+    /// filters the proven non-servers; `respect_cooldown` skips peers inside
+    /// their updates-serve cooldown. Never starves: falls back to everyone.
+    fn candidates(
+        &mut self,
+        n: usize,
+        skip_no_lc: bool,
+        respect_cooldown: bool,
+        prefer: &HashSet<PeerId>,
+    ) -> Vec<Peer> {
+        if self.peers.is_empty() {
+            return Vec::new();
+        }
+        let ok = |pool: &Self, id: &PeerId| {
+            (!skip_no_lc || !pool.no_lc_updates.contains(id))
+                && (!respect_cooldown || pool.cooled_down(id))
+        };
+        let mut out: Vec<Peer> = Vec::with_capacity(n);
+        // Tier 1: peers that actually served light-client data before.
+        // Tier 2: positive-signal peers (Identify-confirmed LC servers).
+        for tier in [&self.proven, prefer] {
+            for p in &self.peers {
+                if out.len() >= n {
+                    break;
+                }
+                if tier.contains(&p.id) && ok(self, &p.id) && !out.iter().any(|q| q.id == p.id) {
+                    out.push(p.clone());
+                }
+            }
+        }
+        // Fill from a rotating window of the rest.
+        let start = self.sweep % self.peers.len();
+        self.sweep = self.sweep.wrapping_add(n);
+        for i in 0..self.peers.len() {
+            if out.len() >= n {
+                break;
+            }
+            let p = &self.peers[(start + i) % self.peers.len()];
+            if out.iter().any(|q| q.id == p.id) || !ok(self, &p.id) {
+                continue;
+            }
+            out.push(p.clone());
+        }
+        if out.is_empty() {
+            // Never starve the batch (Java: `if (capable.isEmpty()) capable = peers`).
+            out.extend(self.peers.iter().take(n).cloned());
+        }
+        out
+    }
+}
+
+fn parse_static_peer(multiaddr: &str) -> Option<Peer> {
+    let addr: Multiaddr = multiaddr.parse().ok()?;
+    let mut base = Multiaddr::empty();
+    let mut peer_id = None;
+    for proto in addr.iter() {
+        if let libp2p::multiaddr::Protocol::P2p(id) = proto {
+            peer_id = Some(id);
+        } else {
+            base.push(proto);
+        }
+    }
+    Some(Peer { id: peer_id?, addr: base })
+}
+
+// -------------------------------------------------------------------------
+// The sync loop
+// -------------------------------------------------------------------------
+
+async fn run_sync(
+    config: ChainConfig,
+    client: ReqRespClient,
+    local_status: Arc<LocalStatus>,
+    status_tx: watch::Sender<SyncStatus>,
+    discovery_cfg: DiscoveryConfig,
+) {
+    let mut pool = PeerPool::new();
+    for s in &config.static_peers {
+        match parse_static_peer(s) {
+            Some(p) => pool.add(p.id, p.addr),
+            None => tracing::warn!(peer = s, "skipping unparseable static peer multiaddr"),
+        }
+    }
+    tracing::info!(chain = config.name, static_peers = pool.len(),
+        fork_digest = %hex_str(&config.current_fork_digest()),
+        "sync starting");
+
+    // Discovery feeds the pool continuously; failure is non-fatal (Java treats
+    // discv5 the same way). The discovery task self-terminates once this task
+    // is gone: the channel closes and its lookup loop returns, dropping Discv5.
+    let (peer_tx, mut peer_rx) = mpsc::channel::<discovery::DiscoveredPeer>(64);
+    if let Err(e) = discovery::spawn(discovery_cfg, peer_tx).await {
+        tracing::warn!(error = %e, "discv5 unavailable — continuing with static peers");
+    }
+
+    let mut processor = LightClientProcessor::new(
+        LightClientStore::new(),
+        config.fork_version,
+        config.genesis_validators_root,
+    );
+
+    let mut status = SyncStatus::initial();
+    status.state = SyncState::Bootstrapping;
+    let _ = status_tx.send(status.clone());
+
+    // Catch-up pipeline buffer (see catch_up) — lives here so staged periods
+    // survive catch_up returning empty-handed between poll cycles.
+    let mut staged_updates: std::collections::BTreeMap<u64, Vec<u8>> =
+        std::collections::BTreeMap::new();
+
+    // Phase 1: bootstrap from the embedded checkpoint.
+    loop {
+        drain_discovered(&mut peer_rx, &mut pool);
+        if try_bootstrap(&config, &client, &mut pool, &mut processor).await {
+            break;
+        }
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    }
+    refresh_local_status(&config, &processor, &local_status);
+    publish_status(&config, &client, &processor, &status_tx).await;
+
+    // Phase 1b + steady state: catch up when behind, poll finality every slot.
+    loop {
+        drain_discovered(&mut peer_rx, &mut pool);
+
+        let wall_period = spec::compute_sync_committee_period(config.current_slot_estimate());
+        if wall_period > processor.store.current_period() {
+            catch_up(&config, &client, &mut pool, &mut processor, &status_tx, &mut peer_rx,
+                &mut staged_updates)
+                .await;
+            refresh_local_status(&config, &processor, &local_status);
+            publish_status(&config, &client, &processor, &status_tx).await;
+            if spec::compute_sync_committee_period(config.current_slot_estimate())
+                > processor.store.current_period()
+            {
+                // Still behind: skip the finality poll — while the committee is
+                // stale every finality update fails BLS verify (Java does the
+                // same to avoid burning the whole cycle).
+                tokio::time::sleep(Duration::from_secs(config.seconds_per_slot)).await;
+                continue;
+            }
+        }
+
+        poll_finality(&client, &mut pool, &mut processor).await;
+        refresh_local_status(&config, &processor, &local_status);
+        publish_status(&config, &client, &processor, &status_tx).await;
+
+        tokio::time::sleep(Duration::from_secs(config.seconds_per_slot)).await;
+    }
+    // No code after the loop: the task ends via SyncHandle::stop (abort).
+}
+
+fn drain_discovered(rx: &mut mpsc::Receiver<discovery::DiscoveredPeer>, pool: &mut PeerPool) {
+    while let Ok(p) = rx.try_recv() {
+        pool.add(p.peer_id, p.addr);
+    }
+}
+
+fn hex_str(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// Fan a bootstrap request out to a few peers; first VALID response wins.
+/// Validation mirrors the Java `bootstrap()`: checkpoint pin (header
+/// hash_tree_root == checkpoint root), current-sync-committee branch, and
+/// execution branch — all before `store.initialize`.
+async fn try_bootstrap(
+    config: &ChainConfig,
+    client: &ReqRespClient,
+    pool: &mut PeerPool,
+    processor: &mut LightClientProcessor,
+) -> bool {
+    if pool.is_empty() {
+        tracing::info!("bootstrap: no peers yet (waiting on discovery)");
+        return false;
+    }
+    let peers = pool.candidates(8, false, false, &HashSet::new());
+    tracing::info!(peers = peers.len(), root = %hex_str(&config.checkpoint_root),
+        slot = config.checkpoint_slot, "bootstrap: requesting by checkpoint root");
+
+    let wire = codec::encode_request(&config.checkpoint_root);
+    let mut futures = Vec::new();
+    for peer in &peers {
+        let client = client.clone();
+        let wire = wire.clone();
+        let (id, addr) = (peer.id, peer.addr.clone());
+        futures.push(async move {
+            let res = client.request_raw(id, addr, protocols::BOOTSTRAP, wire).await;
+            (id, res)
+        });
+    }
+    let results = futures::future::join_all(futures).await;
+
+    for (peer, res) in results {
+        let raw = match res {
+            Ok(raw) => raw,
+            Err(e) => {
+                tracing::debug!(peer = %peer, error = %e, "bootstrap request failed");
+                continue;
+            }
+        };
+        let ssz_payload = match codec::decode_response(&raw, true) {
+            Ok(d) => d.ssz_payload,
+            Err(e) => {
+                tracing::debug!(peer = %peer, error = %e, "bootstrap frame invalid");
+                continue;
+            }
+        };
+        let bootstrap = match LightClientBootstrap::decode(&ssz_payload) {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::debug!(peer = %peer, error = %e, "bootstrap decode failed");
+                continue;
+            }
+        };
+
+        // Checkpoint pin: the peer chose the payload, WE chose the root.
+        let header_root = bootstrap.header.beacon.hash_tree_root();
+        if header_root != config.checkpoint_root {
+            tracing::warn!(peer = %peer, got = %hex_str(&header_root),
+                "bootstrap rejected: header root does not match checkpoint");
+            continue;
+        }
+        let depth = bootstrap.current_sync_committee_branch.len();
+        if !ssz::verify_merkle_branch(
+            &bootstrap.current_sync_committee.hash_tree_root(),
+            &bootstrap.current_sync_committee_branch,
+            depth,
+            spec::sync_committee_gindex(depth),
+            &bootstrap.header.beacon.state_root,
+        ) {
+            tracing::warn!(peer = %peer, depth, "bootstrap rejected: sync committee branch invalid");
+            continue;
+        }
+        if !LightClientProcessor::verify_execution_branch(&bootstrap.header) {
+            tracing::warn!(peer = %peer, "bootstrap rejected: execution branch invalid");
+            continue;
+        }
+
+        processor
+            .store
+            .initialize(bootstrap.header.clone(), bootstrap.current_sync_committee.clone());
+        pool.mark_proven(peer);
+        tracing::info!(peer = %peer, slot = bootstrap.header.beacon.slot,
+            period = processor.store.current_period(), "bootstrap verified and applied");
+        return true;
+    }
+    false
+}
+
+/// Periods fetched per catch-up round (≤16 per the plan; the spec request cap
+/// is 128).
+const UPDATES_BATCH_MAX: u64 = 16;
+/// Peer candidates asked per round — all in parallel, first useful response
+/// wins (Java CATCHUP_FANOUT_MAX is 48; the discovered pool is failure-heavy,
+/// so a wide fan-out is what makes rounds land).
+const CATCHUP_FANOUT: usize = 32;
+
+/// Consecutive no-progress rounds before returning to the outer loop (which
+/// refreshes the discovered-peer pool and republishes status). Rounds inside
+/// retry after a short pause — the Java equivalent is MAX_CATCHUP_BATCHES
+/// per call with a 12 s outer cycle.
+const CATCHUP_MAX_IDLE_ROUNDS: u32 = 6;
+
+/// Catch the store's committee period up to wall clock — the behavioral twin
+/// of the Java `catchUpSyncCommittee`/`attemptCatchUpBatch`/
+/// `applyCatchUpResponses`: every fan-out peer gets the SAME
+/// `(current_period, count ≤ 16)` range request in parallel, so any single
+/// successful response starts with the EARLIEST missing period (the whole
+/// pipeline's bottleneck — the committee chain admits no gaps). Response
+/// chunks are staged at consecutive periods (a mislabeled chunk just fails
+/// verification at apply time and gets refetched) and the contiguous prefix
+/// is verified+applied as it forms, `force_rotate_if_past_period` after each
+/// applied update, exactly like the Java.
+async fn catch_up(
+    config: &ChainConfig,
+    client: &ReqRespClient,
+    pool: &mut PeerPool,
+    processor: &mut LightClientProcessor,
+    status_tx: &watch::Sender<SyncStatus>,
+    peer_rx: &mut mpsc::Receiver<discovery::DiscoveredPeer>,
+    // Fetched-but-not-yet-applied updates keyed by target period, owned by the
+    // caller so partial pipeline progress survives across catch_up calls.
+    // Raw SSZ — everything is BLS/Merkle-verified at apply time, in order.
+    staged: &mut std::collections::BTreeMap<u64, Vec<u8>>,
+) {
+    let mut idle_rounds = 0u32;
+    // Exponential pause after fruitless rounds: hammering the whole pool every
+    // ~13 s is exactly what CL peer scoring penalizes, and it burns request
+    // quota on servers that will serve happily a minute later.
+    let mut empty_backoff = Duration::from_secs(0);
+    loop {
+        if !empty_backoff.is_zero() {
+            tracing::info!(backoff_s = empty_backoff.as_secs(),
+                "catch-up: no progress last round — backing off before retrying");
+            tokio::time::sleep(empty_backoff).await;
+        }
+        drain_discovered(peer_rx, pool);
+        let slot_estimate = config.current_slot_estimate();
+        let wall_period = spec::compute_sync_committee_period(slot_estimate);
+        // Start from the committee's own period, NOT the finalized slot's:
+        // after a force-rotate the two diverge by one period (see the Java
+        // comment in catchUpSyncCommittee).
+        let committee_period = processor.store.current_period();
+        if wall_period <= committee_period {
+            tracing::info!(period = committee_period, "sync committee is current");
+            return;
+        }
+        *staged = staged.split_off(&committee_period); // drop already-passed periods
+        let span = (wall_period - committee_period).min(UPDATES_BATCH_MAX);
+        tracing::info!(from_period = committee_period, wall_period, span,
+            staged = staged.len(), "catch-up: requesting updates_by_range");
+
+        let lc_servers = client.lc_update_servers().await;
+        let peers = pool.candidates(CATCHUP_FANOUT, true, true, &lc_servers);
+        if peers.is_empty() {
+            tracing::warn!("catch-up: no peers available — retrying after discovery");
+            return;
+        }
+
+        // Every peer gets the SAME (committee_period, span) request — the Java
+        // attemptCatchUpBatch fan-out, kept deliberately: the prefix period is
+        // the whole pipeline's bottleneck, so it must be redundantly requested;
+        // any single good response advances it. (A staggered disjoint-range
+        // variant was tried live 2026-07-06 and performed WORSE — it made the
+        // prefix a single point of failure among mostly-unserving peers.)
+        let mut ssz_request = Vec::with_capacity(16);
+        ssz_request.extend_from_slice(&committee_period.to_le_bytes());
+        ssz_request.extend_from_slice(&span.to_le_bytes());
+        let wire = codec::encode_request(&ssz_request);
+
+        let staged_before = staged.len();
+        let mut in_flight: FuturesUnordered<_> = peers
+            .into_iter()
+            .map(|peer| {
+                let wire = wire.clone();
+                let client = client.clone();
+                // Same (period, span) for every peer — see the fan-out comment
+                // above. Kept as per-future bindings so the response handler can
+                // stay range-agnostic if staggering is ever reintroduced.
+                let (sub_from, sub_count) = (committee_period, span);
+                async move {
+                    let res = client
+                        .request_raw(peer.id, peer.addr.clone(), protocols::UPDATES_BY_RANGE, wire)
+                        .await;
+                    (peer, sub_from, sub_count, res)
+                }
+            })
+            .collect();
+
+        // Collect responses into the staging buffer: chunk i of a response is
+        // staged at its request's sub_from + i (responses are consecutive per
+        // spec; a peer that violates that just fails verify at apply time).
+        // The contiguous prefix is applied AS RESPONSES ARRIVE; the round runs
+        // until every sub-range answered or the span is fully staged — with
+        // disjoint ranges, stragglers carry periods nobody else was asked for.
+        let mut applied = 0usize;
+        while let Some((peer, sub_from, sub_count, res)) = in_flight.next().await {
+            let raw = match res {
+                Ok(raw) => raw,
+                Err(e) => {
+                    if e == RequestError::UnsupportedProtocol {
+                        // Doesn't serve updates_by_range at all — skip in future
+                        // batches (Java peersNoLcUpdates). Peer is alive, keep it.
+                        pool.mark_no_lc_updates(peer.id);
+                    } else if e != RequestError::Shutdown {
+                        // Dial/timeout/connection-closed — count toward eviction
+                        // so dead peers stop occupying MAX_POOL slots.
+                        pool.note_failure(peer.id);
+                    }
+                    tracing::debug!(peer = %peer.id, error = %e, "updates_by_range failed");
+                    continue;
+                }
+            };
+            if raw.len() < 64 {
+                // Tiny frames are peers closing without serving (0 B) or sending
+                // near-empty chunks; dumped verbatim at debug for peer forensics.
+                tracing::debug!(peer = %peer.id, raw_len = raw.len(),
+                    hex = %raw.iter().map(|b| format!("{b:02x}")).collect::<String>(),
+                    "small updates_by_range frame");
+            }
+            let chunks = match codec::decode_multi_chunk_response(&raw, sub_count as usize) {
+                Ok(c) => c,
+                Err(e) => {
+                    tracing::debug!(peer = %peer.id, raw_len = raw.len(), error = %e,
+                        "updates_by_range frame invalid");
+                    continue;
+                }
+            };
+            let mut served = 0usize;
+            for (i, chunk) in chunks.into_iter().enumerate() {
+                if chunk.is_empty() {
+                    break; // truncated/empty chunk — nothing after it is trustworthy
+                }
+                served += 1;
+                staged.entry(sub_from + i as u64).or_insert(chunk);
+            }
+            if served > 0 {
+                tracing::info!(peer = %peer.id, sub_from, sub_count, served,
+                    raw_len = raw.len(), "updates_by_range served");
+                pool.mark_proven(peer.id);
+                // Deliberately NO cooldown for a peer that just served: it is
+                // often the only willing server in the pool, and the ~13 s
+                // round cadence sits at Lighthouse's ~1-per-10s quota anyway —
+                // the Java client re-asks its serving peer the same way.
+                applied += apply_staged_prefix(processor, staged, slot_estimate);
+                if applied > 0 {
+            empty_backoff = Duration::from_secs(0);
+                    // The fastest serving peer won this round — abandon the
+                    // stragglers (identical requests make them redundant) and
+                    // start the next round from the advanced period.
+                    break;
+                }
+            } else {
+                // Unserving answer — NOW the cooldown applies, so the next
+                // round rotates toward peers that might actually serve.
+                pool.set_updates_cooldown(peer.id);
+                tracing::debug!(peer = %peer.id, sub_from, sub_count, raw_len = raw.len(),
+                    "updates_by_range returned no chunks");
+            }
+        }
+        drop(in_flight);
+
+        if applied > 0 {
+            tracing::info!(applied, staged = staged.len(),
+                period = processor.store.current_period(),
+                finalized_slot = processor.store.finalized_slot(),
+                "catch-up round applied");
+            publish_status(config, client, processor, status_tx).await;
+            idle_rounds = 0;
+        } else if staged.len() > staged_before {
+            // No prefix advance yet, but the buffer grew — that's progress
+            // toward unblocking the earliest period; keep going.
+            tracing::debug!(staged = staged.len(), "catch-up staged new periods");
+            idle_rounds = 0;
+            empty_backoff = Duration::from_secs(0);
+        } else {
+            idle_rounds += 1;
+            if idle_rounds >= CATCHUP_MAX_IDLE_ROUNDS {
+                tracing::warn!(period = processor.store.current_period(), idle_rounds,
+                    "catch-up made no progress — returning to the poll loop");
+                return;
+            }
+            // Grow the pre-round pause 5s → 60s: rapid-fire empty rounds burn
+            // server quota and our own peer score; a quiet minute lets rate
+            // limiters refill and discovery deliver fresh candidates.
+            empty_backoff = if empty_backoff.is_zero() {
+                Duration::from_secs(5)
+            } else {
+                (empty_backoff * 2).min(Duration::from_secs(60))
+            };
+            tracing::debug!(period = processor.store.current_period(), idle_rounds,
+                "catch-up round made no progress — retrying after backoff");
+        }
+    }
+}
+
+/// Verify+apply the contiguous staged prefix: each staged update is decoded
+/// and processed in period order, advancing the store's committee period by
+/// one per applied update (`force_rotate_if_past_period` on the recorded
+/// wall-clock estimate after each — Java `applyCatchUpResponses`). A chunk
+/// that fails decode/verify is dropped from the buffer so the next round
+/// refetches that period from a different peer.
+fn apply_staged_prefix(
+    processor: &mut LightClientProcessor,
+    staged: &mut std::collections::BTreeMap<u64, Vec<u8>>,
+    slot_estimate: u64,
+) -> usize {
+    let mut applied = 0usize;
+    while let Some(chunk) = staged.remove(&processor.store.current_period()) {
+        let target_period = processor.store.current_period();
+        match LightClientUpdate::decode(&chunk) {
+            Ok(update) => {
+                if processor.process_update(&update) {
+                    applied += 1;
+                    processor.store.force_rotate_if_past_period(slot_estimate);
+                    tracing::debug!(target_period,
+                        finalized_slot = update.finalized_header.beacon.slot,
+                        period = processor.store.current_period(),
+                        "catch-up update applied");
+                } else {
+                    tracing::debug!(target_period,
+                        finalized_slot = update.finalized_header.beacon.slot,
+                        "catch-up update rejected");
+                    break;
+                }
+            }
+            Err(e) => {
+                tracing::debug!(target_period, error = %e, "catch-up update decode failed");
+                break;
+            }
+        }
+    }
+    applied
+}
+
+/// One finality-poll pass: try peers until one update verifies and applies —
+/// the Java `pollFinalityUpdate` steady-state branch (POLL_FINALITY_PEER_LIMIT=16).
+async fn poll_finality(
+    client: &ReqRespClient,
+    pool: &mut PeerPool,
+    processor: &mut LightClientProcessor,
+) {
+    let lc_servers = client.lc_update_servers().await;
+    let peers = pool.candidates(16, false, false, &lc_servers);
+    // Parallel fan-out; first update that verifies AND advances wins.
+    let mut in_flight: FuturesUnordered<_> = peers
+        .into_iter()
+        .map(|peer| {
+            let client = client.clone();
+            async move {
+                // Finality/optimistic requests carry NO body: write nothing,
+                // half-close (the empty Vec is the reqresp layer's "write
+                // nothing" contract).
+                let res = client
+                    .request_raw(peer.id, peer.addr.clone(), protocols::FINALITY_UPDATE, Vec::new())
+                    .await;
+                (peer, res)
+            }
+        })
+        .collect();
+    while let Some((peer, res)) = in_flight.next().await {
+        let raw = match res {
+            Ok(raw) => raw,
+            Err(e) => {
+                if e != RequestError::Shutdown && e != RequestError::UnsupportedProtocol {
+                    pool.note_failure(peer.id);
+                }
+                tracing::debug!(peer = %peer.id, error = %e, "finality_update request failed");
+                continue;
+            }
+        };
+        let ssz_payload = match codec::decode_response(&raw, true) {
+            Ok(d) => d.ssz_payload,
+            Err(e) => {
+                tracing::debug!(peer = %peer.id, error = %e, "finality_update frame invalid");
+                continue;
+            }
+        };
+        match LightClientFinalityUpdate::decode(&ssz_payload) {
+            Ok(update) => {
+                // Answered a finality request → alive and useful: clear its
+                // failure count so a later blip doesn't drop it prematurely.
+                pool.mark_proven(peer.id);
+                if processor.process_finality_update(&update) {
+                    tracing::info!(peer = %peer.id,
+                        finalized_slot = processor.store.finalized_slot(),
+                        optimistic_slot = processor.store.optimistic_slot(),
+                        period = processor.store.current_period(),
+                        "finality update applied");
+                    return;
+                }
+                tracing::debug!(peer = %peer.id,
+                    finalized_slot = update.finalized_header.beacon.slot,
+                    "finality update did not advance state");
+            }
+            Err(e) => tracing::debug!(peer = %peer.id, error = %e, "finality update decode failed"),
+        }
+    }
+}
+
+/// Keep the Status we serve to peers in step with verified store state
+/// (Java `buildLocalStatusFor` post-bootstrap branch).
+fn refresh_local_status(
+    config: &ChainConfig,
+    processor: &LightClientProcessor,
+    local_status: &LocalStatus,
+) {
+    let store = &processor.store;
+    let (Some(finalized), Some(optimistic)) = (store.finalized_header(), store.optimistic_header())
+    else {
+        return;
+    };
+    let finalized_root = finalized.beacon.hash_tree_root();
+    let (head_slot, head_root) = if optimistic.beacon.slot >= finalized.beacon.slot {
+        (optimistic.beacon.slot, optimistic.beacon.hash_tree_root())
+    } else {
+        (finalized.beacon.slot, finalized_root)
+    };
+    local_status.set(StatusMessage {
+        fork_digest: config.current_fork_digest(),
+        finalized_root,
+        finalized_epoch: finalized.beacon.slot / config.slots_per_epoch.max(1),
+        head_root,
+        head_slot,
+        earliest_available_slot: 0,
+    });
+}
+
+/// SYNCED gate: committee period current AND the finalized header within ~5
+/// epochs of wall clock (finality itself trails the head by ~2 epochs).
+const SYNCED_SLOT_SLACK_EPOCHS: u64 = 5;
+
+async fn publish_status(
+    config: &ChainConfig,
+    client: &ReqRespClient,
+    processor: &LightClientProcessor,
+    status_tx: &watch::Sender<SyncStatus>,
+) {
+    let store = &processor.store;
+    let wall_slot = config.current_slot_estimate();
+    let wall_period = spec::compute_sync_committee_period(wall_slot);
+    let state = if !store.is_initialized() {
+        SyncState::Bootstrapping
+    } else if wall_period == store.current_period()
+        && store.finalized_slot() + SYNCED_SLOT_SLACK_EPOCHS * config.slots_per_epoch >= wall_slot
+    {
+        SyncState::Synced
+    } else {
+        SyncState::CatchingUp
+    };
+    let finalized_root = store
+        .finalized_header()
+        .map(|h| h.beacon.hash_tree_root())
+        .unwrap_or([0u8; 32]);
+    let status = SyncStatus {
+        state,
+        finalized_slot: store.finalized_slot(),
+        finalized_root,
+        optimistic_slot: store.optimistic_slot(),
+        period: store.current_period(),
+        peer_count: client.connected_peer_count().await,
+    };
+    let _ = status_tx.send(status);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mainnet_config_matches_networkconfig_java() {
+        let c = ChainConfig::mainnet();
+        assert_eq!(c.fork_version, [6, 0, 0, 0]);
+        assert_eq!(c.checkpoint_slot, 14_560_000);
+        assert_eq!(
+            hex_str(&c.checkpoint_root),
+            "58cb432571912a434ab7fb83317bb60d09632cce53839fc2541417710465b42e"
+        );
+        assert_eq!(
+            hex_str(&c.genesis_validators_root),
+            "4b363db94e286120d76eb905340fdd4e54bfe9f06bf33ff6cf5ad27f511bfe95"
+        );
+        assert_eq!(c.genesis_time, 1_606_824_023);
+        // Checkpoint period 1777 (slot / 8192).
+        assert_eq!(spec::compute_sync_committee_period(c.checkpoint_slot), 1777);
+        // The live digest the Java computes (verified against jshell).
+        assert_eq!(c.current_fork_digest(), [0x8C, 0x9F, 0x62, 0xFE]);
+        assert_eq!(c.accepted_fork_digests(), vec![[0x8C, 0x9F, 0x62, 0xFE]]);
+        assert_eq!(c.static_peers.len(), 18);
+        assert_eq!(c.bootstrap_enrs.len(), 17);
+    }
+
+    #[test]
+    fn static_peer_parsing() {
+        let p = parse_static_peer(
+            "/ip4/176.229.58.1/tcp/9001/p2p/16Uiu2HAmHu1BxzrSWg7sN9JyJenC5unK5ntdk5QFYqQdQyyD7x3a",
+        )
+        .unwrap();
+        assert_eq!(p.addr.to_string(), "/ip4/176.229.58.1/tcp/9001");
+        assert!(parse_static_peer("/ip4/1.2.3.4/tcp/9000").is_none()); // no peer id
+        assert!(parse_static_peer("nonsense").is_none());
+    }
+
+    #[test]
+    fn peer_pool_rotates_and_respects_no_lc() {
+        let mut pool = PeerPool::new();
+        let mut ids = Vec::new();
+        for i in 0..4u8 {
+            let kp = libp2p::identity::Keypair::generate_secp256k1();
+            let id = kp.public().to_peer_id();
+            ids.push(id);
+            pool.add(id, format!("/ip4/10.0.0.{i}/tcp/9000").parse().unwrap());
+        }
+        assert_eq!(pool.len(), 4);
+        // Duplicate add is ignored.
+        pool.add(ids[0], "/ip4/10.0.0.9/tcp/9000".parse().unwrap());
+        assert_eq!(pool.len(), 4);
+
+        pool.mark_no_lc_updates(ids[1]);
+        let c = pool.candidates(4, true, false, &HashSet::new());
+        assert_eq!(c.len(), 3);
+        assert!(c.iter().all(|p| p.id != ids[1]));
+
+        // Preferred peers come first.
+        let mut prefer = HashSet::new();
+        prefer.insert(ids[3]);
+        let c = pool.candidates(2, false, false, &prefer);
+        assert_eq!(c[0].id, ids[3]);
+
+        // Never starve: everything marked no-lc still returns candidates.
+        for id in &ids {
+            pool.mark_no_lc_updates(*id);
+        }
+        assert!(!pool.candidates(2, true, false, &HashSet::new()).is_empty());
+    }
+
+    #[test]
+    fn dead_peers_are_evicted_and_slots_freed() {
+        let mut pool = PeerPool::new();
+        let mut ids = Vec::new();
+        for i in 0..3u8 {
+            let id = libp2p::identity::Keypair::generate_secp256k1()
+                .public()
+                .to_peer_id();
+            ids.push(id);
+            pool.add(id, format!("/ip4/10.0.0.{i}/tcp/9000").parse().unwrap());
+        }
+        assert_eq!(pool.len(), 3);
+
+        // Un-proven peer: one terminal failure evicts it and frees its slot +
+        // its `known` entry (so discovery may re-add a recovered peer).
+        pool.note_failure(ids[0]);
+        assert_eq!(pool.len(), 2);
+        assert!(!pool.known.contains(&ids[0]));
+
+        // Proven peer: survives transient blips, evicted only past the threshold.
+        pool.mark_proven(ids[1]);
+        pool.note_failure(ids[1]);
+        pool.note_failure(ids[1]);
+        assert_eq!(pool.len(), 2, "proven peer kept below threshold");
+        pool.note_failure(ids[1]);
+        assert_eq!(pool.len(), 1, "proven peer evicted at threshold");
+
+        // A serve resets the failure count: a proven server that blips twice,
+        // serves (reset), then blips twice more is still alive — the resets
+        // keep it under the threshold.
+        pool.mark_proven(ids[2]);
+        pool.note_failure(ids[2]);
+        pool.note_failure(ids[2]);
+        pool.mark_proven(ids[2]); // serve resets the count
+        pool.note_failure(ids[2]);
+        pool.note_failure(ids[2]);
+        assert_eq!(pool.len(), 1, "serve-reset keeps a blippy proven server alive");
+    }
+}

--- a/rust/myotis-net/tests/live_mainnet.rs
+++ b/rust/myotis-net/tests/live_mainnet.rs
@@ -1,0 +1,53 @@
+//! Live-network integration test: sync to SYNCED against real mainnet peers.
+//!
+//! Ignored by default (network + up to 15 minutes). Run with:
+//!
+//! ```bash
+//! cargo test -p myotis-net --test live_mainnet -- --ignored --nocapture
+//! ```
+
+use std::time::Duration;
+
+use myotis_net::{ChainConfig, SyncHandle, SyncState};
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "live network test: dials mainnet CL peers, takes minutes"]
+async fn syncs_to_head_on_live_mainnet() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info,myotis_net=debug".into()),
+        )
+        .try_init();
+
+    let config = ChainConfig::mainnet();
+    let checkpoint_root = config.checkpoint_root;
+    let handle = SyncHandle::start(config).expect("sync start");
+
+    // 15 min: measured live (2026-07-06), an 18-period-stale checkpoint takes
+    // ~8-12 min — LC servers cap updates_by_range at ~1 update per 10 s per
+    // peer, so deep catch-up is peer-quota-bound.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(900);
+    let mut synced = None;
+    while tokio::time::Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_secs(5)).await;
+        let s = handle.status();
+        eprintln!(
+            "[live_mainnet] state={} finalized_slot={} period={} peers={}",
+            s.state, s.finalized_slot, s.period, s.peer_count
+        );
+        if s.state == SyncState::Synced {
+            synced = Some(s);
+            break;
+        }
+    }
+
+    let status = synced.expect("did not reach SYNCED within the 15-minute cap");
+    // The finalized chain must have ADVANCED beyond the embedded checkpoint:
+    // a fresh root at a later slot, i.e. bootstrap + verified updates applied.
+    assert!(status.finalized_slot > 14_560_000, "finalized slot did not advance");
+    assert_ne!(status.finalized_root, checkpoint_root, "finalized root did not advance");
+    assert_ne!(status.finalized_root, [0u8; 32]);
+
+    handle.stop().await;
+}


### PR DESCRIPTION
Fifth checkpoint PR of the Rust-engine phase (base: `rust-engine`): the Rust light client goes **live**. New `myotis-net` crate owns ALL I/O (tokio, sigp discv5, rust-libp2p tcp/noise/yamux/identify, snap, tracing) around the sans-I/O `myotis-consensus` verification core — dependency direction one-way, enforced by the new `cargoCheckWasm` canary.

## Modules

- **codec** — eth2 req/resp framing (varint of UNCOMPRESSED length + snappy frames; per-chunk result byte + fork-digest context), multi-chunk scanner mirroring the Java `ReqRespCodec`/`skipSnappyFrames`. Golden-pinned round-trips.
- **protocols / status** — the `BeaconP2PService` protocol set; Status v1/v2 SSZ + fork-digest math (incl. the EIP-7892 BPO blob-schedule variant).
- **reqresp** — libp2p dialer + minimal responder (status/ping/metadata/goodbye — peers drop silent clients); per-protocol deadlines with a quiet-window reader that tolerates paced chunks and salvages reset streams.
- **discovery** — sigp discv5 over the mainnet bootstrap ENRs, `eth2`-ENR fork-digest filtering (current + prior fork), TCP multiaddr + peer-id extraction.
- **sync** — checkpoint-pinned bootstrap (same validation ladder as the Java client) → `updates_by_range` catch-up driving `LightClientProcessor` (clock crosses in as a plain slot estimate) → 12 s finality polling; `SyncHandle` start/stop/status for the PR6 engine.

## Live evidence (`examples/live_sync --once`, 2026-07-06)

Bootstrap verified at slot 14560000 in <1 min (5/5 attempts across the session), 18 BLS-verified committee rotations, **SYNCED at finalized slot 14706368 / period 1795 in 8m38s** from an 18-period-stale checkpoint, exit 0.

**Live-tuning findings** (recorded in code comments — this is why the sync loop looks the way it does): mainstream LC servers (Lighthouse) truncate a `count=16` `updates_by_range` to ONE ~27 KB chunk per request (rate-limiter policy), so identical full-span fan-out requests are correct (any response advances the prefix) and a staggered disjoint-range variant is WORSE (tried live — makes the prefix a single point of failure); serving peers are never cooldowned (often the only willing server; the Java client re-asks its server too); empty rounds back off 5s→60s (rapid-fire full-pool rounds get the client downscored into a wedge). Proven-server persistence (the Java CL peer cache's role) is the structural improvement and lands with the engine `dataDir` in PR6.

## Independent review (async-networking + consensus specialist)

No BLOCKERs; bootstrap ladder confirmed an exact behavioral match to the Java, fork-digest math golden-pinned, all four hard rules upheld (consensus stays I/O-free per `cargo tree`, tracing-only, no globals, clock only in myotis-net). Fixes applied:
- **MAJOR — unbounded snappy decompression** (a crafted 16 MiB frame → multi-hundred-MiB alloc, OOM vector on mobile amplified by the catch-up fan-out): `snappy_decompress` now takes the wire's declared length, rejects it against a 10 MiB spec ceiling BEFORE allocating, caps the reader, and rejects any output≠declared mismatch. New bound-enforcement test.
- **MINOR — unbounded inbound connections**: added libp2p `connection_limits` (64 incoming / 2 per-peer / 16 pending).
- NITs (debug hex-dump demoted, dead-generality documented) addressed.

## Verified

`cargo test --workspace` green (22 net unit tests incl. the decompression bound); `cargo build --release` zero warnings; live bootstrap+catch-up re-smoked through the bounded decompressor; full `./gradlew build` + no-cargo build green; `cargoCheckWasm` self-skips here (no clang) and is wired into `check`; `cargo tree -p myotis-consensus` shows no tokio/libp2p/discv5. Also commits `docs/myotis-rust-engine-guidelines.md` (the embeddability guidelines this sans-I/O split implements).

## Next

PR 6: the `myotis-engine` R1 — wrap `SyncHandle` behind the JNI engine surface (status snapshot, `dataDir`-persisted peer/proven-server cache), then the benchmark gate (Rust vs JVM: same finalized root, cold-sync wall-time, steady-state CPU/RSS → `docs/reimplementation/benchmarks.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)