### PR TITLE
Android: on-device failure forensics (memory / CL / snap-peer heartbeat + prior-exit reason)

### DIFF
--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -12,6 +12,7 @@ import android.net.LinkProperties;
 import android.net.Network;
 import android.os.Binder;
 import android.os.IBinder;
+import com.jaeckel.ethp2p.android.diag.ProcessHealthDiag;
 import com.jaeckel.ethp2p.android.log.LogBuffer;
 
 import io.myotis.api.AccountProofResult;
@@ -734,6 +735,11 @@ public final class NodeService extends Service {
             return START_NOT_STICKY;
         }
         startTimeMs = System.currentTimeMillis();
+        // Failure forensics: report how the PREVIOUS process died (OOM-kill vs crash
+        // vs clean), then start the health heartbeat. This is what makes an on-device
+        // sync failure diagnosable instead of a silent "it doesn't work".
+        com.jaeckel.ethp2p.android.diag.ProcessHealthDiag.logLastExitReason(this);
+        startHealthHeartbeat();
         // API 34+ requires the foregroundServiceType to be passed here and
         // to match the manifest's <service android:foregroundServiceType="...">
         // declaration. API 29-33 ignore the third arg. minSdk is 29.
@@ -1086,6 +1092,89 @@ public final class NodeService extends Service {
                 cachedCl, bs.finalizedSlot(), bs.executionBlockNumber(), bs.executionBlockHashHex(),
                 s.syncStartPeriod(), syncCurrent, syncTarget,
                 s.verifiedHeadAgeMs(), s.readyPeerList(), network);
+    }
+
+    // ---- Failure forensics (see ProcessHealthDiag) ----
+
+    private static final AtomicBoolean HEARTBEAT_STARTED = new AtomicBoolean(false);
+    /** How often the health line is emitted. Cheap; the info is time-series (you want
+     *  the trajectory of memory + sync + snap-peers as it approaches the failure). */
+    private static final long HEARTBEAT_INTERVAL_MS = 20_000;
+
+    /**
+     * Emit one consolidated health line every {@link #HEARTBEAT_INTERVAL_MS}: process
+     * memory, CL sync progress, and EL snap-peer pool state. When the node fails on a
+     * phone, the last few of these + the next launch's prior-exit line pin the mode
+     * (OOM vs CL-wedge vs snap-never-warm). Started once per process; runs until the
+     * process dies (which, for an OOM-kill, is the point — the last line is the clue).
+     */
+    private void startHealthHeartbeat() {
+        // Debuggable builds only: the 20s Debug.getMemoryInfo poll is diagnostic
+        // overhead a shipping user shouldn't pay. The one-shot prior-exit log and the
+        // event-driven onTrimMemory warning stay on in every build (cheap + valuable).
+        boolean debuggable = (getApplicationInfo().flags
+                & android.content.pm.ApplicationInfo.FLAG_DEBUGGABLE) != 0;
+        if (!debuggable) return;
+        if (!HEARTBEAT_STARTED.compareAndSet(false, true)) return;
+        Thread t = new Thread(() -> {
+            while (true) {
+                try {
+                    LogBuffer.i(ProcessHealthDiag.TAG, buildHealthLine());
+                    Thread.sleep(HEARTBEAT_INTERVAL_MS);
+                } catch (InterruptedException e) {
+                    return;
+                } catch (Throwable ignored) {
+                    // Diagnostics must never take the process down.
+                }
+            }
+        }, "ethp2p-health");
+        t.setDaemon(true);
+        t.start();
+    }
+
+    private String buildHealthLine() {
+        long upSec = (System.currentTimeMillis() - startTimeMs) / 1000;
+        String mem = ProcessHealthDiag.memorySummary(this);
+        String cl = "cl: (not running)";
+        String el = "";
+        try {
+            String n = primaryNetwork(this);
+            ChainHandle h = handles.get(n);
+            if (h != null) {
+                StatusSnapshot s = h.status();
+                // CL: is catch-up progressing toward the wall-clock period, and how
+                // stale is the verified head?
+                cl = "cl: period=" + s.syncCurrentPeriod() + "/" + s.wallClockPeriod()
+                        + " fin=" + s.finalizedSlot()
+                        + " headAge=" + headAge(s.verifiedHeadAgeMs());
+                // EL: the snap-peer pool is what gates verified reads. snapServing==0
+                // over time = the "snap peers never warm" failure mode.
+                el = " | el: conn=" + s.connectedPeers()
+                        + " snap=" + s.snapPeers()
+                        + " serving=" + s.snapServingPeers()
+                        + " backoff=" + s.backedOffPeers()
+                        + " blacklist=" + s.blacklistedPeers()
+                        + " discv5=" + s.discv5TableSize()
+                        + " elBlock=" + s.executionBlockNumber();
+            }
+        } catch (Throwable t) {
+            cl = "cl: (status read failed: " + t.getClass().getSimpleName() + ")";
+        }
+        return "up=" + upSec + "s | mem: " + mem + " | " + cl + el;
+    }
+
+    private static String headAge(long ms) {
+        return ms == Long.MAX_VALUE ? "n/a" : (ms / 1000) + "s";
+    }
+
+    @Override
+    public void onTrimMemory(int level) {
+        super.onTrimMemory(level);
+        // The system sends this under memory pressure; RUNNING_CRITICAL / COMPLETE are
+        // the "you're about to be OOM-killed" warning — the last thing logged before a
+        // silent SIGKILL. Pair with the next launch's prior-exit=LOW_MEMORY line.
+        LogBuffer.w(ProcessHealthDiag.TAG, "onTrimMemory " + ProcessHealthDiag.trimLevelName(level)
+                + " | " + ProcessHealthDiag.memorySummary(this));
     }
 
     @Override

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -738,7 +738,7 @@ public final class NodeService extends Service {
         // Failure forensics: report how the PREVIOUS process died (OOM-kill vs crash
         // vs clean), then start the health heartbeat. This is what makes an on-device
         // sync failure diagnosable instead of a silent "it doesn't work".
-        com.jaeckel.ethp2p.android.diag.ProcessHealthDiag.logLastExitReason(this);
+        ProcessHealthDiag.logLastExitReason(this);
         startHealthHeartbeat();
         // API 34+ requires the foregroundServiceType to be passed here and
         // to match the manifest's <service android:foregroundServiceType="...">
@@ -1096,17 +1096,20 @@ public final class NodeService extends Service {
 
     // ---- Failure forensics (see ProcessHealthDiag) ----
 
-    private static final AtomicBoolean HEARTBEAT_STARTED = new AtomicBoolean(false);
     /** How often the health line is emitted. Cheap; the info is time-series (you want
      *  the trajectory of memory + sync + snap-peers as it approaches the failure). */
     private static final long HEARTBEAT_INTERVAL_MS = 20_000;
+    /** The heartbeat thread for THIS service instance, interrupted in {@link #onDestroy}
+     *  so it stops WITH the instance (no NodeService leak) and restarts cleanly on the
+     *  next service start. An OOM-kill is a SIGKILL with no onDestroy, so on that path the
+     *  thread runs until the kill — the last emitted line is the clue we want. */
+    private volatile Thread healthThread;
 
     /**
      * Emit one consolidated health line every {@link #HEARTBEAT_INTERVAL_MS}: process
      * memory, CL sync progress, and EL snap-peer pool state. When the node fails on a
      * phone, the last few of these + the next launch's prior-exit line pin the mode
-     * (OOM vs CL-wedge vs snap-never-warm). Started once per process; runs until the
-     * process dies (which, for an OOM-kill, is the point — the last line is the clue).
+     * (OOM vs CL-wedge vs snap-never-warm).
      */
     private void startHealthHeartbeat() {
         // Debuggable builds only: the 20s Debug.getMemoryInfo poll is diagnostic
@@ -1114,26 +1117,29 @@ public final class NodeService extends Service {
         // event-driven onTrimMemory warning stay on in every build (cheap + valuable).
         boolean debuggable = (getApplicationInfo().flags
                 & android.content.pm.ApplicationInfo.FLAG_DEBUGGABLE) != 0;
-        if (!debuggable) return;
-        if (!HEARTBEAT_STARTED.compareAndSet(false, true)) return;
+        if (!debuggable || healthThread != null) return;
+        // Monotonic baseline captured here, not read from wall-clock, so an NTP step
+        // can't skew the reported uptime.
+        final long startNano = System.nanoTime();
         Thread t = new Thread(() -> {
-            while (true) {
+            while (!Thread.currentThread().isInterrupted()) {
                 try {
-                    LogBuffer.i(ProcessHealthDiag.TAG, buildHealthLine());
+                    LogBuffer.i(ProcessHealthDiag.TAG, buildHealthLine(startNano));
                     Thread.sleep(HEARTBEAT_INTERVAL_MS);
                 } catch (InterruptedException e) {
-                    return;
+                    return; // onDestroy interrupted us
                 } catch (Throwable ignored) {
                     // Diagnostics must never take the process down.
                 }
             }
         }, "ethp2p-health");
         t.setDaemon(true);
+        healthThread = t;
         t.start();
     }
 
-    private String buildHealthLine() {
-        long upSec = (System.currentTimeMillis() - startTimeMs) / 1000;
+    private String buildHealthLine(long startNano) {
+        long upSec = (System.nanoTime() - startNano) / 1_000_000_000L;
         String mem = ProcessHealthDiag.memorySummary(this);
         String cl = "cl: (not running)";
         String el = "";
@@ -1180,6 +1186,13 @@ public final class NodeService extends Service {
     @Override
     public void onDestroy() {
         LogBuffer.i(TAG, "Stopping node (onDestroy)");
+        // Stop the heartbeat with the instance so it doesn't leak this NodeService and
+        // restarts cleanly on the next start.
+        Thread hb = healthThread;
+        if (hb != null) {
+            hb.interrupt();
+            healthThread = null;
+        }
         // Same fire-and-forget pattern as shutdown(): the system gives us a
         // brief window to return from onDestroy and we don't want to spend
         // it blocking on libp2p host shutdown / Netty graceful drain. doShutdown()

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/diag/ProcessHealthDiag.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/diag/ProcessHealthDiag.java
@@ -1,0 +1,161 @@
+package com.jaeckel.ethp2p.android.diag;
+
+import android.app.ActivityManager;
+import android.app.ApplicationExitInfo;
+import android.content.Context;
+import android.os.Build;
+import android.os.Debug;
+
+import com.jaeckel.ethp2p.android.log.LogBuffer;
+
+import java.util.List;
+
+/**
+ * On-device failure forensics for the Android node. The hypothesis under test is
+ * WHY the light client didn't work on a real phone: OOM-kill (memory), CL catch-up
+ * wedge, or the EL snap-peer pool never warming. None of those leaves an obvious
+ * trace by default — an OOM-kill is a silent SIGKILL, and a wedge just looks like
+ * "nothing happens" — so this makes each mode legible:
+ *
+ * <ul>
+ *   <li>{@link #logLastExitReason} — on start, report HOW the previous process
+ *       died ({@code ApplicationExitInfo}). {@code REASON_LOW_MEMORY} is the
+ *       definitive "I was OOM-killed" signal; it also carries the PSS/RSS at death.
+ *   <li>{@link #memorySummary} — the process's own PSS + JVM heap + the system's
+ *       available memory / low-memory flag, for the periodic heartbeat.
+ *   <li>{@link #trimLevelName} — decode an {@code onTrimMemory} level; the
+ *       {@code RUNNING_CRITICAL}/{@code COMPLETE} levels are the "about to be
+ *       killed" warning the system sends just before an OOM-kill.
+ * </ul>
+ *
+ * All lines go through {@link LogBuffer} (tag {@code health}) so they land in the
+ * in-app Logs tab AND logcat — capture either and send it over.
+ */
+public final class ProcessHealthDiag {
+
+    public static final String TAG = "health";
+
+    private ProcessHealthDiag() {}
+
+    /**
+     * Report how the previous process instance(s) exited — the single most useful
+     * signal for "was it OOM-killed?". API 30+ (Pixel 7a is well past this); a no-op
+     * with a note on older devices.
+     */
+    public static void logLastExitReason(Context ctx) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+            LogBuffer.i(TAG, "exit-reason history needs Android 11+ (this device is API "
+                    + Build.VERSION.SDK_INT + ") — rely on the live memory heartbeat instead");
+            return;
+        }
+        try {
+            ActivityManager am = ctx.getSystemService(ActivityManager.class);
+            if (am == null) return;
+            List<ApplicationExitInfo> infos =
+                    am.getHistoricalProcessExitReasons(ctx.getPackageName(), 0, 5);
+            if (infos == null || infos.isEmpty()) {
+                LogBuffer.i(TAG, "no prior process-exit records (first run, or cleared)");
+                return;
+            }
+            for (ApplicationExitInfo info : infos) {
+                LogBuffer.i(TAG, "prior exit: " + describeReason(info.getReason())
+                        + " status=" + info.getStatus()
+                        + " importance=" + info.getImportance()
+                        + " pssAtExit=" + kib(info.getPss())
+                        + " rssAtExit=" + kib(info.getRss())
+                        + " desc=" + info.getDescription());
+            }
+        } catch (Throwable t) {
+            LogBuffer.i(TAG, "could not read exit-reason history: " + t);
+        }
+    }
+
+    /** One-line memory summary for the heartbeat. Never throws. */
+    public static String memorySummary(Context ctx) {
+        StringBuilder sb = new StringBuilder();
+        // Our own resident footprint — the number the low-memory killer scores.
+        try {
+            Debug.MemoryInfo mi = new Debug.MemoryInfo();
+            Debug.getMemoryInfo(mi);
+            sb.append("pss=").append(mib(mi.getTotalPss()));
+            String nativeHeap = mi.getMemoryStat("summary.native-heap");
+            String javaHeap = mi.getMemoryStat("summary.java-heap");
+            if (javaHeap != null) sb.append(" jHeap=").append(mibStr(javaHeap));
+            if (nativeHeap != null) sb.append(" nHeap=").append(mibStr(nativeHeap));
+        } catch (Throwable t) {
+            sb.append("pss=?");
+        }
+        // JVM heap headroom (an OutOfMemoryError vs an LMK-kill are different failures).
+        try {
+            Runtime rt = Runtime.getRuntime();
+            long used = rt.totalMemory() - rt.freeMemory();
+            sb.append(" jvmUsed=").append(mibB(used)).append("/").append(mibB(rt.maxMemory()));
+        } catch (Throwable ignored) {
+        }
+        // System-wide pressure: is the phone itself low, and how close to the LMK threshold.
+        try {
+            ActivityManager am = ctx.getSystemService(ActivityManager.class);
+            if (am != null) {
+                ActivityManager.MemoryInfo mem = new ActivityManager.MemoryInfo();
+                am.getMemoryInfo(mem);
+                sb.append(" sysAvail=").append(mibB(mem.availMem))
+                        .append(" low=").append(mem.lowMemory)
+                        .append(" lmkThreshold=").append(mibB(mem.threshold));
+            }
+        } catch (Throwable ignored) {
+        }
+        return sb.toString();
+    }
+
+    /** Human name for an onTrimMemory level. */
+    public static String trimLevelName(int level) {
+        switch (level) {
+            case ComponentCallbacksLevels.RUNNING_MODERATE: return "RUNNING_MODERATE";
+            case ComponentCallbacksLevels.RUNNING_LOW: return "RUNNING_LOW";
+            case ComponentCallbacksLevels.RUNNING_CRITICAL: return "RUNNING_CRITICAL (near OOM-kill)";
+            case ComponentCallbacksLevels.UI_HIDDEN: return "UI_HIDDEN";
+            case ComponentCallbacksLevels.BACKGROUND: return "BACKGROUND";
+            case ComponentCallbacksLevels.MODERATE: return "MODERATE";
+            case ComponentCallbacksLevels.COMPLETE: return "COMPLETE (imminent kill)";
+            default: return "level=" + level;
+        }
+    }
+
+    private static String describeReason(int reason) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) return "reason=" + reason;
+        switch (reason) {
+            case ApplicationExitInfo.REASON_LOW_MEMORY: return "LOW_MEMORY (OOM-killed)";
+            case ApplicationExitInfo.REASON_CRASH: return "CRASH";
+            case ApplicationExitInfo.REASON_CRASH_NATIVE: return "CRASH_NATIVE";
+            case ApplicationExitInfo.REASON_ANR: return "ANR";
+            case ApplicationExitInfo.REASON_SIGNALED: return "SIGNALED (killed)";
+            case ApplicationExitInfo.REASON_USER_REQUESTED: return "USER_REQUESTED";
+            case ApplicationExitInfo.REASON_EXIT_SELF: return "EXIT_SELF (clean stop)";
+            case ApplicationExitInfo.REASON_DEPENDENCY_DIED: return "DEPENDENCY_DIED";
+            case ApplicationExitInfo.REASON_OTHER: return "OTHER";
+            case ApplicationExitInfo.REASON_UNKNOWN: return "UNKNOWN";
+            default: return "reason=" + reason;
+        }
+    }
+
+    // ---- formatting (KB inputs from Debug, byte inputs from Runtime/AM) ----
+
+    private static String mib(int kib) { return (kib / 1024) + "MiB"; }
+    private static String kib(long kib) { return kib + "KiB"; }
+    private static String mibB(long bytes) { return (bytes / (1024 * 1024)) + "MiB"; }
+    private static String mibStr(String kibStr) {
+        try { return (Long.parseLong(kibStr.trim()) / 1024) + "MiB"; }
+        catch (NumberFormatException e) { return kibStr; }
+    }
+
+    /** ComponentCallbacks2 level constants, inlined so callers needn't import it. */
+    private static final class ComponentCallbacksLevels {
+        static final int RUNNING_MODERATE = 5;
+        static final int RUNNING_LOW = 10;
+        static final int RUNNING_CRITICAL = 15;
+        static final int UI_HIDDEN = 20;
+        static final int BACKGROUND = 40;
+        static final int MODERATE = 60;
+        static final int COMPLETE = 80;
+    }
+}


### PR DESCRIPTION
Instruments the Android node so a **light-client failure on a real phone is diagnosable** instead of a silent "it just doesn't work". Targets the pure-Java build (the one that ran on the Pixel 7a). The open question is *which* mode fails — OOM-kill, CL catch-up wedge, or the EL snap-peer pool never warming — and none of those leaves a default trace: an OOM-kill is a silent SIGKILL, a wedge looks like nothing happening, and snap-starvation looks like reads timing out.

## What it adds

- **`ProcessHealthDiag`** — reads `ApplicationExitInfo` (API 30+, SDK_INT-guarded) to report **how the previous process died**: `REASON_LOW_MEMORY` is the definitive OOM-kill signal and carries the PSS/RSS at death. Also builds a memory summary (own PSS + JVM heap used/max + system availMem / lowMemory flag / LMK threshold) and decodes `onTrimMemory` levels.
- **`NodeService`**:
  - On start, logs the prior-exit reason.
  - A 20 s **health heartbeat** (debuggable builds only) emitting one greppable line: `mem: pss=… jvmUsed=…/… sysAvail=… low=… | cl: period=current/wall fin=… headAge=… | el: conn=… snap=… serving=… backoff=… blacklist=… discv5=… elBlock=…`. The trajectory of these tells the mode: rising PSS + `low=true` → OOM; `period` stuck below `wall` → CL wedge; `serving=0` over time → snap-starvation.
  - `onTrimMemory` logs the `RUNNING_CRITICAL`/`COMPLETE` near-OOM warning — the last line before a silent kill.

All output via `LogBuffer` (tag `health`) → the in-app **Logs tab** *and* logcat. Capture either; the last few health lines plus the next launch's prior-exit line pin the failure.

## How to use it on the Pixel 7a

1. Install the debug APK (`./gradlew :android-app:assembleDebug`).
2. Start the node, let it try to sync.
3. If it fails: grab the Logs tab (or `adb logcat -s health:*`). Restart once so the prior-exit line reports whether it was OOM-killed.

## Verified

`:android-app:compileDebugJavaWithJavac`, `:android-app:lintDebug` (0 NewApi — every API-30 call is SDK_INT-guarded; no repeat of the HexFormat-on-device crash), and `:android-app:assembleDebug` all green. Independent review: no blockers/majors/minors — API-level audit clean, thread-safety confirmed (daemon heartbeat, ConcurrentHashMap reads, Throwable-guarded), unit conversions verified (KB vs byte divisors correct), the StatusSnapshot fields used are genuinely populated by the Java engine. The heartbeat is gated behind a debuggable build per the review (no battery cost in release).

Non-Rust, branched from main — independent of the Rust-engine work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)