### PR TITLE
Fix the on-device catch-up freeze: don't hold the store monitor across BLS; never default to compare

### DIFF
--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/EthP2PApplication.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/EthP2PApplication.java
@@ -30,16 +30,15 @@ public final class EthP2PApplication extends Application {
         Security.addProvider(new BouncyCastleProvider());
 
         // BLS backend selection (must be set before the light client's first verify).
-        // DEBUGGABLE builds default to "compare": run BOTH the pure-Java Milagro path and
-        // the bundled native blst (jniLibs/<abi>/libmyotis_bls.so) on every sync-committee
-        // verify and log a per-verify head-to-head (tag: ComparingBlsBackend /
-        // "[bls-compare]") so the on-device speedup is directly measurable. RELEASE builds
-        // default to "auto" (native when present, else Milagro) — running Milagro too would
-        // double every verify and, since Milagro is ~30-55s cold on ART, defeat the whole
-        // point of native acceleration. Override anytime with -Dmyotis.bls.backend=
-        // auto|native|milagro|compare.
+        // EVERY build defaults to "auto" (native blst from jniLibs when present, else
+        // Milagro). Debuggable builds USED to default to "compare" (Milagro AND native per
+        // verify, logging a head-to-head) — but on-device that costs 10-16 s of Milagro
+        // math per sync-committee update and, combined with lock contention, froze
+        // catch-up/status for minutes (Pixel 7 diagnosis, 2026-07-06). Compare stays a
+        // deliberate opt-in for measurement runs (-Dmyotis.bls.backend=compare; the daemon
+        // via -Pbls=compare).
         // Seed from the user's "Native BLS acceleration" setting (default ON): OFF forces
-        // Milagro; ON keeps the build-type default (compare on debuggable, auto on release).
+        // Milagro; ON means auto.
         // The Settings toggle applies live via NodeService.applyBlsBackend (and every node
         // start re-applies it) — this just sets the initial value for any pre-start verify.
         if (System.getProperty("myotis.bls.backend") == null) {

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -297,7 +297,8 @@ public final class NodeService extends Service {
      *  (Milagro AND native per verify, as a measurement harness), but on-device that costs
      *  10-16 s of Milagro math per sync-committee update (~500x slower than blst alone) and
      *  froze catch-up/status for minutes — diagnosed on a Pixel 7, 2026-07-06. Compare mode
-     *  remains available where it belongs: the daemon via {@code -Pbls=compare}. */
+     *  is explicit opt-in only, via the {@code myotis.bls.backend=compare} system property
+     *  ({@code -Pbls=compare} on the daemon); no build type defaults to it. */
     public static String blsBackendChoice(android.content.Context c) {
         return nativeBlsEnabled(c) ? "auto" : "milagro";
     }

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -292,15 +292,14 @@ public final class NodeService extends Service {
         return choice;
     }
     /** The {@code myotis.bls.backend} choice for the current setting: {@code milagro} when
-     *  native BLS is disabled, otherwise the build-type default — {@code compare} on a
-     *  debuggable build (runs Milagro AND native per verify and logs a head-to-head) or
-     *  {@code auto} on release (native when present, else Milagro). Keeping the ON case equal
-     *  to the prior default means enabling native BLS preserves today's behavior exactly. */
+     *  native BLS is disabled, otherwise {@code auto} (native blst when present, else
+     *  Milagro) — on EVERY build type. Debuggable builds used to default to {@code compare}
+     *  (Milagro AND native per verify, as a measurement harness), but on-device that costs
+     *  10-16 s of Milagro math per sync-committee update (~500x slower than blst alone) and
+     *  froze catch-up/status for minutes — diagnosed on a Pixel 7, 2026-07-06. Compare mode
+     *  remains available where it belongs: the daemon via {@code -Pbls=compare}. */
     public static String blsBackendChoice(android.content.Context c) {
-        if (!nativeBlsEnabled(c)) return "milagro";
-        boolean debuggable = (c.getApplicationInfo().flags
-                & android.content.pm.ApplicationInfo.FLAG_DEBUGGABLE) != 0;
-        return debuggable ? "compare" : "auto";
+        return nativeBlsEnabled(c) ? "auto" : "milagro";
     }
     /** Live-update the snap-peer target (no restart) on every live stack and persist it. */
     public void setTargetSnapPeers(int v) {

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
@@ -52,6 +52,20 @@ public class BeaconLightClient implements AutoCloseable {
 
     private final BeaconP2PService p2pService;
     private final LightClientStore store;
+    /**
+     * Serializes CATCH-UP APPLIERS (racing per-peer updates_by_range responses;
+     * first apply-success wins) WITHOUT holding the {@link LightClientStore}
+     * monitor across BLS verification. Diagnosed on-device (Pixel 7, 2026-07-06):
+     * synchronizing the whole batch on {@code store} starved every status reader —
+     * the UI snapshot poll ({@code isInitialized}) and {@code rpc-head-build}
+     * ({@code getFinalizedHeader}) blocked for the entire multi-minute catch-up,
+     * because each update's sync-aggregate verify held the monitor for seconds
+     * (10-16 s/update under the Milagro/compare backend). The store's own
+     * synchronized methods keep individual reads/mutations atomic; appliers only
+     * need mutual exclusion among THEMSELVES, and interleaved finality applies
+     * stay safe by monotonicity (updateFinalized/rotation both re-check).
+     */
+    private final Object catchUpApplyLock = new Object();
     private final LightClientProcessor processor;
     private final BeaconSyncState syncState;
     private final List<String> clPeerMultiaddrs;  // mutable, synchronized
@@ -1224,7 +1238,15 @@ public class BeaconLightClient implements AutoCloseable {
                             // the future so that catchUpSyncCommittee() sees the initialized state.
                             String successPeer = null;
                             synchronized (store) {
-                                if (!winnerFuture.isDone()) {
+                                // isInitialized guard: requestBootstrap has no per-request
+                                // deadline, so a straggler response from an EARLIER bootstrap
+                                // attempt (whose winnerFuture timed out un-completed) can land
+                                // here long after catch-up started. Re-initializing would rewind
+                                // the store to the checkpoint MID catch-up batch and mis-pair the
+                                // committee/period label — a wedge that persists via the snapshot.
+                                // An initialized store is never re-initialized; isInitialized can
+                                // never go false within a store's lifetime, so this is safe.
+                                if (!winnerFuture.isDone() && !store.isInitialized()) {
                                     store.initialize(bootstrap.header(), bootstrap.currentSyncCommittee());
                                     updateSyncState();
                                     winnerFuture.complete(response);
@@ -1477,8 +1499,9 @@ public class BeaconLightClient implements AutoCloseable {
                             }
                             return;
                         }
-                        // Serialize state mutation; first apply-success wins.
-                        synchronized (store) {
+                        // Serialize state mutation among appliers; first apply-success
+                        // wins. Deliberately NOT synchronized(store) — see catchUpApplyLock.
+                        synchronized (catchUpApplyLock) {
                             if (winner.isDone()) return;
                             if (responses == null || responses.isEmpty()) {
                                 emptyCount.incrementAndGet();
@@ -1535,7 +1558,7 @@ public class BeaconLightClient implements AutoCloseable {
 
     /**
      * Decode and process a list of catch-up response SSZ blobs, returning the number applied.
-     * Must be called while holding the {@code store} monitor.
+     * Must be called while holding {@code catchUpApplyLock} (writer serialization).
      */
     private int applyCatchUpResponses(List<byte[]> responses, long currentSlotEstimate,
                                       String peer, long servedFromPeriod) {
@@ -1840,7 +1863,14 @@ public class BeaconLightClient implements AutoCloseable {
 
                 LightClientFinalityUpdate update = LightClientFinalityUpdate.decode(response);
 
-                if (store.isInitialized() && processor.processFinalityUpdate(update)) {
+                final boolean finalityApplied;
+                // Writers serialize on catchUpApplyLock (see its javadoc): without this a
+                // straggler catch-up applier's gate-check→store-next sequence can interleave
+                // with this finality apply's rotation and re-arm a stale next committee.
+                synchronized (catchUpApplyLock) {
+                    finalityApplied = store.isInitialized() && processor.processFinalityUpdate(update);
+                }
+                if (finalityApplied) {
                     updateSyncState();
                     fillChainStateRoots(peer, true);
                     notifyPeerSuccess(peer);

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
@@ -60,10 +60,14 @@ public class BeaconLightClient implements AutoCloseable {
      * the UI snapshot poll ({@code isInitialized}) and {@code rpc-head-build}
      * ({@code getFinalizedHeader}) blocked for the entire multi-minute catch-up,
      * because each update's sync-aggregate verify held the monitor for seconds
-     * (10-16 s/update under the Milagro/compare backend). The store's own
-     * synchronized methods keep individual reads/mutations atomic; appliers only
-     * need mutual exclusion among THEMSELVES, and interleaved finality applies
-     * stay safe by monotonicity (updateFinalized/rotation both re-check).
+     * (10-16 s/update under the Milagro/compare backend). Two invariants replace
+     * the old whole-batch store lock: (1) ALL store writers — catch-up appliers
+     * AND the live finality poll — take THIS lock, so verify-then-apply sequences
+     * never interleave (a finality apply slipping between a catch-up verify and
+     * its apply could re-arm a stale next committee); (2) the multi-step
+     * apply-mutations inside {@link LightClientProcessor} hold the store monitor
+     * for just those memory writes, so readers ({@code snapshot()} for
+     * persistence, status getters) never observe a torn state.
      */
     private final Object catchUpApplyLock = new Object();
     private final LightClientProcessor processor;

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/lightclient/LightClientProcessor.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/lightclient/LightClientProcessor.java
@@ -117,14 +117,22 @@ public class LightClientProcessor {
             return false;
         }
 
-        long oldFinalizedSlot = store.getFinalizedSlot();
-        store.updateFinalized(update.finalizedHeader(), finalizedSlot);
-        store.updateOptimistic(update.attestedHeader(), update.signatureSlot());
-
-        // Rotate sync committee if we crossed a period boundary.
-        // Pass the OLD finalized slot so the period comparison is correct
-        // (updateFinalized may have already advanced this.finalizedSlot).
-        store.applyNextSyncCommitteeWhenPeriodChanges(oldFinalizedSlot, finalizedSlot);
+        // The three store mutations must be one atomic transaction w.r.t. readers:
+        // store.snapshot() (persistence) interleaving between updateFinalized and the
+        // rotation would capture finalizedSlot in the new period with the OLD committee
+        // still current — restored after a restart, that state can't rotate via the
+        // slot-crossing path anymore. Verification above runs without the monitor;
+        // only these fast memory writes hold it.
+        final long oldFinalizedSlot;
+        synchronized (store) {
+            oldFinalizedSlot = store.getFinalizedSlot();
+            store.updateFinalized(update.finalizedHeader(), finalizedSlot);
+            store.updateOptimistic(update.attestedHeader(), update.signatureSlot());
+            // Rotate sync committee if we crossed a period boundary.
+            // Pass the OLD finalized slot so the period comparison is correct
+            // (updateFinalized may have already advanced this.finalizedSlot).
+            store.applyNextSyncCommitteeWhenPeriodChanges(oldFinalizedSlot, finalizedSlot);
+        }
 
         lastAppliedFinalitySig = sig.clone();
         log.debug("[lc-processor] Finality update applied: finalizedSlot {} → {}", oldFinalizedSlot, finalizedSlot);
@@ -240,13 +248,16 @@ public class LightClientProcessor {
             store.updateNextSyncCommittee(nextSyncCommittee);
         }
 
-        long oldFinalizedSlot = store.getFinalizedSlot();
-        store.updateFinalized(update.finalizedHeader(), finalizedSlot);
-        store.updateOptimistic(update.attestedHeader(), update.signatureSlot());
-
-        // Rotate sync committee if we crossed a period boundary.
-        // Pass the OLD finalized slot so the period comparison is correct.
-        store.applyNextSyncCommitteeWhenPeriodChanges(oldFinalizedSlot, finalizedSlot);
+        // Atomic w.r.t. store.snapshot() — see the matching block in
+        // processFinalityUpdate for why a torn snapshot here wedges a restart.
+        synchronized (store) {
+            long oldFinalizedSlot = store.getFinalizedSlot();
+            store.updateFinalized(update.finalizedHeader(), finalizedSlot);
+            store.updateOptimistic(update.attestedHeader(), update.signatureSlot());
+            // Rotate sync committee if we crossed a period boundary.
+            // Pass the OLD finalized slot so the period comparison is correct.
+            store.applyNextSyncCommitteeWhenPeriodChanges(oldFinalizedSlot, finalizedSlot);
+        }
 
         return true;
     }

--- a/docs/bls-rust-acceleration.md
+++ b/docs/bls-rust-acceleration.md
@@ -14,7 +14,7 @@ all done and verified. Summary first; the original evaluation follows.
   native; `-Pbls=compare` runs the head-to-head.
 - Android: `rust/build-android.sh` (cargo-ndk) builds `arm64-v8a` + `x86_64`
   `libmyotis_bls.so` into `android-app/src/main/jniLibs` (confirmed packaged in the debug
-  APK); `EthP2PApplication` sets `compare` so logcat shows the A/B on-device.
+  APK); compare mode is an explicit opt-in (-Dmyotis.bls.backend=compare) — it was briefly the debuggable default, but 10-16 s of Milagro per update froze on-device catch-up (Pixel 7, 2026-07-06).
 
 **Measured — `BlsBackendBenchmark`, real 511-pubkey mainnet aggregate, x86-64 desktop:**
 | backend | cold (ms) | warm (ms/op) |


### PR DESCRIPTION
## The bug (diagnosed on a Pixel 7, Android 16, via the #132 forensics build)

The "app looks dead on the phone" failure was **not** memory, not a CL wedge, and not snap-peer starvation — the node actually syncs fine on-device (checkpoint → head in ~9 min, PSS 105–283 MiB, LMK never triggered, verified reads served afterwards). It was a lock-contention freeze with two multiplying causes:

1. **Debuggable builds defaulted the BLS backend to `compare`** — a debug measurement harness that runs Milagro AND blst per verification. Milagro on ART takes **10–16 s per LC update** (vs ~30 ms for blst): a ~500x tax on exactly the builds we sideload onto phones.
2. **`BeaconLightClient.applyCatchUpResponses` held the `LightClientStore` monitor across BLS verification.** Every status reader — the UI snapshot poll (`beaconStatus` → `isInitialized`) and `rpc-head-build` (`getFinalizedHeader`) — blocks on that monitor, so during a month-long catch-up batch the whole app is unresponsive for minutes. Thread-dump evidence from the device confirmed the poll threads parked on the store monitor while a Milagro verify ran.

## The fix

**Lock scope** (`BeaconLightClient`): catch-up application now serializes on a dedicated `catchUpApplyLock` instead of `synchronized (store)`. BLS verification happens without the store monitor; the store's own short synchronized methods still make each mutation atomic, so readers see consistent state and are never blocked for longer than one field-level update. The finality-update apply site takes the same lock, keeping the single-writer discipline (verify-then-apply races between catch-up and live finality updates stay impossible).

**BLS default** (`NodeService`/`EthP2PApplication`): no build ever defaults to `compare` anymore. Android now picks `auto` (blst native when the ABI ships it) or `milagro` only when the native toggle is off; `compare` is explicit opt-in (`-Dmyotis.bls.backend=compare`, daemon `-Pbls=compare`). `docs/bls-rust-acceleration.md` updated to match.

## Review findings addressed (independent concurrency review, pre-PR)

- **MAJOR** — with the store monitor no longer held across the batch, a straggler bootstrap response (from an earlier timed-out attempt; `requestBootstrap` has no per-request deadline) could re-`store.initialize()` mid-batch and wedge the persisted committee/period. Fixed: the bootstrap winner path now also requires `!store.isInitialized()` (initialization is one-way, so the guard is race-free).
- **MINOR** — live finality updates could interleave with a catch-up batch and re-arm a stale next committee. Fixed: finality apply is wrapped in `synchronized (catchUpApplyLock)`.
- Stale javadoc/comments about the old locking updated (`applyCatchUpResponses`, catch-up executor, bls doc).

## Verification

- Full daemon cold sync to SYNCED (period 1795) with the new locking; `beacon-status` polls stayed responsive throughout catch-up.
- `:consensus:test`, `:android-app:compileDebugJavaWithJavac` green.
- On-device retest recommended: with this build the Status UI should stay live during catch-up, and debuggable installs get blst-speed verification out of the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)