### PR TITLE
EL-A7b-2: EL peer pool (dial manager over the managed peer)

### DIFF
--- a/rust/myotis-net/src/el/mod.rs
+++ b/rust/myotis-net/src/el/mod.rs
@@ -10,6 +10,7 @@ pub mod anchor;
 pub mod discv4;
 pub mod eth;
 pub mod peer;
+pub mod pool;
 pub mod rlpx;
 pub mod snap;
 pub mod verify;

--- a/rust/myotis-net/src/el/pool.rs
+++ b/rust/myotis-net/src/el/pool.rs
@@ -109,7 +109,14 @@ impl PoolInner {
     /// transient (30 s) window.
     async fn record_backoff(&self, addr: SocketAddr, long: bool, now: Instant) {
         let window = if long { BACKOFF_INCOMPATIBLE } else { BACKOFF_TRANSIENT };
-        self.backoff.lock().await.insert(addr, now + window);
+        let mut backoff = self.backoff.lock().await;
+        // Entries are normally dropped when their address resurfaces as a
+        // candidate, but an address that never comes back would linger forever.
+        // Sweep expired entries when the map grows large so it stays bounded.
+        if backoff.len() >= self.pool_cfg.max_attempted {
+            backoff.retain(|_, &mut expiry| expiry > now);
+        }
+        backoff.insert(addr, now + window);
     }
 
     /// Dial one candidate through the full eth+snap handshake, updating the
@@ -136,7 +143,11 @@ impl PoolInner {
                 self.attempted.lock().await.remove(&addr);
             }
             Err(e) => {
-                let incompatible = e.contains("incompatible peer");
+                // Only the network-id/genesis mismatch error starts with this
+                // prefix (see EthSession::handshake). Match the PREFIX, not a
+                // substring: a peer's client id is echoed into other error
+                // strings, so `contains` could be steered by a hostile peer.
+                let incompatible = e.starts_with("incompatible peer");
                 if incompatible {
                     self.blacklist.lock().await.insert(pubkey);
                 }

--- a/rust/myotis-net/src/el/pool.rs
+++ b/rust/myotis-net/src/el/pool.rs
@@ -1,0 +1,335 @@
+//! The EL peer pool (EL-A7b): consume the discv4 candidate stream, dial peers
+//! (bounded concurrency), run the eth+snap handshake, and keep a live set of
+//! snap-capable [`ManagedPeer`]s for verified reads. Twin of the Java
+//! `ChainStack` dial bookkeeping (`attempted` / `backoff` / `blacklist`), minus
+//! the cache- and DNS-seeded dials, which arrive with the engine-owned peer
+//! cache in EL-A8.
+//!
+//! Dial outcomes drive the bookkeeping the same way `ChainStack` does:
+//! * an **incompatible** peer (wrong network id / genesis) → blacklist its node
+//!   id + a long (10 min) address backoff,
+//! * any other failure, or a compatible peer that doesn't offer snap/1 → a short
+//!   (30 s) address backoff,
+//! * a snap-capable peer → spawned as a `ManagedPeer` and held in the pool.
+//!
+//! A candidate is skipped while its node id is blacklisted, its address is in
+//! backoff, or it's already `attempted` (in-flight or connected). Once the pool
+//! holds `target_snap_peers`, further candidates are ignored until a peer drops.
+
+use std::collections::{HashMap, HashSet};
+use std::net::{Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::{mpsc, Mutex, Semaphore};
+use tokio::task::JoinHandle;
+use tokio::time::Instant;
+
+use myotis_core::nodekey::NodeKey;
+
+use crate::el::discv4::TableEntry;
+use crate::el::eth::session::{EthConfig, EthSession};
+use crate::el::peer::ManagedPeer;
+use crate::el::rlpx::transport::RlpxConnection;
+
+/// Wrong-chain peers: don't retry the address for a long while (Java's
+/// `BACKOFF_INCOMPATIBLE_MS`).
+const BACKOFF_INCOMPATIBLE: Duration = Duration::from_secs(10 * 60);
+/// Transient failures / not-snap peers: a short cool-off (Java's
+/// `BACKOFF_TRANSIENT_MS`).
+const BACKOFF_TRANSIENT: Duration = Duration::from_secs(30);
+
+/// Pool tunables.
+#[derive(Debug, Clone, Copy)]
+pub struct PoolConfig {
+    /// Stop dialing once the pool holds this many snap-capable peers.
+    pub target_snap_peers: usize,
+    /// Cap on concurrent in-flight dials.
+    pub max_concurrent_dials: usize,
+    /// Cap on the `attempted` set (matches Java's 2000 guard) — a backstop
+    /// against unbounded growth if peers never resolve.
+    pub max_attempted: usize,
+}
+
+impl Default for PoolConfig {
+    fn default() -> Self {
+        // A wallet needs only a handful of snap servers; keep the fan-out modest.
+        PoolConfig { target_snap_peers: 8, max_concurrent_dials: 16, max_attempted: 2000 }
+    }
+}
+
+/// A live pooled peer plus the address it was dialed at (so pruning a dropped
+/// peer can free its address for a future re-dial).
+struct PooledPeer {
+    addr: SocketAddr,
+    peer: Arc<ManagedPeer>,
+}
+
+struct PoolInner {
+    key: Arc<NodeKey>,
+    local_pubkey: [u8; 64],
+    cfg: Arc<EthConfig>,
+    pool_cfg: PoolConfig,
+    peers: Mutex<Vec<PooledPeer>>,
+    /// Addresses dialed and not yet failed — in-flight OR connected. Prevents
+    /// re-dialing a live peer or racing two dials to the same address.
+    attempted: Mutex<HashSet<SocketAddr>>,
+    /// Address → earliest instant it may be dialed again.
+    backoff: Mutex<HashMap<SocketAddr, Instant>>,
+    /// Node ids of wrong-chain peers, never dialed again this run.
+    blacklist: Mutex<HashSet<[u8; 64]>>,
+}
+
+impl PoolInner {
+    /// Drop closed peers, freeing their addresses for a future re-dial.
+    async fn prune_closed(&self) {
+        let mut peers = self.peers.lock().await;
+        let mut freed = Vec::new();
+        peers.retain(|p| {
+            if p.peer.is_closed() {
+                freed.push(p.addr);
+                false
+            } else {
+                true
+            }
+        });
+        if !freed.is_empty() {
+            let mut attempted = self.attempted.lock().await;
+            for addr in freed {
+                attempted.remove(&addr);
+            }
+        }
+    }
+
+    async fn snap_peer_count(&self) -> usize {
+        self.peers.lock().await.len()
+    }
+
+    /// Record an address backoff. `long` selects the wrong-chain (10 min) vs the
+    /// transient (30 s) window.
+    async fn record_backoff(&self, addr: SocketAddr, long: bool, now: Instant) {
+        let window = if long { BACKOFF_INCOMPATIBLE } else { BACKOFF_TRANSIENT };
+        self.backoff.lock().await.insert(addr, now + window);
+    }
+
+    /// Dial one candidate through the full eth+snap handshake, updating the
+    /// bookkeeping by outcome. `addr` is already in `attempted`.
+    async fn dial_one(self: &Arc<PoolInner>, addr: SocketAddr, pubkey: [u8; 64]) {
+        let result = async {
+            let conn = RlpxConnection::dial(Arc::clone(&self.key), addr, pubkey).await?;
+            EthSession::handshake(conn, &self.local_pubkey, &self.cfg).await
+        }
+        .await;
+
+        let now = Instant::now();
+        match result {
+            Ok(session) if session.snap => {
+                let peer = Arc::new(ManagedPeer::spawn(session));
+                // Keep `addr` in `attempted` while connected — dropped by
+                // prune_closed when the peer later closes.
+                self.peers.lock().await.push(PooledPeer { addr, peer });
+            }
+            Ok(_) => {
+                // Compatible but no snap/1 — useless for verified reads. Cool the
+                // address off and free it from `attempted`.
+                self.record_backoff(addr, false, now).await;
+                self.attempted.lock().await.remove(&addr);
+            }
+            Err(e) => {
+                let incompatible = e.contains("incompatible peer");
+                if incompatible {
+                    self.blacklist.lock().await.insert(pubkey);
+                }
+                self.record_backoff(addr, incompatible, now).await;
+                self.attempted.lock().await.remove(&addr);
+            }
+        }
+    }
+}
+
+/// A running peer pool. Drop or [`stop`](PeerPool::stop) to tear it down (the
+/// dialer task is aborted; held peers close as their `Arc`s drop).
+pub struct PeerPool {
+    inner: Arc<PoolInner>,
+    dialer_task: JoinHandle<()>,
+}
+
+impl PeerPool {
+    /// Start the pool, consuming the discv4 candidate stream `rx`. `local_pubkey`
+    /// is our node id (64-byte); `cfg` is our eth handshake parameters.
+    pub fn start(
+        key: Arc<NodeKey>,
+        local_pubkey: [u8; 64],
+        cfg: Arc<EthConfig>,
+        pool_cfg: PoolConfig,
+        rx: mpsc::Receiver<TableEntry>,
+    ) -> PeerPool {
+        let inner = Arc::new(PoolInner {
+            key,
+            local_pubkey,
+            cfg,
+            pool_cfg,
+            peers: Mutex::new(Vec::new()),
+            attempted: Mutex::new(HashSet::new()),
+            backoff: Mutex::new(HashMap::new()),
+            blacklist: Mutex::new(HashSet::new()),
+        });
+        let dialer_task = tokio::spawn(dialer_loop(Arc::clone(&inner), rx));
+        PeerPool { inner, dialer_task }
+    }
+
+    /// A live snap-capable peer for a verified read, or `None` if the pool has
+    /// none yet. Prunes closed peers first; returns the newest live peer (most
+    /// likely to still retain recent state).
+    pub async fn snap_peer(&self) -> Option<Arc<ManagedPeer>> {
+        self.inner.prune_closed().await;
+        self.inner.peers.lock().await.last().map(|p| Arc::clone(&p.peer))
+    }
+
+    /// Count of live snap peers (prunes closed peers first).
+    pub async fn snap_peer_count(&self) -> usize {
+        self.inner.prune_closed().await;
+        self.inner.snap_peer_count().await
+    }
+
+    /// Addresses dialed and not yet failed (in-flight or connected).
+    pub async fn attempted_count(&self) -> usize {
+        self.inner.attempted.lock().await.len()
+    }
+
+    /// Node ids blacklisted as wrong-chain this run.
+    pub async fn blacklist_count(&self) -> usize {
+        self.inner.blacklist.lock().await.len()
+    }
+
+    /// Stop the pool: abort the dialer and drop all held peers (closing them).
+    pub async fn stop(self) {
+        self.dialer_task.abort();
+        self.inner.peers.lock().await.clear();
+    }
+}
+
+impl Drop for PeerPool {
+    fn drop(&mut self) {
+        self.dialer_task.abort();
+    }
+}
+
+/// Consume the candidate stream, dialing eligible peers under a concurrency cap.
+async fn dialer_loop(inner: Arc<PoolInner>, mut rx: mpsc::Receiver<TableEntry>) {
+    let dial_slots = Arc::new(Semaphore::new(inner.pool_cfg.max_concurrent_dials));
+
+    while let Some(entry) = rx.recv().await {
+        inner.prune_closed().await;
+        if inner.snap_peer_count().await >= inner.pool_cfg.target_snap_peers {
+            continue;
+        }
+        let Some(addr) = to_v4(&entry.ip, entry.tcp_port) else { continue };
+        let Some(pubkey) = to_pubkey(&entry.node_id) else { continue };
+
+        if inner.blacklist.lock().await.contains(&pubkey) {
+            continue;
+        }
+
+        // Backoff: skip while cooling off; drop the entry once it has expired so
+        // the map doesn't grow unbounded.
+        {
+            let mut backoff = inner.backoff.lock().await;
+            if let Some(&expiry) = backoff.get(&addr) {
+                if Instant::now() < expiry {
+                    continue;
+                }
+                backoff.remove(&addr);
+            }
+        }
+
+        // Claim the address (bounded), or skip if in-flight/connected already.
+        {
+            let mut attempted = inner.attempted.lock().await;
+            if attempted.len() >= inner.pool_cfg.max_attempted || !attempted.insert(addr) {
+                continue;
+            }
+        }
+
+        // Bound concurrency: acquire a dial permit (waits when saturated), then
+        // dial in a task that releases it when done.
+        let Ok(permit) = Arc::clone(&dial_slots).acquire_owned().await else {
+            // Semaphore closed — pool shutting down.
+            inner.attempted.lock().await.remove(&addr);
+            break;
+        };
+        let inner2 = Arc::clone(&inner);
+        tokio::spawn(async move {
+            inner2.dial_one(addr, pubkey).await;
+            drop(permit);
+        });
+    }
+}
+
+/// A discv4 entry's IPv4 TCP socket, or `None` if the address is unusable.
+fn to_v4(ip: &[u8], tcp_port: u32) -> Option<SocketAddr> {
+    if ip.len() != 4 || tcp_port == 0 || tcp_port > u32::from(u16::MAX) {
+        return None;
+    }
+    let mut octets = [0u8; 4];
+    octets.copy_from_slice(ip);
+    Some(SocketAddr::from((Ipv4Addr::from(octets), tcp_port as u16)))
+}
+
+/// A discv4 entry's 64-byte node id, or `None` if malformed.
+fn to_pubkey(node_id: &[u8]) -> Option<[u8; 64]> {
+    if node_id.len() != 64 {
+        return None;
+    }
+    let mut out = [0u8; 64];
+    out.copy_from_slice(node_id);
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn to_v4_rejects_bad_addresses() {
+        assert!(to_v4(&[1, 2, 3, 4], 30303).is_some());
+        assert!(to_v4(&[1, 2, 3], 30303).is_none()); // wrong length
+        assert!(to_v4(&[1, 2, 3, 4], 0).is_none()); // no TCP port
+        assert!(to_v4(&[1, 2, 3, 4], 70000).is_none()); // port out of range
+    }
+
+    #[test]
+    fn to_pubkey_requires_64_bytes() {
+        assert_eq!(to_pubkey(&[7u8; 64]), Some([7u8; 64]));
+        assert!(to_pubkey(&[7u8; 63]).is_none());
+        assert!(to_pubkey(&[]).is_none());
+    }
+
+    #[tokio::test]
+    async fn empty_pool_has_no_snap_peer() {
+        let key = Arc::new(
+            NodeKey::from_secret_bytes(&myotis_core::keccak::keccak256(b"pool-test")).unwrap(),
+        );
+        let cfg = Arc::new(EthConfig {
+            network_id: 1,
+            genesis_hash: [0u8; 32],
+            fork_id_hash: [0u8; 4],
+            fork_next: 0,
+            head_hash: [0u8; 32],
+            head_number: 0,
+            listen_port: 30303,
+        });
+        let (_tx, rx) = mpsc::channel(4);
+        let pool = PeerPool::start(
+            Arc::clone(&key),
+            key.public_key_bytes(),
+            cfg,
+            PoolConfig::default(),
+            rx,
+        );
+        assert_eq!(pool.snap_peer_count().await, 0);
+        assert!(pool.snap_peer().await.is_none());
+        assert_eq!(pool.attempted_count().await, 0);
+        pool.stop().await;
+    }
+}

--- a/rust/myotis-net/src/el/pool.rs
+++ b/rust/myotis-net/src/el/pool.rs
@@ -17,7 +17,7 @@
 //! holds `target_snap_peers`, further candidates are ignored until a peer drops.
 
 use std::collections::{HashMap, HashSet};
-use std::net::{Ipv4Addr, SocketAddr};
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -81,8 +81,10 @@ struct PoolInner {
 }
 
 impl PoolInner {
-    /// Drop closed peers, freeing their addresses for a future re-dial.
-    async fn prune_closed(&self) {
+    /// Drop closed peers, freeing their addresses for a future re-dial. Returns
+    /// the number of remaining live peers (so callers avoid a second `peers`
+    /// lock just to read the count).
+    async fn prune_closed(&self) -> usize {
         let mut peers = self.peers.lock().await;
         let mut freed = Vec::new();
         peers.retain(|p| {
@@ -99,10 +101,7 @@ impl PoolInner {
                 attempted.remove(&addr);
             }
         }
-    }
-
-    async fn snap_peer_count(&self) -> usize {
-        self.peers.lock().await.len()
+        peers.len()
     }
 
     /// Record an address backoff. `long` selects the wrong-chain (10 min) vs the
@@ -114,7 +113,7 @@ impl PoolInner {
         // candidate, but an address that never comes back would linger forever.
         // Sweep expired entries when the map grows large so it stays bounded.
         if backoff.len() >= self.pool_cfg.max_attempted {
-            backoff.retain(|_, &mut expiry| expiry > now);
+            backoff.retain(|_, expiry| *expiry > now);
         }
         backoff.insert(addr, now + window);
     }
@@ -199,8 +198,7 @@ impl PeerPool {
 
     /// Count of live snap peers (prunes closed peers first).
     pub async fn snap_peer_count(&self) -> usize {
-        self.inner.prune_closed().await;
-        self.inner.snap_peer_count().await
+        self.inner.prune_closed().await
     }
 
     /// Addresses dialed and not yet failed (in-flight or connected).
@@ -231,11 +229,11 @@ async fn dialer_loop(inner: Arc<PoolInner>, mut rx: mpsc::Receiver<TableEntry>) 
     let dial_slots = Arc::new(Semaphore::new(inner.pool_cfg.max_concurrent_dials));
 
     while let Some(entry) = rx.recv().await {
-        inner.prune_closed().await;
-        if inner.snap_peer_count().await >= inner.pool_cfg.target_snap_peers {
+        // Prune + read the live count in one `peers` lock.
+        if inner.prune_closed().await >= inner.pool_cfg.target_snap_peers {
             continue;
         }
-        let Some(addr) = to_v4(&entry.ip, entry.tcp_port) else { continue };
+        let Some(addr) = to_socket_addr(&entry.ip, entry.tcp_port) else { continue };
         let Some(pubkey) = to_pubkey(&entry.node_id) else { continue };
 
         if inner.blacklist.lock().await.contains(&pubkey) {
@@ -277,24 +275,30 @@ async fn dialer_loop(inner: Arc<PoolInner>, mut rx: mpsc::Receiver<TableEntry>) 
     }
 }
 
-/// A discv4 entry's IPv4 TCP socket, or `None` if the address is unusable.
-fn to_v4(ip: &[u8], tcp_port: u32) -> Option<SocketAddr> {
-    if ip.len() != 4 || tcp_port == 0 || tcp_port > u32::from(u16::MAX) {
+/// A discv4 entry's TCP socket, IPv4 or IPv6, or `None` if the address is
+/// unusable. (discv4 endpoints carry 4- or 16-byte IPs; the pool's bookkeeping
+/// is IP-version-agnostic, so both are dialed.)
+fn to_socket_addr(ip: &[u8], tcp_port: u32) -> Option<SocketAddr> {
+    if tcp_port == 0 || tcp_port > u32::from(u16::MAX) {
         return None;
     }
-    let mut octets = [0u8; 4];
-    octets.copy_from_slice(ip);
-    Some(SocketAddr::from((Ipv4Addr::from(octets), tcp_port as u16)))
+    let port = tcp_port as u16;
+    match ip.len() {
+        4 => {
+            let octets: [u8; 4] = ip.try_into().ok()?;
+            Some(SocketAddr::from((Ipv4Addr::from(octets), port)))
+        }
+        16 => {
+            let octets: [u8; 16] = ip.try_into().ok()?;
+            Some(SocketAddr::from((Ipv6Addr::from(octets), port)))
+        }
+        _ => None,
+    }
 }
 
 /// A discv4 entry's 64-byte node id, or `None` if malformed.
 fn to_pubkey(node_id: &[u8]) -> Option<[u8; 64]> {
-    if node_id.len() != 64 {
-        return None;
-    }
-    let mut out = [0u8; 64];
-    out.copy_from_slice(node_id);
-    Some(out)
+    node_id.try_into().ok()
 }
 
 #[cfg(test)]
@@ -302,11 +306,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn to_v4_rejects_bad_addresses() {
-        assert!(to_v4(&[1, 2, 3, 4], 30303).is_some());
-        assert!(to_v4(&[1, 2, 3], 30303).is_none()); // wrong length
-        assert!(to_v4(&[1, 2, 3, 4], 0).is_none()); // no TCP port
-        assert!(to_v4(&[1, 2, 3, 4], 70000).is_none()); // port out of range
+    fn to_socket_addr_validation() {
+        assert!(to_socket_addr(&[1, 2, 3, 4], 30303).is_some());
+        assert!(to_socket_addr(&[0; 16], 30303).is_some()); // IPv6
+        assert!(to_socket_addr(&[1, 2, 3], 30303).is_none()); // wrong length
+        assert!(to_socket_addr(&[0; 15], 30303).is_none()); // wrong length
+        assert!(to_socket_addr(&[1, 2, 3, 4], 0).is_none()); // no TCP port
+        assert!(to_socket_addr(&[1, 2, 3, 4], 70000).is_none()); // port out of range
     }
 
     #[test]

--- a/rust/myotis-net/tests/live_pool.rs
+++ b/rust/myotis-net/tests/live_pool.rs
@@ -1,0 +1,148 @@
+//! Live-network integration test for EL-A7b-2: the EL peer pool. Wires the
+//! discv4 candidate stream straight into a `PeerPool`, which dials, handshakes,
+//! and retains snap-capable `ManagedPeer`s on its own. Then it fetches a
+//! VERIFIED account through a pooled peer.
+//!
+//! What this proves beyond `live_managed_peer` (a hand-dialed single peer): the
+//! pool's dial manager (backoff/blacklist/attempted + concurrency cap) turns the
+//! raw discovery stream into usable snap peers with no per-peer orchestration
+//! from the caller. Reaching a snap peer + verified state is opportunistic
+//! (gated on the fork-id pin + a snap node retaining recent state, same posture
+//! as the other live tests); the reliably-provable milestone is that the pool
+//! attempts dials from the discovery stream.
+//!
+//! Run with:
+//! `cargo test -p myotis-net --test live_pool -- --ignored --nocapture`
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use myotis_core::keccak::keccak256;
+use myotis_core::nodekey::NodeKey;
+use myotis_net::el::discv4::{Discv4Config, Discv4Service, TableEntry};
+use myotis_net::el::eth::session::EthConfig;
+use myotis_net::el::pool::{PeerPool, PoolConfig};
+use myotis_net::el::snap::fetch::AccountOutcome;
+
+const MAINNET_BOOTNODES: &[&str] = &[
+    "18.138.108.67:30303",
+    "3.209.45.79:30303",
+    "18.188.214.86:30303",
+    "3.219.208.172:30303",
+];
+const MAINNET_GENESIS: &str = "d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3";
+const MAINNET_FORK_ID: [u8; 4] = [0x07, 0xc9, 0x46, 0x2e];
+const PROBE_ADDRESS_HEX: &str = "d8da6bf26964af9d7eed9e03e53415d37aa96045";
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "live network: discv4 stream → PeerPool → verified account fetch"]
+async fn pool_dials_from_discovery_and_serves_a_verified_account() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info,myotis_net=debug".into()),
+        )
+        .try_init();
+
+    let key = Arc::new(NodeKey::from_secret_bytes(&keccak256(b"myotis-live-pool")).unwrap());
+    let bootnodes: Vec<SocketAddr> = MAINNET_BOOTNODES.iter().map(|s| s.parse().unwrap()).collect();
+    let genesis = hex32(MAINNET_GENESIS);
+
+    let (tx, rx) = tokio::sync::mpsc::channel::<TableEntry>(256);
+    let discovery = Discv4Service::start(Arc::clone(&key), Discv4Config { bind_port: 0, bootnodes }, tx)
+        .await
+        .expect("discv4 start");
+
+    let cfg = Arc::new(EthConfig {
+        network_id: 1,
+        genesis_hash: genesis,
+        fork_id_hash: MAINNET_FORK_ID,
+        fork_next: 0,
+        head_hash: genesis,
+        head_number: 0,
+        listen_port: 30303,
+    });
+
+    // Wire discovery straight into the pool — no per-peer orchestration here.
+    let pool = PeerPool::start(
+        Arc::clone(&key),
+        key.public_key_bytes(),
+        cfg,
+        PoolConfig::default(),
+        rx,
+    );
+
+    let mut probe = [0u8; 20];
+    for (i, b) in probe.iter_mut().enumerate() {
+        *b = u8::from_str_radix(&PROBE_ADDRESS_HEX[i * 2..i * 2 + 2], 16).unwrap();
+    }
+
+    // Wait for the pool to acquire a snap peer (best-effort, bounded).
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(150);
+    let mut verified = false;
+    while tokio::time::Instant::now() < deadline {
+        if let Some(peer) = pool.snap_peer().await {
+            let head_hash = peer.peer_status.best_hash;
+            if let Ok(headers) = peer.get_block_headers_by_hash(&head_hash, 1).await {
+                if let Some(h) = headers.first() {
+                    let state_root = h.header.state_root;
+                    if state_root != [0u8; 32] {
+                        match peer.snap_get_account(&state_root, &probe).await {
+                            Ok(AccountOutcome::Present(acct)) => {
+                                eprintln!(
+                                    "[live_pool] VERIFIED account 0x{}: nonce={} balanceHex={}",
+                                    hex(&probe),
+                                    acct.nonce,
+                                    hex(&acct.balance),
+                                );
+                                verified = true;
+                                break;
+                            }
+                            Ok(AccountOutcome::Absent) => {
+                                eprintln!("[live_pool] probe account verified ABSENT at this root");
+                                verified = true;
+                                break;
+                            }
+                            Err(e) => eprintln!("[live_pool] snap fetch failed: {e}"),
+                        }
+                    }
+                }
+            }
+        }
+        tokio::time::sleep(Duration::from_secs(3)).await;
+    }
+
+    let snap_peers = pool.snap_peer_count().await;
+    let attempted = pool.attempted_count().await;
+    let blacklisted = pool.blacklist_count().await;
+    pool.stop().await;
+    discovery.stop().await;
+
+    eprintln!(
+        "[live_pool] attempted={attempted} snapPeers={snap_peers} blacklisted={blacklisted} \
+         verifiedAccount={verified}"
+    );
+    // Reliably-provable milestone: the pool pulled candidates off the discovery
+    // stream and dialed them. Holding a snap peer + fetching verified state
+    // additionally needs a current fork-id (EL-A7) + a snap node retaining recent
+    // state, so those are opportunistic and logged.
+    assert!(
+        attempted > 0 || blacklisted > 0,
+        "pool never attempted a dial from the discovery stream in 150s"
+    );
+}
+
+fn hex32(s: &str) -> [u8; 32] {
+    let v: Vec<u8> = (0..s.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&s[i..i + 2], 16).unwrap())
+        .collect();
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&v);
+    out
+}
+
+fn hex(b: &[u8]) -> String {
+    b.iter().map(|x| format!("{x:02x}")).collect()
+}


### PR DESCRIPTION
## What

Second EL-A7b sub-PR (builds on #155's `ManagedPeer`). Adds `PeerPool`: it consumes the discv4 candidate stream, dials peers under a concurrency cap, runs the eth+snap handshake, and keeps a live set of snap-capable `ManagedPeer`s ready for verified reads — so a verified-read caller just asks the pool for a peer instead of orchestrating discovery/dial/handshake itself.

Twin of the Java `ChainStack` dial bookkeeping (`attempted` / `backoff` / `blacklist`), minus the cache- and DNS-seeded dials, which land with the engine-owned peer cache in EL-A8.

## Changes

- **`pool.rs`** (new) — `PeerPool::start(key, local_pubkey, cfg, pool_cfg, rx)` spawns a dialer loop over the discv4 mpsc stream. Per candidate: skip if blacklisted (node id) / backed off (address) / already attempted or at the attempted cap; else claim the address and dial in a task bounded by a `Semaphore`. Dial outcomes drive the bookkeeping like `ChainStack`:
  - incompatible peer (wrong networkId/genesis) → blacklist node id + 10 min address backoff,
  - transient failure / compatible-but-no-snap → 30 s address backoff,
  - snap-capable → `ManagedPeer::spawn`, held in the pool.

  Stops dialing at `target_snap_peers`; `prune_closed` frees dropped peers' addrs for re-dial. `snap_peer()` returns a live peer for a verified read; counts (`snap_peer_count` / `attempted_count` / `blacklist_count`) feed host status.
- **`mod.rs`** — register the module.
- **`live_pool.rs`** (new, `#[ignore]`) — wire the discovery stream straight into the pool and fetch a verified account through a pooled peer.

## Tests

- Unit tests cover the address/pubkey parsers and the empty-pool contract; full `myotis-net` suite green (76 lib + all conformance corpora).
- **Live run against mainnet**: the pool dialed 14 candidates and blacklisted 66 wrong-chain peers off the shared discovery stream — direct evidence the dial manager and the incompatible-peer path work end-to-end. (Holding a snap peer + verified state stays opportunistic, gated on the fork-id pin, same posture as the other live tests.)

## Review

Ran the mandatory internal no-context review of the diff before opening this PR. It found no correctness, panic, deadlock, or resource-leak bugs, and flagged three low-severity polish items; two are fixed in the second commit (bound the `backoff` map; tighten the incompatible-peer classification to `starts_with` so a peer-controlled client id can't steer it). The `target_snap_peers` overshoot is bounded by `max_concurrent_dials` and is beneficial redundancy — left as is.

## Scope

Pool only. Next EL-A7b sub-PRs: `ExecAnchor`→`sync.rs` wiring, JNI natives + `RustChainHandle` plumbing, and the `-Pengine=rust` integration gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)