### PR TITLE
el: log EL pool dial outcomes (snap connected at info, failures at debug)

### DIFF
--- a/rust/myotis-net/src/el/pool.rs
+++ b/rust/myotis-net/src/el/pool.rs
@@ -133,6 +133,11 @@ impl PoolInner {
         let now = Instant::now();
         match result {
             Ok(session) if session.snap => {
+                // INFO: the operator-visible signal that the EL found a usable
+                // snap peer (bounded to ~target occurrences per run). Per-peer
+                // failures/non-snap stay at debug to avoid the discv4 cross-chain
+                // noise (most discovered peers are other networks or full).
+                tracing::info!(%addr, eth = session.eth_version, "el dial: snap peer connected");
                 let peer = Arc::new(ManagedPeer::spawn(session, addr));
                 // Keep `addr` in `attempted` while connected — dropped by
                 // prune_closed when the peer later closes.
@@ -144,9 +149,10 @@ impl PoolInner {
                 cache.add(addr, &pubkey, true);
                 cache.flush();
             }
-            Ok(_) => {
+            Ok(session) => {
                 // Compatible but no snap/1 — useless for verified reads. Cool the
                 // address off and free it from `attempted`.
+                tracing::debug!(%addr, eth = session.eth_version, "el dial: connected but no snap/1");
                 self.record_backoff(addr, false, now).await;
                 self.attempted.lock().await.remove(&addr);
             }
@@ -156,6 +162,7 @@ impl PoolInner {
                 // substring: a peer's client id is echoed into other error
                 // strings, so `contains` could be steered by a hostile peer.
                 let incompatible = e.starts_with("incompatible peer");
+                tracing::debug!(%addr, incompatible, error = %e, "el dial: failed");
                 if incompatible {
                     self.blacklist.lock().await.insert(pubkey);
                 }


### PR DESCRIPTION
## What

The EL pool's dial path was **silent** — only the warm-start line logged — so an operator couldn't tell whether snap peers were being found. They were, invisibly: this directly caused a "cached snap peers aren't found under the Rust engine" report that turned out to be an observability gap, not a connectivity problem.

`dial_one` now logs each outcome:
- **snap peer connected → INFO** — the operator-visible "the EL is working" signal (bounded to ~`target_snap_peers` occurrences per run).
- **connected-but-no-snap / failed → DEBUG** with the reason (disconnect reason, incompatible networkId, no-common-eth-version, transport error), so the discv4 cross-chain noise doesn't flood the default log.

## Confirmed live

A warm-started `-Pengine=rust` daemon with `-Prustlog=info,myotis_net::el=debug`:
```
INFO  myotis_net::el::pool: EL pool warm-starting from peer cache count=11
INFO  myotis_net::el::pool: el dial: snap peer connected addr=52.59.210.14:30303 eth=69
INFO  myotis_net::el::pool: el dial: snap peer connected addr=141.98.217.147:30303 eth=69
DEBUG myotis_net::el::pool: el dial: failed addr=176.9.41.84:30303 error=peer disconnected during handshake: reason=4
DEBUG myotis_net::el::pool: el dial: failed addr=135.181.235.131:30303 incompatible=true error=incompatible peer: networkId=369 ...
```
**7 snap peers connected** from the warm-start cache, plus the expected failures: wrong-chain peers (networkId 369/56/9745/1378 — PulseChain/BSC/etc. sharing discv4, correctly rejected), full peers (`reason=4` too-many-peers), and ancient eth/65 nodes. The mainnet fork-id (`07c9462e`) is fine — real mainnet peers complete the eth68/eth69 handshake.

## Scope

Pure observability — 3 tracing calls in `dial_one`, no behavior change. Pool tests + `myotis-net` build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)