### PR TITLE
EL-C-2: eth_call view executor + mainnet fork table

### DIFF
--- a/docs/reimplementation/07-el-implementation-plan.md
+++ b/docs/reimplementation/07-el-implementation-plan.md
@@ -373,6 +373,26 @@ Spec: doc 03 §§3–7, doc 04 §3. New crate `myotis-evm` (sans-I/O; revm gated
    `eth_call` overload, `isStatic`, 30 M gas, EIP-7702 one-hop, BLOCKHASH unsupported →
    fail fast); mainnet fork schedule (throws below London; Shanghai keeps Istanbul
    precompiles) mapped to revm `SpecId`.
+   - **Landed (EL-C-2).** `fork::spec_for(block_number, timestamp) -> SpecId` — the
+     mainnet cascade verbatim (LONDON_BLOCK/PARIS_BLOCK/SHANGHAI_TIME/CANCUN_TIME/
+     PRAGUE_TIME; timestamp checked before block number; `EvmError::ForkTooOld` below
+     London). revm applies the correct precompile set per `SpecId`, so the "Shanghai keeps
+     Istanbul precompiles" nuance needs no special handling (revm's `SHANGHAI` predates the
+     Cancun KZG precompile). `BlockContext` (all fields from the verified header) →
+     `BlockEnv` (`prev_randao` feeds both `prevrandao` and `difficulty`). `EvmExecutor`
+     with `call_view` (from-less zero sender) / `call_view_from` (explicit sender+value for
+     `msg.sender`-gated contracts), a fresh per-call `OracleDatabase` over the shared
+     caches, and `EvmError` (Reverted{data} / OutOfGas / Halted / ForkTooOld / Oracle /
+     Transaction). Resolves the C-1 carry: **30 M gas** works via `CfgEnv.tx_gas_limit_cap =
+     Some(30M)` (overrides the EIP-7825 2²⁴ spec cap); the eth_call relaxations use revm's
+     pure-config `optional_*` features (`optional_balance_check`/`optional_block_gas_limit`/
+     `optional_eip3607`/`optional_no_base_fee` — still zero C crates, `cargo tree -i c-kzg`
+     prints nothing). EIP-7702 one-hop is handled by revm (the oracle serves the designator
+     as code). Tested with a fixture-backed `eth_call`: Cancun SLOAD-return uint256 (mirrors
+     the Java `EvmFactoryTest`), `msg.sender`/`msg.value` pass-through, revert-data surfacing,
+     out-of-gas, pre-London rejection; plus fork-boundary unit tests. *Not yet wired to the
+     host* — the production `SnapStateOracle` over `ElReader` (the async→sync bridge) and the
+     JNI/Java `eth_call` routing land in a following slice, which lights the live MetaMask path.
 3. **Prefetch + dispatch fairness.** Sentinel-on-miss convergence loop (cap 4, result only
    from a fully cache-hit run, fail closed); batch coalescing (64 path-sets/request,
    independent per-item verification, whole-chunk rotation); semaphore-bounded waves; lanes +

--- a/docs/reimplementation/07-el-implementation-plan.md
+++ b/docs/reimplementation/07-el-implementation-plan.md
@@ -379,7 +379,9 @@ Spec: doc 03 §§3–7, doc 04 §3. New crate `myotis-evm` (sans-I/O; revm gated
      London). revm applies the correct precompile set per `SpecId`, so the "Shanghai keeps
      Istanbul precompiles" nuance needs no special handling (revm's `SHANGHAI` predates the
      Cancun KZG precompile). `BlockContext` (all fields from the verified header) →
-     `BlockEnv` (`prev_randao` feeds both `prevrandao` and `difficulty`). `EvmExecutor`
+     `BlockEnv` (post-merge `DIFFICULTY` reads `prevrandao`, so `difficulty` is 0 — its
+     true post-merge value; pre-merge difficulty and Cancun+ blob base fee aren't modelled,
+     as those blocks aren't servable). `EvmExecutor`
      with `call_view` (from-less zero sender) / `call_view_from` (explicit sender+value for
      `msg.sender`-gated contracts), a fresh per-call `OracleDatabase` over the shared
      caches, and `EvmError` (Reverted{data} / OutOfGas / Halted / ForkTooOld / Oracle /

--- a/rust/myotis-evm/Cargo.toml
+++ b/rust/myotis-evm/Cargo.toml
@@ -22,9 +22,18 @@ myotis-core = { path = "../myotis-core" }
 # cargo-ndk / mobile burden). NB: `c-kzg` and `secp256k1-sys` still appear as
 # ENTRIES in the workspace `Cargo.lock` — they are optional deps of `revm-precompile`
 # that Cargo pins for reproducibility but our feature selection never enables or
-# builds. Exact-pinned like every workspace dep; a revm bump is a deliberate,
-# reviewed change (its API churns across majors).
-revm = { version = "=41.0.0", default-features = false, features = ["std"] }
+# builds. The `optional_*` features are pure config (no new crates): they expose
+# the CfgEnv `disable_*` flags an `eth_call` needs — a view call runs with a real
+# header base fee but zero gas price, an arbitrary/zero sender that may hold code,
+# and 30 M gas regardless of the block limit. Exact-pinned like every workspace
+# dep; a revm bump is a deliberate, reviewed change (its API churns across majors).
+revm = { version = "=41.0.0", default-features = false, features = [
+    "std",
+    "optional_balance_check",
+    "optional_block_gas_limit",
+    "optional_eip3607",
+    "optional_no_base_fee",
+] }
 
 [features]
 # In-memory FixtureSnapStateOracle for downstream tests (the engine crate's

--- a/rust/myotis-evm/src/block.rs
+++ b/rust/myotis-evm/src/block.rs
@@ -1,0 +1,51 @@
+//! [`BlockContext`]: the verified block-level inputs a view call runs against.
+//!
+//! Mirrors the Java `BlockContext`. **Every field must come from the verified
+//! header** — none may be sourced locally (a local clock for `timestamp`, say,
+//! would desync the fork selection from consensus). `block_number` + `timestamp`
+//! select the fork (see [`crate::fork`]); the rest feed EVM opcodes.
+
+use revm::context::BlockEnv;
+use revm::primitives::{Address, B256, U256};
+
+/// Verified block-level context for one view call.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BlockContext {
+    /// State root the call's proofs verify against (SNAP view root). Not a fork
+    /// or opcode input — it selects the world the [`crate::database::OracleDatabase`]
+    /// reads.
+    pub state_root: [u8; 32],
+    /// Block number: NUMBER opcode, and pre-merge fork selection.
+    pub block_number: u64,
+    /// Unix-seconds timestamp: TIMESTAMP opcode, and post-merge fork selection.
+    pub timestamp: u64,
+    /// EIP-1559 base fee (wei): BASEFEE opcode. 0 pre-London (there is none).
+    pub base_fee_per_gas: u64,
+    /// Block proposer: COINBASE opcode.
+    pub coinbase: [u8; 20],
+    /// Post-merge PREVRANDAO (and the pre-merge DIFFICULTY slot — the two share
+    /// the field, as in the header): the DIFFICULTY/PREVRANDAO opcode.
+    pub prev_randao: [u8; 32],
+    /// EIP-155 chain id: CHAINID opcode (and the cfg chain id).
+    pub chain_id: u64,
+    /// Block gas limit: GASLIMIT opcode.
+    pub gas_limit: u64,
+}
+
+impl BlockContext {
+    /// The revm [`BlockEnv`] for this context. `prev_randao` feeds both the
+    /// `prevrandao` field (post-merge) and `difficulty` (pre-merge) so revm reads
+    /// the right one for the active spec, exactly as the header packs them.
+    pub fn block_env(&self) -> BlockEnv {
+        BlockEnv {
+            number: U256::from(self.block_number),
+            timestamp: U256::from(self.timestamp),
+            gas_limit: self.gas_limit,
+            basefee: self.base_fee_per_gas,
+            beneficiary: Address::from(self.coinbase),
+            difficulty: U256::from_be_bytes(self.prev_randao),
+            prevrandao: Some(B256::from(self.prev_randao)),
+            ..BlockEnv::default()
+        }
+    }
+}

--- a/rust/myotis-evm/src/block.rs
+++ b/rust/myotis-evm/src/block.rs
@@ -23,8 +23,8 @@ pub struct BlockContext {
     pub base_fee_per_gas: u64,
     /// Block proposer: COINBASE opcode.
     pub coinbase: [u8; 20],
-    /// Post-merge PREVRANDAO (and the pre-merge DIFFICULTY slot — the two share
-    /// the field, as in the header): the DIFFICULTY/PREVRANDAO opcode.
+    /// The header's mixHash slot = post-merge PREVRANDAO. The DIFFICULTY/PREVRANDAO
+    /// opcode (0x44) reads this on every spec this engine serves (all post-merge).
     pub prev_randao: [u8; 32],
     /// EIP-155 chain id: CHAINID opcode (and the cfg chain id).
     pub chain_id: u64,
@@ -33,9 +33,17 @@ pub struct BlockContext {
 }
 
 impl BlockContext {
-    /// The revm [`BlockEnv`] for this context. `prev_randao` feeds both the
-    /// `prevrandao` field (post-merge) and `difficulty` (pre-merge) so revm reads
-    /// the right one for the active spec, exactly as the header packs them.
+    /// The revm [`BlockEnv`] for this context.
+    ///
+    /// Post-merge (every spec this engine serves), the DIFFICULTY opcode reads
+    /// `prevrandao`, so the `difficulty` field is unused and left 0 — which is also
+    /// the true value in a post-merge header. It is deliberately NOT fed from the
+    /// mixHash bytes: a pre-London..Paris block would then read a wrong difficulty,
+    /// but such blocks aren't servable anyway (no snap state, outside the anchored
+    /// head window). Likewise BLOBBASEFEE reads revm's default floor because
+    /// `BlockContext` carries no excess-blob-gas field yet (matching the Java
+    /// `BlockContextValues`, which maps no blob fields). Add a `difficulty` /
+    /// `excess_blob_gas` field here if pre-merge or blob-fee `eth_call` is ever needed.
     pub fn block_env(&self) -> BlockEnv {
         BlockEnv {
             number: U256::from(self.block_number),
@@ -43,7 +51,7 @@ impl BlockContext {
             gas_limit: self.gas_limit,
             basefee: self.base_fee_per_gas,
             beneficiary: Address::from(self.coinbase),
-            difficulty: U256::from_be_bytes(self.prev_randao),
+            difficulty: U256::ZERO,
             prevrandao: Some(B256::from(self.prev_randao)),
             ..BlockEnv::default()
         }

--- a/rust/myotis-evm/src/error.rs
+++ b/rust/myotis-evm/src/error.rs
@@ -24,6 +24,11 @@ pub enum EvmError {
     /// The target block predates London; the engine does not execute pre-London
     /// state (no local archive, and the fork rules below London aren't modelled).
     ForkTooOld { block_number: u64, timestamp: u64 },
+    /// The block context is for a chain this executor can't run. The fork table is
+    /// mainnet-only, so a non-mainnet chain id would otherwise get mainnet forks —
+    /// fail closed instead of returning a silently-wrong result. (Multichain support
+    /// makes the fork table chain-aware and relaxes this.)
+    UnsupportedChain { chain_id: u64 },
     /// revm rejected the transaction envelope itself (should not happen for a
     /// well-formed view call — surfaced rather than swallowed).
     Transaction { detail: String },
@@ -48,6 +53,9 @@ impl std::fmt::Display for EvmError {
                 f,
                 "pre-London blocks are not supported (blockNumber={block_number}, timestamp={timestamp})"
             ),
+            EvmError::UnsupportedChain { chain_id } => {
+                write!(f, "unsupported chain id {chain_id} (executor is mainnet-only)")
+            }
             EvmError::Transaction { detail } => write!(f, "invalid transaction: {detail}"),
         }
     }

--- a/rust/myotis-evm/src/error.rs
+++ b/rust/myotis-evm/src/error.rs
@@ -1,0 +1,56 @@
+//! [`EvmError`]: the closed outcome set of a view call.
+//!
+//! Wraps the state-fetch failures ([`OracleError`], surfaced from the revm
+//! `Database`) and adds the execution outcomes an `eth_call` can produce. Like
+//! [`OracleError`] it is fail-closed: a caller must handle every arm, and a
+//! revert carries its raw data so the JSON-RPC layer can echo it.
+
+use crate::oracle::OracleError;
+
+/// Everything a view call can return other than the success bytes.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum EvmError {
+    /// State could not be fetched or verified (from the oracle / revm `Database`)
+    /// — includes `BlockHashUnsupported`. See [`OracleError`].
+    Oracle(OracleError),
+    /// The contract reverted. `data` is the raw revert payload (a Solidity
+    /// `Error(string)` is ABI-encoded behind the `0x08c379a0` selector).
+    Reverted { data: Vec<u8> },
+    /// The call ran out of gas within the 30 M ceiling.
+    OutOfGas,
+    /// The EVM halted for another reason (invalid opcode, stack error, …). The
+    /// string is revm's `HaltReason` debug form — diagnostic, not a stable token.
+    Halted { reason: String },
+    /// The target block predates London; the engine does not execute pre-London
+    /// state (no local archive, and the fork rules below London aren't modelled).
+    ForkTooOld { block_number: u64, timestamp: u64 },
+    /// revm rejected the transaction envelope itself (should not happen for a
+    /// well-formed view call — surfaced rather than swallowed).
+    Transaction { detail: String },
+}
+
+impl From<OracleError> for EvmError {
+    fn from(e: OracleError) -> EvmError {
+        EvmError::Oracle(e)
+    }
+}
+
+impl std::fmt::Display for EvmError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            EvmError::Oracle(e) => write!(f, "{e}"),
+            EvmError::Reverted { data } => {
+                write!(f, "execution reverted ({} bytes of data)", data.len())
+            }
+            EvmError::OutOfGas => write!(f, "out of gas"),
+            EvmError::Halted { reason } => write!(f, "execution halted: {reason}"),
+            EvmError::ForkTooOld { block_number, timestamp } => write!(
+                f,
+                "pre-London blocks are not supported (blockNumber={block_number}, timestamp={timestamp})"
+            ),
+            EvmError::Transaction { detail } => write!(f, "invalid transaction: {detail}"),
+        }
+    }
+}
+
+impl std::error::Error for EvmError {}

--- a/rust/myotis-evm/src/executor.rs
+++ b/rust/myotis-evm/src/executor.rs
@@ -1,0 +1,350 @@
+//! [`EvmExecutor`]: `eth_call` over proof-verified state.
+//!
+//! Runs a read-only call against the SNAP-verified world exposed by a
+//! [`SnapStateOracle`], at the fork the block's `(number, timestamp)` selects.
+//! Nothing is committed — a fresh [`OracleDatabase`] is built per call and
+//! discarded, and revm's journal is thrown away.
+//!
+//! ## Why the checks are relaxed
+//!
+//! A view call is not a real transaction: the sender need not exist, hold a
+//! balance, or pay the base fee, and it gets the full block-sized gas allowance.
+//! We therefore run with revm's `CfgEnv` disables — balance, nonce, base fee,
+//! EIP-3607 (sender-has-code), block gas limit — matching the Java executor,
+//! which drives the message processor directly and so performs none of the
+//! transaction-level validations. The call is deliberately NON-static
+//! (`is_static` unset) so a simulated `SSTORE` (every ERC-20 `transfer`/`approve`)
+//! doesn't halt — the writes journal into the per-call state and are discarded.
+//!
+//! EIP-7702 one-hop delegation is handled by revm itself: the oracle serves the
+//! delegation designator as the account's code, and revm resolves the one hop to
+//! the delegate's code (fetched, again, through the oracle). BLOCKHASH is
+//! unsupported — the `Database` returns an error, surfaced as [`EvmError`].
+
+use std::sync::Arc;
+
+use revm::context::result::{ExecutionResult, HaltReason, Output};
+use revm::context::{CfgEnv, TxEnv};
+use revm::database_interface::DBErrorMarker;
+use revm::primitives::{Address, TxKind, U256};
+use revm::{Context, ExecuteEvm, MainBuilder, MainContext};
+
+use crate::block::BlockContext;
+use crate::cache::{BytecodeCache, StateProofCache};
+use crate::database::OracleDatabase;
+use crate::error::EvmError;
+use crate::fork::spec_for;
+use crate::oracle::{OracleError, SnapStateOracle};
+
+/// The gas a view call is given — the mainnet block gas limit. Also set as the
+/// per-tx gas cap so revm's spec-default cap (2²⁴ on the latest fork, EIP-7825)
+/// doesn't clip an `eth_call` that legitimately wants the full block budget.
+pub const VIEW_CALL_GAS: u64 = 30_000_000;
+
+/// The from-less `eth_call` sender: the zero address (Geth's default). A caller
+/// that needs `msg.sender` set (ERC-20 `transfer`/`approve`) uses [`EvmExecutor::call_view_from`].
+const VIEW_CALLER: Address = Address::ZERO;
+
+/// Executes view calls against verified state. Owns the shared cross-call caches,
+/// so repeated calls (e.g. a MetaMask number-pinned retry) reuse verified facts.
+pub struct EvmExecutor {
+    oracle: Arc<dyn SnapStateOracle>,
+    proof_cache: Arc<dyn StateProofCache>,
+    bytecode_cache: Arc<dyn BytecodeCache>,
+}
+
+impl EvmExecutor {
+    pub fn new(
+        oracle: Arc<dyn SnapStateOracle>,
+        proof_cache: Arc<dyn StateProofCache>,
+        bytecode_cache: Arc<dyn BytecodeCache>,
+    ) -> EvmExecutor {
+        EvmExecutor {
+            oracle,
+            proof_cache,
+            bytecode_cache,
+        }
+    }
+
+    /// `eth_call` with a from-less, zero-value anonymous sender.
+    pub fn call_view(
+        &self,
+        target: [u8; 20],
+        calldata: &[u8],
+        ctx: &BlockContext,
+    ) -> Result<Vec<u8>, EvmError> {
+        self.run(VIEW_CALLER, target, calldata, U256::ZERO, ctx)
+    }
+
+    /// `eth_call` with an explicit `sender` and `value` — needed so `msg.sender`-
+    /// gated contracts don't revert against the zero address.
+    pub fn call_view_from(
+        &self,
+        sender: [u8; 20],
+        target: [u8; 20],
+        calldata: &[u8],
+        value: U256,
+        ctx: &BlockContext,
+    ) -> Result<Vec<u8>, EvmError> {
+        self.run(Address::from(sender), target, calldata, value, ctx)
+    }
+
+    fn run(
+        &self,
+        caller: Address,
+        target: [u8; 20],
+        calldata: &[u8],
+        value: U256,
+        ctx: &BlockContext,
+    ) -> Result<Vec<u8>, EvmError> {
+        let spec = spec_for(ctx.block_number, ctx.timestamp)?;
+
+        let db = OracleDatabase::new(
+            Arc::clone(&self.oracle),
+            ctx.state_root,
+            Arc::clone(&self.proof_cache),
+            Arc::clone(&self.bytecode_cache),
+        );
+
+        let mut cfg = CfgEnv::new_with_spec(spec);
+        cfg.chain_id = ctx.chain_id;
+        // A view call isn't a real tx: relax the transaction-level checks (see the
+        // module docs). `tx_gas_limit_cap` is raised to VIEW_CALL_GAS so the spec's
+        // own per-tx cap doesn't clip the full-block gas budget.
+        cfg.disable_nonce_check = true;
+        cfg.disable_balance_check = true;
+        cfg.disable_base_fee = true;
+        cfg.disable_eip3607 = true;
+        cfg.disable_block_gas_limit = true;
+        cfg.tx_gas_limit_cap = Some(VIEW_CALL_GAS);
+
+        let tx = TxEnv::builder()
+            .caller(caller)
+            .kind(TxKind::Call(Address::from(target)))
+            .value(value)
+            .data(calldata.to_vec().into())
+            .gas_limit(VIEW_CALL_GAS)
+            .build_fill();
+
+        let mut evm = Context::mainnet()
+            .with_ref_db(db)
+            .with_block(ctx.block_env())
+            .with_cfg(cfg)
+            .build_mainnet();
+
+        let out = evm.transact(tx).map_err(map_evm_error)?;
+        match out.result {
+            ExecutionResult::Success { output, .. } => Ok(output_bytes(output)),
+            ExecutionResult::Revert { output, .. } => Err(EvmError::Reverted {
+                data: output.to_vec(),
+            }),
+            ExecutionResult::Halt { reason, .. } => Err(map_halt(reason)),
+        }
+    }
+}
+
+fn output_bytes(output: Output) -> Vec<u8> {
+    output.into_data().to_vec()
+}
+
+fn map_halt(reason: HaltReason) -> EvmError {
+    match reason {
+        HaltReason::OutOfGas(_) => EvmError::OutOfGas,
+        other => EvmError::Halted {
+            reason: format!("{other:?}"),
+        },
+    }
+}
+
+/// Map revm's top-level error into [`EvmError`]. A `Database` error is our
+/// [`OracleError`] (state couldn't be fetched/verified); a `Transaction` error is
+/// an envelope rejection we surface rather than swallow.
+fn map_evm_error<E: DBErrorMarker + Into<EvmError> + std::fmt::Display>(
+    err: revm::context::result::EVMError<E>,
+) -> EvmError {
+    use revm::context::result::EVMError;
+    match err {
+        EVMError::Database(e) => e.into(),
+        other => EvmError::Transaction {
+            detail: other.to_string(),
+        },
+    }
+}
+
+// Ensure the DB error the executor threads is exactly OracleError (a compile-time
+// guard: if OracleDatabase's Error type ever diverges, `run` stops compiling).
+const _: fn() = || {
+    fn assert_db_error<T: DBErrorMarker + Into<EvmError>>() {}
+    assert_db_error::<OracleError>();
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cache::{NoopBytecodeCache, NoopStateProofCache};
+    use crate::fork::{CANCUN_TIME, LONDON_BLOCK};
+    use crate::oracle::{FixtureSnapStateOracle, OracleAccount};
+    use myotis_core::keccak::keccak256;
+
+    const ROOT: [u8; 32] = [0xAA; 32];
+    const TARGET: [u8; 20] = [0x11; 20];
+
+    fn ctx(block: u64, ts: u64) -> BlockContext {
+        BlockContext {
+            state_root: ROOT,
+            block_number: block,
+            timestamp: ts,
+            base_fee_per_gas: 7, // non-zero: proves disable_base_fee lets a 0-price call run
+            coinbase: [0x22; 20],
+            prev_randao: [0x33; 32],
+            chain_id: 1,
+            gas_limit: 30_000_000,
+        }
+    }
+
+    /// Build an executor whose fixture hosts `code` (and optional slot-0 value) at
+    /// TARGET, with Noop caches.
+    fn executor_with(code: Vec<u8>, slot0: Option<U256>) -> EvmExecutor {
+        let ch = keccak256(&code);
+        let mut fx = FixtureSnapStateOracle::new().with_account(
+            ROOT,
+            TARGET,
+            OracleAccount {
+                nonce: 1,
+                balance: U256::ZERO,
+                code_hash: ch,
+                storage_root: [0x9; 32],
+            },
+        );
+        assert_eq!(fx.with_bytecode(code), ch);
+        if let Some(v) = slot0 {
+            fx = fx.with_storage(ROOT, TARGET, [0u8; 32], v);
+        }
+        EvmExecutor::new(
+            Arc::new(fx),
+            Arc::new(NoopStateProofCache),
+            Arc::new(NoopBytecodeCache),
+        )
+    }
+
+    #[test]
+    fn cancun_call_returns_verified_storage_uint256() {
+        // Mirrors the Java EvmFactoryTest: Cancun EVM, SLOAD slot 0 → return 32
+        // bytes. PUSH1 0 SLOAD PUSH1 0 MSTORE PUSH1 0x20 PUSH1 0 RETURN.
+        let code = vec![
+            0x60u8, 0x00, 0x54, 0x60, 0x00, 0x52, 0x60, 0x20, 0x60, 0x00, 0xf3,
+        ];
+        let exec = executor_with(code, Some(U256::from(12_345_678_900_000_000_000_000u128)));
+        let out = exec
+            .call_view(TARGET, &[], &ctx(19_500_000, CANCUN_TIME + 1))
+            .unwrap();
+        assert_eq!(out.len(), 32);
+        assert_eq!(
+            U256::from_be_slice(&out),
+            U256::from(12_345_678_900_000_000_000_000u128)
+        );
+    }
+
+    #[test]
+    fn from_overload_sets_msg_sender() {
+        // CALLER PUSH1 0 MSTORE PUSH1 0x20 PUSH1 0 RETURN — returns msg.sender.
+        let code = vec![0x33u8, 0x60, 0x00, 0x52, 0x60, 0x20, 0x60, 0x00, 0xf3];
+        let exec = executor_with(code, None);
+        let sender = [0x42u8; 20];
+        let out = exec
+            .call_view_from(
+                sender,
+                TARGET,
+                &[],
+                U256::ZERO,
+                &ctx(19_500_000, CANCUN_TIME + 1),
+            )
+            .unwrap();
+        assert_eq!(
+            &out[12..32],
+            &sender,
+            "msg.sender must be the supplied from"
+        );
+        // The from-less overload is the zero address.
+        let anon = exec
+            .call_view(TARGET, &[], &ctx(19_500_000, CANCUN_TIME + 1))
+            .unwrap();
+        assert_eq!(U256::from_be_slice(&anon), U256::ZERO);
+    }
+
+    #[test]
+    fn callvalue_is_passed_through() {
+        // CALLVALUE PUSH1 0 MSTORE PUSH1 0x20 PUSH1 0 RETURN — returns msg.value.
+        let code = vec![0x34u8, 0x60, 0x00, 0x52, 0x60, 0x20, 0x60, 0x00, 0xf3];
+        let exec = executor_with(code, None);
+        let out = exec
+            .call_view_from(
+                [0x1; 20],
+                TARGET,
+                &[],
+                U256::from(777),
+                &ctx(19_500_000, CANCUN_TIME + 1),
+            )
+            .unwrap();
+        assert_eq!(U256::from_be_slice(&out), U256::from(777));
+    }
+
+    #[test]
+    fn revert_surfaces_raw_data() {
+        // PUSH1 0xAB PUSH1 0 MSTORE PUSH1 0x20 PUSH1 0 REVERT.
+        let code = vec![0x60u8, 0xAB, 0x60, 0x00, 0x52, 0x60, 0x20, 0x60, 0x00, 0xfd];
+        let exec = executor_with(code, None);
+        let err = exec
+            .call_view(TARGET, &[], &ctx(19_500_000, CANCUN_TIME + 1))
+            .unwrap_err();
+        match err {
+            EvmError::Reverted { data } => {
+                assert_eq!(data.len(), 32);
+                assert_eq!(data.last(), Some(&0xABu8));
+            }
+            other => panic!("expected revert, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn out_of_gas_is_reported() {
+        // An unbounded loop: JUMPDEST PUSH1 0 JUMP (0x5b 0x60 0x00 0x56) spins until
+        // the 30 M gas runs out.
+        let code = vec![0x5bu8, 0x60, 0x00, 0x56];
+        let exec = executor_with(code, None);
+        let err = exec
+            .call_view(TARGET, &[], &ctx(19_500_000, CANCUN_TIME + 1))
+            .unwrap_err();
+        assert!(matches!(err, EvmError::OutOfGas), "got {err:?}");
+    }
+
+    #[test]
+    fn pre_london_block_is_fork_too_old() {
+        let code = vec![
+            0x60u8, 0x00, 0x54, 0x60, 0x00, 0x52, 0x60, 0x20, 0x60, 0x00, 0xf3,
+        ];
+        let exec = executor_with(code, None);
+        // Below London and no post-merge timestamp → rejected before any execution.
+        let err = exec
+            .call_view(TARGET, &[], &ctx(LONDON_BLOCK - 1, 0))
+            .unwrap_err();
+        assert!(matches!(err, EvmError::ForkTooOld { .. }), "got {err:?}");
+    }
+
+    #[test]
+    fn absent_target_returns_empty_output() {
+        // Empty fixture: the target account is absent → calling it returns empty
+        // (no code to run), which revm treats as an immediate success with empty
+        // output. A *state-unavailable* oracle would instead surface EvmError::Oracle;
+        // here we assert the absent-account path returns empty, not a panic.
+        let exec = EvmExecutor::new(
+            Arc::new(FixtureSnapStateOracle::new()),
+            Arc::new(NoopStateProofCache),
+            Arc::new(NoopBytecodeCache),
+        );
+        let out = exec
+            .call_view(TARGET, &[], &ctx(19_500_000, CANCUN_TIME + 1))
+            .unwrap();
+        assert!(out.is_empty());
+    }
+}

--- a/rust/myotis-evm/src/executor.rs
+++ b/rust/myotis-evm/src/executor.rs
@@ -45,6 +45,11 @@ pub const VIEW_CALL_GAS: u64 = 30_000_000;
 /// that needs `msg.sender` set (ERC-20 `transfer`/`approve`) uses [`EvmExecutor::call_view_from`].
 const VIEW_CALLER: Address = Address::ZERO;
 
+/// The only chain this executor runs: the fork table and `Context::mainnet()` are
+/// mainnet-specific, so a non-mainnet context is rejected rather than silently
+/// given mainnet forks. Relaxed when the fork table becomes chain-aware.
+const MAINNET_CHAIN_ID: u64 = 1;
+
 /// Executes view calls against verified state. Owns the shared cross-call caches,
 /// so repeated calls (e.g. a MetaMask number-pinned retry) reuse verified facts.
 pub struct EvmExecutor {
@@ -97,6 +102,13 @@ impl EvmExecutor {
         value: U256,
         ctx: &BlockContext,
     ) -> Result<Vec<u8>, EvmError> {
+        // Fail closed on a non-mainnet context: the fork table and Context::mainnet()
+        // below are mainnet-specific, so any other chain would run the wrong rules.
+        if ctx.chain_id != MAINNET_CHAIN_ID {
+            return Err(EvmError::UnsupportedChain {
+                chain_id: ctx.chain_id,
+            });
+        }
         let spec = spec_for(ctx.block_number, ctx.timestamp)?;
 
         let db = OracleDatabase::new(
@@ -328,6 +340,21 @@ mod tests {
             .call_view(TARGET, &[], &ctx(19_500_000, CANCUN_TIME + 1))
             .unwrap_err();
         assert!(matches!(err, EvmError::OutOfGas), "got {err:?}");
+    }
+
+    #[test]
+    fn non_mainnet_chain_is_rejected() {
+        let code = vec![
+            0x60u8, 0x00, 0x54, 0x60, 0x00, 0x52, 0x60, 0x20, 0x60, 0x00, 0xf3,
+        ];
+        let exec = executor_with(code, None);
+        let mut c = ctx(19_500_000, CANCUN_TIME + 1);
+        c.chain_id = 100; // Gnosis — mainnet-only executor must fail closed
+        let err = exec.call_view(TARGET, &[], &c).unwrap_err();
+        assert!(
+            matches!(err, EvmError::UnsupportedChain { chain_id: 100 }),
+            "got {err:?}"
+        );
     }
 
     #[test]

--- a/rust/myotis-evm/src/executor.rs
+++ b/rust/myotis-evm/src/executor.rs
@@ -290,6 +290,18 @@ mod tests {
     }
 
     #[test]
+    fn prevrandao_opcode_returns_context_value() {
+        // PREVRANDAO PUSH1 0 MSTORE PUSH1 0x20 PUSH1 0 RETURN — opcode 0x44 reads
+        // prevrandao post-merge; must be the context's prev_randao ([0x33; 32]).
+        let code = vec![0x44u8, 0x60, 0x00, 0x52, 0x60, 0x20, 0x60, 0x00, 0xf3];
+        let exec = executor_with(code, None);
+        let out = exec
+            .call_view(TARGET, &[], &ctx(19_500_000, CANCUN_TIME + 1))
+            .unwrap();
+        assert_eq!(out.as_slice(), &[0x33u8; 32]);
+    }
+
+    #[test]
     fn revert_surfaces_raw_data() {
         // PUSH1 0xAB PUSH1 0 MSTORE PUSH1 0x20 PUSH1 0 REVERT.
         let code = vec![0x60u8, 0xAB, 0x60, 0x00, 0x52, 0x60, 0x20, 0x60, 0x00, 0xfd];

--- a/rust/myotis-evm/src/fork.rs
+++ b/rust/myotis-evm/src/fork.rs
@@ -1,0 +1,91 @@
+//! The mainnet fork table: `(block_number, timestamp) → revm SpecId`.
+//!
+//! Mirrors the Java `EvmFactory` cascade verbatim. Pre-merge forks activate by
+//! block number, post-merge forks by timestamp, so the cascade checks timestamp
+//! first (a post-merge block is always at/after the merge block) and falls back
+//! to block number. Everything below London throws — the engine has no local
+//! archive and does not model pre-London fork rules.
+//!
+//! revm applies the correct precompile set per `SpecId` automatically, so the
+//! Java "Shanghai keeps Istanbul precompiles" nuance needs no special handling
+//! here: revm's `SpecId::SHANGHAI` predates the Cancun KZG point-evaluation
+//! precompile (0x0A), exactly as intended.
+
+use revm::primitives::hardfork::SpecId;
+
+use crate::error::EvmError;
+
+/// London activation block (EIP-1559 base fee).
+pub const LONDON_BLOCK: u64 = 12_965_000;
+/// The Merge (Paris) activation block.
+pub const PARIS_BLOCK: u64 = 15_537_394;
+/// Shanghai activation timestamp (withdrawals, PUSH0).
+pub const SHANGHAI_TIME: u64 = 1_681_338_455;
+/// Cancun activation timestamp (blobs, transient storage, KZG precompile).
+pub const CANCUN_TIME: u64 = 1_710_338_135;
+/// Prague activation timestamp (EIP-7702, …).
+pub const PRAGUE_TIME: u64 = 1_746_612_311;
+
+/// The revm `SpecId` a mainnet `(block_number, timestamp)` activates, or
+/// [`EvmError::ForkTooOld`] below London.
+pub fn spec_for(block_number: u64, timestamp: u64) -> Result<SpecId, EvmError> {
+    if timestamp >= PRAGUE_TIME {
+        Ok(SpecId::PRAGUE)
+    } else if timestamp >= CANCUN_TIME {
+        Ok(SpecId::CANCUN)
+    } else if timestamp >= SHANGHAI_TIME {
+        Ok(SpecId::SHANGHAI)
+    } else if block_number >= PARIS_BLOCK {
+        Ok(SpecId::MERGE)
+    } else if block_number >= LONDON_BLOCK {
+        Ok(SpecId::LONDON)
+    } else {
+        Err(EvmError::ForkTooOld {
+            block_number,
+            timestamp,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn below_london_is_rejected() {
+        assert!(matches!(
+            spec_for(LONDON_BLOCK - 1, 0),
+            Err(EvmError::ForkTooOld { .. })
+        ));
+        assert!(matches!(spec_for(0, 0), Err(EvmError::ForkTooOld { .. })));
+    }
+
+    #[test]
+    fn each_boundary_maps_to_its_spec() {
+        // London/Paris are block-gated; timestamp below Shanghai so it doesn't win.
+        assert_eq!(spec_for(LONDON_BLOCK, 0).unwrap(), SpecId::LONDON);
+        assert_eq!(spec_for(PARIS_BLOCK - 1, 0).unwrap(), SpecId::LONDON);
+        assert_eq!(spec_for(PARIS_BLOCK, 0).unwrap(), SpecId::MERGE);
+        // Post-merge forks are timestamp-gated (block number well past Paris).
+        assert_eq!(
+            spec_for(20_000_000, SHANGHAI_TIME).unwrap(),
+            SpecId::SHANGHAI
+        );
+        assert_eq!(
+            spec_for(20_000_000, CANCUN_TIME - 1).unwrap(),
+            SpecId::SHANGHAI
+        );
+        assert_eq!(spec_for(20_000_000, CANCUN_TIME).unwrap(), SpecId::CANCUN);
+        assert_eq!(
+            spec_for(20_000_000, PRAGUE_TIME - 1).unwrap(),
+            SpecId::CANCUN
+        );
+        assert_eq!(spec_for(20_000_000, PRAGUE_TIME).unwrap(), SpecId::PRAGUE);
+    }
+
+    #[test]
+    fn timestamp_takes_precedence_over_block_for_post_merge() {
+        // A block at the merge height but with a Cancun timestamp is Cancun.
+        assert_eq!(spec_for(PARIS_BLOCK, CANCUN_TIME).unwrap(), SpecId::CANCUN);
+    }
+}

--- a/rust/myotis-evm/src/fork.rs
+++ b/rust/myotis-evm/src/fork.rs
@@ -28,6 +28,11 @@ pub const PRAGUE_TIME: u64 = 1_746_612_311;
 
 /// The revm `SpecId` a mainnet `(block_number, timestamp)` activates, or
 /// [`EvmError::ForkTooOld`] below London.
+///
+/// MAINNET ONLY. These are Ethereum mainnet activation points; a different chain
+/// (e.g. Gnosis) forks at different heights/times. When multichain `eth_call` is
+/// wired, this must become chain-aware (keyed on the context's chain id) — do not
+/// call it for a non-mainnet block.
 pub fn spec_for(block_number: u64, timestamp: u64) -> Result<SpecId, EvmError> {
     if timestamp >= PRAGUE_TIME {
         Ok(SpecId::PRAGUE)

--- a/rust/myotis-evm/src/lib.rs
+++ b/rust/myotis-evm/src/lib.rs
@@ -8,46 +8,48 @@
 //!
 //! This is the Rust twin of the Java `io.myotis.evm` module (see
 //! `docs/reimplementation/03` and the Milestone-C section of `…/07`). It is built
-//! up over several PRs; **EL-C-1 (this slice)** lands the foundation only:
+//! up over several PRs:
 //!
-//! * [`SnapStateOracle`] — the verified world-state trait, with an in-memory
-//!   [`FixtureSnapStateOracle`] for tests;
-//! * the cache tiers — [`StateProofCache`] (cross-call, `stateRoot`-keyed) and
-//!   [`BytecodeCache`] (content-addressed, forever), plus a per-call view cache
-//!   private to the adapter;
-//! * [`OracleDatabase`] — the `revm` `DatabaseRef` adapter over the oracle and
-//!   the caches.
+//! * the foundation ([`SnapStateOracle`] + [`FixtureSnapStateOracle`], the
+//!   [`StateProofCache`]/[`BytecodeCache`] tiers, and [`OracleDatabase`] — the
+//!   `revm` `DatabaseRef` adapter);
+//! * **EL-C-2 (this slice)**: the [`EvmExecutor`] — `eth_call` view calls over
+//!   verified state — and the mainnet [`fork`] table mapping
+//!   `(block_number, timestamp)` to a revm `SpecId`.
 //!
-//! The view-call / gas-estimation executor, the mainnet fork table, the async
-//! prefetch loop, and ENS/CCIP-Read arrive in the following Milestone-C slices.
+//! The async prefetch loop, `estimateGas`, and ENS/CCIP-Read arrive in the
+//! following slices.
 //!
-//! ## Wiring the EVM
+//! ## Running a view call
 //!
 //! ```ignore
 //! use std::sync::Arc;
-//! use myotis_evm::{OracleDatabase, cache::{NoopStateProofCache, NoopBytecodeCache}};
-//! use revm::database_interface::WrapDatabaseRef;
-//! use revm::{Context, ExecuteEvm, MainBuilder, MainContext};
+//! use myotis_evm::{BlockContext, EvmExecutor, InMemoryStateProofCache, InMemoryBytecodeCache};
 //!
-//! let db = OracleDatabase::new(
-//!     oracle,                                  // Arc<dyn SnapStateOracle>
-//!     state_root,                              // the block's beacon-anchored root
-//!     Arc::new(NoopStateProofCache),
-//!     Arc::new(NoopBytecodeCache),
+//! let exec = EvmExecutor::new(
+//!     oracle,                                     // Arc<dyn SnapStateOracle>
+//!     Arc::new(InMemoryStateProofCache::new(8192)),
+//!     Arc::new(InMemoryBytecodeCache::new()),
 //! );
-//! let mut evm = Context::mainnet().with_db(WrapDatabaseRef(db)).build_mainnet();
-//! // evm.transact(TxEnv::builder()…build_fill())  // EL-C-2
+//! let ret = exec.call_view(token, &balance_of_calldata, &ctx)?; // BlockContext ctx
 //! ```
 
+pub mod block;
 pub mod cache;
 pub mod database;
+pub mod error;
+pub mod executor;
+pub mod fork;
 pub mod oracle;
 
+pub use block::BlockContext;
 pub use cache::{
     BytecodeCache, InMemoryBytecodeCache, InMemoryStateProofCache, NoopBytecodeCache,
     NoopStateProofCache, StateProofCache,
 };
 pub use database::OracleDatabase;
+pub use error::EvmError;
+pub use executor::EvmExecutor;
 pub use oracle::{OracleAccount, OracleError, SnapStateOracle};
 
 #[cfg(any(test, feature = "fixture"))]


### PR DESCRIPTION
Second slice of **Milestone C**. `myotis-evm` now runs read-only `eth_call`s over SNAP-proof-verified state, at the fork the block selects. Builds on the EL-C-1 oracle/adapter/caches.

## What lands
- **`fork::spec_for(block_number, timestamp) → SpecId`** — the mainnet cascade verbatim (`LONDON_BLOCK`/`PARIS_BLOCK`/`SHANGHAI_TIME`/`CANCUN_TIME`/`PRAGUE_TIME`; timestamp checked before block; `EvmError::ForkTooOld` below London). revm applies the correct precompile set per `SpecId`, so the "Shanghai keeps Istanbul precompiles" nuance is automatic. Documented mainnet-only (a guard for future Gnosis wiring).
- **`BlockContext` → `BlockEnv`** — every field from the verified header. Post-merge `DIFFICULTY` reads `prevrandao`; `difficulty` is left 0 (its true post-merge value), and pre-merge difficulty / Cancun+ blob base fee are documented as not-modelled (matches the Java `BlockContextValues`; pre-merge blocks aren't servable anyway).
- **`EvmExecutor`** — `call_view` (from-less zero sender) and `call_view_from` (explicit sender+value so `msg.sender`-gated ERC-20 calls don't revert). Fresh per-call `OracleDatabase` over the shared caches (nothing committed); non-static so simulated SSTOREs don't halt; EIP-7702 one-hop handled by revm; BLOCKHASH surfaces fail-closed as `EvmError`.
- **`EvmError`** — closed, fail-closed taxonomy (`Reverted{data}` / `OutOfGas` / `Halted` / `ForkTooOld` / `Oracle` / `Transaction`).

## Resolves the EL-C-1 carry
- **30 M gas** works via `CfgEnv.tx_gas_limit_cap = Some(30M)` (overrides the EIP-7825 2²⁴ spec cap).
- The `eth_call` check relaxations use revm's **pure-config `optional_*` features** (`optional_balance_check`/`optional_block_gas_limit`/`optional_eip3607`/`optional_no_base_fee`) — still **zero C crates** (`cargo tree -p myotis-evm -i c-kzg` prints nothing).

## Tests
Fixture-backed `eth_call`: Cancun SLOAD-return uint256 (mirrors the Java `EvmFactoryTest`), `msg.sender`/`msg.value` pass-through, PREVRANDAO pass-through, revert-data surfacing, out-of-gas, pre-London rejection; plus fork-boundary unit tests. **24 tests, full workspace green.**

An independent no-context review of the diff ran before this PR — it confirmed the fail-closed / isolation / no-C-deps properties and flagged the two block-mapping divergences fixed in the last commit.

**Not yet wired to the host:** the production `SnapStateOracle` over `ElReader` (the async→sync bridge) and the JNI/Java `eth_call` routing are the next slice — that's what lights the live MetaMask path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)