### PR TITLE
Expose node status over JSON-RPC (myotis_status / myotis_beaconStatus)

### DIFF
--- a/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/MyotisRpcServer.kt
+++ b/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/MyotisRpcServer.kt
@@ -37,6 +37,7 @@ class MyotisRpcServer(
     private val upstreamUrl: String? = null,
     private val host: String = "127.0.0.1",
     private val backend: io.myotis.api.VerifiedReads? = null,
+    private val statusReads: io.myotis.api.NodeStatusReads? = null,
 ) {
     private val log = LoggerFactory.getLogger(MyotisRpcServer::class.java)
 
@@ -47,7 +48,7 @@ class MyotisRpcServer(
 
     private val proxy: UpstreamProxy? = upstreamUrl?.takeIf { it.isNotBlank() }?.let { UpstreamProxy(it) }
     private val logger = MethodLogger()
-    private val router = RpcRouter(proxy, logger, backend)
+    private val router = RpcRouter(proxy, logger, backend, statusReads)
 
     /**
      * Optional request/response capture for debugging + replay. Off unless the

--- a/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/RpcRouter.kt
+++ b/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/RpcRouter.kt
@@ -30,6 +30,7 @@ class RpcRouter(
     private val proxy: UpstreamProxy?,
     private val logger: MethodLogger,
     private val backend: io.myotis.api.VerifiedReads? = null,
+    private val statusReads: io.myotis.api.NodeStatusReads? = null,
 ) {
     private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
 
@@ -105,6 +106,30 @@ class RpcRouter(
         if (method == "myotis_rpcCoverage") {
             logger.record(method, idStr, "LOCAL", 0)
             return resultEnvelope(id, logger.coverage())
+        }
+        // Local node-status introspection — the JSON-RPC counterpart of the daemon's
+        // status / beacon-status IPC commands. Like myotis_rpcCoverage these bypass the
+        // verified backend, so a myotis-aware client can poll sync progress even when the
+        // node isn't synced / has no peers. -32601 when the host didn't wire a source.
+        if (method == "myotis_status" || method == "myotis_beaconStatus") {
+            val sr = statusReads
+            if (sr == null) {
+                logger.record(method, idStr, "ERROR", 0, -32601)
+                return errorEnvelope(id, -32601, "method '$method' is not supported by this node")
+            }
+            // Isolate the read like the IPC command does (CommandHandler wraps dispatch in
+            // try/catch): a throw becomes a JSON-RPC error envelope, never a raw Ktor 500.
+            return try {
+                val result = if (method == "myotis_status")
+                    StatusJson.status(sr.status(), sr.uptimeSeconds())
+                else
+                    StatusJson.beaconStatus(sr.beaconStatus(), sr.uptimeSeconds())
+                logger.record(method, idStr, "LOCAL", 0)
+                resultEnvelope(id, result)
+            } catch (e: Exception) {
+                logger.record(method, idStr, "ERROR", 0, -32603)
+                errorEnvelope(id, -32603, "status read failed: ${e.message}")
+            }
         }
         val t0 = System.nanoTime()
         val verified = tryVerified(method, id, root)

--- a/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/RpcRouter.kt
+++ b/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/RpcRouter.kt
@@ -120,15 +120,17 @@ class RpcRouter(
             // Isolate the read like the IPC command does (CommandHandler wraps dispatch in
             // try/catch): a throw becomes a JSON-RPC error envelope, never a raw Ktor 500.
             return try {
+                val uptime = sr.uptimeSeconds()   // read once so both fields/branches agree
                 val result = if (method == "myotis_status")
-                    StatusJson.status(sr.status(), sr.uptimeSeconds())
+                    StatusJson.status(sr.status(), uptime)
                 else
-                    StatusJson.beaconStatus(sr.beaconStatus(), sr.uptimeSeconds())
+                    StatusJson.beaconStatus(sr.beaconStatus(), uptime)
                 logger.record(method, idStr, "LOCAL", 0)
                 resultEnvelope(id, result)
             } catch (e: Exception) {
                 logger.record(method, idStr, "ERROR", 0, -32603)
-                errorEnvelope(id, -32603, "status read failed: ${e.message}")
+                val detail = e.message?.takeIf { it.isNotBlank() } ?: e.javaClass.simpleName
+                errorEnvelope(id, -32603, "status read failed: $detail")
             }
         }
         val t0 = System.nanoTime()

--- a/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/StatusJson.kt
+++ b/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/StatusJson.kt
@@ -1,0 +1,101 @@
+package io.myotis.jsonrpc
+
+import io.myotis.api.BeaconState
+import io.myotis.api.BeaconStatus
+import io.myotis.api.ClPeerInfo
+import io.myotis.api.StatusSnapshot
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+/**
+ * Serializers for the `myotis_status` / `myotis_beaconStatus` JSON-RPC results.
+ *
+ * The object shape (fields AND order) mirrors the daemon's `status` / `beacon-status`
+ * IPC commands field-for-field — see [com.jaeckel.ethp2p.app.CommandHandler]'s
+ * `handleStatus` / `handleBeaconStatus` — so a myotis-aware client can reuse a single
+ * parser across the IPC and JSON-RPC transports. The IPC `"ok":true` field is kept for
+ * exact parity; on the JSON-RPC side this object is the `result`, and success is already
+ * implied by `result` being present.
+ *
+ * The two serializers can't share code with CommandHandler (different module, no build
+ * edge), so [StatusJsonTest] pins the shape to catch drift.
+ */
+internal object StatusJson {
+
+    /** Mirrors CommandHandler.handleStatus. [uptimeSeconds] is supplied by the host. */
+    fun status(s: StatusSnapshot, uptimeSeconds: Long): JsonObject = buildJsonObject {
+        put("ok", true)
+        put("state", s.lifecycle().name)
+        put("uptimeSeconds", uptimeSeconds)
+        put("discoveredPeers", s.discoveredPeers())
+        put("connectedPeers", s.connectedPeers())
+        put("readyPeers", s.readyPeers())
+        put("snapPeers", s.snapPeers())
+        put("backedOffPeers", s.backedOffPeers())
+        put("blacklistedPeers", s.blacklistedPeers())
+        put("pauseCount", s.pauseCount())
+        put("totalPausedMs", s.totalPausedMs())
+        put("lastPauseEpochMs", s.lastPauseEpochMs())
+        put("lastResumeEpochMs", s.lastResumeEpochMs())
+        val reason = s.lastWakeReason()
+        if (reason == null) put("lastWakeReason", JsonNull) else put("lastWakeReason", reason)
+    }
+
+    /** Mirrors CommandHandler.handleBeaconStatus, incl. its SYNCING-vs-synced branch. */
+    fun beaconStatus(bs: BeaconStatus, uptimeSeconds: Long): JsonObject = buildJsonObject {
+        val syncing = bs.state() == BeaconState.SYNCING || bs.state() == BeaconState.STARTING
+        put("ok", true)
+        put("state", if (syncing) "SYNCING" else bs.state().name)
+        // periodProgress
+        put("currentPeriod", bs.currentPeriod())
+        put("targetPeriod", bs.targetPeriod())
+        // peerStats
+        put("uptimeSeconds", uptimeSeconds)
+        put("discoveredPeers", bs.discv5TableSize())
+        put("connectedPeers", bs.connectedPeers())
+        put("lightClientPeers", bs.lightClientPeers())
+        put("servedPeersLastMinute", bs.servedPeersLastMinute())
+        if (syncing) {
+            put("finalizedSlot", 0)
+            put("optimisticSlot", 0)
+            put("executionStateRoot", JsonNull)
+            put("knownStateRoots", bs.knownStateRoots())
+        } else {
+            put("finalizedSlot", bs.finalizedSlot())
+            put("optimisticSlot", bs.optimisticSlot())
+            put("finalizedPeriod", bs.finalizedPeriod())
+            put("syncCommitteePeriod", bs.currentPeriod())
+            put("wallClockPeriod", bs.targetPeriod())
+            val stateRoot = bs.executionStateRootHex()
+            if (stateRoot == null) put("executionStateRoot", JsonNull) else put("executionStateRoot", stateRoot)
+            put("executionBlockNumber", bs.executionBlockNumber())
+            put("knownStateRoots", bs.knownStateRoots())
+            put("fillThreshold", bs.fillThreshold())
+        }
+        put("peers", beaconPeers(bs.peers()))
+    }
+
+    private fun beaconPeers(peers: List<ClPeerInfo>): JsonArray = buildJsonArray {
+        for (p in peers) {
+            add(buildJsonObject {
+                // Match the IPC command exactly: it renders these through escapeJson(), which
+                // maps null -> "" (CommandHandler.escapeJson), so a null id/address is "", not null.
+                put("peerId", truncatePeerId(p.peerId()) ?: "")
+                put("remoteAddress", p.remoteAddress() ?: "")
+                val clientId = p.clientId()
+                if (clientId != null) put("clientId", clientId)
+                put("lightClient", p.lightClient())
+                put("protocols", p.protocols())
+            })
+        }
+    }
+
+    /** Same 16-char truncation the daemon's beacon-status uses. */
+    private fun truncatePeerId(peerId: String?): String? =
+        if (peerId != null && peerId.length > 16) peerId.substring(0, 16) + "..." else peerId
+}

--- a/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/StatusJson.kt
+++ b/jsonrpc-server/src/main/kotlin/io/myotis/jsonrpc/StatusJson.kt
@@ -23,7 +23,7 @@ import kotlinx.serialization.json.put
  * implied by `result` being present.
  *
  * The two serializers can't share code with CommandHandler (different module, no build
- * edge), so [StatusJsonTest] pins the shape to catch drift.
+ * edge), so [MyotisStatusRpcTest] pins the shape to catch drift.
  */
 internal object StatusJson {
 

--- a/jsonrpc-server/src/test/kotlin/io/myotis/jsonrpc/MyotisStatusRpcTest.kt
+++ b/jsonrpc-server/src/test/kotlin/io/myotis/jsonrpc/MyotisStatusRpcTest.kt
@@ -203,14 +203,19 @@ class MyotisStatusRpcTest {
     @Test fun myotisStatus_readThrows_errorsInternal_notRaw500() {
         // A throwing status source must become a JSON-RPC error envelope (like the IPC path),
         // not an unhandled exception surfacing as a raw HTTP 500.
+        // Throw with a NULL message so the error detail must fall back to the exception type
+        // (never the literal "status read failed: null").
         val throwing = object : NodeStatusReads {
-            override fun status(): StatusSnapshot = throw IllegalStateException("boom")
-            override fun beaconStatus(): BeaconStatus = throw IllegalStateException("boom")
+            override fun status(): StatusSnapshot = throw IllegalStateException()
+            override fun beaconStatus(): BeaconStatus = throw IllegalStateException()
             override fun uptimeSeconds() = 0L
         }
         val resp = route(throwing, """{"jsonrpc":"2.0","id":1,"method":"myotis_status","params":[]}""")
         val err = json.parseToJsonElement(resp).jsonObject["error"]!!.jsonObject
         assertEquals(-32603, err["code"]!!.jsonPrimitive.content.toInt())
+        val msg = err["message"]!!.jsonPrimitive.content
+        assertTrue(msg.contains("IllegalStateException"), "expected exception type in: $msg")
+        assertFalse(msg.contains("null"), "message must not leak a null: $msg")
     }
 
     @Test fun myotisStatus_unwired_errorsMethodNotSupported() {

--- a/jsonrpc-server/src/test/kotlin/io/myotis/jsonrpc/MyotisStatusRpcTest.kt
+++ b/jsonrpc-server/src/test/kotlin/io/myotis/jsonrpc/MyotisStatusRpcTest.kt
@@ -1,0 +1,225 @@
+package io.myotis.jsonrpc
+
+import io.myotis.api.BeaconState
+import io.myotis.api.BeaconStatus
+import io.myotis.api.ClPeerInfo
+import io.myotis.api.LifecycleState
+import io.myotis.api.NodeStatusReads
+import io.myotis.api.PeerInfo
+import io.myotis.api.StatusSnapshot
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * The `myotis_status` / `myotis_beaconStatus` JSON-RPC methods: their result shape must
+ * mirror the daemon's `status` / `beacon-status` IPC commands
+ * ([com.jaeckel.ethp2p.app.CommandHandler]) field-for-field, and — being local
+ * introspection — they must answer without a verified backend. The exact-string asserts
+ * pin the shape so it can't silently drift from the IPC command.
+ */
+class MyotisStatusRpcTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private fun statusSnapshot(
+        lifecycle: LifecycleState = LifecycleState.RUNNING,
+        lastWakeReason: String? = "REQUEST",
+    ) = StatusSnapshot(
+        /* running */ true,
+        lifecycle,
+        /* network */ "mainnet",
+        /* beaconState */ BeaconState.SYNCED,
+        /* connectedPeers */ 4,
+        /* readyPeers */ 3,
+        /* snapPeers */ 2,
+        /* snapServingPeers */ 2,
+        /* discoveredPeers */ 5,
+        /* backedOffPeers */ 1,
+        /* blacklistedPeers */ 0,
+        /* attemptedDials */ 9,
+        /* discv5TableSize */ 8,
+        /* executionBlockNumber */ 123L,
+        /* optimisticBlockNumber */ 124L,
+        /* finalizedSlot */ 500L,
+        /* finalizedBlockNumber */ 122L,
+        /* syncStartPeriod */ -1L,
+        /* syncCurrentPeriod */ 1000L,
+        /* syncTargetPeriod */ 1000L,
+        /* finalizedPeriod */ 15L,
+        /* wallClockPeriod */ 1000L,
+        /* verifiedHeadAgeMs */ 0L,
+        /* readyPeerList */ listOf(PeerInfo("1.2.3.4:30303", true, "geth/v1")),
+        /* pauseCount */ 7,
+        /* totalPausedMs */ 1000L,
+        /* lastPauseEpochMs */ 111L,
+        /* lastResumeEpochMs */ 222L,
+        lastWakeReason,
+    )
+
+    private fun beaconStatus(
+        state: BeaconState,
+        peers: List<ClPeerInfo> = emptyList(),
+        stateRootHex: String? = "0xabc",
+    ) = BeaconStatus(
+        state,
+        /* bootstrapped */ true,
+        /* currentPeriod */ if (state == BeaconState.SYNCING) 10L else 1000L,
+        /* targetPeriod */ if (state == BeaconState.SYNCING) 20L else 1000L,
+        /* discv5TableSize */ 8,
+        /* connectedPeers */ 6,
+        /* lightClientPeers */ 2L,
+        /* servedPeersLastMinute */ 3,
+        /* finalizedSlot */ 500L,
+        /* optimisticSlot */ 501L,
+        /* finalizedPeriod */ 15L,
+        /* executionStateRootHex */ stateRootHex,
+        /* executionBlockHashHex */ "0xdef",
+        /* executionBlockNumber */ 123L,
+        /* knownStateRoots */ 10,
+        /* fillThreshold */ 4,
+        peers,
+    )
+
+    private fun encode(obj: JsonObject) = Json.encodeToString(JsonObject.serializer(), obj)
+
+    // ---- serializer shape (pinned to the IPC command output) ------------------------
+
+    @Test fun statusJson_mirrorsIpcStatusShape() {
+        assertEquals(
+            """{"ok":true,"state":"RUNNING","uptimeSeconds":42,"discoveredPeers":5,""" +
+                """"connectedPeers":4,"readyPeers":3,"snapPeers":2,"backedOffPeers":1,""" +
+                """"blacklistedPeers":0,"pauseCount":7,"totalPausedMs":1000,""" +
+                """"lastPauseEpochMs":111,"lastResumeEpochMs":222,"lastWakeReason":"REQUEST"}""",
+            encode(StatusJson.status(statusSnapshot(), 42L)),
+        )
+    }
+
+    @Test fun statusJson_nullWakeReason_isJsonNull() {
+        assertTrue(
+            encode(StatusJson.status(statusSnapshot(lastWakeReason = null), 0L))
+                .endsWith(""""lastWakeReason":null}"""),
+        )
+    }
+
+    @Test fun beaconStatusJson_synced_mirrorsIpcShape() {
+        assertEquals(
+            """{"ok":true,"state":"SYNCED","currentPeriod":1000,"targetPeriod":1000,""" +
+                """"uptimeSeconds":42,"discoveredPeers":8,"connectedPeers":6,""" +
+                """"lightClientPeers":2,"servedPeersLastMinute":3,"finalizedSlot":500,""" +
+                """"optimisticSlot":501,"finalizedPeriod":15,"syncCommitteePeriod":1000,""" +
+                """"wallClockPeriod":1000,"executionStateRoot":"0xabc","executionBlockNumber":123,""" +
+                """"knownStateRoots":10,"fillThreshold":4,"peers":[]}""",
+            encode(StatusJson.beaconStatus(beaconStatus(BeaconState.SYNCED), 42L)),
+        )
+    }
+
+    @Test fun beaconStatusJson_syncing_collapsesToSyncingBranch() {
+        // STARTING/SYNCING both render as "SYNCING" with zeroed slots + null state root, and
+        // OMIT the synced-only fields (finalizedPeriod, syncCommitteePeriod, …) — exactly the
+        // daemon's SYNCING branch.
+        assertEquals(
+            """{"ok":true,"state":"SYNCING","currentPeriod":10,"targetPeriod":20,""" +
+                """"uptimeSeconds":42,"discoveredPeers":8,"connectedPeers":6,""" +
+                """"lightClientPeers":2,"servedPeersLastMinute":3,"finalizedSlot":0,""" +
+                """"optimisticSlot":0,"executionStateRoot":null,"knownStateRoots":10,"peers":[]}""",
+            encode(StatusJson.beaconStatus(beaconStatus(BeaconState.SYNCING, stateRootHex = null), 42L)),
+        )
+        // STARTING collapses to the same branch.
+        assertTrue(
+            encode(StatusJson.beaconStatus(beaconStatus(BeaconState.STARTING, stateRootHex = null), 0L))
+                .contains(""""state":"SYNCING""""),
+        )
+    }
+
+    @Test fun beaconPeers_truncateLongId_andOmitNullClientId() {
+        val peers = listOf(
+            ClPeerInfo("QmVeryLongPeerIdBeyondSixteen", "1.2.3.4:9000", "Lighthouse/v1", true, 3),
+            ClPeerInfo("shortId", "5.6.7.8:9000", null, false, 1),
+        )
+        val arr = StatusJson.beaconStatus(beaconStatus(BeaconState.SYNCED, peers), 0L)["peers"]!!.jsonArray
+        val p0 = arr[0].jsonObject
+        assertEquals("QmVeryLongPeerId...", p0["peerId"]!!.jsonPrimitive.content) // first 16 + "..."
+        assertEquals("Lighthouse/v1", p0["clientId"]!!.jsonPrimitive.content)
+        assertEquals(true, p0["lightClient"]!!.jsonPrimitive.content.toBoolean())
+        val p1 = arr[1].jsonObject
+        assertEquals("shortId", p1["peerId"]!!.jsonPrimitive.content)             // no truncation
+        assertFalse(p1.containsKey("clientId"))                                   // null clientId omitted
+    }
+
+    @Test fun beaconPeers_nullPeerIdAndAddress_renderEmptyString() {
+        // The IPC command runs these through escapeJson(), which maps null -> "" — so parity
+        // requires "" here too, not JSON null. (Fields are documented always-present; this
+        // guards the parity claim regardless.)
+        val peers = listOf(ClPeerInfo(null, null, null, false, 0))
+        val p = StatusJson.beaconStatus(beaconStatus(BeaconState.SYNCED, peers), 0L)["peers"]!!
+            .jsonArray[0].jsonObject
+        assertEquals("", p["peerId"]!!.jsonPrimitive.content)
+        assertEquals("", p["remoteAddress"]!!.jsonPrimitive.content)
+        assertFalse(p.containsKey("clientId"))
+    }
+
+    // ---- router dispatch ------------------------------------------------------------
+
+    private class StubStatus(
+        private val s: StatusSnapshot,
+        private val bs: BeaconStatus,
+        private val up: Long,
+    ) : NodeStatusReads {
+        override fun status() = s
+        override fun beaconStatus() = bs
+        override fun uptimeSeconds() = up
+    }
+
+    private fun route(statusReads: NodeStatusReads?, body: String): String =
+        runBlocking { RpcRouter(null, MethodLogger(), null, statusReads).handle(body) }
+
+    @Test fun myotisStatus_returnsResult_withoutBackend() {
+        val stub = StubStatus(statusSnapshot(), beaconStatus(BeaconState.SYNCED), 42L)
+        val resp = route(stub, """{"jsonrpc":"2.0","id":1,"method":"myotis_status","params":[]}""")
+        val obj = json.parseToJsonElement(resp).jsonObject
+        assertFalse(obj.containsKey("error"))                                     // local method, no backend needed
+        val result = obj["result"]!!.jsonObject
+        assertEquals("RUNNING", result["state"]!!.jsonPrimitive.content)
+        assertEquals(42, result["uptimeSeconds"]!!.jsonPrimitive.content.toInt())
+    }
+
+    @Test fun myotisBeaconStatus_returnsResult_withoutBackend() {
+        val stub = StubStatus(statusSnapshot(), beaconStatus(BeaconState.SYNCED), 7L)
+        val resp = route(stub, """{"jsonrpc":"2.0","id":2,"method":"myotis_beaconStatus","params":[]}""")
+        val result = json.parseToJsonElement(resp).jsonObject["result"]!!.jsonObject
+        assertEquals("SYNCED", result["state"]!!.jsonPrimitive.content)
+        assertEquals(500, result["finalizedSlot"]!!.jsonPrimitive.content.toInt())
+    }
+
+    @Test fun myotisStatus_readThrows_errorsInternal_notRaw500() {
+        // A throwing status source must become a JSON-RPC error envelope (like the IPC path),
+        // not an unhandled exception surfacing as a raw HTTP 500.
+        val throwing = object : NodeStatusReads {
+            override fun status(): StatusSnapshot = throw IllegalStateException("boom")
+            override fun beaconStatus(): BeaconStatus = throw IllegalStateException("boom")
+            override fun uptimeSeconds() = 0L
+        }
+        val resp = route(throwing, """{"jsonrpc":"2.0","id":1,"method":"myotis_status","params":[]}""")
+        val err = json.parseToJsonElement(resp).jsonObject["error"]!!.jsonObject
+        assertEquals(-32603, err["code"]!!.jsonPrimitive.content.toInt())
+    }
+
+    @Test fun myotisStatus_unwired_errorsMethodNotSupported() {
+        // No status source injected (e.g. an engine host that didn't wire it) → -32601, not a crash.
+        for (m in listOf("myotis_status", "myotis_beaconStatus")) {
+            val resp = route(null, """{"jsonrpc":"2.0","id":1,"method":"$m","params":[]}""")
+            val err = json.parseToJsonElement(resp).jsonObject["error"]!!.jsonObject
+            assertEquals(-32601, err["code"]!!.jsonPrimitive.content.toInt())
+            assertNull(json.parseToJsonElement(resp).jsonObject["result"])
+        }
+    }
+}

--- a/myotis-api/src/main/java/io/myotis/api/NodeStatusReads.java
+++ b/myotis-api/src/main/java/io/myotis/api/NodeStatusReads.java
@@ -1,0 +1,28 @@
+package io.myotis.api;
+
+/**
+ * Narrow status source the JSON-RPC server consumes to answer the local
+ * {@code myotis_status} / {@code myotis_beaconStatus} introspection methods — the
+ * JSON-RPC counterpart of the daemon's {@code status} / {@code beacon-status} IPC
+ * commands.
+ *
+ * <p>Kept separate from {@link ChainHandle} so the RPC layer depends only on the two
+ * status shapes plus uptime, not the full engine surface. Both engine hosts already
+ * assemble {@link StatusSnapshot} / {@link BeaconStatus}; this just adds node uptime
+ * so the RPC result mirrors the IPC command's {@code uptimeSeconds} field.
+ *
+ * <p>Like the IPC commands, these are pure introspection: implementations must answer
+ * even when the node is not synced / has no peers — that is precisely when a client
+ * wants to poll progress. FFI-portable: flat records + a primitive only.
+ */
+public interface NodeStatusReads {
+
+    /** EL/networking + lifecycle view (the {@code status} command's source). */
+    StatusSnapshot status();
+
+    /** CL light-client view (the {@code beacon-status} command's source). */
+    BeaconStatus beaconStatus();
+
+    /** Node uptime in seconds; {@code 0} before the first start. */
+    long uptimeSeconds();
+}

--- a/node-core/src/main/java/io/myotis/node/ChainStack.java
+++ b/node-core/src/main/java/io/myotis/node/ChainStack.java
@@ -186,7 +186,6 @@ public final class ChainStack {
      */
     public synchronized boolean start() {
         if (!phase.compareAndSet(STOPPED, RUNNING)) return true; // already started
-        if (!started) { startedAtNs = System.nanoTime(); started = true; }
         try {
             log.info("[{}] Node ID: {}", network.name(), nodeKey.nodeId().toHexString());
 
@@ -227,6 +226,9 @@ public final class ChainStack {
             //    the refreshing DNS pool. The discv4-independent path NAT'd hosts need.
             if (maintainerEnabled) startPeerMaintainer();
 
+            // Anchor uptime only after a fully successful start (a failed start below tears
+            // the stack down via shutdown(), which clears `started` so a later start re-anchors).
+            if (!started) { startedAtNs = System.nanoTime(); started = true; }
             return true;
         } catch (Throwable t) {
             log.error("[{}] stack failed to start: {}", network.name(), t.toString());
@@ -347,6 +349,7 @@ public final class ChainStack {
      */
     public synchronized void shutdown() {
         phase.set(STOPPED);
+        started = false;   // a fresh start() after shutdown re-anchors uptime to that run
         ScheduledExecutorService pm = peerMaintainer;
         if (pm != null) { pm.shutdownNow(); peerMaintainer = null; }
         if (rpcServer != null) { try { rpcServer.stop(); } catch (Throwable ignored) {} }

--- a/node-core/src/main/java/io/myotis/node/ChainStack.java
+++ b/node-core/src/main/java/io/myotis/node/ChainStack.java
@@ -116,6 +116,12 @@ public final class ChainStack {
     private volatile io.myotis.rpc.VerifiedRpcBackend rpcBackend;
     private volatile io.myotis.jsonrpc.MyotisRpcServer rpcServer;
 
+    /** Status source for the JSON-RPC myotis_status / myotis_beaconStatus methods; the
+     *  wrapping handle late-binds it (see {@link #setStatusReads}) before start(). */
+    private volatile io.myotis.api.NodeStatusReads statusReads;
+    /** Epoch ms of the first successful start; 0 until then. Drives {@link #uptimeSeconds()}. */
+    private volatile long startedAtMs;
+
     public ChainStack(NetworkConfig network,
                       ChainPorts ports,
                       NodeKey nodeKey,
@@ -178,6 +184,7 @@ public final class ChainStack {
      */
     public synchronized boolean start() {
         if (!phase.compareAndSet(STOPPED, RUNNING)) return true; // already started
+        if (startedAtMs == 0L) startedAtMs = System.currentTimeMillis();
         try {
             log.info("[{}] Node ID: {}", network.name(), nodeKey.nodeId().toHexString());
 
@@ -404,6 +411,15 @@ public final class ChainStack {
     }
 
     // -- idle-sleep metrics (for status snapshots) --
+    /** Late-bind the JSON-RPC status source (the wrapping handle), before {@link #start()}. */
+    public void setStatusReads(io.myotis.api.NodeStatusReads statusReads) { this.statusReads = statusReads; }
+
+    /** Node uptime in seconds since the first successful start; 0 before then. */
+    public long uptimeSeconds() {
+        long s = startedAtMs;
+        return s == 0L ? 0L : (System.currentTimeMillis() - s) / 1000L;
+    }
+
     public int pauseCount() { return sleepMetrics.pauseCount(); }
     public long totalPausedMs() { return sleepMetrics.totalPausedMs(); }
     public long lastPauseEpochMs() { return sleepMetrics.lastPauseEpochMs(); }
@@ -772,7 +788,7 @@ public final class ChainStack {
                 // it survives pause() (keeps listening) while the backend underneath
                 // is torn down and rebuilt, and a request on a paused stack wakes it.
                 io.myotis.jsonrpc.MyotisRpcServer server =
-                        new io.myotis.jsonrpc.MyotisRpcServer(rpcPort, null, "127.0.0.1", gatedReads);
+                        new io.myotis.jsonrpc.MyotisRpcServer(rpcPort, null, "127.0.0.1", gatedReads, statusReads);
                 server.start();
                 this.rpcServer = server;
                 this.rpcBackend = backend;

--- a/node-core/src/main/java/io/myotis/node/ChainStack.java
+++ b/node-core/src/main/java/io/myotis/node/ChainStack.java
@@ -119,8 +119,10 @@ public final class ChainStack {
     /** Status source for the JSON-RPC myotis_status / myotis_beaconStatus methods; the
      *  wrapping handle late-binds it (see {@link #setStatusReads}) before start(). */
     private volatile io.myotis.api.NodeStatusReads statusReads;
-    /** Epoch ms of the first successful start; 0 until then. Drives {@link #uptimeSeconds()}. */
-    private volatile long startedAtMs;
+    /** Monotonic start time (ns) of the first start; drives {@link #uptimeSeconds()}. Paired
+     *  with {@link #started} because nanoTime()'s origin is arbitrary (0 is a valid reading). */
+    private volatile long startedAtNs;
+    private volatile boolean started;
 
     public ChainStack(NetworkConfig network,
                       ChainPorts ports,
@@ -184,7 +186,7 @@ public final class ChainStack {
      */
     public synchronized boolean start() {
         if (!phase.compareAndSet(STOPPED, RUNNING)) return true; // already started
-        if (startedAtMs == 0L) startedAtMs = System.currentTimeMillis();
+        if (!started) { startedAtNs = System.nanoTime(); started = true; }
         try {
             log.info("[{}] Node ID: {}", network.name(), nodeKey.nodeId().toHexString());
 
@@ -414,10 +416,10 @@ public final class ChainStack {
     /** Late-bind the JSON-RPC status source (the wrapping handle), before {@link #start()}. */
     public void setStatusReads(io.myotis.api.NodeStatusReads statusReads) { this.statusReads = statusReads; }
 
-    /** Node uptime in seconds since the first successful start; 0 before then. */
+    /** Node uptime in seconds since the first start; 0 before then. Monotonic (nanoTime),
+     *  so it's immune to wall-clock/NTP adjustments. */
     public long uptimeSeconds() {
-        long s = startedAtMs;
-        return s == 0L ? 0L : (System.currentTimeMillis() - s) / 1000L;
+        return !started ? 0L : (System.nanoTime() - startedAtNs) / 1_000_000_000L;
     }
 
     public int pauseCount() { return sleepMetrics.pauseCount(); }

--- a/node-core/src/main/java/io/myotis/node/api/JavaChainHandle.java
+++ b/node-core/src/main/java/io/myotis/node/api/JavaChainHandle.java
@@ -13,6 +13,7 @@ import io.myotis.api.EngineException;
 import io.myotis.api.EnsApi;
 import io.myotis.api.HeadersResult;
 import io.myotis.api.LifecycleState;
+import io.myotis.api.NodeStatusReads;
 import io.myotis.api.PeerInfo;
 import io.myotis.api.StatusSnapshot;
 import io.myotis.api.StorageProofResult;
@@ -34,7 +35,7 @@ import java.util.concurrent.TimeUnit;
  * status snapshot is built (previously duplicated across the desktop, Android, and daemon
  * status paths).
  */
-public final class JavaChainHandle implements ChainHandle {
+public final class JavaChainHandle implements ChainHandle, NodeStatusReads {
 
     private final ChainStack stack;
     private final boolean strictStateFreshness;
@@ -167,6 +168,10 @@ public final class JavaChainHandle implements ChainHandle {
                 stack.lastResumeEpochMs(),
                 stack.lastWakeReason());
     }
+
+    /** {@link NodeStatusReads}: node uptime for the JSON-RPC status result's {@code uptimeSeconds}. */
+    @Override
+    public long uptimeSeconds() { return stack.uptimeSeconds(); }
 
     @Override
     public java.util.List<io.myotis.api.DiscoveredPeer> discoveredPeers() {

--- a/node-core/src/main/java/io/myotis/node/api/JavaMyotisEngine.java
+++ b/node-core/src/main/java/io/myotis/node/api/JavaMyotisEngine.java
@@ -104,6 +104,9 @@ public final class JavaMyotisEngine implements MyotisEngine {
         }
 
         JavaChainHandle handle = new JavaChainHandle(stack, config.strictStateFreshness());
+        // Late-bind the JSON-RPC status source (resolves the stack↔handle cycle): the
+        // handle is the NodeStatusReads, and startRpc() runs later inside handle.start().
+        stack.setStatusReads(handle);
         // Atomic claim: two concurrent create()s for the same network must not both
         // register (the check above is only a fast fail).
         if (handles.putIfAbsent(name, handle) != null) {


### PR DESCRIPTION
## What

Adds two JSON-RPC methods that expose the node's status to **myotis-aware** clients, mirroring the daemon's existing `status` / `beacon-status` IPC commands:

- **`myotis_status`** — EL/networking + lifecycle view (peer counts, lifecycle state, pause metrics)
- **`myotis_beaconStatus`** — beacon light-client view (sync-committee periods, finalized/optimistic slots, verified execution state root, CL peers)

A wallet that speaks JSON-RPC can now check whether this Myotis node is synced / how far the light client has progressed, over the same endpoint it already uses for `eth_*` — instead of only seeing standard `eth_*` with no visibility into verified-read readiness.

## How

- These are **local introspection** methods, dispatched in `RpcRouter.handleOne` *before* the verified backend (the existing `myotis_rpcCoverage` precedent). They answer even when the node has no peers / isn't synced — precisely when a client wants to poll progress.
- New narrow **`io.myotis.api.NodeStatusReads`** interface (zero-dependency, FFI-portable: two flat records + a `long`) is the injection seam, keeping the RPC layer decoupled from the full engine surface.
- `JavaChainHandle` implements it; `ChainStack.startRpc()` injects it into `MyotisRpcServer`; `JavaMyotisEngine` late-binds it (`stack.setStatusReads(handle)`) to resolve the stack↔handle cycle — the handle exists before `handle.start()` → `stack.start()` → `startRpc()`, so the `volatile` field is a genuine happens-before.
- **`StatusJson.kt`** serializes the results, mirroring `CommandHandler.handleStatus` / `handleBeaconStatus` field-for-field (field names + order, the SYNCING-vs-synced branch, null handling, peer-id truncation, omitted null `clientId`). The `"ok":true` field is kept so the result object is drop-in identical to the IPC output.

## Branching

Based on **`main`** (not `rust-engine`). `jsonrpc-server/` is byte-identical on both branches — the Rust rewrite doesn't touch it — so this fast-forwards into `rust-engine` cleanly. The only follow-up needed there is wiring the Rust host (`RustChainHandle.startRpc`), which lives in the `myotis-engines` module that exists only on `rust-engine`; until then, `-Pengine=rust` gracefully returns `-32601` for these two methods (null default on the new ctor param).

## Testing

- `MyotisStatusRpcTest` (10 tests): exact-string shape parity vs. the IPC command output (both beacon branches), peer-id truncation, null-field handling (`""` to match IPC's `escapeJson(null)`), router dispatch returning a result without a backend, `-32601` when unwired, and `-32603` (not a raw 500) when a status read throws.
- Full `jsonrpc-server` suite green (58 tests): the new `NodeStatusReads` ctor param defaults to null, so the 44 existing router tests are unchanged.
- `myotis-api`, `node-core`, `app` compile clean. (Android module not compiled here — no SDK in CI env — but the change adds no Android-incompatible APIs.)

## Reviewed

An independent no-context review ran before this PR; its two should-fix findings are addressed in this branch (null peer-field parity → `""`; exception isolation around the status read → JSON-RPC error envelope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)