### PR TITLE
EL-A7b-1: managed-peer connection layer (Rust)

### DIFF
--- a/rust/myotis-net/src/el/eth/messages.rs
+++ b/rust/myotis-net/src/el/eth/messages.rs
@@ -178,6 +178,17 @@ pub fn encode_get_block_headers_by_hash(
     encode_get_headers(request_id, Item::Bytes(block_hash.to_vec()), max_headers, skip, reverse)
 }
 
+/// `[reqId, []]` — an empty BlockHeaders / BlockBodies / Receipts response, the
+/// answer a passive wallet returns to any inbound eth Get* request (it serves
+/// no chain data). The response code is the request code + 1 (the caller picks
+/// it).
+pub fn encode_empty_response(request_id: u64) -> Vec<u8> {
+    rlp::encode(&Item::List(vec![
+        Item::Bytes(rlp::u64_to_minimal_be(request_id)),
+        Item::List(vec![]),
+    ]))
+}
+
 fn encode_get_headers(request_id: u64, start: Item, max_headers: u64, skip: u64, reverse: bool) -> Vec<u8> {
     let body = Item::List(vec![
         start,

--- a/rust/myotis-net/src/el/eth/session.rs
+++ b/rust/myotis-net/src/el/eth/session.rs
@@ -243,6 +243,13 @@ impl EthSession {
         self.conn.peer_pubkey()
     }
 
+    /// Consume the negotiated session, handing the framed connection and the
+    /// negotiated metadata to the [`ManagedPeer`](crate::el::peer::ManagedPeer)
+    /// actor, which drives it from a background read loop.
+    pub fn into_parts(self) -> (RlpxConnection, u64, bool, Status, Hello) {
+        (self.conn, self.eth_version, self.snap, self.peer_status, self.peer_hello)
+    }
+
     // -----------------------------------------------------------------------
     // snap/1 verified state fetch (EL-A6). These share the eth peer's RLPx
     // connection, multiplexed by the dynamic snap message codes.

--- a/rust/myotis-net/src/el/mod.rs
+++ b/rust/myotis-net/src/el/mod.rs
@@ -9,6 +9,7 @@
 pub mod anchor;
 pub mod discv4;
 pub mod eth;
+pub mod peer;
 pub mod rlpx;
 pub mod snap;
 pub mod verify;

--- a/rust/myotis-net/src/el/peer.rs
+++ b/rust/myotis-net/src/el/peer.rs
@@ -1,0 +1,544 @@
+//! The managed-peer connection actor (EL-A7b): a negotiated eth/snap peer whose
+//! RLPx connection is driven by a background read loop, so requests correlate
+//! by request id concurrently instead of the single-shot, one-request-at-a-time
+//! [`EthSession`](crate::el::eth::session::EthSession) model.
+//!
+//! Since the RLPx frame codec's egress and ingress state are independent, the
+//! connection splits into a [`RlpxReader`]/[`RlpxWriter`] pair
+//! ([`RlpxConnection::split`]). The read task owns the reader and a clone of the
+//! shared writer; it classifies each inbound frame:
+//!
+//! * p2p **Ping** → **Pong** (keeps the peer from dropping us on idle),
+//! * p2p **Disconnect** / a read error → fail every in-flight request and stop,
+//! * an inbound eth/snap **Get\*** request → an **empty** response (the wallet
+//!   serves no chain data, but a well-behaved empty answer beats a timeout),
+//! * a response → delivered to the waiting request by `(reqId, code)`,
+//! * anything else (gossip, mempool) → ignored.
+//!
+//! Request methods take `&self`: the writer is an `Arc<Mutex<…>>` and the
+//! request-id counter is atomic, so several requests can be outstanding at once.
+//! This is the twin of the Java `EthHandler`'s always-listening channel (its
+//! Netty pipeline answers Ping and unsolicited Get\* the same way).
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::{oneshot, Mutex};
+use tokio::task::JoinHandle;
+
+use myotis_core::rlp;
+use myotis_core::trie::{AccountLeaf, EMPTY_CODE_HASH, EMPTY_TRIE_ROOT};
+
+use crate::el::anchor::ExecAnchor;
+use crate::el::eth::messages::{self, Status, VerifiedHeader};
+use crate::el::eth::session::EthSession;
+use crate::el::rlpx::transport::{
+    Hello, RlpxConnection, RlpxReader, RlpxWriter, P2P_DISCONNECT, P2P_PING, P2P_PONG,
+};
+use crate::el::snap::fetch::{self, AccountOutcome};
+use crate::el::snap::messages as snap;
+use crate::el::verify::Verdict;
+
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// One in-flight request: the response code it expects and the delivery channel.
+struct Pending {
+    want_code: u64,
+    tx: oneshot::Sender<Result<Vec<u8>, String>>,
+}
+
+type PendingMap = Arc<Mutex<HashMap<u64, Pending>>>;
+
+/// A negotiated eth/snap peer, driven by a background read loop.
+pub struct ManagedPeer {
+    writer: Arc<Mutex<RlpxWriter>>,
+    pending: PendingMap,
+    next_id: AtomicU64,
+    /// Set once the read loop terminates (disconnect / read error); requests
+    /// short-circuit instead of hanging until timeout.
+    closed: Arc<AtomicBool>,
+    reader_task: JoinHandle<()>,
+
+    /// Negotiated eth version (66-69).
+    pub eth_version: u64,
+    /// Whether the peer also advertised snap/1.
+    pub snap: bool,
+    /// The peer's Status (head, fork id).
+    pub peer_status: Status,
+    /// The peer's Hello (client id, capabilities).
+    pub peer_hello: Hello,
+    peer_pubkey: [u8; 64],
+    snap_codes: Option<snap::SnapCodes>,
+}
+
+impl ManagedPeer {
+    /// Take over a handshook [`EthSession`], splitting its connection and
+    /// spawning the background read loop. From here the peer serves concurrent
+    /// requests and answers Ping/Get\* on its own.
+    pub fn spawn(session: EthSession) -> ManagedPeer {
+        let (conn, eth_version, snap, peer_status, peer_hello) = session.into_parts();
+        Self::from_connection(conn, eth_version, snap, peer_status, peer_hello)
+    }
+
+    fn from_connection(
+        conn: RlpxConnection,
+        eth_version: u64,
+        snap: bool,
+        peer_status: Status,
+        peer_hello: Hello,
+    ) -> ManagedPeer {
+        let (reader, writer, peer_pubkey) = conn.split();
+        let snap_codes = snap.then(|| snap::SnapCodes::for_eth_version(eth_version));
+        let writer = Arc::new(Mutex::new(writer));
+        let pending: PendingMap = Arc::new(Mutex::new(HashMap::new()));
+        let closed = Arc::new(AtomicBool::new(false));
+
+        let reader_task = tokio::spawn(read_loop(
+            reader,
+            Arc::clone(&writer),
+            Arc::clone(&pending),
+            Arc::clone(&closed),
+            snap_codes,
+        ));
+
+        ManagedPeer {
+            writer,
+            pending,
+            next_id: AtomicU64::new(1),
+            closed,
+            reader_task,
+            eth_version,
+            snap,
+            peer_status,
+            peer_hello,
+            peer_pubkey,
+            snap_codes,
+        }
+    }
+
+    pub fn peer_pubkey(&self) -> [u8; 64] {
+        self.peer_pubkey
+    }
+
+    /// True once the read loop has stopped (peer disconnect or fatal read
+    /// error); the peer serves no further requests.
+    pub fn is_closed(&self) -> bool {
+        self.closed.load(Ordering::SeqCst)
+    }
+
+    /// Send one request and await its response, correlating by request id. The
+    /// closure receives the allocated id so the encoded body carries it. Fails
+    /// fast if the peer is already closed, on a write error, or on timeout.
+    async fn request(
+        &self,
+        send_code: u64,
+        want_code: u64,
+        encode: impl FnOnce(u64) -> Vec<u8>,
+    ) -> Result<Vec<u8>, String> {
+        if self.is_closed() {
+            return Err("peer connection closed".to_string());
+        }
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let body = encode(id);
+        let (tx, rx) = oneshot::channel();
+        self.pending.lock().await.insert(id, Pending { want_code, tx });
+
+        // Send under the writer lock; drop the pending entry if the write fails.
+        if let Err(e) = self.writer.lock().await.send(send_code, &body).await {
+            self.pending.lock().await.remove(&id);
+            return Err(e);
+        }
+
+        match tokio::time::timeout(REQUEST_TIMEOUT, rx).await {
+            Ok(Ok(result)) => result,
+            // The read loop dropped the sender (disconnect drained the map).
+            Ok(Err(_)) => Err("peer connection closed".to_string()),
+            Err(_) => {
+                self.pending.lock().await.remove(&id);
+                Err(format!("timed out awaiting code 0x{want_code:02x}"))
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // eth requests.
+    // -----------------------------------------------------------------------
+
+    /// Request a batch of headers by starting block number. Verifies nothing
+    /// here — the caller checks hashes against the beacon anchor.
+    pub async fn get_block_headers_by_number(
+        &self,
+        block_number: u64,
+        max_headers: u64,
+        skip: u64,
+        reverse: bool,
+    ) -> Result<Vec<VerifiedHeader>, String> {
+        let payload = self
+            .request(messages::GET_BLOCK_HEADERS, messages::BLOCK_HEADERS, |id| {
+                messages::encode_get_block_headers_by_number(id, block_number, max_headers, skip, reverse)
+            })
+            .await?;
+        let (_rid, headers) = messages::decode_block_headers(&payload)
+            .map_err(|e| format!("BlockHeaders decode: {}", e.0))?;
+        Ok(headers)
+    }
+
+    /// Request headers starting at a block HASH (fetch a peer's fresh head).
+    pub async fn get_block_headers_by_hash(
+        &self,
+        block_hash: &[u8; 32],
+        max_headers: u64,
+    ) -> Result<Vec<VerifiedHeader>, String> {
+        let payload = self
+            .request(messages::GET_BLOCK_HEADERS, messages::BLOCK_HEADERS, |id| {
+                messages::encode_get_block_headers_by_hash(id, block_hash, max_headers, 0, false)
+            })
+            .await?;
+        let (_rid, headers) = messages::decode_block_headers(&payload)
+            .map_err(|e| format!("BlockHeaders decode: {}", e.0))?;
+        Ok(headers)
+    }
+
+    /// Request block bodies by hash.
+    pub async fn get_block_bodies(
+        &self,
+        hashes: &[[u8; 32]],
+    ) -> Result<Vec<messages::BlockBody>, String> {
+        let payload = self
+            .request(messages::GET_BLOCK_BODIES, messages::BLOCK_BODIES, |id| {
+                messages::encode_get_block_bodies(id, hashes)
+            })
+            .await?;
+        let (_rid, bodies) = messages::decode_block_bodies(&payload)
+            .map_err(|e| format!("BlockBodies decode: {}", e.0))?;
+        Ok(bodies)
+    }
+
+    // -----------------------------------------------------------------------
+    // snap/1 verified state fetch (shares the eth peer's RLPx connection).
+    // -----------------------------------------------------------------------
+
+    fn snap_codes(&self) -> Option<snap::SnapCodes> {
+        self.snap_codes
+    }
+
+    /// Fetch and verify one account at `state_root` (a FRESH root the peer still
+    /// retains). The returned fields come from the MPT-verified proof leaf,
+    /// never the peer's slim body.
+    pub async fn snap_get_account(
+        &self,
+        state_root: &[u8; 32],
+        address: &[u8; 20],
+    ) -> Result<AccountOutcome, String> {
+        let codes = self.snap_codes().ok_or("peer does not support snap/1")?;
+        let account_hash = myotis_core::keccak::keccak256(address);
+        let payload = self
+            .request(codes.get_account_range, codes.account_range, |id| {
+                snap::encode_get_account(id, state_root, &account_hash, 4096)
+            })
+            .await?;
+        let response = snap::decode_account_range(&payload)
+            .map_err(|e| format!("AccountRange decode: {}", e.0))?;
+        fetch::verify_account(state_root, address, &response).map_err(|e| e.0)
+    }
+
+    /// Fetch and verify one storage slot against the account's proven
+    /// `storage_root` (not the world state root).
+    pub async fn snap_get_storage(
+        &self,
+        state_root: &[u8; 32],
+        address: &[u8; 20],
+        account: &AccountLeaf,
+        slot: &[u8; 32],
+    ) -> Result<Vec<u8>, String> {
+        // No storage trie → every slot is provably zero; skip the round trip.
+        if account.storage_root == EMPTY_TRIE_ROOT {
+            return Ok(Vec::new());
+        }
+        let codes = self.snap_codes().ok_or("peer does not support snap/1")?;
+        let account_hash = myotis_core::keccak::keccak256(address);
+        let slot_hash = myotis_core::keccak::keccak256(slot);
+        let payload = self
+            .request(codes.get_storage_ranges, codes.storage_ranges, |id| {
+                snap::encode_get_storage_slot(id, state_root, &account_hash, &slot_hash, 4096)
+            })
+            .await?;
+        let response = snap::decode_storage_ranges(&payload)
+            .map_err(|e| format!("StorageRanges decode: {}", e.0))?;
+        fetch::verify_storage(account, slot, &response).map_err(|e| e.0)
+    }
+
+    /// Fetch and verify one contract's bytecode by its `code_hash`.
+    pub async fn snap_get_bytecode(&self, code_hash: &[u8; 32]) -> Result<Vec<u8>, String> {
+        // A code-less account (EOAs — the vast majority): no round trip.
+        if code_hash == &EMPTY_CODE_HASH {
+            return Ok(Vec::new());
+        }
+        let codes = self.snap_codes().ok_or("peer does not support snap/1")?;
+        let payload = self
+            .request(codes.get_byte_codes, codes.byte_codes, |id| {
+                snap::encode_get_byte_codes(id, &[*code_hash], 256 * 1024)
+            })
+            .await?;
+        let (_id, codes_returned) =
+            snap::decode_byte_codes(&payload).map_err(|e| format!("ByteCodes decode: {}", e.0))?;
+        fetch::verify_bytecode(code_hash, &codes_returned)
+            .ok_or_else(|| "no returned bytecode matched the requested hash".to_string())
+    }
+
+    // -----------------------------------------------------------------------
+    // Verified-read verdicts (the ladder over the anchored beacon state).
+    // -----------------------------------------------------------------------
+
+    /// Anchor a peer-served `state_root` (for `block_number`) to the beacon
+    /// chain: `stateRootMatch` fast path, else the `headerChain` walk.
+    /// `proof_valid` is the caller's MPT-proof result against `state_root`.
+    pub async fn verified_state_root(
+        &self,
+        anchor: &ExecAnchor,
+        state_root: &[u8; 32],
+        block_number: i64,
+        proof_valid: bool,
+    ) -> Verdict {
+        use crate::el::verify::{ladder_precheck, LadderStep};
+        match ladder_precheck(Some(state_root), proof_valid, block_number, anchor) {
+            LadderStep::Done(verdict) => verdict,
+            LadderStep::NeedHeaderChain {
+                finalized_block,
+                peer_block,
+                beacon_block_hash,
+                finalized_slot,
+            } => {
+                self.header_chain_verdict(
+                    finalized_block,
+                    peer_block,
+                    &beacon_block_hash,
+                    state_root,
+                    finalized_slot,
+                )
+                .await
+            }
+        }
+    }
+
+    /// Fetch `[finalized_block ..= peer_block]` and run the header-chain verdict
+    /// against the beacon-anchored block hash. `headerChainError` on transport
+    /// failure, `headerChainInvalid` on a short/over-long/out-of-range response
+    /// (matching the Java ladder). A single request, so it only spans a gap the
+    /// peer serves in one response — a multi-thousand-block gap truncates and
+    /// fails closed (batched fetch lands in a later A7b sub-PR).
+    async fn header_chain_verdict(
+        &self,
+        finalized_block: u64,
+        peer_block: u64,
+        beacon_block_hash: &[u8; 32],
+        peer_state_root: &[u8; 32],
+        finalized_slot: i64,
+    ) -> Verdict {
+        use crate::el::verify::{header_chain_verdict, ChainHeader, MAX_HEADER_CHAIN_GAP};
+        let total = peer_block - finalized_block + 1;
+        // Java's verifyHeaderChainBatched re-guard: total in [2, MAX].
+        if total < 2 || total > MAX_HEADER_CHAIN_GAP {
+            return Verdict {
+                fail_reason: Some("headerChainInvalid"),
+                ..Verdict::default()
+            };
+        }
+        let headers = match self
+            .get_block_headers_by_number(finalized_block, total, 0, false)
+            .await
+        {
+            Ok(h) => h,
+            Err(_) => {
+                return Verdict {
+                    fail_reason: Some("headerChainError"),
+                    ..Verdict::default()
+                }
+            }
+        };
+        let chain: Vec<ChainHeader> = headers
+            .into_iter()
+            .map(|vh| ChainHeader { hash: vh.hash, header: vh.header })
+            .collect();
+        if chain.len() as u64 != total {
+            return Verdict {
+                fail_reason: Some("headerChainInvalid"),
+                ..Verdict::default()
+            };
+        }
+        header_chain_verdict(&chain, beacon_block_hash, peer_state_root, finalized_slot)
+    }
+}
+
+impl Drop for ManagedPeer {
+    fn drop(&mut self) {
+        // Stop the background read loop when the last handle goes away.
+        self.reader_task.abort();
+    }
+}
+
+/// The background read loop: classify each inbound frame and either answer it
+/// (Ping/Get\*), deliver it to a waiting request, or ignore it. Exits on a read
+/// error or a peer Disconnect, failing every in-flight request on the way out.
+async fn read_loop(
+    mut reader: RlpxReader,
+    writer: Arc<Mutex<RlpxWriter>>,
+    pending: PendingMap,
+    closed: Arc<AtomicBool>,
+    snap_codes: Option<snap::SnapCodes>,
+) {
+    loop {
+        let frame = match reader.recv().await {
+            Ok(f) => f,
+            Err(e) => {
+                fail_all(&pending, format!("peer read loop ended: {e}")).await;
+                break;
+            }
+        };
+        let code = frame.message_code;
+
+        if code == P2P_PING {
+            // Pong body is an empty RLP list. A write failure ends the loop next
+            // iteration; ignore it here.
+            let _ = writer.lock().await.send(P2P_PONG, &[0xc0]).await;
+            continue;
+        }
+        if code == P2P_DISCONNECT {
+            fail_all(&pending, format!("peer disconnected: {}", describe_disconnect(&frame.payload)))
+                .await;
+            break;
+        }
+
+        // An inbound Get* request we answer with an empty response.
+        if let Some((resp_code, empty)) = empty_answer(code, &snap_codes, &frame.payload) {
+            let _ = writer.lock().await.send(resp_code, &empty).await;
+            continue;
+        }
+
+        // Otherwise try to correlate a response by (reqId, code). Anything that
+        // doesn't match a waiting request is gossip/mempool — ignore it.
+        if let Some(id) = leading_request_id(&frame.payload) {
+            let mut map = pending.lock().await;
+            if let Some(entry) = map.get(&id) {
+                if entry.want_code == code {
+                    let entry = map.remove(&id).expect("just checked present");
+                    let _ = entry.tx.send(Ok(frame.payload));
+                }
+            }
+        }
+    }
+    closed.store(true, Ordering::SeqCst);
+}
+
+/// If `code` is an inbound eth/snap Get\* request, return the `(responseCode,
+/// emptyBody)` to answer it with — echoing the request's id. `None` for any
+/// other frame.
+fn empty_answer(
+    code: u64,
+    snap_codes: &Option<snap::SnapCodes>,
+    payload: &[u8],
+) -> Option<(u64, Vec<u8>)> {
+    let id = leading_request_id(payload)?;
+    match code {
+        messages::GET_BLOCK_HEADERS => {
+            Some((messages::BLOCK_HEADERS, messages::encode_empty_response(id)))
+        }
+        messages::GET_BLOCK_BODIES => {
+            Some((messages::BLOCK_BODIES, messages::encode_empty_response(id)))
+        }
+        messages::GET_RECEIPTS => Some((messages::RECEIPTS, messages::encode_empty_response(id))),
+        _ => {
+            let c = snap_codes.as_ref()?;
+            if code == c.get_account_range {
+                Some((c.account_range, snap::encode_empty_range(id)))
+            } else if code == c.get_storage_ranges {
+                Some((c.storage_ranges, snap::encode_empty_range(id)))
+            } else if code == c.get_byte_codes {
+                Some((c.byte_codes, snap::encode_empty_codes(id)))
+            } else if code == c.get_trie_nodes {
+                Some((c.trie_nodes, snap::encode_empty_codes(id)))
+            } else {
+                None
+            }
+        }
+    }
+}
+
+/// Fail every in-flight request with `reason`, draining the pending map.
+async fn fail_all(pending: &PendingMap, reason: String) {
+    let mut map = pending.lock().await;
+    for (_id, entry) in map.drain() {
+        let _ = entry.tx.send(Err(reason.clone()));
+    }
+}
+
+/// The leading request id of an eth/snap request or response (`[reqId, …]`).
+fn leading_request_id(payload: &[u8]) -> Option<u64> {
+    let items = rlp::raw_list_items(payload).ok()?;
+    rlp::decode(items.first()?).ok()?.as_u64().ok()
+}
+
+/// A p2p Disconnect body is `[reason]` (or a bare `reason`); decode it.
+fn describe_disconnect(payload: &[u8]) -> String {
+    let reason = rlp::decode(payload)
+        .ok()
+        .and_then(|it| match it {
+            rlp::Item::List(items) => items.first().and_then(|r| r.as_u64().ok()),
+            rlp::Item::Bytes(_) => it.as_u64().ok(),
+        })
+        .unwrap_or(u64::MAX);
+    format!("reason={reason}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn leading_request_id_reads_reqid() {
+        let msg = rlp::encode(&rlp::Item::List(vec![
+            rlp::Item::Bytes(rlp::u64_to_minimal_be(4242)),
+            rlp::Item::List(vec![]),
+        ]));
+        assert_eq!(leading_request_id(&msg), Some(4242));
+        // A bare byte string is not a `[reqId, …]` list.
+        assert_eq!(leading_request_id(&[0x80]), None);
+    }
+
+    #[test]
+    fn empty_answer_maps_eth_get_star() {
+        let req = rlp::encode(&rlp::Item::List(vec![
+            rlp::Item::Bytes(rlp::u64_to_minimal_be(7)),
+            rlp::Item::List(vec![]),
+        ]));
+        let (code, body) = empty_answer(messages::GET_BLOCK_HEADERS, &None, &req).unwrap();
+        assert_eq!(code, messages::BLOCK_HEADERS);
+        assert_eq!(leading_request_id(&body), Some(7));
+
+        let (code, _) = empty_answer(messages::GET_RECEIPTS, &None, &req).unwrap();
+        assert_eq!(code, messages::RECEIPTS);
+
+        // A response code is not an inbound request.
+        assert!(empty_answer(messages::BLOCK_HEADERS, &None, &req).is_none());
+    }
+
+    #[test]
+    fn empty_answer_maps_snap_get_star() {
+        let codes = snap::SnapCodes::for_eth_version(68);
+        let req = rlp::encode(&rlp::Item::List(vec![
+            rlp::Item::Bytes(rlp::u64_to_minimal_be(9)),
+            rlp::Item::List(vec![]),
+        ]));
+        let (code, body) = empty_answer(codes.get_account_range, &Some(codes), &req).unwrap();
+        assert_eq!(code, codes.account_range);
+        assert_eq!(leading_request_id(&body), Some(9));
+
+        let (code, _) = empty_answer(codes.get_byte_codes, &Some(codes), &req).unwrap();
+        assert_eq!(code, codes.byte_codes);
+
+        // Without snap negotiated, snap codes aren't answered.
+        assert!(empty_answer(codes.get_account_range, &None, &req).is_none());
+    }
+}

--- a/rust/myotis-net/src/el/peer.rs
+++ b/rust/myotis-net/src/el/peer.rs
@@ -137,16 +137,28 @@ impl ManagedPeer {
         want_code: u64,
         encode: impl FnOnce(u64) -> Vec<u8>,
     ) -> Result<Vec<u8>, String> {
-        if self.is_closed() {
-            return Err("peer connection closed".to_string());
-        }
         let id = self.next_id.fetch_add(1, Ordering::Relaxed);
         let body = encode(id);
         let (tx, rx) = oneshot::channel();
-        self.pending.lock().await.insert(id, Pending { want_code, tx });
 
-        // Send under the writer lock; drop the pending entry if the write fails.
+        // Insert while holding the pending lock, checking `closed` inside it.
+        // `fail_all` sets `closed` under the SAME lock, so we can't lose the
+        // race where the read loop drains the map (on disconnect) between an
+        // unlocked check and our insert — either we insert before the drain (and
+        // it delivers our Err) or we observe `closed` and bail here.
+        {
+            let mut map = self.pending.lock().await;
+            if self.closed.load(Ordering::SeqCst) {
+                return Err("peer connection closed".to_string());
+            }
+            map.insert(id, Pending { want_code, tx });
+        }
+
+        // Send under the writer lock; a write failure leaves the egress frame
+        // stream in an indeterminate state (a partial frame may be on the wire),
+        // so mark the peer closed and drop the pending entry.
         if let Err(e) = self.writer.lock().await.send(send_code, &body).await {
+            self.closed.store(true, Ordering::SeqCst);
             self.pending.lock().await.remove(&id);
             return Err(e);
         }
@@ -393,7 +405,7 @@ async fn read_loop(
         let frame = match reader.recv().await {
             Ok(f) => f,
             Err(e) => {
-                fail_all(&pending, format!("peer read loop ended: {e}")).await;
+                fail_all(&pending, &closed, format!("peer read loop ended: {e}")).await;
                 break;
             }
         };
@@ -406,8 +418,12 @@ async fn read_loop(
             continue;
         }
         if code == P2P_DISCONNECT {
-            fail_all(&pending, format!("peer disconnected: {}", describe_disconnect(&frame.payload)))
-                .await;
+            fail_all(
+                &pending,
+                &closed,
+                format!("peer disconnected: {}", describe_disconnect(&frame.payload)),
+            )
+            .await;
             break;
         }
 
@@ -429,6 +445,8 @@ async fn read_loop(
             }
         }
     }
+    // Backstop: every break above already set `closed` via `fail_all`, but keep
+    // this so any future exit path can't leave the peer looking open.
     closed.store(true, Ordering::SeqCst);
 }
 
@@ -466,9 +484,13 @@ fn empty_answer(
     }
 }
 
-/// Fail every in-flight request with `reason`, draining the pending map.
-async fn fail_all(pending: &PendingMap, reason: String) {
+/// Fail every in-flight request with `reason`, draining the pending map. Marks
+/// the peer closed under the pending lock (before draining) so a concurrent
+/// [`ManagedPeer::request`] either inserted before the drain — and gets its Err
+/// here — or observes `closed` and bails, never hanging on a dead connection.
+async fn fail_all(pending: &PendingMap, closed: &Arc<AtomicBool>, reason: String) {
     let mut map = pending.lock().await;
+    closed.store(true, Ordering::SeqCst);
     for (_id, entry) in map.drain() {
         let _ = entry.tx.send(Err(reason.clone()));
     }

--- a/rust/myotis-net/src/el/peer.rs
+++ b/rust/myotis-net/src/el/peer.rs
@@ -156,10 +156,10 @@ impl ManagedPeer {
 
         // Send under the writer lock; a write failure leaves the egress frame
         // stream in an indeterminate state (a partial frame may be on the wire),
-        // so mark the peer closed and drop the pending entry.
+        // so fail EVERY in-flight request — not just this one, which would leave
+        // the others hanging until their own timeouts on a dead connection.
         if let Err(e) = self.writer.lock().await.send(send_code, &body).await {
-            self.closed.store(true, Ordering::SeqCst);
-            self.pending.lock().await.remove(&id);
+            fail_all(&self.pending, &self.closed, format!("peer write failure: {e}")).await;
             return Err(e);
         }
 
@@ -350,7 +350,18 @@ impl ManagedPeer {
         finalized_slot: i64,
     ) -> Verdict {
         use crate::el::verify::{header_chain_verdict, ChainHeader, MAX_HEADER_CHAIN_GAP};
-        let total = peer_block - finalized_block + 1;
+        // `ladder_precheck` only reaches here with peer_block > finalized_block,
+        // but guard the subtraction anyway — under panic="abort" an underflow
+        // would kill the process, so fail the verdict closed instead.
+        let total = match peer_block.checked_sub(finalized_block) {
+            Some(diff) => diff + 1,
+            None => {
+                return Verdict {
+                    fail_reason: Some("headerChainInvalid"),
+                    ..Verdict::default()
+                }
+            }
+        };
         // Java's verifyHeaderChainBatched re-guard: total in [2, MAX].
         if total < 2 || total > MAX_HEADER_CHAIN_GAP {
             return Verdict {
@@ -412,9 +423,13 @@ async fn read_loop(
         let code = frame.message_code;
 
         if code == P2P_PING {
-            // Pong body is an empty RLP list. A write failure ends the loop next
-            // iteration; ignore it here.
-            let _ = writer.lock().await.send(P2P_PONG, &[0xc0]).await;
+            // Pong body is an empty RLP list. A write failure (e.g. a half-closed
+            // connection where reads still succeed) means the peer is dead — fail
+            // in-flight requests and stop, rather than spin on a zombie.
+            if let Err(e) = writer.lock().await.send(P2P_PONG, &[0xc0]).await {
+                fail_all(&pending, &closed, format!("peer write failure on Pong: {e}")).await;
+                break;
+            }
             continue;
         }
         if code == P2P_DISCONNECT {
@@ -429,7 +444,11 @@ async fn read_loop(
 
         // An inbound Get* request we answer with an empty response.
         if let Some((resp_code, empty)) = empty_answer(code, &snap_codes, &frame.payload) {
-            let _ = writer.lock().await.send(resp_code, &empty).await;
+            if let Err(e) = writer.lock().await.send(resp_code, &empty).await {
+                fail_all(&pending, &closed, format!("peer write failure on empty response: {e}"))
+                    .await;
+                break;
+            }
             continue;
         }
 

--- a/rust/myotis-net/src/el/rlpx/frame.rs
+++ b/rust/myotis-net/src/el/rlpx/frame.rs
@@ -40,14 +40,27 @@ pub struct DecodedFrame {
     pub payload: Vec<u8>,
 }
 
+/// The EGRESS half of the frame codec (outbound): AES-256-CTR keystream +
+/// keccak MAC chain. Independent of the ingress half, so the two can live on
+/// separate tokio tasks / socket halves (the managed-peer read/write split).
+pub struct FrameEncoder {
+    encrypt: Aes256Ctr,
+    egress_mac: KeccakMac,
+}
+
+/// The INGRESS half (inbound): AES-256-CTR + keccak MAC chain.
+pub struct FrameDecoder {
+    decrypt: Aes256Ctr,
+    ingress_mac: KeccakMac,
+}
+
 /// Stateful RLPx frame codec — NOT thread-safe (the ciphers and MAC chains are
 /// position-dependent; all sends/receives must be serialized, as on the Java
-/// side). Built from the initiator's [`SessionSecrets`].
+/// side). Composes the two independent halves; [`FrameCodec::split`] hands them
+/// out for the managed-peer read/write tasks.
 pub struct FrameCodec {
-    encrypt: Aes256Ctr,
-    decrypt: Aes256Ctr,
-    egress_mac: KeccakMac,
-    ingress_mac: KeccakMac,
+    encoder: FrameEncoder,
+    decoder: FrameDecoder,
 }
 
 impl FrameCodec {
@@ -55,24 +68,50 @@ impl FrameCodec {
     /// nonce and auth/ack-wire roles swapped — see the handshake tests.)
     pub fn new(secrets: &SessionSecrets) -> FrameCodec {
         let zero_iv = [0u8; 16];
-        let encrypt = Aes256Ctr::new((&secrets.aes_secret).into(), (&zero_iv).into());
-        let decrypt = Aes256Ctr::new((&secrets.aes_secret).into(), (&zero_iv).into());
-
         // egress:  keccak(macSecret XOR ingressNonce ‖ authWire)  [initiator]
         // ingress: keccak(macSecret XOR egressNonce  ‖ ackWire)
         let egress_seed = xor(&secrets.mac_secret, &secrets.ingress_nonce);
-        let egress_mac = KeccakMac::new(&egress_seed, &secrets.mac_secret, &secrets.auth_wire);
         let ingress_seed = xor(&secrets.mac_secret, &secrets.egress_nonce);
-        let ingress_mac = KeccakMac::new(&ingress_seed, &secrets.mac_secret, &secrets.ack_wire);
-
         FrameCodec {
-            encrypt,
-            decrypt,
-            egress_mac,
-            ingress_mac,
+            encoder: FrameEncoder {
+                encrypt: Aes256Ctr::new((&secrets.aes_secret).into(), (&zero_iv).into()),
+                egress_mac: KeccakMac::new(&egress_seed, &secrets.mac_secret, &secrets.auth_wire),
+            },
+            decoder: FrameDecoder {
+                decrypt: Aes256Ctr::new((&secrets.aes_secret).into(), (&zero_iv).into()),
+                ingress_mac: KeccakMac::new(&ingress_seed, &secrets.mac_secret, &secrets.ack_wire),
+            },
         }
     }
 
+    /// Split into the independent egress/ingress halves for the managed peer's
+    /// separate read and write tasks.
+    pub fn split(self) -> (FrameEncoder, FrameDecoder) {
+        (self.encoder, self.decoder)
+    }
+
+    /// Encode one message into a full frame (delegates to the egress half).
+    pub fn encode_frame(&mut self, message_code: u64, body: &[u8]) -> Vec<u8> {
+        self.encoder.encode_frame(message_code, body)
+    }
+
+    /// Verify + decrypt a 16-byte encrypted header (delegates to the ingress half).
+    pub fn decode_header(&mut self, enc_header: &[u8], header_mac: &[u8]) -> Result<usize, CoreError> {
+        self.decoder.decode_header(enc_header, header_mac)
+    }
+
+    /// Verify + decrypt a frame body (delegates to the ingress half).
+    pub fn decode_body(
+        &mut self,
+        enc_body: &[u8],
+        body_mac: &[u8],
+        body_len: usize,
+    ) -> Result<DecodedFrame, CoreError> {
+        self.decoder.decode_body(enc_body, body_mac, body_len)
+    }
+}
+
+impl FrameEncoder {
     /// Encode one message into a full frame (header ‖ header-mac ‖ body ‖ body-mac).
     pub fn encode_frame(&mut self, message_code: u64, body: &[u8]) -> Vec<u8> {
         // Snappy-compress everything except Hello.
@@ -112,7 +151,9 @@ impl FrameCodec {
         frame.extend_from_slice(&body_mac);
         frame
     }
+}
 
+impl FrameDecoder {
     /// Verify + decrypt a 16-byte encrypted header, returning the body length.
     pub fn decode_header(&mut self, enc_header: &[u8], header_mac: &[u8]) -> Result<usize, CoreError> {
         if enc_header.len() != 16 || header_mac.len() != 16 {
@@ -359,10 +400,10 @@ mod tests {
         header[1] = (body_len >> 8) as u8;
         header[2] = body_len as u8;
         header[3] = 0xc0;
-        a.encrypt.apply_keystream(&mut header);
-        let header_mac = a.egress_mac.update_header(&header);
-        a.encrypt.apply_keystream(&mut coded);
-        let body_mac = a.egress_mac.update_body(&coded);
+        a.encoder.encrypt.apply_keystream(&mut header);
+        let header_mac = a.encoder.egress_mac.update_header(&header);
+        a.encoder.encrypt.apply_keystream(&mut coded);
+        let body_mac = a.encoder.egress_mac.update_body(&coded);
 
         let len = b.decode_header(&header, &header_mac).unwrap();
         // The key assertion: this returns (raw fallback) rather than aborting.

--- a/rust/myotis-net/src/el/rlpx/transport.rs
+++ b/rust/myotis-net/src/el/rlpx/transport.rs
@@ -11,11 +11,12 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
 use tokio::net::TcpStream;
 
 use myotis_core::nodekey::NodeKey;
 
-use super::frame::{DecodedFrame, FrameCodec};
+use super::frame::{DecodedFrame, FrameCodec, FrameDecoder, FrameEncoder};
 use super::handshake::Initiator;
 
 /// p2p base message codes (shared prefix below the eth sub-protocol).
@@ -102,6 +103,18 @@ impl RlpxConnection {
         self.peer_pubkey
     }
 
+    /// Split into independent read/write halves for the managed-peer's separate
+    /// tasks (the frame codec's egress/ingress state are independent).
+    pub fn split(self) -> (RlpxReader, RlpxWriter, [u8; 64]) {
+        let (read_half, write_half) = self.stream.into_split();
+        let (encoder, decoder) = self.codec.split();
+        (
+            RlpxReader { read_half, decoder },
+            RlpxWriter { write_half, encoder },
+            self.peer_pubkey,
+        )
+    }
+
     /// Frame and send one message.
     pub async fn send(&mut self, message_code: u64, body: &[u8]) -> Result<(), String> {
         let frame = self.codec.encode_frame(message_code, body);
@@ -143,6 +156,65 @@ impl RlpxConnection {
             .await
             .map(|_| ())
             .map_err(|e| format!("rlpx read: {e}"))
+    }
+}
+
+/// The write half of a split [`RlpxConnection`] — owns the egress cipher/MAC.
+/// Serialize all sends through `&mut self`.
+pub struct RlpxWriter {
+    write_half: OwnedWriteHalf,
+    encoder: FrameEncoder,
+}
+
+impl RlpxWriter {
+    /// Frame and send one message.
+    pub async fn send(&mut self, message_code: u64, body: &[u8]) -> Result<(), String> {
+        let frame = self.encoder.encode_frame(message_code, body);
+        self.write_half
+            .write_all(&frame)
+            .await
+            .map_err(|e| format!("rlpx write frame: {e}"))
+    }
+}
+
+/// The read half of a split [`RlpxConnection`] — owns the ingress cipher/MAC.
+pub struct RlpxReader {
+    read_half: OwnedReadHalf,
+    decoder: FrameDecoder,
+}
+
+impl RlpxReader {
+    /// Read and decode the next frame. Blocks indefinitely on the header (a
+    /// legitimate idle state); once it arrives the body must follow within
+    /// [`FRAME_BODY_TIMEOUT`].
+    pub async fn recv(&mut self) -> Result<DecodedFrame, String> {
+        let mut header = [0u8; 16];
+        let mut header_mac = [0u8; 16];
+        self.read_half
+            .read_exact(&mut header)
+            .await
+            .map_err(|e| format!("rlpx read: {e}"))?;
+        self.read_half
+            .read_exact(&mut header_mac)
+            .await
+            .map_err(|e| format!("rlpx read: {e}"))?;
+        let body_len = self
+            .decoder
+            .decode_header(&header, &header_mac)
+            .map_err(|e| format!("rlpx header: {}", e.0))?;
+        let padded = (body_len + 15) & !15;
+        let mut enc_body = vec![0u8; padded];
+        let mut body_mac = [0u8; 16];
+        tokio::time::timeout(FRAME_BODY_TIMEOUT, async {
+            self.read_half.read_exact(&mut enc_body).await?;
+            self.read_half.read_exact(&mut body_mac).await
+        })
+        .await
+        .map_err(|_| "rlpx frame body timed out".to_string())?
+        .map_err(|e| format!("rlpx read: {e}"))?;
+        self.decoder
+            .decode_body(&enc_body, &body_mac, body_len)
+            .map_err(|e| format!("rlpx body: {}", e.0))
     }
 }
 

--- a/rust/myotis-net/src/el/rlpx/transport.rs
+++ b/rust/myotis-net/src/el/rlpx/transport.rs
@@ -33,6 +33,12 @@ const MAX_ACK_SIZE: usize = 2048;
 /// body buffer. (Waiting on the header itself is a legitimate idle state and is
 /// NOT bounded here.)
 const FRAME_BODY_TIMEOUT: Duration = Duration::from_secs(30);
+/// Bound a single frame write. A peer that advertises a zero receive window and
+/// stops reading would otherwise block `write_all` forever — and with the split
+/// connection's shared writer, that stalls every other request and the read
+/// loop's Pong. A write timeout means the egress frame stream is in an
+/// indeterminate state, so callers must treat it as a fatal connection error.
+const FRAME_WRITE_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// A live framed RLPx connection: the TCP stream plus the session's stateful
 /// [`FrameCodec`]. Read/write are serialized through `&mut self` (the codec is
@@ -115,13 +121,10 @@ impl RlpxConnection {
         )
     }
 
-    /// Frame and send one message.
+    /// Frame and send one message (bounded by [`FRAME_WRITE_TIMEOUT`]).
     pub async fn send(&mut self, message_code: u64, body: &[u8]) -> Result<(), String> {
         let frame = self.codec.encode_frame(message_code, body);
-        self.stream
-            .write_all(&frame)
-            .await
-            .map_err(|e| format!("rlpx write frame: {e}"))
+        write_frame(&mut self.stream, &frame).await
     }
 
     /// Read and decode the next frame. Blocks indefinitely waiting for the next
@@ -167,14 +170,21 @@ pub struct RlpxWriter {
 }
 
 impl RlpxWriter {
-    /// Frame and send one message.
+    /// Frame and send one message (bounded by [`FRAME_WRITE_TIMEOUT`]).
     pub async fn send(&mut self, message_code: u64, body: &[u8]) -> Result<(), String> {
         let frame = self.encoder.encode_frame(message_code, body);
-        self.write_half
-            .write_all(&frame)
-            .await
-            .map_err(|e| format!("rlpx write frame: {e}"))
+        write_frame(&mut self.write_half, &frame).await
     }
+}
+
+/// Write a full frame, bounded by [`FRAME_WRITE_TIMEOUT`]. A timeout leaves the
+/// egress stream mid-frame (the codec's MAC has already advanced), so it is a
+/// fatal error for the connection — the caller must not reuse the writer.
+async fn write_frame<W: AsyncWriteExt + Unpin>(w: &mut W, frame: &[u8]) -> Result<(), String> {
+    tokio::time::timeout(FRAME_WRITE_TIMEOUT, w.write_all(frame))
+        .await
+        .map_err(|_| "rlpx write frame timed out".to_string())?
+        .map_err(|e| format!("rlpx write frame: {e}"))
 }
 
 /// The read half of a split [`RlpxConnection`] — owns the ingress cipher/MAC.

--- a/rust/myotis-net/tests/live_managed_peer.rs
+++ b/rust/myotis-net/tests/live_managed_peer.rs
@@ -1,0 +1,243 @@
+//! Live-network integration test for EL-A7b-1: the managed-peer connection
+//! layer. Discovers mainnet peers, RLPx-dials, does the eth+snap handshake, then
+//! hands the connection to a [`ManagedPeer`] whose BACKGROUND read loop answers
+//! Ping and correlates responses.
+//!
+//! What this proves beyond `live_snap` (single-shot `EthSession`): the managed
+//! peer stays alive under the background loop — it fetches a verified account,
+//! then idles long enough for the peer to Ping us (answered by the loop, not a
+//! request path), then fetches AGAIN successfully. A single-shot session that
+//! ignored Pings while idle would be dropped by the peer; the managed peer is
+//! not.
+//!
+//! Run with:
+//! `cargo test -p myotis-net --test live_managed_peer -- --ignored --nocapture`
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use myotis_core::keccak::keccak256;
+use myotis_core::nodekey::NodeKey;
+use myotis_net::el::discv4::{Discv4Config, Discv4Service, TableEntry};
+use myotis_net::el::eth::session::{EthConfig, EthSession};
+use myotis_net::el::peer::ManagedPeer;
+use myotis_net::el::rlpx::transport::RlpxConnection;
+use myotis_net::el::snap::fetch::AccountOutcome;
+
+const MAINNET_BOOTNODES: &[&str] = &[
+    "18.138.108.67:30303",
+    "3.209.45.79:30303",
+    "18.188.214.86:30303",
+    "3.219.208.172:30303",
+];
+const MAINNET_GENESIS: &str = "d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3";
+const MAINNET_FORK_ID: [u8; 4] = [0x07, 0xc9, 0x46, 0x2e];
+const PROBE_ADDRESS_HEX: &str = "d8da6bf26964af9d7eed9e03e53415d37aa96045";
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "live network: managed peer stays alive across an idle Ping and serves twice"]
+async fn managed_peer_survives_idle_and_serves_twice() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info,myotis_net=debug".into()),
+        )
+        .try_init();
+
+    let key = Arc::new(NodeKey::from_secret_bytes(&keccak256(b"myotis-live-managed")).unwrap());
+    let bootnodes: Vec<SocketAddr> = MAINNET_BOOTNODES.iter().map(|s| s.parse().unwrap()).collect();
+    let genesis = hex32(MAINNET_GENESIS);
+
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<TableEntry>(256);
+    let discovery = Discv4Service::start(Arc::clone(&key), Discv4Config { bind_port: 0, bootnodes }, tx)
+        .await
+        .expect("discv4 start");
+
+    let cfg = Arc::new(EthConfig {
+        network_id: 1,
+        genesis_hash: genesis,
+        fork_id_hash: MAINNET_FORK_ID,
+        fork_next: 0,
+        head_hash: genesis,
+        head_number: 0,
+        listen_port: 30303,
+    });
+
+    let mut probe = [0u8; 20];
+    for (i, b) in probe.iter_mut().enumerate() {
+        *b = u8::from_str_radix(&PROBE_ADDRESS_HEX[i * 2..i * 2 + 2], 16).unwrap();
+    }
+    let probe = Arc::new(probe);
+
+    let mut handles = Vec::new();
+    let overall = tokio::time::Instant::now() + Duration::from_secs(150);
+    let mut tried = std::collections::HashSet::new();
+
+    while tokio::time::Instant::now() < overall && handles.len() < 200 {
+        let entry = match tokio::time::timeout(Duration::from_secs(5), rx.recv()).await {
+            Ok(Some(e)) => e,
+            _ => continue,
+        };
+        if entry.node_id.len() != 64 || entry.ip.len() != 4 || entry.tcp_port == 0 {
+            continue;
+        }
+        let Some(addr) = to_v4(&entry.ip, entry.tcp_port) else { continue };
+        if !tried.insert(addr) {
+            continue;
+        }
+        let mut peer_pubkey = [0u8; 64];
+        peer_pubkey.copy_from_slice(&entry.node_id);
+        let key = Arc::clone(&key);
+        let cfg = Arc::clone(&cfg);
+        let probe = Arc::clone(&probe);
+        handles.push(tokio::spawn(async move { try_peer(key, addr, peer_pubkey, &cfg, &probe).await }));
+        if handles.iter().filter(|h| !h.is_finished()).count() >= 32 {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    }
+
+    let mut reached_status = 0usize;
+    let mut served_twice = 0usize;
+    for h in handles {
+        if let Ok(o) = h.await {
+            reached_status += usize::from(o.reached_status);
+            served_twice += usize::from(o.served_twice);
+        }
+    }
+    discovery.stop().await;
+
+    eprintln!(
+        "[live_managed] {reached_status} Status exchanges, \
+         {served_twice} peers served a verified account twice across an idle gap"
+    );
+    // Reliably-provable milestone (matching live_snap): the eth handshake
+    // reaches the Status exchange. Surviving an idle Ping and serving twice
+    // additionally needs a current fork-id (EL-A7) + a snap node retaining
+    // recent state, so it's verified opportunistically and logged.
+    assert!(
+        reached_status > 0,
+        "eth handshake never reached the Status exchange with any peer in 150s"
+    );
+}
+
+#[derive(Default)]
+struct Outcome {
+    reached_status: bool,
+    served_twice: bool,
+}
+
+async fn try_peer(
+    key: Arc<NodeKey>,
+    addr: SocketAddr,
+    peer_pubkey: [u8; 64],
+    cfg: &EthConfig,
+    probe: &[u8; 20],
+) -> Outcome {
+    let mut outcome = Outcome::default();
+    let Ok(conn) = RlpxConnection::dial(Arc::clone(&key), addr, peer_pubkey).await else {
+        return outcome;
+    };
+    let session = match EthSession::handshake(conn, &key.public_key_bytes(), cfg).await {
+        Ok(s) => s,
+        Err(e) => {
+            if e.contains("incompatible peer") {
+                outcome.reached_status = true;
+            }
+            return outcome;
+        }
+    };
+    outcome.reached_status = true;
+    if !session.snap {
+        return outcome;
+    }
+
+    // Hand the connection to the managed peer — from here a background task
+    // reads frames, answers Ping, and correlates responses.
+    let peer = ManagedPeer::spawn(session);
+    eprintln!(
+        "[live_managed] snap READY with {addr}: eth/{} client={:?}",
+        peer.eth_version, peer.peer_hello.client_id
+    );
+
+    // First fetch: the peer's fresh head → its state root → a verified account.
+    let head_hash = peer.peer_status.best_hash;
+    let headers = match peer.get_block_headers_by_hash(&head_hash, 1).await {
+        Ok(h) if !h.is_empty() => h,
+        _ => return outcome,
+    };
+    let state_root = headers[0].header.state_root;
+    if state_root == [0u8; 32] {
+        return outcome;
+    }
+    if !fetch_ok(&peer, &state_root, probe, addr, "first").await {
+        return outcome;
+    }
+
+    // Idle past a typical peer Ping interval (geth pings ~15 s). The background
+    // loop must answer it; a session that ignored Pings would be disconnected.
+    tokio::time::sleep(Duration::from_secs(20)).await;
+    if peer.is_closed() {
+        eprintln!("[live_managed] {addr}: peer closed during the idle gap");
+        return outcome;
+    }
+
+    // Second fetch on the SAME connection proves it survived the idle Ping.
+    if fetch_ok(&peer, &state_root, probe, addr, "second").await {
+        outcome.served_twice = true;
+    }
+    outcome
+}
+
+/// Fetch + verify the probe account, logging the outcome. Returns whether the
+/// account verified (Present or Absent are both cryptographic verdicts).
+async fn fetch_ok(
+    peer: &ManagedPeer,
+    state_root: &[u8; 32],
+    probe: &[u8; 20],
+    addr: SocketAddr,
+    label: &str,
+) -> bool {
+    match peer.snap_get_account(state_root, probe).await {
+        Ok(AccountOutcome::Present(acct)) => {
+            eprintln!(
+                "[live_managed] {addr} {label} VERIFIED 0x{}: nonce={} balanceHex={}",
+                hex(probe),
+                acct.nonce,
+                hex(&acct.balance),
+            );
+            true
+        }
+        Ok(AccountOutcome::Absent) => {
+            eprintln!("[live_managed] {addr} {label}: probe verified ABSENT at this root");
+            true
+        }
+        Err(e) => {
+            eprintln!("[live_managed] {addr} {label} snap fetch failed: {e}");
+            false
+        }
+    }
+}
+
+fn to_v4(ip: &[u8], port: u32) -> Option<SocketAddr> {
+    if ip.len() != 4 || port == 0 || port > u32::from(u16::MAX) {
+        return None;
+    }
+    let mut o = [0u8; 4];
+    o.copy_from_slice(ip);
+    Some(SocketAddr::from((std::net::Ipv4Addr::from(o), port as u16)))
+}
+
+fn hex32(s: &str) -> [u8; 32] {
+    let v: Vec<u8> = (0..s.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&s[i..i + 2], 16).unwrap())
+        .collect();
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&v);
+    out
+}
+
+fn hex(b: &[u8]) -> String {
+    b.iter().map(|x| format!("{x:02x}")).collect()
+}


### PR DESCRIPTION
## What

First EL-A7b sub-PR: restructure the single-shot, one-request-at-a-time `EthSession` into a **background-driven managed peer**, so a live EL peer stays alive (answers p2p Ping while idle) and serves concurrent requests correlated by request id.

Because the RLPx frame codec's egress and ingress state are independent, the connection splits into reader/writer halves so a background read task runs concurrently with request sending.

## Changes

- **`frame.rs`** — split `FrameCodec` into `FrameEncoder` (egress cipher/MAC) and `FrameDecoder` (ingress cipher/MAC). `FrameCodec` composes both and exposes `split()`; `encode_frame`/`decode_header`/`decode_body` move to the halves and `FrameCodec` delegates (byte-identical behavior).
- **`transport.rs`** — `RlpxConnection::split() -> (RlpxReader, RlpxWriter, pubkey)` via `TcpStream::into_split()`; each half owns its frame-codec half. Frame writes are now bounded by `FRAME_WRITE_TIMEOUT` (30s).
- **`peer.rs`** (new) — `ManagedPeer` actor. `spawn(EthSession)` takes over the framed connection and starts a background read loop that:
  - answers p2p **Ping → Pong** (keeps the peer from dropping us on idle),
  - fails every in-flight request on **Disconnect** / read error,
  - answers inbound eth/snap **Get\*** with **empty** responses (a passive wallet serves no chain data),
  - **correlates** responses to waiting requests by `(reqId, code)`.

  Request methods take `&self` (shared `Arc<Mutex>` writer + atomic req-id counter) so several requests can be outstanding. Ports the verified-read verdicts (header-chain walk, snap account/storage/bytecode).
- **`eth/messages.rs`** — `encode_empty_response` (`[reqId, []]`).
- **`session.rs`** — `EthSession::into_parts()` hands the connection + negotiated metadata to `ManagedPeer`.
- **`live_managed_peer.rs`** (new, `#[ignore]`) — proves the managed peer survives an idle Ping (answered by the background loop) and serves a verified account **twice** across the idle gap.

## Tests

- Unit tests cover the reqId / empty-answer classifier; the frame split, decode, and **all EL conformance corpora** still pass (`cargo test -p myotis-net`: 73 lib + all `el_*_conformance` green).
- Live run reached 55 Status exchanges on mainnet; the twice-serve is opportunistic (gated on the fork-id pin + a snap node retaining recent state, same posture as `live_snap`).

## Review

Ran the mandatory internal no-context review of the diff before opening this PR. It confirmed no panics, no misdelivery, no crypto regression, and flagged two low-severity fail-closed robustness issues, both fixed in the second commit:
1. TOCTOU where a request enqueued exactly at disconnect would wait the full timeout — now `closed` is checked/set under the pending-map lock in both the request path and `fail_all`.
2. Unbounded frame write on the shared writer — now bounded by `FRAME_WRITE_TIMEOUT`, and a write failure marks the peer closed.

## Scope

This is the connection layer only. The PeerManager pool, `ExecAnchor`→`sync.rs` wiring, JNI natives + `RustChainHandle` plumbing, and the `-Pengine=rust` integration gate follow in later EL-A7b sub-PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)