### PR TITLE
EL-A7b-4c: Java verified-read wiring + ABI 4 (lights the -Pengine=rust gate)

### DIFF
--- a/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
@@ -247,6 +247,7 @@ final class RustChainHandle implements ChainHandle {
     }
 
     private static AccountProofResult accountFromJson(String hexAddress, JsonObject o) {
+        try {
         return new AccountProofResult(
                 o.getString("address", hexAddress),
                 o.getBoolean("exists", false),
@@ -269,6 +270,11 @@ final class RustChainHandle implements ChainHandle {
                 o.getLong("wallClockPeriod", 0L),
                 o.getLong("finalizedBlockNumber", 0L),
                 o.getLong("optimisticBlockNumber", 0L));
+        } catch (RuntimeException e) {
+            // A type-mismatched field (Rust-side shape drift) surfaces as an
+            // EngineException, never a raw UnsupportedOperationException.
+            throw new EngineException("malformed account JSON from the Rust engine: " + e.getMessage(), e);
+        }
     }
 
     @Override
@@ -285,6 +291,7 @@ final class RustChainHandle implements ChainHandle {
     }
 
     private static StorageProofResult storageFromJson(String hexAddress, long slot, JsonObject o) {
+        try {
         return new StorageProofResult(
                 o.getString("addressHex", hexAddress),
                 o.getLong("slot", slot),
@@ -310,6 +317,9 @@ final class RustChainHandle implements ChainHandle {
                 o.getLong("finalizedSlot", 0L),
                 o.getLong("optimisticSlot", 0L),
                 o.getInt("maxHeaderChainGap", 0));
+        } catch (RuntimeException e) {
+            throw new EngineException("malformed storage JSON from the Rust engine: " + e.getMessage(), e);
+        }
     }
 
     /**

--- a/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
@@ -341,7 +341,9 @@ final class RustChainHandle implements ChainHandle {
         }
         var error = o.get("error");
         if (error != null && !error.isNull()) {
-            throw new EngineException(error.asString());
+            // The Rust side always emits a string error, but tolerate a
+            // structured value rather than throwing a raw library exception.
+            throw new EngineException(error.isString() ? error.asString() : error.toString());
         }
         return o;
     }
@@ -358,7 +360,8 @@ final class RustChainHandle implements ChainHandle {
         if (v == null || !v.isArray()) return List.of();
         List<String> out = new java.util.ArrayList<>();
         v.asArray().forEach(e -> out.add(e.isNull() ? null : e.asString()));
-        return out;
+        // Unmodifiable: these lists live inside immutable result records.
+        return java.util.Collections.unmodifiableList(out);
     }
 
     @Override

--- a/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
@@ -330,7 +330,8 @@ final class RustChainHandle implements ChainHandle {
      */
     private static JsonObject parseResultOrThrow(String json, String what) {
         if (json == null || json.isBlank()) {
-            throw new EngineException("null " + what + " JSON from the Rust engine (native failure?)");
+            throw new EngineException((json == null ? "null" : "blank") + " " + what
+                    + " JSON from the Rust engine (native failure?)");
         }
         JsonObject o;
         try {
@@ -354,12 +355,18 @@ final class RustChainHandle implements ChainHandle {
         return (v == null || v.isNull()) ? null : v.asString();
     }
 
-    /** A JSON string-array field as a List, or empty when absent/not an array. */
+    /**
+     * A JSON string-array field as an unmodifiable List. An ABSENT field yields
+     * an empty list (forward-compat with an older native that omits it), but a
+     * PRESENT field that isn't a string array throws (via {@code asArray()} /
+     * {@code asString()}) — caught by the field-mapping try/catch as an
+     * {@link EngineException}, failing closed on Rust-side shape drift.
+     */
     private static List<String> stringList(JsonObject o, String key) {
         var v = o.get(key);
-        if (v == null || !v.isArray()) return List.of();
+        if (v == null || v.isNull()) return List.of();
         List<String> out = new java.util.ArrayList<>();
-        v.asArray().forEach(e -> out.add(e.isNull() ? null : e.asString()));
+        v.asArray().forEach(e -> out.add(e.asString()));
         // Unmodifiable: these lists live inside immutable result records.
         return java.util.Collections.unmodifiableList(out);
     }

--- a/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
@@ -30,11 +30,14 @@ import java.util.List;
  * {@link RustEngineNative}; compound status is a JSON object (the hand-JNI + JSON
  * decision, pinned by golden tests on both sides).
  *
- * <p>R1 scope is CL-only + mainnet-only: the beacon fields of the status snapshot
- * are real (finalized slot, sync period, peer count, beacon state); the EL-side
- * fields (execution block number, snap peers, RPC head age, …) are zero because
- * this engine has no execution layer yet. The verified-read / proof / header
- * queries throw {@link EngineException} until the EL surface lands.
+ * <p>Mainnet-only. The beacon fields of the status snapshot are real (finalized
+ * slot, sync period, peer count, beacon state); some EL-side status fields
+ * (snap-peer counts, RPC head age) are still zero. The verified-read
+ * {@link #requestAccount}/{@link #getStorageProof} queries ARE live — they cross
+ * to the Rust {@code ElReader} (discovery + peer pool + the CL-fed execution
+ * anchor) and return the same proof/verdict records as the Java engine. The
+ * remaining EL queries ({@link #getHeaders}/{@link #getBlockVerified}/
+ * {@link #dialPeer}) throw {@link EngineException} until those surfaces land.
  */
 final class RustChainHandle implements ChainHandle {
 
@@ -233,12 +236,119 @@ final class RustChainHandle implements ChainHandle {
 
     @Override
     public AccountProofResult requestAccount(String hexAddress) {
-        throw new EngineException(NOT_AVAILABLE);
+        JsonObject o = parseResultOrThrow(
+                RustEngineNative.nativeRequestAccountJson(handle, hexAddress), "account");
+        return accountFromJson(hexAddress, o);
+    }
+
+    /** Package-private test seam: JSON → {@link AccountProofResult} without JNI. */
+    static AccountProofResult accountFromJson(String hexAddress, String json) {
+        return accountFromJson(hexAddress, parseResultOrThrow(json, "account"));
+    }
+
+    private static AccountProofResult accountFromJson(String hexAddress, JsonObject o) {
+        return new AccountProofResult(
+                o.getString("address", hexAddress),
+                o.getBoolean("exists", false),
+                o.getLong("nonce", -1L),
+                stringOrNull(o, "balanceWei"),
+                stringOrNull(o, "storageRootHex"),
+                stringOrNull(o, "codeHashHex"),
+                o.getLong("blockNumber", 0L),
+                stringOrNull(o, "peerStateRootHex"),
+                o.getBoolean("peerProofValid", false),
+                o.getBoolean("beaconChainVerified", false),
+                o.getBoolean("blsVerified", false),
+                o.getLong("matchedBeaconSlot", -1L),
+                stringOrNull(o, "verifyMethod"),
+                stringOrNull(o, "failReason"),
+                stringOrNull(o, "accountHashHex"),
+                stringList(o, "proofNodesHex"),
+                o.getBoolean("beaconSynced", false),
+                o.getLong("finalizedPeriod", 0L),
+                o.getLong("wallClockPeriod", 0L),
+                o.getLong("finalizedBlockNumber", 0L),
+                o.getLong("optimisticBlockNumber", 0L));
     }
 
     @Override
     public StorageProofResult getStorageProof(String hexAddress, long slot, String holderHexOrNull) {
-        throw new EngineException(NOT_AVAILABLE);
+        JsonObject o = parseResultOrThrow(
+                RustEngineNative.nativeGetStorageProofJson(handle, hexAddress, slot, holderHexOrNull),
+                "storage");
+        return storageFromJson(hexAddress, slot, o);
+    }
+
+    /** Package-private test seam: JSON → {@link StorageProofResult} without JNI. */
+    static StorageProofResult storageFromJson(String hexAddress, long slot, String json) {
+        return storageFromJson(hexAddress, slot, parseResultOrThrow(json, "storage"));
+    }
+
+    private static StorageProofResult storageFromJson(String hexAddress, long slot, JsonObject o) {
+        return new StorageProofResult(
+                o.getString("addressHex", hexAddress),
+                o.getLong("slot", slot),
+                stringOrNull(o, "holderHex"),
+                stringOrNull(o, "storageKeyHex"),
+                stringOrNull(o, "storageKeyHashHex"),
+                o.getBoolean("exists", false),
+                stringOrNull(o, "valueHex"),
+                stringOrNull(o, "valueDecimal"),
+                o.getInt("slotsReturned", 0),
+                stringOrNull(o, "storageRootHex"),
+                stringList(o, "proofNodesHex"),
+                o.getBoolean("storageProofValid", false),
+                o.getBoolean("beaconSynced", false),
+                o.getBoolean("beaconChainVerified", false),
+                o.getBoolean("blsVerified", false),
+                o.getLong("matchedBeaconSlot", -1L),
+                stringOrNull(o, "verifyMethod"),
+                stringOrNull(o, "failReason"),
+                o.getLong("peerBlockNumber", 0L),
+                o.getLong("finalizedBlockNumber", 0L),
+                o.getLong("optimisticBlockNumber", 0L),
+                o.getLong("finalizedSlot", 0L),
+                o.getLong("optimisticSlot", 0L),
+                o.getInt("maxHeaderChainGap", 0));
+    }
+
+    /**
+     * Parse a native verified-read payload. A {@code {"error": "..."}} object (a
+     * transport / not-running / bad-input failure) becomes an {@link EngineException};
+     * a null/blank/malformed payload likewise. A verification FAILURE is NOT an error —
+     * it is a full result whose {@code failReason} is set, and is returned normally.
+     */
+    private static JsonObject parseResultOrThrow(String json, String what) {
+        if (json == null || json.isBlank()) {
+            throw new EngineException("null " + what + " JSON from the Rust engine (native failure?)");
+        }
+        JsonObject o;
+        try {
+            o = Json.parse(json).asObject();
+        } catch (RuntimeException e) {
+            throw new EngineException(
+                    "malformed " + what + " JSON from the Rust engine: " + e.getMessage(), e);
+        }
+        var error = o.get("error");
+        if (error != null && !error.isNull()) {
+            throw new EngineException(error.asString());
+        }
+        return o;
+    }
+
+    /** A JSON string field, or null when absent/JSON-null. */
+    private static String stringOrNull(JsonObject o, String key) {
+        var v = o.get(key);
+        return (v == null || v.isNull()) ? null : v.asString();
+    }
+
+    /** A JSON string-array field as a List, or empty when absent/not an array. */
+    private static List<String> stringList(JsonObject o, String key) {
+        var v = o.get(key);
+        if (v == null || !v.isArray()) return List.of();
+        List<String> out = new java.util.ArrayList<>();
+        v.asArray().forEach(e -> out.add(e.isNull() ? null : e.asString()));
+        return out;
     }
 
     @Override

--- a/myotis-engines/src/main/java/io/myotis/engines/RustEngineNative.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustEngineNative.java
@@ -23,7 +23,7 @@ final class RustEngineNative {
     private static final Logger log = LoggerFactory.getLogger(RustEngineNative.class);
 
     /** Must match {@code ABI_VERSION} in rust/myotis-engine/src/lib.rs. */
-    static final int EXPECTED_ABI_VERSION = 3; // 3: + nativeDrainLogs
+    static final int EXPECTED_ABI_VERSION = 4; // 4: + EL verified-read natives
 
     private static final boolean AVAILABLE = load();
 
@@ -99,4 +99,24 @@ final class RustEngineNative {
      *  newline-joined; empty when idle). The drainable-ring end of the
      *  on-device observability seam — see the engine's {@code ringlog}. */
     static native String nativeDrainLogs(int max);
+
+    // ---- EL verified-read surface (ABI 4). See RustChainHandle. ----
+
+    /**
+     * A verified account query for a running handle, returned as JSON: the full
+     * {@link io.myotis.api.AccountProofResult} shape on success (a verification
+     * failure carries a {@code failReason}), or {@code {"error": "..."}} for a
+     * transport / not-running / bad-input failure (which RustChainHandle raises
+     * as an {@link io.myotis.api.EngineException}). {@code address} is 0x-hex.
+     */
+    static native String nativeRequestAccountJson(long handle, String address);
+
+    /**
+     * A verified storage-slot query for a running handle, as JSON (the
+     * {@link io.myotis.api.StorageProofResult} shape, same error convention as
+     * {@link #nativeRequestAccountJson}). {@code holderOrNull} selects the ERC-20
+     * mapping key {@code keccak256(pad32(holder) ‖ uint256(slot))} when non-null.
+     */
+    static native String nativeGetStorageProofJson(
+            long handle, String address, long slot, String holderOrNull);
 }

--- a/myotis-engines/src/test/java/io/myotis/engines/RustVerifiedReadJsonTest.java
+++ b/myotis-engines/src/test/java/io/myotis/engines/RustVerifiedReadJsonTest.java
@@ -112,6 +112,14 @@ class RustVerifiedReadJsonTest {
     }
 
     @Test
+    void driftedArrayFieldFailsClosed() {
+        // proofNodesHex present but not an array → EngineException (fail closed),
+        // NOT a silently-swallowed empty list.
+        String json = "{\"exists\":true,\"nonce\":0,\"proofNodesHex\":{\"unexpected\":true}}";
+        assertThrows(EngineException.class, () -> RustChainHandle.accountFromJson("0x0", json));
+    }
+
+    @Test
     void typeMismatchedFieldBecomesEngineException() {
         // Rust-side shape drift: a numeric field arrives as a string. The
         // field-extraction must surface an EngineException, not a raw

--- a/myotis-engines/src/test/java/io/myotis/engines/RustVerifiedReadJsonTest.java
+++ b/myotis-engines/src/test/java/io/myotis/engines/RustVerifiedReadJsonTest.java
@@ -1,0 +1,143 @@
+package io.myotis.engines;
+
+import io.myotis.api.AccountProofResult;
+import io.myotis.api.EngineException;
+import io.myotis.api.StorageProofResult;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The Java half of the EL verified-read JSON golden contract: parse the exact
+ * {@link AccountProofResult} / {@link StorageProofResult} shapes the Rust
+ * {@code eljson} module emits (pinned there by its {@code account_json_shape} /
+ * {@code storage_json_shape} tests) into the api records, and assert the
+ * mapping. Needs no native library — it exercises the JSON→record seam that
+ * {@link RustChainHandle} uses once {@code nativeRequestAccountJson} /
+ * {@code nativeGetStorageProofJson} return.
+ *
+ * <p>The values here mirror the Rust {@code eljson} sample (a headerChain-verified
+ * vitalik-style account), so the two sides are visibly parallel.
+ */
+class RustVerifiedReadJsonTest {
+
+    /** A headerChain-verified account (mirrors the Rust eljson sample_account). */
+    private static final String ACCOUNT_JSON =
+            "{\"address\":\"0xd8da6bf26964af9d7eed9e03e53415d37aa96045\","
+            + "\"exists\":true,\"nonce\":5898,\"balanceWei\":\"1000000000000000000\","
+            + "\"storageRootHex\":\"0x56e81f171bcac1a441cf3f1d5f0b8d5f0f3f0e5e5b5b5b5b5b5b5b5b5b5b5b5b5\","
+            + "\"codeHashHex\":\"0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470\","
+            + "\"blockNumber\":21000000,"
+            + "\"peerStateRootHex\":\"0x5555555555555555555555555555555555555555555555555555555555555555\","
+            + "\"peerProofValid\":true,\"beaconChainVerified\":true,\"blsVerified\":true,"
+            + "\"matchedBeaconSlot\":7000000,\"verifyMethod\":\"headerChain\",\"failReason\":null,"
+            + "\"accountHashHex\":\"0x2222222222222222222222222222222222222222222222222222222222222222\","
+            + "\"proofNodesHex\":[],\"beaconSynced\":true,"
+            + "\"finalizedPeriod\":1777,\"wallClockPeriod\":1795,"
+            + "\"finalizedBlockNumber\":20999000,\"optimisticBlockNumber\":21000010}";
+
+    @Test
+    void accountJsonMapsToRecord() {
+        AccountProofResult r = RustChainHandle.accountFromJson(
+                "0xd8da6bf26964af9d7eed9e03e53415d37aa96045", ACCOUNT_JSON);
+        assertEquals("0xd8da6bf26964af9d7eed9e03e53415d37aa96045", r.address());
+        assertTrue(r.exists());
+        assertEquals(5898L, r.nonce());
+        assertEquals("1000000000000000000", r.balanceWei());
+        assertEquals(21000000L, r.blockNumber());
+        assertTrue(r.peerProofValid());
+        assertTrue(r.beaconChainVerified());
+        assertTrue(r.blsVerified());
+        assertEquals(7000000L, r.matchedBeaconSlot());
+        // THE gate token.
+        assertEquals("headerChain", r.verifyMethod());
+        assertNull(r.failReason());
+        assertTrue(r.beaconSynced());
+        assertEquals(1777L, r.finalizedPeriod());
+        assertEquals(1795L, r.wallClockPeriod());
+        assertEquals(20999000L, r.finalizedBlockNumber());
+        assertEquals(21000010L, r.optimisticBlockNumber());
+        assertTrue(r.proofNodesHex().isEmpty());
+    }
+
+    @Test
+    void absentAccountUsesNegativeOneAndNull() {
+        String json = "{\"address\":\"0x0\",\"exists\":false,\"nonce\":-1,\"balanceWei\":null,"
+                + "\"beaconChainVerified\":false,\"verifyMethod\":null,\"failReason\":\"beaconNotSynced\","
+                + "\"matchedBeaconSlot\":-1,\"proofNodesHex\":[]}";
+        AccountProofResult r = RustChainHandle.accountFromJson("0x0", json);
+        assertFalse(r.exists());
+        assertEquals(-1L, r.nonce());
+        assertNull(r.balanceWei());
+    }
+
+    @Test
+    void verificationFailureIsAResultNotAnException() {
+        // beaconNotSynced is a VERDICT, not a transport error — it must parse to a
+        // record with failReason set, never throw.
+        String json = "{\"address\":\"0x0\",\"exists\":true,\"nonce\":0,\"balanceWei\":\"0\","
+                + "\"beaconChainVerified\":false,\"blsVerified\":false,\"verifyMethod\":null,"
+                + "\"failReason\":\"beaconNotSynced\",\"matchedBeaconSlot\":-1,\"proofNodesHex\":[]}";
+        AccountProofResult r = RustChainHandle.accountFromJson("0x0", json);
+        assertNull(r.verifyMethod());
+        assertEquals("beaconNotSynced", r.failReason());
+        assertFalse(r.beaconChainVerified());
+    }
+
+    @Test
+    void errorObjectBecomesEngineException() {
+        EngineException e = assertThrows(EngineException.class,
+                () -> RustChainHandle.accountFromJson("0x0", "{\"error\":\"no snap peer available\"}"));
+        assertTrue(e.getMessage().contains("no snap peer available"));
+    }
+
+    @Test
+    void nullAndMalformedPayloadsThrow() {
+        assertThrows(EngineException.class, () -> RustChainHandle.accountFromJson("0x0", null));
+        assertThrows(EngineException.class, () -> RustChainHandle.accountFromJson("0x0", ""));
+        assertThrows(EngineException.class, () -> RustChainHandle.accountFromJson("0x0", "not json"));
+    }
+
+    /** A headerChain-verified storage slot (mirrors the Rust eljson storage sample). */
+    private static final String STORAGE_JSON =
+            "{\"addressHex\":\"0xC0\",\"slot\":3,\"holderHex\":null,"
+            + "\"storageKeyHex\":\"0x0000000000000000000000000000000000000000000000000000000000000003\","
+            + "\"storageKeyHashHex\":\"0x6666666666666666666666666666666666666666666666666666666666666666\","
+            + "\"exists\":true,\"valueHex\":\"0x2a\",\"valueDecimal\":\"42\",\"slotsReturned\":1,"
+            + "\"storageRootHex\":\"0x3333333333333333333333333333333333333333333333333333333333333333\","
+            + "\"proofNodesHex\":[],\"storageProofValid\":true,\"beaconSynced\":true,"
+            + "\"beaconChainVerified\":true,\"blsVerified\":true,\"matchedBeaconSlot\":7000000,"
+            + "\"verifyMethod\":\"headerChain\",\"failReason\":null,\"peerBlockNumber\":21000000,"
+            + "\"finalizedBlockNumber\":20999000,\"optimisticBlockNumber\":21000010,"
+            + "\"finalizedSlot\":14560000,\"optimisticSlot\":14560032,\"maxHeaderChainGap\":8192}";
+
+    @Test
+    void storageJsonMapsToRecord() {
+        StorageProofResult r = RustChainHandle.storageFromJson("0xC0", 3, STORAGE_JSON);
+        assertEquals("0xC0", r.addressHex());
+        assertEquals(3L, r.slot());
+        assertNull(r.holderHex());
+        assertTrue(r.exists());
+        assertEquals("0x2a", r.valueHex());
+        assertEquals("42", r.valueDecimal());
+        assertEquals(1, r.slotsReturned());
+        assertTrue(r.storageProofValid());
+        assertTrue(r.beaconChainVerified());
+        assertEquals("headerChain", r.verifyMethod());
+        assertNull(r.failReason());
+        assertEquals(21000000L, r.peerBlockNumber());
+        assertEquals(14560000L, r.finalizedSlot());
+        assertEquals(14560032L, r.optimisticSlot());
+        assertEquals(8192, r.maxHeaderChainGap());
+    }
+
+    @Test
+    void storageErrorObjectBecomesEngineException() {
+        assertThrows(EngineException.class,
+                () -> RustChainHandle.storageFromJson("0x0", 1, "{\"error\":\"handle not started\"}"));
+    }
+}

--- a/myotis-engines/src/test/java/io/myotis/engines/RustVerifiedReadJsonTest.java
+++ b/myotis-engines/src/test/java/io/myotis/engines/RustVerifiedReadJsonTest.java
@@ -96,6 +96,13 @@ class RustVerifiedReadJsonTest {
     }
 
     @Test
+    void structuredErrorValueStillBecomesEngineException() {
+        // A non-string error value must not leak a raw library exception.
+        assertThrows(EngineException.class, () -> RustChainHandle.accountFromJson(
+                "0x0", "{\"error\":{\"code\":-32000,\"message\":\"boom\"}}"));
+    }
+
+    @Test
     void nullAndMalformedPayloadsThrow() {
         assertThrows(EngineException.class, () -> RustChainHandle.accountFromJson("0x0", null));
         assertThrows(EngineException.class, () -> RustChainHandle.accountFromJson("0x0", ""));

--- a/myotis-engines/src/test/java/io/myotis/engines/RustVerifiedReadJsonTest.java
+++ b/myotis-engines/src/test/java/io/myotis/engines/RustVerifiedReadJsonTest.java
@@ -100,6 +100,17 @@ class RustVerifiedReadJsonTest {
         assertThrows(EngineException.class, () -> RustChainHandle.accountFromJson("0x0", null));
         assertThrows(EngineException.class, () -> RustChainHandle.accountFromJson("0x0", ""));
         assertThrows(EngineException.class, () -> RustChainHandle.accountFromJson("0x0", "not json"));
+        // A non-object payload (e.g. a bare number) → EngineException, not a raw throw.
+        assertThrows(EngineException.class, () -> RustChainHandle.accountFromJson("0x0", "42"));
+    }
+
+    @Test
+    void typeMismatchedFieldBecomesEngineException() {
+        // Rust-side shape drift: a numeric field arrives as a string. The
+        // field-extraction must surface an EngineException, not a raw
+        // UnsupportedOperationException from the JSON library.
+        String json = "{\"exists\":true,\"nonce\":\"not-a-number\",\"proofNodesHex\":[]}";
+        assertThrows(EngineException.class, () -> RustChainHandle.accountFromJson("0x0", json));
     }
 
     /** A headerChain-verified storage slot (mirrors the Rust eljson storage sample). */

--- a/rust/myotis-engine/src/lib.rs
+++ b/rust/myotis-engine/src/lib.rs
@@ -20,14 +20,11 @@ pub mod ringlog;
 /// crashing on a missing/renamed symbol.
 ///
 /// v2: added the hosting surface (nativeCreate/Start/StatusJson/Stop).
-///
-/// The EL verified-read natives (nativeRequestAccountJson,
-/// nativeGetStorageProofJson) are present as of this build but are DORMANT: the
-/// Java side does not declare or call them yet, so the ABI stays 3 (JNI resolves
-/// only declared natives lazily). The bump to 4 lands atomically with the Java
-/// RustEngineNative declarations + RustChainHandle wiring, so no .so ever reports
-/// an ABI the running Java engine treats as stale.
-pub const ABI_VERSION: i32 = 3;
+/// v4: added the EL verified-read surface (nativeRequestAccountJson,
+///     nativeGetStorageProofJson), wired into the Java RustEngineNative /
+///     RustChainHandle at the same time so no .so ever reports an ABI the
+///     running Java engine treats as stale.
+pub const ABI_VERSION: i32 = 4;
 
 // Keep the workspace edge alive so `cargo build -p myotis-engine` type-checks the
 // consensus crate too.
@@ -189,13 +186,10 @@ mod jni_shim {
     }
 
     // ---------------------------------------------------------------------
-    // EL verified-read surface. DORMANT in this build: ABI_VERSION stays 3 and
-    // the Java side declares neither native yet, so these symbols are present
-    // but unresolved (the bump to 4 lands with the Java wiring — see
-    // ABI_VERSION's doc). Each returns a JSON string: the full AccountProofResult
-    // / StorageProofResult shape on success (verification failures carry a
-    // `failReason`), or `{"error": "..."}` for a transport / not-running /
-    // bad-input failure the Java side raises as an EngineException.
+    // EL verified-read surface (ABI 4). Each returns a JSON string: the full
+    // AccountProofResult / StorageProofResult shape on success (verification
+    // failures carry a `failReason`), or `{"error": "..."}` for a transport /
+    // not-running / bad-input failure the Java side raises as an EngineException.
     // ---------------------------------------------------------------------
 
     /// `RustEngineNative.nativeRequestAccountJson(long handle, String address)`.


### PR DESCRIPTION
## What

The finish line for EL-A7: bump the JNI ABI to 4 and wire the Java engine to the EL verified-read natives (#159), so the daemon's `get-account` / `get-storage` answer through the **Rust** engine end to end.

## Changes

- **`rust/myotis-engine/lib.rs`** — `ABI_VERSION` 3 → 4 (the natives added in #159 are now live).
- **`RustEngineNative`** — `EXPECTED_ABI_VERSION` → 4; declare `nativeRequestAccountJson` / `nativeGetStorageProofJson`.
- **`RustChainHandle`** — implement `requestAccount` / `getStorageProof`: call the native, parse the JSON into `AccountProofResult` / `StorageProofResult`. A `{"error": ...}` object (transport / not-running / bad-input) becomes an `EngineException`; a **verification failure** (`failReason` set) is returned as a normal result. Field extraction is wrapped so a future Rust-side shape drift surfaces as an `EngineException`, not a raw library throw. (`getHeaders`/`getBlockVerified`/`dialPeer` still throw — out of scope.)
- **`RustVerifiedReadJsonTest`** (new) — the Java half of the JSON golden contract: parses the exact shapes the Rust `eljson` module emits (headerChain-verified account + storage, absent account, a `beaconNotSynced` verdict returned **not thrown**, `{"error"}` → `EngineException`, null/malformed/type-mismatched → `EngineException`).

## The gate is now live

`./gradlew :app:run -Pengine=rust` routes `CommandHandler`'s `handle.requestAccount` / `handle.getStorageProof` to the Rust `ElReader` (discovery + peer pool + the CL-fed execution anchor). The CLAUDE.md integration gate — `beacon-status` SYNCED, then `get-account` / `get-storage` returning `verifyMethod:"headerChain"` — is achievable end to end. It's a live, multi-hour run gated on a synced beacon + a snap-serving EL peer (same fork-id caveat as the live reader test), so it isn't a CI check; the golden tests pin the JSON contract both sides.

## Tests

- Rust engine (16) + the full `myotis-engines` Java module green; the app module compiles against the new surface.

## Review

Ran the mandatory no-context review before opening. It verified **no positional field-order swaps** in either record mapping (21 + 24 args checked against the record constructors), correct `{"error"}`-vs-`failReason` handling, NPE-safe helpers, and consistent ABI. Adopted its one optional hardening (wrap field extraction) in the second commit.

## Scope

This completes the EL-A7b arc (#155 → #159 → this). Follow-ups tracked elsewhere: EL status snap-peer counts, `getHeaders`/`getBlockVerified`/`dialPeer`, gnosis/sepolia EL wiring, and EL-A8 (DNS discovery + engine-owned EL peer cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)