### PR TITLE
app: -Prustlog to set the Rust engine's RUST_LOG on :app:run

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -84,7 +84,11 @@ tasks.register<JavaExec>("run") {
     // env_logger/tracing syntax: `-Prustlog=debug` for everything, or a targeted
     // filter like `-Prustlog=myotis_net=debug,info` (default when unset:
     // info with the noisy deps at warn).
-    (project.findProperty("rustlog") as String?)?.let { environment("RUST_LOG", it) }
+    // Guard against a blank value: `-Prustlog=` would set RUST_LOG="" and
+    // OVERRIDE the engine's default filter with an empty one (silencing the Rust
+    // logs) — treat blank as unset so the default stands.
+    (project.findProperty("rustlog") as? String)?.takeIf { it.isNotBlank() }
+        ?.let { environment("RUST_LOG", it) }
     // -Plcdump=<dir> → -Dmyotis.lc.dumpVectors: capture raw light-client SSZ
     // (bootstrap/updates/finality) for the rust/testdata conformance corpus.
     (project.findProperty("lcdump") as String?)?.let { systemProperty("myotis.lc.dumpVectors", it) }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -78,6 +78,13 @@ tasks.register<JavaExec>("run") {
     (project.findProperty("bls") as String?)?.let { systemProperty("myotis.bls.backend", it) }
     // -Pengine=java|rust|auto → -Dmyotis.engine (the :myotis-engines selector).
     (project.findProperty("engine") as String?)?.let { systemProperty("myotis.engine", it) }
+    // -Prustlog=<filter> → RUST_LOG for the Rust engine's tracing (drained to
+    // stdout via the `rust` logger). Gradle's run task doesn't forward the
+    // shell's RUST_LOG to the forked JVM, so set it explicitly. Accepts the full
+    // env_logger/tracing syntax: `-Prustlog=debug` for everything, or a targeted
+    // filter like `-Prustlog=myotis_net=debug,info` (default when unset:
+    // info with the noisy deps at warn).
+    (project.findProperty("rustlog") as String?)?.let { environment("RUST_LOG", it) }
     // -Plcdump=<dir> → -Dmyotis.lc.dumpVectors: capture raw light-client SSZ
     // (bootstrap/updates/finality) for the rust/testdata conformance corpus.
     (project.findProperty("lcdump") as String?)?.let { systemProperty("myotis.lc.dumpVectors", it) }


### PR DESCRIPTION
## What

The Rust engine's tracing honors `RUST_LOG` (`EnvFilter::try_from_default_env()` in `ringlog::init`), but Gradle's `run` task runs in the daemon and **doesn't forward the shell's `RUST_LOG`** to the forked JVM — so `RUST_LOG=debug ./gradlew :app:run` has no effect. Add a `-Prustlog=<filter>` property that sets `RUST_LOG` explicitly on the run task's JVM.

## Usage

```bash
./gradlew :app:run -Pengine=rust -Prustlog=debug
./gradlew :app:run -Pengine=rust -Prustlog=myotis_net=debug,info   # targeted
```

Full env_logger/tracing filter syntax. Unset → the engine's default (`info`, noisy deps at `warn`). The more-verbose lines flow to stdout through the rust-log drain pump added in #166.

## Verification

Build script evaluates cleanly and the `run` task configures with `-Prustlog` (dry-run realizes the task without error). Mirrors the adjacent `-Pengine`/`-Pbls` property pattern (`environment(...)` instead of `systemProperty(...)`). A full runtime confirmation needs a daemon restart, which I didn't do because a live `-Pengine=rust` daemon is currently holding the mainnet socket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)