### PR TITLE
EL-A7b-4b: engine EL host + verified-read natives (JSON, dormant ABI)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2073,6 +2073,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
  "tracing-subscriber",
 ]
 

--- a/rust/myotis-engine/Cargo.toml
+++ b/rust/myotis-engine/Cargo.toml
@@ -25,4 +25,5 @@ serde_json = "1"
 # Global tracing subscriber feeding the drainable ring buffer behind
 # nativeDrainLogs — the on-device observability seam (Rust logs were
 # invisible on Android; hosts pump the drain into their own log pipeline).
+tracing = "=0.1.44"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/rust/myotis-engine/src/eljson.rs
+++ b/rust/myotis-engine/src/eljson.rs
@@ -35,8 +35,13 @@ pub fn account_json(
     let mut obj = serde_json::Map::new();
     obj.insert("address".into(), address_echo.into());
     obj.insert("exists".into(), a.exists.into());
-    // Java convention: nonce -1 and balance null when the account is absent.
-    obj.insert("nonce".into(), if a.exists { json_i64(a.nonce as i64) } else { json_i64(-1) });
+    // Java convention: nonce -1 and balance null when the account is absent. On
+    // the (unrealistic) chance a nonce exceeds i64::MAX, saturate rather than
+    // wrap — a wrap to -1 would collide with the absent sentinel.
+    obj.insert(
+        "nonce".into(),
+        if a.exists { json_i64(i64::try_from(a.nonce).unwrap_or(i64::MAX)) } else { json_i64(-1) },
+    );
     obj.insert(
         "balanceWei".into(),
         if a.exists { be_to_decimal(&a.balance).into() } else { serde_json::Value::Null },

--- a/rust/myotis-engine/src/eljson.rs
+++ b/rust/myotis-engine/src/eljson.rs
@@ -130,10 +130,12 @@ fn hex0x(bytes: &[u8; 32]) -> String {
 
 /// Variable-length bytes as `0x`-prefixed lowercase hex.
 fn hex0x_var(bytes: &[u8]) -> String {
+    use std::fmt::Write;
     let mut s = String::with_capacity(2 + bytes.len() * 2);
     s.push_str("0x");
     for b in bytes {
-        s.push_str(&format!("{b:02x}"));
+        // Append directly into the buffer — no per-byte String allocation.
+        let _ = write!(s, "{b:02x}");
     }
     s
 }

--- a/rust/myotis-engine/src/eljson.rs
+++ b/rust/myotis-engine/src/eljson.rs
@@ -1,0 +1,309 @@
+//! Pure JSON serializers for the EL verified-read natives — the golden contract
+//! the Java `RustChainHandle` parses into `AccountProofResult` /
+//! `StorageProofResult`. Hand-built (not serde derive) so the key set + shape is
+//! the pinned contract both sides' tests assert.
+//!
+//! A successful query serializes the full result object. A transport/no-peer
+//! failure (NOT a verification failure — those are reported in `failReason`)
+//! serializes `{"error": "..."}`, which the Java side raises as an
+//! `EngineException`.
+
+use myotis_net::el::reader::{VerifiedAccount, VerifiedStorage};
+
+/// The header-chain gap cap the ladder enforces (mirrors the Java
+/// `VerifiedAccountQuery.MAX_HEADER_CHAIN_GAP`), echoed in the storage result's
+/// diagnostics.
+const MAX_HEADER_CHAIN_GAP: i64 = 8192;
+
+/// `{"error": "..."}` — a transport / not-running / bad-input failure the Java
+/// side turns into an `EngineException` (distinct from a verification failure,
+/// which is a full result with `failReason` set).
+pub fn error_json(message: &str) -> String {
+    let mut obj = serde_json::Map::new();
+    obj.insert("error".into(), message.into());
+    serde_json::Value::Object(obj).to_string()
+}
+
+/// Serialize a verified account result to the `AccountProofResult` shape.
+/// `address_echo` is the address exactly as the caller supplied it.
+pub fn account_json(
+    address_echo: &str,
+    a: &VerifiedAccount,
+    finalized_period: u64,
+    wall_clock_period: u64,
+) -> String {
+    let mut obj = serde_json::Map::new();
+    obj.insert("address".into(), address_echo.into());
+    obj.insert("exists".into(), a.exists.into());
+    // Java convention: nonce -1 and balance null when the account is absent.
+    obj.insert("nonce".into(), if a.exists { json_i64(a.nonce as i64) } else { json_i64(-1) });
+    obj.insert(
+        "balanceWei".into(),
+        if a.exists { be_to_decimal(&a.balance).into() } else { serde_json::Value::Null },
+    );
+    obj.insert("storageRootHex".into(), hex0x(&a.storage_root).into());
+    obj.insert("codeHashHex".into(), hex0x(&a.code_hash).into());
+    obj.insert("blockNumber".into(), json_u64(a.block_number));
+    obj.insert("peerStateRootHex".into(), hex0x(&a.peer_state_root).into());
+    obj.insert("peerProofValid".into(), a.peer_proof_valid.into());
+    obj.insert("beaconChainVerified".into(), a.beacon_chain_verified.into());
+    obj.insert("blsVerified".into(), a.bls_verified.into());
+    obj.insert("matchedBeaconSlot".into(), json_i64(a.matched_beacon_slot));
+    obj.insert("verifyMethod".into(), opt_str(a.verify_method));
+    obj.insert("failReason".into(), opt_str(a.fail_reason));
+    obj.insert("accountHashHex".into(), hex0x(&a.account_hash).into());
+    // proofNodesHex: the proof-node echo is a diagnostic, not part of the trust
+    // path (the proof is verified inside snap_get_account before this result
+    // exists). Threading the raw nodes out is deferred; emit an empty array.
+    obj.insert("proofNodesHex".into(), serde_json::Value::Array(Vec::new()));
+    obj.insert("beaconSynced".into(), a.beacon_synced.into());
+    obj.insert("finalizedPeriod".into(), json_u64(finalized_period));
+    obj.insert("wallClockPeriod".into(), json_u64(wall_clock_period));
+    obj.insert("finalizedBlockNumber".into(), json_u64(a.finalized_block_number));
+    obj.insert("optimisticBlockNumber".into(), json_u64(a.optimistic_block_number));
+    serde_json::Value::Object(obj).to_string()
+}
+
+/// Serialize a verified storage result to the `StorageProofResult` shape.
+pub fn storage_json(
+    address_echo: &str,
+    holder_echo: Option<&str>,
+    s: &VerifiedStorage,
+    finalized_slot: u64,
+    optimistic_slot: u64,
+) -> String {
+    let mut obj = serde_json::Map::new();
+    obj.insert("addressHex".into(), address_echo.into());
+    obj.insert("slot".into(), json_u64(s.slot));
+    obj.insert("holderHex".into(), holder_echo.map(Into::into).unwrap_or(serde_json::Value::Null));
+    obj.insert("storageKeyHex".into(), hex0x(&s.storage_key).into());
+    obj.insert("storageKeyHashHex".into(), hex0x(&s.slot_key_hash).into());
+    obj.insert("exists".into(), s.found.into());
+    obj.insert(
+        "valueHex".into(),
+        if s.found { hex0x_var(&s.value).into() } else { serde_json::Value::Null },
+    );
+    obj.insert(
+        "valueDecimal".into(),
+        if s.found { be_to_decimal(&s.value).into() } else { serde_json::Value::Null },
+    );
+    obj.insert("slotsReturned".into(), json_i64(if s.found { 1 } else { 0 }));
+    obj.insert("storageRootHex".into(), hex0x(&s.storage_root).into());
+    obj.insert("proofNodesHex".into(), serde_json::Value::Array(Vec::new()));
+    obj.insert("storageProofValid".into(), s.storage_proof_valid.into());
+    obj.insert("beaconSynced".into(), s.beacon_synced.into());
+    obj.insert("beaconChainVerified".into(), s.beacon_chain_verified.into());
+    obj.insert("blsVerified".into(), s.bls_verified.into());
+    obj.insert("matchedBeaconSlot".into(), json_i64(s.matched_beacon_slot));
+    obj.insert("verifyMethod".into(), opt_str(s.verify_method));
+    obj.insert("failReason".into(), opt_str(s.fail_reason));
+    obj.insert("peerBlockNumber".into(), json_u64(s.block_number));
+    obj.insert("finalizedBlockNumber".into(), json_u64(s.finalized_block_number));
+    obj.insert("optimisticBlockNumber".into(), json_u64(s.optimistic_block_number));
+    obj.insert("finalizedSlot".into(), json_u64(finalized_slot));
+    obj.insert("optimisticSlot".into(), json_u64(optimistic_slot));
+    obj.insert("maxHeaderChainGap".into(), json_i64(MAX_HEADER_CHAIN_GAP));
+    serde_json::Value::Object(obj).to_string()
+}
+
+fn opt_str(v: Option<&'static str>) -> serde_json::Value {
+    v.map(Into::into).unwrap_or(serde_json::Value::Null)
+}
+
+fn json_u64(v: u64) -> serde_json::Value {
+    serde_json::Value::Number(v.into())
+}
+
+fn json_i64(v: i64) -> serde_json::Value {
+    serde_json::Value::Number(v.into())
+}
+
+/// A 32-byte hash as `0x`-prefixed lowercase hex.
+fn hex0x(bytes: &[u8; 32]) -> String {
+    hex0x_var(bytes)
+}
+
+/// Variable-length bytes as `0x`-prefixed lowercase hex.
+fn hex0x_var(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(2 + bytes.len() * 2);
+    s.push_str("0x");
+    for b in bytes {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+/// Big-endian bytes → base-10 decimal string (schoolbook division by 10; no
+/// bignum dep). Empty / all-zero → "0".
+fn be_to_decimal(bytes: &[u8]) -> String {
+    // Strip leading zero bytes.
+    let start = bytes.iter().position(|&b| b != 0).unwrap_or(bytes.len());
+    let digits = &bytes[start..];
+    if digits.is_empty() {
+        return "0".to_string();
+    }
+    let mut value = digits.to_vec();
+    let mut out = Vec::new();
+    while value.iter().any(|&b| b != 0) {
+        let mut remainder = 0u16;
+        for byte in value.iter_mut() {
+            let acc = (remainder << 8) | u16::from(*byte);
+            *byte = (acc / 10) as u8;
+            remainder = acc % 10;
+        }
+        out.push(b'0' + remainder as u8);
+    }
+    out.reverse();
+    String::from_utf8(out).unwrap_or_else(|_| "0".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use myotis_net::el::reader::{VerifiedAccount, VerifiedStorage};
+
+    fn sample_account() -> VerifiedAccount {
+        VerifiedAccount {
+            address: [0x11; 20],
+            account_hash: [0x22; 32],
+            exists: true,
+            nonce: 5898,
+            // 6.6 ETH ≈ 6_600_000_000_000_000_000 wei = 0x5b9b7c... ; use a round value.
+            balance: 1_000_000_000_000_000_000u64.to_be_bytes().to_vec(),
+            storage_root: [0x33; 32],
+            code_hash: [0x44; 32],
+            block_number: 21_000_000,
+            peer_state_root: [0x55; 32],
+            peer_proof_valid: true,
+            beacon_chain_verified: true,
+            bls_verified: true,
+            matched_beacon_slot: 7_000_000,
+            verify_method: Some("headerChain"),
+            fail_reason: None,
+            beacon_synced: true,
+            finalized_block_number: 20_999_000,
+            optimistic_block_number: 21_000_010,
+        }
+    }
+
+    #[test]
+    fn account_json_shape_and_values() {
+        let json = account_json("0xabc", &sample_account(), 1777, 1795);
+        let v: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+        assert_eq!(v["address"], "0xabc");
+        assert_eq!(v["exists"], true);
+        assert_eq!(v["nonce"], 5898);
+        assert_eq!(v["balanceWei"], "1000000000000000000");
+        assert_eq!(v["storageRootHex"], hex0x(&[0x33; 32]));
+        assert_eq!(v["codeHashHex"], hex0x(&[0x44; 32]));
+        assert_eq!(v["blockNumber"], 21_000_000);
+        assert_eq!(v["peerStateRootHex"], hex0x(&[0x55; 32]));
+        assert_eq!(v["peerProofValid"], true);
+        assert_eq!(v["beaconChainVerified"], true);
+        assert_eq!(v["blsVerified"], true);
+        assert_eq!(v["matchedBeaconSlot"], 7_000_000);
+        assert_eq!(v["verifyMethod"], "headerChain");
+        assert_eq!(v["failReason"], serde_json::Value::Null);
+        assert_eq!(v["accountHashHex"], hex0x(&[0x22; 32]));
+        assert!(v["proofNodesHex"].is_array());
+        assert_eq!(v["beaconSynced"], true);
+        assert_eq!(v["finalizedPeriod"], 1777);
+        assert_eq!(v["wallClockPeriod"], 1795);
+        assert_eq!(v["finalizedBlockNumber"], 20_999_000);
+        assert_eq!(v["optimisticBlockNumber"], 21_000_010);
+    }
+
+    #[test]
+    fn absent_account_uses_negative_one_and_null() {
+        let mut a = sample_account();
+        a.exists = false;
+        let v: serde_json::Value =
+            serde_json::from_str(&account_json("0x0", &a, 1, 1)).unwrap();
+        assert_eq!(v["exists"], false);
+        assert_eq!(v["nonce"], -1);
+        assert_eq!(v["balanceWei"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn failed_verdict_carries_tokens_not_error() {
+        let mut a = sample_account();
+        a.beacon_chain_verified = false;
+        a.bls_verified = false;
+        a.verify_method = None;
+        a.fail_reason = Some("beaconNotSynced");
+        a.matched_beacon_slot = -1;
+        let v: serde_json::Value =
+            serde_json::from_str(&account_json("0x0", &a, 1, 1)).unwrap();
+        assert!(v.get("error").is_none());
+        assert_eq!(v["verifyMethod"], serde_json::Value::Null);
+        assert_eq!(v["failReason"], "beaconNotSynced");
+        assert_eq!(v["matchedBeaconSlot"], -1);
+    }
+
+    #[test]
+    fn storage_json_shape() {
+        let s = VerifiedStorage {
+            address: [0x11; 20],
+            slot: 3,
+            holder: None,
+            storage_key: {
+                let mut k = [0u8; 32];
+                k[31] = 3;
+                k
+            },
+            slot_key_hash: [0x66; 32],
+            found: true,
+            value: vec![0x2a],
+            storage_root: [0x33; 32],
+            storage_proof_valid: true,
+            block_number: 21_000_000,
+            peer_state_root: [0x55; 32],
+            beacon_chain_verified: true,
+            bls_verified: true,
+            matched_beacon_slot: 7_000_000,
+            verify_method: Some("headerChain"),
+            fail_reason: None,
+            beacon_synced: true,
+            finalized_block_number: 20_999_000,
+            optimistic_block_number: 21_000_010,
+        };
+        let v: serde_json::Value =
+            serde_json::from_str(&storage_json("0xC0", None, &s, 14_560_000, 14_560_032)).unwrap();
+        assert_eq!(v["addressHex"], "0xC0");
+        assert_eq!(v["slot"], 3);
+        assert_eq!(v["holderHex"], serde_json::Value::Null);
+        assert_eq!(v["exists"], true);
+        assert_eq!(v["valueHex"], "0x2a");
+        assert_eq!(v["valueDecimal"], "42");
+        assert_eq!(v["storageRootHex"], hex0x(&[0x33; 32]));
+        assert_eq!(v["verifyMethod"], "headerChain");
+        assert_eq!(v["peerBlockNumber"], 21_000_000);
+        assert_eq!(v["finalizedSlot"], 14_560_000);
+        assert_eq!(v["optimisticSlot"], 14_560_032);
+        assert_eq!(v["maxHeaderChainGap"], 8192);
+        // Plain-slot key: 32 bytes ending in 0x03.
+        assert!(v["storageKeyHex"].as_str().unwrap().ends_with("03"));
+    }
+
+    #[test]
+    fn error_json_shape() {
+        let v: serde_json::Value = serde_json::from_str(&error_json("no snap peer")).unwrap();
+        assert_eq!(v["error"], "no snap peer");
+    }
+
+    #[test]
+    fn be_to_decimal_cases() {
+        assert_eq!(be_to_decimal(&[]), "0");
+        assert_eq!(be_to_decimal(&[0, 0]), "0");
+        assert_eq!(be_to_decimal(&[0x2a]), "42");
+        assert_eq!(be_to_decimal(&255u64.to_be_bytes()), "255");
+        assert_eq!(
+            be_to_decimal(&1_000_000_000_000_000_000u64.to_be_bytes()),
+            "1000000000000000000"
+        );
+        // A value larger than u64: 2^64 = 18446744073709551616.
+        let mut big = vec![0x01];
+        big.extend_from_slice(&[0u8; 8]);
+        assert_eq!(be_to_decimal(&big), "18446744073709551616");
+    }
+}

--- a/rust/myotis-engine/src/host.rs
+++ b/rust/myotis-engine/src/host.rs
@@ -24,7 +24,14 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 
+use myotis_net::el::reader::ElReader;
 use myotis_net::{ChainConfig, SyncHandle, SyncState, SyncStatus};
+
+use crate::eljson;
+
+/// Slots per sync-committee period (for the finalized-slot → period diagnostics
+/// the verified-read results carry).
+const SLOTS_PER_PERIOD: u64 = 8192;
 
 // Distinct negative sentinels from `create` (all `< 0` = failure to the Java side,
 // but distinguishable for tests / future callers):
@@ -40,7 +47,12 @@ const UNSUPPORTED_NETWORK: i64 = -2;
 /// `SyncHandle::start`.
 enum ChainEntry {
     Created(Arc<ChainConfig>),
-    Running(Arc<ChainConfig>, SyncHandle),
+    /// A running chain: the CL sync loop plus (optionally) the EL verified-read
+    /// reader. The reader is `None` if its discovery/pool failed to start — the
+    /// CL still runs, but EL queries report the reader unavailable. `Arc` so a
+    /// query can clone it out and run OUTSIDE the handle-map lock (a verified
+    /// read can take up to ~60 s for a header-chain walk).
+    Running(Arc<ChainConfig>, SyncHandle, Option<Arc<ElReader>>),
 }
 
 /// The single legitimate engine singleton. Owns the runtime + the handle map;
@@ -151,6 +163,20 @@ pub fn start(handle: i64) -> bool {
         Ok(s) => s,
         Err(_) => return false,
     };
+    // Start the EL reader against the sync loop's execution anchor (the CL→EL
+    // bridge). Mainnet-only for now, matching the CL host scope. A failure
+    // (e.g. a discv4 UDP bind error) is non-fatal: the CL still runs and EL
+    // queries report the reader unavailable, rather than failing the whole start.
+    let reader = match engine
+        .rt
+        .block_on(async { ElReader::start_mainnet(sync.exec_anchor()).await })
+    {
+        Ok(r) => Some(Arc::new(r)),
+        Err(e) => {
+            tracing::warn!(handle, error = %e, "EL reader failed to start; CL runs without EL");
+            None
+        }
+    };
     // Re-lock and publish ONLY if the entry is still the same Created one: a
     // concurrent stop() may have removed it, or a racing start() may have already
     // published a Running one, while we were starting. Either way, shut the handle
@@ -158,21 +184,37 @@ pub fn start(handle: i64) -> bool {
     let mut map = match engine.handles.lock() {
         Ok(m) => m,
         Err(_) => {
-            engine.rt.block_on(async { sync.stop().await });
+            shutdown(engine, sync, reader);
             return false;
         }
     };
     match map.get(&handle) {
         Some(ChainEntry::Created(_)) => {
-            map.insert(handle, ChainEntry::Running(config, sync));
+            map.insert(handle, ChainEntry::Running(config, sync, reader));
             true
         }
         _ => {
             drop(map);
-            engine.rt.block_on(async { sync.stop().await });
+            shutdown(engine, sync, reader);
             false
         }
     }
+}
+
+/// Shut down a started-but-not-published sync handle + reader (the lost-race
+/// path). Runs the async stops on the engine runtime.
+fn shutdown(engine: &EngineState, sync: SyncHandle, reader: Option<Arc<ElReader>>) {
+    engine.rt.block_on(async move {
+        sync.stop().await;
+        if let Some(reader) = reader {
+            // Only our just-started reader holds an Arc here, so unwrapping the
+            // Arc to consume `stop(self)` succeeds; if it somehow doesn't, the
+            // reader's Drop still aborts its tasks.
+            if let Ok(reader) = Arc::try_unwrap(reader) {
+                reader.stop().await;
+            }
+        }
+    });
 }
 
 /// `nativeStatusJson`: the status of one handle as a JSON object (see
@@ -193,7 +235,7 @@ pub fn status_json(handle: i64) -> String {
         Some(ChainEntry::Created(config)) => {
             status_object(false, None, config.wall_clock_period())
         }
-        Some(ChainEntry::Running(config, sync)) => {
+        Some(ChainEntry::Running(config, sync, _reader)) => {
             status_object(true, Some(sync.status()), config.wall_clock_period())
         }
         None => "{}".to_string(),
@@ -212,9 +254,127 @@ pub fn stop(handle: i64) {
         Ok(mut m) => m.remove(&handle),
         Err(_) => return,
     };
-    if let Some(ChainEntry::Running(_, sync)) = entry {
-        engine.rt.block_on(async move { sync.stop().await });
+    if let Some(ChainEntry::Running(_, sync, reader)) = entry {
+        engine.rt.block_on(async move {
+            sync.stop().await;
+            if let Some(reader) = reader {
+                if let Ok(reader) = Arc::try_unwrap(reader) {
+                    reader.stop().await;
+                }
+            }
+        });
     }
+}
+
+/// `nativeRequestAccountJson`: run a verified account query for a running
+/// handle, returning the `AccountProofResult` JSON, or `{"error": "..."}` for a
+/// transport / not-running / bad-input failure.
+pub fn request_account_json(handle: i64, address_hex: &str) -> String {
+    let Some(address) = parse_address(address_hex) else {
+        return eljson::error_json("invalid address (expected 20-byte hex)");
+    };
+    let Some(engine) = engine() else {
+        return eljson::error_json("engine unavailable");
+    };
+    // Snapshot the reader + the CL status/config under the lock, then release it
+    // before the (potentially slow) query — never hold the map lock across a
+    // verified read.
+    let (reader, finalized_period, wall_period) = match snapshot_reader(engine, handle) {
+        Ok(snap) => snap,
+        Err(msg) => return eljson::error_json(msg),
+    };
+    match engine.rt.block_on(async { reader.get_account(address).await }) {
+        Ok(account) => eljson::account_json(address_hex, &account, finalized_period, wall_period),
+        Err(e) => eljson::error_json(&e),
+    }
+}
+
+/// `nativeGetStorageProofJson`: run a verified storage-slot query for a running
+/// handle. `holder_hex` (if present) selects the ERC-20 mapping key.
+pub fn get_storage_proof_json(
+    handle: i64,
+    address_hex: &str,
+    slot: i64,
+    holder_hex: Option<&str>,
+) -> String {
+    let Some(address) = parse_address(address_hex) else {
+        return eljson::error_json("invalid address (expected 20-byte hex)");
+    };
+    let holder = match holder_hex {
+        Some(h) => match parse_address(h) {
+            Some(a) => Some(a),
+            None => return eljson::error_json("invalid holder (expected 20-byte hex)"),
+        },
+        None => None,
+    };
+    let slot = slot.max(0) as u64;
+    let Some(engine) = engine() else {
+        return eljson::error_json("engine unavailable");
+    };
+    let (reader, finalized_slot, optimistic_slot) = match snapshot_reader_slots(engine, handle) {
+        Ok(snap) => snap,
+        Err(msg) => return eljson::error_json(msg),
+    };
+    match engine.rt.block_on(async { reader.get_storage(address, slot, holder).await }) {
+        Ok(storage) => eljson::storage_json(
+            address_hex,
+            holder_hex,
+            &storage,
+            finalized_slot,
+            optimistic_slot,
+        ),
+        Err(e) => eljson::error_json(&e),
+    }
+}
+
+/// Snapshot `(reader, finalizedPeriod, wallClockPeriod)` for a running handle,
+/// or an error message. Holds the map lock only for the clone.
+fn snapshot_reader(
+    engine: &EngineState,
+    handle: i64,
+) -> Result<(Arc<ElReader>, u64, u64), &'static str> {
+    let map = engine.handles.lock().map_err(|_| "engine lock poisoned")?;
+    match map.get(&handle) {
+        Some(ChainEntry::Running(config, sync, Some(reader))) => Ok((
+            Arc::clone(reader),
+            sync.status().finalized_slot / SLOTS_PER_PERIOD,
+            config.wall_clock_period(),
+        )),
+        Some(ChainEntry::Running(_, _, None)) => Err("EL reader unavailable on this handle"),
+        Some(ChainEntry::Created(_)) => Err("handle not started"),
+        None => Err("unknown handle"),
+    }
+}
+
+/// Snapshot `(reader, finalizedSlot, optimisticSlot)` for a running handle.
+fn snapshot_reader_slots(
+    engine: &EngineState,
+    handle: i64,
+) -> Result<(Arc<ElReader>, u64, u64), &'static str> {
+    let map = engine.handles.lock().map_err(|_| "engine lock poisoned")?;
+    match map.get(&handle) {
+        Some(ChainEntry::Running(_, sync, Some(reader))) => {
+            let s = sync.status();
+            Ok((Arc::clone(reader), s.finalized_slot, s.optimistic_slot))
+        }
+        Some(ChainEntry::Running(_, _, None)) => Err("EL reader unavailable on this handle"),
+        Some(ChainEntry::Created(_)) => Err("handle not started"),
+        None => Err("unknown handle"),
+    }
+}
+
+/// Parse a `0x`-prefixed-or-bare 40-char hex address into 20 bytes. Panic-free:
+/// returns `None` for any malformed input (JNI callers pass untrusted strings).
+fn parse_address(hex: &str) -> Option<[u8; 20]> {
+    let hex = hex.strip_prefix("0x").or_else(|| hex.strip_prefix("0X")).unwrap_or(hex);
+    if hex.len() != 40 {
+        return None;
+    }
+    let mut out = [0u8; 20];
+    for (i, byte) in out.iter_mut().enumerate() {
+        *byte = u8::from_str_radix(hex.get(i * 2..i * 2 + 2)?, 16).ok()?;
+    }
+    Some(out)
 }
 
 /// Map a `SyncState` to the API `beaconState` string.
@@ -378,5 +538,37 @@ mod tests {
         // No engine calls here — just the contract for a missing handle, which
         // status_json returns directly.
         assert_eq!(status_json(i64::MIN), "{}");
+    }
+
+    #[test]
+    fn parse_address_accepts_valid_and_rejects_malformed() {
+        assert_eq!(parse_address(&"11".repeat(20)), Some([0x11; 20]));
+        assert_eq!(parse_address(&format!("0x{}", "22".repeat(20))), Some([0x22; 20]));
+        assert_eq!(parse_address(&format!("0X{}", "22".repeat(20))), Some([0x22; 20]));
+        assert!(parse_address("0x1234").is_none()); // too short
+        assert!(parse_address(&"zz".repeat(20)).is_none()); // non-hex
+        assert!(parse_address("").is_none());
+    }
+
+    #[test]
+    fn account_query_rejects_bad_address_and_unknown_handle() {
+        // Bad address → error before any handle lookup.
+        let v: serde_json::Value =
+            serde_json::from_str(&request_account_json(1, "0xnothex")).unwrap();
+        assert!(v["error"].as_str().unwrap().contains("invalid address"));
+
+        // Valid address, unknown handle → "unknown handle" error.
+        let addr = format!("0x{}", "ab".repeat(20));
+        let v: serde_json::Value =
+            serde_json::from_str(&request_account_json(i64::MIN, &addr)).unwrap();
+        assert_eq!(v["error"], "unknown handle");
+    }
+
+    #[test]
+    fn storage_query_rejects_bad_holder() {
+        let addr = format!("0x{}", "ab".repeat(20));
+        let v: serde_json::Value =
+            serde_json::from_str(&get_storage_proof_json(i64::MIN, &addr, 1, Some("0xbad"))).unwrap();
+        assert!(v["error"].as_str().unwrap().contains("invalid holder"));
     }
 }

--- a/rust/myotis-engine/src/host.rs
+++ b/rust/myotis-engine/src/host.rs
@@ -307,7 +307,10 @@ pub fn get_storage_proof_json(
         },
         None => None,
     };
-    let slot = slot.max(0) as u64;
+    // Preserve the bit pattern: a slot index >= 2^63 arrives as a negative
+    // Java long; `as u64` recovers the intended unsigned slot (clamping to 0
+    // would silently query slot 0 instead).
+    let slot = slot as u64;
     let Some(engine) = engine() else {
         return eljson::error_json("engine unavailable");
     };

--- a/rust/myotis-engine/src/host.rs
+++ b/rust/myotis-engine/src/host.rs
@@ -367,7 +367,9 @@ fn snapshot_reader_slots(
 /// returns `None` for any malformed input (JNI callers pass untrusted strings).
 fn parse_address(hex: &str) -> Option<[u8; 20]> {
     let hex = hex.strip_prefix("0x").or_else(|| hex.strip_prefix("0X")).unwrap_or(hex);
-    if hex.len() != 40 {
+    // Require exactly 40 hex digits — reject the sign/whitespace that
+    // `u8::from_str_radix` would otherwise accept (e.g. a "+f" byte-pair).
+    if hex.len() != 40 || !hex.bytes().all(|b| b.is_ascii_hexdigit()) {
         return None;
     }
     let mut out = [0u8; 20];
@@ -547,6 +549,7 @@ mod tests {
         assert_eq!(parse_address(&format!("0X{}", "22".repeat(20))), Some([0x22; 20]));
         assert!(parse_address("0x1234").is_none()); // too short
         assert!(parse_address(&"zz".repeat(20)).is_none()); // non-hex
+        assert!(parse_address(&"+f".repeat(20)).is_none()); // sign rejected
         assert!(parse_address("").is_none());
     }
 

--- a/rust/myotis-engine/src/lib.rs
+++ b/rust/myotis-engine/src/lib.rs
@@ -189,10 +189,13 @@ mod jni_shim {
     }
 
     // ---------------------------------------------------------------------
-    // EL verified-read surface (ABI 4). Each returns a JSON string: the full
-    // AccountProofResult / StorageProofResult shape on success (verification
-    // failures carry a `failReason`), or `{"error": "..."}` for a transport /
-    // not-running / bad-input failure the Java side raises as an EngineException.
+    // EL verified-read surface. DORMANT in this build: ABI_VERSION stays 3 and
+    // the Java side declares neither native yet, so these symbols are present
+    // but unresolved (the bump to 4 lands with the Java wiring — see
+    // ABI_VERSION's doc). Each returns a JSON string: the full AccountProofResult
+    // / StorageProofResult shape on success (verification failures carry a
+    // `failReason`), or `{"error": "..."}` for a transport / not-running /
+    // bad-input failure the Java side raises as an EngineException.
     // ---------------------------------------------------------------------
 
     /// `RustEngineNative.nativeRequestAccountJson(long handle, String address)`.

--- a/rust/myotis-engine/src/lib.rs
+++ b/rust/myotis-engine/src/lib.rs
@@ -10,6 +10,7 @@
 //! and the EL surface land later.
 
 pub mod catalog;
+mod eljson;
 mod host;
 pub mod ringlog;
 
@@ -19,6 +20,13 @@ pub mod ringlog;
 /// crashing on a missing/renamed symbol.
 ///
 /// v2: added the hosting surface (nativeCreate/Start/StatusJson/Stop).
+///
+/// The EL verified-read natives (nativeRequestAccountJson,
+/// nativeGetStorageProofJson) are present as of this build but are DORMANT: the
+/// Java side does not declare or call them yet, so the ABI stays 3 (JNI resolves
+/// only declared natives lazily). The bump to 4 lands atomically with the Java
+/// RustEngineNative declarations + RustChainHandle wiring, so no .so ever reports
+/// an ABI the running Java engine treats as stale.
 pub const ABI_VERSION: i32 = 3;
 
 // Keep the workspace edge alive so `cargo build -p myotis-engine` type-checks the
@@ -178,5 +186,49 @@ mod jni_shim {
         handle: jlong,
     ) {
         crate::host::stop(handle);
+    }
+
+    // ---------------------------------------------------------------------
+    // EL verified-read surface (ABI 4). Each returns a JSON string: the full
+    // AccountProofResult / StorageProofResult shape on success (verification
+    // failures carry a `failReason`), or `{"error": "..."}` for a transport /
+    // not-running / bad-input failure the Java side raises as an EngineException.
+    // ---------------------------------------------------------------------
+
+    /// `RustEngineNative.nativeRequestAccountJson(long handle, String address)`.
+    #[no_mangle]
+    pub extern "system" fn Java_io_myotis_engines_RustEngineNative_nativeRequestAccountJson(
+        mut env: JNIEnv,
+        _class: JClass,
+        handle: jlong,
+        address: JString,
+    ) -> jstring {
+        let address = read_string(&mut env, &address).unwrap_or_default();
+        let json = crate::host::request_account_json(handle, &address);
+        match env.new_string(json) {
+            Ok(s) => s.into_raw(),
+            Err(_) => std::ptr::null_mut(),
+        }
+    }
+
+    /// `RustEngineNative.nativeGetStorageProofJson(long handle, String address,
+    /// long slot, String holderOrNull)`.
+    #[no_mangle]
+    pub extern "system" fn Java_io_myotis_engines_RustEngineNative_nativeGetStorageProofJson(
+        mut env: JNIEnv,
+        _class: JClass,
+        handle: jlong,
+        address: JString,
+        slot: jlong,
+        holder: JString,
+    ) -> jstring {
+        let address = read_string(&mut env, &address).unwrap_or_default();
+        // A null/absent holder is the plain-slot lookup.
+        let holder = read_string(&mut env, &holder);
+        let json = crate::host::get_storage_proof_json(handle, &address, slot, holder.as_deref());
+        match env.new_string(json) {
+            Ok(s) => s.into_raw(),
+            Err(_) => std::ptr::null_mut(),
+        }
     }
 }

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -372,9 +372,6 @@ fn storage_key(slot: u64, holder: Option<[u8; 20]>) -> [u8; 32] {
     }
 }
 
-/// Decode a fixed 64-char hex CONSTANT. Panics on a malformed literal (a
-/// programming error caught immediately in dev/tests — never runs on peer data),
-/// matching the `sync.rs` convention; it does NOT silently zero-pad bad input.
 /// Generate a valid secp256k1 node key from OS entropy. Returns `Err` rather
 /// than panicking (the engine host is panic-free by construction); retries the
 /// negligibly-rare out-of-range secret.
@@ -389,6 +386,9 @@ pub fn generate_node_key() -> Result<Arc<NodeKey>, String> {
     Err("could not generate a valid node key from OS entropy".to_string())
 }
 
+/// Decode a fixed 64-char hex CONSTANT. Panics on a malformed literal (a
+/// programming error caught immediately in dev/tests — never runs on peer data),
+/// matching the `sync.rs` convention; it does NOT silently zero-pad bad input.
 fn hex32(s: &str) -> [u8; 32] {
     let mut out = [0u8; 32];
     for (i, byte) in out.iter_mut().enumerate() {

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -108,6 +108,9 @@ pub struct VerifiedStorage {
     pub slot: u64,
     /// The holder address for an ERC-20 mapping lookup, if any.
     pub holder: Option<[u8; 20]>,
+    /// The 32-byte storage key: the plain padded slot, or the ERC-20 mapping
+    /// slot `keccak256(pad32(holder) ‖ uint256(slot))`.
+    pub storage_key: [u8; 32],
     /// keccak256(storage key) — the slot's trie key.
     pub slot_key_hash: [u8; 32],
     pub found: bool,
@@ -136,6 +139,14 @@ pub struct ElReader {
 }
 
 impl ElReader {
+    /// Start a mainnet reader with a freshly-generated ephemeral node key (the
+    /// CL side generates its libp2p identity per run too; a persistent EL
+    /// identity for peer-cache stability is an EL-A8 concern).
+    pub async fn start_mainnet(anchor: Arc<ExecAnchor>) -> Result<ElReader, String> {
+        let key = generate_node_key()?;
+        ElReader::start(key, anchor, ElConfig::mainnet()).await
+    }
+
     /// Start discovery + the peer pool for `cfg`, reading verified state against
     /// `anchor` (the beacon sync loop's execution anchor).
     pub async fn start(
@@ -238,6 +249,7 @@ impl ElReader {
             address,
             slot,
             holder,
+            storage_key,
             slot_key_hash,
             found: false,
             value: Vec::new(),
@@ -363,6 +375,20 @@ fn storage_key(slot: u64, holder: Option<[u8; 20]>) -> [u8; 32] {
 /// Decode a fixed 64-char hex CONSTANT. Panics on a malformed literal (a
 /// programming error caught immediately in dev/tests — never runs on peer data),
 /// matching the `sync.rs` convention; it does NOT silently zero-pad bad input.
+/// Generate a valid secp256k1 node key from OS entropy. Returns `Err` rather
+/// than panicking (the engine host is panic-free by construction); retries the
+/// negligibly-rare out-of-range secret.
+pub fn generate_node_key() -> Result<Arc<NodeKey>, String> {
+    for _ in 0..8 {
+        let mut secret = [0u8; 32];
+        getrandom::getrandom(&mut secret).map_err(|e| format!("OS entropy: {e}"))?;
+        if let Ok(key) = NodeKey::from_secret_bytes(&secret) {
+            return Ok(Arc::new(key));
+        }
+    }
+    Err("could not generate a valid node key from OS entropy".to_string())
+}
+
 fn hex32(s: &str) -> [u8; 32] {
     let mut out = [0u8; 32];
     for (i, byte) in out.iter_mut().enumerate() {


### PR DESCRIPTION
## What

The Rust half of the EL verified-read surface: wires the `ElReader` (#158) into each hosted chain and exposes verified account/storage reads over hand-JNI as JSON.

## Changes

- **`reader.rs`** — `ElReader::start_mainnet` (fresh ephemeral node key, like the CL's per-run libp2p identity) + `generate_node_key` (panic-free, OS entropy). `VerifiedStorage` gains the 32-byte `storage_key` for the result echo.
- **`host.rs`** — `ChainEntry::Running` now also holds `Option<Arc<ElReader>>`, started against the sync loop's `exec_anchor()` when the chain starts (non-fatal if discovery/pool fail — the CL still runs). `request_account_json` / `get_storage_proof_json` **snapshot** the reader + CL status/config under the map lock, then run the query **outside** it (a header-chain walk can take ~60 s — never hold the map mutex across a verified read). `parse_address` is panic-free on untrusted JNI strings.
- **`eljson.rs`** (new) — pure serializers for the `AccountProofResult` / `StorageProofResult` shapes (hand-built golden contract), plus `be_to_decimal` (big-endian wei → decimal, no bignum dep). Success serializes the full result (verification failures carry `failReason`); a transport/not-running/bad-input failure serializes `{"error": "..."}`.
- **`lib.rs`** — `nativeRequestAccountJson` / `nativeGetStorageProofJson` shims.

## ABI stays 3 (deliberate)

The two natives are **dormant**: JNI resolves a native lazily on first call of a *declared* method, and the Java side declares neither yet, so a running Java engine (which does a strict `abi != EXPECTED_ABI_VERSION` check) is unaffected. The bump to 4 + the Java `RustEngineNative`/`RustChainHandle` wiring + the `-Pengine=rust` integration gate land **atomically** in EL-A7b-4c, so no `.so` ever reports an ABI the Java engine treats as stale.

## Tests

- 16 engine unit tests: 6 `eljson` golden-shape (both record shapes, absent-account convention, failed-verdict-carries-tokens, `be_to_decimal` incl. a > u64 value), 4 `host` error-path (bad address, unknown handle, bad holder, `parse_address`), plus existing status tests. Full rust workspace green (28 suites).

## Review

Ran the mandatory no-context review before opening. **No blocking issues** — verified panic-safety on untrusted input (`parse_address`, `be_to_decimal` division bounds, `generate_node_key` Err path), the lock/`block_on` discipline (map mutex dropped before the query), no real task leak on the lost-race shutdown, and all 21+24 JSON keys present and correctly named/typed. Tightened `parse_address` to reject sign chars (the one nit it flagged) in the second commit.

## Scope

Rust engine only. **Next (EL-A7b-4c)**: bump ABI → 4, declare the natives in `RustEngineNative`, implement `RustChainHandle.requestAccount`/`getStorageProof` (parse the JSON into the api records; `{"error"}` → `EngineException`), a Java-parses-Rust-JSON golden test, and the `-Pengine=rust` integration gate (`beacon-status` SYNCED → `get-account`/`get-storage` return `verifyMethod:"headerChain"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)