### PR TITLE
EL-B-1: serve verified eth_getBalance/getTransactionCount/chainId under -Pengine=rust

### DIFF
--- a/myotis-engines/build.gradle.kts
+++ b/myotis-engines/build.gradle.kts
@@ -18,6 +18,10 @@ dependencies {
     api(project(":myotis-api"))
     // The Java engine (JavaMyotisEngine) — one of the two selectable engines.
     implementation(project(":node-core"))
+    // The shared JSON-RPC server (MyotisRpcServer/RpcRouter): the Rust engine self-
+    // starts it over RustVerifiedReads, mirroring how the Java engine (node-core)
+    // self-starts it internally. Consumers already ship it transitively via node-core.
+    implementation(project(":jsonrpc-server"))
     implementation(libs.minimal.json)
     implementation(libs.slf4j.api)
 

--- a/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
@@ -73,7 +73,7 @@ final class RustChainHandle implements ChainHandle {
     @Override public long chainId() { return chainId; }
 
     @Override
-    public boolean start() {
+    public synchronized boolean start() {
         boolean ok = RustEngineNative.nativeStart(handle);
         // Only expose the verified JSON-RPC endpoint once the native stack is up.
         if (ok) startRpc();
@@ -81,7 +81,7 @@ final class RustChainHandle implements ChainHandle {
     }
 
     @Override
-    public void stop() {
+    public synchronized void stop() {
         // Stop serving before tearing down the native stack the reads depend on.
         io.myotis.jsonrpc.MyotisRpcServer server = this.rpcServer;
         if (server != null) {
@@ -99,7 +99,8 @@ final class RustChainHandle implements ChainHandle {
      * Java engine): the IPC socket still serves the same verified primitives.
      */
     private void startRpc() {
-        if (rpcPort <= 0) return; // RPC disabled (test seam / explicit opt-out)
+        if (rpcPort <= 0) return;        // RPC disabled (test seam / explicit opt-out)
+        if (rpcServer != null) return;   // already started — avoid a re-bind / server leak
         try {
             // Deterministic up-front bind probe: Ktor's CIO engine surfaces bind
             // failures asynchronously, which a try/catch around start() can miss.

--- a/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
@@ -281,6 +281,14 @@ final class RustChainHandle implements ChainHandle {
     // account query as requestAccount below; the rest of VerifiedReads returns null
     // ("can't answer verified") until later EL-B / EL-C slices land.
     //
+    // Per the ChainHandle contract, reads() is null "while the RPC backend isn't
+    // started (e.g. the RPC port was unavailable at start())". The adapter is itself
+    // transport-independent (it queries the native directly), but reads() gates on
+    // rpcServer so it means the same thing on both engines: the Java engine's
+    // rpcBackend is null until startRpc() succeeds, and hosts null-check reads()
+    // to decide whether verified RPC is available. So: null before start(), when
+    // rpcPort<=0, or on a bind failure; non-null once serving.
+    //
     // ens() still returns null (no ENS registry served yet) — that IS the ChainHandle
     // contract ("or null when this network has no ENS registry"), and callers
     // null-check it. The EL QUERY methods further down (getHeaders/getBlockVerified/
@@ -289,7 +297,7 @@ final class RustChainHandle implements ChainHandle {
     // error (no verification to report a failReason for) — a failReason record would
     // misrepresent "we can't" as "we tried and failed".
 
-    @Override public VerifiedReads reads() { return verifiedReads; }
+    @Override public VerifiedReads reads() { return rpcServer != null ? verifiedReads : null; }
 
     @Override public EnsApi ens() { return null; }
 

--- a/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
@@ -38,6 +38,11 @@ import java.util.List;
  * anchor) and return the same proof/verdict records as the Java engine. The
  * remaining EL queries ({@link #getHeaders}/{@link #getBlockVerified}/
  * {@link #dialPeer}) throw {@link EngineException} until those surfaces land.
+ *
+ * <p>{@link #reads()} now serves the verified JSON-RPC endpoint (EL-B): on
+ * {@link #start()} this handle self-starts the shared {@code jsonrpc-server} on
+ * {@code 127.0.0.1:rpcPort} backed by {@link RustVerifiedReads}, mirroring how the
+ * Java engine self-starts it inside {@code ChainStack}.
  */
 final class RustChainHandle implements ChainHandle {
 
@@ -49,20 +54,73 @@ final class RustChainHandle implements ChainHandle {
     private final long handle;
     private final String networkName;
     private final long chainId;
+    /** Loopback JSON-RPC port; {@code <= 0} disables the server (e.g. the JSON test seams). */
+    private final int rpcPort;
+    /** The verified read surface the JSON-RPC server serves; never null. */
+    private final RustVerifiedReads verifiedReads = new RustVerifiedReads(this);
+    /** The running JSON-RPC server, or null when disabled / not started. */
+    private volatile io.myotis.jsonrpc.MyotisRpcServer rpcServer;
 
-    RustChainHandle(long handle, String networkName, long chainId) {
+    RustChainHandle(long handle, String networkName, long chainId, int rpcPort) {
         this.handle = handle;
         this.networkName = networkName;
         this.chainId = chainId;
+        this.rpcPort = rpcPort;
     }
 
     @Override public String networkName() { return networkName; }
 
     @Override public long chainId() { return chainId; }
 
-    @Override public boolean start() { return RustEngineNative.nativeStart(handle); }
+    @Override
+    public boolean start() {
+        boolean ok = RustEngineNative.nativeStart(handle);
+        // Only expose the verified JSON-RPC endpoint once the native stack is up.
+        if (ok) startRpc();
+        return ok;
+    }
 
-    @Override public void stop() { RustEngineNative.nativeStop(handle); }
+    @Override
+    public void stop() {
+        // Stop serving before tearing down the native stack the reads depend on.
+        io.myotis.jsonrpc.MyotisRpcServer server = this.rpcServer;
+        if (server != null) {
+            try { server.stop(); } catch (Throwable ignored) {}
+            this.rpcServer = null;
+        }
+        RustEngineNative.nativeStop(handle);
+    }
+
+    /**
+     * Start the shared {@code jsonrpc-server} on {@code 127.0.0.1:rpcPort}, backed by
+     * {@link RustVerifiedReads} — the Rust-engine counterpart to
+     * {@code ChainStack.startRpc()}. Loopback only, strict (no upstream proxy). A
+     * bind failure is logged and the stack continues without JSON-RPC (mirrors the
+     * Java engine): the IPC socket still serves the same verified primitives.
+     */
+    private void startRpc() {
+        if (rpcPort <= 0) return; // RPC disabled (test seam / explicit opt-out)
+        try {
+            // Deterministic up-front bind probe: Ktor's CIO engine surfaces bind
+            // failures asynchronously, which a try/catch around start() can miss.
+            try (java.net.ServerSocket probe = new java.net.ServerSocket()) {
+                probe.setReuseAddress(true);
+                probe.bind(new java.net.InetSocketAddress("127.0.0.1", rpcPort));
+            }
+            io.myotis.jsonrpc.MyotisRpcServer server =
+                    new io.myotis.jsonrpc.MyotisRpcServer(rpcPort, null, "127.0.0.1", verifiedReads);
+            server.start();
+            this.rpcServer = server;
+            log.info("[{}] JSON-RPC listening on http://127.0.0.1:{} (verified, strict)",
+                    networkName, rpcPort);
+        } catch (java.io.IOException bindEx) {
+            log.warn("[{}][rpc] port {} unavailable ({}); continuing without JSON-RPC",
+                    networkName, rpcPort, bindEx.getMessage());
+        } catch (Throwable t) {
+            log.warn("[{}][rpc] failed to start JSON-RPC; continuing without it: {}",
+                    networkName, t.toString());
+        }
+    }
 
     @Override public boolean isRunning() { return readStatus().running(); }
 
@@ -138,12 +196,12 @@ final class RustChainHandle implements ChainHandle {
      * Package-private test seam: exercises the JSON→snapshot mapping without JNI.
      */
     static StatusSnapshot statusFromJson(String network, String json) {
-        return new RustChainHandle(0L, network, 1L).status(ParsedStatus.parse(json));
+        return new RustChainHandle(0L, network, 1L, 0).status(ParsedStatus.parse(json));
     }
 
     /** Package-private test seam: JSON→{@link BeaconStatus} without JNI. */
     static BeaconStatus beaconStatusFromJson(String network, String json) {
-        return new RustChainHandle(0L, network, 1L).beaconStatus(ParsedStatus.parse(json));
+        return new RustChainHandle(0L, network, 1L, 0).beaconStatus(ParsedStatus.parse(json));
     }
 
     private StatusSnapshot status(ParsedStatus s) {
@@ -213,21 +271,24 @@ final class RustChainHandle implements ChainHandle {
                 List.<ClPeerInfo>of());
     }
 
-    // ---- CL-only R1 scope: EL / verified-read surface not available yet ----
+    // ---- verified-read surface (EL-B) ----
     //
-    // reads()/ens() return null — that IS the ChainHandle contract ("or null when
-    // this network has no ENS registry" / "or null ... if the RPC port was
-    // unavailable"), and callers null-check it. The EL QUERY methods below
-    // (requestAccount/getStorageProof/getHeaders/getBlockVerified/dialPeer) throw
-    // EngineException: the contract reserves exceptions for malformed input / not
-    // running, and a CL-only engine asked for an EL proof is a capability-state
-    // error (there is no verification to report a failReason for — the capability
-    // categorically does not exist yet). A failReason record would misrepresent
-    // "we can't" as "we tried and failed". The real fix is EL support (or the
-    // selector routing EL queries to the Java engine while Rust hosts the CL side);
-    // tracked for a later phase.
+    // reads() returns the RustVerifiedReads adapter — the JSON-RPC read surface the
+    // shared jsonrpc-server serves on 127.0.0.1:rpcPort (started in startRpc()). It
+    // answers the beacon-anchored reads a wallet needs to build a plain-ETH send
+    // (chainId/getBalance/getTransactionCount/syncState) from the same proof-verified
+    // account query as requestAccount below; the rest of VerifiedReads returns null
+    // ("can't answer verified") until later EL-B / EL-C slices land.
+    //
+    // ens() still returns null (no ENS registry served yet) — that IS the ChainHandle
+    // contract ("or null when this network has no ENS registry"), and callers
+    // null-check it. The EL QUERY methods further down (getHeaders/getBlockVerified/
+    // dialPeer) still throw EngineException: the contract reserves exceptions for
+    // malformed input / not running, and an unimplemented EL surface is a capability
+    // error (no verification to report a failReason for) — a failReason record would
+    // misrepresent "we can't" as "we tried and failed".
 
-    @Override public VerifiedReads reads() { return null; }
+    @Override public VerifiedReads reads() { return verifiedReads; }
 
     @Override public EnsApi ens() { return null; }
 

--- a/myotis-engines/src/main/java/io/myotis/engines/RustMyotisEngine.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustMyotisEngine.java
@@ -113,7 +113,11 @@ public final class RustMyotisEngine implements MyotisEngine {
             throw new EngineException("the Rust engine could not initialize the runtime for "
                     + canonical);
         }
-        RustChainHandle handle = new RustChainHandle(id, canonical, 1L);
+        // Mirror JavaMyotisEngine: honour a host-supplied RPC port, else the
+        // mainnet default (8545). The Rust engine hosts mainnet only, so the
+        // per-network default is a constant here.
+        int rpcPort = config.rpcPort() > 0 ? config.rpcPort() : 8545;
+        RustChainHandle handle = new RustChainHandle(id, canonical, 1L, rpcPort);
         // Atomic claim (mirrors JavaMyotisEngine.putIfAbsent): reject a re-create rather
         // than orphaning the previous handle's native entry. On a lost race, release the
         // native handle we just allocated so it doesn't leak a tokio/libp2p host.

--- a/myotis-engines/src/main/java/io/myotis/engines/RustVerifiedReads.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustVerifiedReads.java
@@ -67,9 +67,12 @@ final class RustVerifiedReads implements VerifiedReads {
                 case CATCHING_UP -> SyncState.CATCHING_UP;
                 case STARTING, SYNCING -> SyncState.SYNCING;
             };
-        } catch (EngineException e) {
+        } catch (RuntimeException e) {
             // Never throw from the read surface: an unreadable status reads as
-            // "not synced yet" rather than crashing the eth_syncing request.
+            // "not synced yet" rather than crashing the eth_syncing request. Catch
+            // the broad RuntimeException (not just EngineException) so any unchecked
+            // failure from the native status path stays contained (the router's
+            // tryVerified dispatch is not exception-guarded).
             log.debug("[engines] syncState fell back to SYNCING: {}", e.getMessage());
             return SyncState.SYNCING;
         }
@@ -93,6 +96,16 @@ final class RustVerifiedReads implements VerifiedReads {
         // Verified-absent → nonce 0 (r.nonce() is -1 when !exists). No pending
         // overlay yet: "pending" resolves to the verified head nonce, which is
         // correct for a wallet sending its first not-yet-mined tx.
+        //
+        // Nonce freshness: the Java backend (VerifiedRpcBackend) gates nonce
+        // serving on a TIGHTER staleness bound than balance, because a stale nonce
+        // is uniquely dangerous — the wallet signs against it and the tx bounces
+        // ("nonce too low") or silently replaces a pending one. This adapter has no
+        // separate bound: the Rust verified read only sets verifyMethod against a
+        // beacon-anchored head that is not behind finalized (a stale-behind peer
+        // fails verification → null), so staleness is bounded to the peer's current
+        // tip (slot-scale seconds). Replicating the Java engine's explicit tighter
+        // nonce gate is a follow-up, pending a head-age field in the Rust status.
         return r.exists() ? r.nonce() : 0L;
     }
 
@@ -117,7 +130,11 @@ final class RustVerifiedReads implements VerifiedReads {
     private AccountProofResult queryAccount(byte[] address) {
         try {
             return handle.requestAccount(toHex(address));
-        } catch (EngineException e) {
+        } catch (RuntimeException e) {
+            // Contain any unchecked failure (transport/not-running EngineException,
+            // or a raw unchecked throwable off the native path) as "can't answer
+            // verified right now" — the router's tryVerified dispatch is not
+            // exception-guarded, so nothing may escape this adapter.
             log.debug("[engines] verified account read unavailable: {}", e.getMessage());
             return null;
         }

--- a/myotis-engines/src/main/java/io/myotis/engines/RustVerifiedReads.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustVerifiedReads.java
@@ -128,6 +128,10 @@ final class RustVerifiedReads implements VerifiedReads {
 
     /** Run the verified account query, mapping a transport/not-running failure to null. */
     private AccountProofResult queryAccount(byte[] address) {
+        // An eth address is exactly 20 bytes. Reject any other length (incl. null) up
+        // front — "can't answer" (null) rather than round-tripping a bogus key through
+        // the native query — so a malformed address never crosses the JNI boundary.
+        if (address == null || address.length != 20) return null;
         try {
             return handle.requestAccount(toHex(address));
         } catch (RuntimeException e) {

--- a/myotis-engines/src/main/java/io/myotis/engines/RustVerifiedReads.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustVerifiedReads.java
@@ -1,0 +1,148 @@
+package io.myotis.engines;
+
+import io.myotis.api.AccountProofResult;
+import io.myotis.api.EngineException;
+import io.myotis.api.SyncState;
+import io.myotis.api.VerifiedReads;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The Rust engine's {@link VerifiedReads} adapter — the verified eth_* read
+ * surface the shared {@code jsonrpc-server} ({@code MyotisRpcServer}/{@code RpcRouter})
+ * serves on {@code 127.0.0.1:rpcPort}. It maps each JSON-RPC read onto the Rust
+ * engine's already-live, beacon-anchored verified queries
+ * ({@link RustChainHandle#requestAccount}) and status.
+ *
+ * <p>EL-B lands these methods incrementally. This first slice answers exactly the
+ * reads a wallet needs before it can build a plain-ETH send — {@code chainId},
+ * {@code getBalance}, {@code getTransactionCount}, and the beacon {@code syncState}
+ * — all derived from the proof-verified account query. The remaining methods
+ * return {@code null} ("cannot answer verified right now"), which the router maps
+ * to a strict-mode JSON-RPC {@code -32000} until later slices wire them: bytecode
+ * + raw-32-byte-slot natives ({@code getCode}/{@code getStorageAt}), block/tx/
+ * receipt lookup, the fee trio, {@code sendRawTransaction}, and the revm-backed
+ * {@code call}/{@code estimateGas} (EL-C).
+ *
+ * <p><b>Head-anchored only.</b> The Rust reader verifies against the peer's fresh
+ * head (the CL-anchored latest state), so a {@code "latest"}/{@code "pending"}/
+ * default block selector is answerable and any specific historical block returns
+ * {@code null} (unverifiable here) rather than silently returning head data for
+ * the wrong block.
+ *
+ * <p><b>Never throws.</b> {@link RustChainHandle#requestAccount} raises an
+ * {@link EngineException} on a transport / not-running failure, but the router's
+ * {@code tryVerified} dispatch is not exception-guarded and the Java backend it
+ * mirrors never throws — so every method here maps such a failure to {@code null}
+ * ("can't answer verified right now"), never an HTTP 500 to the wallet.
+ */
+final class RustVerifiedReads implements VerifiedReads {
+
+    private static final Logger log = LoggerFactory.getLogger(RustVerifiedReads.class);
+
+    private final RustChainHandle handle;
+
+    RustVerifiedReads(RustChainHandle handle) {
+        this.handle = handle;
+    }
+
+    @Override
+    public long chainId() {
+        return handle.chainId();
+    }
+
+    @Override
+    public Long headBlockNumber() {
+        // The Rust status JSON does not yet carry the anchored execution block
+        // number (a later EL-B slice wires the ExecAnchor head into status), so
+        // eth_blockNumber cannot be answered verified until then.
+        return null;
+    }
+
+    @Override
+    public SyncState syncState() {
+        try {
+            return switch (handle.status().beaconState()) {
+                case SYNCED -> SyncState.SYNCED;
+                case CATCHING_UP -> SyncState.CATCHING_UP;
+                case STARTING, SYNCING -> SyncState.SYNCING;
+            };
+        } catch (EngineException e) {
+            // Never throw from the read surface: an unreadable status reads as
+            // "not synced yet" rather than crashing the eth_syncing request.
+            log.debug("[engines] syncState fell back to SYNCING: {}", e.getMessage());
+            return SyncState.SYNCING;
+        }
+    }
+
+    @Override
+    public String getBalance(byte[] address, String block) {
+        if (!isHeadSelector(block)) return null;
+        AccountProofResult r = queryAccount(address);
+        if (r == null || !isVerified(r)) return null;
+        // A verified-absent account has balance 0 (eth semantics), even though the
+        // proof-of-exclusion carries a null balanceWei.
+        return r.exists() ? r.balanceWei() : "0";
+    }
+
+    @Override
+    public Long getTransactionCount(byte[] address, String block) {
+        if (!isHeadSelector(block)) return null;
+        AccountProofResult r = queryAccount(address);
+        if (r == null || !isVerified(r)) return null;
+        // Verified-absent → nonce 0 (r.nonce() is -1 when !exists). No pending
+        // overlay yet: "pending" resolves to the verified head nonce, which is
+        // correct for a wallet sending its first not-yet-mined tx.
+        return r.exists() ? r.nonce() : 0L;
+    }
+
+    // ---- not yet served verified on the Rust engine (later EL-B / EL-C slices) ----
+
+    @Override public byte[] call(byte[] from, byte[] to, byte[] data, String valueWei, String block) { return null; }
+    @Override public byte[] getCode(byte[] address, String block) { return null; }
+    @Override public byte[] getStorageAt(byte[] address, byte[] slot32, String block) { return null; }
+    @Override public byte[] sendRawTransaction(byte[] rawTx) { return null; }
+    @Override public String getTransactionReceipt(byte[] txHash) { return null; }
+    @Override public String getTransactionByHash(byte[] txHash) { return null; }
+    @Override public String getBlockByNumber(String block, boolean fullTransactions) { return null; }
+    @Override public String getBlockByHash(byte[] blockHash32, boolean fullTransactions) { return null; }
+    @Override public String gasPrice() { return null; }
+    @Override public String maxPriorityFeePerGas() { return null; }
+    @Override public String feeHistory(long blockCount, String newestBlock, double[] rewardPercentiles) { return null; }
+    @Override public Long estimateGas(byte[] from, byte[] to, byte[] data, String valueWei) { return null; }
+
+    // ---- helpers ----
+
+    /** Run the verified account query, mapping a transport/not-running failure to null. */
+    private AccountProofResult queryAccount(byte[] address) {
+        try {
+            return handle.requestAccount(toHex(address));
+        } catch (EngineException e) {
+            log.debug("[engines] verified account read unavailable: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    /** A verified answer produced a verdict (verifyMethod set), not a failReason. */
+    private static boolean isVerified(AccountProofResult r) {
+        return r.verifyMethod() != null;
+    }
+
+    /** true for the head selector ("latest"/"pending"/default) the anchored reader serves. */
+    private static boolean isHeadSelector(String block) {
+        if (block == null || block.isBlank()) return true;
+        String b = block.trim();
+        return b.equalsIgnoreCase("latest") || b.equalsIgnoreCase("pending");
+    }
+
+    /** 20-byte address → lowercase 0x-hex (the form {@code requestAccount} expects). */
+    private static String toHex(byte[] address) {
+        if (address == null) throw new EngineException("address is required");
+        StringBuilder sb = new StringBuilder(2 + address.length * 2).append("0x");
+        for (byte b : address) {
+            sb.append(Character.forDigit((b >> 4) & 0xF, 16));
+            sb.append(Character.forDigit(b & 0xF, 16));
+        }
+        return sb.toString();
+    }
+}

--- a/myotis-engines/src/main/java/io/myotis/engines/RustVerifiedReads.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustVerifiedReads.java
@@ -155,11 +155,8 @@ final class RustVerifiedReads implements VerifiedReads {
     /** 20-byte address → lowercase 0x-hex (the form {@code requestAccount} expects). */
     private static String toHex(byte[] address) {
         if (address == null) throw new EngineException("address is required");
-        StringBuilder sb = new StringBuilder(2 + address.length * 2).append("0x");
-        for (byte b : address) {
-            sb.append(Character.forDigit((b >> 4) & 0xF, 16));
-            sb.append(Character.forDigit(b & 0xF, 16));
-        }
-        return sb.toString();
+        // HexFormat is desugared for Android here (desugar_jdk_libs 2.1.x) — the same
+        // API node-core (ChainStack) and myotis-ens already rely on in main code.
+        return "0x" + java.util.HexFormat.of().formatHex(address);
     }
 }


### PR DESCRIPTION
## What & why

First slice of **EL milestone B** (the VerifiedReads surface a wallet/MetaMask needs) from `docs/reimplementation/07-el-implementation-plan.md`.

Until now `RustChainHandle.reads()` returned `null`, so the Rust engine served **no JSON-RPC endpoint at all** — a wallet couldn't even read a balance or nonce to build a plain-ETH send. This lands the first read slice and wires the Rust engine into the shared JSON-RPC server.

## Changes

- **`RustVerifiedReads`** (new) — a `VerifiedReads` adapter over the already-live, beacon-anchored verified account query (`nativeRequestAccountJson`). Answers exactly what a wallet needs before a send:
  - `chainId`, `getBalance`, `getTransactionCount`, `syncState` — for the head selector (`latest`/`pending`/default).
  - Every other method returns `null` ("can't answer verified") → the router maps that to a strict-mode `-32000` until later EL-B / EL-C slices land (bytecode + raw-slot natives, block/tx/receipt lookup, fee trio, `sendRawTransaction`, revm `call`/`estimateGas`).
  - **Head-anchored only**: a specific historical block returns `null` rather than silently serving head data for the wrong block.
  - **Never throws**: the router's `tryVerified` dispatch is not exception-guarded and the Java backend it mirrors never throws, so a transport/not-running failure (or any unchecked throwable off the native path) maps to `null`.
- **`RustChainHandle`** — `reads()` returns the adapter; `start()`/`stop()` self-start and tear down the shared `MyotisRpcServer` on `127.0.0.1:rpcPort`, mirroring `ChainStack.startRpc()` (up-front bind probe, loopback, strict, fault-isolated).
- **`RustMyotisEngine`** — passes the host RPC port (else the mainnet default 8545).
- **`myotis-engines/build.gradle.kts`** — adds the `:jsonrpc-server` dependency (already shipped transitively via `node-core`).

**No native / ABI change** — reuses the existing account native (ABI 4). Pure-Java slice.

## Testing (built + run)

`:myotis-engines:test` + `:app:compileJava` green. Live, `-Pengine=rust`, beacon `SYNCED`:

| Call | Result |
|------|--------|
| `eth_chainId` | `0x1` |
| `net_version` | `1` |
| `eth_getBalance` vitalik `latest` | `0x5c8d19c642540bcb` (6.67 ETH — matches the EL-A7 integration gate) |
| `eth_getTransactionCount` vitalik `latest` | `0x170a` |
| `eth_getBalance` @ historical `0x1000000` | `-32000` (correctly refused, not wrong-block data) |
| `eth_gasPrice` (not-yet-served) | `-32000` (graceful, no crash) |

## Review

Independent no-context review of the diff before this PR (per workflow): verdict **sound, no blockers**. Both findings folded in — (1) broadened the never-throws catches to `RuntimeException`; (2) documented the nonce-freshness asymmetry vs the Java backend (staleness is bounded because `verifyMethod` is set only for a beacon-anchored head not behind finalized; an explicit tighter nonce gate is tracked as a follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)