### PR TITLE
EL-C-1: myotis-evm foundation — SnapStateOracle + revm DatabaseRef adapter + caches

### DIFF
--- a/docs/reimplementation/07-el-implementation-plan.md
+++ b/docs/reimplementation/07-el-implementation-plan.md
@@ -357,8 +357,11 @@ Spec: doc 03 §§3–7, doc 04 §3. New crate `myotis-evm` (sans-I/O; revm gated
      SPIs. Validated by a real revm `transact` of an SLOAD-return contract through the adapter.
      Decisions: **revm `=41.0.0`, `default-features=false, features=["std"]`** — drops the
      C precompile backends (c-kzg/libsecp256k1/blst) for revm's pure-Rust fallbacks, so
-     `cargo tree` shows zero new C-linking crates (cargo-ndk/mobile-clean); revm's 1.91 MSRV
-     is met by the workspace `stable` toolchain. The oracle trait is **synchronous** (the
+     `cargo tree -p myotis-evm` COMPILES only k256 for crypto (`cargo tree -i c-kzg` /
+     `-i secp256k1-sys` print "nothing to print" — no C toolchain invoked, cargo-ndk/
+     mobile-clean). `c-kzg`/`secp256k1-sys` remain as unbuilt *entries* in the workspace
+     `Cargo.lock` (optional deps of `revm-precompile` that Cargo pins but our features never
+     enable). revm's 1.91 MSRV is met by the workspace `stable` toolchain. The oracle trait is **synchronous** (the
      async→sync bridge belongs in the I/O impl that wraps `ElReader`, not this sans-I/O
      crate); the **in-flight-dedup** tier is deferred to the async prefetch slice (a single
      synchronous `transact` reads serially, so the per-call view cache already dedups). Not

--- a/docs/reimplementation/07-el-implementation-plan.md
+++ b/docs/reimplementation/07-el-implementation-plan.md
@@ -348,6 +348,24 @@ Spec: doc 03 §§3–7, doc 04 §3. New crate `myotis-evm` (sans-I/O; revm gated
    `Database` adapter; three cache tiers (per-call view / in-flight dedup / cross-call
    `StateProofCache` keyed by stateRoot — cryptographic facts, safe to share); `BytecodeCache`
    forever-valid; sync↔async bridge off I/O threads.
+   - **Landed (EL-C-1).** `myotis-evm` crate: sync `SnapStateOracle` trait (`fetch_account`/
+     `fetch_storage`/`fetch_bytecode`) + `OracleAccount` + closed `OracleError`
+     (`StateUnavailable`/`BytecodeUnavailable`/`InvalidProof`/`BlockHashUnsupported`) +
+     `FixtureSnapStateOracle`; `OracleDatabase` implementing revm `DatabaseRef` (three-tier
+     read: per-call view → cross-call `StateProofCache` → oracle); `StateProofCache`
+     (Noop + bounded-LRU `InMemory`) and `BytecodeCache` (Noop + forever `InMemory`), both
+     SPIs. Validated by a real revm `transact` of an SLOAD-return contract through the adapter.
+     Decisions: **revm `=41.0.0`, `default-features=false, features=["std"]`** — drops the
+     C precompile backends (c-kzg/libsecp256k1/blst) for revm's pure-Rust fallbacks, so
+     `cargo tree` shows zero new C-linking crates (cargo-ndk/mobile-clean); revm's 1.91 MSRV
+     is met by the workspace `stable` toolchain. The oracle trait is **synchronous** (the
+     async→sync bridge belongs in the I/O impl that wraps `ElReader`, not this sans-I/O
+     crate); the **in-flight-dedup** tier is deferred to the async prefetch slice (a single
+     synchronous `transact` reads serially, so the per-call view cache already dedups). Not
+     on the wasm32 canary (revm pulls `std`). *Carried to EL-C-2:* the latest spec caps per-tx
+     gas at 2²⁴ (EIP-7825), so the 30 M `eth_call` ceiling needs the fork/`CfgEnv` selection
+     that C-2 owns; and precompile completeness under the pure-Rust backends (ecrecover via
+     k256, KZG via kzg-rs) must be verified when the EVM actually executes.
 2. **View calls + fork table.** Frame setup verbatim (zero-sender anonymous vs sender/value
    `eth_call` overload, `isStatic`, 30 M gas, EIP-7702 one-hop, BLOCKHASH unsupported →
    fail fast); mainnet fork schedule (throws below London; Shanghai keeps Istanbul

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -38,6 +38,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,13 +59,155 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "alloy-eip2124"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "741bdd7499908b3aa0b159bba11e71c8cddd009a2c2eb7a06e825f1ec87900a5"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "crc",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-eip2930"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9441120fa82df73e8959ae0e4ab8ade03de2aaae61be313fbf5746277847ce25"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "borsh",
+ "serde",
+]
+
+[[package]]
+name = "alloy-eip7702"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2919c5a56a1007492da313e7a3b6d45ef5edc5d33416fdec63c0d7a2702a0d20"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "borsh",
+ "k256",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-eip7928"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3b12337f74cbfa451cb04dac173974814a6ff463079e1793aa09600ba8813ab"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "borsh",
+ "once_cell",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea4c0453065b9206acc0f869a258dc8dcbbd595e144b4446f2c493a24a814d1f"
+dependencies = [
+ "alloy-eip2124",
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "alloy-eip7928",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "auto_impl",
+ "borsh",
+ "c-kzg",
+ "derive_more",
+ "either",
+ "serde",
+ "serde_with",
+ "sha2",
+]
+
+[[package]]
+name = "alloy-primitives"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4885c1409b6936c4898e646ef58baf6ec54edaf6d8179f79df805a7b85b7cf3e"
+dependencies = [
+ "alloy-rlp",
+ "bytes",
+ "cfg-if",
+ "const-hex",
+ "derive_more",
+ "foldhash 0.2.0",
+ "hashbrown 0.17.1",
+ "indexmap 2.14.0",
+ "itoa",
+ "k256",
+ "keccak-asm",
+ "paste",
+ "proptest",
+ "rand 0.9.4",
+ "rapidhash",
+ "ruint",
+ "rustc-hash",
+ "secp256k1",
+ "serde",
+ "sha3 0.11.0",
+]
+
+[[package]]
 name = "alloy-rlp"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24671b1f62edcf0f9b62994c7bf72cd621a04a4b99f5020ece1a647b40e2f103"
 dependencies = [
+ "alloy-rlp-derive",
  "arrayvec",
  "bytes",
+]
+
+[[package]]
+name = "alloy-rlp-derive"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d4311c03125e8a18296504560b9de3d75ecbd0dcda7f71e6cf2a196d57e6fba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e97b3e0b9f816b25083045dcfa69431bd059a078e828e4d82d296d1949b96c"
+dependencies = [
+ "alloy-primitives",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -61,6 +215,370 @@ name = "anyhow"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+
+[[package]]
+name = "ark-bls12-381"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df4dcc01ff89867cd86b0da835f23c3f02738353aaee7dde7495af71363b8d5"
+dependencies = [
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+]
+
+[[package]]
+name = "ark-bn254"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
+dependencies = [
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-r1cs-std",
+ "ark-std 0.5.0",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
+dependencies = [
+ "ahash",
+ "ark-ff 0.5.0",
+ "ark-poly",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.5",
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
+dependencies = [
+ "ark-ff-asm 0.3.0",
+ "ark-ff-macros 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
+ "derivative",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version 0.3.3",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
+dependencies = [
+ "ark-ff-asm 0.4.2",
+ "ark-ff-macros 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "derivative",
+ "digest 0.10.7",
+ "itertools 0.10.5",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version 0.4.1",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
+dependencies = [
+ "ark-ff-asm 0.5.0",
+ "ark-ff-macros 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "arrayvec",
+ "digest 0.10.7",
+ "educe",
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7a806ac6c8307b929df4645776290a50ee2aac754ad09d8bdf73391309e43af"
+dependencies = [
+ "ark-ff-asm 0.6.0",
+ "ark-ff-macros 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "digest 0.10.7",
+ "educe",
+ "num-bigint",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
+dependencies = [
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1479009684adc073dff49a1025d3a7065b317a9ead25aaaca38cdc70058ba8a2"
+dependencies = [
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0691ed21ef00ef89c1e9bda832eba493dda3ec2f8d892fb25b705f73f06bb8"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "ark-poly"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
+dependencies = [
+ "ahash",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "ark-r1cs-std"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941551ef1df4c7a401de7068758db6503598e6f01850bdb2cfdb614a1f9dbea1"
+dependencies = [
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-relations",
+ "ark-std 0.5.0",
+ "educe",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "tracing",
+]
+
+[[package]]
+name = "ark-relations"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec46ddc93e7af44bcab5230937635b06fb5744464dd6a7e7b083e80ebd274384"
+dependencies = [
+ "ark-ff 0.5.0",
+ "ark-std 0.5.0",
+ "tracing",
+ "tracing-subscriber 0.2.25",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
+dependencies = [
+ "ark-std 0.3.0",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
+dependencies = [
+ "ark-std 0.4.0",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
+dependencies = [
+ "ark-serialize-derive 0.5.0",
+ "ark-std 0.5.0",
+ "arrayvec",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a74dd304fd536fb95d0a328e72be759209cc496a9da094c5bc56e5fea4f9e86b"
+dependencies = [
+ "ark-serialize-derive 0.6.0",
+ "ark-std 0.6.0",
+ "digest 0.10.7",
+ "num-bigint",
+ "serde_with",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f153690697a2b91e5e1251ff98411ee5371500a111a0fd317a70e588eb300f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "367c9c827ed431bff6868b7aa926e05b16eb46603cc8b6e768e4a5553fa1d155"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+]
 
 [[package]]
 name = "arrayref"
@@ -98,7 +616,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -110,7 +628,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -145,7 +663,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -177,6 +695,27 @@ dependencies = [
  "http",
  "log",
  "url",
+]
+
+[[package]]
+name = "aurora-engine-modexp"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "518bc5745a6264b5fd7b09dffb9667e400ee9e2bbe18555fac75e1fe9afa0df9"
+dependencies = [
+ "hex",
+ "num",
+]
+
+[[package]]
+name = "auto_impl"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -226,10 +765,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitcoin-consensus-encoding"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2d6094e2a1ba3c93b5a596fe5a10d1a10c3c6e06785cde89f693a044c01aa40"
+dependencies = [
+ "bitcoin-internals",
+]
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a30a22d1f112dde8e16be7b45c63645dc165cef254f835b3e1e9553e485cfa64"
+dependencies = [
+ "hex-conservative 0.3.2",
+]
+
+[[package]]
+name = "bitcoin-io"
+version = "0.1.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb5de036369d1ac59d3c1819ebc4d850f89466f5401c571a285b6ed564a4cb78"
+dependencies = [
+ "bitcoin-consensus-encoding",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bca4c7abb40c8817d77403c880988cfd484f23ab2365726afb2f798363e2c4a2"
+dependencies = [
+ "bitcoin-io",
+ "hex-conservative 0.2.2",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "bitvec"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
 
 [[package]]
 name = "blake2"
@@ -237,7 +840,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -250,6 +853,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "blst"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,6 +871,30 @@ dependencies = [
  "glob",
  "threadpool",
  "zeroize",
+]
+
+[[package]]
+name = "borsh"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
+dependencies = [
+ "borsh-derive",
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8fb4fb5740e4b2c4884ff95f5f32f5e8479db1e8fd8eb49ddbe09eb09bb7c"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -277,6 +913,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "byte-slice-cast"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,6 +929,24 @@ name = "bytes"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "c-kzg"
+version = "2.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6648ed1e4ea8e8a1a4a2c78e1cda29a3fd500bc622899c340d8525ea9a76b24a"
+dependencies = [
+ "blst",
+ "cc",
+ "glob",
+ "hex",
+ "libc",
+ "once_cell",
+ "serde",
+]
 
 [[package]]
 name = "cc"
@@ -352,12 +1012,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
  "zeroize",
 ]
@@ -382,6 +1054,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-hex"
+version = "1.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e2a781ebdf4467d1428dc4593067825fb646f6871475098d8577421af73558"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "proptest",
+ "serde_core",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,6 +1076,36 @@ name = "const-str"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f421161cb492475f1661ddc9815a745a1c894592070661180fdec3d4872e9c3"
+
+[[package]]
+name = "const_format"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
+dependencies = [
+ "const_format_proc_macros",
+ "konst",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "core-foundation"
@@ -426,6 +1140,21 @@ checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "critical-section"
@@ -487,6 +1216,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,9 +1242,9 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
- "rustc_version",
+ "rustc_version 0.4.1",
  "subtle",
  "zeroize",
 ]
@@ -519,7 +1257,41 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -545,7 +1317,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -588,6 +1360,63 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive-where"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.1",
+ "syn 2.0.118",
+ "unicode-xid",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "digest"
@@ -595,10 +1424,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -627,7 +1466,7 @@ dependencies = [
  "socket2 0.6.4",
  "tokio",
  "tracing",
- "uint",
+ "uint 0.10.0",
  "zeroize",
 ]
 
@@ -639,7 +1478,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -649,13 +1488,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -688,6 +1533,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -701,7 +1558,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -728,7 +1585,7 @@ dependencies = [
  "log",
  "rand 0.8.6",
  "serde",
- "sha3",
+ "sha3 0.10.9",
  "zeroize",
 ]
 
@@ -741,7 +1598,27 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07f808d588c10e464ea6f7d3eaed500049eff30aaac103460f61828c2d65b3eb"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e528e2d34ba8a67a1a650b86beae8ef69fc5fdb638016f386b973226590432"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -773,6 +1650,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fastrlp"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139834ddba373bbdd213dffe02c8d110508dcf1726c2be27e8d1f7d7e1856418"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "bytes",
+]
+
+[[package]]
+name = "fastrlp"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce8dba4714ef14b8274c371879b175aa55b16b30f269663f19d576f380018dc4"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "bytes",
+]
+
+[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -793,6 +1698,18 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixed-hash"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
+dependencies = [
+ "byteorder",
+ "rand 0.8.6",
+ "rustc-hex",
+ "static_assertions",
+]
 
 [[package]]
 name = "fnv"
@@ -820,6 +1737,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -897,7 +1820,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1035,7 +1958,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1044,10 +1967,17 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
  "foldhash 0.1.5",
 ]
 
@@ -1065,6 +1995,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "hashlink"
@@ -1101,6 +2036,24 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-conservative"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "hex-conservative"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830e599c2904b08f0834ee6337d8fe8f0ed4a63b5d9e7a7f49c0ffa06d08d360"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "hickory-proto"
@@ -1164,7 +2117,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1207,6 +2160,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1245,6 +2207,30 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1330,6 +2316,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1405,6 +2397,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-codec"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-trait-for-tuples"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1412,6 +2435,8 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1441,6 +2466,24 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1498,7 +2541,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1534,6 +2577,41 @@ checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
  "cpufeatures 0.2.17",
 ]
+
+[[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "keccak-asm"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5dc2c0d691cbf7595cde551ced329cca99c2387c2cbc97754c5d0cd045d3ee"
+dependencies = [
+ "digest 0.10.7",
+ "sha3-asm",
+]
+
+[[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "lazy_static"
@@ -1817,7 +2895,7 @@ checksum = "dd297cf53f0cb3dee4d2620bb319ae47ef27c702684309f682bdb7e55a18ae9c"
 dependencies = [
  "heck",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1926,7 +3004,7 @@ checksum = "757aee279b8bdbb9f9e676796fd459e4207a1f986e87886700abf589f5abf771"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2060,7 +3138,7 @@ name = "myotis-core"
 version = "0.1.0"
 dependencies = [
  "k256",
- "sha3",
+ "sha3 0.10.9",
 ]
 
 [[package]]
@@ -2075,7 +3153,15 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.23",
+]
+
+[[package]]
+name = "myotis-evm"
+version = "0.1.0"
+dependencies = [
+ "myotis-core",
+ "revm",
 ]
 
 [[package]]
@@ -2094,13 +3180,13 @@ dependencies = [
  "myotis-consensus",
  "myotis-core",
  "sha2",
- "sha3",
+ "sha3 0.10.9",
  "snap",
  "socket2 0.5.10",
  "subtle",
  "tokio",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -2180,6 +3266,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nonmax"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2189,12 +3281,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
  "num-traits",
 ]
 
@@ -2214,12 +3329,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2256,6 +3393,46 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "parity-scale-codec"
+version = "3.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799781ae679d79a948e13d4824a40970bfa500058d245760dd857301059810fa"
+dependencies = [
+ "arrayvec",
+ "bitvec",
+ "byte-slice-cast",
+ "const_format",
+ "impl-trait-for-tuples",
+ "parity-scale-codec-derive",
+ "rustversion",
+ "serde",
+]
+
+[[package]]
+name = "parity-scale-codec-derive"
+version = "3.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b4653168b563151153c9e4c08ebed57fb8262bebfa79711552fa983c623e7a"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "parking"
@@ -2309,6 +3486,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pest"
+version = "2.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47627dd7305c6a2d6c8c6bcd24c5a4c17dbbf425f4f9c5313e724b38fc9782e9"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2325,7 +3555,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2412,6 +3642,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
+dependencies = [
+ "fixed-hash",
+ "impl-codec",
+ "uint 0.9.5",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2440,7 +3699,26 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
 ]
 
 [[package]]
@@ -2460,11 +3738,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-protobuf"
@@ -2568,6 +3852,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2586,6 +3876,7 @@ checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+ "serde",
 ]
 
 [[package]]
@@ -2635,6 +3926,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+ "serde",
 ]
 
 [[package]]
@@ -2650,6 +3942,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rapidhash"
+version = "4.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5da7e78a036ce858e8d55b7e7dc8ba3a88b78350fd2155d3591bbd966b58589e"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -2672,6 +3982,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2698,6 +4028,199 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
+name = "revm"
+version = "41.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d51c254839fb36357d0b02d02e46ba57e683d7b017e2da33b47ae74685a9e59"
+dependencies = [
+ "revm-bytecode",
+ "revm-context",
+ "revm-context-interface",
+ "revm-database",
+ "revm-database-interface",
+ "revm-handler",
+ "revm-inspector",
+ "revm-interpreter",
+ "revm-precompile",
+ "revm-primitives",
+ "revm-state",
+]
+
+[[package]]
+name = "revm-bytecode"
+version = "41.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e33493cf6d996e9242db4f2002caef48ec9aa8c4f3fff3b18aed10ef3942eec7"
+dependencies = [
+ "bitvec",
+ "phf",
+ "revm-primitives",
+ "serde",
+]
+
+[[package]]
+name = "revm-context"
+version = "41.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86e48fc736d9542c082ea5305be44b6a14b53a615f0147ad57f62189fd813068"
+dependencies = [
+ "bitvec",
+ "cfg-if",
+ "derive-where",
+ "revm-bytecode",
+ "revm-context-interface",
+ "revm-database-interface",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-context-interface"
+version = "41.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac68282a454318246817486835a446519291dd0a8167d09de14c7e96f2147696"
+dependencies = [
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "auto_impl",
+ "either",
+ "revm-database-interface",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-database"
+version = "41.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d761681a43e48408ea23f7f66ff56ff7b6128cadb8f9135d1b94787d0c0fc6b4"
+dependencies = [
+ "alloy-eips",
+ "derive_more",
+ "either",
+ "revm-bytecode",
+ "revm-database-interface",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-database-interface"
+version = "41.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96e37d62fa60b45987b408486c84ebef4af4e7ddf1b3b96b4955a7263fd4e92"
+dependencies = [
+ "auto_impl",
+ "either",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "revm-handler"
+version = "41.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5e043ebfc0899c435e44475796285898e4f822e637bd67856da79cc170bd9df"
+dependencies = [
+ "auto_impl",
+ "derive-where",
+ "revm-bytecode",
+ "revm-context",
+ "revm-context-interface",
+ "revm-database-interface",
+ "revm-interpreter",
+ "revm-precompile",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-inspector"
+version = "41.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e470b2a5e177918944d8cd26174455b61b8fbfbbe7fe411d28b4097e410d11e"
+dependencies = [
+ "auto_impl",
+ "either",
+ "revm-context",
+ "revm-database-interface",
+ "revm-handler",
+ "revm-interpreter",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "revm-interpreter"
+version = "41.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa5547f653f9e4c47b4f9a9075a0b7c0faea5fa29b7873f392733a943837825d"
+dependencies = [
+ "revm-bytecode",
+ "revm-context-interface",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-precompile"
+version = "41.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d785931e4b8750cf9d79c808c22f05979c8d191baafc8badd4651db82584c1c"
+dependencies = [
+ "ark-bls12-381",
+ "ark-bn254",
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "arrayref",
+ "aurora-engine-modexp",
+ "c-kzg",
+ "cfg-if",
+ "k256",
+ "p256",
+ "revm-context-interface",
+ "revm-primitives",
+ "ripemd",
+ "secp256k1",
+ "sha2",
+]
+
+[[package]]
+name = "revm-primitives"
+version = "41.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66f39151a31afe93d97f7ac894dd9dcc989368d5ccba19ce079bfc1d73b77452"
+dependencies = [
+ "alloy-primitives",
+ "once_cell",
+ "serde",
+]
+
+[[package]]
+name = "revm-state"
+version = "41.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ef2fffc28acc41e8ef7525f2b1d16288a10f80579a1b33e7e62abc9892314a"
+dependencies = [
+ "alloy-eip7928",
+ "bitflags",
+ "nonmax",
+ "revm-bytecode",
+ "revm-primitives",
+ "serde",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2722,6 +4245,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "ripemd"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "rlp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
+dependencies = [
+ "bytes",
+ "rustc-hex",
+]
+
+[[package]]
 name = "rtnetlink"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2740,10 +4282,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruint"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45caf26f647c19115bf9c453c70ffe4a4a3a6390dceebd942610584f99b8ddce"
+dependencies = [
+ "alloy-rlp",
+ "ark-ff 0.3.0",
+ "ark-ff 0.4.2",
+ "ark-ff 0.5.0",
+ "ark-ff 0.6.0",
+ "bytes",
+ "fastrlp 0.3.1",
+ "fastrlp 0.4.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "parity-scale-codec",
+ "primitive-types",
+ "proptest",
+ "rand 0.8.6",
+ "rand 0.9.4",
+ "rlp",
+ "ruint-macro",
+ "serde_core",
+ "valuable",
+ "zeroize",
+]
+
+[[package]]
+name = "ruint-macro"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
+
+[[package]]
+name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
+]
 
 [[package]]
 name = "rustc_version"
@@ -2751,7 +4343,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver",
+ "semver 1.0.28",
 ]
 
 [[package]]
@@ -2818,6 +4410,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "rw-stream-sink"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2835,6 +4439,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2858,10 +4486,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "secp256k1"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
+dependencies = [
+ "bitcoin_hashes",
+ "rand 0.9.4",
+ "secp256k1-sys",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb913707158fadaf0d8702c2db0e857de66eb003ccfdda5924b5f5ac98efb38"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "semver-parser"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "serde"
@@ -2890,7 +4556,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2899,11 +4565,44 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+dependencies = [
+ "base64",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2914,7 +4613,7 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2923,8 +4622,28 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
- "digest",
- "keccak",
+ "digest 0.10.7",
+ "keccak 0.1.6",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.3",
+ "keccak 0.2.0",
+]
+
+[[package]]
+name = "sha3-asm"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6287fd675f713484342a89cbf0a386abef5f15919cfad607e5e1f19e1e15331"
+dependencies = [
+ "cc",
+ "cfg-if",
 ]
 
 [[package]]
@@ -2958,7 +4677,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -2998,7 +4717,7 @@ dependencies = [
  "curve25519-dalek",
  "rand_core 0.6.4",
  "ring",
- "rustc_version",
+ "rustc_version 0.4.1",
  "sha2",
  "subtle",
 ]
@@ -3046,10 +4765,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -3070,7 +4806,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3101,6 +4837,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3126,7 +4881,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3137,7 +4892,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3237,7 +4992,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3252,6 +5007,36 @@ dependencies = [
  "pin-project-lite",
  "slab",
  "tokio",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap 2.14.0",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
 ]
 
 [[package]]
@@ -3280,7 +5065,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3301,6 +5086,15 @@ checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
  "log",
  "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
+dependencies = [
  "tracing-core",
 ]
 
@@ -3335,6 +5129,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "uint"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
 name = "uint"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3347,10 +5159,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "universal-hash"
@@ -3358,7 +5188,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -3420,6 +5250,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"
@@ -3487,7 +5326,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
@@ -3578,7 +5417,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3589,7 +5428,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3795,6 +5634,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3805,6 +5653,15 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "x25519-dalek"
@@ -3909,7 +5766,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -3930,7 +5787,7 @@ checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3950,7 +5807,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -3971,7 +5828,7 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4004,7 +5861,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -14,6 +14,10 @@
 #   myotis-net       — ALL consensus-layer I/O: discv5 discovery, libp2p eth2
 #                      req/resp, and the sync loop driving myotis-consensus.
 #                      Depends on myotis-consensus; never the other way around.
+#   myotis-evm       — the EVM: eth_call / gas-estimation over SNAP-proof-verified
+#                      state (revm behind a SnapStateOracle trait; sans-I/O). THE
+#                      one heavy EL dep (revm) is gated to this crate. Grows through
+#                      the EL-phase Milestone-C PRs (docs/reimplementation/07).
 #   myotis-engine    — the Rust implementation of the io.myotis.api engine contract,
 #                      exposed to the JVM via hand-JNI (libmyotis_engine).
 #
@@ -22,7 +26,7 @@
 
 [workspace]
 resolver = "2"
-members = ["myotis-bls", "myotis-consensus", "myotis-core", "myotis-engine", "myotis-net"]
+members = ["myotis-bls", "myotis-consensus", "myotis-core", "myotis-evm", "myotis-engine", "myotis-net"]
 
 # Release profile is workspace-owned (crate-level [profile.*] is ignored in a
 # workspace): same tuning myotis-bls always shipped with.

--- a/rust/myotis-evm/Cargo.toml
+++ b/rust/myotis-evm/Cargo.toml
@@ -16,10 +16,14 @@ myotis-core = { path = "../myotis-core" }
 # revm — the EVM. THE one heavy EL dependency, deliberately gated to this crate
 # (docs/reimplementation/07, Milestone C). `default-features = false` + `std`
 # only drops revm's C-building precompile backends (c-kzg, libsecp256k1, blst)
-# in favour of its pure-Rust fallbacks (k256, kzg-rs): `cargo tree` over this
-# graph shows ZERO C-linking crates, so it adds no cargo-ndk / mobile cross-build
-# burden beyond the blst already in myotis-bls. Exact-pinned like every workspace
-# dep; a revm bump is a deliberate, reviewed change (its API churns across majors).
+# in favour of its pure-Rust fallbacks (k256, …). `cargo tree -p myotis-evm`
+# COMPILES only k256 for crypto — `cargo tree -i c-kzg` / `-i secp256k1-sys` print
+# "nothing to print", so no C toolchain is invoked for this crate's build (no
+# cargo-ndk / mobile burden). NB: `c-kzg` and `secp256k1-sys` still appear as
+# ENTRIES in the workspace `Cargo.lock` — they are optional deps of `revm-precompile`
+# that Cargo pins for reproducibility but our feature selection never enables or
+# builds. Exact-pinned like every workspace dep; a revm bump is a deliberate,
+# reviewed change (its API churns across majors).
 revm = { version = "=41.0.0", default-features = false, features = ["std"] }
 
 [features]

--- a/rust/myotis-evm/Cargo.toml
+++ b/rust/myotis-evm/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "myotis-evm"
+version = "0.1.0"
+edition = "2021"
+description = "Myotis EVM: view-call / gas-estimation over SNAP-proof-verified state (revm behind a SnapStateOracle trait; sans-I/O). Grows through the EL-phase Milestone-C PRs (docs/reimplementation/07)."
+license = "MIT OR Apache-2.0"
+
+# Sans-I/O like myotis-core / myotis-consensus: no tokio, sockets, fs, clock, or
+# entropy in this crate. The oracle trait is SYNCHRONOUS by contract — the
+# async→sync bridge (blocking on the tokio snap-fetch path) lives in the I/O
+# crate that implements the trait, never here (see the SnapStateOracle docs).
+# NOT on the wasm32 canary: revm pulls `std`, so this crate is host/mobile only.
+[dependencies]
+myotis-core = { path = "../myotis-core" }
+
+# revm — the EVM. THE one heavy EL dependency, deliberately gated to this crate
+# (docs/reimplementation/07, Milestone C). `default-features = false` + `std`
+# only drops revm's C-building precompile backends (c-kzg, libsecp256k1, blst)
+# in favour of its pure-Rust fallbacks (k256, kzg-rs): `cargo tree` over this
+# graph shows ZERO C-linking crates, so it adds no cargo-ndk / mobile cross-build
+# burden beyond the blst already in myotis-bls. Exact-pinned like every workspace
+# dep; a revm bump is a deliberate, reviewed change (its API churns across majors).
+revm = { version = "=41.0.0", default-features = false, features = ["std"] }
+
+[features]
+# In-memory FixtureSnapStateOracle for downstream tests (the engine crate's
+# EVM tests). Off by default so it never ships in the engine .so; the crate's
+# own tests see it through `cfg(test)`.
+fixture = []

--- a/rust/myotis-evm/src/cache.rs
+++ b/rust/myotis-evm/src/cache.rs
@@ -1,0 +1,199 @@
+//! The EVM state caches.
+//!
+//! Two of the three cache tiers the Java `myotis-evm` uses live here (the third,
+//! the per-call view cache, is private to [`crate::database::OracleDatabase`]
+//! because it is bound to one `eth_call` run):
+//!
+//! * [`StateProofCache`] — the CROSS-CALL cache, keyed by `stateRoot`. An entry
+//!   is stored only *after* its MPT proof verified against that root, and state
+//!   at a fixed `stateRoot` is immutable — so a cached `(stateRoot, address[,
+//!   slot]) → value` is a cryptographic fact, not peer-trusted data. Reusing it
+//!   across any call pinned to that same root is sound, which is what lets a
+//!   MetaMask number-pinned retry (the identical call, over and over) converge
+//!   instead of re-fetching hundreds of proofs each time.
+//! * [`BytecodeCache`] — code is content-addressed (`keccak256(code) == codeHash`)
+//!   and therefore immutable forever, so this cache never evicts and is safe to
+//!   share across calls and (later) persist across sessions.
+//!
+//! Both are traits (SPIs) so a wallet host can later swap the in-memory backend
+//! for a persistent one without touching the EVM. The defaults are a no-op
+//! (correct, just cold) and a bounded in-memory LRU.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use revm::primitives::{Bytes, U256};
+
+use crate::oracle::OracleAccount;
+
+/// Cross-call, `stateRoot`-keyed cache of proof-verified account and storage
+/// facts. Every getter/putter takes the `stateRoot` the fact was proven against;
+/// implementations MUST NOT return a value cached under a different root.
+pub trait StateProofCache: Send + Sync {
+    fn get_account(&self, state_root: &[u8; 32], address: &[u8; 20]) -> Option<OracleAccount>;
+    fn put_account(&self, state_root: &[u8; 32], address: &[u8; 20], account: &OracleAccount);
+    fn get_storage(&self, state_root: &[u8; 32], address: &[u8; 20], slot: &U256) -> Option<U256>;
+    fn put_storage(&self, state_root: &[u8; 32], address: &[u8; 20], slot: &U256, value: U256);
+}
+
+/// The default: caches nothing (every read goes to the oracle). Correct, cold —
+/// used until a host installs [`InMemoryStateProofCache`].
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NoopStateProofCache;
+
+impl StateProofCache for NoopStateProofCache {
+    fn get_account(&self, _root: &[u8; 32], _addr: &[u8; 20]) -> Option<OracleAccount> {
+        None
+    }
+    fn put_account(&self, _root: &[u8; 32], _addr: &[u8; 20], _account: &OracleAccount) {}
+    fn get_storage(&self, _root: &[u8; 32], _addr: &[u8; 20], _slot: &U256) -> Option<U256> {
+        None
+    }
+    fn put_storage(&self, _root: &[u8; 32], _addr: &[u8; 20], _slot: &U256, _value: U256) {}
+}
+
+type AccountKey = ([u8; 32], [u8; 20]);
+type StorageKey = ([u8; 32], [u8; 20], U256);
+
+/// A bounded, in-memory [`StateProofCache`]. Accounts and storage slots are
+/// bounded independently at `max_per_kind` entries, each evicting least-recently
+/// used. Thread-safe via a `Mutex` per kind (contention is trivial next to a
+/// network proof fetch).
+pub struct InMemoryStateProofCache {
+    accounts: Mutex<Lru<AccountKey, OracleAccount>>,
+    storage: Mutex<Lru<StorageKey, U256>>,
+}
+
+impl InMemoryStateProofCache {
+    /// `max_per_kind` bounds the account cache and the storage cache separately
+    /// (mirrors the Java `StateProofCache.inMemory(maxEntriesPerKind)`).
+    pub fn new(max_per_kind: usize) -> InMemoryStateProofCache {
+        InMemoryStateProofCache {
+            accounts: Mutex::new(Lru::new(max_per_kind)),
+            storage: Mutex::new(Lru::new(max_per_kind)),
+        }
+    }
+}
+
+impl StateProofCache for InMemoryStateProofCache {
+    fn get_account(&self, root: &[u8; 32], addr: &[u8; 20]) -> Option<OracleAccount> {
+        self.accounts.lock().unwrap().get(&(*root, *addr)).cloned()
+    }
+    fn put_account(&self, root: &[u8; 32], addr: &[u8; 20], account: &OracleAccount) {
+        self.accounts
+            .lock()
+            .unwrap()
+            .put((*root, *addr), account.clone());
+    }
+    fn get_storage(&self, root: &[u8; 32], addr: &[u8; 20], slot: &U256) -> Option<U256> {
+        self.storage
+            .lock()
+            .unwrap()
+            .get(&(*root, *addr, *slot))
+            .copied()
+    }
+    fn put_storage(&self, root: &[u8; 32], addr: &[u8; 20], slot: &U256, value: U256) {
+        self.storage
+            .lock()
+            .unwrap()
+            .put((*root, *addr, *slot), value);
+    }
+}
+
+/// Content-addressed bytecode cache: `codeHash → code`. Immutable forever, so no
+/// eviction and safe to share across calls (and sessions, once persisted).
+pub trait BytecodeCache: Send + Sync {
+    fn get(&self, code_hash: &[u8; 32]) -> Option<Bytes>;
+    fn put(&self, code_hash: &[u8; 32], code: Bytes);
+}
+
+/// The default: caches nothing.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NoopBytecodeCache;
+
+impl BytecodeCache for NoopBytecodeCache {
+    fn get(&self, _code_hash: &[u8; 32]) -> Option<Bytes> {
+        None
+    }
+    fn put(&self, _code_hash: &[u8; 32], _code: Bytes) {}
+}
+
+/// Unbounded in-memory bytecode cache (content-addressed → never evicts).
+#[derive(Default)]
+pub struct InMemoryBytecodeCache {
+    map: Mutex<HashMap<[u8; 32], Bytes>>,
+}
+
+impl InMemoryBytecodeCache {
+    pub fn new() -> InMemoryBytecodeCache {
+        InMemoryBytecodeCache::default()
+    }
+}
+
+impl BytecodeCache for InMemoryBytecodeCache {
+    fn get(&self, code_hash: &[u8; 32]) -> Option<Bytes> {
+        self.map.lock().unwrap().get(code_hash).cloned()
+    }
+    fn put(&self, code_hash: &[u8; 32], code: Bytes) {
+        // Content-addressed: first writer wins; a re-put is the identical blob.
+        self.map.lock().unwrap().entry(*code_hash).or_insert(code);
+    }
+}
+
+/// A tiny least-recently-used map: O(1) `get`/`put`, O(n) eviction scan only when
+/// a new key overflows `cap` (n is the cap, negligible beside the network fetch
+/// an eviction stands in for). Recency is a monotonically increasing tick, not a
+/// wall clock — safe in the sans-I/O crate. `cap == 0` disables caching.
+struct Lru<K, V> {
+    cap: usize,
+    tick: u64,
+    map: HashMap<K, (V, u64)>,
+}
+
+impl<K: std::hash::Hash + Eq + Clone, V> Lru<K, V> {
+    fn new(cap: usize) -> Lru<K, V> {
+        Lru {
+            cap,
+            tick: 0,
+            map: HashMap::new(),
+        }
+    }
+
+    fn get(&mut self, key: &K) -> Option<&V> {
+        self.tick = self.tick.wrapping_add(1);
+        let tick = self.tick;
+        match self.map.get_mut(key) {
+            Some(entry) => {
+                entry.1 = tick;
+                Some(&entry.0)
+            }
+            None => None,
+        }
+    }
+
+    fn put(&mut self, key: K, value: V) {
+        if self.cap == 0 {
+            return;
+        }
+        self.tick = self.tick.wrapping_add(1);
+        let tick = self.tick;
+        if !self.map.contains_key(&key) && self.map.len() >= self.cap {
+            self.evict_lru();
+        }
+        self.map.insert(key, (value, tick));
+    }
+
+    fn evict_lru(&mut self) {
+        // Lowest tick == least recently touched. Ticks are monotonic within the
+        // map's lifetime; a `wrapping_add` overflow would need 2^64 operations,
+        // far beyond any process lifetime, so ordering is effectively total.
+        if let Some(victim) = self
+            .map
+            .iter()
+            .min_by_key(|(_, (_, t))| *t)
+            .map(|(k, _)| k.clone())
+        {
+            self.map.remove(&victim);
+        }
+    }
+}

--- a/rust/myotis-evm/src/cache.rs
+++ b/rust/myotis-evm/src/cache.rs
@@ -29,9 +29,25 @@ use crate::oracle::OracleAccount;
 /// Cross-call, `stateRoot`-keyed cache of proof-verified account and storage
 /// facts. Every getter/putter takes the `stateRoot` the fact was proven against;
 /// implementations MUST NOT return a value cached under a different root.
+///
+/// `get_account` returns `Option<Option<OracleAccount>>` so the two "absents" stay
+/// distinct: the OUTER `None` is a cache miss, while `Some(None)` is the cached,
+/// proof-verified fact that the account is ABSENT at this root. Absent-account
+/// reads are common in EVM execution (any never-touched address), so caching the
+/// exclusion proof — like storage caches a zero slot — keeps a repeated call from
+/// going cold to the oracle each time.
 pub trait StateProofCache: Send + Sync {
-    fn get_account(&self, state_root: &[u8; 32], address: &[u8; 20]) -> Option<OracleAccount>;
-    fn put_account(&self, state_root: &[u8; 32], address: &[u8; 20], account: &OracleAccount);
+    fn get_account(
+        &self,
+        state_root: &[u8; 32],
+        address: &[u8; 20],
+    ) -> Option<Option<OracleAccount>>;
+    fn put_account(
+        &self,
+        state_root: &[u8; 32],
+        address: &[u8; 20],
+        account: Option<OracleAccount>,
+    );
     fn get_storage(&self, state_root: &[u8; 32], address: &[u8; 20], slot: &U256) -> Option<U256>;
     fn put_storage(&self, state_root: &[u8; 32], address: &[u8; 20], slot: &U256, value: U256);
 }
@@ -42,10 +58,10 @@ pub trait StateProofCache: Send + Sync {
 pub struct NoopStateProofCache;
 
 impl StateProofCache for NoopStateProofCache {
-    fn get_account(&self, _root: &[u8; 32], _addr: &[u8; 20]) -> Option<OracleAccount> {
+    fn get_account(&self, _root: &[u8; 32], _addr: &[u8; 20]) -> Option<Option<OracleAccount>> {
         None
     }
-    fn put_account(&self, _root: &[u8; 32], _addr: &[u8; 20], _account: &OracleAccount) {}
+    fn put_account(&self, _root: &[u8; 32], _addr: &[u8; 20], _account: Option<OracleAccount>) {}
     fn get_storage(&self, _root: &[u8; 32], _addr: &[u8; 20], _slot: &U256) -> Option<U256> {
         None
     }
@@ -58,9 +74,10 @@ type StorageKey = ([u8; 32], [u8; 20], U256);
 /// A bounded, in-memory [`StateProofCache`]. Accounts and storage slots are
 /// bounded independently at `max_per_kind` entries, each evicting least-recently
 /// used. Thread-safe via a `Mutex` per kind (contention is trivial next to a
-/// network proof fetch).
+/// network proof fetch). The account value is `Option<OracleAccount>` so a
+/// proof-verified ABSENCE (`None`) is cached too.
 pub struct InMemoryStateProofCache {
-    accounts: Mutex<Lru<AccountKey, OracleAccount>>,
+    accounts: Mutex<Lru<AccountKey, Option<OracleAccount>>>,
     storage: Mutex<Lru<StorageKey, U256>>,
 }
 
@@ -76,14 +93,11 @@ impl InMemoryStateProofCache {
 }
 
 impl StateProofCache for InMemoryStateProofCache {
-    fn get_account(&self, root: &[u8; 32], addr: &[u8; 20]) -> Option<OracleAccount> {
+    fn get_account(&self, root: &[u8; 32], addr: &[u8; 20]) -> Option<Option<OracleAccount>> {
         self.accounts.lock().unwrap().get(&(*root, *addr)).cloned()
     }
-    fn put_account(&self, root: &[u8; 32], addr: &[u8; 20], account: &OracleAccount) {
-        self.accounts
-            .lock()
-            .unwrap()
-            .put((*root, *addr), account.clone());
+    fn put_account(&self, root: &[u8; 32], addr: &[u8; 20], account: Option<OracleAccount>) {
+        self.accounts.lock().unwrap().put((*root, *addr), account);
     }
     fn get_storage(&self, root: &[u8; 32], addr: &[u8; 20], slot: &U256) -> Option<U256> {
         self.storage

--- a/rust/myotis-evm/src/database.rs
+++ b/rust/myotis-evm/src/database.rs
@@ -78,22 +78,23 @@ impl OracleDatabase {
         if let Some(cached) = self.view.lock().unwrap().accounts.get(&addr) {
             return Ok(cached.clone());
         }
-        // Tier 2 — a verified fact from an earlier call at this root.
-        if let Some(acc) = self.proof_cache.get_account(&self.state_root, &addr) {
+        // Tier 2 — a verified fact from an earlier call at this root. `Some(None)`
+        // is a cached ABSENCE (exclusion proof), still a hit — don't re-fetch.
+        if let Some(maybe_acc) = self.proof_cache.get_account(&self.state_root, &addr) {
             self.view
                 .lock()
                 .unwrap()
                 .accounts
-                .insert(addr, Some(acc.clone()));
-            return Ok(Some(acc));
+                .insert(addr, maybe_acc.clone());
+            return Ok(maybe_acc);
         }
         // Tier 3 — a fresh verified fetch. The lock is NOT held across it: the
         // oracle may block on the network, and a call runs single-threaded so
-        // there is no concurrent view-cache writer to race.
+        // there is no concurrent view-cache writer to race. Both a present account
+        // and a proven absence (`None`) are promoted to the cross-call cache.
         let fetched = self.oracle.fetch_account(&self.state_root, addr)?;
-        if let Some(ref acc) = fetched {
-            self.proof_cache.put_account(&self.state_root, &addr, acc);
-        }
+        self.proof_cache
+            .put_account(&self.state_root, &addr, fetched.clone());
         self.view
             .lock()
             .unwrap()
@@ -159,10 +160,14 @@ impl DatabaseRef for OracleDatabase {
         let got = keccak256(&bytes);
         if got != hash {
             return Err(OracleError::InvalidProof {
-                state_root: [0u8; 32],
+                // Carry the call's state root for telemetry; address is left zero
+                // because bytecode is content-addressed (keyed by code hash, not by
+                // an account) — the detail says so rather than implying an account.
+                state_root: self.state_root,
                 address: [0u8; 20],
                 detail: format!(
-                    "bytecode hash mismatch: expected {}, got {}",
+                    "bytecode hash mismatch (content-addressed, no account context): \
+                     expected {}, got {}",
                     B256::from(hash),
                     B256::from(got)
                 ),

--- a/rust/myotis-evm/src/database.rs
+++ b/rust/myotis-evm/src/database.rs
@@ -21,6 +21,7 @@ use revm::database_interface::DatabaseRef;
 use revm::primitives::{Address, Bytes, B256, U256};
 use revm::state::{AccountInfo, Bytecode};
 
+use myotis_core::keccak::keccak256;
 use myotis_core::trie::EMPTY_CODE_HASH;
 
 use crate::cache::{BytecodeCache, StateProofCache};
@@ -102,6 +103,21 @@ impl OracleDatabase {
     }
 }
 
+/// Build a revm [`Bytecode`] from verified raw code WITHOUT panicking.
+///
+/// `Bytecode::new_raw` is not panic-free — it `.expect()`s inside, and any blob
+/// beginning `0xEF01` (the EIP-7702 magic) that is not a well-formed 23-byte
+/// delegation makes it panic → `abort` under the workspace's release
+/// `panic = "abort"`. Such code is legal on-chain (e.g. pre-London `0xEF`-leading
+/// legacy code), so it must not crash the engine. `new_raw_checked` returns the
+/// correct `Eip7702` variant for a valid delegation and `Legacy` for everything
+/// else; on the rare malformed-`0xEF01` error we fall back to `new_legacy`, which
+/// loads the real verified bytes as legacy code (it reverts on the invalid `0xEF`
+/// opcode at run time — exactly what a full node does) and never panics.
+fn to_bytecode(bytes: Bytes) -> Bytecode {
+    Bytecode::new_raw_checked(bytes.clone()).unwrap_or_else(|_| Bytecode::new_legacy(bytes))
+}
+
 fn to_account_info(acc: &OracleAccount) -> AccountInfo {
     AccountInfo {
         balance: acc.balance,
@@ -131,12 +147,29 @@ impl DatabaseRef for OracleDatabase {
         if hash == EMPTY_CODE_HASH {
             return Ok(Bytecode::default());
         }
+        // A cache hit was verified (below) when first stored, and the cache is
+        // keyed by hash, so it needs no re-check.
         if let Some(bytes) = self.bytecode_cache.get(&hash) {
-            return Ok(Bytecode::new_raw(bytes));
+            return Ok(to_bytecode(bytes));
         }
         let bytes: Bytes = self.oracle.fetch_bytecode(&hash)?.into();
+        // Defense-in-depth at the trust boundary: bytecode is content-addressed,
+        // so re-verify keccak(code) == hash here even though the oracle already
+        // checked it. Fail closed on any mismatch — never execute unverified code.
+        let got = keccak256(&bytes);
+        if got != hash {
+            return Err(OracleError::InvalidProof {
+                state_root: [0u8; 32],
+                address: [0u8; 20],
+                detail: format!(
+                    "bytecode hash mismatch: expected {}, got {}",
+                    B256::from(hash),
+                    B256::from(got)
+                ),
+            });
+        }
         self.bytecode_cache.put(&hash, bytes.clone());
-        Ok(Bytecode::new_raw(bytes))
+        Ok(to_bytecode(bytes))
     }
 
     fn storage_ref(&self, address: Address, index: U256) -> Result<U256, Self::Error> {

--- a/rust/myotis-evm/src/database.rs
+++ b/rust/myotis-evm/src/database.rs
@@ -1,0 +1,174 @@
+//! [`OracleDatabase`]: the `revm` [`DatabaseRef`] adapter over a
+//! [`SnapStateOracle`] and the caches.
+//!
+//! One instance is bound to ONE block's anchored `state_root` — build a fresh
+//! one per `eth_call`. Reads resolve in three tiers, cheapest first:
+//!
+//! 1. the per-call **view cache** (private here) — dedups repeated reads within
+//!    this one call;
+//! 2. the cross-call [`StateProofCache`] — a `stateRoot`-keyed verified fact from
+//!    an earlier call (this is what makes a MetaMask number-pinned retry cheap);
+//! 3. the [`SnapStateOracle`] — a fresh, verified network fetch, whose result is
+//!    promoted into both caches.
+//!
+//! To drive the EVM, wrap it: `WrapDatabaseRef(oracle_database)` implements
+//! `revm::Database`.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use revm::database_interface::DatabaseRef;
+use revm::primitives::{Address, Bytes, B256, U256};
+use revm::state::{AccountInfo, Bytecode};
+
+use myotis_core::trie::EMPTY_CODE_HASH;
+
+use crate::cache::{BytecodeCache, StateProofCache};
+use crate::oracle::{OracleAccount, OracleError, SnapStateOracle};
+
+/// The per-call cache (tier 1). Bound to one `OracleDatabase` (one call) and
+/// discarded with it — it holds this call's reads regardless of proof/root and
+/// so is NEVER shared across calls (unlike the cross-call [`StateProofCache`]).
+///
+/// Note: the Java engine also has a per-*resolution* "in-flight dedup" tier that
+/// collapses concurrent async account fetches into one future. That tier only
+/// exists to dedup *parallelism*; a single synchronous `transact` reads serially,
+/// so the view cache already dedups every repeat. True in-flight dedup arrives
+/// with the async prefetch layer (a later Milestone-C slice).
+#[derive(Default)]
+struct ViewCache {
+    /// `None` marks an address proven absent — cached so we don't re-fetch it.
+    accounts: HashMap<[u8; 20], Option<OracleAccount>>,
+    storage: HashMap<([u8; 20], U256), U256>,
+}
+
+/// A `revm` state source backed by a verified oracle + the caches, pinned to one
+/// block's `state_root`.
+pub struct OracleDatabase {
+    oracle: Arc<dyn SnapStateOracle>,
+    state_root: [u8; 32],
+    proof_cache: Arc<dyn StateProofCache>,
+    bytecode_cache: Arc<dyn BytecodeCache>,
+    view: Mutex<ViewCache>,
+}
+
+impl OracleDatabase {
+    /// A database for `state_root`, sharing the cross-call `proof_cache` and
+    /// `bytecode_cache` across every call the host makes.
+    pub fn new(
+        oracle: Arc<dyn SnapStateOracle>,
+        state_root: [u8; 32],
+        proof_cache: Arc<dyn StateProofCache>,
+        bytecode_cache: Arc<dyn BytecodeCache>,
+    ) -> OracleDatabase {
+        OracleDatabase {
+            oracle,
+            state_root,
+            proof_cache,
+            bytecode_cache,
+            view: Mutex::new(ViewCache::default()),
+        }
+    }
+
+    /// Resolve an account through the three tiers. Returns the cached/ fetched
+    /// account, or `None` when proven absent.
+    fn account(&self, addr: [u8; 20]) -> Result<Option<OracleAccount>, OracleError> {
+        // Tier 1 — this call.
+        if let Some(cached) = self.view.lock().unwrap().accounts.get(&addr) {
+            return Ok(cached.clone());
+        }
+        // Tier 2 — a verified fact from an earlier call at this root.
+        if let Some(acc) = self.proof_cache.get_account(&self.state_root, &addr) {
+            self.view
+                .lock()
+                .unwrap()
+                .accounts
+                .insert(addr, Some(acc.clone()));
+            return Ok(Some(acc));
+        }
+        // Tier 3 — a fresh verified fetch. The lock is NOT held across it: the
+        // oracle may block on the network, and a call runs single-threaded so
+        // there is no concurrent view-cache writer to race.
+        let fetched = self.oracle.fetch_account(&self.state_root, addr)?;
+        if let Some(ref acc) = fetched {
+            self.proof_cache.put_account(&self.state_root, &addr, acc);
+        }
+        self.view
+            .lock()
+            .unwrap()
+            .accounts
+            .insert(addr, fetched.clone());
+        Ok(fetched)
+    }
+}
+
+fn to_account_info(acc: &OracleAccount) -> AccountInfo {
+    AccountInfo {
+        balance: acc.balance,
+        nonce: acc.nonce,
+        code_hash: B256::from(acc.code_hash),
+        // Left None: revm loads the code lazily via `code_by_hash_ref` only when
+        // the account is actually executed, so a balance/nonce read never pulls
+        // bytecode.
+        code: None,
+        ..AccountInfo::default()
+    }
+}
+
+impl DatabaseRef for OracleDatabase {
+    type Error = OracleError;
+
+    fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+        Ok(self
+            .account(address.into_array())?
+            .as_ref()
+            .map(to_account_info))
+    }
+
+    fn code_by_hash_ref(&self, code_hash: B256) -> Result<Bytecode, Self::Error> {
+        let hash: [u8; 32] = code_hash.0;
+        // Empty-code hash → provably empty code, no fetch.
+        if hash == EMPTY_CODE_HASH {
+            return Ok(Bytecode::default());
+        }
+        if let Some(bytes) = self.bytecode_cache.get(&hash) {
+            return Ok(Bytecode::new_raw(bytes));
+        }
+        let bytes: Bytes = self.oracle.fetch_bytecode(&hash)?.into();
+        self.bytecode_cache.put(&hash, bytes.clone());
+        Ok(Bytecode::new_raw(bytes))
+    }
+
+    fn storage_ref(&self, address: Address, index: U256) -> Result<U256, Self::Error> {
+        let addr = address.into_array();
+        // Tier 1.
+        if let Some(v) = self.view.lock().unwrap().storage.get(&(addr, index)) {
+            return Ok(*v);
+        }
+        // Tier 2.
+        if let Some(v) = self
+            .proof_cache
+            .get_storage(&self.state_root, &addr, &index)
+        {
+            self.view.lock().unwrap().storage.insert((addr, index), v);
+            return Ok(v);
+        }
+        // Tier 3 — verified fetch (the oracle handles the account/storage-root and
+        // empty-trie short-circuit internally). Lock released across it as above.
+        let value = self.oracle.fetch_storage(&self.state_root, addr, index)?;
+        self.proof_cache
+            .put_storage(&self.state_root, &addr, &index, value);
+        self.view
+            .lock()
+            .unwrap()
+            .storage
+            .insert((addr, index), value);
+        Ok(value)
+    }
+
+    fn block_hash_ref(&self, number: u64) -> Result<B256, Self::Error> {
+        // No local block store to serve historical hashes; a contract reading
+        // BLOCKHASH cannot be executed. Fail fast (matches the Java engine).
+        Err(OracleError::BlockHashUnsupported { number })
+    }
+}

--- a/rust/myotis-evm/src/lib.rs
+++ b/rust/myotis-evm/src/lib.rs
@@ -1,0 +1,377 @@
+//! # myotis-evm
+//!
+//! The Rust EVM engine: `eth_call` / `estimateGas` over SNAP-proof-verified state,
+//! built on [`revm`] behind a [`SnapStateOracle`] trait. Sans-I/O — this crate
+//! holds no runtime, sockets, or clock; a synchronous oracle trait is the only
+//! seam to the (async) snap-fetch path, and the bridge across it lives in the
+//! implementing I/O crate.
+//!
+//! This is the Rust twin of the Java `io.myotis.evm` module (see
+//! `docs/reimplementation/03` and the Milestone-C section of `…/07`). It is built
+//! up over several PRs; **EL-C-1 (this slice)** lands the foundation only:
+//!
+//! * [`SnapStateOracle`] — the verified world-state trait, with an in-memory
+//!   [`FixtureSnapStateOracle`] for tests;
+//! * the cache tiers — [`StateProofCache`] (cross-call, `stateRoot`-keyed) and
+//!   [`BytecodeCache`] (content-addressed, forever), plus a per-call view cache
+//!   private to the adapter;
+//! * [`OracleDatabase`] — the `revm` `DatabaseRef` adapter over the oracle and
+//!   the caches.
+//!
+//! The view-call / gas-estimation executor, the mainnet fork table, the async
+//! prefetch loop, and ENS/CCIP-Read arrive in the following Milestone-C slices.
+//!
+//! ## Wiring the EVM
+//!
+//! ```ignore
+//! use std::sync::Arc;
+//! use myotis_evm::{OracleDatabase, cache::{NoopStateProofCache, NoopBytecodeCache}};
+//! use revm::database_interface::WrapDatabaseRef;
+//! use revm::{Context, ExecuteEvm, MainBuilder, MainContext};
+//!
+//! let db = OracleDatabase::new(
+//!     oracle,                                  // Arc<dyn SnapStateOracle>
+//!     state_root,                              // the block's beacon-anchored root
+//!     Arc::new(NoopStateProofCache),
+//!     Arc::new(NoopBytecodeCache),
+//! );
+//! let mut evm = Context::mainnet().with_db(WrapDatabaseRef(db)).build_mainnet();
+//! // evm.transact(TxEnv::builder()…build_fill())  // EL-C-2
+//! ```
+
+pub mod cache;
+pub mod database;
+pub mod oracle;
+
+pub use cache::{
+    BytecodeCache, InMemoryBytecodeCache, InMemoryStateProofCache, NoopBytecodeCache,
+    NoopStateProofCache, StateProofCache,
+};
+pub use database::OracleDatabase;
+pub use oracle::{OracleAccount, OracleError, SnapStateOracle};
+
+#[cfg(any(test, feature = "fixture"))]
+pub use oracle::FixtureSnapStateOracle;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use revm::database_interface::DatabaseRef;
+    use revm::primitives::{Address, B256, U256};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    use myotis_core::keccak::keccak256;
+    use myotis_core::trie::{EMPTY_CODE_HASH, EMPTY_TRIE_ROOT};
+
+    const ROOT_A: [u8; 32] = [0xAA; 32];
+    const ROOT_B: [u8; 32] = [0xBB; 32];
+    const ADDR: [u8; 20] = [0x11; 20];
+
+    fn acct(balance: u64, nonce: u64, code_hash: [u8; 32]) -> OracleAccount {
+        OracleAccount {
+            nonce,
+            balance: U256::from(balance),
+            code_hash,
+            storage_root: EMPTY_TRIE_ROOT,
+        }
+    }
+
+    fn db(
+        oracle: Arc<dyn SnapStateOracle>,
+        root: [u8; 32],
+        proofs: Arc<dyn StateProofCache>,
+        codes: Arc<dyn BytecodeCache>,
+    ) -> OracleDatabase {
+        OracleDatabase::new(oracle, root, proofs, codes)
+    }
+
+    #[test]
+    fn present_account_maps_to_account_info() {
+        let oracle = Arc::new(FixtureSnapStateOracle::new().with_account(
+            ROOT_A,
+            ADDR,
+            acct(1_000, 7, EMPTY_CODE_HASH),
+        ));
+        let d = db(
+            oracle,
+            ROOT_A,
+            Arc::new(NoopStateProofCache),
+            Arc::new(NoopBytecodeCache),
+        );
+        let info = d.basic_ref(Address::from(ADDR)).unwrap().expect("present");
+        assert_eq!(info.balance, U256::from(1_000));
+        assert_eq!(info.nonce, 7);
+        assert_eq!(info.code_hash, B256::from(EMPTY_CODE_HASH));
+    }
+
+    #[test]
+    fn absent_account_is_none() {
+        let oracle = Arc::new(FixtureSnapStateOracle::new());
+        let d = db(
+            oracle,
+            ROOT_A,
+            Arc::new(NoopStateProofCache),
+            Arc::new(NoopBytecodeCache),
+        );
+        assert!(d.basic_ref(Address::from(ADDR)).unwrap().is_none());
+    }
+
+    #[test]
+    fn state_root_selects_the_account() {
+        // Same address, value only present under ROOT_A: a DB pinned to ROOT_B
+        // must not see it (the root, not the address, is the key).
+        let oracle = Arc::new(FixtureSnapStateOracle::new().with_account(
+            ROOT_A,
+            ADDR,
+            acct(42, 0, EMPTY_CODE_HASH),
+        ));
+        let a = db(
+            Arc::clone(&oracle) as Arc<dyn SnapStateOracle>,
+            ROOT_A,
+            Arc::new(NoopStateProofCache),
+            Arc::new(NoopBytecodeCache),
+        );
+        let b = db(
+            oracle,
+            ROOT_B,
+            Arc::new(NoopStateProofCache),
+            Arc::new(NoopBytecodeCache),
+        );
+        assert!(a.basic_ref(Address::from(ADDR)).unwrap().is_some());
+        assert!(b.basic_ref(Address::from(ADDR)).unwrap().is_none());
+    }
+
+    #[test]
+    fn storage_read_returns_value_and_zero_for_absent() {
+        let mut slot0 = [0u8; 32];
+        slot0[31] = 5; // position 5
+        let oracle = Arc::new(FixtureSnapStateOracle::new().with_storage(
+            ROOT_A,
+            ADDR,
+            slot0,
+            U256::from(99),
+        ));
+        let d = db(
+            oracle,
+            ROOT_A,
+            Arc::new(NoopStateProofCache),
+            Arc::new(NoopBytecodeCache),
+        );
+        assert_eq!(
+            d.storage_ref(Address::from(ADDR), U256::from(5)).unwrap(),
+            U256::from(99)
+        );
+        assert_eq!(
+            d.storage_ref(Address::from(ADDR), U256::from(6)).unwrap(),
+            U256::ZERO
+        );
+    }
+
+    #[test]
+    fn empty_code_hash_short_circuits_without_fetch() {
+        // A counting oracle proves code_by_hash never calls fetch_bytecode for the
+        // empty hash.
+        struct Counting(AtomicUsize);
+        impl SnapStateOracle for Counting {
+            fn fetch_account(
+                &self,
+                _r: &[u8; 32],
+                _a: [u8; 20],
+            ) -> Result<Option<OracleAccount>, OracleError> {
+                Ok(None)
+            }
+            fn fetch_storage(
+                &self,
+                _r: &[u8; 32],
+                _a: [u8; 20],
+                _s: U256,
+            ) -> Result<U256, OracleError> {
+                Ok(U256::ZERO)
+            }
+            fn fetch_bytecode(&self, _h: &[u8; 32]) -> Result<Vec<u8>, OracleError> {
+                self.0.fetch_add(1, Ordering::SeqCst);
+                Ok(Vec::new())
+            }
+        }
+        let oracle = Arc::new(Counting(AtomicUsize::new(0)));
+        let d = db(
+            Arc::clone(&oracle) as Arc<dyn SnapStateOracle>,
+            ROOT_A,
+            Arc::new(NoopStateProofCache),
+            Arc::new(NoopBytecodeCache),
+        );
+        let code = d.code_by_hash_ref(B256::from(EMPTY_CODE_HASH)).unwrap();
+        assert!(code.is_empty());
+        assert_eq!(
+            oracle.0.load(Ordering::SeqCst),
+            0,
+            "empty hash must not fetch"
+        );
+    }
+
+    #[test]
+    fn bytecode_is_content_addressed_and_cached() {
+        let mut fixture = FixtureSnapStateOracle::new();
+        let code = vec![0x60u8, 0x00, 0x60, 0x00, 0xf3]; // PUSH1 0 PUSH1 0 RETURN
+        let hash = fixture.with_bytecode(code.clone());
+        assert_eq!(hash, keccak256(&code));
+        let codes = Arc::new(InMemoryBytecodeCache::new());
+        let d = db(
+            Arc::new(fixture),
+            ROOT_A,
+            Arc::new(NoopStateProofCache),
+            Arc::clone(&codes) as Arc<dyn BytecodeCache>,
+        );
+        let bc = d.code_by_hash_ref(B256::from(hash)).unwrap();
+        assert_eq!(bc.original_bytes().as_ref(), code.as_slice());
+        // Second read is served from the bytecode cache (now populated).
+        assert!(codes.get(&hash).is_some());
+        assert_eq!(
+            d.code_by_hash_ref(B256::from(hash))
+                .unwrap()
+                .original_bytes()
+                .as_ref(),
+            code
+        );
+    }
+
+    #[test]
+    fn missing_bytecode_is_fail_closed() {
+        let d = db(
+            Arc::new(FixtureSnapStateOracle::new()),
+            ROOT_A,
+            Arc::new(NoopStateProofCache),
+            Arc::new(NoopBytecodeCache),
+        );
+        let err = d.code_by_hash_ref(B256::from([0x77u8; 32])).unwrap_err();
+        assert!(matches!(err, OracleError::BytecodeUnavailable { .. }));
+    }
+
+    #[test]
+    fn blockhash_is_unsupported() {
+        let d = db(
+            Arc::new(FixtureSnapStateOracle::new()),
+            ROOT_A,
+            Arc::new(NoopStateProofCache),
+            Arc::new(NoopBytecodeCache),
+        );
+        assert!(matches!(
+            d.block_hash_ref(21_000_000).unwrap_err(),
+            OracleError::BlockHashUnsupported { number: 21_000_000 }
+        ));
+    }
+
+    #[test]
+    fn revm_executes_a_contract_reading_verified_storage() {
+        // End-to-end: a real revm run of an SLOAD-and-return contract, driven
+        // entirely through OracleDatabase. Proves the DatabaseRef adapter is the
+        // correct shape for revm's executor (and de-risks the EL-C-2 eth_call).
+        use revm::context::TxEnv;
+        use revm::database_interface::WrapDatabaseRef;
+        use revm::primitives::TxKind;
+        use revm::{Context, ExecuteEvm, MainBuilder, MainContext};
+
+        // PUSH1 0 SLOAD PUSH1 0 MSTORE PUSH1 0x20 PUSH1 0 RETURN — returns slot 0.
+        let code = vec![
+            0x60u8, 0x00, 0x54, 0x60, 0x00, 0x52, 0x60, 0x20, 0x60, 0x00, 0xf3,
+        ];
+        let code_hash = keccak256(&code);
+        let slot0 = [0u8; 32]; // storage position 0
+        let mut fixture = FixtureSnapStateOracle::new()
+            .with_account(
+                ROOT_A,
+                ADDR,
+                OracleAccount {
+                    nonce: 1,
+                    balance: U256::ZERO,
+                    code_hash,
+                    storage_root: [0x01; 32],
+                },
+            )
+            .with_storage(ROOT_A, ADDR, slot0, U256::from(0xdead_beefu64));
+        assert_eq!(fixture.with_bytecode(code), code_hash);
+
+        let d = db(
+            Arc::new(fixture),
+            ROOT_A,
+            Arc::new(NoopStateProofCache),
+            Arc::new(NoopBytecodeCache),
+        );
+        let mut evm = Context::mainnet()
+            .with_db(WrapDatabaseRef(d))
+            .build_mainnet();
+        // gas_limit under the latest spec's per-tx cap (EIP-7825, 2^24); the 30 M
+        // eth_call ceiling + fork/cfg selection is EL-C-2's concern.
+        let tx = TxEnv::builder()
+            .caller(Address::ZERO)
+            .kind(TxKind::Call(Address::from(ADDR)))
+            .gas_limit(1_000_000)
+            .build_fill();
+        let out = evm.transact(tx).expect("execution");
+        let data = out.result.output().expect("output").to_vec();
+        assert_eq!(data.len(), 32);
+        assert_eq!(U256::from_be_slice(&data), U256::from(0xdead_beefu64));
+    }
+
+    #[test]
+    fn cross_call_cache_serves_without_a_second_fetch() {
+        // An oracle that fails after its first account fetch: a second read must be
+        // served from the cross-call cache, proving tier 2 short-circuits the oracle.
+        struct OneShot {
+            calls: AtomicUsize,
+            acc: OracleAccount,
+        }
+        impl SnapStateOracle for OneShot {
+            fn fetch_account(
+                &self,
+                _r: &[u8; 32],
+                _a: [u8; 20],
+            ) -> Result<Option<OracleAccount>, OracleError> {
+                if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                    Ok(Some(self.acc.clone()))
+                } else {
+                    Err(OracleError::StateUnavailable {
+                        state_root: ROOT_A,
+                        address: ADDR,
+                        slot: None,
+                    })
+                }
+            }
+            fn fetch_storage(
+                &self,
+                _r: &[u8; 32],
+                _a: [u8; 20],
+                _s: U256,
+            ) -> Result<U256, OracleError> {
+                Ok(U256::ZERO)
+            }
+            fn fetch_bytecode(&self, _h: &[u8; 32]) -> Result<Vec<u8>, OracleError> {
+                Ok(Vec::new())
+            }
+        }
+        let oracle = Arc::new(OneShot {
+            calls: AtomicUsize::new(0),
+            acc: acct(500, 1, EMPTY_CODE_HASH),
+        });
+        let proofs: Arc<dyn StateProofCache> = Arc::new(InMemoryStateProofCache::new(16));
+        // First call populates the shared proof cache, then is discarded.
+        {
+            let d1 = db(
+                Arc::clone(&oracle) as Arc<dyn SnapStateOracle>,
+                ROOT_A,
+                Arc::clone(&proofs),
+                Arc::new(NoopBytecodeCache),
+            );
+            assert_eq!(d1.basic_ref(Address::from(ADDR)).unwrap().unwrap().nonce, 1);
+        }
+        // Fresh call (new view cache); the oracle would now error, so success
+        // proves the cross-call cache served it.
+        let d2 = db(oracle, ROOT_A, proofs, Arc::new(NoopBytecodeCache));
+        let info = d2
+            .basic_ref(Address::from(ADDR))
+            .unwrap()
+            .expect("cross-call hit");
+        assert_eq!(info.balance, U256::from(500));
+    }
+}

--- a/rust/myotis-evm/src/lib.rs
+++ b/rust/myotis-evm/src/lib.rs
@@ -249,6 +249,61 @@ mod tests {
     }
 
     #[test]
+    fn malformed_eip7702_prefixed_bytecode_does_not_panic() {
+        // Regression: verified bytecode beginning 0xEF01 that is NOT a well-formed
+        // 23-byte EIP-7702 delegation must load (as legacy), not abort the process
+        // (Bytecode::new_raw would panic → abort under panic="abort").
+        let mut fixture = FixtureSnapStateOracle::new();
+        let weird = vec![0xEFu8, 0x01, 0x02, 0x03]; // 0xEF01-prefixed, only 4 bytes
+        let hash = fixture.with_bytecode(weird.clone());
+        let d = db(
+            Arc::new(fixture),
+            ROOT_A,
+            Arc::new(NoopStateProofCache),
+            Arc::new(InMemoryBytecodeCache::new()),
+        );
+        let bc = d
+            .code_by_hash_ref(B256::from(hash))
+            .expect("must not panic/err");
+        assert_eq!(bc.original_bytes().as_ref(), weird.as_slice());
+    }
+
+    #[test]
+    fn bytecode_hash_mismatch_is_fail_closed() {
+        // An oracle that serves bytes NOT hashing to the requested code hash must
+        // be rejected (InvalidProof), never executed.
+        struct Liar;
+        impl SnapStateOracle for Liar {
+            fn fetch_account(
+                &self,
+                _r: &[u8; 32],
+                _a: [u8; 20],
+            ) -> Result<Option<OracleAccount>, OracleError> {
+                Ok(None)
+            }
+            fn fetch_storage(
+                &self,
+                _r: &[u8; 32],
+                _a: [u8; 20],
+                _s: U256,
+            ) -> Result<U256, OracleError> {
+                Ok(U256::ZERO)
+            }
+            fn fetch_bytecode(&self, _h: &[u8; 32]) -> Result<Vec<u8>, OracleError> {
+                Ok(vec![0x60, 0x00]) // does not hash to the requested (all-0x33) hash
+            }
+        }
+        let d = db(
+            Arc::new(Liar),
+            ROOT_A,
+            Arc::new(NoopStateProofCache),
+            Arc::new(InMemoryBytecodeCache::new()),
+        );
+        let err = d.code_by_hash_ref(B256::from([0x33u8; 32])).unwrap_err();
+        assert!(matches!(err, OracleError::InvalidProof { .. }));
+    }
+
+    #[test]
     fn blockhash_is_unsupported() {
         let d = db(
             Arc::new(FixtureSnapStateOracle::new()),

--- a/rust/myotis-evm/src/lib.rs
+++ b/rust/myotis-evm/src/lib.rs
@@ -429,4 +429,55 @@ mod tests {
             .expect("cross-call hit");
         assert_eq!(info.balance, U256::from(500));
     }
+
+    #[test]
+    fn absent_account_is_cached_cross_call() {
+        // A proven ABSENCE must be cached cross-call too: an oracle that returns
+        // None once then errors proves the second call is served from the cache
+        // (Some(None)) rather than re-fetching an absent account.
+        struct AbsentOnce(AtomicUsize);
+        impl SnapStateOracle for AbsentOnce {
+            fn fetch_account(
+                &self,
+                _r: &[u8; 32],
+                _a: [u8; 20],
+            ) -> Result<Option<OracleAccount>, OracleError> {
+                if self.0.fetch_add(1, Ordering::SeqCst) == 0 {
+                    Ok(None)
+                } else {
+                    Err(OracleError::StateUnavailable {
+                        state_root: ROOT_A,
+                        address: ADDR,
+                        slot: None,
+                    })
+                }
+            }
+            fn fetch_storage(
+                &self,
+                _r: &[u8; 32],
+                _a: [u8; 20],
+                _s: U256,
+            ) -> Result<U256, OracleError> {
+                Ok(U256::ZERO)
+            }
+            fn fetch_bytecode(&self, _h: &[u8; 32]) -> Result<Vec<u8>, OracleError> {
+                Ok(Vec::new())
+            }
+        }
+        let oracle = Arc::new(AbsentOnce(AtomicUsize::new(0)));
+        let proofs: Arc<dyn StateProofCache> = Arc::new(InMemoryStateProofCache::new(16));
+        {
+            let d1 = db(
+                Arc::clone(&oracle) as Arc<dyn SnapStateOracle>,
+                ROOT_A,
+                Arc::clone(&proofs),
+                Arc::new(NoopBytecodeCache),
+            );
+            assert!(d1.basic_ref(Address::from(ADDR)).unwrap().is_none());
+        }
+        // Fresh call; the oracle would now error, so a clean `None` proves the
+        // absence was served from the cross-call cache.
+        let d2 = db(oracle, ROOT_A, proofs, Arc::new(NoopBytecodeCache));
+        assert!(d2.basic_ref(Address::from(ADDR)).unwrap().is_none());
+    }
 }

--- a/rust/myotis-evm/src/oracle.rs
+++ b/rust/myotis-evm/src/oracle.rs
@@ -1,0 +1,244 @@
+//! The [`SnapStateOracle`] trait: the EVM's only source of world state.
+//!
+//! Mirrors the Java `io.myotis.evm.world.SnapStateOracle`. Every value an
+//! implementation returns MUST be backed by an MPT proof that verified against
+//! the caller-supplied `state_root` (accounts, storage) or a `keccak256(code)
+//! == code_hash` check (bytecode). An implementation that cannot verify a value
+//! returns [`OracleError`] — it NEVER returns unverified data. This is the trust
+//! boundary of the whole engine, so the error set is *closed* (fail-closed):
+//! callers must handle every case, and [`OracleError::InvalidProof`] is
+//! security-critical.
+//!
+//! # Threading contract
+//!
+//! The trait is **synchronous**: `revm`'s `Database` is synchronous, and keeping
+//! the bridge here (rather than an async trait the EVM would have to block on)
+//! keeps this crate sans-I/O. A production implementation fetches over the
+//! network, so its methods MAY BLOCK — callers MUST therefore run the EVM (and
+//! hence these calls) on a worker thread, never a tokio reactor / UI thread. The
+//! concrete async→sync bridge (blocking on the snap-peer fetch path) lives in the
+//! I/O crate that implements this trait; this crate never spawns or blocks a
+//! runtime itself.
+
+use revm::primitives::U256;
+
+use myotis_core::trie::{EMPTY_CODE_HASH, EMPTY_TRIE_ROOT};
+
+/// A proof-verified account snapshot at a fixed `state_root`.
+///
+/// Carries `storage_root` — which `revm`'s own `AccountInfo` drops — because a
+/// storage-slot proof anchors at the account's storage root, so a cached account
+/// lets a later storage read skip re-fetching the account.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OracleAccount {
+    pub nonce: u64,
+    pub balance: U256,
+    pub code_hash: [u8; 32],
+    pub storage_root: [u8; 32],
+}
+
+impl OracleAccount {
+    /// The account an *exclusion* proof verifies: nonce 0, zero balance, the
+    /// empty-code hash, the empty-trie storage root. Returned for an address the
+    /// proof shows is absent.
+    pub fn empty() -> OracleAccount {
+        OracleAccount {
+            nonce: 0,
+            balance: U256::ZERO,
+            code_hash: EMPTY_CODE_HASH,
+            storage_root: EMPTY_TRIE_ROOT,
+        }
+    }
+
+    /// Whether this account has no contract code (an EOA or empty-code account) —
+    /// its code is provably empty, so no bytecode fetch is needed.
+    pub fn has_no_code(&self) -> bool {
+        self.code_hash == EMPTY_CODE_HASH
+    }
+}
+
+/// The closed, fail-closed error set an oracle may return. Mirrors the relevant
+/// arm of the Java `EvmExecutionError`; the EVM-execution arms (Reverted,
+/// OutOfGas, …) belong to the executor, added in a later Milestone-C slice.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum OracleError {
+    /// State for `address` (and `slot`, if a storage read) could not be fetched
+    /// or verified against `state_root` — peers exhausted, transport failure, or
+    /// no anchored head. Not necessarily an attack; retryable.
+    StateUnavailable {
+        state_root: [u8; 32],
+        address: [u8; 20],
+        slot: Option<[u8; 32]>,
+    },
+    /// No peer served bytecode hashing to `code_hash`. Retryable.
+    BytecodeUnavailable { code_hash: [u8; 32] },
+    /// An MPT proof FAILED to verify (or bytecode did not hash to its code hash).
+    /// Security-critical: a peer served data inconsistent with the anchored root.
+    /// Fail closed — surface, deprioritise the peer; never fall back to the value.
+    InvalidProof {
+        state_root: [u8; 32],
+        address: [u8; 20],
+        detail: String,
+    },
+    /// `BLOCKHASH` is unsupported (no local block store to serve historical
+    /// hashes) — a contract that reads it cannot be executed. Fail fast.
+    BlockHashUnsupported { number: u64 },
+}
+
+impl std::fmt::Display for OracleError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OracleError::StateUnavailable { address, slot, .. } => match slot {
+                Some(s) => write!(
+                    f,
+                    "state unavailable for 0x{}, slot 0x{}",
+                    hex(address),
+                    hex(s)
+                ),
+                None => write!(f, "state unavailable for 0x{}", hex(address)),
+            },
+            OracleError::BytecodeUnavailable { code_hash } => {
+                write!(f, "bytecode unavailable for code hash 0x{}", hex(code_hash))
+            }
+            OracleError::InvalidProof {
+                address, detail, ..
+            } => {
+                write!(f, "invalid proof for 0x{}: {detail}", hex(address))
+            }
+            OracleError::BlockHashUnsupported { number } => {
+                write!(f, "BLOCKHASH unsupported (requested block {number})")
+            }
+        }
+    }
+}
+
+impl std::error::Error for OracleError {}
+
+// `revm`'s `Database::Error` bound. Marks our error as a database error type.
+impl revm::database_interface::DBErrorMarker for OracleError {}
+
+fn hex(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+/// The verified world-state source the EVM reads through. See the module docs
+/// for the verification and threading contract.
+pub trait SnapStateOracle: Send + Sync {
+    /// The proof-verified account at `address`, or `Ok(None)` when an exclusion
+    /// proof shows it absent. `Err` only when it cannot be verified.
+    fn fetch_account(
+        &self,
+        state_root: &[u8; 32],
+        address: [u8; 20],
+    ) -> Result<Option<OracleAccount>, OracleError>;
+
+    /// The proof-verified value at `slot` (a raw 32-byte storage position, as the
+    /// `U256` index `revm` passes). `Ok(U256::ZERO)` for an absent/zero slot.
+    fn fetch_storage(
+        &self,
+        state_root: &[u8; 32],
+        address: [u8; 20],
+        slot: U256,
+    ) -> Result<U256, OracleError>;
+
+    /// Bytecode whose `keccak256` equals `code_hash` (content-addressed, so not
+    /// tied to a state root). Empty for the empty-code hash.
+    fn fetch_bytecode(&self, code_hash: &[u8; 32]) -> Result<Vec<u8>, OracleError>;
+}
+
+#[cfg(any(test, feature = "fixture"))]
+mod fixture {
+    use super::*;
+    use myotis_core::keccak::keccak256;
+    use std::collections::HashMap;
+
+    /// An in-memory [`SnapStateOracle`] for tests — no proofs, no network. Values
+    /// are keyed by `(state_root, …)` so a test can assert the root actually
+    /// selects the answer (a mismatched root reads as absent/zero). Mirrors the
+    /// Java `FixtureSnapStateOracle`.
+    #[derive(Default)]
+    pub struct FixtureSnapStateOracle {
+        accounts: HashMap<([u8; 32], [u8; 20]), OracleAccount>,
+        storage: HashMap<([u8; 32], [u8; 20], [u8; 32]), U256>,
+        bytecode: HashMap<[u8; 32], Vec<u8>>,
+    }
+
+    impl FixtureSnapStateOracle {
+        pub fn new() -> FixtureSnapStateOracle {
+            FixtureSnapStateOracle::default()
+        }
+
+        /// Add an account under `state_root`. Returns `self` for chaining.
+        pub fn with_account(
+            mut self,
+            state_root: [u8; 32],
+            address: [u8; 20],
+            account: OracleAccount,
+        ) -> Self {
+            self.accounts.insert((state_root, address), account);
+            self
+        }
+
+        /// Add a storage slot (raw 32-byte position) under `state_root`.
+        pub fn with_storage(
+            mut self,
+            state_root: [u8; 32],
+            address: [u8; 20],
+            slot: [u8; 32],
+            value: U256,
+        ) -> Self {
+            self.storage.insert((state_root, address, slot), value);
+            self
+        }
+
+        /// Add bytecode, keyed by its own `keccak256`. Returns the code hash.
+        pub fn with_bytecode(&mut self, code: Vec<u8>) -> [u8; 32] {
+            let hash = keccak256(&code);
+            self.bytecode.insert(hash, code);
+            hash
+        }
+    }
+
+    impl SnapStateOracle for FixtureSnapStateOracle {
+        fn fetch_account(
+            &self,
+            state_root: &[u8; 32],
+            address: [u8; 20],
+        ) -> Result<Option<OracleAccount>, OracleError> {
+            Ok(self.accounts.get(&(*state_root, address)).cloned())
+        }
+
+        fn fetch_storage(
+            &self,
+            state_root: &[u8; 32],
+            address: [u8; 20],
+            slot: U256,
+        ) -> Result<U256, OracleError> {
+            let key = slot.to_be_bytes::<32>();
+            Ok(self
+                .storage
+                .get(&(*state_root, address, key))
+                .copied()
+                .unwrap_or(U256::ZERO))
+        }
+
+        fn fetch_bytecode(&self, code_hash: &[u8; 32]) -> Result<Vec<u8>, OracleError> {
+            if code_hash == &EMPTY_CODE_HASH {
+                return Ok(Vec::new());
+            }
+            self.bytecode
+                .get(code_hash)
+                .cloned()
+                .ok_or(OracleError::BytecodeUnavailable {
+                    code_hash: *code_hash,
+                })
+        }
+    }
+}
+
+#[cfg(any(test, feature = "fixture"))]
+pub use fixture::FixtureSnapStateOracle;

--- a/rust/myotis-evm/src/oracle.rs
+++ b/rust/myotis-evm/src/oracle.rs
@@ -118,9 +118,12 @@ impl std::error::Error for OracleError {}
 impl revm::database_interface::DBErrorMarker for OracleError {}
 
 fn hex(bytes: &[u8]) -> String {
+    use std::fmt::Write;
     let mut s = String::with_capacity(bytes.len() * 2);
     for b in bytes {
-        s.push_str(&format!("{b:02x}"));
+        // Writing into the buffer avoids the per-byte `String` a `format!` would
+        // allocate; `write!` to a `String` is infallible, so the result is ignored.
+        let _ = write!(s, "{b:02x}");
     }
     s
 }


### PR DESCRIPTION
First slice of **Milestone C** (the EVM) from `docs/reimplementation/07`. A new sans-I/O `myotis-evm` crate with `revm` — the one heavy EL dependency — gated to it.

## What lands
- **`SnapStateOracle`** — the verified world-state trait (`fetch_account`/`fetch_storage`/`fetch_bytecode`). Synchronous by design: revm's `Database` is sync, and keeping the async→sync bridge in the I/O impl (which wraps `ElReader`) keeps this crate sans-I/O. `OracleAccount` carries `storage_root` (revm's `AccountInfo` drops it). Closed, fail-closed `OracleError` (`StateUnavailable`/`BytecodeUnavailable`/`InvalidProof`/`BlockHashUnsupported`). `FixtureSnapStateOracle` for tests.
- **`OracleDatabase`** — the revm `DatabaseRef` adapter over the oracle + caches, pinned to one block's `state_root`. Three-tier reads: per-call view cache → cross-call `StateProofCache` → oracle (fresh fetches promoted into both). BLOCKHASH fails fast; empty-code hash short-circuits with no fetch; bytecode is re-verified `keccak(code)==hash` at the boundary and built panic-free.
- **Caches** — `StateProofCache` (Noop + bounded-LRU `InMemory`, `stateRoot`-keyed cryptographic facts) and `BytecodeCache` (Noop + forever `InMemory`, content-addressed). Both SPIs so a wallet host can plug a persistent backend.

## Validation
A real revm `transact` of an SLOAD-return contract driven through the adapter, plus cache / root-selection / fail-closed / panic-free unit tests — **12 tests**. Full workspace suite green (myotis-evm 12, myotis-net 107, myotis-engine 22, all conformance), no regressions.

## Key decisions
- **revm `=41.0.0`, `default-features=false, features=["std"]`** → pure-Rust precompile backends; `cargo tree` shows **zero new C-linking crates** (no c-kzg/libsecp256k1/blst), so it adds no cargo-ndk / mobile cross-build burden. revm's 1.91 MSRV is met by the workspace `stable` toolchain.
- **Deferred to EL-C-2** (documented in the plan): the 30M-gas `eth_call` ceiling + fork-table / `CfgEnv` selection (the latest spec caps per-tx gas at 2²⁴, EIP-7825) and precompile-completeness verification under the pure-Rust backends; the **in-flight-dedup** cache tier (needs the async prefetch layer — a single synchronous `transact` reads serially, so the per-call view cache already dedups).

An independent no-context review of the diff ran before this PR; its one HIGH finding (a `Bytecode::new_raw` panic on `0xEF01`-prefixed bytecode → `abort`) is fixed in the second commit with a regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)