### PR TITLE
el: Java parity — snap-peer maintainer + verification-aware retry across peers

### DIFF
--- a/rust/myotis-net/src/el/pool.rs
+++ b/rust/myotis-net/src/el/pool.rs
@@ -408,7 +408,11 @@ async fn maintainer_loop(inner: Arc<PoolInner>, dial_slots: Arc<Semaphore>) {
             "EL pool below target — maintainer re-dialing cached snap peers"
         );
         for c in cached {
-            if inner.prune_closed().await >= inner.pool_cfg.target_snap_peers {
+            // Cheap live-count check: the guard above already pruned, and this
+            // tight loop rarely spans a peer closing, so read `peers` length
+            // directly (freshly-connected dials show up here) rather than
+            // re-pruning both maps every iteration.
+            if inner.peers.lock().await.len() >= inner.pool_cfg.target_snap_peers {
                 break;
             }
             if !try_dial(&inner, &dial_slots, c.addr, c.pubkey).await {

--- a/rust/myotis-net/src/el/pool.rs
+++ b/rust/myotis-net/src/el/pool.rs
@@ -39,6 +39,9 @@ const BACKOFF_INCOMPATIBLE: Duration = Duration::from_secs(10 * 60);
 /// Transient failures / not-snap peers: a short cool-off (Java's
 /// `BACKOFF_TRANSIENT_MS`).
 const BACKOFF_TRANSIENT: Duration = Duration::from_secs(30);
+/// How often the maintainer checks the pool and tops it back up to target
+/// (Java's `maintainSnapPeers` fixed delay).
+const MAINTAINER_INTERVAL: Duration = Duration::from_secs(10);
 
 /// Pool tunables.
 #[derive(Debug, Clone, Copy)]
@@ -178,6 +181,9 @@ impl PoolInner {
 pub struct PeerPool {
     inner: Arc<PoolInner>,
     dialer_task: JoinHandle<()>,
+    /// Keeps the live snap-peer count at target by re-dialing cached peers when
+    /// they die (twin of the Java `ChainStack.maintainSnapPeers` loop).
+    maintainer_task: JoinHandle<()>,
 }
 
 impl PeerPool {
@@ -202,8 +208,12 @@ impl PeerPool {
             blacklist: Mutex::new(HashSet::new()),
             cache: Mutex::new(cache),
         });
-        let dialer_task = tokio::spawn(dialer_loop(Arc::clone(&inner), rx));
-        PeerPool { inner, dialer_task }
+        // Both the discv4 dialer and the maintainer dial through one shared
+        // concurrency budget.
+        let dial_slots = Arc::new(Semaphore::new(inner.pool_cfg.max_concurrent_dials));
+        let dialer_task = tokio::spawn(dialer_loop(Arc::clone(&inner), rx, Arc::clone(&dial_slots)));
+        let maintainer_task = tokio::spawn(maintainer_loop(Arc::clone(&inner), dial_slots));
+        PeerPool { inner, dialer_task, maintainer_task }
     }
 
     /// A live snap-capable peer for a verified read, or `None` if the pool has
@@ -212,6 +222,22 @@ impl PeerPool {
     pub async fn snap_peer(&self) -> Option<Arc<ManagedPeer>> {
         self.inner.prune_closed().await;
         self.inner.peers.lock().await.last().map(|p| Arc::clone(&p.peer))
+    }
+
+    /// All live snap peers, NEWEST first (freshest head → most likely to still
+    /// retain the state a query needs). The verified-read ladder tries them in
+    /// order, moving to the next on a failure — twin of the Java
+    /// `RLPxConnector.trySnapPeer` retry loop. Prunes closed peers first.
+    pub async fn snap_peers(&self) -> Vec<Arc<ManagedPeer>> {
+        self.inner.prune_closed().await;
+        self.inner
+            .peers
+            .lock()
+            .await
+            .iter()
+            .rev()
+            .map(|p| Arc::clone(&p.peer))
+            .collect()
     }
 
     /// Count of live snap peers (prunes closed peers first).
@@ -257,11 +283,12 @@ impl PeerPool {
         cache.flush();
     }
 
-    /// Stop the pool: flush the peer cache, abort the dialer, and drop all held
-    /// peers (closing them).
+    /// Stop the pool: flush the peer cache, abort the background tasks, and drop
+    /// all held peers (closing them).
     pub async fn stop(self) {
         self.inner.cache.lock().await.flush();
         self.dialer_task.abort();
+        self.maintainer_task.abort();
         self.inner.peers.lock().await.clear();
     }
 }
@@ -269,14 +296,17 @@ impl PeerPool {
 impl Drop for PeerPool {
     fn drop(&mut self) {
         self.dialer_task.abort();
+        self.maintainer_task.abort();
     }
 }
 
 /// Dial cached snap peers first (warm start), then consume the discv4 candidate
 /// stream — both through the same eligibility + concurrency-capped dial path.
-async fn dialer_loop(inner: Arc<PoolInner>, mut rx: mpsc::Receiver<TableEntry>) {
-    let dial_slots = Arc::new(Semaphore::new(inner.pool_cfg.max_concurrent_dials));
-
+async fn dialer_loop(
+    inner: Arc<PoolInner>,
+    mut rx: mpsc::Receiver<TableEntry>,
+    dial_slots: Arc<Semaphore>,
+) {
     // Warm start: re-dial proven snap peers from the cache, snap-quality first
     // (Confirmed → Unknown → Denied). Snapshot the list so the cache lock isn't
     // held across the dials.
@@ -350,6 +380,42 @@ async fn try_dial(
         drop(permit);
     });
     true
+}
+
+/// The snap-peer maintainer: on a timer, if the live snap count has dropped
+/// below `target_snap_peers`, re-dial cached snap peers (snap-quality first) to
+/// top back up. Twin of the Java `ChainStack.maintainSnapPeers` loop — the
+/// discv4 dialer alone can starve on a long-running daemon once its stream goes
+/// quiet and pooled peers die, so this keeps the pool healed from the cache.
+async fn maintainer_loop(inner: Arc<PoolInner>, dial_slots: Arc<Semaphore>) {
+    loop {
+        tokio::time::sleep(MAINTAINER_INTERVAL).await;
+        // prune_closed frees dead peers' addresses so try_dial can re-dial them.
+        let live = inner.prune_closed().await;
+        if live >= inner.pool_cfg.target_snap_peers {
+            continue;
+        }
+        // Snapshot the cache (snap-quality-sorted) without holding its lock
+        // across the dials.
+        let cached = inner.cache.lock().await.peers();
+        if cached.is_empty() {
+            continue;
+        }
+        tracing::debug!(
+            live,
+            target = inner.pool_cfg.target_snap_peers,
+            cached = cached.len(),
+            "EL pool below target — maintainer re-dialing cached snap peers"
+        );
+        for c in cached {
+            if inner.prune_closed().await >= inner.pool_cfg.target_snap_peers {
+                break;
+            }
+            if !try_dial(&inner, &dial_slots, c.addr, c.pubkey).await {
+                return; // pool shutting down
+            }
+        }
+    }
 }
 
 /// A discv4 entry's TCP socket, IPv4 or IPv6, or `None` if the address is

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -214,24 +214,45 @@ impl ElReader {
     }
 
     /// Fetch + verify one account, running the full beacon-anchor ladder.
+    ///
+    /// Tries each live snap peer in turn (newest first) and returns the first
+    /// that serves — twin of the Java `RLPxConnector.trySnapPeer` retry loop, so
+    /// a single hung/dead peer doesn't fail the query. A serving peer is marked
+    /// CONFIRMED in the cache, a failing one records a strike (→ deprioritized).
     pub async fn get_account(&self, address: [u8; 20]) -> Result<VerifiedAccount, String> {
-        let peer = self.pool.snap_peer().await.ok_or("no snap peer available")?;
-        let (state_root, block_number) = fresh_head(&peer).await?;
+        let peers = self.pool.snap_peers().await;
+        if peers.is_empty() {
+            return Err("no snap peer available".to_string());
+        }
+        let total = peers.len();
+        let mut last_err = String::new();
+        for peer in &peers {
+            match self.get_account_from(peer, address).await {
+                Ok(result) => {
+                    self.pool.record_snap_served(peer.addr()).await;
+                    return Ok(result);
+                }
+                Err(e) => {
+                    self.pool.record_snap_failure(peer.addr()).await;
+                    last_err = e;
+                }
+            }
+        }
+        Err(format!("all {total} snap peer(s) failed to serve account: {last_err}"))
+    }
 
+    /// One account fetch + verdict against a single peer (no retry, no cache
+    /// bookkeeping — the caller loop owns those). Any transport/proof error
+    /// propagates so the loop can move to the next peer.
+    async fn get_account_from(
+        &self,
+        peer: &ManagedPeer,
+        address: [u8; 20],
+    ) -> Result<VerifiedAccount, String> {
+        let (state_root, block_number) = fresh_head(peer).await?;
         // Verify-on-fetch: snap_get_account MPT-verifies against state_root and
-        // returns Present/Absent only when the proof holds. Feed the outcome to
-        // the peer cache so a proven server is dialed first next run and a
-        // hanger is deprioritized.
-        let outcome = match peer.snap_get_account(&state_root, &address).await {
-            Ok(o) => {
-                self.pool.record_snap_served(peer.addr()).await;
-                o
-            }
-            Err(e) => {
-                self.pool.record_snap_failure(peer.addr()).await;
-                return Err(e);
-            }
-        };
+        // returns Present/Absent only when the proof holds.
+        let outcome = peer.snap_get_account(&state_root, &address).await?;
         // Anchor the (proof-valid) peer state root to the beacon chain.
         let verdict = peer
             .verified_state_root(&self.anchor, &state_root, to_ladder_block(block_number), true)
@@ -278,20 +299,43 @@ impl ElReader {
         slot: u64,
         holder: Option<[u8; 20]>,
     ) -> Result<VerifiedStorage, String> {
-        let peer = self.pool.snap_peer().await.ok_or("no snap peer available")?;
-        let (state_root, block_number) = fresh_head(&peer).await?;
+        let peers = self.pool.snap_peers().await;
+        if peers.is_empty() {
+            return Err("no snap peer available".to_string());
+        }
+        let total = peers.len();
+        let mut last_err = String::new();
+        for peer in &peers {
+            match self.get_storage_from(peer, address, slot, holder).await {
+                Ok(result) => {
+                    self.pool.record_snap_served(peer.addr()).await;
+                    return Ok(result);
+                }
+                Err(e) => {
+                    self.pool.record_snap_failure(peer.addr()).await;
+                    last_err = e;
+                }
+            }
+        }
+        Err(format!("all {total} snap peer(s) failed to serve storage: {last_err}"))
+    }
+
+    /// One storage-slot fetch + verdict against a single peer (no retry / cache
+    /// bookkeeping — the caller loop owns those). Errors propagate for retry.
+    async fn get_storage_from(
+        &self,
+        peer: &ManagedPeer,
+        address: [u8; 20],
+        slot: u64,
+        holder: Option<[u8; 20]>,
+    ) -> Result<VerifiedStorage, String> {
+        let (state_root, block_number) = fresh_head(peer).await?;
 
         let storage_key = storage_key(slot, holder);
         let slot_key_hash = keccak256(&storage_key);
 
         // Step 1: the proof-verified account gives the trusted storage root.
-        let outcome = match peer.snap_get_account(&state_root, &address).await {
-            Ok(o) => o,
-            Err(e) => {
-                self.pool.record_snap_failure(peer.addr()).await;
-                return Err(e);
-            }
-        };
+        let outcome = peer.snap_get_account(&state_root, &address).await?;
 
         let (fin_num, opt_num, synced) = self.anchor_diagnostics();
         let mut result = VerifiedStorage {
@@ -317,9 +361,8 @@ impl ElReader {
         };
 
         // An absent account has no storage: every slot is provably zero. The
-        // account exclusion proof verified, so the peer served.
+        // account exclusion proof verified, so this counts as served.
         let AccountOutcome::Present(leaf) = outcome else {
-            self.pool.record_snap_served(peer.addr()).await;
             // Still anchor the state root so the verdict reflects the beacon tie.
             let verdict = peer
                 .verified_state_root(&self.anchor, &state_root, to_ladder_block(block_number), true)
@@ -331,19 +374,9 @@ impl ElReader {
         result.storage_root = leaf.storage_root;
 
         // Step 2: verify the slot against the proof-verified storage root.
-        let value = match peer
+        let value = peer
             .snap_get_storage(&state_root, &address, &leaf, &storage_key)
-            .await
-        {
-            Ok(v) => {
-                self.pool.record_snap_served(peer.addr()).await;
-                v
-            }
-            Err(e) => {
-                self.pool.record_snap_failure(peer.addr()).await;
-                return Err(e);
-            }
-        };
+            .await?;
         result.storage_proof_valid = true;
         // `found` means the slot holds a non-zero value (Java's convention): a
         // zero slot is pruned from the trie and indistinguishable from unset,

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -380,8 +380,11 @@ impl ElReader {
             optimistic_block_number: opt_num,
         };
 
-        // An absent account has no storage: every slot is provably zero. The
-        // account exclusion proof verified, so this counts as served.
+        // An absent account has no storage: every slot is provably zero, and the
+        // account exclusion proof verified. Anchor the state root so the result
+        // carries the beacon verdict, then return it; this per-peer helper does no
+        // cache bookkeeping — the outer retry loop records served/failure from the
+        // verdict.
         let AccountOutcome::Present(leaf) = outcome else {
             // Still anchor the state root so the verdict reflects the beacon tie.
             let verdict = peer
@@ -519,10 +522,6 @@ fn hex32(s: &str) -> [u8; 32] {
     out
 }
 
-/// Convert a peer-reported block number to the `i64` the verify ladder takes.
-/// A realistic block number always fits; an out-of-range value (a hostile peer
-/// claiming >= 2^63) maps to a negative sentinel, which the ladder rejects as
-/// `noPeerBlockNumber` — fail-closed and explicit, no wrapping cast.
 /// Whether a ladder `fail_reason` is GLOBAL — determined by the beacon anchor's
 /// state, identical for every peer — vs PER-PEER (a stale/behind head, an
 /// invalid proof: another peer can still verify). A global failure short-circuits
@@ -531,6 +530,10 @@ fn is_global_fail(reason: Option<&'static str>) -> bool {
     matches!(reason, Some("beaconNotSynced") | Some("beaconBlockUnavailable"))
 }
 
+/// Convert a peer-reported block number to the `i64` the verify ladder takes.
+/// A realistic block number always fits; an out-of-range value (a hostile peer
+/// claiming >= 2^63) maps to a negative sentinel, which the ladder rejects as
+/// `noPeerBlockNumber` — fail-closed and explicit, no wrapping cast.
 fn to_ladder_block(block_number: u64) -> i64 {
     i64::try_from(block_number).unwrap_or(-1)
 }

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -225,12 +225,22 @@ impl ElReader {
             return Err("no snap peer available".to_string());
         }
         let total = peers.len();
+        let mut fallback: Option<VerifiedAccount> = None;
         let mut last_err = String::new();
         for peer in &peers {
             match self.get_account_from(peer, address).await {
                 Ok(result) => {
-                    self.pool.record_snap_served(peer.addr()).await;
-                    return Ok(result);
+                    // Verified, or a GLOBAL verdict failure (beacon not ready —
+                    // identical for every peer): this is the answer.
+                    if result.verify_method.is_some() || is_global_fail(result.fail_reason) {
+                        self.pool.record_snap_served(peer.addr()).await;
+                        return Ok(result);
+                    }
+                    // A PER-PEER verdict failure (a stale/behind head or a bad
+                    // proof — a different peer can still verify): keep it as a
+                    // fallback and try the next peer.
+                    self.pool.record_snap_failure(peer.addr()).await;
+                    fallback.get_or_insert(result);
                 }
                 Err(e) => {
                     self.pool.record_snap_failure(peer.addr()).await;
@@ -238,7 +248,10 @@ impl ElReader {
                 }
             }
         }
-        Err(format!("all {total} snap peer(s) failed to serve account: {last_err}"))
+        // No peer verified; return the best per-peer result if we got one.
+        fallback.map(Ok).unwrap_or_else(|| {
+            Err(format!("all {total} snap peer(s) failed to serve a verifiable account: {last_err}"))
+        })
     }
 
     /// One account fetch + verdict against a single peer (no retry, no cache
@@ -304,12 +317,17 @@ impl ElReader {
             return Err("no snap peer available".to_string());
         }
         let total = peers.len();
+        let mut fallback: Option<VerifiedStorage> = None;
         let mut last_err = String::new();
         for peer in &peers {
             match self.get_storage_from(peer, address, slot, holder).await {
                 Ok(result) => {
-                    self.pool.record_snap_served(peer.addr()).await;
-                    return Ok(result);
+                    if result.verify_method.is_some() || is_global_fail(result.fail_reason) {
+                        self.pool.record_snap_served(peer.addr()).await;
+                        return Ok(result);
+                    }
+                    self.pool.record_snap_failure(peer.addr()).await;
+                    fallback.get_or_insert(result);
                 }
                 Err(e) => {
                     self.pool.record_snap_failure(peer.addr()).await;
@@ -317,7 +335,9 @@ impl ElReader {
                 }
             }
         }
-        Err(format!("all {total} snap peer(s) failed to serve storage: {last_err}"))
+        fallback.map(Ok).unwrap_or_else(|| {
+            Err(format!("all {total} snap peer(s) failed to serve verifiable storage: {last_err}"))
+        })
     }
 
     /// One storage-slot fetch + verdict against a single peer (no retry / cache
@@ -422,6 +442,14 @@ async fn fresh_head(peer: &ManagedPeer) -> Result<([u8; 32], u64), String> {
     if head.hash != head_hash {
         return Err("peer returned a header not matching the requested hash".to_string());
     }
+    // A peer advertising a genesis head (block 0) can't serve current state —
+    // vitalik.eth would verify as ABSENT at the genesis root, and the ladder
+    // rejects it as noPeerBlockNumber. Treat it as a failure so the retry loop
+    // moves to a peer with a real head (junk/light-client nodes can negotiate
+    // snap/1 yet still advertise genesis).
+    if head.header.number == 0 {
+        return Err("peer advertises a genesis head (block 0 — no current state)".to_string());
+    }
     let state_root = head.header.state_root;
     if state_root == [0u8; 32] {
         return Err("peer head has no state root".to_string());
@@ -495,6 +523,14 @@ fn hex32(s: &str) -> [u8; 32] {
 /// A realistic block number always fits; an out-of-range value (a hostile peer
 /// claiming >= 2^63) maps to a negative sentinel, which the ladder rejects as
 /// `noPeerBlockNumber` — fail-closed and explicit, no wrapping cast.
+/// Whether a ladder `fail_reason` is GLOBAL — determined by the beacon anchor's
+/// state, identical for every peer — vs PER-PEER (a stale/behind head, an
+/// invalid proof: another peer can still verify). A global failure short-circuits
+/// the cross-peer retry (no point re-asking); a per-peer failure moves on.
+fn is_global_fail(reason: Option<&'static str>) -> bool {
+    matches!(reason, Some("beaconNotSynced") | Some("beaconBlockUnavailable"))
+}
+
 fn to_ladder_block(block_number: u64) -> i64 {
     i64::try_from(block_number).unwrap_or(-1)
 }


### PR DESCRIPTION
## What

Restores the two Java-engine behaviors a long-lived `-Pengine=rust` daemon needs to keep serving verified reads (it currently decays: pooled snap peers die and queries hit corpses/stale peers with no retry).

## Changes

**1. Snap-peer maintainer** (twin of `ChainStack.maintainSnapPeers`) — `pool.rs`
A background task on a 10s timer: when the live snap count drops below `target`, re-dials cached snap peers (snap-quality first) through the shared dial path. `prune_closed` frees dead peers' addresses so they're re-dialed. Dialer + maintainer share one concurrency budget; `stop()`/`Drop` abort both.

**2. Verification-aware retry across peers** (twin of `RLPxConnector.trySnapPeer`) — `reader.rs`
`PeerPool::snap_peers()` returns all live peers (newest first); `get_account`/`get_storage` iterate them, **returning the first that VERIFIES**:
- transport/proof error → try next peer;
- a **genesis-head** peer (block 0 — junk/light-client nodes that negotiate snap/1 but can't serve current state) → `fresh_head` fails → skip;
- a **per-peer verdict failure** (stale/behind head → `peerBlockBehindFinalized`, bad proof, header-chain error) → try next peer, keeping the result as a fallback;
- a **global** failure (`beaconNotSynced`/`beaconBlockUnavailable`, identical for every peer) → return it (no point retrying).

## Validated live

On a warm-started daemon (13 snap peers), `get-account 0xd8dA…96045` returns:
```
exists:true  balance:6669014962512595915 (6.67 ETH)  verifyMethod:"headerChain"  beaconChainVerified:true
```
Before these changes the same query returned `exists:false`/`noPeerBlockNumber` (genesis-head peer) or `peerBlockBehindFinalized` (stale peer), because it used one peer with no retry. The maintainer + retry find a peer that verifies.

## Tests / review

62 EL lib tests + engine build green. The base commit's maintainer + retry passed a no-context review (lock discipline, no lock-across-await, correct one-record-per-peer, and — critically — a `beaconNotSynced` verdict is returned immediately, never retried). The retry classification: only `beaconNotSynced`/`beaconBlockUnavailable` are global (anchor state); all others are per-peer. The trust-critical proof/verdict computation is unchanged — the retry only selects *which* peer's verdict to return.

## Follow-up (noted, not in scope)

Update each peer's head from `NewBlockHashes` gossip (the Java engine does this) so fewer pooled peers go stale — the retry makes reads work regardless, but head-tracking would reduce retries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)