### PR TITLE
app: log the daemon to stdout + drain Rust engine logs to stdout

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -107,13 +107,11 @@ tasks.register<JavaExec>("run") {
     appArgs.addAll(cmdArgs)
     args(appArgs)
     // Force our logback config over the one trueblocks-kotlin bundles on the
-    // classpath. Daemon (no -Pargs) → truncate-on-start devp2p.log; client command
-    // → console-only so it never wipes the running daemon's log.
+    // classpath. Both are console-only (stdout); the daemon vs client split just
+    // differs in log levels. Follow the daemon with `./gradlew :app:run` in the
+    // terminal (or redirect its stdout).
     systemProperty(
         "logback.configurationFile",
         if (cmdArgs.isEmpty()) "logback-daemon.xml" else "logback-client.xml",
     )
-    // Stable daemon log at the repo root regardless of the JVM working dir (which
-    // defaults to the :app module dir). `tail -F devp2p.log` from the repo root.
-    systemProperty("myotis.logfile", rootProject.file("devp2p.log").absolutePath)
 }

--- a/app/src/main/java/com/jaeckel/ethp2p/app/Main.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/Main.java
@@ -95,6 +95,47 @@ public final class Main {
     }
 
     /**
+     * Drain the Rust engine's tracing ring to the {@code rust} logger (→ stdout)
+     * on a short poll, so its own logs surface near-real-time under
+     * {@code -Pengine=rust}. A daemon thread for the process lifetime; the ring
+     * is process-global (all networks) and drainRustLogs is a no-op under the
+     * Java engine. Observability must never take the daemon down, so every
+     * failure is swallowed. Mirrors the desktop/Android hosts' pump.
+     */
+    private static void startRustLogPump() {
+        Logger rustLog = LoggerFactory.getLogger("rust");
+        Thread pump = new Thread(() -> {
+            while (!Thread.currentThread().isInterrupted()) {
+                try {
+                    String batch = Engines.drainRustLogs(1000);
+                    if (!batch.isEmpty()) {
+                        for (String line : batch.split("\n")) {
+                            if (line.isBlank()) continue;
+                            String s = line.strip();
+                            // The Rust fmt layer puts the level first; preserve it.
+                            if (s.startsWith("ERROR")) rustLog.error("{}", line);
+                            else if (s.startsWith("WARN")) rustLog.warn("{}", line);
+                            else rustLog.info("{}", line);
+                        }
+                    }
+                } catch (Throwable ignored) {
+                    // Never let log draining take the daemon down.
+                }
+                try {
+                    // Short poll → near-real-time without a busy spin. The ring
+                    // buffers between drains, so nothing is lost at this cadence.
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+            }
+        }, "myotis-rust-logs");
+        pump.setDaemon(true);
+        pump.start();
+    }
+
+    /**
      * Node-identity key file, per network — mainnet keeps the legacy {@code nodekey.hex}, every
      * other network gets {@code nodekey-<net>.hex}. This holds regardless of how many networks the
      * daemon hosts, so a network always has a stable identity of its own: previously a
@@ -303,6 +344,12 @@ public final class Main {
             }
             servers.add(server);
         }
+
+        // Relay the Rust engine's own tracing to stdout (via the `rust` logger)
+        // so `-Pengine=rust` sync/EL activity is visible in the daemon log. The
+        // ring is process-global, so one pump covers every network; it is a
+        // no-op under the Java engine. Daemon-only path (client commands exit).
+        startRustLogPump();
 
         // 2. Run cleanup exactly once, whether reached via the await() below or the
         //    shutdown hook (Ctrl-C / SIGTERM, or normal exit after await returns).

--- a/app/src/main/java/com/jaeckel/ethp2p/app/Main.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/Main.java
@@ -118,8 +118,14 @@ public final class Main {
                             else rustLog.info("{}", line);
                         }
                     }
-                } catch (Throwable ignored) {
-                    // Never let log draining take the daemon down.
+                } catch (Throwable t) {
+                    // Never let log draining take the daemon down — but don't
+                    // swallow an interrupt: restore the flag and stop.
+                    if (t instanceof InterruptedException) {
+                        Thread.currentThread().interrupt();
+                        return;
+                    }
+                    // Any other error is dropped; keep pumping.
                 }
                 try {
                     // Short poll → near-real-time without a busy spin. The ring

--- a/app/src/main/resources/logback-client.xml
+++ b/app/src/main/resources/logback-client.xml
@@ -1,8 +1,7 @@
 <!-- Client-command logging config. Forced via -Dlogback.configurationFile=logback-client.xml
      in the :app `run` task whenever -Pargs is present (status/peers/get-account/etc).
-     Console-only on purpose: a short-lived client invocation must NOT open (and with
-     append=false TRUNCATE) the daemon's devp2p.log, which would wipe the running
-     service's log out from under a `tail -F`. -->
+     Console-only with quieter levels than the daemon config, so a short-lived client
+     command (which shares the terminal/stdout) prints just its result, not a firehose. -->
 <configuration>
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/app/src/main/resources/logback-daemon.xml
+++ b/app/src/main/resources/logback-daemon.xml
@@ -2,24 +2,13 @@
      in the :app `run` task (only when no -Pargs, i.e. the long-running service),
      so it wins over the logback.xml that trueblocks-kotlin bundles on the classpath.
 
-     Writes to a STABLE file (${user.dir}/devp2p.log — the project's canonical daemon
-     log, see CLAUDE.md) and TRUNCATES it on each start (<append>false</append>) so a
-     `tail -F devp2p.log` always follows the current run, not a months-long pile-up.
-     Client commands (./gradlew :app:run -Pargs=...) use logback-client.xml instead,
-     which is console-only and never touches this file. -->
+     Console-only: the daemon logs to STDOUT (follow it in the terminal, or via the
+     launcher's own redirect). The Rust engine's own tracing is drained to the
+     `rust` logger on a short poll (Main.startRustLogPump), so `-Pengine=rust`
+     activity shows up here too — set RUST_LOG for more verbosity. Client commands
+     (./gradlew :app:run -Pargs=...) use logback-client.xml, also console-only. -->
 <configuration>
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
-        </encoder>
-    </appender>
-
-    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-        <!-- Path set by the :app run task (myotis.logfile = <repo-root>/devp2p.log),
-             so it's the same file no matter the JVM working dir; falls back to the
-             working dir for a bare `java -jar` launch. -->
-        <file>${myotis.logfile:-${user.dir}/devp2p.log}</file>
-        <append>false</append>
         <encoder>
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
@@ -35,6 +24,5 @@
 
     <root level="INFO">
         <appender-ref ref="CONSOLE"/>
-        <appender-ref ref="FILE"/>
     </root>
 </configuration>

--- a/app/src/main/resources/logback.xml
+++ b/app/src/main/resources/logback.xml
@@ -5,13 +5,6 @@
         </encoder>
     </appender>
 
-    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-        <file>${user.dir}/devp2p.log</file>
-        <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
-        </encoder>
-    </appender>
-
     <logger name="com.jaeckel.ethp2p" level="DEBUG"/>
     <logger name="io.netty" level="WARN"/>
     <logger name="org.apache.tuweni" level="WARN"/>
@@ -22,6 +15,5 @@
 
     <root level="INFO">
         <appender-ref ref="CONSOLE"/>
-        <appender-ref ref="FILE"/>
     </root>
 </configuration>

--- a/tools/mm-replay/README.md
+++ b/tools/mm-replay/README.md
@@ -15,7 +15,7 @@ send against `127.0.0.1:8545` was recorded into
 ## Running
 ```bash
 # 1. start a synced daemon (serves http://127.0.0.1:8545)
-./gradlew :app:run            # wait until devp2p.log shows it serving
+./gradlew :app:run            # wait until stdout shows it serving
 
 # 2. replay the golden session against it
 python3 tools/mm-replay/replay.py tools/mm-replay/sessions/metamask-send-mainnet.jsonl


### PR DESCRIPTION
## What

The CLI daemon wrote to `devp2p.log` and **never drained the Rust engine's tracing ring**, so `-Pengine=rust` produced almost no visible logs — all the sync/EL activity was trapped in the in-process ring buffer (the desktop and Android hosts pump it; the CLI `:app` daemon didn't). This makes the daemon log to **stdout** and relays the Rust logs there.

## Changes

- **`logback-daemon.xml` / `logback.xml`** — drop the FILE appender (`devp2p.log`); the daemon is now CONSOLE-only (stdout). **`app/build.gradle.kts`** — drop the now-unused `myotis.logfile` system property.
- **`Main.startRustLogPump()`** — a process-lifetime **daemon thread** drains `Engines.drainRustLogs` on a 100 ms poll and relays each line to the `rust` logger (→ stdout), preserving severity (ERROR/WARN/else-info). Started once, after the network loop, daemon-path only. No-op under the Java engine; every failure is swallowed so observability never takes the daemon down. Set `RUST_LOG` for more verbosity.
- **`logback-client.xml` comment + mm-replay README** — drop stale `devp2p.log` references.

## Tests / verification

- `:app` build + tests green; all three logback XMLs validated as well-formed.
- **Runtime check deferred**: a fresh mainnet daemon start is needed to observe stdout output (incl. `[rust]` lines) and the absence of `devp2p.log`, but a live `-Pengine=rust` daemon is currently occupying the mainnet socket, so I didn't start a conflicting one. It'll be visible on the next `./gradlew :app:run -Pengine=rust`.

## Review

Ran the mandatory no-context review before opening. It confirmed: the pump can't NPE (`drainRustLogs` never returns null — verified against its contract) and swallows all throwables + interruption; it's a daemon thread started exactly once on the daemon path only; no dangling `FILE` appender-ref (removed with its appender in both configs); `myotis.logfile` has no remaining readers; and stdout logging can't corrupt the daemon's Unix-socket IPC. No defects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)