### PR TITLE
Add lifecycle-aware pause/resume: idle sleep with wake-on-RPC

### DIFF
--- a/android-app/build.gradle.kts
+++ b/android-app/build.gradle.kts
@@ -259,4 +259,9 @@ dependencies {
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.compose.ui.tooling.preview)
     debugImplementation(libs.androidx.compose.ui.tooling)
+
+    // WorkManager: the ~daily beacon catch-up while the node is idle-paused
+    // (resume → sync → persist snapshot → pause), so wakes stay fast after
+    // days of sleep. Java-only Worker — no ktx/coroutines artifact needed.
+    implementation(libs.androidx.work.runtime)
 }

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/CatchUpWorker.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/CatchUpWorker.java
@@ -1,0 +1,40 @@
+package com.jaeckel.ethp2p.android;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+import androidx.work.Worker;
+import androidx.work.WorkerParameters;
+
+/**
+ * The ~daily maintenance pass while the node sleeps: resume each idle-paused
+ * stack, let the beacon light client catch up the sync-committee periods missed
+ * since the last run (a period is ~27 h — staying current keeps a wake at zero
+ * BLS catch-up), persist a fresh snapshot, and pause again. Scheduled by
+ * {@link EthP2PApplication} as a network-constrained periodic job.
+ *
+ * <p>Never boots a stopped node — if the user stopped the service, there is
+ * nothing to maintain and the job is a no-op success.
+ */
+public final class CatchUpWorker extends Worker {
+
+    /** WorkManager stops workers at ~10 min; leave margin for the final pause+persist. */
+    private static final long BUDGET_MS = 8 * 60_000L;
+
+    public CatchUpWorker(@NonNull Context context, @NonNull WorkerParameters params) {
+        super(context, params);
+    }
+
+    @NonNull
+    @Override
+    public Result doWork() {
+        if (!NodeService.isRunning()) return Result.success();
+        try {
+            NodeService.dailyCatchUp(BUDGET_MS);
+        } catch (Throwable t) {
+            // Maintenance must never crash the process; the next daily run retries.
+            return Result.success();
+        }
+        return Result.success();
+    }
+}

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/EthP2PApplication.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/EthP2PApplication.java
@@ -44,5 +44,19 @@ public final class EthP2PApplication extends Application {
         if (System.getProperty("myotis.bls.backend") == null) {
             System.setProperty("myotis.bls.backend", NodeService.blsBackendChoice(this));
         }
+
+        // Daily beacon catch-up while the node sleeps (see CatchUpWorker): resume →
+        // sync-committee catch-up → persist snapshot → pause. Network-constrained;
+        // KEEP preserves the existing schedule across app restarts. A sync-committee
+        // period is ~27 h, so a daily pass keeps wakes at zero BLS catch-up.
+        androidx.work.WorkManager.getInstance(this).enqueueUniquePeriodicWork(
+                "myotis-daily-catchup",
+                androidx.work.ExistingPeriodicWorkPolicy.KEEP,
+                new androidx.work.PeriodicWorkRequest.Builder(
+                        CatchUpWorker.class, 24, java.util.concurrent.TimeUnit.HOURS)
+                        .setConstraints(new androidx.work.Constraints.Builder()
+                                .setRequiredNetworkType(androidx.work.NetworkType.CONNECTED)
+                                .build())
+                        .build());
     }
 }

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/MainActivity.kt
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/MainActivity.kt
@@ -45,7 +45,11 @@ class MainActivity : ComponentActivity() {
 
     private val connection = object : ServiceConnection {
         override fun onServiceConnected(name: ComponentName?, service: IBinder?) {
-            boundServiceState.value = (service as NodeService.LocalBinder).service()
+            val svc = (service as NodeService.LocalBinder).service()
+            boundServiceState.value = svc
+            // Fresh bind = the app just came to the foreground: count it as activity and
+            // proactively wake any idle-paused stack so the UI shows live data.
+            svc.onAppForeground()
         }
 
         override fun onServiceDisconnected(name: ComponentName?) {
@@ -102,6 +106,9 @@ class MainActivity : ComponentActivity() {
         // (which actually boots the node) is NOT called by binding alone, so this does not
         // auto-start peer discovery.
         bindService(Intent(this, NodeService::class.java), connection, Context.BIND_AUTO_CREATE)
+        // Already bound (rebind is async and may not fire onServiceConnected again): treat
+        // foregrounding as activity and wake idle-paused stacks now.
+        boundServiceState.value?.onAppForeground()
     }
 
     override fun onStop() {

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -502,7 +502,10 @@ public final class NodeService extends Service {
                     ChainHandle cur = handles.get(n);
                     if (cur != null && RUNNING.get()) {
                         LogBuffer.i(TAG, "[" + n + "] resuming (app foreground)");
-                        try { cur.resume(); } catch (Throwable t) {
+                        // FOREGROUND is an observation wake: counts toward the pause total but
+                        // must not overwrite the last-wake reason, or opening the app to view
+                        // the status page would hide the request/catch-up wake being debugged.
+                        try { cur.resume(io.myotis.api.WakeReason.FOREGROUND); } catch (Throwable t) {
                             LogBuffer.w(TAG, "[" + n + "] foreground resume failed: " + t);
                         }
                     }
@@ -622,7 +625,7 @@ public final class NodeService extends Service {
                 // Hold the grace stamp BEFORE resume returns RUNNING, so the idle ticker
                 // can't pause the stack in the window between resume() and the loop.
                 lastResumeMs.put(n, System.currentTimeMillis());
-                resumed = h.resume();
+                resumed = h.resume(io.myotis.api.WakeReason.CATCH_UP);
             }
             if (!resumed) continue; // stays paused; next daily run retries
             // Monotonic deadline (nanoTime, overflow-safe compare) so an NTP/wall-clock
@@ -741,7 +744,13 @@ public final class NodeService extends Service {
             // calls serve instead of hitting "no verified head".
             long verifiedHeadAgeMs,
             List<io.myotis.api.PeerInfo> readyPeerList,
-            String network) {}            // active chain ("mainnet"/"gnosis")
+            String network,               // active chain ("mainnet"/"gnosis")
+            // Idle-sleep metrics (see WakeReason / SleepMetrics) — for the Status screen.
+            int pauseCount,               // times this stack entered idle sleep since start
+            long totalPausedMs,           // cumulative time paused (ms)
+            long lastPauseEpochMs,        // wall-clock ms of the last pause; 0 if never
+            long lastResumeEpochMs,       // wall-clock ms of the last DEMAND wake; 0 if none
+            String lastWakeReason) {}     // reason tag of the last demand wake; null if none
 
     /** Result of a get-account query. Mirrors the JVM daemon's JSON response shape. */
     public record AccountQueryResult(
@@ -1334,7 +1343,9 @@ public final class NodeService extends Service {
                     beaconState, bs.bootstrapped(), bs.connectedPeers(), (int) bs.lightClientPeers(),
                     bs.servedPeersLastMinute(), cachedCl, bs.finalizedSlot(), bs.executionBlockNumber(), bs.executionBlockHashHex(),
                     s.syncStartPeriod(), syncCurrent, syncTarget,
-                    Long.MAX_VALUE, List.of(), network);
+                    Long.MAX_VALUE, List.of(), network,
+                    s.pauseCount(), s.totalPausedMs(), s.lastPauseEpochMs(),
+                    s.lastResumeEpochMs(), s.lastWakeReason());
         }
         return new Snapshot(true, lifecycle, startTimeMs,
                 s.discoveredPeers(), s.connectedPeers(), s.readyPeers(),
@@ -1344,7 +1355,9 @@ public final class NodeService extends Service {
                 beaconState, bs.bootstrapped(), bs.connectedPeers(), (int) bs.lightClientPeers(),
                 bs.servedPeersLastMinute(), cachedCl, bs.finalizedSlot(), bs.executionBlockNumber(), bs.executionBlockHashHex(),
                 s.syncStartPeriod(), syncCurrent, syncTarget,
-                s.verifiedHeadAgeMs(), s.readyPeerList(), network);
+                s.verifiedHeadAgeMs(), s.readyPeerList(), network,
+                s.pauseCount(), s.totalPausedMs(), s.lastPauseEpochMs(),
+                s.lastResumeEpochMs(), s.lastWakeReason());
     }
 
     // ---- Failure forensics (see ProcessHealthDiag) ----

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -467,12 +467,16 @@ public final class NodeService extends Service {
     private static final long IDLE_TICK_MS = 30_000;
     /** Last UI-originated activity (query tab, ENS lookup, enable, app foreground). */
     private volatile long uiActivityMs;
-    /** Per-network boot stamp: a freshly-started stack gets a full idle window. */
-    private final Map<String, Long> stackStartMs = new ConcurrentHashMap<>();
+    /** Per-network boot stamp: a freshly-started stack gets a full idle window.
+     *  STATIC (matching ENGINE / RUNNING / BOOT_LOCKS): this is per-network-stack state that
+     *  outlives a service instance, and the static {@link #dailyCatchUp} worker path reads/writes it. */
+    private static final Map<String, Long> stackStartMs = new ConcurrentHashMap<>();
     /** Per-network HOST-side resume stamp (foreground resume, daily catch-up): gives
      *  the resumed stack a full idle window even though no request bumped the engine's
-     *  activity clock. Engine-side wakes need no stamp — the waking request did it. */
-    private final Map<String, Long> lastResumeMs = new ConcurrentHashMap<>();
+     *  activity clock. Engine-side wakes need no stamp — the waking request did it.
+     *  STATIC so the {@link #dailyCatchUp} worker (no service binder) can hold the grace
+     *  stamp while it catches up, keeping the instance idle ticker from pausing it mid-pass. */
+    private static final Map<String, Long> lastResumeMs = new ConcurrentHashMap<>();
     private volatile java.util.concurrent.ScheduledExecutorService idleTicker;
     /** What the notification currently shows, to notify() only on transitions. */
     private volatile Boolean notifiedSleeping;
@@ -592,11 +596,17 @@ public final class NodeService extends Service {
      * resume, wait until the beacon client is SYNCED and the verified head is warm (or
      * the per-network budget slice runs out), and pause again — but only if no real
      * activity arrived meanwhile (then the idle controller owns the stack again).
-     * Deliberately does NOT count as activity: resume()/catch-up never bump the
-     * engine's activity clock (only gated requests do), so the worker can't fight the
-     * idle policy. Snapshot persistence is free — the engine persists on every pause.
      *
-     * <p>Static: the Worker has no binder, and ENGINE/BOOT_LOCKS are process-global.
+     * <p>Two distinct clocks, deliberately: the worker never touches the ENGINE's
+     * activity clock ({@code lastActivityEpochMillis}), so the "did real activity
+     * arrive?" check at the end stays honest. It DOES hold the host-side
+     * {@link #lastResumeMs} grace stamp (refreshed each loop) while it runs, so the
+     * instance idle ticker — which also considers {@code lastResumeMs} — won't pause
+     * the just-resumed stack out from under the catch-up before it reaches SYNCED.
+     * Snapshot persistence is free: the engine persists on every pause.
+     *
+     * <p>Static: the Worker has no binder; ENGINE / BOOT_LOCKS / the idle stamps are
+     * all process-global.
      */
     public static void dailyCatchUp(long budgetMs) {
         List<String> hosted = ENGINE.hostedNetworks();
@@ -609,11 +619,19 @@ public final class NodeService extends Service {
             LogBuffer.i(TAG, "[" + n + "] daily catch-up: resuming");
             boolean resumed;
             synchronized (bootLock(n)) {
+                // Hold the grace stamp BEFORE resume returns RUNNING, so the idle ticker
+                // can't pause the stack in the window between resume() and the loop.
+                lastResumeMs.put(n, System.currentTimeMillis());
                 resumed = h.resume();
             }
             if (!resumed) continue; // stays paused; next daily run retries
-            long deadline = System.currentTimeMillis() + sliceMs;
-            while (System.currentTimeMillis() < deadline) {
+            // Monotonic deadline (nanoTime, overflow-safe compare) so an NTP/wall-clock
+            // step can't cut the pass short or hang it.
+            long deadlineNano = System.nanoTime() + sliceMs * 1_000_000L;
+            while (System.nanoTime() - deadlineNano < 0) {
+                // Refresh the grace stamp each iteration: keeps now-lastResumeMs well under
+                // any idle window (min 60s) so the 30s idle ticker never pauses us mid-pass.
+                lastResumeMs.put(n, System.currentTimeMillis());
                 try {
                     StatusSnapshot s = h.status();
                     if (s.beaconState() == BeaconState.SYNCED

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -108,6 +108,8 @@ public final class NodeService extends Service {
     private static final String K_DEEP_POOL = "deepPoolThreshold";
     private static final String K_STRICT_FRESHNESS = "strictStateFreshness";
     private static final String K_NATIVE_BLS = "nativeBls";
+    private static final String K_IDLE_PAUSE_MIN = "idlePauseMinutes";
+    public static final int DEFAULT_IDLE_PAUSE_MIN = 5;
     public static final int DEFAULT_RPC_PORT = 8545;
     // Gnosis defaults to a distinct port so both networks can be added to MetaMask
     // at once: MetaMask refuses to save two RPC endpoints that share the same URL
@@ -254,6 +256,15 @@ public final class NodeService extends Service {
     public static void setDeepPoolThreshold(android.content.Context c, int v) {
         prefs(c).edit().putInt(K_DEEP_POOL, clampInt(v, 1, 128, DEFAULT_DEEP_POOL)).apply();
     }
+    /** Minutes of no RPC/UI activity before a running stack is paused (networking off,
+     *  RPC keeps listening; the first request wakes it). 0 disables auto-pause. */
+    public static int idlePauseMinutes(android.content.Context c) {
+        return clampInt(prefs(c).getInt(K_IDLE_PAUSE_MIN, DEFAULT_IDLE_PAUSE_MIN),
+                0, 240, DEFAULT_IDLE_PAUSE_MIN);
+    }
+    public static void setIdlePauseMinutes(android.content.Context c, int v) {
+        prefs(c).edit().putInt(K_IDLE_PAUSE_MIN, clampInt(v, 0, 240, DEFAULT_IDLE_PAUSE_MIN)).apply();
+    }
     /** Whether RPC state reads use the strict 2-min head-staleness bound. Default true
      *  (strict). Relaxing it (toggle OFF strict / ON "relaxed") lets eth_call / balance /
      *  estimateGas serve an older root — but that *backfired* into 120-s confirm-screen
@@ -325,6 +336,7 @@ public final class NodeService extends Service {
      * and start just this stack on a worker. No-op if it's already live.
      */
     public void enableNetwork(String name) {
+        noteUiActivity();
         String n = canonicalNetwork(name);
         setNetworkEnabled(this, n, true);
         if (!RUNNING.get()) {
@@ -378,6 +390,8 @@ public final class NodeService extends Service {
         cachedClCounts.remove(n);
         elCaches.remove(n);
         clCaches.remove(n);
+        stackStartMs.remove(n);
+        lastResumeMs.remove(n);
     }
 
     /** True if any network is still enabled (incl. the seeded default). */
@@ -441,6 +455,209 @@ public final class NodeService extends Service {
     // next start; never cleared in doShutdown — see the PR #82 note there.
     private volatile long startTimeMs;
 
+    // ---------------------------------------------------------------------
+    // Idle sleep controller: pause a stack's networking after idlePauseMinutes
+    // of no RPC / UI activity. The engine self-wakes on an incoming JSON-RPC
+    // request (the wake gate holds it until ready), so the controller only has
+    // to decide when to go BACK to sleep — and to reconcile the notification
+    // with wakes it didn't perform.
+    // ---------------------------------------------------------------------
+
+    /** How often the idle controller checks activity and reconciles the notification. */
+    private static final long IDLE_TICK_MS = 30_000;
+    /** Last UI-originated activity (query tab, ENS lookup, enable, app foreground). */
+    private volatile long uiActivityMs;
+    /** Per-network boot stamp: a freshly-started stack gets a full idle window. */
+    private final Map<String, Long> stackStartMs = new ConcurrentHashMap<>();
+    /** Per-network HOST-side resume stamp (foreground resume, daily catch-up): gives
+     *  the resumed stack a full idle window even though no request bumped the engine's
+     *  activity clock. Engine-side wakes need no stamp — the waking request did it. */
+    private final Map<String, Long> lastResumeMs = new ConcurrentHashMap<>();
+    private volatile java.util.concurrent.ScheduledExecutorService idleTicker;
+    /** What the notification currently shows, to notify() only on transitions. */
+    private volatile Boolean notifiedSleeping;
+
+    /** Note UI-originated activity so the idle controller keeps the node awake. */
+    public void noteUiActivity() {
+        uiActivityMs = System.currentTimeMillis();
+    }
+
+    /**
+     * The app came to the foreground: count it as activity and proactively resume
+     * every paused stack so the UI shows live data without waiting for a query.
+     */
+    public void onAppForeground() {
+        noteUiActivity();
+        for (Map.Entry<String, ChainHandle> e : handles.entrySet()) {
+            String n = e.getKey();
+            ChainHandle h = e.getValue();
+            if (h.lifecycle() != io.myotis.api.LifecycleState.PAUSED) continue;
+            lastResumeMs.put(n, System.currentTimeMillis());
+            new Thread(() -> {
+                synchronized (bootLock(n)) {
+                    ChainHandle cur = handles.get(n);
+                    if (cur != null && RUNNING.get()) {
+                        LogBuffer.i(TAG, "[" + n + "] resuming (app foreground)");
+                        try { cur.resume(); } catch (Throwable t) {
+                            LogBuffer.w(TAG, "[" + n + "] foreground resume failed: " + t);
+                        }
+                    }
+                }
+                updateNotification();
+            }, "ethp2p-fg-resume-" + n).start();
+        }
+    }
+
+    private void startIdleTicker() {
+        if (idleTicker != null) return;
+        java.util.concurrent.ScheduledExecutorService ex =
+                Executors.newSingleThreadScheduledExecutor(r -> {
+                    Thread t = new Thread(r, "ethp2p-idle");
+                    t.setDaemon(true);
+                    return t;
+                });
+        ex.scheduleWithFixedDelay(() -> idleTick(idlePauseMinutes(this) * 60_000L),
+                IDLE_TICK_MS, IDLE_TICK_MS, java.util.concurrent.TimeUnit.MILLISECONDS);
+        idleTicker = ex;
+    }
+
+    private void stopIdleTicker() {
+        java.util.concurrent.ScheduledExecutorService ex = idleTicker;
+        if (ex != null) {
+            ex.shutdownNow();
+            idleTicker = null;
+        }
+    }
+
+    /**
+     * One idle-controller pass: pause every RUNNING stack whose last activity —
+     * engine-side (gated RPC/ENS/query), UI-side, or a host resume/boot stamp —
+     * is older than {@code idleMs}, then reconcile the notification. Guarded:
+     * an uncaught throw would silently stop all future scheduled runs.
+     */
+    private void idleTick(long idleMs) {
+        try {
+            long now = System.currentTimeMillis();
+            for (Map.Entry<String, ChainHandle> e : handles.entrySet()) {
+                String n = e.getKey();
+                ChainHandle h = e.getValue();
+                if (idleMs <= 0) break; // auto-pause disabled
+                io.myotis.api.LifecycleState ls;
+                try { ls = h.lifecycle(); } catch (Throwable t) { continue; }
+                if (ls != io.myotis.api.LifecycleState.RUNNING) continue;
+                long lastActivity = Math.max(
+                        Math.max(h.lastActivityEpochMillis(), uiActivityMs),
+                        Math.max(lastResumeMs.getOrDefault(n, 0L),
+                                 stackStartMs.getOrDefault(n, 0L)));
+                if (now - lastActivity <= idleMs) continue;
+                long idleForSec = (now - lastActivity) / 1000;
+                new Thread(() -> {
+                    synchronized (bootLock(n)) {
+                        // Re-check under the lock: a disable/reboot/stop may have raced us,
+                        // and pause() on a stack that lost that race is a no-op anyway.
+                        ChainHandle cur = handles.get(n);
+                        if (cur != null && RUNNING.get() && isNetworkEnabled(this, n)) {
+                            LogBuffer.i(TAG, "[" + n + "] idle " + idleForSec
+                                    + "s; pausing networking (RPC keeps listening)");
+                            try { cur.pause(); } catch (Throwable t) {
+                                LogBuffer.w(TAG, "[" + n + "] pause failed: " + t);
+                            }
+                        }
+                    }
+                    updateNotification();
+                }, "ethp2p-pause-" + n).start();
+            }
+            updateNotification();
+        } catch (Throwable t) {
+            LogBuffer.w(TAG, "idle tick error: " + t);
+        }
+    }
+
+    /** True when the service runs at least one stack and every live stack is paused. */
+    private boolean allStacksPaused() {
+        boolean any = false;
+        for (ChainHandle h : handles.values()) {
+            any = true;
+            try {
+                if (h.lifecycle() != io.myotis.api.LifecycleState.PAUSED) return false;
+            } catch (Throwable t) {
+                return false;
+            }
+        }
+        return any;
+    }
+
+    /**
+     * The daily maintenance pass ({@link CatchUpWorker}): for each idle-PAUSED stack,
+     * resume, wait until the beacon client is SYNCED and the verified head is warm (or
+     * the per-network budget slice runs out), and pause again — but only if no real
+     * activity arrived meanwhile (then the idle controller owns the stack again).
+     * Deliberately does NOT count as activity: resume()/catch-up never bump the
+     * engine's activity clock (only gated requests do), so the worker can't fight the
+     * idle policy. Snapshot persistence is free — the engine persists on every pause.
+     *
+     * <p>Static: the Worker has no binder, and ENGINE/BOOT_LOCKS are process-global.
+     */
+    public static void dailyCatchUp(long budgetMs) {
+        List<String> hosted = ENGINE.hostedNetworks();
+        if (hosted.isEmpty()) return;
+        long sliceMs = Math.max(30_000L, budgetMs / hosted.size());
+        for (String n : hosted) {
+            ChainHandle h = ENGINE.get(n);
+            if (h == null || h.lifecycle() != io.myotis.api.LifecycleState.PAUSED) continue;
+            long activityBefore = h.lastActivityEpochMillis();
+            LogBuffer.i(TAG, "[" + n + "] daily catch-up: resuming");
+            boolean resumed;
+            synchronized (bootLock(n)) {
+                resumed = h.resume();
+            }
+            if (!resumed) continue; // stays paused; next daily run retries
+            long deadline = System.currentTimeMillis() + sliceMs;
+            while (System.currentTimeMillis() < deadline) {
+                try {
+                    StatusSnapshot s = h.status();
+                    if (s.beaconState() == BeaconState.SYNCED
+                            && s.verifiedHeadAgeMs() != Long.MAX_VALUE) {
+                        break;
+                    }
+                    Thread.sleep(5_000);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                } catch (Throwable ignored) {
+                    break;
+                }
+            }
+            // Real user/RPC activity arrived mid-catch-up → leave the stack to the
+            // idle controller; otherwise go straight back to sleep (pause persists
+            // the freshly-caught-up snapshot).
+            if (h.lastActivityEpochMillis() == activityBefore) {
+                synchronized (bootLock(n)) {
+                    try { h.pause(); } catch (Throwable ignored) {}
+                }
+                LogBuffer.i(TAG, "[" + n + "] daily catch-up done; paused again");
+            } else {
+                LogBuffer.i(TAG, "[" + n + "] daily catch-up: activity arrived; staying awake");
+            }
+        }
+    }
+
+    /** Re-issue the foreground notification when the sleeping/active state changed —
+     *  including engine-initiated wakes (an RPC request resumed a paused stack). */
+    private void updateNotification() {
+        if (!RUNNING.get()) return;
+        boolean sleeping = allStacksPaused();
+        Boolean shown = notifiedSleeping;
+        if (shown != null && shown == sleeping) return;
+        notifiedSleeping = sleeping;
+        try {
+            NotificationManager nm = getSystemService(NotificationManager.class);
+            if (nm != null) nm.notify(NOTIFICATION_ID, buildNotification(sleeping));
+        } catch (Throwable t) {
+            LogBuffer.w(TAG, "notification update failed: " + t);
+        }
+    }
+
     // Runs the BLOCKING engine-API calls (requestAccount, ens().resolveAddress) off the
     // caller's thread — the service's public surface stays CompletableFuture-based for
     // the Kotlin bridge, so the blocking API call is wrapped here. Static daemon pool:
@@ -464,6 +681,9 @@ public final class NodeService extends Service {
 
     public record Snapshot(
             boolean running,
+            String lifecycle,         // "RUNNING" | "PAUSED" | "STOPPED" — PAUSED is the
+                                      // idle sleep state: networking off, RPC listening,
+                                      // warm state retained, first request wakes it
             long startTimeMs,
             int discoveredPeers,
             int connectedPeers,
@@ -567,6 +787,7 @@ public final class NodeService extends Service {
     @SuppressLint("NewApi") // CompletableFuture.failedFuture (API 31) is backported to
                             // minSdk 29 via desugar_jdk_libs — see the comment block above.
     public CompletableFuture<AccountQueryResult> requestAccount(String network, String hexAddress) {
+        noteUiActivity();
         ChainHandle handle = handles.get(canonicalNetwork(network));
         if (handle == null) {
             return CompletableFuture.failedFuture(new IllegalStateException("Node is not running"));
@@ -661,6 +882,7 @@ public final class NodeService extends Service {
 
     @SuppressLint("NewApi") // CompletableFuture.failedFuture — see requestAccount
     public CompletableFuture<EnsResolution> resolveEns(String network, String name) {
+        noteUiActivity();
         final String trimmed = name == null ? "" : name.trim();
         final String n = canonicalNetwork(network);
         // ENS is mainnet/Sepolia-only — refuse early so we never run ENS contracts against
@@ -747,8 +969,10 @@ public final class NodeService extends Service {
         // API 34+ requires the foregroundServiceType to be passed here and
         // to match the manifest's <service android:foregroundServiceType="...">
         // declaration. API 29-33 ignore the third arg. minSdk is 29.
-        startForeground(NOTIFICATION_ID, buildNotification(),
+        notifiedSleeping = false;
+        startForeground(NOTIFICATION_ID, buildNotification(false),
                 ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC);
+        startIdleTicker();
 
         // Boot every enabled network as its own stack (Step 9). Each Netty/libp2p boot is
         // blocking-ish, so build + start each on its own worker; they bind distinct ports
@@ -858,6 +1082,10 @@ public final class NodeService extends Service {
                     return;
                 }
             }
+            // A freshly-booted stack gets a full idle window before the controller
+            // may pause it (its engine activity clock starts at 0).
+            stackStartMs.put(n, System.currentTimeMillis());
+            updateNotification();
             LogBuffer.i(TAG, "[" + n + "] node stack started (RPC " + rpcPort + ")");
         } catch (Exception e) {
             LogBuffer.e(TAG, "[" + n + "] node boot failed", e);
@@ -1078,8 +1306,11 @@ public final class NodeService extends Service {
         boolean preBeacon = bs.state() == BeaconState.STARTING;
         long syncCurrent = preBeacon ? -1 : s.syncCurrentPeriod();
         long syncTarget = preBeacon ? -1 : s.syncTargetPeriod();
+        String lifecycle = s.lifecycle() != null ? s.lifecycle().name() : "STOPPED";
         if (!running || !s.running()) {
-            return new Snapshot(running, startTimeMs, 0, 0, 0, 0, /*snapServing*/0,
+            // Covers both a stopped stack and a PAUSED one (running=false, warm state
+            // retained) — the lifecycle string lets the UI tell them apart.
+            return new Snapshot(running, lifecycle, startTimeMs, 0, 0, 0, 0, /*snapServing*/0,
                     cachedEl, s.attemptedDials(), s.backedOffPeers(),
                     s.blacklistedPeers(), s.discv5TableSize(), 0,
                     beaconState, bs.bootstrapped(), bs.connectedPeers(), (int) bs.lightClientPeers(),
@@ -1087,7 +1318,7 @@ public final class NodeService extends Service {
                     s.syncStartPeriod(), syncCurrent, syncTarget,
                     Long.MAX_VALUE, List.of(), network);
         }
-        return new Snapshot(true, startTimeMs,
+        return new Snapshot(true, lifecycle, startTimeMs,
                 s.discoveredPeers(), s.connectedPeers(), s.readyPeers(),
                 s.snapPeers(), s.snapServingPeers(),
                 cachedEl, s.attemptedDials(), s.backedOffPeers(),
@@ -1185,6 +1416,12 @@ public final class NodeService extends Service {
         // silent SIGKILL. Pair with the next launch's prior-exit=LOW_MEMORY line.
         LogBuffer.w(ProcessHealthDiag.TAG, "onTrimMemory " + ProcessHealthDiag.trimLevelName(level)
                 + " | " + ProcessHealthDiag.memorySummary(this));
+        // About to be OOM-killed: pause any stack that's been idle even briefly.
+        // A pause frees the big consumers (Netty buffers, evm pools, libp2p) while
+        // keeping the warm beacon store — far better than dying and cold-starting.
+        if (level >= TRIM_MEMORY_RUNNING_CRITICAL && RUNNING.get()) {
+            idleTick(60_000L);
+        }
     }
 
     @Override
@@ -1197,6 +1434,7 @@ public final class NodeService extends Service {
             hb.interrupt();
             healthThread = null;
         }
+        stopIdleTicker();
         // Same fire-and-forget pattern as shutdown(): the system gives us a
         // brief window to return from onDestroy and we don't want to spend
         // it blocking on libp2p host shutdown / Netty graceful drain. doShutdown()
@@ -1207,14 +1445,17 @@ public final class NodeService extends Service {
         super.onDestroy();
     }
 
-    private Notification buildNotification() {
+    private Notification buildNotification(boolean sleeping) {
         NotificationManager nm = getSystemService(NotificationManager.class);
         NotificationChannel channel = new NotificationChannel(
                 CHANNEL_ID, "ethp2p node",
                 NotificationManager.IMPORTANCE_LOW);
         nm.createNotificationChannel(channel);
         return new Notification.Builder(this, CHANNEL_ID)
-                .setContentTitle("ethp2p node running")
+                .setContentTitle(sleeping ? "ethp2p node sleeping" : "ethp2p node running")
+                .setContentText(sleeping
+                        ? "Networking off — a wallet request wakes it"
+                        : null)
                 .setSmallIcon(android.R.drawable.stat_sys_download)
                 .setOngoing(true)
                 .build();

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/cmp/AndroidNodeBridge.kt
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/cmp/AndroidNodeBridge.kt
@@ -148,6 +148,11 @@ private fun NodeService.Snapshot.toModel(): NodeSnapshot = NodeSnapshot(
     verifiedHeadAgeMs = verifiedHeadAgeMs(),
     uptimeSeconds = if (startTimeMs() > 0) (System.currentTimeMillis() - startTimeMs()) / 1000 else 0,
     readyPeerList = readyPeerList().map { PeerRow(it.remoteAddress(), it.snapSupported(), it.clientId()) },
+    pauseCount = pauseCount(),
+    totalPausedMs = totalPausedMs(),
+    lastPauseEpochMs = lastPauseEpochMs(),
+    lastResumeEpochMs = lastResumeEpochMs(),
+    lastWakeReason = lastWakeReason(),
 )
 
 /** Android actual of [Settings] over the NodeService SharedPreferences statics. */

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/cmp/AndroidNodeBridge.kt
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/cmp/AndroidNodeBridge.kt
@@ -175,6 +175,7 @@ class AndroidSettings(private val ctx: Context) : Settings {
 
     override fun idlePauseMinutes(): Int = NodeService.idlePauseMinutes(ctx)
     override fun setIdlePauseMinutes(v: Int) = NodeService.setIdlePauseMinutes(ctx, v)
+    override fun supportsIdleSleep(): Boolean = true   // NodeService runs the idle controller
 }
 
 /**

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/cmp/AndroidNodeBridge.kt
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/cmp/AndroidNodeBridge.kt
@@ -127,6 +127,7 @@ class AndroidNetworkStatus(private val ctx: Context) : NetworkStatus {
 /** Map the Java `NodeService.Snapshot` record into the shared Kotlin model. */
 private fun NodeService.Snapshot.toModel(): NodeSnapshot = NodeSnapshot(
     running = running(),
+    lifecycle = lifecycle(),
     network = network(),
     beaconState = beaconState(),
     connectedPeers = connectedPeers(),
@@ -171,6 +172,9 @@ class AndroidSettings(private val ctx: Context) : Settings {
     override fun setStrictStateFreshness(v: Boolean) = NodeService.setStrictStateFreshness(ctx, v)
     override fun nativeBlsEnabled(): Boolean = NodeService.nativeBlsEnabled(ctx)
     override fun setNativeBlsEnabled(v: Boolean) = NodeService.setNativeBlsEnabled(ctx, v)
+
+    override fun idlePauseMinutes(): Int = NodeService.idlePauseMinutes(ctx)
+    override fun setIdlePauseMinutes(v: Int) = NodeService.setIdlePauseMinutes(ctx, v)
 }
 
 /**

--- a/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
@@ -235,6 +235,7 @@ class DesktopNodeController(
         val bs = handle.beaconStatus()
         return NodeSnapshot(
             running = s.running(),
+            lifecycle = s.lifecycle().name,
             network = s.network(),
             beaconState = s.beaconState().name,
             connectedPeers = s.connectedPeers(),

--- a/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
@@ -256,6 +256,11 @@ class DesktopNodeController(
             verifiedHeadAgeMs = s.verifiedHeadAgeMs(),
             uptimeSeconds = (System.nanoTime() - startNs) / 1_000_000_000L,
             readyPeerList = s.readyPeerList().map { PeerRow(it.remoteAddress(), it.snapSupported(), it.clientId()) },
+            pauseCount = s.pauseCount(),
+            totalPausedMs = s.totalPausedMs(),
+            lastPauseEpochMs = s.lastPauseEpochMs(),
+            lastResumeEpochMs = s.lastResumeEpochMs(),
+            lastWakeReason = s.lastWakeReason(),
         )
     }
 }

--- a/app-desktop/src/main/resources/logback-desktop.xml
+++ b/app-desktop/src/main/resources/logback-desktop.xml
@@ -54,6 +54,12 @@
          -Dmyotis.log.wire.level=INFO (or DEBUG) to watch the wire during diagnosis. -->
     <logger name="com.jaeckel.ethp2p.networking" level="${WIRE_LEVEL}"/>
 
+    <!-- RPC access log: one concise INFO line per JSON-RPC call the server answers
+         (method/id/outcome/latency), incl. parse/batch errors. Falls under io.myotis
+         already; pinned here so it's discoverable and can go to DEBUG (full req/resp
+         bodies) independently of the app/wire levels. In the Logs tab, filter on "rpc". -->
+    <logger name="io.myotis.jsonrpc.access" level="INFO"/>
+
     <!-- Third-party noise stays pinned regardless of APP_LEVEL. -->
     <logger name="io.netty" level="WARN"/>
     <logger name="org.apache.tuweni" level="WARN"/>

--- a/app/src/main/java/com/jaeckel/ethp2p/app/CommandHandler.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/CommandHandler.java
@@ -75,6 +75,8 @@ public class CommandHandler {
                 case "resolve-ens-dns"         -> handleResolveEnsDns(jsonLine);
                 case "resolve-ens-interface"   -> handleResolveEnsInterface(jsonLine);
                 case "dial"                    -> handleDial(jsonLine);
+                case "pause"                   -> handlePause();
+                case "resume"                  -> handleResume();
                 case "stop"                    -> handleStop();
                 case "beacon-status"           -> handleBeaconStatus();
                 default                        -> jsonError("Unknown command: " + cmd);
@@ -118,10 +120,26 @@ public class CommandHandler {
     // Status / peers
     // -------------------------------------------------------------------------
 
+    /** Pause the stack into idle sleep: networking off, RPC listening, first request wakes it. */
+    private String handlePause() {
+        log.info("[ipc] Pause command received");
+        return handle.pause()
+                ? "{\"ok\":true,\"lifecycle\":\"PAUSED\"}"
+                : jsonError("pause failed (lifecycle: " + handle.lifecycle() + ")");
+    }
+
+    /** Resume a paused stack (also happens automatically on the first verified read). */
+    private String handleResume() {
+        log.info("[ipc] Resume command received");
+        return handle.resume()
+                ? "{\"ok\":true,\"lifecycle\":\"RUNNING\"}"
+                : jsonError("resume failed (lifecycle: " + handle.lifecycle() + ")");
+    }
+
     private String handleStatus() {
         long uptimeSec = (System.currentTimeMillis() - startTimeMs) / 1000;
         StatusSnapshot s = handle.status();
-        return "{\"ok\":true,\"state\":\"RUNNING\",\"uptimeSeconds\":" + uptimeSec
+        return "{\"ok\":true,\"state\":\"" + handle.lifecycle() + "\",\"uptimeSeconds\":" + uptimeSec
                 + ",\"discoveredPeers\":" + s.discoveredPeers()
                 + ",\"connectedPeers\":" + s.connectedPeers()
                 + ",\"readyPeers\":" + s.readyPeers()

--- a/app/src/main/java/com/jaeckel/ethp2p/app/CommandHandler.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/CommandHandler.java
@@ -131,7 +131,7 @@ public class CommandHandler {
     /** Resume a paused stack (also happens automatically on the first verified read). */
     private String handleResume() {
         log.info("[ipc] Resume command received");
-        return handle.resume()
+        return handle.resume(io.myotis.api.WakeReason.IPC)
                 ? "{\"ok\":true,\"lifecycle\":\"RUNNING\"}"
                 : jsonError("resume failed (lifecycle: " + handle.lifecycle() + ")");
     }
@@ -139,13 +139,19 @@ public class CommandHandler {
     private String handleStatus() {
         long uptimeSec = (System.currentTimeMillis() - startTimeMs) / 1000;
         StatusSnapshot s = handle.status();
+        String wakeReason = s.lastWakeReason() == null ? "null" : "\"" + s.lastWakeReason() + "\"";
         return "{\"ok\":true,\"state\":\"" + handle.lifecycle() + "\",\"uptimeSeconds\":" + uptimeSec
                 + ",\"discoveredPeers\":" + s.discoveredPeers()
                 + ",\"connectedPeers\":" + s.connectedPeers()
                 + ",\"readyPeers\":" + s.readyPeers()
                 + ",\"snapPeers\":" + s.snapPeers()
                 + ",\"backedOffPeers\":" + s.backedOffPeers()
-                + ",\"blacklistedPeers\":" + s.blacklistedPeers() + "}";
+                + ",\"blacklistedPeers\":" + s.blacklistedPeers()
+                + ",\"pauseCount\":" + s.pauseCount()
+                + ",\"totalPausedMs\":" + s.totalPausedMs()
+                + ",\"lastPauseEpochMs\":" + s.lastPauseEpochMs()
+                + ",\"lastResumeEpochMs\":" + s.lastResumeEpochMs()
+                + ",\"lastWakeReason\":" + wakeReason + "}";
     }
 
     private String handlePeers() {

--- a/app/src/main/java/com/jaeckel/ethp2p/app/DaemonClient.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/DaemonClient.java
@@ -81,7 +81,7 @@ public class DaemonClient {
         if (args.length == 0) throw new IllegalArgumentException("No command specified");
         String cmd = args[0];
         return switch (cmd) {
-            case "status", "peers", "stop" -> "{\"cmd\":\"" + esc(cmd) + "\"}";
+            case "status", "peers", "stop", "pause", "resume" -> "{\"cmd\":\"" + esc(cmd) + "\"}";
             case "get-headers" -> {
                 long blockNumber = args.length > 1 ? Long.parseLong(args[1]) : 21_000_000L;
                 int count       = args.length > 2 ? Integer.parseInt(args[2]) : 3;

--- a/app/src/main/java/com/jaeckel/ethp2p/app/Main.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/Main.java
@@ -189,6 +189,8 @@ public final class Main {
                     System.err.println("Commands:");
                     System.err.println("  ./gradlew :app:run -Pargs=status");
                     System.err.println("  ./gradlew :app:run -Pargs=peers");
+                    System.err.println("  ./gradlew :app:run -Pargs=pause");
+                    System.err.println("  ./gradlew :app:run -Pargs=resume");
                     System.err.println("  ./gradlew :app:run -Pargs=stop");
                 }
                 System.exit(1);

--- a/app/src/main/resources/logback-daemon.xml
+++ b/app/src/main/resources/logback-daemon.xml
@@ -26,6 +26,11 @@
     </appender>
 
     <logger name="com.jaeckel.ethp2p" level="DEBUG"/>
+    <!-- RPC access log: one concise INFO line per JSON-RPC call the server answers
+         (method/id/outcome/latency), incl. parse/batch errors. Isolate it above the
+         com.jaeckel.ethp2p=DEBUG wire flood with `grep 'jsonrpc.access' devp2p.log`.
+         Bump to DEBUG to also log the full request+response bodies. -->
+    <logger name="io.myotis.jsonrpc.access" level="INFO"/>
     <logger name="io.netty" level="WARN"/>
     <logger name="org.apache.tuweni" level="WARN"/>
     <logger name="io.libp2p" level="WARN"/>

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
@@ -615,6 +615,52 @@ public class BeaconLightClient implements AutoCloseable {
         log.info("[beacon] Light client started with {} peer(s)", clPeerMultiaddrs.size());
     }
 
+    /**
+     * Stop the sync thread and the libp2p host but KEEP the verified store, the
+     * catch-up executor, and the peer-knowledge maps warm for {@link #resume()}.
+     * Persists the snapshot so a process kill while asleep loses nothing.
+     * Idempotent; a no-op unless running.
+     */
+    public synchronized void pause() {
+        if (!running) return;
+        running = false;
+        Thread t = syncThread;
+        if (t != null) {
+            t.interrupt();
+            try {
+                t.join(2_000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+        syncThread = null;
+        persistSnapshot();
+        try {
+            p2pService.close();
+        } catch (Throwable e) {
+            log.warn("[beacon] p2p close on pause: {}", e.toString());
+        }
+        log.info("[beacon] Light client paused (store retained, period {})",
+                store.isInitialized() ? store.getCurrentSyncCommitteePeriod() : -1);
+    }
+
+    /**
+     * Restart the libp2p host and sync loop after {@link #pause()}. The warm
+     * in-memory store makes {@code syncLoop} skip snapshot-restore and bootstrap
+     * and go straight to Identify + committee catch-up (which covers any periods
+     * missed while asleep). Idempotent; a no-op when already running.
+     */
+    public synchronized void resume() {
+        if (running) return;
+        p2pService.start();
+        warmBlsPubkeyCache();
+        running = true;
+        syncThread = new Thread(this::syncLoop, "beacon-sync");
+        syncThread.setDaemon(true);
+        syncThread.start();
+        log.info("[beacon] Light client resumed with {} peer(s)", clPeerMultiaddrs.size());
+    }
+
     // -------------------------------------------------------------------------
     // Sync loop
     // -------------------------------------------------------------------------
@@ -631,7 +677,10 @@ public class BeaconLightClient implements AutoCloseable {
         // Runs BEFORE the network pre-connect: it's disk-only, and it kicks off the
         // background BLS pubkey-cache warm so decompression overlaps the Identify
         // round instead of stalling the first finality verify after it.
-        boolean resumed = tryResumeFromSnapshot();
+        // An already-initialized store means this loop is re-entered by resume()
+        // after a pause: the live in-memory state is strictly newer than (or equal
+        // to) the snapshot pause() just wrote — restoring over it would go backward.
+        boolean resumed = store.isInitialized() || tryResumeFromSnapshot();
 
         // Pre-connect to peers and query Identify to learn protocol support.
         // This lets bootstrap() prioritize peers advertising light_client protocols.
@@ -2354,7 +2403,12 @@ public class BeaconLightClient implements AutoCloseable {
         }
         // Persist final verified state so the next launch resumes from here.
         persistSnapshot();
-        p2pService.close();
+        try {
+            p2pService.close();
+        } catch (Throwable e) {
+            // close-after-pause: the libp2p host is already stopped — not fatal.
+            log.warn("[beacon] p2p close: {}", e.toString());
+        }
         catchUpExecutor.shutdownNow();
         log.info("[beacon] Light client stopped");
     }

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/libp2p/BeaconP2PService.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/libp2p/BeaconP2PService.java
@@ -418,9 +418,17 @@ public class BeaconP2PService implements AutoCloseable {
             keepaliveExecutor = null;
         }
         Host h = host;
+        // Null the reference so a close→start cycle (BeaconLightClient pause/resume)
+        // gets a fresh host, double-close is a no-op, and doReqResp/getConnectedPeers
+        // fail fast between pause and resume instead of touching a stopped host.
+        host = null;
         if (h != null) {
-            h.stop().join();
-            log.info("[beacon-p2p] libp2p host stopped");
+            try {
+                h.stop().join();
+                log.info("[beacon-p2p] libp2p host stopped");
+            } catch (Throwable e) {
+                log.warn("[beacon-p2p] host stop: {}", e.toString());
+            }
         }
     }
 

--- a/consensus/src/test/java/com/jaeckel/ethp2p/consensus/libp2p/BeaconP2PServiceRestartTest.java
+++ b/consensus/src/test/java/com/jaeckel/ethp2p/consensus/libp2p/BeaconP2PServiceRestartTest.java
@@ -1,0 +1,38 @@
+package com.jaeckel.ethp2p.consensus.libp2p;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins the libp2p restart behavior BeaconLightClient.pause()/resume() relies on:
+ * one BeaconP2PService instance must survive start → close → start → close in a
+ * single process (fresh Host, bindings, and keepalive executor per start), and
+ * close must be idempotent.
+ */
+class BeaconP2PServiceRestartTest {
+
+    @Test
+    void startCloseStartClose() {
+        BeaconP2PService svc = new BeaconP2PService(null);
+
+        svc.start();
+        List<BeaconP2PService.PeerInfo> peers = svc.getConnectedPeers();
+        assertTrue(peers.isEmpty(), "fresh local host has no peers");
+        svc.close();
+
+        // Between pause and resume the host is gone: peer queries fail fast/empty.
+        assertEquals(0, svc.getConnectedPeers().size());
+
+        // Second start must build a fresh host (the pause→resume path).
+        svc.start();
+        assertEquals(0, svc.getConnectedPeers().size());
+        svc.close();
+
+        // Double-close is a no-op.
+        svc.close();
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -89,6 +89,8 @@ androidx-compose-ui-graphics      = { module = "androidx.compose.ui:ui-graphics"
 androidx-compose-ui-tooling       = { module = "androidx.compose.ui:ui-tooling" }
 androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
 androidx-compose-material3        = { module = "androidx.compose.material3:material3" }
+# Java-only Worker (no -ktx needed): the daily beacon catch-up job while the node sleeps.
+androidx-work-runtime             = { module = "androidx.work:work-runtime", version = "2.9.1" }
 
 # JSON-RPC server (:jsonrpc-server) — all Android-safe (no java.net.http).
 ktor-server-core           = { module = "io.ktor:ktor-server-core",  version.ref = "ktor" }

--- a/jsonrpc-server/build.gradle.kts
+++ b/jsonrpc-server/build.gradle.kts
@@ -50,7 +50,9 @@ dependencies {
 
     testImplementation(platform(libs.junit.bom))
     testImplementation(libs.junit.jupiter)
-    testRuntimeOnly(libs.logback.classic)
+    // logback on the test COMPILE classpath (not just runtime): RpcAccessLogTest attaches a
+    // ListAppender to the io.myotis.jsonrpc.access logger to assert the access-log lines.
+    testImplementation(libs.logback.classic)
 }
 
 tasks.test {

--- a/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/MethodLogger.kt
+++ b/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/MethodLogger.kt
@@ -8,17 +8,32 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
 
 /**
- * Per-request structured logging + an in-memory coverage map. The point of
- * Phase A: after a MetaMask session, this is the exact "which methods did the
- * wallet call, and how did we serve each" answer that drives Phases B–D.
+ * Per-request access log + an in-memory coverage map. Emits one concise line per
+ * call the server answers — the "which methods did the wallet call, and how did we
+ * serve each" record — and feeds the {@code myotis_rpcCoverage} introspection map.
  *
  * `path` is one of VERIFIED (served by Myotis, cryptographically verified),
  * PROXY (relayed upstream — unverified), ERROR, or LOCAL (answered here, e.g.
  * the coverage introspection method).
+ *
+ * The access line goes out under the dedicated logger [ACCESS_LOGGER] at a UNIFORM
+ * INFO level for every outcome (the outcome is in the text). That's deliberate: it
+ * keeps the whole access stream on one level so raising the Logs-tab / logback level
+ * never silently drops successful calls (the old code logged success at INFO but
+ * errors at WARN, so quieting the log hid exactly the calls you wanted to see).
+ * Full request/response bodies are logged separately at DEBUG by [MyotisRpcServer]
+ * under the same logger name.
  */
 class MethodLogger {
 
-    private val log = LoggerFactory.getLogger("RpcCoverage")
+    private val log = LoggerFactory.getLogger(ACCESS_LOGGER)
+
+    companion object {
+        /** Dedicated logger name for the RPC access log (concise INFO + full-body DEBUG).
+         *  Namespaced under io.myotis.jsonrpc so every host's log config / Logs-tab filter
+         *  can target it; filter the Logs tab on "rpc" (the [rpc] message prefix) to isolate it. */
+        const val ACCESS_LOGGER = "io.myotis.jsonrpc.access"
+    }
 
     private class Stat {
         val count = AtomicLong()
@@ -30,7 +45,17 @@ class MethodLogger {
 
     private val byMethod = ConcurrentHashMap<String, Stat>()
 
-    fun record(method: String, path: String, latencyMs: Long) {
+    /**
+     * Record one answered request: bump the coverage map and emit the access line.
+     *
+     * @param method the JSON-RPC method (or a placeholder like {@code <parse-error>} for
+     *   a request that couldn't be parsed to a method)
+     * @param id     the request id, stringified (e.g. {@code 42}, {@code "abc"}, {@code null})
+     * @param path   the coverage bucket: VERIFIED / PROXY / LOCAL / ERROR
+     * @param latencyMs handling latency in millis (0 when not meaningfully measurable)
+     * @param code   the JSON-RPC error code for ERROR outcomes (e.g. -32000), else null
+     */
+    fun record(method: String, id: String, path: String, latencyMs: Long, code: Int? = null) {
         val s = byMethod.computeIfAbsent(method) { Stat() }
         s.count.incrementAndGet()
         when (path) {
@@ -39,12 +64,8 @@ class MethodLogger {
             "LOCAL" -> s.local.incrementAndGet()
             else -> s.error.incrementAndGet()
         }
-        // PROXY (relayed upstream, unverified) and ERROR are the noteworthy
-        // outcomes — log them at WARN so they stand out; VERIFIED/LOCAL stay INFO.
-        when (path) {
-            "VERIFIED", "LOCAL" -> log.info("[rpc] method={} path={} latencyMs={}", method, path, latencyMs)
-            else -> log.warn("[rpc] method={} path={} latencyMs={}", method, path, latencyMs)
-        }
+        val outcome = if (code != null) "$path($code)" else path
+        log.info("[rpc] method={} id={} outcome={} latencyMs={}", method, id, outcome, latencyMs)
     }
 
     /** Coverage map as a JSON object: method -> {count, verified, proxied, error, local}. */

--- a/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/MyotisRpcServer.kt
+++ b/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/MyotisRpcServer.kt
@@ -40,6 +40,11 @@ class MyotisRpcServer(
 ) {
     private val log = LoggerFactory.getLogger(MyotisRpcServer::class.java)
 
+    /** RPC access log (shared with [MethodLogger]): concise per-call lines land here at INFO;
+     *  this server adds the full request+response body at DEBUG. Filter the Logs tab on "rpc",
+     *  or `grep 'jsonrpc.access'` the daemon log; drop the level to DEBUG for full bodies. */
+    private val accessLog = LoggerFactory.getLogger(MethodLogger.ACCESS_LOGGER)
+
     private val proxy: UpstreamProxy? = upstreamUrl?.takeIf { it.isNotBlank() }?.let { UpstreamProxy(it) }
     private val logger = MethodLogger()
     private val router = RpcRouter(proxy, logger, backend)
@@ -73,11 +78,24 @@ class MyotisRpcServer(
         }
     }
 
+    /** Bound a body for the DEBUG access log: trim whitespace, cap length, and collapse
+     *  newlines so one exchange stays one grep-able line. */
+    private fun cap(s: String): String {
+        val t = s.trim().replace('\n', ' ').replace('\r', ' ')
+        return if (t.length > MAX_BODY_LOG_CHARS) {
+            t.substring(0, MAX_BODY_LOG_CHARS) + "…(" + (t.length - MAX_BODY_LOG_CHARS) + " more)"
+        } else t
+    }
+
     private companion object {
         /** How often to trickle a keep-alive whitespace byte while a response is still
          *  being computed. Short enough to reset any sane per-read socket timeout
          *  (OkHttp defaults to 10s), long enough to stay invisible for normal calls. */
         const val HEARTBEAT_INTERVAL_MS = 5_000L
+
+        /** Per-body cap for the DEBUG access log — keeps a large eth_call / batch from
+         *  blowing the Android 50k-line ring or producing one enormous line. */
+        const val MAX_BODY_LOG_CHARS = 4_096
     }
 
     @Volatile
@@ -128,6 +146,13 @@ class MyotisRpcServer(
                                 }
                             }
                             write(response)
+                            // Full request+response at DEBUG (concise per-call INFO lines come
+                            // from MethodLogger). One record for the whole exchange, incl. batches
+                            // and parse errors; bodies capped so a big eth_call / batch can't blow
+                            // the Android log ring or produce one enormous line.
+                            if (accessLog.isDebugEnabled) {
+                                accessLog.debug("[rpc] req={} resp={}", cap(body), cap(response))
+                            }
                             capture(body, response)
                         }
                     }

--- a/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/RpcRouter.kt
+++ b/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/RpcRouter.kt
@@ -49,9 +49,13 @@ class RpcRouter(
     }
 
     suspend fun handle(body: String): String {
+        val t0 = System.nanoTime()
         val root = try {
             json.parseToJsonElement(body)
         } catch (e: Exception) {
+            // Log the parse failure too — otherwise a malformed request the server DID
+            // respond to (with -32700) would be invisible in the access log.
+            logger.record("<parse-error>", "null", "ERROR", elapsedMs(t0), -32700)
             return errorEnvelope(JsonNull, -32700, "Parse error")
         }
         return when (root) {
@@ -60,15 +64,33 @@ class RpcRouter(
                 // JSON-RPC 2.0 batch: each request gets its own response/error object so
                 // a wallet (MetaMask batches heavily) can match them by id — not a single
                 // error envelope. Elements are handled independently.
-                if (root.isEmpty()) return errorEnvelope(JsonNull, -32600, "Invalid Request")
+                if (root.isEmpty()) {
+                    logger.record("<empty-batch>", "null", "ERROR", elapsedMs(t0), -32600)
+                    return errorEnvelope(JsonNull, -32600, "Invalid Request")
+                }
                 val responses = root.map { el ->
                     (el as? JsonObject)?.let { handleOne(it, null) }
-                        ?: errorEnvelope(JsonNull, -32600, "Invalid Request")
+                        ?: run {
+                            logger.record("<invalid>", "null", "ERROR", 0, -32600)
+                            errorEnvelope(JsonNull, -32600, "Invalid Request")
+                        }
                 }
                 "[" + responses.joinToString(",") + "]"
             }
-            else -> errorEnvelope(JsonNull, -32600, "Invalid Request")
+            else -> {
+                logger.record("<invalid>", "null", "ERROR", elapsedMs(t0), -32600)
+                errorEnvelope(JsonNull, -32600, "Invalid Request")
+            }
         }
+    }
+
+    private fun elapsedMs(t0: Long): Long = (System.nanoTime() - t0) / 1_000_000
+
+    /** The request id rendered for the access log ({@code 42} / {@code "abc"} / {@code null}),
+     *  bounded so a pathological id can't produce a giant log line. */
+    private fun idString(id: JsonElement): String {
+        val s = id.toString()
+        return if (s.length > 64) s.substring(0, 64) + "…" else s
     }
 
     /**
@@ -79,14 +101,15 @@ class RpcRouter(
     private suspend fun handleOne(root: JsonObject, wholeBody: String?): String {
         val method = root["method"]?.jsonPrimitive?.contentOrNull
         val id = root["id"] ?: JsonNull
+        val idStr = idString(id)
         if (method == "myotis_rpcCoverage") {
-            logger.record(method, "LOCAL", 0)
+            logger.record(method, idStr, "LOCAL", 0)
             return resultEnvelope(id, logger.coverage())
         }
         val t0 = System.nanoTime()
         val verified = tryVerified(method, id, root)
         if (verified != null) {
-            logger.record(method!!, "VERIFIED", (System.nanoTime() - t0) / 1_000_000)
+            logger.record(method!!, idStr, "VERIFIED", elapsedMs(t0))
             return verified
         }
         val m = method ?: "request"
@@ -96,7 +119,8 @@ class RpcRouter(
             // rejected method, so myotis_rpcCoverage keeps mapping what the wallet needs.
             // -32601 = we don't implement it verified (wallet can stop asking); -32000 =
             // implemented but can't answer right now — no peer / not synced (retryable).
-            logger.record(m, "ERROR", 0)
+            val code = if (m in VERIFIED_METHODS) -32000 else -32601
+            logger.record(m, idStr, "ERROR", elapsedMs(t0), code)
             return if (m in VERIFIED_METHODS) {
                 errorEnvelope(id, -32000, "method '$m' cannot be served verified right now (no peer / not synced)")
             } else {
@@ -108,11 +132,11 @@ class RpcRouter(
         val forwardBody = wholeBody ?: json.encodeToString(JsonObject.serializer(), root)
         return try {
             val response = proxy.forward(forwardBody)
-            logger.record(m, "PROXY", (System.nanoTime() - pt0) / 1_000_000)
+            logger.record(m, idStr, "PROXY", elapsedMs(pt0))
             response
         } catch (e: Exception) {
             // Upstream down/timeout: JSON-RPC error, not a raw HTTP 500, so the wallet copes.
-            logger.record(m, "ERROR", (System.nanoTime() - pt0) / 1_000_000)
+            logger.record(m, idStr, "ERROR", elapsedMs(pt0), -32603)
             errorEnvelope(id, -32603, "upstream proxy error: ${e.message}")
         }
     }

--- a/jsonrpc-server/src/test/kotlin/io/myotis/jsonrpc/RpcAccessLogTest.kt
+++ b/jsonrpc-server/src/test/kotlin/io/myotis/jsonrpc/RpcAccessLogTest.kt
@@ -1,0 +1,97 @@
+package io.myotis.jsonrpc
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
+
+/**
+ * Pins the RPC access log: every request the router answers — including parse and
+ * batch errors — emits one concise line under [MethodLogger.ACCESS_LOGGER], and all
+ * lines are INFO regardless of outcome (so raising the log level never silently hides
+ * successful calls, the original bug).
+ */
+class RpcAccessLogTest {
+
+    private lateinit var accessLogger: Logger
+    private lateinit var appender: ListAppender<ILoggingEvent>
+
+    /** Minimal synced backend so verified methods (eth_chainId) take the VERIFIED path. */
+    private class StubBackend : io.myotis.api.VerifiedReads {
+        override fun chainId() = 1L
+        override fun headBlockNumber() = 0x1L
+        override fun syncState() = io.myotis.api.SyncState.SYNCED
+        override fun call(from: ByteArray?, to: ByteArray, data: ByteArray, valueWei: String?, block: String): ByteArray? = null
+        override fun getBalance(address: ByteArray, block: String): String? = null
+        override fun getTransactionCount(address: ByteArray, block: String): Long? = null
+        override fun getCode(address: ByteArray, block: String): ByteArray? = null
+        override fun getStorageAt(address: ByteArray, slot32: ByteArray, block: String): ByteArray? = null
+        override fun sendRawTransaction(rawTx: ByteArray): ByteArray? = null
+        override fun getTransactionReceipt(txHash: ByteArray): String? = null
+        override fun getTransactionByHash(txHash: ByteArray): String? = null
+        override fun getBlockByNumber(block: String, fullTransactions: Boolean): String? = null
+        override fun getBlockByHash(blockHash32: ByteArray, fullTransactions: Boolean): String? = null
+        override fun gasPrice(): String? = null
+        override fun maxPriorityFeePerGas(): String? = null
+        override fun feeHistory(blockCount: Long, newestBlock: String, rewardPercentiles: DoubleArray?): String? = null
+        override fun estimateGas(from: ByteArray?, to: ByteArray?, data: ByteArray?, valueWei: String?): Long? = null
+    }
+
+    @BeforeEach fun setUp() {
+        accessLogger = LoggerFactory.getLogger(MethodLogger.ACCESS_LOGGER) as Logger
+        accessLogger.level = Level.INFO
+        appender = ListAppender<ILoggingEvent>().apply { start() }
+        accessLogger.addAppender(appender)
+    }
+
+    @AfterEach fun tearDown() {
+        accessLogger.detachAppender(appender)
+        appender.stop()
+    }
+
+    private fun route(body: String) {
+        runBlocking { RpcRouter(null, MethodLogger(), StubBackend()).handle(body) }
+    }
+
+    private fun lines(): List<String> = appender.list.map { it.formattedMessage }
+
+    @Test fun validCall_logsVerifiedInfoLineWithId() {
+        route("""{"jsonrpc":"2.0","id":42,"method":"eth_chainId","params":[]}""")
+        val l = lines().single { it.contains("method=eth_chainId") }
+        assertTrue(l.contains("id=42"), l)
+        assertTrue(l.contains("outcome=VERIFIED"), l)
+        assertTrue(appender.list.all { it.level == Level.INFO }, "all access lines are INFO")
+    }
+
+    @Test fun unsupportedMethod_logsErrorWithCode_atInfo() {
+        route("""{"jsonrpc":"2.0","id":2,"method":"eth_getLogs","params":[{}]}""")
+        val l = lines().single { it.contains("method=eth_getLogs") }
+        assertTrue(l.contains("outcome=ERROR(-32601)"), l)
+        // The whole access stream stays INFO — an error must NOT be emitted at WARN,
+        // or raising the Logs-tab level would hide it along with the rest.
+        assertTrue(appender.list.all { it.level == Level.INFO }, "error lines are INFO too")
+    }
+
+    @Test fun parseError_isLogged() {
+        route("this is not json")
+        val l = lines().single { it.contains("method=<parse-error>") }
+        assertTrue(l.contains("outcome=ERROR(-32700)"), l)
+    }
+
+    @Test fun batch_logsOneLinePerElement() {
+        route(
+            """[
+                {"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]},
+                {"jsonrpc":"2.0","id":2,"method":"eth_getLogs","params":[{}]}
+            ]""",
+        )
+        assertTrue(lines().any { it.contains("method=eth_chainId") && it.contains("id=1") }, lines().toString())
+        assertTrue(lines().any { it.contains("method=eth_getLogs") && it.contains("id=2") }, lines().toString())
+    }
+}

--- a/myotis-api/src/main/java/io/myotis/api/ChainHandle.java
+++ b/myotis-api/src/main/java/io/myotis/api/ChainHandle.java
@@ -31,6 +31,37 @@ public interface ChainHandle {
 
     boolean isRunning();
 
+    /**
+     * Suspend all networking (zero sockets, zero periodic timers) while keeping
+     * the stack instance and its warm verified state — beacon light-client
+     * store, sync state, peer knowledge — in memory. The JSON-RPC server keeps
+     * listening; a verified read arriving while paused triggers {@link #resume()}
+     * and is held until the node can answer (bounded, ~90 s). Blocking (a few
+     * seconds). Idempotent; a no-op unless {@code RUNNING}.
+     *
+     * @return {@code true} when the stack is {@code PAUSED} on return
+     */
+    boolean pause();
+
+    /**
+     * Rebuild networking after {@link #pause()}. Blocking (seconds; skips the
+     * cold DNS walk). Fault-isolated like {@link #start()}: on failure returns
+     * {@code false} and the stack stays {@code PAUSED} (retryable). A no-op
+     * returning {@code true} when already {@code RUNNING}.
+     */
+    boolean resume();
+
+    /** Coarse lifecycle state; {@link #isRunning()} == {@code lifecycle() == RUNNING}. */
+    LifecycleState lifecycle();
+
+    /**
+     * Epoch millis of the last host-relevant activity: any gated verified read
+     * (JSON-RPC / ENS) or verified operator query. {@code 0} if none since
+     * start. Hosts poll this for their idle-sleep timer — deliberately a getter
+     * rather than a callback so the engine surface stays FFI-portable.
+     */
+    long lastActivityEpochMillis();
+
     /** Live-update the snap-peer maintainer target (no restart). */
     void setTargetSnapPeers(int target);
 

--- a/myotis-api/src/main/java/io/myotis/api/ChainHandle.java
+++ b/myotis-api/src/main/java/io/myotis/api/ChainHandle.java
@@ -51,6 +51,13 @@ public interface ChainHandle {
      */
     boolean resume();
 
+    /**
+     * As {@link #resume()}, but records {@code reason} (a {@link WakeReason} tag) as
+     * the wake cause for the status screens' "last wake" line. {@link WakeReason#FOREGROUND}
+     * is treated as an observation and does not overwrite the recorded last-wake reason.
+     */
+    boolean resume(String reason);
+
     /** Coarse lifecycle state; {@link #isRunning()} == {@code lifecycle() == RUNNING}. */
     LifecycleState lifecycle();
 

--- a/myotis-api/src/main/java/io/myotis/api/LifecycleState.java
+++ b/myotis-api/src/main/java/io/myotis/api/LifecycleState.java
@@ -1,0 +1,20 @@
+package io.myotis.api;
+
+/**
+ * Coarse lifecycle of one hosted network's stack.
+ *
+ * <ul>
+ *   <li>{@code STOPPED} — never started, or fully shut down (terminal).</li>
+ *   <li>{@code RUNNING} — networking live: discovery, RLPx, beacon sync, RPC.</li>
+ *   <li>{@code PAUSED}  — pseudo-sleep: zero network sockets and zero periodic
+ *       timers (the radio can sleep), but the stack instance and its warm
+ *       verified state stay in memory and the JSON-RPC listener keeps
+ *       listening. A verified read arriving while paused triggers
+ *       {@link ChainHandle#resume()} and is held until the node can answer.</li>
+ * </ul>
+ */
+public enum LifecycleState {
+    STOPPED,
+    RUNNING,
+    PAUSED
+}

--- a/myotis-api/src/main/java/io/myotis/api/StatusSnapshot.java
+++ b/myotis-api/src/main/java/io/myotis/api/StatusSnapshot.java
@@ -7,7 +7,8 @@ import java.util.List;
  * hosts' status surfaces render (UI status tabs, the daemon's {@code status} /
  * {@code beacon-status} / {@code peers} IPC commands).
  *
- * @param running               whether the stack is running
+ * @param running               whether the stack is running ({@code lifecycle == RUNNING})
+ * @param lifecycle             coarse lifecycle state (paused ⇒ {@code running=false})
  * @param network               canonical network name
  * @param beaconState           beacon light-client state (STARTING before first state)
  * @param connectedPeers        EL peers with an open RLPx session (incl. still handshaking)
@@ -35,6 +36,7 @@ import java.util.List;
  */
 public record StatusSnapshot(
         boolean running,
+        LifecycleState lifecycle,
         String network,
         BeaconState beaconState,
         int connectedPeers,

--- a/myotis-api/src/main/java/io/myotis/api/StatusSnapshot.java
+++ b/myotis-api/src/main/java/io/myotis/api/StatusSnapshot.java
@@ -33,6 +33,12 @@ import java.util.List;
  * @param verifiedHeadAgeMs     age of the last verified RPC head context;
  *                              {@code Long.MAX_VALUE} = none built yet
  * @param readyPeerList         per-peer detail for the READY peers, snap-capable first
+ * @param pauseCount            times this stack entered idle sleep since start
+ * @param totalPausedMs         cumulative time spent paused (ms), across all pauses
+ * @param lastPauseEpochMs      wall-clock ms of the most recent pause; 0 if never paused
+ * @param lastResumeEpochMs     wall-clock ms of the most recent DEMAND wake; 0 if none
+ *                              (a foreground/observation wake does not update this)
+ * @param lastWakeReason        {@link WakeReason} tag of the most recent demand wake; null if none
  */
 public record StatusSnapshot(
         boolean running,
@@ -58,5 +64,10 @@ public record StatusSnapshot(
         long finalizedPeriod,
         long wallClockPeriod,
         long verifiedHeadAgeMs,
-        List<PeerInfo> readyPeerList) {
+        List<PeerInfo> readyPeerList,
+        int pauseCount,
+        long totalPausedMs,
+        long lastPauseEpochMs,
+        long lastResumeEpochMs,
+        String lastWakeReason) {
 }

--- a/myotis-api/src/main/java/io/myotis/api/WakeReason.java
+++ b/myotis-api/src/main/java/io/myotis/api/WakeReason.java
@@ -1,0 +1,33 @@
+package io.myotis.api;
+
+/**
+ * The shared vocabulary of reasons a paused stack was resumed, recorded for the
+ * status screens' "last wake" line. Defined here (not in the engine) so hosts and
+ * the engine agree on the exact strings without a host importing engine internals.
+ *
+ * <p>{@link #FOREGROUND} is an <em>observation</em> wake — the user opened the app,
+ * which proactively resumes a sleeping stack. It still counts toward the pause
+ * count / total-slept accounting (the node genuinely slept and woke), but it must
+ * NOT be recorded as the "last wake reason": otherwise merely viewing the status
+ * page would overwrite the interesting reason (a request / catch-up wake) every
+ * time. The other reasons are <em>demand</em> wakes and are recorded.
+ */
+public final class WakeReason {
+
+    /** Engine self-wake: a verified read / operator query / ENS lookup hit the wake gate. */
+    public static final String REQUEST = "request";
+
+    /** Observation wake: the app came to the foreground and proactively resumed. Not recorded. */
+    public static final String FOREGROUND = "foreground";
+
+    /** The daily WorkManager maintenance pass resumed the stack to catch up + persist. */
+    public static final String CATCH_UP = "catch-up";
+
+    /** The daemon's {@code resume} IPC command. */
+    public static final String IPC = "ipc";
+
+    /** A plain {@link ChainHandle#resume()} with no reason given. */
+    public static final String MANUAL = "manual";
+
+    private WakeReason() {}
+}

--- a/node-core/src/main/java/io/myotis/node/ChainStack.java
+++ b/node-core/src/main/java/io/myotis/node/ChainStack.java
@@ -364,12 +364,19 @@ public final class ChainStack {
      * elapses.
      *
      * @return the live backend to query, or {@code null} when no verified answer
-     *         is possible (stack stopped, RPC never started, or still paused at
-     *         the deadline). A stack that is RUNNING but still cold at the
-     *         deadline returns the backend anyway — it produces its own precise
-     *         bounded errors.
+     *         is possible (stack stopped, RPC never started / failed to bind, or
+     *         still paused at the deadline). A stack that is RUNNING but still cold
+     *         at the deadline returns the backend anyway — it produces its own
+     *         precise bounded errors.
      */
     public io.myotis.rpc.VerifiedRpcBackend awaitReadyForReads(long capMs) {
+        // RUNNING with no backend means the JSON-RPC bind failed at start (the failure
+        // is swallowed and the phase stays RUNNING). No amount of waiting will produce a
+        // backend without a pause→resume, so fast-fail instead of holding the full cap —
+        // otherwise ENS / operator queries would hang ~90s and still fail. (PAUSED with a
+        // null backend is the normal sleep state and falls through to await(), which
+        // triggers the wake.)
+        if (phase.get() == RUNNING && rpcBackend == null) return null;
         return wakeGate.await(capMs) ? rpcBackend : null;
     }
 
@@ -378,9 +385,22 @@ public final class ChainStack {
         wakeGate.poke();
     }
 
-    /** Epoch millis of the last gated verified read / operator query; 0 if none. */
+    /**
+     * Requests currently being served (gated JSON-RPC reads + operator queries). While
+     * non-zero, {@link #lastActivityMs()} reports "now" so the host idle timer never
+     * pauses the stack mid-request — pausing would close the backend/connector under a
+     * slow in-flight call (e.g. a multi-second confirm-screen sweep). Balanced with
+     * {@link #beginRequest()}/{@link #endRequest()}.
+     */
+    private final AtomicInteger inFlight = new AtomicInteger();
+
+    public void beginRequest() { inFlight.incrementAndGet(); }
+    public void endRequest() { inFlight.decrementAndGet(); }
+
+    /** Epoch millis of the last gated verified read / operator query; 0 if none. While a
+     *  request is in flight this returns the current time, so the idle timer holds off. */
     public long lastActivityMs() {
-        return wakeGate.lastActivityMs();
+        return inFlight.get() > 0 ? System.currentTimeMillis() : wakeGate.lastActivityMs();
     }
 
     // -- idle-sleep metrics (for status snapshots) --

--- a/node-core/src/main/java/io/myotis/node/ChainStack.java
+++ b/node-core/src/main/java/io/myotis/node/ChainStack.java
@@ -10,6 +10,7 @@ import com.jaeckel.ethp2p.networking.discv4.KademliaTable;
 import com.jaeckel.ethp2p.networking.discv5.DiscV5Service;
 import com.jaeckel.ethp2p.networking.dns.DnsEnrResolver;
 import com.jaeckel.ethp2p.networking.rlpx.RLPxConnector;
+import io.myotis.api.LifecycleState;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.crypto.SECP256K1;
 import org.slf4j.Logger;
@@ -35,6 +36,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+
+import static io.myotis.api.LifecycleState.PAUSED;
+import static io.myotis.api.LifecycleState.RUNNING;
+import static io.myotis.api.LifecycleState.STOPPED;
 
 /**
  * One Ethereum network's full node stack — RLPx (EL) + discv4 + discv5 (CL discovery)
@@ -64,6 +69,10 @@ public final class ChainStack {
     private static final int DNS_DIALS_PER_MIN = 60;         // rolling-minute rate cap
     private static final int DNS_POOL_MAX = 600;             // candidate-pool size cap
     private static final long DNS_REFRESH_INTERVAL_MS = 4 * 60 * 1000L;
+    /** Max time a verified read arriving on a paused stack is held while the wake completes. */
+    public static final long WAKE_WAIT_CAP_MS = 90_000L;
+    /** Wake-wait poll interval. */
+    private static final long WAKE_POLL_MS = 250L;
 
     // -- injected configuration ------------------------------------------------
     private final NetworkConfig network;
@@ -79,7 +88,11 @@ public final class ChainStack {
     private final Set<String> attempted = ConcurrentHashMap.newKeySet();
     private final Map<String, Long> backoff = new ConcurrentHashMap<>();
     private final Set<String> blacklistedNodeIds = ConcurrentHashMap.newKeySet();
-    private final AtomicBoolean running = new AtomicBoolean(false);
+    private final AtomicReference<LifecycleState> phase = new AtomicReference<>(STOPPED);
+    /** Wake-on-request: activity stamping + single-flight resume + bounded request hold. */
+    private final WakeGate wakeGate;
+    /** The stable VerifiedReads the RPC server holds across pause/resume cycles. */
+    private final GatedVerifiedReads gatedReads;
 
     // -- snap-peer maintainer (optional; enabled via configureSnapMaintainer) --
     private volatile boolean maintainerEnabled = false;
@@ -117,6 +130,9 @@ public final class ChainStack {
         this.ccipGateway = ccipGateway;
         this.syncSnapshotFile = syncSnapshotFile;
         this.gossipsubEnabled = gossipsubEnabled;
+        this.wakeGate = new WakeGate(phase::get, this::readyForReads, this::resume,
+                System::currentTimeMillis, WAKE_POLL_MS, "wake-resume-" + network.name());
+        this.gatedReads = new GatedVerifiedReads(this);
     }
 
     /**
@@ -130,7 +146,7 @@ public final class ChainStack {
      * any host wanting aggressive snap-peer retention) turns it on.
      */
     public void configureSnapMaintainer(int targetSnapPeers, DnsServerProvider dnsServers) {
-        if (running.get()) {
+        if (phase.get() != STOPPED) {
             throw new IllegalStateException("configureSnapMaintainer must be called before start()");
         }
         this.maintainerEnabled = true;
@@ -158,7 +174,7 @@ public final class ChainStack {
      * flipping {@code running} mid-build and leaking the components started afterward.
      */
     public synchronized boolean start() {
-        if (!running.compareAndSet(false, true)) return true; // already started
+        if (!phase.compareAndSet(STOPPED, RUNNING)) return true; // already started
         try {
             log.info("[{}] Node ID: {}", network.name(), nodeKey.nodeId().toHexString());
 
@@ -180,27 +196,17 @@ public final class ChainStack {
             List<Enr> dnsClEnrs = clFuture.join();
             this.dnsElPool = dnsElEnrs;  // seed the maintainer's candidate pool
 
-            List<InetSocketAddress> mergedBootnodes = mergeBootnodes(dnsElEnrs);
-
             // 2. RLPx connector + immediate cached / DNS-direct dials.
             this.connector = buildConnector();
-            dialCachedPeers();
-            directDialDnsEnodes(dnsElEnrs);
-            directDialStaticEnodes();   // enrtree substitute for chains without one (Gnosis)
+            dialInitialPeers(dnsElEnrs);
 
             // 3. discv4.
-            this.discV4 = buildDiscV4(mergedBootnodes);
-            try {
-                discV4.start(ports.elPort());
-            } catch (Exception e) {
-                log.error("[{}] discv4 failed to bind UDP {}: {}", network.name(), ports.elPort(), e.toString());
-                throw e; // EL is essential — fail this stack
-            }
-            log.info("[{}] discv4 started on UDP port {}", network.name(), ports.elPort());
+            startDiscV4(dnsElEnrs);
 
             // 4. Beacon: sync-state + discv5 (CL discovery) + light client.
             this.beaconSyncState = new BeaconSyncState();
-            startDiscV5AndBeacon(dnsClEnrs);
+            startDiscV5();
+            buildAndStartBeacon(dnsClEnrs);
 
             // 5. Verified JSON-RPC (best-effort; a bind failure here does not fail the stack).
             startRpc();
@@ -217,9 +223,104 @@ public final class ChainStack {
         }
     }
 
-    /** Tear down this stack's components (reverse order) and release its caches. */
+    /**
+     * Suspend all networking — every socket and every periodic timer — while keeping
+     * the stack instance and its warm verified state in memory: the beacon light
+     * client's store, {@code beaconSyncState}'s roots window, the peer caches (NOT
+     * closed, unlike {@link #shutdown()}), the DNS candidate pool, and the dial
+     * backoff/blacklist. The JSON-RPC server keeps LISTENING (an idle loopback
+     * socket holds no radio); a verified read arriving while paused goes through
+     * {@link #awaitReadyForReads}, which triggers {@link #resume()} and holds the
+     * request until the node can answer.
+     *
+     * @return {@code true} when the stack is {@code PAUSED} on return
+     */
+    public synchronized boolean pause() {
+        if (!phase.compareAndSet(RUNNING, PAUSED)) return phase.get() == PAUSED;
+        log.info("[{}] pausing: quiescing networking (RPC keeps listening)", network.name());
+        closeNetworkingComponents();
+        log.info("[{}] paused", network.name());
+        return true;
+    }
+
+    /**
+     * Rebuild networking after {@link #pause()}. Skips the cold-start DNS tree walk
+     * (the retained {@code dnsElPool} seeds the dials) and re-anchors the beacon
+     * light client from its warm in-memory store. Fault-isolated like
+     * {@link #start()}: on failure whatever was rebuilt is closed again and the
+     * stack stays {@code PAUSED} (retryable).
+     */
+    public synchronized boolean resume() {
+        LifecycleState p = phase.get();
+        if (p == RUNNING) return true;
+        if (p != PAUSED) return false; // STOPPED is terminal
+        log.info("[{}] resuming from pause", network.name());
+        try {
+            this.connector = buildConnector();
+            dialInitialPeers(dnsElPool);
+            startDiscV4(dnsElPool);          // essential — throws on bind failure
+            startDiscV5();                   // non-essential, warn-and-continue
+            BeaconLightClient blc = beaconLightClient;
+            if (blc != null) blc.resume();
+            if (rpcServer != null) {
+                // The listener survived the pause; swap a fresh backend in behind
+                // the gate (the old one died with the previous connector).
+                io.myotis.rpc.VerifiedRpcBackend backend = buildAndStartBackend();
+                this.rpcBackend = backend;
+            } else {
+                startRpc(); // first start's bind failed — retry best-effort
+            }
+            if (maintainerEnabled) startPeerMaintainer();
+            phase.set(RUNNING);
+            log.info("[{}] resumed", network.name());
+            return true;
+        } catch (Throwable t) {
+            log.error("[{}] resume failed (staying paused): {}", network.name(), t.toString());
+            closeNetworkingComponents();
+            return false;
+        }
+    }
+
+    /**
+     * The teardown shared by {@link #pause()} and a failed {@link #resume()}'s
+     * cleanup: stop every timer and socket, keep the RPC listener and all warm
+     * state. {@code attempted} is cleared because its entries are normally freed
+     * by connect-future listeners that die with the connector — leaving them
+     * would block re-dials on resume.
+     */
+    private void closeNetworkingComponents() {
+        ScheduledExecutorService pm = peerMaintainer;
+        if (pm != null) { pm.shutdownNow(); peerMaintainer = null; }
+        io.myotis.rpc.VerifiedRpcBackend backend = rpcBackend;
+        if (backend != null) {
+            rpcBackend = null; // gate re-reads this; null → requests hold instead of hitting a closed backend
+            try { backend.close(); } catch (Throwable ignored) {}
+        }
+        BeaconLightClient blc = beaconLightClient;
+        if (blc != null) {
+            try { blc.pause(); } catch (Throwable e) {
+                log.warn("[{}] beacon pause: {}", network.name(), e.toString());
+            }
+        }
+        RLPxConnector conn = connector;
+        if (conn != null) { connector = null; try { conn.close(); } catch (Throwable ignored) {} }
+        DiscV5Service d5 = discV5;
+        if (d5 != null) { discV5 = null; try { d5.close(); } catch (Throwable ignored) {} }
+        DiscV4Service d4 = discV4;
+        if (d4 != null) { discV4 = null; try { d4.close(); } catch (Throwable ignored) {} }
+        attempted.clear();
+    }
+
+    /**
+     * Tear down this stack's components (reverse order) and release its caches.
+     * Valid from any phase — a paused stack's components are already null and the
+     * closes are null-guarded; {@code BeaconLightClient.close()} after a pause is
+     * safe. Setting the phase to {@code STOPPED} first also releases any request
+     * threads parked in {@link #awaitReadyForReads} (they observe STOPPED on
+     * their next poll and return null).
+     */
     public synchronized void shutdown() {
-        running.set(false);
+        phase.set(STOPPED);
         ScheduledExecutorService pm = peerMaintainer;
         if (pm != null) { pm.shutdownNow(); peerMaintainer = null; }
         if (rpcServer != null) { try { rpcServer.stop(); } catch (Throwable ignored) {} }
@@ -236,12 +337,54 @@ public final class ChainStack {
     }
 
     // -------------------------------------------------------------------------
+    // Wake-on-request gate
+    // -------------------------------------------------------------------------
+
+    /**
+     * The wake-on-request choke point every verified read goes through: notes
+     * host-visible activity, triggers a single-flight async {@link #resume()}
+     * when paused, and blocks until reads are answerable or {@code capMs}
+     * elapses.
+     *
+     * @return the live backend to query, or {@code null} when no verified answer
+     *         is possible (stack stopped, RPC never started, or still paused at
+     *         the deadline). A stack that is RUNNING but still cold at the
+     *         deadline returns the backend anyway — it produces its own precise
+     *         bounded errors.
+     */
+    public io.myotis.rpc.VerifiedRpcBackend awaitReadyForReads(long capMs) {
+        return wakeGate.await(capMs) ? rpcBackend : null;
+    }
+
+    /** Note activity and kick a wake if paused, without blocking (status probes). */
+    public void noteActivityAndWake() {
+        wakeGate.poke();
+    }
+
+    /** Epoch millis of the last gated verified read / operator query; 0 if none. */
+    public long lastActivityMs() {
+        return wakeGate.lastActivityMs();
+    }
+
+    /** Readiness for verified reads: beacon SYNCED and the head warmer has an anchored head. */
+    private boolean readyForReads() {
+        if (phase.get() != RUNNING) return false;
+        BeaconSyncState bss = beaconSyncState;
+        io.myotis.rpc.VerifiedRpcBackend b = rpcBackend;
+        return bss != null && b != null
+                && bss.getSyncState(network.clGenesisTime(), network.secondsPerSlot())
+                        == BeaconSyncState.State.SYNCED
+                && b.verifiedHeadAgeMs() != Long.MAX_VALUE;
+    }
+
+    // -------------------------------------------------------------------------
     // Accessors (for the host's IPC / UI layer)
     // -------------------------------------------------------------------------
 
     public NetworkConfig network() { return network; }
     public ChainPorts ports() { return ports; }
-    public boolean isRunning() { return running.get(); }
+    public boolean isRunning() { return phase.get() == RUNNING; }
+    public LifecycleState lifecycle() { return phase.get(); }
     public RLPxConnector connector() { return connector; }
     public DiscV4Service discV4() { return discV4; }
     public DiscV5Service discV5() { return discV5; }
@@ -249,6 +392,17 @@ public final class ChainStack {
     public BeaconLightClient beaconLightClient() { return beaconLightClient; }
     /** The verified backend (for ENS resolution / verified reads), or null if RPC didn't start. */
     public io.myotis.rpc.VerifiedRpcBackend rpcBackend() { return rpcBackend; }
+
+    /**
+     * The pause-stable verified read surface hosts should hold: routes every read
+     * through the wake gate, so it stays valid across pause/resume cycles while
+     * the backend underneath is rebuilt. Null when the RPC pipeline never came up
+     * (bind failure at start and no successful resume since) and the stack has no
+     * backend — matching the old "reads unavailable" contract.
+     */
+    public io.myotis.api.VerifiedReads verifiedReads() {
+        return (rpcServer != null || rpcBackend != null) ? gatedReads : null;
+    }
     public Map<String, Long> backoff() { return backoff; }
     public Set<String> blacklistedNodeIds() { return blacklistedNodeIds; }
     /** Count of in-flight / recently-attempted dials (for host status snapshots). */
@@ -359,6 +513,28 @@ public final class ChainStack {
         }
     }
 
+    /** The immediate dial burst after a connector is (re)built: cached peers first,
+     *  then DNS-resolved enodes, then the static enode list (Gnosis's enrtree substitute). */
+    private void dialInitialPeers(List<Enr> dnsElEnrs) {
+        dialCachedPeers();
+        directDialDnsEnodes(dnsElEnrs);
+        directDialStaticEnodes();
+    }
+
+    /** Build and bind discv4 (EL discovery). Essential: a bind failure throws and
+     *  fails the start/resume that called this. */
+    private void startDiscV4(List<Enr> dnsElEnrs) throws Exception {
+        List<InetSocketAddress> mergedBootnodes = mergeBootnodes(dnsElEnrs);
+        this.discV4 = buildDiscV4(mergedBootnodes);
+        try {
+            discV4.start(ports.elPort());
+        } catch (Exception e) {
+            log.error("[{}] discv4 failed to bind UDP {}: {}", network.name(), ports.elPort(), e.toString());
+            throw e; // EL is essential — fail this stack
+        }
+        log.info("[{}] discv4 started on UDP port {}", network.name(), ports.elPort());
+    }
+
     private RLPxConnector buildConnector() {
         return new RLPxConnector(nodeKey, ports.elPort(), network, headers -> {
             if (!headers.isEmpty()) {
@@ -443,10 +619,14 @@ public final class ChainStack {
         });
     }
 
-    private void startDiscV5AndBeacon(List<Enr> dnsClEnrs) {
+    /** Build and bind discv5 (CL discovery). Non-essential: a failure is logged and
+     *  swallowed — EL keeps working and CL falls back to cache + seed list. The
+     *  found-peer callback reads the volatile {@code beaconLightClient} field: null
+     *  during the first start's brief pre-BLC window (peers land in the cache and
+     *  are picked up moments later), already-set on resume. */
+    private void startDiscV5() {
         List<byte[]> acceptedForkDigests = network.acceptedForkDigests();
         AtomicInteger mismatchesLogged = new AtomicInteger();
-        AtomicReference<BeaconLightClient> blcRef = new AtomicReference<>();
 
         this.discV5 = new DiscV5Service(nodeKey, network.clDiscv5Bootnodes(), enr -> {
             var eth2 = enr.eth2();
@@ -468,7 +648,7 @@ public final class ChainStack {
             final int mi = matchIdx;
             enr.toLibp2pMultiaddr().ifPresent(ma -> {
                 clPeerCache.add(ma);
-                BeaconLightClient blc = blcRef.get();
+                BeaconLightClient blc = beaconLightClient;
                 boolean liveAdded = blc != null && blc.addPeer(ma);
                 log.info("[{}][discv5] CL peer {} ({} match){}", network.name(), ma,
                         mi == 0 ? "current" : "prior", liveAdded ? " → live pool" : "");
@@ -481,8 +661,11 @@ public final class ChainStack {
             log.warn("[{}][discv5] failed to start on UDP {}, continuing without CL discovery: {}",
                     network.name(), ports.discv5Port(), t.toString());
         }
+    }
 
-        // Beacon light client.
+    /** Construct and start the beacon light client (first start only — a resume
+     *  reuses the retained instance via {@code BeaconLightClient.resume()}). */
+    private void buildAndStartBeacon(List<Enr> dnsClEnrs) {
         List<String> clPeers = new ArrayList<>(clPeerCache.load());
         for (String peer : network.clPeerMultiaddrs()) {
             if (!clPeers.contains(peer)) clPeers.add(peer);
@@ -506,10 +689,28 @@ public final class ChainStack {
         blc.setOnLightClientVerdict(clPeerCache::markLightClientBatch);
         blc.setSnapshotFile(syncSnapshotFile);
         blc.setGossipsubEnabled(gossipsubEnabled);
-        blcRef.set(blc);
         blc.start();
         this.beaconLightClient = blc;
         log.info("[{}] Beacon light client started with {} CL peer(s)", network.name(), clPeers.size());
+    }
+
+    /** Build and start a fresh verified backend over the CURRENT connector/light
+     *  client. One-shot like the components it binds to — pause closes it and
+     *  resume calls this again. */
+    private io.myotis.rpc.VerifiedRpcBackend buildAndStartBackend() {
+        io.myotis.rpc.SnapQualitySink snapQualitySink = new io.myotis.rpc.SnapQualitySink() {
+            @Override public void recordSnapServed(InetSocketAddress address) { peerCache.recordSnapServed(address); }
+            @Override public void recordSnapFailure(InetSocketAddress address) { peerCache.recordSnapFailure(address); }
+        };
+        io.myotis.rpc.RpcLogger rpcLogger = new io.myotis.rpc.RpcLogger() {
+            @Override public void info(String message) { log.info(message); }
+            @Override public void warn(String message) { log.warn(message); }
+        };
+        io.myotis.rpc.VerifiedRpcBackend backend = new io.myotis.rpc.VerifiedRpcBackend(
+                connector, beaconLightClient, beaconSyncState, ccipGateway,
+                rpcLogger, io.myotis.rpc.RpcClock.monotonic(), snapQualitySink);
+        backend.start();
+        return backend;
     }
 
     private void startRpc() {
@@ -521,21 +722,13 @@ public final class ChainStack {
                 probe.setReuseAddress(true);
                 probe.bind(new InetSocketAddress("127.0.0.1", rpcPort));
             }
-            io.myotis.rpc.SnapQualitySink snapQualitySink = new io.myotis.rpc.SnapQualitySink() {
-                @Override public void recordSnapServed(InetSocketAddress address) { peerCache.recordSnapServed(address); }
-                @Override public void recordSnapFailure(InetSocketAddress address) { peerCache.recordSnapFailure(address); }
-            };
-            io.myotis.rpc.RpcLogger rpcLogger = new io.myotis.rpc.RpcLogger() {
-                @Override public void info(String message) { log.info(message); }
-                @Override public void warn(String message) { log.warn(message); }
-            };
-            io.myotis.rpc.VerifiedRpcBackend backend = new io.myotis.rpc.VerifiedRpcBackend(
-                    connector, beaconLightClient, beaconSyncState, ccipGateway,
-                    rpcLogger, io.myotis.rpc.RpcClock.monotonic(), snapQualitySink);
+            io.myotis.rpc.VerifiedRpcBackend backend = buildAndStartBackend();
             try {
-                backend.start();
+                // The server is constructed over the GATE, never the raw backend:
+                // it survives pause() (keeps listening) while the backend underneath
+                // is torn down and rebuilt, and a request on a paused stack wakes it.
                 io.myotis.jsonrpc.MyotisRpcServer server =
-                        new io.myotis.jsonrpc.MyotisRpcServer(rpcPort, null, "127.0.0.1", backend);
+                        new io.myotis.jsonrpc.MyotisRpcServer(rpcPort, null, "127.0.0.1", gatedReads);
                 server.start();
                 this.rpcServer = server;
                 this.rpcBackend = backend;
@@ -605,7 +798,7 @@ public final class ChainStack {
     /** Keep {@code activeSnapHandlers() >= targetSnapPeers}: re-dial cached snap peers,
      *  then top up from the DNS ENR pool (rate-capped), then refresh the pool if still low. */
     private void maintainSnapPeers() {
-        if (!running.get()) return;
+        if (phase.get() != RUNNING) return;
         // Guard the whole body: an uncaught throw would make scheduleWithFixedDelay
         // silently stop all future runs.
         try {
@@ -677,9 +870,9 @@ public final class ChainStack {
             }
             List<Enr> resolved = resolver.resolveAllFromStrings(
                     network.elEnrTreeUrls(), Duration.ofSeconds(25));
-            // The resolve can take ~25s; if the stack was shut down meanwhile, drop the
-            // result instead of merging into / writing the pool of a dead stack.
-            if (!running.get()) return;
+            // The resolve can take ~25s; if the stack was shut down or paused meanwhile,
+            // drop the result instead of merging into / writing the pool of a dead stack.
+            if (phase.get() != RUNNING) return;
             lastDnsResolveMs = System.currentTimeMillis();
 
             byte[] ourFork = network.forkIdHash();

--- a/node-core/src/main/java/io/myotis/node/ChainStack.java
+++ b/node-core/src/main/java/io/myotis/node/ChainStack.java
@@ -93,6 +93,8 @@ public final class ChainStack {
     private final WakeGate wakeGate;
     /** The stable VerifiedReads the RPC server holds across pause/resume cycles. */
     private final GatedVerifiedReads gatedReads;
+    /** Idle-sleep bookkeeping (pause count / total paused / last wake) for the status screens. */
+    private final SleepMetrics sleepMetrics = new SleepMetrics();
 
     // -- snap-peer maintainer (optional; enabled via configureSnapMaintainer) --
     private volatile boolean maintainerEnabled = false;
@@ -130,7 +132,8 @@ public final class ChainStack {
         this.ccipGateway = ccipGateway;
         this.syncSnapshotFile = syncSnapshotFile;
         this.gossipsubEnabled = gossipsubEnabled;
-        this.wakeGate = new WakeGate(phase::get, this::readyForReads, this::resume,
+        this.wakeGate = new WakeGate(phase::get, this::readyForReads,
+                () -> resume(io.myotis.api.WakeReason.REQUEST),
                 System::currentTimeMillis, WAKE_POLL_MS, "wake-resume-" + network.name());
         this.gatedReads = new GatedVerifiedReads(this);
     }
@@ -237,6 +240,7 @@ public final class ChainStack {
      */
     public synchronized boolean pause() {
         if (!phase.compareAndSet(RUNNING, PAUSED)) return phase.get() == PAUSED;
+        sleepMetrics.onPause(System.currentTimeMillis(), System.nanoTime());
         log.info("[{}] pausing: quiescing networking (RPC keeps listening)", network.name());
         closeNetworkingComponents();
         log.info("[{}] paused", network.name());
@@ -251,10 +255,19 @@ public final class ChainStack {
      * stack stays {@code PAUSED} (retryable).
      */
     public synchronized boolean resume() {
+        return resume(io.myotis.api.WakeReason.MANUAL);
+    }
+
+    /**
+     * As {@link #resume()}, recording {@code reason} as the wake cause for the status
+     * screens. {@link io.myotis.api.WakeReason#FOREGROUND} is an observation wake: it
+     * still counts toward the pause total but does not overwrite the last-wake reason.
+     */
+    public synchronized boolean resume(String reason) {
         LifecycleState p = phase.get();
         if (p == RUNNING) return true;
         if (p != PAUSED) return false; // STOPPED is terminal
-        log.info("[{}] resuming from pause", network.name());
+        log.info("[{}] resuming from pause ({})", network.name(), reason);
         try {
             this.connector = buildConnector();
             dialInitialPeers(dnsElPool);
@@ -272,7 +285,11 @@ public final class ChainStack {
             }
             if (maintainerEnabled) startPeerMaintainer();
             phase.set(RUNNING);
-            log.info("[{}] resumed", network.name());
+            // Foreground (observation) wakes count toward the total but must not overwrite
+            // the last-wake reason — see WakeReason / SleepMetrics.
+            sleepMetrics.onResume(System.currentTimeMillis(), System.nanoTime(), reason,
+                    !io.myotis.api.WakeReason.FOREGROUND.equals(reason));
+            log.info("[{}] resumed ({})", network.name(), reason);
             return true;
         } catch (Throwable t) {
             log.error("[{}] resume failed (staying paused): {}", network.name(), t.toString());
@@ -365,6 +382,13 @@ public final class ChainStack {
     public long lastActivityMs() {
         return wakeGate.lastActivityMs();
     }
+
+    // -- idle-sleep metrics (for status snapshots) --
+    public int pauseCount() { return sleepMetrics.pauseCount(); }
+    public long totalPausedMs() { return sleepMetrics.totalPausedMs(); }
+    public long lastPauseEpochMs() { return sleepMetrics.lastPauseEpochMs(); }
+    public long lastResumeEpochMs() { return sleepMetrics.lastResumeEpochMs(); }
+    public String lastWakeReason() { return sleepMetrics.lastWakeReason(); }
 
     /** Readiness for verified reads: beacon SYNCED and the head warmer has an anchored head. */
     private boolean readyForReads() {

--- a/node-core/src/main/java/io/myotis/node/GatedVerifiedReads.java
+++ b/node-core/src/main/java/io/myotis/node/GatedVerifiedReads.java
@@ -33,13 +33,22 @@ final class GatedVerifiedReads implements VerifiedReads {
     }
 
     /**
-     * Wake-and-wait, then return the live backend — or null (unanswerable). The
-     * backend reference is re-read from the stack after the wait, so a resume's
-     * freshly-built backend is picked up and a paused stack's torn-down one is
-     * never touched.
+     * Wake-and-wait, then run {@code call} against the live backend under an in-flight
+     * guard; returns null (unanswerable) without calling when no backend is available.
+     * The backend is re-read from the stack after the wait, so a resume's freshly-built
+     * backend is picked up and a paused stack's torn-down one is never touched. The
+     * {@code beginRequest}/{@code endRequest} pair marks the stack busy so the host idle
+     * timer can't pause it mid-call (which would close the backend under the request).
      */
-    private VerifiedReads awaitReady() {
-        return stack.awaitReadyForReads(ChainStack.WAKE_WAIT_CAP_MS);
+    private <T> T guarded(java.util.function.Function<VerifiedReads, T> call) {
+        VerifiedReads d = stack.awaitReadyForReads(ChainStack.WAKE_WAIT_CAP_MS);
+        if (d == null) return null;
+        stack.beginRequest();
+        try {
+            return call.apply(d);
+        } finally {
+            stack.endRequest();
+        }
     }
 
     @Override
@@ -58,91 +67,76 @@ final class GatedVerifiedReads implements VerifiedReads {
 
     @Override
     public Long headBlockNumber() {
-        VerifiedReads d = awaitReady();
-        return d == null ? null : d.headBlockNumber();
+        return guarded(d -> d.headBlockNumber());
     }
 
     @Override
     public byte[] call(byte[] from, byte[] to, byte[] data, String valueWei, String block) {
-        VerifiedReads d = awaitReady();
-        return d == null ? null : d.call(from, to, data, valueWei, block);
+        return guarded(d -> d.call(from, to, data, valueWei, block));
     }
 
     @Override
     public String getBalance(byte[] address, String block) {
-        VerifiedReads d = awaitReady();
-        return d == null ? null : d.getBalance(address, block);
+        return guarded(d -> d.getBalance(address, block));
     }
 
     @Override
     public Long getTransactionCount(byte[] address, String block) {
-        VerifiedReads d = awaitReady();
-        return d == null ? null : d.getTransactionCount(address, block);
+        return guarded(d -> d.getTransactionCount(address, block));
     }
 
     @Override
     public byte[] getCode(byte[] address, String block) {
-        VerifiedReads d = awaitReady();
-        return d == null ? null : d.getCode(address, block);
+        return guarded(d -> d.getCode(address, block));
     }
 
     @Override
     public byte[] getStorageAt(byte[] address, byte[] slot32, String block) {
-        VerifiedReads d = awaitReady();
-        return d == null ? null : d.getStorageAt(address, slot32, block);
+        return guarded(d -> d.getStorageAt(address, slot32, block));
     }
 
     @Override
     public byte[] sendRawTransaction(byte[] rawTx) {
-        VerifiedReads d = awaitReady();
-        return d == null ? null : d.sendRawTransaction(rawTx);
+        return guarded(d -> d.sendRawTransaction(rawTx));
     }
 
     @Override
     public String getTransactionReceipt(byte[] txHash) {
-        VerifiedReads d = awaitReady();
-        return d == null ? null : d.getTransactionReceipt(txHash);
+        return guarded(d -> d.getTransactionReceipt(txHash));
     }
 
     @Override
     public String getTransactionByHash(byte[] txHash) {
-        VerifiedReads d = awaitReady();
-        return d == null ? null : d.getTransactionByHash(txHash);
+        return guarded(d -> d.getTransactionByHash(txHash));
     }
 
     @Override
     public String getBlockByNumber(String block, boolean fullTransactions) {
-        VerifiedReads d = awaitReady();
-        return d == null ? null : d.getBlockByNumber(block, fullTransactions);
+        return guarded(d -> d.getBlockByNumber(block, fullTransactions));
     }
 
     @Override
     public String getBlockByHash(byte[] blockHash32, boolean fullTransactions) {
-        VerifiedReads d = awaitReady();
-        return d == null ? null : d.getBlockByHash(blockHash32, fullTransactions);
+        return guarded(d -> d.getBlockByHash(blockHash32, fullTransactions));
     }
 
     @Override
     public String gasPrice() {
-        VerifiedReads d = awaitReady();
-        return d == null ? null : d.gasPrice();
+        return guarded(VerifiedReads::gasPrice);
     }
 
     @Override
     public String maxPriorityFeePerGas() {
-        VerifiedReads d = awaitReady();
-        return d == null ? null : d.maxPriorityFeePerGas();
+        return guarded(VerifiedReads::maxPriorityFeePerGas);
     }
 
     @Override
     public String feeHistory(long blockCount, String newestBlock, double[] rewardPercentiles) {
-        VerifiedReads d = awaitReady();
-        return d == null ? null : d.feeHistory(blockCount, newestBlock, rewardPercentiles);
+        return guarded(d -> d.feeHistory(blockCount, newestBlock, rewardPercentiles));
     }
 
     @Override
     public Long estimateGas(byte[] from, byte[] to, byte[] data, String valueWei) {
-        VerifiedReads d = awaitReady();
-        return d == null ? null : d.estimateGas(from, to, data, valueWei);
+        return guarded(d -> d.estimateGas(from, to, data, valueWei));
     }
 }

--- a/node-core/src/main/java/io/myotis/node/GatedVerifiedReads.java
+++ b/node-core/src/main/java/io/myotis/node/GatedVerifiedReads.java
@@ -1,0 +1,148 @@
+package io.myotis.node;
+
+import com.jaeckel.ethp2p.consensus.BeaconSyncState;
+import io.myotis.api.SyncState;
+import io.myotis.api.VerifiedReads;
+
+/**
+ * The {@link VerifiedReads} the JSON-RPC server (and any host holding
+ * {@code ChainHandle.reads()}) keeps across the stack's whole lifetime, while the
+ * real {@code VerifiedRpcBackend} underneath is torn down on pause and rebuilt on
+ * resume. Every verified read first goes through
+ * {@link ChainStack#awaitReadyForReads}: a request arriving while the stack is
+ * paused triggers the wake and is held (bounded) until the node can answer — a
+ * {@code null} return then maps to the router's retryable "cannot be served
+ * verified right now" error, so no jsonrpc-server change is needed.
+ *
+ * <p>Two deliberate exceptions to the hold:
+ * <ul>
+ *   <li>{@link #chainId()} answers from static network config without waking —
+ *       wallet polling must not keep the node awake.</li>
+ *   <li>{@link #syncState()} notes activity and kicks the wake but answers
+ *       non-blocking from the retained {@code BeaconSyncState} — wallets gate on
+ *       sync state, and holding a status probe for the full wake would deadlock
+ *       them.</li>
+ * </ul>
+ */
+final class GatedVerifiedReads implements VerifiedReads {
+
+    private final ChainStack stack;
+
+    GatedVerifiedReads(ChainStack stack) {
+        this.stack = stack;
+    }
+
+    /**
+     * Wake-and-wait, then return the live backend — or null (unanswerable). The
+     * backend reference is re-read from the stack after the wait, so a resume's
+     * freshly-built backend is picked up and a paused stack's torn-down one is
+     * never touched.
+     */
+    private VerifiedReads awaitReady() {
+        return stack.awaitReadyForReads(ChainStack.WAKE_WAIT_CAP_MS);
+    }
+
+    @Override
+    public long chainId() {
+        return stack.network().networkId();
+    }
+
+    @Override
+    public SyncState syncState() {
+        stack.noteActivityAndWake();
+        BeaconSyncState bss = stack.beaconSyncState();
+        if (bss == null) return SyncState.SYNCING;
+        return SyncState.valueOf(bss.getSyncState(
+                stack.network().clGenesisTime(), stack.network().secondsPerSlot()).name());
+    }
+
+    @Override
+    public Long headBlockNumber() {
+        VerifiedReads d = awaitReady();
+        return d == null ? null : d.headBlockNumber();
+    }
+
+    @Override
+    public byte[] call(byte[] from, byte[] to, byte[] data, String valueWei, String block) {
+        VerifiedReads d = awaitReady();
+        return d == null ? null : d.call(from, to, data, valueWei, block);
+    }
+
+    @Override
+    public String getBalance(byte[] address, String block) {
+        VerifiedReads d = awaitReady();
+        return d == null ? null : d.getBalance(address, block);
+    }
+
+    @Override
+    public Long getTransactionCount(byte[] address, String block) {
+        VerifiedReads d = awaitReady();
+        return d == null ? null : d.getTransactionCount(address, block);
+    }
+
+    @Override
+    public byte[] getCode(byte[] address, String block) {
+        VerifiedReads d = awaitReady();
+        return d == null ? null : d.getCode(address, block);
+    }
+
+    @Override
+    public byte[] getStorageAt(byte[] address, byte[] slot32, String block) {
+        VerifiedReads d = awaitReady();
+        return d == null ? null : d.getStorageAt(address, slot32, block);
+    }
+
+    @Override
+    public byte[] sendRawTransaction(byte[] rawTx) {
+        VerifiedReads d = awaitReady();
+        return d == null ? null : d.sendRawTransaction(rawTx);
+    }
+
+    @Override
+    public String getTransactionReceipt(byte[] txHash) {
+        VerifiedReads d = awaitReady();
+        return d == null ? null : d.getTransactionReceipt(txHash);
+    }
+
+    @Override
+    public String getTransactionByHash(byte[] txHash) {
+        VerifiedReads d = awaitReady();
+        return d == null ? null : d.getTransactionByHash(txHash);
+    }
+
+    @Override
+    public String getBlockByNumber(String block, boolean fullTransactions) {
+        VerifiedReads d = awaitReady();
+        return d == null ? null : d.getBlockByNumber(block, fullTransactions);
+    }
+
+    @Override
+    public String getBlockByHash(byte[] blockHash32, boolean fullTransactions) {
+        VerifiedReads d = awaitReady();
+        return d == null ? null : d.getBlockByHash(blockHash32, fullTransactions);
+    }
+
+    @Override
+    public String gasPrice() {
+        VerifiedReads d = awaitReady();
+        return d == null ? null : d.gasPrice();
+    }
+
+    @Override
+    public String maxPriorityFeePerGas() {
+        VerifiedReads d = awaitReady();
+        return d == null ? null : d.maxPriorityFeePerGas();
+    }
+
+    @Override
+    public String feeHistory(long blockCount, String newestBlock, double[] rewardPercentiles) {
+        VerifiedReads d = awaitReady();
+        return d == null ? null : d.feeHistory(blockCount, newestBlock, rewardPercentiles);
+    }
+
+    @Override
+    public Long estimateGas(byte[] from, byte[] to, byte[] data, String valueWei) {
+        VerifiedReads d = awaitReady();
+        return d == null ? null : d.estimateGas(from, to, data, valueWei);
+    }
+}

--- a/node-core/src/main/java/io/myotis/node/SleepMetrics.java
+++ b/node-core/src/main/java/io/myotis/node/SleepMetrics.java
@@ -1,0 +1,62 @@
+package io.myotis.node;
+
+/**
+ * Idle-sleep bookkeeping for one {@link ChainStack}: how many times it paused, how
+ * long it spent paused in total, and when/why it last woke — surfaced on the status
+ * screens to make the pause/resume cycle debuggable. Extracted from ChainStack so
+ * the accounting (especially the observer-effect rule below) is unit-testable
+ * without standing up a network.
+ *
+ * <p>Durations use the caller's monotonic clock (nanos) so an NTP/wall-clock step
+ * can't distort the total; the display timestamps use the caller's wall clock
+ * (epoch ms) because the UI renders them as clock times.
+ *
+ * <p><b>Observer effect:</b> {@link #onResume} takes a {@code recordAsWake} flag.
+ * A foreground/observation wake (the user opened the app, which resumes a sleeping
+ * stack) passes {@code false}: it still accrues into the pause count / total, but
+ * must not overwrite the last-wake reason/time, or simply viewing the status page
+ * would hide the request/catch-up wake you're trying to observe.
+ *
+ * <p>Not thread-safe on its own; ChainStack only mutates it under its lifecycle
+ * monitor (pause/resume are {@code synchronized}), and the volatile-free reads are
+ * fine for the status snapshot (a torn read at worst shows a value one transition
+ * stale, which is harmless for a diagnostic display).
+ */
+final class SleepMetrics {
+
+    private int pauseCount;
+    private long totalPausedNanos;
+    private long lastPauseNanos;          // 0 = not currently timing a pause
+    private long lastPauseEpochMs;        // 0 = never paused
+    private long lastResumeEpochMs;       // 0 = never woken by a demand wake
+    private String lastWakeReason;        // null = never woken by a demand wake
+
+    /** Record entry into idle sleep. */
+    void onPause(long nowEpochMs, long nowNanos) {
+        pauseCount++;
+        lastPauseEpochMs = nowEpochMs;
+        lastPauseNanos = nowNanos;
+    }
+
+    /**
+     * Record a wake. Always closes the current pause interval into {@link #totalPausedMs};
+     * only records the reason/time as the "last wake" when {@code recordAsWake} (i.e. a
+     * demand wake, not a foreground observation).
+     */
+    void onResume(long nowEpochMs, long nowNanos, String reason, boolean recordAsWake) {
+        if (lastPauseNanos != 0) {
+            totalPausedNanos += nowNanos - lastPauseNanos;
+            lastPauseNanos = 0;
+        }
+        if (recordAsWake) {
+            lastResumeEpochMs = nowEpochMs;
+            lastWakeReason = reason;
+        }
+    }
+
+    int pauseCount() { return pauseCount; }
+    long totalPausedMs() { return totalPausedNanos / 1_000_000L; }
+    long lastPauseEpochMs() { return lastPauseEpochMs; }
+    long lastResumeEpochMs() { return lastResumeEpochMs; }
+    String lastWakeReason() { return lastWakeReason; }
+}

--- a/node-core/src/main/java/io/myotis/node/WakeGate.java
+++ b/node-core/src/main/java/io/myotis/node/WakeGate.java
@@ -34,7 +34,8 @@ final class WakeGate {
      * @param phase          live lifecycle state of the guarded stack
      * @param ready          true when verified reads are answerable (only consulted while RUNNING)
      * @param resume         the blocking resume action; run on a fresh daemon thread, single-flight
-     * @param clock          epoch-millis source (injected for tests)
+     * @param clock          wall-clock epoch-millis source for activity stamping (injected for
+     *                       tests); the wait DEADLINE uses monotonic {@code System.nanoTime}
      * @param pollMs         wait-loop poll interval
      * @param wakeThreadName name for the spawned resume thread
      */
@@ -60,13 +61,17 @@ final class WakeGate {
      */
     boolean await(long capMs) {
         noteActivity();
-        long deadline = clock.getAsLong() + capMs;
+        // Monotonic deadline (nanoTime, overflow-safe compare): capMs is a DURATION, so an
+        // NTP / manual wall-clock step must not extend or prematurely expire the hold. The
+        // injected wall-clock `clock` is used only for activity stamping (noteActivity),
+        // which the host idle timer compares against its own wall clock.
+        long deadlineNanos = System.nanoTime() + capMs * 1_000_000L;
         while (true) {
             LifecycleState p = phase.get();
             if (p == LifecycleState.STOPPED) return false;
             if (p == LifecycleState.PAUSED) triggerWake();
             if (p == LifecycleState.RUNNING && ready.getAsBoolean()) return true;
-            if (clock.getAsLong() >= deadline) return p == LifecycleState.RUNNING;
+            if (System.nanoTime() - deadlineNanos >= 0) return p == LifecycleState.RUNNING;
             try {
                 Thread.sleep(pollMs);
             } catch (InterruptedException e) {

--- a/node-core/src/main/java/io/myotis/node/WakeGate.java
+++ b/node-core/src/main/java/io/myotis/node/WakeGate.java
@@ -1,0 +1,111 @@
+package io.myotis.node;
+
+import io.myotis.api.LifecycleState;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BooleanSupplier;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
+
+/**
+ * The wake-on-request primitive behind {@link ChainStack#awaitReadyForReads}:
+ * stamps host-visible activity, triggers a single-flight asynchronous resume
+ * when the stack is {@code PAUSED}, and parks the calling (request) thread
+ * until the stack can answer verified reads or a deadline passes.
+ *
+ * <p>Extracted from {@code ChainStack} so the wait/single-flight behavior is
+ * hermetically testable — every dependency (phase, readiness, resume action,
+ * clock) is injected.
+ */
+final class WakeGate {
+
+    private final Supplier<LifecycleState> phase;
+    private final BooleanSupplier ready;
+    private final Runnable resume;
+    private final LongSupplier clock;
+    private final long pollMs;
+    private final String wakeThreadName;
+
+    private final AtomicBoolean wakeInFlight = new AtomicBoolean(false);
+    private final AtomicLong lastActivityMs = new AtomicLong(0);
+
+    /**
+     * @param phase          live lifecycle state of the guarded stack
+     * @param ready          true when verified reads are answerable (only consulted while RUNNING)
+     * @param resume         the blocking resume action; run on a fresh daemon thread, single-flight
+     * @param clock          epoch-millis source (injected for tests)
+     * @param pollMs         wait-loop poll interval
+     * @param wakeThreadName name for the spawned resume thread
+     */
+    WakeGate(Supplier<LifecycleState> phase, BooleanSupplier ready, Runnable resume,
+             LongSupplier clock, long pollMs, String wakeThreadName) {
+        this.phase = phase;
+        this.ready = ready;
+        this.resume = resume;
+        this.clock = clock;
+        this.pollMs = pollMs;
+        this.wakeThreadName = wakeThreadName;
+    }
+
+    /**
+     * Note activity, kick a wake if paused, and block until the stack is ready
+     * for verified reads or {@code capMs} elapses.
+     *
+     * @return {@code true} when reads should be attempted: the stack is ready, or
+     *         it is {@code RUNNING} but still cold at the deadline (the backend
+     *         produces its own precise bounded errors). {@code false} when the
+     *         stack is {@code STOPPED}, still {@code PAUSED} at the deadline
+     *         (resume kept failing), or the wait was interrupted.
+     */
+    boolean await(long capMs) {
+        noteActivity();
+        long deadline = clock.getAsLong() + capMs;
+        while (true) {
+            LifecycleState p = phase.get();
+            if (p == LifecycleState.STOPPED) return false;
+            if (p == LifecycleState.PAUSED) triggerWake();
+            if (p == LifecycleState.RUNNING && ready.getAsBoolean()) return true;
+            if (clock.getAsLong() >= deadline) return p == LifecycleState.RUNNING;
+            try {
+                Thread.sleep(pollMs);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return false;
+            }
+        }
+    }
+
+    /** Note activity and kick a wake if paused, without blocking (status probes). */
+    void poke() {
+        noteActivity();
+        if (phase.get() == LifecycleState.PAUSED) triggerWake();
+    }
+
+    void noteActivity() {
+        lastActivityMs.set(clock.getAsLong());
+    }
+
+    /** Epoch millis of the last {@link #await}/{@link #poke}; 0 if none yet. */
+    long lastActivityMs() {
+        return lastActivityMs.get();
+    }
+
+    /**
+     * Single-flight: N concurrent waiters produce one resume run. The flag is
+     * released when the run finishes, so a failed resume is retried by whichever
+     * waiter polls next.
+     */
+    private void triggerWake() {
+        if (!wakeInFlight.compareAndSet(false, true)) return;
+        Thread t = new Thread(() -> {
+            try {
+                resume.run();
+            } finally {
+                wakeInFlight.set(false);
+            }
+        }, wakeThreadName);
+        t.setDaemon(true);
+        t.start();
+    }
+}

--- a/node-core/src/main/java/io/myotis/node/api/JavaChainHandle.java
+++ b/node-core/src/main/java/io/myotis/node/api/JavaChainHandle.java
@@ -12,6 +12,7 @@ import io.myotis.api.DialResult;
 import io.myotis.api.EngineException;
 import io.myotis.api.EnsApi;
 import io.myotis.api.HeadersResult;
+import io.myotis.api.LifecycleState;
 import io.myotis.api.PeerInfo;
 import io.myotis.api.StatusSnapshot;
 import io.myotis.api.StorageProofResult;
@@ -67,6 +68,28 @@ public final class JavaChainHandle implements ChainHandle {
 
     @Override public boolean isRunning() { return stack.isRunning(); }
 
+    @Override public boolean pause() { return stack.pause(); }
+
+    @Override public boolean resume() { return stack.resume(); }
+
+    @Override public LifecycleState lifecycle() { return stack.lifecycle(); }
+
+    @Override public long lastActivityEpochMillis() { return stack.lastActivityMs(); }
+
+    /**
+     * Wake-and-wait shared by the verified operator queries: a query on a paused
+     * stack triggers resume and holds here until the node is ready. On a
+     * PAUSED-at-deadline timeout (resume kept failing) this throws; a STOPPED
+     * stack falls through to each query's existing "Node is not running" guard.
+     */
+    private void awaitWake() {
+        stack.awaitReadyForReads(ChainStack.WAKE_WAIT_CAP_MS);
+        if (stack.lifecycle() == LifecycleState.PAUSED) {
+            throw new EngineException("node did not become ready within "
+                    + (ChainStack.WAKE_WAIT_CAP_MS / 1000) + "s (paused; resume failing)");
+        }
+    }
+
     @Override public void setTargetSnapPeers(int target) { stack.setTargetSnapPeers(target); }
 
     @Override
@@ -112,6 +135,7 @@ public final class JavaChainHandle implements ChainHandle {
 
         return new StatusSnapshot(
                 stack.isRunning(),
+                stack.lifecycle(),
                 net.name(),
                 beaconState,
                 active.size(),
@@ -208,9 +232,10 @@ public final class JavaChainHandle implements ChainHandle {
 
     @Override
     public VerifiedReads reads() {
-        // VerifiedRpcBackend implements VerifiedReads directly (since the jsonrpc-server SPI
-        // was retired), so no adapter is needed — return it as the contract type.
-        return stack.rpcBackend();
+        // The gate, not the raw backend: it stays valid across pause/resume cycles
+        // (the backend is torn down on pause and rebuilt on resume) and a read on a
+        // paused stack wakes it. Null only when the RPC pipeline never came up.
+        return stack.verifiedReads();
     }
 
     @Override
@@ -221,6 +246,7 @@ public final class JavaChainHandle implements ChainHandle {
 
     @Override
     public AccountProofResult requestAccount(String hexAddress) {
+        awaitWake();
         try {
             // queryProof internally bounds the header fetch (60 s); the outer bound covers
             // the snap fetch + verification end to end.
@@ -237,6 +263,7 @@ public final class JavaChainHandle implements ChainHandle {
 
     @Override
     public StorageProofResult getStorageProof(String hexAddress, long slot, String holderHexOrNull) {
+        awaitWake();
         RLPxConnector conn = stack.connector();
         if (!stack.isRunning() || conn == null) throw new EngineException("Node is not running");
         try {
@@ -254,6 +281,7 @@ public final class JavaChainHandle implements ChainHandle {
 
     @Override
     public HeadersResult getHeaders(long startBlock, int count) {
+        awaitWake();
         RLPxConnector conn = stack.connector();
         if (!stack.isRunning() || conn == null) throw new EngineException("Node is not running");
         return io.myotis.node.HeaderQuery.fetch(conn, startBlock, count);
@@ -261,6 +289,7 @@ public final class JavaChainHandle implements ChainHandle {
 
     @Override
     public BlockResult getBlockVerified(long blockNumber) {
+        awaitWake();
         RLPxConnector conn = stack.connector();
         if (!stack.isRunning() || conn == null) throw new EngineException("Node is not running");
         return io.myotis.node.VerifiedBlockQuery.query(conn, stack.beaconSyncState(), blockNumber);
@@ -268,6 +297,7 @@ public final class JavaChainHandle implements ChainHandle {
 
     @Override
     public DialResult dialPeer(String host, int port, String pubkeyHex) {
+        awaitWake();
         RLPxConnector conn = stack.connector();
         if (!stack.isRunning() || conn == null) throw new EngineException("Node is not running");
         try {

--- a/node-core/src/main/java/io/myotis/node/api/JavaChainHandle.java
+++ b/node-core/src/main/java/io/myotis/node/api/JavaChainHandle.java
@@ -80,9 +80,10 @@ public final class JavaChainHandle implements ChainHandle {
 
     /**
      * Wake-and-wait shared by the verified operator queries: a query on a paused
-     * stack triggers resume and holds here until the node is ready. On a
-     * PAUSED-at-deadline timeout (resume kept failing) this throws; a STOPPED
-     * stack falls through to each query's existing "Node is not running" guard.
+     * stack triggers resume and waits up to the cap for readiness. A RUNNING-but-cold
+     * stack does NOT block to full readiness — it proceeds and the query/backend emits
+     * its own bounded errors. Only a PAUSED-at-deadline (resume kept failing) throws;
+     * a STOPPED stack falls through to each query's existing "Node is not running" guard.
      */
     private void awaitWake() {
         stack.awaitReadyForReads(ChainStack.WAKE_WAIT_CAP_MS);
@@ -254,6 +255,7 @@ public final class JavaChainHandle implements ChainHandle {
     @Override
     public AccountProofResult requestAccount(String hexAddress) {
         awaitWake();
+        stack.beginRequest();   // hold off the idle timer while this (slow) query runs
         try {
             // queryProof internally bounds the header fetch (60 s); the outer bound covers
             // the snap fetch + verification end to end.
@@ -265,6 +267,8 @@ public final class JavaChainHandle implements ChainHandle {
             Throwable cause = e.getCause() != null ? e.getCause() : e;
             throw new EngineException(cause.getMessage() != null
                     ? cause.getMessage() : cause.getClass().getSimpleName(), cause);
+        } finally {
+            stack.endRequest();
         }
     }
 
@@ -273,6 +277,7 @@ public final class JavaChainHandle implements ChainHandle {
         awaitWake();
         RLPxConnector conn = stack.connector();
         if (!stack.isRunning() || conn == null) throw new EngineException("Node is not running");
+        stack.beginRequest();
         try {
             return io.myotis.node.VerifiedStorageQuery.query(
                     conn, stack.beaconSyncState(), hexAddress, slot, holderHexOrNull);
@@ -283,6 +288,8 @@ public final class JavaChainHandle implements ChainHandle {
             Throwable cause = e.getCause() != null ? e.getCause() : e;
             throw new EngineException(cause.getMessage() != null
                     ? cause.getMessage() : cause.getClass().getSimpleName(), cause);
+        } finally {
+            stack.endRequest();
         }
     }
 
@@ -291,7 +298,12 @@ public final class JavaChainHandle implements ChainHandle {
         awaitWake();
         RLPxConnector conn = stack.connector();
         if (!stack.isRunning() || conn == null) throw new EngineException("Node is not running");
-        return io.myotis.node.HeaderQuery.fetch(conn, startBlock, count);
+        stack.beginRequest();
+        try {
+            return io.myotis.node.HeaderQuery.fetch(conn, startBlock, count);
+        } finally {
+            stack.endRequest();
+        }
     }
 
     @Override
@@ -299,7 +311,12 @@ public final class JavaChainHandle implements ChainHandle {
         awaitWake();
         RLPxConnector conn = stack.connector();
         if (!stack.isRunning() || conn == null) throw new EngineException("Node is not running");
-        return io.myotis.node.VerifiedBlockQuery.query(conn, stack.beaconSyncState(), blockNumber);
+        stack.beginRequest();
+        try {
+            return io.myotis.node.VerifiedBlockQuery.query(conn, stack.beaconSyncState(), blockNumber);
+        } finally {
+            stack.endRequest();
+        }
     }
 
     @Override

--- a/node-core/src/main/java/io/myotis/node/api/JavaChainHandle.java
+++ b/node-core/src/main/java/io/myotis/node/api/JavaChainHandle.java
@@ -72,6 +72,8 @@ public final class JavaChainHandle implements ChainHandle {
 
     @Override public boolean resume() { return stack.resume(); }
 
+    @Override public boolean resume(String reason) { return stack.resume(reason); }
+
     @Override public LifecycleState lifecycle() { return stack.lifecycle(); }
 
     @Override public long lastActivityEpochMillis() { return stack.lastActivityMs(); }
@@ -157,7 +159,12 @@ public final class JavaChainHandle implements ChainHandle {
                 bss != null ? bss.getFinalizedPeriod() : 0L,
                 wallClockPeriod,
                 backend != null ? backend.verifiedHeadAgeMs() : Long.MAX_VALUE,
-                readyRows);
+                readyRows,
+                stack.pauseCount(),
+                stack.totalPausedMs(),
+                stack.lastPauseEpochMs(),
+                stack.lastResumeEpochMs(),
+                stack.lastWakeReason());
     }
 
     @Override

--- a/node-core/src/main/java/io/myotis/node/api/JavaEnsApi.java
+++ b/node-core/src/main/java/io/myotis/node/api/JavaEnsApi.java
@@ -37,7 +37,10 @@ final class JavaEnsApi implements EnsApi {
     }
 
     private VerifiedRpcBackend backend() {
-        VerifiedRpcBackend backend = stack.rpcBackend();
+        // Wake-and-wait: ENS resolution on a paused stack triggers resume and holds
+        // here (bounded) exactly like the JSON-RPC path; the returned backend is the
+        // live post-resume one.
+        VerifiedRpcBackend backend = stack.awaitReadyForReads(ChainStack.WAKE_WAIT_CAP_MS);
         if (backend == null) throw new EngineException("node not running (RPC backend not started)");
         return backend;
     }

--- a/node-core/src/main/java/io/myotis/node/api/JavaEnsApi.java
+++ b/node-core/src/main/java/io/myotis/node/api/JavaEnsApi.java
@@ -41,7 +41,16 @@ final class JavaEnsApi implements EnsApi {
         // here (bounded) exactly like the JSON-RPC path; the returned backend is the
         // live post-resume one.
         VerifiedRpcBackend backend = stack.awaitReadyForReads(ChainStack.WAKE_WAIT_CAP_MS);
-        if (backend == null) throw new EngineException("node not running (RPC backend not started)");
+        if (backend == null) {
+            // null has three distinct causes — report the actual one so wake / bind
+            // failures are debuggable (not all "node not running").
+            throw new EngineException(switch (stack.lifecycle()) {
+                case STOPPED -> "node not running";
+                case PAUSED -> "node did not wake within "
+                        + (ChainStack.WAKE_WAIT_CAP_MS / 1000) + "s (paused; resume failing)";
+                case RUNNING -> "verified RPC backend unavailable (JSON-RPC may have failed to bind)";
+            });
+        }
         return backend;
     }
 

--- a/node-core/src/test/java/io/myotis/node/SleepMetricsTest.java
+++ b/node-core/src/test/java/io/myotis/node/SleepMetricsTest.java
@@ -1,0 +1,63 @@
+package io.myotis.node;
+
+import io.myotis.api.WakeReason;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Hermetic tests for the idle-sleep accounting, including the load-bearing
+ * observer-effect rule: a foreground (observation) wake still accrues into the
+ * pause count / total, but must not overwrite the recorded last-wake reason/time.
+ */
+class SleepMetricsTest {
+
+    private static final long MS = 1_000_000L; // nanos per ms
+
+    @Test
+    void freshMetricsAreZero() {
+        SleepMetrics m = new SleepMetrics();
+        assertEquals(0, m.pauseCount());
+        assertEquals(0L, m.totalPausedMs());
+        assertEquals(0L, m.lastPauseEpochMs());
+        assertEquals(0L, m.lastResumeEpochMs());
+        assertNull(m.lastWakeReason());
+    }
+
+    @Test
+    void countsPausesAndAccumulatesTotal() {
+        SleepMetrics m = new SleepMetrics();
+        // Pause at t=1000ms, wake 5s later.
+        m.onPause(1_000L, 1_000L * MS);
+        m.onResume(6_000L, 6_000L * MS, WakeReason.REQUEST, true);
+        // Pause again at t=10s, wake 3s later.
+        m.onPause(10_000L, 10_000L * MS);
+        m.onResume(13_000L, 13_000L * MS, WakeReason.CATCH_UP, true);
+
+        assertEquals(2, m.pauseCount());
+        assertEquals(8_000L, m.totalPausedMs());          // 5s + 3s
+        assertEquals(10_000L, m.lastPauseEpochMs());
+        assertEquals(13_000L, m.lastResumeEpochMs());
+        assertEquals(WakeReason.CATCH_UP, m.lastWakeReason());
+    }
+
+    @Test
+    void foregroundWakeCountsButDoesNotClobberLastReason() {
+        SleepMetrics m = new SleepMetrics();
+        // A real demand wake (request) at t=6s.
+        m.onPause(1_000L, 1_000L * MS);
+        m.onResume(6_000L, 6_000L * MS, WakeReason.REQUEST, /*recordAsWake*/ true);
+        // Then the user opens the app: a foreground observation wake at t=13s.
+        m.onPause(10_000L, 10_000L * MS);
+        m.onResume(13_000L, 13_000L * MS, WakeReason.FOREGROUND, /*recordAsWake*/ false);
+
+        // Both sleeps counted (the node genuinely slept + woke both times)...
+        assertEquals(2, m.pauseCount());
+        assertEquals(8_000L, m.totalPausedMs());          // 5s + 3s
+        // ...but the last-wake display still shows the REQUEST wake, not foreground —
+        // opening the status page did not hide the reason being debugged.
+        assertEquals(WakeReason.REQUEST, m.lastWakeReason());
+        assertEquals(6_000L, m.lastResumeEpochMs());
+    }
+}

--- a/node-core/src/test/java/io/myotis/node/WakeGateTest.java
+++ b/node-core/src/test/java/io/myotis/node/WakeGateTest.java
@@ -1,0 +1,126 @@
+package io.myotis.node;
+
+import io.myotis.api.LifecycleState;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Hermetic tests for the wake-on-request primitive: single-flight resume,
+ * bounded holds, activity stamping, and fast-fail on STOPPED.
+ */
+@Timeout(value = 30, unit = TimeUnit.SECONDS)
+class WakeGateTest {
+
+    private static final long POLL_MS = 5;
+
+    @Test
+    void concurrentWaitersTriggerExactlyOneResume() throws Exception {
+        AtomicReference<LifecycleState> phase = new AtomicReference<>(LifecycleState.PAUSED);
+        AtomicBoolean ready = new AtomicBoolean(false);
+        AtomicInteger resumeRuns = new AtomicInteger();
+        CountDownLatch resumeEntered = new CountDownLatch(1);
+        CountDownLatch releaseResume = new CountDownLatch(1);
+
+        WakeGate gate = new WakeGate(phase::get, ready::get, () -> {
+            resumeRuns.incrementAndGet();
+            resumeEntered.countDown();
+            try {
+                releaseResume.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            phase.set(LifecycleState.RUNNING);
+            ready.set(true);
+        }, System::currentTimeMillis, POLL_MS, "test-wake");
+
+        int waiters = 8;
+        CountDownLatch done = new CountDownLatch(waiters);
+        AtomicInteger successes = new AtomicInteger();
+        for (int i = 0; i < waiters; i++) {
+            Thread t = new Thread(() -> {
+                if (gate.await(10_000)) successes.incrementAndGet();
+                done.countDown();
+            });
+            t.setDaemon(true);
+            t.start();
+        }
+        // Let every waiter observe PAUSED and try to trigger a wake, then release
+        // the (single) resume run.
+        assertTrue(resumeEntered.await(5, TimeUnit.SECONDS));
+        Thread.sleep(POLL_MS * 20);
+        releaseResume.countDown();
+
+        assertTrue(done.await(10, TimeUnit.SECONDS));
+        assertEquals(1, resumeRuns.get(), "N concurrent waiters must produce exactly one resume");
+        assertEquals(waiters, successes.get(), "all held requests answer after the wake");
+    }
+
+    @Test
+    void pausedTimeoutReturnsFalseAndLaterCallRetriesTheWake() throws Exception {
+        AtomicReference<LifecycleState> phase = new AtomicReference<>(LifecycleState.PAUSED);
+        AtomicInteger resumeRuns = new AtomicInteger();
+
+        // Resume that fails: runs, but leaves the phase PAUSED.
+        WakeGate gate = new WakeGate(phase::get, () -> false, resumeRuns::incrementAndGet,
+                System::currentTimeMillis, POLL_MS, "test-wake");
+
+        assertFalse(gate.await(50), "still PAUSED at the deadline → false");
+        int runsAfterFirst = resumeRuns.get();
+        assertTrue(runsAfterFirst >= 1, "the failed wake ran at least once");
+
+        // A later call finds wakeInFlight released and re-triggers the wake.
+        assertFalse(gate.await(50));
+        assertTrue(resumeRuns.get() > runsAfterFirst, "a later call retries the wake");
+    }
+
+    @Test
+    void everyCallBumpsLastActivity() {
+        AtomicReference<LifecycleState> phase = new AtomicReference<>(LifecycleState.RUNNING);
+        long[] now = {1_000L};
+        WakeGate gate = new WakeGate(phase::get, () -> true, () -> { },
+                () -> now[0], POLL_MS, "test-wake");
+
+        assertEquals(0, gate.lastActivityMs());
+        assertTrue(gate.await(1_000));
+        assertEquals(1_000L, gate.lastActivityMs());
+
+        now[0] = 2_000L;
+        gate.poke();
+        assertEquals(2_000L, gate.lastActivityMs());
+    }
+
+    @Test
+    void stoppedReturnsImmediately() {
+        AtomicReference<LifecycleState> phase = new AtomicReference<>(LifecycleState.STOPPED);
+        AtomicInteger resumeRuns = new AtomicInteger();
+        WakeGate gate = new WakeGate(phase::get, () -> true, resumeRuns::incrementAndGet,
+                System::currentTimeMillis, POLL_MS, "test-wake");
+
+        long t0 = System.nanoTime();
+        assertFalse(gate.await(60_000));
+        long elapsedMs = (System.nanoTime() - t0) / 1_000_000;
+        assertTrue(elapsedMs < 5_000, "STOPPED must not hold the request");
+        assertEquals(0, resumeRuns.get(), "STOPPED never triggers a wake");
+    }
+
+    @Test
+    void runningButColdAtDeadlineReturnsTrue() {
+        AtomicReference<LifecycleState> phase = new AtomicReference<>(LifecycleState.RUNNING);
+        WakeGate gate = new WakeGate(phase::get, () -> false, () -> { },
+                System::currentTimeMillis, POLL_MS, "test-wake");
+
+        // RUNNING but never ready: at the cap the request is handed to the backend
+        // anyway (it produces its own precise bounded errors).
+        assertTrue(gate.await(50));
+    }
+}

--- a/node-core/src/test/java/io/myotis/node/api/JavaMyotisEngineTest.java
+++ b/node-core/src/test/java/io/myotis/node/api/JavaMyotisEngineTest.java
@@ -89,6 +89,29 @@ class JavaMyotisEngineTest {
     }
 
     @Test
+    void lifecycleSurfaceOnNeverStartedHandle() {
+        JavaMyotisEngine engine = new JavaMyotisEngine();
+        EngineConfig config = new EngineConfig("gnosis", 0, 0, 0, null, false, 0, true);
+        ChainHandle handle = engine.create(config, testPorts(new MemoryKeyStore()));
+
+        assertEquals(io.myotis.api.LifecycleState.STOPPED, handle.lifecycle());
+        assertFalse(handle.isRunning());
+        assertEquals(0L, handle.lastActivityEpochMillis());
+
+        // pause()/resume() on a never-started stack are safe no-ops: STOPPED is
+        // terminal, so neither transitions and both report failure.
+        assertFalse(handle.pause());
+        assertFalse(handle.resume());
+        assertEquals(io.myotis.api.LifecycleState.STOPPED, handle.lifecycle());
+
+        // status() reflects the lifecycle without a running stack.
+        assertEquals(io.myotis.api.LifecycleState.STOPPED, handle.status().lifecycle());
+        assertFalse(handle.status().running());
+
+        engine.stop("gnosis");
+    }
+
+    @Test
     void createReusesStoredKey() {
         JavaMyotisEngine engine = new JavaMyotisEngine();
         MemoryKeyStore keyStore = new MemoryKeyStore();

--- a/node-core/src/test/java/io/myotis/node/api/JavaMyotisEngineTest.java
+++ b/node-core/src/test/java/io/myotis/node/api/JavaMyotisEngineTest.java
@@ -108,6 +108,17 @@ class JavaMyotisEngineTest {
         assertEquals(io.myotis.api.LifecycleState.STOPPED, handle.status().lifecycle());
         assertFalse(handle.status().running());
 
+        // Sleep metrics are zeroed on a never-started stack.
+        io.myotis.api.StatusSnapshot snap = handle.status();
+        assertEquals(0, snap.pauseCount());
+        assertEquals(0L, snap.totalPausedMs());
+        assertEquals(0L, snap.lastResumeEpochMs());
+        assertNull(snap.lastWakeReason());
+
+        // resume(reason) is a safe no-op on STOPPED (same as resume()).
+        assertFalse(handle.resume(io.myotis.api.WakeReason.CATCH_UP));
+        assertEquals(io.myotis.api.LifecycleState.STOPPED, handle.lifecycle());
+
         engine.stop("gnosis");
     }
 

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeController.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeController.kt
@@ -119,6 +119,14 @@ interface Settings {
     /** true = use bundled native blst (default on Android); false = pure-Java Milagro. */
     fun nativeBlsEnabled(): Boolean
     fun setNativeBlsEnabled(v: Boolean)
+
+    /**
+     * Minutes of no RPC/UI activity before a running stack is paused into idle sleep
+     * (networking off, RPC listening, first request wakes it). 0 disables auto-pause.
+     * Defaults keep hosts without an idle controller (desktop) compiling: auto-pause off.
+     */
+    fun idlePauseMinutes(): Int = 0
+    fun setIdlePauseMinutes(v: Int) {}
 }
 
 /** Device network connectivity, as an observable stream so the UI can react to changes. */
@@ -135,6 +143,8 @@ interface NetworkStatus {
  */
 data class NodeSnapshot(
     val running: Boolean,
+    val lifecycle: String,          // RUNNING / PAUSED / STOPPED — PAUSED = idle sleep
+                                    // (networking off, RPC listening, wakes on request)
     val network: String,
     val beaconState: String,        // STOPPED / SYNCING / CATCHING_UP / SYNCED
     val connectedPeers: Int,

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeController.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeController.kt
@@ -127,6 +127,13 @@ interface Settings {
      */
     fun idlePauseMinutes(): Int = 0
     fun setIdlePauseMinutes(v: Int) {}
+
+    /**
+     * Whether this host actually has an idle-sleep controller (Android). The idle-sleep
+     * Settings row is shown only when true — desktop has no controller, so surfacing a
+     * battery-saving toggle there would imply a feature that can't take effect. Default false.
+     */
+    fun supportsIdleSleep(): Boolean = false
 }
 
 /** Device network connectivity, as an observable stream so the UI can react to changes. */

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeController.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeController.kt
@@ -172,6 +172,12 @@ data class NodeSnapshot(
     val verifiedHeadAgeMs: Long,
     val uptimeSeconds: Long,
     val readyPeerList: List<PeerRow>,  // per-peer detail for the READY peers
+    // Idle-sleep metrics (pseudo-sleep observability). See WakeReason.
+    val pauseCount: Int,               // times the stack idle-slept since start
+    val totalPausedMs: Long,           // cumulative time paused
+    val lastPauseEpochMs: Long,        // wall-clock ms of the last pause; 0 if never
+    val lastResumeEpochMs: Long,       // wall-clock ms of the last DEMAND wake; 0 if none
+    val lastWakeReason: String?,       // reason of the last demand wake; null if none
 )
 
 /** One connected READY peer, for the Status peer list. */

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
@@ -172,6 +172,8 @@ private fun NetworkChips(chains: List<String>, selected: String, onSelect: (Stri
 @Composable
 private fun ReadinessStrip(s: NodeSnapshot?, deepPoolThreshold: Int) {
     val (color, height, label) = when {
+        s != null && s.lifecycle == "PAUSED" ->
+            Triple(Color(0xFF78909C), 3.dp, "Node readiness: sleeping — a request wakes it")
         s == null || !s.running ->
             Triple(Color(0xFFD32F2F), 3.dp, "Node readiness: not running")
         s.beaconState != "SYNCED" ->
@@ -236,6 +238,7 @@ private fun SettingsTab(
     }
     var snapTarget by remember { mutableStateOf(settings.snapTarget().toString()) }
     var deepPool by remember { mutableStateOf(settings.deepPoolThreshold().toString()) }
+    var idlePause by remember { mutableStateOf(settings.idlePauseMinutes().toString()) }
     var strictFreshness by remember { mutableStateOf(settings.strictStateFreshness()) }
     var nativeBls by remember { mutableStateOf(settings.nativeBlsEnabled()) }
 
@@ -297,6 +300,21 @@ private fun SettingsTab(
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
             modifier = Modifier.fillMaxWidth(),
         )
+        OutlinedTextField(
+            value = idlePause,
+            onValueChange = { idlePause = it.filter(Char::isDigit).take(3) },
+            label = { Text("Idle sleep after (minutes, 0 = never)") },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Text(
+            "After this many minutes without a wallet request or query, the node goes to " +
+                "sleep: all P2P networking stops (saving battery) while the JSON-RPC port keeps " +
+                "listening. The first request wakes it — expect that call to take a little longer.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
 
         // Strict freshness is the default; the switch exposes the RELAXED (opt-in) state, so the
         // checked value is the negation. Persisted immediately; applies on the next node restart.
@@ -340,6 +358,8 @@ private fun SettingsTab(
                 val deep = deepPool.toIntOrNull() ?: 16
                 settings.setSnapTarget(snap)          // persist
                 settings.setDeepPool(deep)            // persist (read at readiness-check time)
+                // Idle sleep: persisted; the controller reads it on every tick, so it applies live.
+                settings.setIdlePauseMinutes(idlePause.toIntOrNull() ?: 5)
                 controller.setTargetSnapPeers(snap)   // live-apply to running stacks
                 networks.forEach { id ->
                     // Compare the EFFECTIVE (post-clamp) persisted port before vs after, not the
@@ -514,6 +534,11 @@ private fun OfflineBanner(onOpenNetworkSettings: () -> Unit) {
 private fun StatusView(s: NodeSnapshot) {
     Column {
         StatusRow("Network", s.network)
+        StatusRow("State", when (s.lifecycle) {
+            "PAUSED" -> "Sleeping (wakes on request)"
+            "RUNNING" -> "Running"
+            else -> "Stopped"
+        })
         StatusRow("Beacon", s.beaconState)
         StatusRow("EL block", s.executionBlockNumber.toString())
         StatusRow("CL peers", "served ${s.clServedPeersLastMin}/min, con ${s.clConnectedPeers}")

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
@@ -541,6 +541,7 @@ private fun OfflineBanner(onOpenNetworkSettings: () -> Unit) {
 
 @Composable
 private fun StatusView(s: NodeSnapshot) {
+    val tz = remember { TimeZone.currentSystemDefault() }
     Column {
         StatusRow("Network", s.network)
         StatusRow("State", when (s.lifecycle) {
@@ -561,6 +562,19 @@ private fun StatusView(s: NodeSnapshot) {
         // dash instead of the raw ~9.2e18 ms, which would read as a nonsensical age.
         StatusRow("Verified head age", if (s.verifiedHeadAgeMs == Long.MAX_VALUE) "—" else "${s.verifiedHeadAgeMs} ms")
         StatusRow("Uptime", "${s.uptimeSeconds}s")
+        // Pseudo-sleep observability: how much the node has idle-slept, and when/why it
+        // last woke. Foreground (opening the app) is excluded from the "last woke" reason,
+        // so this keeps showing the last real request/catch-up wake even as you view it.
+        StatusRow(
+            "Sleep",
+            if (s.pauseCount == 0) "never slept"
+            else "${formatDuration(s.totalPausedMs)} over ${s.pauseCount} " +
+                if (s.pauseCount == 1) "pause" else "pauses",
+        )
+        if (s.lastResumeEpochMs > 0) {
+            val slept = if (s.lastPauseEpochMs > 0) " · slept ${formatLogTime(s.lastPauseEpochMs, tz)}" else ""
+            StatusRow("Last woke", "${formatLogTime(s.lastResumeEpochMs, tz)} (${s.lastWakeReason ?: "?"})$slept")
+        }
     }
 }
 
@@ -1016,6 +1030,19 @@ private fun formatLogs(lines: List<LogLine>, tz: TimeZone): String = buildString
     for (l in lines) {
         append(formatLogTime(l.timestampMillis, tz)).append(' ').append(l.level)
         append(' ').append(l.tag).append(": ").append(l.message).append('\n')
+    }
+}
+
+/** Compact elapsed duration: "45s" / "3m 12s" / "1h 3m". */
+private fun formatDuration(ms: Long): String {
+    val totalSec = ms / 1000
+    val h = totalSec / 3600
+    val m = (totalSec % 3600) / 60
+    val sec = totalSec % 60
+    return when {
+        h > 0 -> "${h}h ${m}m"
+        m > 0 -> "${m}m ${sec}s"
+        else -> "${sec}s"
     }
 }
 

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
@@ -300,21 +300,26 @@ private fun SettingsTab(
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
             modifier = Modifier.fillMaxWidth(),
         )
-        OutlinedTextField(
-            value = idlePause,
-            onValueChange = { idlePause = it.filter(Char::isDigit).take(3) },
-            label = { Text("Idle sleep after (minutes, 0 = never)") },
-            singleLine = true,
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-            modifier = Modifier.fillMaxWidth(),
-        )
-        Text(
-            "After this many minutes without a wallet request or query, the node goes to " +
-                "sleep: all P2P networking stops (saving battery) while the JSON-RPC port keeps " +
-                "listening. The first request wakes it — expect that call to take a little longer.",
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
+        // Idle-sleep is only meaningful on a host that actually runs the idle controller
+        // (Android). On desktop (no controller) the setting is a no-op, so don't surface a
+        // battery-saving toggle that can't take effect.
+        if (settings.supportsIdleSleep()) {
+            OutlinedTextField(
+                value = idlePause,
+                onValueChange = { idlePause = it.filter(Char::isDigit).take(3) },
+                label = { Text("Idle sleep after (minutes, 0 = never)") },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Text(
+                "After this many minutes without a wallet request or query, the node goes to " +
+                    "sleep: all P2P networking stops (saving battery) while the JSON-RPC port keeps " +
+                    "listening. The first request wakes it — expect that call to take a little longer.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
 
         // Strict freshness is the default; the switch exposes the RELAXED (opt-in) state, so the
         // checked value is the negation. Persisted immediately; applies on the next node restart.
@@ -358,8 +363,12 @@ private fun SettingsTab(
                 val deep = deepPool.toIntOrNull() ?: 16
                 settings.setSnapTarget(snap)          // persist
                 settings.setDeepPool(deep)            // persist (read at readiness-check time)
-                // Idle sleep: persisted; the controller reads it on every tick, so it applies live.
-                settings.setIdlePauseMinutes(idlePause.toIntOrNull() ?: 5)
+                // Idle sleep: persisted only on hosts that run the controller; the tick reads it
+                // live. Blank/invalid input keeps the CURRENT value rather than silently enabling
+                // sleep (the label says "0 = never"), so a stray edit can't turn it on by accident.
+                if (settings.supportsIdleSleep()) {
+                    settings.setIdlePauseMinutes(idlePause.toIntOrNull() ?: settings.idlePauseMinutes())
+                }
                 controller.setTargetSnapPeers(snap)   // live-apply to running stacks
                 networks.forEach { id ->
                     // Compare the EFFECTIVE (post-clamp) persisted port before vs after, not the


### PR DESCRIPTION
Make Myotis battery-friendly on Android: after a configurable idle window
(default 5 min without RPC/UI activity) a running stack enters pseudo-sleep —
every socket and periodic timer stops (discv4/discv5, RLPx, libp2p, beacon
finality poll, snap maintainer, head warmer) so the radio can sleep, while the
JSON-RPC server keeps listening and the warm verified state (light-client
store, sync-state roots window, peer caches, DNS pool) stays in memory. The
first verified read triggers a single-flight resume and is held (bounded 90s,
kept alive by the existing whitespace heartbeat) until the node can answer.

- myotis-api: LifecycleState enum; ChainHandle.pause()/resume()/lifecycle()/
  lastActivityEpochMillis() (FFI-flat polling surface for host idle timers);
  StatusSnapshot.lifecycle.
- consensus: BeaconLightClient.pause()/resume() keep the verified store and
  catch-up executor warm across sleep (resume skips snapshot-restore and
  bootstrap, catches up only missed periods); BeaconP2PService.close() nulls
  the host so a close->start cycle rebuilds cleanly (restart test included).
- node-core: ChainStack phase machine (STOPPED/RUNNING/PAUSED) with pause()/
  resume() sharing the start/shutdown monitor; build steps extracted so resume
  rebuilds connector/discv4/discv5/backend from the warm DNS pool; WakeGate
  (single-flight async resume + bounded request hold, hermetically tested);
  GatedVerifiedReads — the RPC server is constructed over the gate so it
  survives pause while the backend is rebuilt underneath; eth_chainId answers
  without waking, syncState pokes the wake but never blocks. Operator queries
  and ENS resolution wake the node the same way.
- android-app: NodeService idle controller (30s tick, settings-backed idle
  minutes, boot/resume grace stamps, notification flips between running and
  sleeping); app-foreground proactively resumes; onTrimMemory CRITICAL
  early-pauses; WorkManager daily catch-up resumes a sleeping stack, waits for
  SYNCED + warm head, persists the snapshot and pauses again without counting
  as activity.
- ui/app-desktop: lifecycle in the snapshot model, sleeping state on the
  status card and readiness strip, idle-minutes setting row.
- app daemon: pause/resume IPC verbs; status now reports the lifecycle state.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01R5S5D7HSE1R7Diuo11cMQY