### PR TITLE
beacon: pace catch-up batches to the LC serve quota (remainder-based)

### DIFF
--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
@@ -1302,14 +1302,23 @@ public class BeaconLightClient implements AutoCloseable {
     private static final int MAX_CL_PEERS = 1024;
     /** Max 128-period batches per catch-up call. Bounds wall-clock on very old checkpoints. */
     private static final int MAX_CATCHUP_BATCHES = 8;
-    /** Pause between ADVANCING catch-up batches. Live LC servers (Lighthouse) serve
-     *  ~one update per ~10 s request-quota window; re-asking instantly after a served
-     *  batch always came back empty, wasting the round as "no progress — will retry
-     *  on next sync cycle" and stretching multi-period catch-ups by a full cycle per
-     *  period. Pacing one quota window keeps the proven server serving every round
-     *  (measured on-device with the Rust twin: 20-95 s/period collapsed to ~11 s).
-     *  Same value as the Rust engine's UPDATES_SERVE_COOLDOWN. */
+    /** LC serve-quota window. Live LC servers (Lighthouse) serve ~one update per
+     *  ~10 s request-quota window; re-asking instantly after a served batch always
+     *  came back empty, wasting the round as "no progress — will retry on next
+     *  sync cycle" (measured on-device with the Rust twin: 20-95 s/period
+     *  collapsed to ~11 s once paced; same value as the Rust engine's
+     *  UPDATES_SERVE_COOLDOWN). The pace is the REMAINDER of this window since
+     *  the last batch request FIRED, not a flat sleep: BLS apply time — minutes
+     *  on-device for big batches — already refills the window (a flat sleep
+     *  would add up to ~77 s of dead time per 8-batch call), and the fire stamp
+     *  lives on an instance field so the NEXT call's batch 0 can't re-ask
+     *  inside the window either (Gnosis's 5 s poll cycle would otherwise do
+     *  exactly that at every batch-cap call boundary). */
     private static final long CATCHUP_QUOTA_PACE_MS = 11_000;
+    /** Wall-clock of the last catch-up batch request fire — the quota
+     *  consumption point (every fan-out consumes serving peers' windows,
+     *  advancing or not). Spans catchUpSyncCommittee calls by design. */
+    private volatile long lastCatchupBatchRequestMs;
     /** Max peers dialed per catch-up batch. The discovered CL pool runs to thousands of
      *  fork-matched nodes, most of which don't run a light-client server — fanning
      *  updates_by_range at all of them burned minutes of ProtocolNegotiation/Timeout
@@ -1342,12 +1351,17 @@ public class BeaconLightClient implements AutoCloseable {
             }
 
             // Pace AFTER the done-check (a finished catch-up must not pay a
-            // pointless pause) and only between advancing batches: batch > 0
-            // means the previous batch applied updates — its server's quota
-            // needs a window to refill before it can serve again.
-            if (batch > 0) {
+            // pointless pause): sleep only the REMAINDER of the serve-quota
+            // window since the last batch request fired — see the constant's
+            // javadoc for why remainder-based and why the stamp spans calls.
+            long sinceLastFire = System.currentTimeMillis() - lastCatchupBatchRequestMs;
+            long paceMs = CATCHUP_QUOTA_PACE_MS - sinceLastFire;
+            if (paceMs > 0) {
+                // Explicit stall marker: this code path's history (#132/#133)
+                // earns making every deliberate pause self-explanatory in logs.
+                log.debug("[beacon] Pacing {} ms for the LC serve quota before the next batch", paceMs);
                 try {
-                    Thread.sleep(CATCHUP_QUOTA_PACE_MS);
+                    Thread.sleep(paceMs);
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     return;
@@ -1380,6 +1394,8 @@ public class BeaconLightClient implements AutoCloseable {
      * Run one parallel 128-period fetch across all peers; return true if the store advanced.
      */
     private boolean attemptCatchUpBatch(long bootstrapPeriod, long periodsToFetch, long slotEstimate) {
+        // Quota consumption point: stamp before firing (see CATCHUP_QUOTA_PACE_MS).
+        lastCatchupBatchRequestMs = System.currentTimeMillis();
         // Fire requests to all peers in parallel — first peer to deliver a response that
         // actually advances the store wins. Serial iteration with 30s timeouts meant ~9
         // minutes worst case with a list full of dead peers.

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
@@ -1302,6 +1302,14 @@ public class BeaconLightClient implements AutoCloseable {
     private static final int MAX_CL_PEERS = 1024;
     /** Max 128-period batches per catch-up call. Bounds wall-clock on very old checkpoints. */
     private static final int MAX_CATCHUP_BATCHES = 8;
+    /** Pause between ADVANCING catch-up batches. Live LC servers (Lighthouse) serve
+     *  ~one update per ~10 s request-quota window; re-asking instantly after a served
+     *  batch always came back empty, wasting the round as "no progress — will retry
+     *  on next sync cycle" and stretching multi-period catch-ups by a full cycle per
+     *  period. Pacing one quota window keeps the proven server serving every round
+     *  (measured on-device with the Rust twin: 20-95 s/period collapsed to ~11 s).
+     *  Same value as the Rust engine's UPDATES_SERVE_COOLDOWN. */
+    private static final long CATCHUP_QUOTA_PACE_MS = 11_000;
     /** Max peers dialed per catch-up batch. The discovered CL pool runs to thousands of
      *  fork-matched nodes, most of which don't run a light-client server — fanning
      *  updates_by_range at all of them burned minutes of ProtocolNegotiation/Timeout
@@ -1331,6 +1339,20 @@ public class BeaconLightClient implements AutoCloseable {
                     log.info("[beacon] Sync committee is current (period {}), no catch-up needed", committeePeriod);
                 }
                 return;
+            }
+
+            // Pace AFTER the done-check (a finished catch-up must not pay a
+            // pointless pause) and only between advancing batches: batch > 0
+            // means the previous batch applied updates — its server's quota
+            // needs a window to refill before it can serve again.
+            if (batch > 0) {
+                try {
+                    Thread.sleep(CATCHUP_QUOTA_PACE_MS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+                if (!running) return;
             }
 
             long periodsToFetch = currentPeriod - committeePeriod;

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
@@ -1398,8 +1398,6 @@ public class BeaconLightClient implements AutoCloseable {
      * Run one parallel 128-period fetch across all peers; return true if the store advanced.
      */
     private boolean attemptCatchUpBatch(long bootstrapPeriod, long periodsToFetch, long slotEstimate) {
-        // Quota consumption point: stamp before firing (see CATCHUP_QUOTA_PACE_MS).
-        lastCatchupBatchFireNanos = System.nanoTime();
         // Fire requests to all peers in parallel — first peer to deliver a response that
         // actually advances the store wins. Serial iteration with 30s timeouts meant ~9
         // minutes worst case with a list full of dead peers.
@@ -1496,6 +1494,10 @@ public class BeaconLightClient implements AutoCloseable {
             log.warn("[beacon] Catch-up: no capable peers for period {} — retry next cycle", bootstrapPeriod);
             return false;
         }
+        // Quota consumption point: stamp only when a fan-out actually FIRES —
+        // the empty-pool early return above consumed nobody's window, and
+        // pacing after it would delay the next attempt for nothing.
+        lastCatchupBatchFireNanos = System.nanoTime();
         // {@link BeaconP2PService#doReqResp} detects a dying connection and
         // retries with a fresh one, so we no longer pre-emptively disconnect
         // every peer here — that was costing us Lighthouse/Teku connections

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
@@ -1315,10 +1315,14 @@ public class BeaconLightClient implements AutoCloseable {
      *  inside the window either (Gnosis's 5 s poll cycle would otherwise do
      *  exactly that at every batch-cap call boundary). */
     private static final long CATCHUP_QUOTA_PACE_MS = 11_000;
-    /** Wall-clock of the last catch-up batch request fire — the quota
+    /** nanoTime (monotonic — an NTP step must not skew the pace, same rule as
+     *  the uptime stamps) of the last catch-up batch request fire — the quota
      *  consumption point (every fan-out consumes serving peers' windows,
-     *  advancing or not). Spans catchUpSyncCommittee calls by design. */
-    private volatile long lastCatchupBatchRequestMs;
+     *  advancing or not). Spans catchUpSyncCommittee calls by design.
+     *  Initialized one window in the past so the first-ever batch never pays
+     *  a pace against nanoTime's arbitrary origin. */
+    private volatile long lastCatchupBatchFireNanos =
+            System.nanoTime() - CATCHUP_QUOTA_PACE_MS * 1_000_000L;
     /** Max peers dialed per catch-up batch. The discovered CL pool runs to thousands of
      *  fork-matched nodes, most of which don't run a light-client server — fanning
      *  updates_by_range at all of them burned minutes of ProtocolNegotiation/Timeout
@@ -1354,8 +1358,8 @@ public class BeaconLightClient implements AutoCloseable {
             // pointless pause): sleep only the REMAINDER of the serve-quota
             // window since the last batch request fired — see the constant's
             // javadoc for why remainder-based and why the stamp spans calls.
-            long sinceLastFire = System.currentTimeMillis() - lastCatchupBatchRequestMs;
-            long paceMs = CATCHUP_QUOTA_PACE_MS - sinceLastFire;
+            long sinceLastFireMs = (System.nanoTime() - lastCatchupBatchFireNanos) / 1_000_000L;
+            long paceMs = CATCHUP_QUOTA_PACE_MS - sinceLastFireMs;
             if (paceMs > 0) {
                 // Explicit stall marker: this code path's history (#132/#133)
                 // earns making every deliberate pause self-explanatory in logs.
@@ -1395,7 +1399,7 @@ public class BeaconLightClient implements AutoCloseable {
      */
     private boolean attemptCatchUpBatch(long bootstrapPeriod, long periodsToFetch, long slotEstimate) {
         // Quota consumption point: stamp before firing (see CATCHUP_QUOTA_PACE_MS).
-        lastCatchupBatchRequestMs = System.currentTimeMillis();
+        lastCatchupBatchFireNanos = System.nanoTime();
         // Fire requests to all peers in parallel — first peer to deliver a response that
         // actually advances the store wins. Serial iteration with 30s timeouts meant ~9
         // minutes worst case with a list full of dead peers.


### PR DESCRIPTION
## Why

Port of the Rust engine's catch-up pacing fix (rust-engine PR #150), where the pathology was diagnosed live on-device: LC servers (Lighthouse) serve ~one update per ~10 s request-quota window, so re-asking instantly after an advancing batch always returned empty — the batch loop burned its budget on "no progress" exits and waited a full sync cycle per period (the Java engine's measured ~9 min on-device catch-up).

## Design (shaped by the internal review)

Not a flat sleep — the pace is the **remainder of the quota window since the last batch request fired**, stamped on an instance field at the top of `attemptCatchUpBatch` (the quota consumption point):

- **BLS apply time counts toward the window**: on-device applies can exceed the window, in which case there's no pause at all. A flat 11 s sleep would have added up to ~77 s of dead time per 8-batch call.
- **The stamp survives across `catchUpSyncCommittee` calls**: otherwise the next call's batch 0 re-asks the just-served proven peer inside its window — guaranteed on Gnosis (5 s poll cycle) at every batch-cap boundary, and possible on mainnet's 12 s cycle.
- Placed after the loop-top done-check (a finished catch-up pays nothing), interruptible with the flag restored, re-checks `running`, and logs the pause (this code path's #132/#133 history earns explicit stall markers in daemon logs).

## Testing

`:consensus:test` green. Mechanism identical to the Rust twin verified on a Pixel 7 (steady ~11 s per period; a 16-period catch-up ≈ 3 min, down from 15+).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VatktQHbiiUwBUWxo1ZUXs