### PR TITLE
Gate idle-sleep on first SYNCED; add "stay awake while charging"

### DIFF
--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -109,6 +109,7 @@ public final class NodeService extends Service {
     private static final String K_STRICT_FRESHNESS = "strictStateFreshness";
     private static final String K_NATIVE_BLS = "nativeBls";
     private static final String K_IDLE_PAUSE_MIN = "idlePauseMinutes";
+    private static final String K_STAY_AWAKE_CHARGING = "stayAwakeWhileCharging";
     public static final int DEFAULT_IDLE_PAUSE_MIN = 5;
     public static final int DEFAULT_RPC_PORT = 8545;
     // Gnosis defaults to a distinct port so both networks can be added to MetaMask
@@ -265,6 +266,15 @@ public final class NodeService extends Service {
     public static void setIdlePauseMinutes(android.content.Context c, int v) {
         prefs(c).edit().putInt(K_IDLE_PAUSE_MIN, clampInt(v, 0, 240, DEFAULT_IDLE_PAUSE_MIN)).apply();
     }
+    /** When true (default), the idle controller skips auto-pause while the device is charging
+     *  — plugged in, battery isn't a concern, so the node stays awake and synced. The emergency
+     *  low-memory pause ({@link #onTrimMemory}) ignores this. Read live by the idle tick. */
+    public static boolean stayAwakeWhileCharging(android.content.Context c) {
+        return prefs(c).getBoolean(K_STAY_AWAKE_CHARGING, true);
+    }
+    public static void setStayAwakeWhileCharging(android.content.Context c, boolean v) {
+        prefs(c).edit().putBoolean(K_STAY_AWAKE_CHARGING, v).apply();
+    }
     /** Whether RPC state reads use the strict 2-min head-staleness bound. Default true
      *  (strict). Relaxing it (toggle OFF strict / ON "relaxed") lets eth_call / balance /
      *  estimateGas serve an older root — but that *backfired* into 120-s confirm-screen
@@ -392,6 +402,7 @@ public final class NodeService extends Service {
         clCaches.remove(n);
         stackStartMs.remove(n);
         lastResumeMs.remove(n);
+        reachedSynced.remove(n);   // a re-enable cold-starts the SYNCED-once gate again
     }
 
     /** True if any network is still enabled (incl. the seeded default). */
@@ -477,6 +488,21 @@ public final class NodeService extends Service {
      *  STATIC so the {@link #dailyCatchUp} worker (no service binder) can hold the grace
      *  stamp while it catches up, keeping the instance idle ticker from pausing it mid-pass. */
     private static final Map<String, Long> lastResumeMs = new ConcurrentHashMap<>();
+    /** Per-network flag: the stack has reached SYNCED (with a warm verified head) at least once
+     *  since it (re)started. A fresh start must run through to SYNCED before the idle controller
+     *  is allowed to pause it — pausing mid-initial-sync just makes the next wake redo the work.
+     *  STATIC (like the stamps above): survives a service instance. Set true when first observed
+     *  SYNCED and cleared when the network is torn down (so a disable→re-enable cold-starts the
+     *  gate again); a stack that briefly falls out of sync after its first SYNCED still pauses on
+     *  the normal idle rules. */
+    private static final java.util.Set<String> reachedSynced = ConcurrentHashMap.newKeySet();
+    /** Backstop for the SYNCED-once gate: if a fresh stack has been trying to reach SYNCED for
+     *  this long (measured from its boot stamp) without success — no peers, a wedged sync, a
+     *  perpetually-throwing status() — stop keeping it awake and let the idle controller pause it.
+     *  Otherwise "run until synced" could drain the battery indefinitely on a node that never
+     *  syncs, the exact thing the feature fights. Generous so a slow-but-progressing initial sync
+     *  on a poor network still completes first. */
+    private static final long SYNC_RUN_CEILING_MS = 30 * 60_000L;
     private volatile java.util.concurrent.ScheduledExecutorService idleTicker;
     /** What the notification currently shows, to notify() only on transitions. */
     private volatile Boolean notifiedSleeping;
@@ -542,9 +568,30 @@ public final class NodeService extends Service {
      * is older than {@code idleMs}, then reconcile the notification. Guarded:
      * an uncaught throw would silently stop all future scheduled runs.
      */
-    private void idleTick(long idleMs) {
+    private void idleTick(long idleMs) { idleTick(idleMs, true); }
+
+    /**
+     * @param routine {@code true} for the scheduled idle ticker — applies the battery-saving
+     *   gates below. {@code false} for the emergency {@link #onTrimMemory} pause, which must go
+     *   through regardless (a pre-sync node under memory pressure is better paused than
+     *   OOM-killed and cold-started).
+     *
+     * <p>Routine gates, all skipped when {@code routine} is false:
+     * <ul>
+     *   <li><b>SYNCED-once</b> — never pause a stack that hasn't yet reached SYNCED (+ warm head)
+     *       this run, so a fresh start finishes initial sync before its first sleep. Exception:
+     *       if no network is available it can't sync anyway, so allow the pause rather than keep
+     *       the radio scanning.</li>
+     *   <li><b>Charging</b> — when {@link #stayAwakeWhileCharging} is on (default) and the device
+     *       is plugged in, skip auto-pause entirely: battery isn't a concern, stay synced.</li>
+     * </ul>
+     */
+    private void idleTick(long idleMs, boolean routine) {
         try {
             long now = System.currentTimeMillis();
+            // Process-global conditions, evaluated once per pass rather than per stack.
+            boolean skipWhileCharging = routine && stayAwakeWhileCharging(this) && isCharging();
+            boolean netUp = networkAvailable();
             for (Map.Entry<String, ChainHandle> e : handles.entrySet()) {
                 String n = e.getKey();
                 ChainHandle h = e.getValue();
@@ -557,6 +604,24 @@ public final class NodeService extends Service {
                         Math.max(lastResumeMs.getOrDefault(n, 0L),
                                  stackStartMs.getOrDefault(n, 0L)));
                 if (now - lastActivity <= idleMs) continue;
+                if (skipWhileCharging) continue; // plugged in: keep awake and synced
+                // SYNCED-once gate: don't pause a stack still doing its initial sync — unless
+                // there's no network to sync over, in which case sleeping saves battery.
+                if (routine && !reachedSynced.contains(n)) {
+                    if (isSyncedWarm(h)) {
+                        reachedSynced.add(n); // first SYNCED reached; fall through to the pause
+                        LogBuffer.i(TAG, "[" + n + "] reached SYNCED; idle-pause now eligible");
+                    } else if (netUp
+                            && now - stackStartMs.getOrDefault(n, 0L) < SYNC_RUN_CEILING_MS) {
+                        continue; // still catching up with a network available — keep networking on
+                    } else if (netUp) {
+                        // Online but still not synced after the ceiling — stop draining battery
+                        // on a stack that can't sync; let it pause and wake/retry later.
+                        LogBuffer.i(TAG, "[" + n + "] not SYNCED after "
+                                + (SYNC_RUN_CEILING_MS / 60_000L) + "m; allowing idle pause");
+                    }
+                    // else: not synced and offline → allow the pause below
+                }
                 long idleForSec = (now - lastActivity) / 1000;
                 new Thread(() -> {
                     synchronized (bootLock(n)) {
@@ -577,6 +642,59 @@ public final class NodeService extends Service {
             updateNotification();
         } catch (Throwable t) {
             LogBuffer.w(TAG, "idle tick error: " + t);
+        }
+    }
+
+    /** The stack has a fresh verified head from a SYNCED beacon light client — the same
+     *  "synced + warm head" bar the daily catch-up waits for before pausing again. */
+    private static boolean isSyncedWarm(ChainHandle h) {
+        try {
+            StatusSnapshot s = h.status();
+            return s.beaconState() == BeaconState.SYNCED
+                    && s.verifiedHeadAgeMs() != Long.MAX_VALUE;
+        } catch (Throwable t) {
+            return false;
+        }
+    }
+
+    /** True when a network with Internet capability is active. Fail-open (true) if the state
+     *  can't be read, so a transient query error doesn't wrongly let the idle tick pause a
+     *  still-syncing stack. */
+    private boolean networkAvailable() {
+        try {
+            ConnectivityManager cm = getSystemService(ConnectivityManager.class);
+            if (cm == null) return true;
+            Network net = cm.getActiveNetwork();
+            if (net == null) return false;
+            android.net.NetworkCapabilities caps = cm.getNetworkCapabilities(net);
+            return caps != null
+                    && caps.hasCapability(android.net.NetworkCapabilities.NET_CAPABILITY_INTERNET);
+        } catch (Throwable t) {
+            return true;
+        }
+    }
+
+    /** True when the device is plugged in (AC / USB / wireless) or actively charging — i.e.
+     *  battery isn't a concern. Plug-state is read first (via the sticky ACTION_BATTERY_CHANGED
+     *  intent) because {@code BatteryManager.isCharging()} reports charge state, which is false
+     *  when plugged in but momentarily discharging under load. Fail-safe to false so a read error
+     *  never blocks a pause. */
+    private boolean isCharging() {
+        try {
+            android.content.Intent i = registerReceiver(null,
+                    new android.content.IntentFilter(android.content.Intent.ACTION_BATTERY_CHANGED));
+            if (i != null
+                    && i.getIntExtra(android.os.BatteryManager.EXTRA_PLUGGED, 0) != 0) {
+                return true; // plugged into AC / USB / wireless
+            }
+        } catch (Throwable ignored) {
+            // fall through to the charge-state check
+        }
+        try {
+            android.os.BatteryManager bm = getSystemService(android.os.BatteryManager.class);
+            return bm != null && bm.isCharging();
+        } catch (Throwable t) {
+            return false;
         }
     }
 
@@ -1226,6 +1344,9 @@ public final class NodeService extends Service {
         cachedClCounts.clear();
         elCaches.clear();
         clCaches.clear();
+        // Safe to clear (unlike startTimeMs below): a Stop->Start just re-runs the SYNCED-once
+        // gate until the restarted stack re-observes SYNCED — fast off the warm store, no freeze.
+        reachedSynced.clear();
         // NB: do NOT clear startTimeMs here. doShutdown() runs on a worker thread and its
         // teardown takes seconds; a quick Stop -> Start has onStartCommand() flip RUNNING back
         // to true and stamp a fresh startTimeMs while we're still mid-teardown (buildAndStart's
@@ -1451,7 +1572,9 @@ public final class NodeService extends Service {
         // A pause frees the big consumers (Netty buffers, evm pools, libp2p) while
         // keeping the warm beacon store — far better than dying and cold-starting.
         if (level >= TRIM_MEMORY_RUNNING_CRITICAL && RUNNING.get()) {
-            idleTick(60_000L);
+            // Emergency pass: bypass the SYNCED-once / charging gates. Freeing the big consumers
+            // beats getting OOM-killed and cold-starting, even mid-initial-sync or while charging.
+            idleTick(60_000L, false);
         }
     }
 

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -385,6 +385,10 @@ public final class NodeService extends Service {
         // nothing — the new port is already persisted and applies on the next enable. Without this,
         // saving settings would start a chain the user has turned off.
         if (handles.remove(n) == null) return;
+        // A reboot is a cold restart of this stack: clear the SYNCED-once flag so it runs through
+        // to SYNCED again before the idle controller may pause it. buildAndStart re-stamps the
+        // start clocks. (rebootNetwork doesn't go through forgetStack, so clear it explicitly here.)
+        reachedSynced.remove(n);
         new Thread(() -> {
             synchronized (bootLock(n)) {
                 try { ENGINE.stop(n); } catch (Throwable ignored) {}
@@ -401,6 +405,7 @@ public final class NodeService extends Service {
         elCaches.remove(n);
         clCaches.remove(n);
         stackStartMs.remove(n);
+        stackStartNano.remove(n);
         lastResumeMs.remove(n);
         reachedSynced.remove(n);   // a re-enable cold-starts the SYNCED-once gate again
     }
@@ -482,6 +487,12 @@ public final class NodeService extends Service {
      *  STATIC (matching ENGINE / RUNNING / BOOT_LOCKS): this is per-network-stack state that
      *  outlives a service instance, and the static {@link #dailyCatchUp} worker path reads/writes it. */
     private static final Map<String, Long> stackStartMs = new ConcurrentHashMap<>();
+    /** Per-network stack-start stamp in monotonic {@link System#nanoTime} for the SYNCED-once
+     *  ceiling only. Separate from {@link #stackStartMs} (wall-clock, used for idle-window display
+     *  and the pause decision) so a wall-clock/NTP step can't prematurely expire or indefinitely
+     *  extend the 30-minute run-until-synced backstop. Stamped alongside stackStartMs at boot,
+     *  cleared on teardown. */
+    private static final Map<String, Long> stackStartNano = new ConcurrentHashMap<>();
     /** Per-network HOST-side resume stamp (foreground resume, daily catch-up): gives
      *  the resumed stack a full idle window even though no request bumped the engine's
      *  activity clock. Engine-side wakes need no stamp — the waking request did it.
@@ -587,6 +598,10 @@ public final class NodeService extends Service {
      * </ul>
      */
     private void idleTick(long idleMs, boolean routine) {
+        // Bail if the service is being torn down: doShutdown() runs on a worker thread, so a
+        // scheduled tick (or the onTrimMemory pass) could otherwise spawn pause threads or mutate
+        // reachedSynced after Stop. The per-stack pause thread re-checks RUNNING under bootLock too.
+        if (!RUNNING.get()) return;
         try {
             long now = System.currentTimeMillis();
             // Process-global conditions, evaluated once per pass rather than per stack.
@@ -611,8 +626,7 @@ public final class NodeService extends Service {
                     if (isSyncedWarm(h)) {
                         reachedSynced.add(n); // first SYNCED reached; fall through to the pause
                         LogBuffer.i(TAG, "[" + n + "] reached SYNCED; idle-pause now eligible");
-                    } else if (netUp
-                            && now - stackStartMs.getOrDefault(n, 0L) < SYNC_RUN_CEILING_MS) {
+                    } else if (netUp && !syncRunCeilingReached(n)) {
                         continue; // still catching up with a network available — keep networking on
                     } else if (netUp) {
                         // Online but still not synced after the ceiling — stop draining battery
@@ -655,6 +669,17 @@ public final class NodeService extends Service {
         } catch (Throwable t) {
             return false;
         }
+    }
+
+    /** True once a still-unsynced stack has been running past {@link #SYNC_RUN_CEILING_MS}, measured
+     *  on the monotonic clock so a wall-clock/NTP step can't skew it. This is the backstop that stops
+     *  "run until synced" from keeping networking on (and draining the battery) forever on a stack
+     *  that never syncs. An absent stamp (shouldn't happen — set at boot) is treated as reached, so
+     *  the SYNCED-once gate can't wedge a stack awake indefinitely. */
+    private static boolean syncRunCeilingReached(String n) {
+        Long startNano = stackStartNano.get(n);
+        if (startNano == null) return true;
+        return System.nanoTime() - startNano >= SYNC_RUN_CEILING_MS * 1_000_000L;
     }
 
     /** True when a network with Internet capability is active. Fail-open (true) if the state
@@ -1230,6 +1255,7 @@ public final class NodeService extends Service {
             // A freshly-booted stack gets a full idle window before the controller
             // may pause it (its engine activity clock starts at 0).
             stackStartMs.put(n, System.currentTimeMillis());
+            stackStartNano.put(n, System.nanoTime());   // monotonic clock for the sync-run ceiling
             updateNotification();
             LogBuffer.i(TAG, "[" + n + "] node stack started (RPC " + rpcPort + ")");
         } catch (Exception e) {

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -266,9 +266,10 @@ public final class NodeService extends Service {
     public static void setIdlePauseMinutes(android.content.Context c, int v) {
         prefs(c).edit().putInt(K_IDLE_PAUSE_MIN, clampInt(v, 0, 240, DEFAULT_IDLE_PAUSE_MIN)).apply();
     }
-    /** When true (default), the idle controller skips auto-pause while the device is charging
-     *  — plugged in, battery isn't a concern, so the node stays awake and synced. The emergency
-     *  low-memory pause ({@link #onTrimMemory}) ignores this. Read live by the idle tick. */
+    /** When true (default), the idle controller skips auto-pause while the device is charging and
+     *  online — plugged in with a network, battery isn't a concern, so the node stays awake and
+     *  synced. Plugged in but offline still pauses (nothing to sync). The emergency low-memory
+     *  pause ({@link #onTrimMemory}) ignores this. Read live by the idle tick. */
     public static boolean stayAwakeWhileCharging(android.content.Context c) {
         return prefs(c).getBoolean(K_STAY_AWAKE_CHARGING, true);
     }
@@ -593,8 +594,9 @@ public final class NodeService extends Service {
      *       this run, so a fresh start finishes initial sync before its first sleep. Exception:
      *       if no network is available it can't sync anyway, so allow the pause rather than keep
      *       the radio scanning.</li>
-     *   <li><b>Charging</b> — when {@link #stayAwakeWhileCharging} is on (default) and the device
-     *       is plugged in, skip auto-pause entirely: battery isn't a concern, stay synced.</li>
+     *   <li><b>Charging</b> — when {@link #stayAwakeWhileCharging} is on (default), the device is
+     *       plugged in, <em>and</em> a network is available, skip auto-pause: battery isn't a
+     *       concern, stay synced. Plugged in but offline still pauses (nothing to sync).</li>
      * </ul>
      */
     private void idleTick(long idleMs, boolean routine) {
@@ -605,8 +607,12 @@ public final class NodeService extends Service {
         try {
             long now = System.currentTimeMillis();
             // Process-global conditions, evaluated once per pass rather than per stack.
-            boolean skipWhileCharging = routine && stayAwakeWhileCharging(this) && isCharging();
             boolean netUp = networkAvailable();
+            // Stay awake while charging only when there's actually a network to stay synced over.
+            // Plugged in but offline there's nothing to do, so let the stack pause rather than keep
+            // the radio scanning — the same "no network -> pause anyway" rule the SYNCED gate uses.
+            boolean skipWhileCharging =
+                    routine && stayAwakeWhileCharging(this) && isCharging() && netUp;
             for (Map.Entry<String, ChainHandle> e : handles.entrySet()) {
                 String n = e.getKey();
                 ChainHandle h = e.getValue();

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/cmp/AndroidNodeBridge.kt
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/cmp/AndroidNodeBridge.kt
@@ -180,6 +180,8 @@ class AndroidSettings(private val ctx: Context) : Settings {
 
     override fun idlePauseMinutes(): Int = NodeService.idlePauseMinutes(ctx)
     override fun setIdlePauseMinutes(v: Int) = NodeService.setIdlePauseMinutes(ctx, v)
+    override fun stayAwakeWhileCharging(): Boolean = NodeService.stayAwakeWhileCharging(ctx)
+    override fun setStayAwakeWhileCharging(v: Boolean) = NodeService.setStayAwakeWhileCharging(ctx, v)
     override fun supportsIdleSleep(): Boolean = true   // NodeService runs the idle controller
 }
 

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeController.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeController.kt
@@ -129,6 +129,14 @@ interface Settings {
     fun setIdlePauseMinutes(v: Int) {}
 
     /**
+     * When true (default), the idle controller does NOT auto-pause while the device is
+     * charging — plugged in, battery isn't a concern, so the node stays awake and synced.
+     * Emergency memory-pressure pauses ignore this. Default true keeps desktop compiling.
+     */
+    fun stayAwakeWhileCharging(): Boolean = true
+    fun setStayAwakeWhileCharging(v: Boolean) {}
+
+    /**
      * Whether this host actually has an idle-sleep controller (Android). The idle-sleep
      * Settings row is shown only when true — desktop has no controller, so surfacing a
      * battery-saving toggle there would imply a feature that can't take effect. Default false.

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
@@ -317,7 +317,8 @@ private fun SettingsTab(
                 "After this many minutes without a wallet request or query, the node goes to " +
                     "sleep: all P2P networking stops (saving battery) while the JSON-RPC port keeps " +
                     "listening. The first request wakes it — expect that call to take a little longer. " +
-                    "A fresh start always runs through to SYNCED before the first sleep.",
+                    "On a fresh start it runs through to SYNCED before the first sleep, as long as it " +
+                    "has a network to sync over.",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
@@ -239,6 +239,7 @@ private fun SettingsTab(
     var snapTarget by remember { mutableStateOf(settings.snapTarget().toString()) }
     var deepPool by remember { mutableStateOf(settings.deepPoolThreshold().toString()) }
     var idlePause by remember { mutableStateOf(settings.idlePauseMinutes().toString()) }
+    var stayAwakeCharging by remember { mutableStateOf(settings.stayAwakeWhileCharging()) }
     var strictFreshness by remember { mutableStateOf(settings.strictStateFreshness()) }
     var nativeBls by remember { mutableStateOf(settings.nativeBlsEnabled()) }
 
@@ -315,7 +316,21 @@ private fun SettingsTab(
             Text(
                 "After this many minutes without a wallet request or query, the node goes to " +
                     "sleep: all P2P networking stops (saving battery) while the JSON-RPC port keeps " +
-                    "listening. The first request wakes it — expect that call to take a little longer.",
+                    "listening. The first request wakes it — expect that call to take a little longer. " +
+                    "A fresh start always runs through to SYNCED before the first sleep.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            // Applies live — the idle tick reads it each pass.
+            SwitchRow(
+                label = "Stay awake while charging",
+                checked = stayAwakeCharging,
+                onChange = { on -> stayAwakeCharging = on; settings.setStayAwakeWhileCharging(on) },
+            )
+            Text(
+                "On (default): while the phone is plugged in, skip idle sleep and keep the node " +
+                    "awake and synced (battery isn't a concern). Off: sleep on the same idle timer " +
+                    "whether charging or not. Emergency low-memory pauses happen either way.",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )


### PR DESCRIPTION
## What

Two refinements to the Android idle-sleep controller (from the pause/resume feature in #161):

1. **Run until SYNCED before the first sleep.** The idle controller previously paused a stack as soon as the idle window elapsed — even on a cold start that hadn't reached SYNCED yet, so the next wake had to redo the initial sync. Now the *routine* idle pause is gated on the stack having reached beacon `SYNCED` with a warm verified head at least once since it started.

2. **"Stay awake while charging" setting (default on).** While the phone is plugged in, skip the routine idle pause — battery isn't a concern, so keep the node awake and synced.

## Gates / edge cases

- **No network → pause anyway.** Offline it can't sync, so staying awake would only keep the radio scanning; allow the pause.
- **Sync ceiling backstop (30 min).** A stack that never manages to sync eventually pauses, so "run until synced" can't drain the battery indefinitely.
- **Emergency memory pressure bypasses both gates.** `onTrimMemory` near-OOM still pauses (frees Netty/libp2p buffers) even pre-sync or while charging — better than an OOM-kill + cold start.
- `reachedSynced` is cleared on teardown (`forgetStack` / `doShutdown`), so a disable→re-enable or Stop→Start cold-starts the gate again.

## Wiring

`NodeController.stayAwakeWhileCharging()`/setter (default `true` so desktop compiles) → `AndroidNodeBridge` → `NodeService` prefs. `NodeScreen` adds a switch under the idle-sleep section (gated on `supportsIdleSleep()`).

## Testing (Pixel 7, mainnet)

- **Charging gate ON + plugged in:** node stayed awake the entire idle window (idle=1 min, ~3.5 min observed, zero pauses).
- **Charging gate OFF:** node paused within the idle window — preceded by the new `[mainnet] reached SYNCED; idle-pause now eligible` log line, confirming the SYNCED gate ran before the pause was allowed.
- Compiles on Android + desktop; the pre-existing wake-on-RPC pause/resume path is unchanged.
- An independent no-context review of the diff was run before opening this PR; its findings (unbounded stay-awake, teardown cleanup, plugged-vs-charging semantics) are addressed in the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017YMpbh6rgTwWvxJgsUTEiH