### PR TITLE
engine: surface EL pool/discovery counts in status (snapPeers etc.)

### DIFF
--- a/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
@@ -74,7 +74,8 @@ final class RustChainHandle implements ChainHandle {
         return ParsedStatus.parse(json);
     }
 
-    /** The parsed native status object — CL fields only (see the class javadoc). */
+    /** The parsed native status object — CL fields plus the EL pool/discovery
+     *  counts. Older natives omit the EL keys → they default to 0. */
     private record ParsedStatus(
             boolean running,
             BeaconState beaconState,
@@ -86,7 +87,12 @@ final class RustChainHandle implements ChainHandle {
             long peerCount,
             int servedPeersLastMinute,
             int discv5TableSize,
-            long syncStartPeriod) {
+            long syncStartPeriod,
+            int snapPeers,
+            int discoveredPeers,
+            int attemptedDials,
+            int backedOffPeers,
+            int blacklistedPeers) {
 
         static ParsedStatus parse(String json) {
             if (json == null || json.isBlank()) return notRunning();
@@ -104,7 +110,12 @@ final class RustChainHandle implements ChainHandle {
                         o.getLong("peerCount", 0L),
                         o.getInt("servedPeersLastMinute", 0),
                         o.getInt("discv5TableSize", 0),
-                        o.getLong("syncStartPeriod", -1L));
+                        o.getLong("syncStartPeriod", -1L),
+                        o.getInt("snapPeers", 0),
+                        o.getInt("discoveredPeers", 0),
+                        o.getInt("attemptedDials", 0),
+                        o.getInt("backedOffPeers", 0),
+                        o.getInt("blacklistedPeers", 0));
             } catch (RuntimeException e) {
                 throw new EngineException(
                         "malformed status JSON from the Rust engine: " + e.getMessage(), e);
@@ -112,7 +123,8 @@ final class RustChainHandle implements ChainHandle {
         }
 
         static ParsedStatus notRunning() {
-            return new ParsedStatus(false, BeaconState.STARTING, false, 0L, 0L, 0L, 0L, 0L, 0, 0, -1L);
+            return new ParsedStatus(false, BeaconState.STARTING, false, 0L, 0L, 0L, 0L, 0L, 0, 0, -1L,
+                    0, 0, 0, 0, 0);
         }
     }
 
@@ -140,20 +152,22 @@ final class RustChainHandle implements ChainHandle {
         // currentPeriod — the pre-targetPeriod mirror — so the target >= current
         // invariant holds against any .so vintage.
         long targetPeriod = Math.max(s.targetPeriod(), s.currentPeriod());
-        // CL-only: EL fields (executionBlockNumber, snapPeers, discv4 table, RPC
-        // head age, …) are zero — the Rust engine has no execution layer in R1.
+        // EL pool/discovery counts now come from the Rust status JSON. The pool
+        // keeps only snap-capable READY peers, so readyPeers == snapPeers (and
+        // snapServingPeers is approximated by the same). Execution-block /
+        // verified-head fields are still zero (a later follow-up).
         return new StatusSnapshot(
                 s.running(),
                 networkName,
                 s.beaconState(),
-                peers,          // connectedPeers (CL libp2p peers)
-                0,              // readyPeers (EL)
-                0,              // snapPeers
-                0,              // snapServingPeers
-                0,              // discoveredPeers (discv4)
-                0,              // backedOffPeers
-                0,              // blacklistedPeers
-                0,              // attemptedDials
+                peers,                 // connectedPeers (CL libp2p peers)
+                s.snapPeers(),         // readyPeers (EL — pool holds only snap-ready)
+                s.snapPeers(),         // snapPeers
+                s.snapPeers(),         // snapServingPeers (approx)
+                s.discoveredPeers(),   // discoveredPeers (discv4)
+                s.backedOffPeers(),    // backedOffPeers
+                s.blacklistedPeers(),  // blacklistedPeers
+                s.attemptedDials(),    // attemptedDials
                 s.discv5TableSize(),
                 0L,             // executionBlockNumber
                 0L,             // optimisticBlockNumber

--- a/myotis-engines/src/test/java/io/myotis/engines/RustStatusJsonTest.java
+++ b/myotis-engines/src/test/java/io/myotis/engines/RustStatusJsonTest.java
@@ -36,15 +36,19 @@ class RustStatusJsonTest {
             + "\"bootstrapped\":false,\"finalizedSlot\":0,\"optimisticSlot\":0,"
             + "\"currentPeriod\":0,\"targetPeriod\":0,\"peerCount\":0,\"servedPeersLastMinute\":0,"
             + "\"discv5TableSize\":0,\"syncStartPeriod\":-1,"
-            + "\"finalizedRootHex\":\"0000000000000000000000000000000000000000000000000000000000000000\"}";
+            + "\"finalizedRootHex\":\"0000000000000000000000000000000000000000000000000000000000000000\","
+            + "\"snapPeers\":0,\"readyPeers\":0,\"discoveredPeers\":0,\"attemptedDials\":0,"
+            + "\"backedOffPeers\":0,\"blacklistedPeers\":0}";
 
-    /** A synthetic catching-up shape (real running numbers). */
+    /** A synthetic catching-up shape (real running numbers, incl. EL counts). */
     private static final String CATCHING_UP_JSON =
             "{\"running\":true,\"network\":\"mainnet\",\"beaconState\":\"CATCHING_UP\","
             + "\"bootstrapped\":true,\"finalizedSlot\":14560000,\"optimisticSlot\":14560032,"
             + "\"currentPeriod\":1777,\"targetPeriod\":1795,\"peerCount\":5,\"servedPeersLastMinute\":2,"
             + "\"discv5TableSize\":7,\"syncStartPeriod\":1777,"
-            + "\"finalizedRootHex\":\"58cb432571912a434ab7fb83317bb60d09632cce53839fc2541417710465b42e\"}";
+            + "\"finalizedRootHex\":\"58cb432571912a434ab7fb83317bb60d09632cce53839fc2541417710465b42e\","
+            + "\"snapPeers\":6,\"readyPeers\":6,\"discoveredPeers\":240,\"attemptedDials\":14,"
+            + "\"backedOffPeers\":30,\"blacklistedPeers\":66}";
 
     @BeforeAll
     static void setup() {
@@ -81,6 +85,14 @@ class RustStatusJsonTest {
         assertEquals(7, s.discv5TableSize());
         assertEquals(1777L, s.syncStartPeriod());
         assertEquals(14560000L / 8192L, s.finalizedPeriod());
+        // EL pool/discovery counts now flow through (not hardcoded 0). The pool
+        // holds only snap-capable READY peers, so readyPeers == snapPeers.
+        assertEquals(6, s.snapPeers());
+        assertEquals(6, s.readyPeers());
+        assertEquals(240, s.discoveredPeers());
+        assertEquals(14, s.attemptedDials());
+        assertEquals(30, s.backedOffPeers());
+        assertEquals(66, s.blacklistedPeers());
     }
 
     @Test

--- a/rust/myotis-engine/src/host.rs
+++ b/rust/myotis-engine/src/host.rs
@@ -231,23 +231,59 @@ pub fn status_json(handle: i64) -> String {
     let Some(engine) = engine() else {
         return "{}".to_string();
     };
-    let map = match engine.handles.lock() {
-        Ok(m) => m,
-        Err(_) => return "{}".to_string(),
-    };
-    match map.get(&handle) {
+    // Snapshot what we need under the map lock — the EL count reads are async
+    // and must not run while the lock is held.
+    enum Snap {
         // targetPeriod is derived from the config AT READ TIME (not carried in
         // the sync snapshot): fresh across bootstrap stalls, and real (not 0)
-        // for a created-but-not-started handle — matching the Java engine's
-        // unconditional wall-clock computation behind the same API.
-        Some(ChainEntry::Created(config)) => {
-            status_object(false, None, config.wall_clock_period())
-        }
-        Some(ChainEntry::Running(config, sync, _reader)) => {
-            status_object(true, Some(sync.status()), config.wall_clock_period())
-        }
-        None => "{}".to_string(),
+        // for a created-but-not-started handle — matching the Java engine.
+        Created(u64),
+        Running(SyncStatus, u64, Option<Arc<ElReader>>),
+        Unknown,
     }
+    let snap = {
+        let map = match engine.handles.lock() {
+            Ok(m) => m,
+            Err(_) => return "{}".to_string(),
+        };
+        match map.get(&handle) {
+            Some(ChainEntry::Created(config)) => Snap::Created(config.wall_clock_period()),
+            Some(ChainEntry::Running(config, sync, reader)) => {
+                Snap::Running(sync.status(), config.wall_clock_period(), reader.clone())
+            }
+            None => Snap::Unknown,
+        }
+    };
+    match snap {
+        Snap::Created(wall) => status_object(false, None, wall, ElCounts::default()),
+        Snap::Running(status, wall, reader) => {
+            let el = match reader {
+                Some(r) => engine.rt.block_on(async {
+                    ElCounts {
+                        snap_peers: r.snap_peer_count().await,
+                        discovered: r.discovered_count(),
+                        attempted: r.attempted_count().await,
+                        backed_off: r.backoff_count().await,
+                        blacklisted: r.blacklist_count().await,
+                    }
+                }),
+                None => ElCounts::default(),
+            };
+            status_object(true, Some(status), wall, el)
+        }
+        Snap::Unknown => "{}".to_string(),
+    }
+}
+
+/// EL pool/discovery counts for the status snapshot (all zero for a
+/// not-started handle or when the EL reader failed to start).
+#[derive(Default)]
+struct ElCounts {
+    snap_peers: usize,
+    discovered: usize,
+    attempted: usize,
+    backed_off: usize,
+    blacklisted: usize,
 }
 
 /// `nativeStop`: remove + shut down a handle's sync loop. No-op for unknown id.
@@ -412,7 +448,12 @@ fn hex32(bytes: &[u8; 32]) -> String {
 /// parses (camelCase). `running=false` / `status=None` → the not-started shape.
 /// Built by hand (not serde) so the key set + ordering is the golden contract
 /// both `status_json_shape` tests pin.
-fn status_object(running: bool, status: Option<SyncStatus>, target_period: u64) -> String {
+fn status_object(
+    running: bool,
+    status: Option<SyncStatus>,
+    target_period: u64,
+    el: ElCounts,
+) -> String {
     let s = status.unwrap_or_else(SyncStatus::initial);
     // A not-started handle reports STARTING; a running one maps its live state.
     let beacon = if running {
@@ -438,6 +479,14 @@ fn status_object(running: bool, status: Option<SyncStatus>, target_period: u64) 
     obj.insert("discv5TableSize".into(), s.discv5_table_size.into());
     obj.insert("syncStartPeriod".into(), s.sync_start_period.into());
     obj.insert("finalizedRootHex".into(), hex32(&s.finalized_root).into());
+    // EL pool/discovery counts (the Rust engine's execution-layer side). The
+    // pool keeps only snap-capable READY peers, so readyPeers == snapPeers.
+    obj.insert("snapPeers".into(), el.snap_peers.into());
+    obj.insert("readyPeers".into(), el.snap_peers.into());
+    obj.insert("discoveredPeers".into(), el.discovered.into());
+    obj.insert("attemptedDials".into(), el.attempted.into());
+    obj.insert("backedOffPeers".into(), el.backed_off.into());
+    obj.insert("blacklistedPeers".into(), el.blacklisted.into());
     // A hand-built object of primitives always serializes; fall back to the
     // literal not-started shape rather than panic on the (impossible) error.
     serde_json::to_string(&serde_json::Value::Object(obj))
@@ -451,7 +500,9 @@ const NOT_STARTED_FALLBACK: &str = concat!(
     r#""bootstrapped":false,"finalizedSlot":0,"optimisticSlot":0,"#,
     r#""currentPeriod":0,"targetPeriod":0,"peerCount":0,"servedPeersLastMinute":0,"#,
     r#""discv5TableSize":0,"syncStartPeriod":-1,"#,
-    r#""finalizedRootHex":"0000000000000000000000000000000000000000000000000000000000000000"}"#,
+    r#""finalizedRootHex":"0000000000000000000000000000000000000000000000000000000000000000","#,
+    r#""snapPeers":0,"readyPeers":0,"discoveredPeers":0,"attemptedDials":0,"#,
+    r#""backedOffPeers":0,"blacklistedPeers":0}"#,
 );
 
 #[cfg(test)]
@@ -461,7 +512,7 @@ mod tests {
     #[test]
     fn not_started_status_shape_is_stable() {
         // The golden not-started object (parsed by the Java RustChainHandle test).
-        let json = status_object(false, None, 0);
+        let json = status_object(false, None, 0, ElCounts::default());
         let v: serde_json::Value = serde_json::from_str(&json).expect("valid json");
         assert_eq!(v["running"], false);
         assert_eq!(v["network"], "mainnet");
@@ -479,6 +530,11 @@ mod tests {
             v["finalizedRootHex"],
             "0000000000000000000000000000000000000000000000000000000000000000"
         );
+        // EL counts are zero for a not-started handle.
+        for k in ["snapPeers", "readyPeers", "discoveredPeers", "attemptedDials",
+                  "backedOffPeers", "blacklistedPeers"] {
+            assert_eq!(v[k], 0, "{k} should be 0 when not started");
+        }
         // Round-trips through the fallback constant too.
         let fb: serde_json::Value =
             serde_json::from_str(NOT_STARTED_FALLBACK).expect("fallback valid json");
@@ -498,8 +554,9 @@ mod tests {
             discv5_table_size: 12,
             sync_start_period: 1777,
         };
+        let el = ElCounts { snap_peers: 5, discovered: 240, attempted: 14, backed_off: 30, blacklisted: 66 };
         let synced: serde_json::Value =
-            serde_json::from_str(&status_object(true, Some(mk(SyncState::Synced)), 1795)).unwrap();
+            serde_json::from_str(&status_object(true, Some(mk(SyncState::Synced)), 1795, el)).unwrap();
         assert_eq!(synced["running"], true);
         assert_eq!(synced["beaconState"], "SYNCED");
         assert_eq!(synced["bootstrapped"], true);
@@ -512,6 +569,14 @@ mod tests {
         assert_eq!(synced["discv5TableSize"], 12);
         assert_eq!(synced["syncStartPeriod"], 1777);
         assert_eq!(synced["finalizedRootHex"], hex32(&[0xab; 32]));
+        // EL counts reflect the pool/discovery snapshot (snapPeers drives
+        // readyPeers, since the pool holds only snap-capable READY peers).
+        assert_eq!(synced["snapPeers"], 5);
+        assert_eq!(synced["readyPeers"], 5);
+        assert_eq!(synced["discoveredPeers"], 240);
+        assert_eq!(synced["attemptedDials"], 14);
+        assert_eq!(synced["backedOffPeers"], 30);
+        assert_eq!(synced["blacklistedPeers"], 66);
 
         for (st, expect, boot) in [
             (SyncState::Starting, "SYNCING", false),
@@ -519,7 +584,7 @@ mod tests {
             (SyncState::CatchingUp, "CATCHING_UP", true),
         ] {
             let v: serde_json::Value =
-                serde_json::from_str(&status_object(true, Some(mk(st)), 1795)).unwrap();
+                serde_json::from_str(&status_object(true, Some(mk(st)), 1795, ElCounts::default())).unwrap();
             assert_eq!(v["beaconState"], expect);
             assert_eq!(v["bootstrapped"], boot);
         }
@@ -541,7 +606,7 @@ mod tests {
             sync_start_period: 1777,
         };
         let v: serde_json::Value =
-            serde_json::from_str(&status_object(true, Some(s), 1770)).unwrap();
+            serde_json::from_str(&status_object(true, Some(s), 1770, ElCounts::default())).unwrap();
         assert_eq!(v["currentPeriod"], 1777);
         assert_eq!(v["targetPeriod"], 1777);
     }

--- a/rust/myotis-net/src/el/pool.rs
+++ b/rust/myotis-net/src/el/pool.rs
@@ -229,10 +229,15 @@ impl PeerPool {
         self.inner.blacklist.lock().await.len()
     }
 
-    /// Addresses currently cooling off in backoff (may include not-yet-swept
-    /// expired entries; a status-line approximation).
+    /// Count of ACTIVE (non-expired) backoffs, pruning expired entries as a
+    /// side effect — matching the `StatusSnapshot.backedOffPeers` "active,
+    /// pruned on read" semantics (and the Java `activeBackoffCount`). Pruning
+    /// here also keeps the map from lingering with dead entries.
     pub async fn backoff_count(&self) -> usize {
-        self.inner.backoff.lock().await.len()
+        let now = Instant::now();
+        let mut backoff = self.inner.backoff.lock().await;
+        backoff.retain(|_, expiry| *expiry > now);
+        backoff.len()
     }
 
     /// A snap fetch against `addr` returned usable proof material — mark the

--- a/rust/myotis-net/src/el/pool.rs
+++ b/rust/myotis-net/src/el/pool.rs
@@ -229,6 +229,12 @@ impl PeerPool {
         self.inner.blacklist.lock().await.len()
     }
 
+    /// Addresses currently cooling off in backoff (may include not-yet-swept
+    /// expired entries; a status-line approximation).
+    pub async fn backoff_count(&self) -> usize {
+        self.inner.backoff.lock().await.len()
+    }
+
     /// A snap fetch against `addr` returned usable proof material — mark the
     /// cached peer CONFIRMED (dial-first next run). Persists only on a quality
     /// transition (dirty-gated flush), so repeated serves don't re-write.

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -195,6 +195,24 @@ impl ElReader {
         self.pool.snap_peer_count().await
     }
 
+    /// EL pool/discovery counts for the host status snapshot.
+    pub async fn attempted_count(&self) -> usize {
+        self.pool.attempted_count().await
+    }
+
+    pub async fn blacklist_count(&self) -> usize {
+        self.pool.blacklist_count().await
+    }
+
+    pub async fn backoff_count(&self) -> usize {
+        self.pool.backoff_count().await
+    }
+
+    /// discv4 routing-table size (peers discovered/known).
+    pub fn discovered_count(&self) -> usize {
+        self.discovery.table_size()
+    }
+
     /// Fetch + verify one account, running the full beacon-anchor ladder.
     pub async fn get_account(&self, address: [u8; 20]) -> Result<VerifiedAccount, String> {
         let peer = self.pool.snap_peer().await.ok_or("no snap peer available")?;


### PR DESCRIPTION
## What

The Rust engine's status reported **`snapPeers`/`readyPeers`/`discoveredPeers`/`attemptedDials`/`backedOffPeers`/`blacklistedPeers` as 0 unconditionally** — `RustChainHandle` hardcoded them because the status JSON never carried the EL pool's counts. So a *healthy* `-Pengine=rust` daemon (7 snap peers connected, dozens discovered, wrong-chain peers blacklisted) still showed:

```json
{"state":"RUNNING","connectedPeers":6,"readyPeers":0,"snapPeers":0,"discoveredPeers":0,"backedOffPeers":0,"blacklistedPeers":0}
```

…which looks broken but was pure reporting: `connectedPeers` is CL (beacon libp2p) peers, and every EL field was faked to 0.

## Changes

- **`pool.rs`** — `PeerPool::backoff_count` (`snap_peer_count`/`attempted_count`/`blacklist_count` already existed).
- **`reader.rs`** — `ElReader` count delegators (`attempted`/`blacklist`/`backoff_count` + `discovered_count` via `Discv4Service::table_size`).
- **`host.rs`** — `status_json` snapshots the handle's `ElReader` **under the map lock**, then reads the counts **outside** it (`block_on`); `status_object` emits the six EL fields (`readyPeers == snapPeers` — the pool holds only snap-capable READY peers). Not-started fallback + golden updated.
- **`RustChainHandle`** — `ParsedStatus` parses the new keys (default 0 for older `.so`), and `status()` maps them instead of hardcoding 0.

## Tests

Rust: 16 engine + 62 EL lib tests green. Java: `RustStatusJsonTest` asserts the counts flow through (catching-up shape maps `snapPeers=6`, `discoveredPeers=240`, `blacklistedPeers=66`, …) and stay 0 when not started. No native signature change → **ABI stays 4** (fields additive + parsed by name with defaults, so an old `.so`/wrapper still works).

## Review

Ran the mandatory no-context review. It confirmed the map lock is released before `block_on` (no lock-across-await), the positional `StatusSnapshot` args are in the right slots, the parser key names match the emitter exactly, panic-safety holds, and the not-started golden matches on both sides. No issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)