### PR TITLE
discv5: re-seed from bootnodes when the live table wedges empty

### DIFF
--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/discv5/DiscV5Service.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/discv5/DiscV5Service.java
@@ -7,6 +7,7 @@ import org.ethereum.beacon.discovery.DiscoverySystemBuilder;
 import org.ethereum.beacon.discovery.crypto.DefaultSigner;
 import org.ethereum.beacon.discovery.schema.NodeRecord;
 import org.ethereum.beacon.discovery.schema.NodeRecordBuilder;
+import org.ethereum.beacon.discovery.schema.NodeRecordFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,6 +44,24 @@ public final class DiscV5Service implements AutoCloseable {
     private DiscoverySystem system;
     private ScheduledExecutorService scheduler;
     private final Set<String> seenEnrs = new HashSet<>();
+
+    // Empty-table re-seed: the library pings bootnodes exactly ONCE, inside
+    // start(). If that initial round loses (device network not up yet, transient
+    // UDP loss — both observed on-device), or the table later decays to empty
+    // (mobile NAT liveness churn), searchForNewPeers() has no one to query and
+    // discovery is dead until process restart: live=0 seen-total=0 forever
+    // (Pixel 7, gnosis, 2026-07-06 — 2h wedge, instant recovery on restart).
+    // So: after RESEED_EMPTY_POLLS consecutive empty polls (~1 min at the 15s
+    // cadence), re-ping the bootnodes to refill the K-buckets, and keep doing
+    // that every RESEED_EMPTY_POLLS-th empty poll until the table has nodes.
+    // (DiscV4Service solves the same wedge by re-pinging on EVERY empty
+    // refresh; here the throttle keeps a persistent wedge from pinging the
+    // handful of public CL bootnodes 4x as often for the life of the process.)
+    private static final int RESEED_EMPTY_POLLS = 4;
+    private int consecutiveEmptyPolls;
+    // Bootnode ENRs parsed once, on the first re-seed (malformed entries are
+    // logged once and dropped, not re-swallowed every fire). Poll-thread only.
+    private List<NodeRecord> bootnodeRecords;
 
     public DiscV5Service(NodeKey nodeKey, List<String> bootnodeEnrs,
                          Consumer<Enr> onPeerDiscovered) {
@@ -198,7 +217,9 @@ public final class DiscV5Service implements AutoCloseable {
         try {
             int[] newThisTick = {0};
             int[] withEth2 = {0};
+            int[] live = {0};
             system.streamLiveNodes().forEach(nr -> {
+                live[0]++;
                 String enrStr = nr.asEnr();
                 if (seenEnrs.add(enrStr)) {
                     newThisTick[0]++;
@@ -214,16 +235,75 @@ public final class DiscV5Service implements AutoCloseable {
             // Kick a background search so the table keeps expanding between
             // polls rather than stalling at whatever the bootnodes returned.
             system.searchForNewPeers();
+            reseedIfWedged(live[0]);
             // One INFO line per 15s poll so the daemon log makes it obvious
             // whether the library is making progress. The library itself logs
             // through log4j which our logback pipeline doesn't route — this is
             // the only visibility we have at the slf4j layer.
             log.info("[discv5] poll: live={} seen-total={} new-this-tick={} with-eth2-this-tick={}",
-                    (int) system.streamLiveNodes().count(), seenEnrs.size(),
+                    live[0], seenEnrs.size(),
                     newThisTick[0], withEth2[0]);
         } catch (Exception e) {
             log.warn("[discv5] poll failed: {}", e.getMessage());
         }
+    }
+
+    /**
+     * Re-ping the bootnodes when the live table has been empty for
+     * {@link #RESEED_EMPTY_POLLS} consecutive polls (see the field comment for
+     * why the table can wedge empty). Pings are fire-and-forget: any one
+     * response repopulates a bucket and the next {@code searchForNewPeers()}
+     * takes it from there. Runs on the poll thread; ping() itself is async.
+     */
+    private void reseedIfWedged(int liveNodes) {
+        if (!reseedDue(liveNodes)) {
+            return;
+        }
+        for (NodeRecord bootnode : bootnodeRecords()) {
+            // Fire-and-forget: any one response repopulates a bucket and the
+            // next searchForNewPeers() takes it from there.
+            system.ping(bootnode).exceptionally(ex -> null);
+        }
+        log.info("[discv5] live table empty for {} polls — re-pinged {} bootnode(s)",
+                RESEED_EMPTY_POLLS, bootnodeRecords().size());
+    }
+
+    /** The bootnode ENRs parsed to records, once; malformed entries warn once and drop. */
+    private List<NodeRecord> bootnodeRecords() {
+        if (bootnodeRecords == null) {
+            bootnodeRecords = new java.util.ArrayList<>(bootnodeEnrs.size());
+            for (String enr : bootnodeEnrs) {
+                try {
+                    bootnodeRecords.add(NodeRecordFactory.DEFAULT.fromEnr(enr));
+                } catch (Exception malformed) {
+                    log.warn("[discv5] skipping unparseable bootnode ENR for re-seed: {}",
+                            malformed.getMessage());
+                }
+            }
+        }
+        return bootnodeRecords;
+    }
+
+    /**
+     * The stateful counter step behind {@link #reseedIfWedged} — poll-thread
+     * only (it mutates {@link #consecutiveEmptyPolls}); package-private for
+     * tests. Any live node resets the streak; with no bootnodes configured a
+     * re-seed is never due (nothing to ping — sepolia pins an empty discv5
+     * list, and repeating "re-pinged 0 bootnode(s)" would read as recovery
+     * where none is possible). Otherwise a re-seed is due on every
+     * {@link #RESEED_EMPTY_POLLS}-th consecutive empty poll (the counter
+     * resets when due, so the re-seed repeats while the table stays empty).
+     */
+    boolean reseedDue(int liveNodes) {
+        if (liveNodes > 0 || bootnodeEnrs.isEmpty()) {
+            consecutiveEmptyPolls = 0;
+            return false;
+        }
+        if (++consecutiveEmptyPolls < RESEED_EMPTY_POLLS) {
+            return false;
+        }
+        consecutiveEmptyPolls = 0;
+        return true;
     }
 
     @Override

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/discv5/DiscV5Service.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/discv5/DiscV5Service.java
@@ -259,13 +259,21 @@ public final class DiscV5Service implements AutoCloseable {
         if (!reseedDue(liveNodes)) {
             return;
         }
-        for (NodeRecord bootnode : bootnodeRecords()) {
+        List<NodeRecord> bootnodes = bootnodeRecords();
+        if (bootnodes.isEmpty()) {
+            // Every configured ENR was malformed (each warned once at parse
+            // time): nothing to ping, so don't log a "re-pinged 0" line that
+            // reads as recovery where none is possible (the configured-empty
+            // case is already never-due in reseedDue).
+            return;
+        }
+        for (NodeRecord bootnode : bootnodes) {
             // Fire-and-forget: any one response repopulates a bucket and the
             // next searchForNewPeers() takes it from there.
             system.ping(bootnode).exceptionally(ex -> null);
         }
         log.info("[discv5] live table empty for {} polls — re-pinged {} bootnode(s)",
-                RESEED_EMPTY_POLLS, bootnodeRecords().size());
+                RESEED_EMPTY_POLLS, bootnodes.size());
     }
 
     /** The bootnode ENRs parsed to records, once; malformed entries warn once and drop. */

--- a/networking/src/test/java/com/jaeckel/ethp2p/networking/discv5/DiscV5ReseedTest.java
+++ b/networking/src/test/java/com/jaeckel/ethp2p/networking/discv5/DiscV5ReseedTest.java
@@ -1,0 +1,71 @@
+package com.jaeckel.ethp2p.networking.discv5;
+
+import com.jaeckel.ethp2p.core.crypto.NodeKey;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The empty-table re-seed counter ({@link DiscV5Service#reseedDue}): the live
+ * table wedging empty must trigger a bootnode re-ping every 4th consecutive
+ * empty poll, and any live node must reset the streak. (The wedge itself —
+ * bootnodes pinged only inside the library's start() — is a live-network
+ * behavior; this pins the recovery-decision logic around it.)
+ */
+class DiscV5ReseedTest {
+
+    private DiscV5Service service() {
+        // The ENR is only checked for presence by the counter; parsing happens
+        // lazily at re-seed time, which these tests never reach.
+        return new DiscV5Service(NodeKey.generate(), List.of("enr:-placeholder"), enr -> { });
+    }
+
+    @Test
+    void reseedFiresOnFourthConsecutiveEmptyPoll() {
+        DiscV5Service s = service();
+        assertFalse(s.reseedDue(0));
+        assertFalse(s.reseedDue(0));
+        assertFalse(s.reseedDue(0));
+        assertTrue(s.reseedDue(0), "4th consecutive empty poll must be due");
+    }
+
+    @Test
+    void liveNodesResetTheStreak() {
+        DiscV5Service s = service();
+        s.reseedDue(0);
+        s.reseedDue(0);
+        s.reseedDue(0);
+        assertFalse(s.reseedDue(5), "a live table must reset the streak");
+        // Streak restarts from zero: three more empties are not enough...
+        assertFalse(s.reseedDue(0));
+        assertFalse(s.reseedDue(0));
+        assertFalse(s.reseedDue(0));
+        // ...the fourth is.
+        assertTrue(s.reseedDue(0));
+    }
+
+    @Test
+    void noBootnodesMeansNeverDue() {
+        // Sepolia pins clDiscv5Bootnodes to List.of(): with nothing to ping, a
+        // re-seed must never fire (it would log "re-pinged 0 bootnode(s)"
+        // every minute forever, reading as recovery where none is possible).
+        DiscV5Service s = new DiscV5Service(NodeKey.generate(), List.of(), enr -> { });
+        for (int i = 0; i < 10; i++) {
+            assertFalse(s.reseedDue(0), "no bootnodes: never due (poll " + i + ")");
+        }
+    }
+
+    @Test
+    void reseedRepeatsWhileTableStaysEmpty() {
+        DiscV5Service s = service();
+        for (int i = 0; i < 3; i++) assertFalse(s.reseedDue(0));
+        assertTrue(s.reseedDue(0));
+        // Counter reset on firing: the NEXT due point is 4 empty polls later,
+        // so a persistent wedge keeps re-seeding instead of firing once.
+        for (int i = 0; i < 3; i++) assertFalse(s.reseedDue(0));
+        assertTrue(s.reseedDue(0));
+    }
+}


### PR DESCRIPTION
## Problem

The ConsenSys discv5 library pings bootnodes exactly **once**, inside `start()`. Two on-device failure modes follow (both observed on a Pixel 7 running gnosis, 2026-07-06):

1. **Wedged from boot** — if the initial ping round loses (device network not ready, transient UDP loss), the K-buckets stay empty and `searchForNewPeers()` has no one to query: `poll: live=0 seen-total=0` for 2+ hours, while a chain restart recovered instantly (`live=10` within 5 s).
2. **Decay** — a healthy table can drain to `live=0` (mobile NAT liveness churn: observed `seen-total=108` → `live=0` in ~6 min) with the same terminal result.

Gnosis is fully exposed: it pins **no static CL multiaddrs**, so discv5 is its only CL peer source — a wedged table means `BeaconLightClient` retries bootstrap with 0 peers forever ("0 / 3524").

## Fix

`pollAndNotify` counts consecutive empty polls and re-pings all bootnodes on every 4th one (~1 min at the 15 s cadence), repeating while the table stays empty. Pings are fire-and-forget; one response refills a bucket and the next `searchForNewPeers()` takes it from there.

- Healthy path unchanged: any live node resets the streak; the live count reuses the poll's existing table traversal (no extra `streamLiveNodes()` walk).
- Bootnode ENRs are parsed once, lazily (malformed entries warn once and drop).
- **No bootnodes ⇒ never due**: sepolia pins an empty discv5 list; logging "re-pinged 0 bootnode(s)" every minute would read as recovery where none is possible.
- Throttled (vs `DiscV4Service`'s ping-on-every-empty-refresh precedent) to stay polite to the handful of public CL bootnodes; divergence documented in the field comment.

## Testing

- `DiscV5ReseedTest` pins the counter: due on the 4th consecutive empty poll, reset by any live node, repeats while empty, never due with no bootnodes (4/4 green; full `:networking` suite green).
- Root-cause evidence and restart-recovery behavior verified on-device (logs in the linked session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VatktQHbiiUwBUWxo1ZUXs