### PR TITLE
app: fail fast on an unrecognized -Pengine value

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -77,7 +77,17 @@ tasks.register<JavaExec>("run") {
     // per-verify Milagro-vs-native head-to-head during a live sync).
     (project.findProperty("bls") as String?)?.let { systemProperty("myotis.bls.backend", it) }
     // -Pengine=java|rust|auto → -Dmyotis.engine (the :myotis-engines selector).
-    (project.findProperty("engine") as String?)?.let { systemProperty("myotis.engine", it) }
+    // Fail fast on a typo: an unrecognized value would otherwise silently fall
+    // back to the Java engine (Engines.normalize warns + yields java), so a
+    // `-Pengine=rust.` runs Java without it being obvious. Blank → unset (default
+    // java).
+    (project.findProperty("engine") as? String)?.takeIf { it.isNotBlank() }?.let {
+        val v = it.trim().lowercase()
+        require(v in listOf("java", "rust", "auto")) {
+            "-Pengine must be one of java|rust|auto (got '$it')"
+        }
+        systemProperty("myotis.engine", v)
+    }
     // -Plcdump=<dir> → -Dmyotis.lc.dumpVectors: capture raw light-client SSZ
     // (bootstrap/updates/finality) for the rust/testdata conformance corpus.
     (project.findProperty("lcdump") as String?)?.let { systemProperty("myotis.lc.dumpVectors", it) }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -81,10 +81,10 @@ tasks.register<JavaExec>("run") {
     // back to the Java engine (Engines.normalize warns + yields java), so a
     // `-Pengine=rust.` runs Java without it being obvious. Blank → unset (default
     // java).
-    (project.findProperty("engine") as? String)?.takeIf { it.isNotBlank() }?.let {
-        val v = it.trim().lowercase()
-        require(v in listOf("java", "rust", "auto")) {
-            "-Pengine must be one of java|rust|auto (got '$it')"
+    (project.findProperty("engine") as? String)?.takeIf { it.isNotBlank() }?.let { raw ->
+        val v = raw.trim().lowercase()
+        if (v !in listOf("java", "rust", "auto")) {
+            throw GradleException("-Pengine must be one of java|rust|auto (got '$raw')")
         }
         systemProperty("myotis.engine", v)
     }


### PR DESCRIPTION
## What

An unknown `myotis.engine` value silently falls back to the Java engine — `Engines.normalize` logs a WARN and yields `java`. So a typo like `-Pengine=rust.` runs the **Java** engine while the operator believes they're testing Rust. This just caused real confusion (snap peers appeared reliably — because it was Java, the mature engine, not Rust).

Validate `-Pengine` in the run task and **fail fast** with a clear message instead:

```
> -Pengine must be one of java|rust|auto (got 'rust.')
```

Blank (`-Pengine=`) → treated as unset (default `java`).

## Verified

- `-Pengine=rust.` → BUILD FAILED with the message above.
- `-Pengine=rust` / `-Pengine=java` / `-Pengine=auto` → configure fine.

Catches the typo at the command line, before the daemon starts — impossible to miss, unlike the buried startup WARN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)