### PR TITLE
EL-C-4: verified eth_estimateGas over the revm executor

### DIFF
--- a/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
@@ -556,13 +556,18 @@ final class RustChainHandle implements ChainHandle, NodeStatusReads {
     /** Package-private test seam: estimateGas JSON → gas estimate (or null) without JNI. */
     static Long estimateGasFromJson(String json) {
         JsonObject o = parseResultOrThrow(json, "estimateGas");
+        // A revert / unavailable run has no estimate → null.
+        if (!"ok".equals(stringOrNull(o, "status"))) return null;
+        // status == "ok" MUST carry a numeric gas; a missing/non-numeric one is native
+        // shape drift → fail closed (EngineException), not a silent "unavailable".
         try {
-            // Only "ok" carries a number; a revert / unavailable run has no estimate → null.
             var gas = o.get("gas");
-            if ("ok".equals(stringOrNull(o, "status")) && gas != null && !gas.isNull()) {
-                return gas.asLong();
+            if (gas == null || gas.isNull()) {
+                throw new EngineException("estimateGas JSON: status=ok without a numeric 'gas' field");
             }
-            return null;
+            return gas.asLong();
+        } catch (EngineException e) {
+            throw e;
         } catch (RuntimeException e) {
             throw new EngineException(
                     "malformed estimateGas JSON from the Rust engine: " + e.getMessage(), e);

--- a/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
@@ -544,6 +544,32 @@ final class RustChainHandle implements ChainHandle, NodeStatusReads {
     }
 
     /**
+     * One verified {@code eth_estimateGas}: the gas-limit estimate, or null. {@code
+     * from} empty for an anonymous sender; {@code valueDecimal} is wei as a decimal
+     * string. Throws {@link EngineException} on a transport / not-running failure.
+     */
+    Long estimateGasVerified(String fromHex, String toHex, String dataHex, String valueDecimal) {
+        return estimateGasFromJson(
+                RustEngineNative.nativeEstimateGasJson(handle, fromHex, toHex, dataHex, valueDecimal));
+    }
+
+    /** Package-private test seam: estimateGas JSON → gas estimate (or null) without JNI. */
+    static Long estimateGasFromJson(String json) {
+        JsonObject o = parseResultOrThrow(json, "estimateGas");
+        try {
+            // Only "ok" carries a number; a revert / unavailable run has no estimate → null.
+            var gas = o.get("gas");
+            if ("ok".equals(stringOrNull(o, "status")) && gas != null && !gas.isNull()) {
+                return gas.asLong();
+            }
+            return null;
+        } catch (RuntimeException e) {
+            throw new EngineException(
+                    "malformed estimateGas JSON from the Rust engine: " + e.getMessage(), e);
+        }
+    }
+
+    /**
      * One verified 32-byte storage word at a RAW position (eth_getStorageAt), or
      * null when unverified. The value is left-padded to a full 32-byte word (a
      * zero/unset slot → 32 zero bytes). {@code position32Hex} is the 0x-hex 32-byte

--- a/myotis-engines/src/main/java/io/myotis/engines/RustEngineNative.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustEngineNative.java
@@ -23,7 +23,7 @@ final class RustEngineNative {
     private static final Logger log = LoggerFactory.getLogger(RustEngineNative.class);
 
     /** Must match {@code ABI_VERSION} in rust/myotis-engine/src/lib.rs. */
-    static final int EXPECTED_ABI_VERSION = 9; // 9: + nativeEthCallJson
+    static final int EXPECTED_ABI_VERSION = 10; // 10: + nativeEstimateGasJson
 
     private static final boolean AVAILABLE = load();
 
@@ -151,6 +151,17 @@ final class RustEngineNative {
      */
     static native String nativeEthCallJson(
             long handle, String from, String to, String data, String value, String block);
+
+    /**
+     * A verified {@code eth_estimateGas} over the revm executor for a running handle,
+     * as JSON ({@code {"status":"ok","gas":N}} on success,
+     * {@code {"status":"unavailable","reason":"…"}} for a revert/unverifiable run, or
+     * {@code {"error":"…"}} on a transport/bad-input failure). Runs against the verified
+     * head (no block arg). {@code from} empty ⇒ anonymous sender; {@code value} is wei
+     * as a decimal string.
+     */
+    static native String nativeEstimateGasJson(
+            long handle, String from, String to, String data, String value);
 
     /**
      * Verified {@code eth_getBlockByNumber} (transactions as hashes) for a running

--- a/myotis-engines/src/main/java/io/myotis/engines/RustVerifiedReads.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustVerifiedReads.java
@@ -231,18 +231,29 @@ final class RustVerifiedReads implements VerifiedReads {
     @Override public String feeHistory(long blockCount, String newestBlock, double[] rewardPercentiles) { return null; }
     @Override
     public Long estimateGas(byte[] from, byte[] to, byte[] data, String valueWei) {
-        // The trivial case only, without the EVM (EL-C): a plain value transfer to an
-        // EOA with no calldata costs exactly 21000 intrinsic gas. Anything else needs
-        // the EVM → null:
-        //  - to == null  → contract creation
-        //  - non-empty data → runs code
-        //  - a recipient WITH code (a contract, or a 7702-delegated EOA) → its
-        //    receive/fallback (or delegated code) can run on a bare value transfer.
+        // Contract creation (to == null) isn't handled.
         if (to == null || to.length != 20) return null;
-        if (data != null && data.length != 0) return null;
-        byte[] code = getCode(to, "latest"); // verified recipient bytecode
-        if (code == null || code.length != 0) return null;
-        return 21_000L;
+        if (from != null && from.length != 20) return null;
+        // Fast path: a plain value transfer (no calldata) to a codeless EOA costs
+        // exactly 21000 intrinsic gas — no EVM run needed. A recipient WITH code (a
+        // contract or a 7702-delegated EOA) can run its receive/fallback even on a
+        // bare transfer, so it falls through to the EVM.
+        if (data == null || data.length == 0) {
+            byte[] code = getCode(to, "latest"); // verified recipient bytecode
+            if (code != null && code.length == 0) return 21_000L;
+            if (code == null) return null; // couldn't verify the recipient → can't answer
+        }
+        // EVM path (EL-C): run the call and take the buffered gas-limit estimate.
+        try {
+            return handle.estimateGasVerified(
+                    from == null ? "" : toHex(from),
+                    toHex(to),
+                    data == null ? "" : toHex(data),
+                    valueWei == null ? "" : valueWei);
+        } catch (RuntimeException e) {
+            log.debug("[engines] verified estimateGas unavailable: {}", e.getMessage());
+            return null;
+        }
     }
 
     // ---- helpers ----

--- a/myotis-engines/src/test/java/io/myotis/engines/RustVerifiedReadJsonTest.java
+++ b/myotis-engines/src/test/java/io/myotis/engines/RustVerifiedReadJsonTest.java
@@ -244,6 +244,26 @@ class RustVerifiedReadJsonTest {
                 () -> RustChainHandle.callResultFromJson("{\"error\":\"no snap peer available\"}"));
     }
 
+    // ---- eth_estimateGas (estimateGasFromJson) ----
+
+    @Test
+    void okEstimateReturnsGasNumber() {
+        assertEquals(Long.valueOf(24_150L),
+                RustChainHandle.estimateGasFromJson("{\"status\":\"ok\",\"gas\":24150}"));
+    }
+
+    @Test
+    void unavailableEstimateIsNull() {
+        assertNull(RustChainHandle.estimateGasFromJson(
+                "{\"status\":\"unavailable\",\"reason\":\"execution reverted\"}"));
+    }
+
+    @Test
+    void estimateErrorObjectBecomesEngineException() {
+        assertThrows(EngineException.class,
+                () -> RustChainHandle.estimateGasFromJson("{\"error\":\"handle not started\"}"));
+    }
+
     // ---- eth_getStorageAt (storageValueFromJson) ----
 
     @Test

--- a/myotis-engines/src/test/java/io/myotis/engines/RustVerifiedReadJsonTest.java
+++ b/myotis-engines/src/test/java/io/myotis/engines/RustVerifiedReadJsonTest.java
@@ -264,6 +264,14 @@ class RustVerifiedReadJsonTest {
                 () -> RustChainHandle.estimateGasFromJson("{\"error\":\"handle not started\"}"));
     }
 
+    @Test
+    void okEstimateWithoutGasFailsClosed() {
+        // status=ok but no numeric gas is native shape drift → EngineException, not a
+        // silent null (which would masquerade as a legitimate "unavailable").
+        assertThrows(EngineException.class,
+                () -> RustChainHandle.estimateGasFromJson("{\"status\":\"ok\"}"));
+    }
+
     // ---- eth_getStorageAt (storageValueFromJson) ----
 
     @Test

--- a/rust/myotis-engine/src/eljson.rs
+++ b/rust/myotis-engine/src/eljson.rs
@@ -8,7 +8,7 @@
 //! serializes `{"error": "..."}`, which the Java side raises as an
 //! `EngineException`.
 
-use myotis_net::el::evm::CallOutcome;
+use myotis_net::el::evm::{CallOutcome, GasOutcome};
 use myotis_net::el::reader::{
     FeeEstimate, VerifiedAccount, VerifiedBlock, VerifiedCode, VerifiedStorage,
 };
@@ -250,6 +250,24 @@ pub fn call_json(outcome: &CallOutcome) -> String {
             obj.insert("dataHex".into(), hex0x_var(data).into());
         }
         CallOutcome::Unavailable(reason) => {
+            obj.insert("status".into(), "unavailable".into());
+            obj.insert("reason".into(), reason.as_str().into());
+        }
+    }
+    serde_json::Value::Object(obj).to_string()
+}
+
+/// `estimateGas` result: `{"status":"ok","gas":N}` (a JSON number ≤ 30 M) or
+/// `{"status":"unavailable","reason":"…"}`. The Java side returns the number for
+/// `ok` and null otherwise (a reverting/unverifiable estimate has no number).
+pub fn estimate_json(outcome: &GasOutcome) -> String {
+    let mut obj = serde_json::Map::new();
+    match outcome {
+        GasOutcome::Estimate(gas) => {
+            obj.insert("status".into(), "ok".into());
+            obj.insert("gas".into(), json_u64(*gas));
+        }
+        GasOutcome::Unavailable(reason) => {
             obj.insert("status".into(), "unavailable".into());
             obj.insert("reason".into(), reason.as_str().into());
         }
@@ -501,6 +519,21 @@ mod tests {
         .unwrap();
         assert_eq!(un["status"], "unavailable");
         assert_eq!(un["reason"], "out of gas");
+    }
+
+    #[test]
+    fn estimate_json_shapes() {
+        let ok: serde_json::Value =
+            serde_json::from_str(&estimate_json(&GasOutcome::Estimate(24_150))).unwrap();
+        assert_eq!(ok["status"], "ok");
+        assert_eq!(ok["gas"], 24_150);
+
+        let un: serde_json::Value = serde_json::from_str(&estimate_json(
+            &GasOutcome::Unavailable("execution reverted".to_string()),
+        ))
+        .unwrap();
+        assert_eq!(un["status"], "unavailable");
+        assert_eq!(un["reason"], "execution reverted");
     }
 
     fn sample_code() -> VerifiedCode {

--- a/rust/myotis-engine/src/eljson.rs
+++ b/rust/myotis-engine/src/eljson.rs
@@ -257,7 +257,8 @@ pub fn call_json(outcome: &CallOutcome) -> String {
     serde_json::Value::Object(obj).to_string()
 }
 
-/// `estimateGas` result: `{"status":"ok","gas":N}` (a JSON number ≤ 30 M) or
+/// `estimateGas` result: `{"status":"ok","gas":N}` (the buffered gas-limit estimate
+/// as a JSON number — the 1.15 buffer can put it slightly above the 30 M base) or
 /// `{"status":"unavailable","reason":"…"}`. The Java side returns the number for
 /// `ok` and null otherwise (a reverting/unverifiable estimate has no number).
 pub fn estimate_json(outcome: &GasOutcome) -> String {

--- a/rust/myotis-engine/src/host.rs
+++ b/rust/myotis-engine/src/host.rs
@@ -490,6 +490,61 @@ pub fn eth_call_json(
     }
 }
 
+/// `nativeEstimateGasJson`: verified `eth_estimateGas` for a call (`to` set) over the
+/// revm executor. Args as for [`eth_call_json`] minus the block (estimate always runs
+/// against the verified head). Returns the estimate JSON (`ok`/`unavailable`, see
+/// [`eljson::estimate_json`]) or `{"error": "..."}`.
+pub fn estimate_gas_json(
+    handle: i64,
+    from_hex: &str,
+    to_hex: &str,
+    data_hex: &str,
+    value_dec: &str,
+) -> String {
+    let Some(to) = parse_address(to_hex) else {
+        return eljson::error_json("invalid 'to' address (expected 20-byte hex)");
+    };
+    let from = if from_hex.trim().is_empty() {
+        None
+    } else {
+        match parse_address(from_hex) {
+            Some(a) => Some(a),
+            None => return eljson::error_json("invalid 'from' address (expected 20-byte hex)"),
+        }
+    };
+    let data = if data_hex.trim().is_empty() {
+        Vec::new()
+    } else {
+        match parse_hex_bytes(data_hex) {
+            Some(d) => d,
+            None => return eljson::error_json("invalid call data (expected hex)"),
+        }
+    };
+    let value = if value_dec.trim().is_empty() {
+        U256::ZERO
+    } else {
+        match U256::from_str_radix(value_dec.trim(), 10) {
+            Ok(v) => v,
+            Err(_) => return eljson::error_json("invalid value (expected decimal wei)"),
+        }
+    };
+    let Some(engine) = engine() else {
+        return eljson::error_json("engine unavailable");
+    };
+    let reader = match snapshot_reader(engine, handle) {
+        Ok((reader, _, _)) => reader,
+        Err(msg) => return eljson::error_json(msg),
+    };
+    const MAINNET_CHAIN_ID: u64 = 1;
+    match engine
+        .rt
+        .block_on(async { reader.estimate_gas(from, to, data, value, MAINNET_CHAIN_ID).await })
+    {
+        Ok(outcome) => eljson::estimate_json(&outcome),
+        Err(e) => eljson::error_json(&e),
+    }
+}
+
 /// `nativeGetBlockByNumberJson`: verified `eth_getBlockByNumber` (transactions as
 /// hashes) for a running handle. Returns the block JSON when found+verified, the
 /// literal `"null"` for a future/unknown block (eth's null), or `{"error": "..."}`

--- a/rust/myotis-engine/src/lib.rs
+++ b/rust/myotis-engine/src/lib.rs
@@ -25,7 +25,8 @@ pub mod ringlog;
 ///     RustChainHandle at the same time so no .so ever reports an ABI the
 ///     running Java engine treats as stale.
 /// v9: added nativeEthCallJson (eth_call over verified state via the revm executor).
-pub const ABI_VERSION: i32 = 9;
+/// v10: added nativeEstimateGasJson (eth_estimateGas over the revm executor).
+pub const ABI_VERSION: i32 = 10;
 
 // Keep the workspace edge alive so `cargo build -p myotis-engine` type-checks the
 // consensus crate too.
@@ -287,6 +288,31 @@ mod jni_shim {
         let value = read_string(&mut env, &value).unwrap_or_default();
         let block = read_string(&mut env, &block).unwrap_or_default();
         let json = crate::host::eth_call_json(handle, &from, &to, &data, &value, &block);
+        match env.new_string(json) {
+            Ok(s) => s.into_raw(),
+            Err(_) => std::ptr::null_mut(),
+        }
+    }
+
+    /// `RustEngineNative.nativeEstimateGasJson(long handle, String from, String to,
+    /// String data, String valueDecimal)` — verified `eth_estimateGas` over the revm
+    /// executor (runs against the verified head; no block arg). `from` empty ⇒
+    /// anonymous sender; `valueDecimal` is wei as a decimal string.
+    #[no_mangle]
+    pub extern "system" fn Java_io_myotis_engines_RustEngineNative_nativeEstimateGasJson(
+        mut env: JNIEnv,
+        _class: JClass,
+        handle: jlong,
+        from: JString,
+        to: JString,
+        data: JString,
+        value: JString,
+    ) -> jstring {
+        let from = read_string(&mut env, &from).unwrap_or_default();
+        let to = read_string(&mut env, &to).unwrap_or_default();
+        let data = read_string(&mut env, &data).unwrap_or_default();
+        let value = read_string(&mut env, &value).unwrap_or_default();
+        let json = crate::host::estimate_gas_json(handle, &from, &to, &data, &value);
         match env.new_string(json) {
             Ok(s) => s.into_raw(),
             Err(_) => std::ptr::null_mut(),

--- a/rust/myotis-evm/src/executor.rs
+++ b/rust/myotis-evm/src/executor.rs
@@ -190,7 +190,15 @@ impl EvmExecutor {
         ctx: &BlockContext,
     ) -> Result<u64, EvmError> {
         match self.execute(caller, target, calldata, value, ctx)? {
-            ExecutionResult::Success { gas, .. } => Ok(with_estimate_buffer(gas.spent())),
+            ExecutionResult::Success { gas, .. } => {
+                // The gas-limit base must cover BOTH the gross execution draw
+                // (`total_gas_spent`, before the EIP-3529 refund — so the run never
+                // OOGs mid-execution) AND the EIP-7623 calldata floor (`tx_gas_used`
+                // = max(spent−refund, floor_gas) — the minimum a Prague+ tx is
+                // charged). `max(total_gas_spent, tx_gas_used)` == `max(gross, floor)`.
+                let base = gas.total_gas_spent().max(gas.tx_gas_used());
+                Ok(with_estimate_buffer(base))
+            }
             ExecutionResult::Revert { output, .. } => {
                 Err(EvmError::Reverted { data: output.to_vec() })
             }
@@ -203,14 +211,11 @@ fn output_bytes(output: Output) -> Vec<u8> {
     output.into_data().to_vec()
 }
 
-/// The gas-limit estimate: gross gas × 1.15, rounded up (mirrors the Java engine's
-/// `ceil(total * 1.15)`). The base is revm's GROSS gas (`ResultGas::spent`: intrinsic
-/// + execution, BEFORE the EIP-3529 refund) — the correct base for a limit that never
-/// runs out mid-execution (the refund is only credited at the end, so the tx must be
-/// funded for the gross amount). `spent <= 30 M`, so `* 115` never overflows u64, but
-/// the u128 math + clamp keeps it panic-free regardless.
-fn with_estimate_buffer(spent: u64) -> u64 {
-    let scaled = (spent as u128 * 115).div_ceil(100);
+/// Apply the 1.15 headroom buffer to a gas base, rounded up (mirrors the Java
+/// engine's `ceil(total * 1.15)`). `base <= 30 M`, so `* 115` never overflows u64,
+/// but the u128 math + clamp keeps it panic-free regardless.
+fn with_estimate_buffer(base: u64) -> u64 {
+    let scaled = (base as u128 * 115).div_ceil(100);
     scaled.min(u64::MAX as u128) as u64
 }
 
@@ -424,6 +429,22 @@ mod tests {
             .estimate_gas([0x42; 20], TARGET, &[], U256::ZERO, &ctx(19_500_000, CANCUN_TIME + 1))
             .unwrap();
         assert!(sstore_est > stop_est, "SSTORE={sstore_est} must exceed STOP={stop_est}");
+    }
+
+    #[test]
+    fn estimate_gas_covers_the_eip7623_calldata_floor() {
+        use crate::fork::PRAGUE_TIME;
+        // A STOP contract ignores calldata, but on Prague+ EIP-7623 charges a floor of
+        // 21000 + 10*(zero + 4*nonzero) tokens. 200 nonzero bytes → floor 21000 +
+        // 10*800 = 29000, ABOVE the standard intrinsic (21000 + 16*200 = 24200) — so
+        // the estimate must reflect the FLOOR, or a real tx would be rejected below it.
+        let exec = executor_with(vec![0x00u8], None); // STOP
+        let calldata = vec![0x11u8; 200]; // 200 nonzero bytes
+        let est = exec
+            .estimate_gas([0x42; 20], TARGET, &calldata, U256::ZERO, &ctx(23_000_000, PRAGUE_TIME + 1))
+            .unwrap();
+        // floor = 29000; ceil(29000 * 1.15) = 33350.
+        assert!(est >= 33_350, "estimate must cover the EIP-7623 calldata floor, was {est}");
     }
 
     #[test]

--- a/rust/myotis-evm/src/executor.rs
+++ b/rust/myotis-evm/src/executor.rs
@@ -78,7 +78,7 @@ impl EvmExecutor {
         calldata: &[u8],
         ctx: &BlockContext,
     ) -> Result<Vec<u8>, EvmError> {
-        self.run(VIEW_CALLER, target, calldata, U256::ZERO, ctx)
+        self.call(VIEW_CALLER, target, calldata, U256::ZERO, ctx)
     }
 
     /// `eth_call` with an explicit `sender` and `value` — needed so `msg.sender`-
@@ -91,23 +91,38 @@ impl EvmExecutor {
         value: U256,
         ctx: &BlockContext,
     ) -> Result<Vec<u8>, EvmError> {
-        self.run(Address::from(sender), target, calldata, value, ctx)
+        self.call(Address::from(sender), target, calldata, value, ctx)
     }
 
-    fn run(
+    /// `estimateGas` for a call (`to` != null): run it and return the gas LIMIT that
+    /// would let it succeed. Reverts/halts yield no number (an `Err`) — the host
+    /// maps that to a JSON-RPC null, like the reference engine.
+    pub fn estimate_gas(
+        &self,
+        from: [u8; 20],
+        target: [u8; 20],
+        calldata: &[u8],
+        value: U256,
+        ctx: &BlockContext,
+    ) -> Result<u64, EvmError> {
+        self.estimate(Address::from(from), target, calldata, value, ctx)
+    }
+
+    /// The shared setup + `transact`, returning revm's raw result. Only DB / tx-
+    /// envelope failures become `Err` here; execution outcomes (success/revert/halt)
+    /// are returned for the caller to interpret.
+    fn execute(
         &self,
         caller: Address,
         target: [u8; 20],
         calldata: &[u8],
         value: U256,
         ctx: &BlockContext,
-    ) -> Result<Vec<u8>, EvmError> {
+    ) -> Result<ExecutionResult, EvmError> {
         // Fail closed on a non-mainnet context: the fork table and Context::mainnet()
         // below are mainnet-specific, so any other chain would run the wrong rules.
         if ctx.chain_id != MAINNET_CHAIN_ID {
-            return Err(EvmError::UnsupportedChain {
-                chain_id: ctx.chain_id,
-            });
+            return Err(EvmError::UnsupportedChain { chain_id: ctx.chain_id });
         }
         let spec = spec_for(ctx.block_number, ctx.timestamp)?;
 
@@ -120,9 +135,9 @@ impl EvmExecutor {
 
         let mut cfg = CfgEnv::new_with_spec(spec);
         cfg.chain_id = ctx.chain_id;
-        // A view call isn't a real tx: relax the transaction-level checks (see the
-        // module docs). `tx_gas_limit_cap` is raised to VIEW_CALL_GAS so the spec's
-        // own per-tx cap doesn't clip the full-block gas budget.
+        // Not a real tx: relax the transaction-level checks (see the module docs).
+        // `tx_gas_limit_cap` is raised to VIEW_CALL_GAS so the spec's own per-tx cap
+        // doesn't clip the full-block gas budget (also the estimate ceiling).
         cfg.disable_nonce_check = true;
         cfg.disable_balance_check = true;
         cfg.disable_base_fee = true;
@@ -144,12 +159,41 @@ impl EvmExecutor {
             .with_cfg(cfg)
             .build_mainnet();
 
-        let out = evm.transact(tx).map_err(map_evm_error)?;
-        match out.result {
+        Ok(evm.transact(tx).map_err(map_evm_error)?.result)
+    }
+
+    /// Run a call and return its output bytes (revert/halt → `Err`).
+    fn call(
+        &self,
+        caller: Address,
+        target: [u8; 20],
+        calldata: &[u8],
+        value: U256,
+        ctx: &BlockContext,
+    ) -> Result<Vec<u8>, EvmError> {
+        match self.execute(caller, target, calldata, value, ctx)? {
             ExecutionResult::Success { output, .. } => Ok(output_bytes(output)),
-            ExecutionResult::Revert { output, .. } => Err(EvmError::Reverted {
-                data: output.to_vec(),
-            }),
+            ExecutionResult::Revert { output, .. } => {
+                Err(EvmError::Reverted { data: output.to_vec() })
+            }
+            ExecutionResult::Halt { reason, .. } => Err(map_halt(reason)),
+        }
+    }
+
+    /// Run a call and return the gas-limit estimate (revert/halt → `Err`).
+    fn estimate(
+        &self,
+        caller: Address,
+        target: [u8; 20],
+        calldata: &[u8],
+        value: U256,
+        ctx: &BlockContext,
+    ) -> Result<u64, EvmError> {
+        match self.execute(caller, target, calldata, value, ctx)? {
+            ExecutionResult::Success { gas, .. } => Ok(with_estimate_buffer(gas.spent())),
+            ExecutionResult::Revert { output, .. } => {
+                Err(EvmError::Reverted { data: output.to_vec() })
+            }
             ExecutionResult::Halt { reason, .. } => Err(map_halt(reason)),
         }
     }
@@ -157,6 +201,17 @@ impl EvmExecutor {
 
 fn output_bytes(output: Output) -> Vec<u8> {
     output.into_data().to_vec()
+}
+
+/// The gas-limit estimate: gross gas × 1.15, rounded up (mirrors the Java engine's
+/// `ceil(total * 1.15)`). The base is revm's GROSS gas (`ResultGas::spent`: intrinsic
+/// + execution, BEFORE the EIP-3529 refund) — the correct base for a limit that never
+/// runs out mid-execution (the refund is only credited at the end, so the tx must be
+/// funded for the gross amount). `spent <= 30 M`, so `* 115` never overflows u64, but
+/// the u128 math + clamp keeps it panic-free regardless.
+fn with_estimate_buffer(spent: u64) -> u64 {
+    let scaled = (spent as u128 * 115).div_ceil(100);
+    scaled.min(u64::MAX as u128) as u64
 }
 
 fn map_halt(reason: HaltReason) -> EvmError {
@@ -340,6 +395,46 @@ mod tests {
             .call_view(TARGET, &[], &ctx(19_500_000, CANCUN_TIME + 1))
             .unwrap_err();
         assert!(matches!(err, EvmError::OutOfGas), "got {err:?}");
+    }
+
+    #[test]
+    fn estimate_gas_applies_the_buffer_over_intrinsic() {
+        // A STOP contract does no EVM work, so gross gas ≈ the 21000 intrinsic (empty
+        // calldata). The estimate is ceil(21000 * 1.15) = 24150, plus at most a small
+        // cold-access charge — bounded well below a real-work call.
+        let exec = executor_with(vec![0x00u8], None); // STOP
+        let est = exec
+            .estimate_gas([0x42; 20], TARGET, &[], U256::ZERO, &ctx(19_500_000, CANCUN_TIME + 1))
+            .unwrap();
+        assert!(est >= 24_150, "estimate must apply the 1.15 buffer over intrinsic, was {est}");
+        assert!(est < 30_000, "a STOP contract shouldn't estimate real-work gas, was {est}");
+    }
+
+    #[test]
+    fn estimate_gas_reflects_evm_work() {
+        // A contract that SSTOREs must estimate strictly more than a no-op STOP —
+        // proving execution gas (not just intrinsic) is metered.
+        let stop = executor_with(vec![0x00u8], None);
+        let stop_est = stop
+            .estimate_gas([0x42; 20], TARGET, &[], U256::ZERO, &ctx(19_500_000, CANCUN_TIME + 1))
+            .unwrap();
+        // PUSH1 0x2a PUSH1 0x00 SSTORE STOP — a fresh (0→nonzero) storage write.
+        let sstore = executor_with(vec![0x60u8, 0x2a, 0x60, 0x00, 0x55, 0x00], None);
+        let sstore_est = sstore
+            .estimate_gas([0x42; 20], TARGET, &[], U256::ZERO, &ctx(19_500_000, CANCUN_TIME + 1))
+            .unwrap();
+        assert!(sstore_est > stop_est, "SSTORE={sstore_est} must exceed STOP={stop_est}");
+    }
+
+    #[test]
+    fn estimate_gas_reverts_yield_no_number() {
+        // PUSH1 0xAB PUSH1 0 MSTORE PUSH1 0x20 PUSH1 0 REVERT — a revert has no estimate.
+        let code = vec![0x60u8, 0xAB, 0x60, 0x00, 0x52, 0x60, 0x20, 0x60, 0x00, 0xfd];
+        let exec = executor_with(code, None);
+        let err = exec
+            .estimate_gas([0x42; 20], TARGET, &[], U256::ZERO, &ctx(19_500_000, CANCUN_TIME + 1))
+            .unwrap_err();
+        assert!(matches!(err, EvmError::Reverted { .. }), "got {err:?}");
     }
 
     #[test]

--- a/rust/myotis-net/src/el/evm.rs
+++ b/rust/myotis-net/src/el/evm.rs
@@ -49,6 +49,17 @@ pub enum CallOutcome {
     Unavailable(String),
 }
 
+/// The outcome of an `estimateGas`. `estimateGas` has no number for a revert or a
+/// failed/unverifiable run — the host maps `Unavailable` to a JSON-RPC null, like
+/// the Java engine.
+#[derive(Debug, Clone)]
+pub enum GasOutcome {
+    /// The gas-limit estimate (already buffered by the executor).
+    Estimate(u64),
+    /// No estimate (revert / halt / state unavailable). The string is diagnostic.
+    Unavailable(String),
+}
+
 /// Build a [`BlockContext`] from a verified head header. `chain_id` comes from the
 /// chain config (the header carries no chain id).
 pub fn block_context(header: &BlockHeader, chain_id: u64) -> Result<BlockContext, String> {

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -32,7 +32,7 @@ use myotis_evm::{EvmError, EvmExecutor, InMemoryBytecodeCache, InMemoryStateProo
 use crate::el::anchor::ExecAnchor;
 use crate::el::discv4::{Discv4Config, Discv4Service};
 use crate::el::eth::session::EthConfig;
-use crate::el::evm::{block_context, CallOutcome, PoolOracle};
+use crate::el::evm::{block_context, CallOutcome, GasOutcome, PoolOracle};
 use crate::el::peer::ManagedPeer;
 use crate::el::pool::{PeerPool, PoolConfig};
 use crate::el::snap::fetch::AccountOutcome;
@@ -620,22 +620,10 @@ impl ElReader {
         value: U256,
         chain_id: u64,
     ) -> Result<CallOutcome, String> {
-        let Some(block) = self.get_block_by_number(None).await? else {
-            return Err("no verified head to run eth_call against".to_string());
-        };
-        let ctx = block_context(&block.header, chain_id)?;
-        // Snapshot the snap peers once: one consistent set for the whole call.
-        let peers = self.pool.snap_peers().await;
-        if peers.is_empty() {
-            return Err("no snap peer available for eth_call".to_string());
-        }
-        let oracle = Arc::new(PoolOracle::new(peers, tokio::runtime::Handle::current()));
-        let proof_cache = Arc::clone(&self.evm_proof_cache);
-        let bytecode_cache = Arc::clone(&self.evm_bytecode_cache);
+        let (ctx, executor) = self.evm_setup(chain_id, "eth_call").await?;
         // Run the SYNCHRONOUS executor off the runtime worker so the oracle's
         // per-fetch `block_on` is a fresh (non-nested) runtime entry.
         let joined = tokio::task::spawn_blocking(move || {
-            let executor = EvmExecutor::new(oracle, proof_cache, bytecode_cache);
             // A from-less call still honours `value` — the default sender is the zero
             // ADDRESS, not zero value — so always thread `value` through
             // call_view_from (call_view would force value = 0 and drop it).
@@ -649,6 +637,58 @@ impl ElReader {
             Err(EvmError::Reverted { data }) => CallOutcome::Revert(data),
             Err(other) => CallOutcome::Unavailable(other.to_string()),
         })
+    }
+
+    /// Verified `eth_estimateGas` for a call (`to` set): run the call against the
+    /// verified head and return the gas-limit estimate. A revert / halt / unverifiable
+    /// run yields [`GasOutcome::Unavailable`] (no number → the host returns null, as
+    /// the reference engine does). Same head-pinning + executor bridge as [`Self::eth_call`].
+    pub async fn estimate_gas(
+        &self,
+        from: Option<[u8; 20]>,
+        to: [u8; 20],
+        data: Vec<u8>,
+        value: U256,
+        chain_id: u64,
+    ) -> Result<GasOutcome, String> {
+        let (ctx, executor) = self.evm_setup(chain_id, "estimateGas").await?;
+        let joined = tokio::task::spawn_blocking(move || {
+            let sender = from.unwrap_or([0u8; 20]);
+            executor.estimate_gas(sender, to, &data, value, &ctx)
+        })
+        .await
+        .map_err(|e| format!("estimateGas task join error: {e}"))?;
+        Ok(match joined {
+            Ok(gas) => GasOutcome::Estimate(gas),
+            Err(e) => GasOutcome::Unavailable(e.to_string()),
+        })
+    }
+
+    /// Shared setup for the EVM reads: a [`BlockContext`](myotis_evm::BlockContext)
+    /// from the verified head + an [`EvmExecutor`] over a fresh snap-peer snapshot and
+    /// the reader's cross-call caches. `what` names the caller in the error messages.
+    async fn evm_setup(
+        &self,
+        chain_id: u64,
+        what: &str,
+    ) -> Result<(myotis_evm::BlockContext, EvmExecutor), String> {
+        let Some(block) = self.get_block_by_number(None).await? else {
+            return Err(format!("no verified head to run {what} against"));
+        };
+        let ctx = block_context(&block.header, chain_id)?;
+        // Snapshot the snap peers once: one consistent set for the whole call.
+        let peers = self.pool.snap_peers().await;
+        if peers.is_empty() {
+            return Err(format!("no snap peer available for {what}"));
+        }
+        let oracle = Arc::new(PoolOracle::new(peers, tokio::runtime::Handle::current()));
+        // Bind the concrete Arc types first, then let the unsizing coercion to the
+        // trait objects happen at the constructor call (a coercion directly on
+        // `Arc::clone` would instead infer `Arc<dyn Trait>` and fail to type-check).
+        let proof_cache = Arc::clone(&self.evm_proof_cache);
+        let bytecode_cache = Arc::clone(&self.evm_bytecode_cache);
+        let executor = EvmExecutor::new(oracle, proof_cache, bytecode_cache);
+        Ok((ctx, executor))
     }
 
     /// Verified `eth_getBlockByNumber` (transactions as hashes). `target` is the


### PR DESCRIPTION
Lights the **MetaMask ERC-20 network fee**: `estimateGas` for contract calls (and value transfers to a contract / 7702-delegated EOA) now runs the revm executor over SNAP-proof-verified state instead of returning null. The plain-transfer-to-codeless-EOA 21000 fast path stays. Builds directly on the EL-C-2b eth_call wiring.

## What lands
- **`myotis-evm`**: `EvmExecutor::estimate_gas`; `run` refactored into a shared `execute` (returns revm's raw `ExecutionResult`) + `call`/`estimate` interpreters (eth_call behavior byte-for-byte preserved). The estimate is `ceil(base × 1.15)` where **`base = max(total_gas_spent, tx_gas_used)` = max(gross execution gas, EIP-7623 calldata floor)** — gross so the run never OOGs mid-execution (before the EIP-3529 refund), floor so a Prague+ tx is funded for its minimum charge. Revert/halt → no number. Panic-safe u128 buffer math. (revm's `transact` already charges intrinsic, so it's not double-counted, unlike the Java engine.)
- **`myotis-net`**: `ElReader::estimate_gas` mirrors `eth_call` (head `BlockContext` + `PoolOracle` + `spawn_blocking` bridge) via a new shared `evm_setup` helper. `GasOutcome { Estimate(u64) | Unavailable }` → Unavailable (revert/unverifiable) maps to a JSON-RPC null.
- **`myotis-engine`**: `nativeEstimateGasJson` + `host::estimate_gas_json` + `eljson::estimate_json`. **ABI 9→10.**
- **Java**: `RustEngineNative` ABI 9→10 + native decl; `RustChainHandle.estimateGasVerified`/`estimateGasFromJson` (number on ok, null otherwise); `RustVerifiedReads.estimateGas` — keeps the 21000 shortcut for a codeless-EOA transfer (bails to null if the recipient code can't be verified), routes everything else through the EVM.

## Validation
Rust unit tests (buffer over intrinsic for a STOP contract; SSTORE > STOP; **EIP-7623 calldata floor covered on Prague**; revert → no number) + `eljson` + Java golden tests (`estimateGasFromJson` ok/unavailable/error). Full Rust workspace + broad Java compile green. Clean diff (no `cargo fmt` churn).

An independent no-context review verified the fail-closed integrity end-to-end (no fabricated estimate on unverifiable state; revert/halt → null), the no-double-count of intrinsic gas, panic-freedom, and the fast-path gating. Its one substantive finding — the EIP-7623 floor — is fixed in the last commit (this engine now handles it, which the Java reference does not).

**Note (safe direction, not fixed):** a near-30M call estimates ~34.5M (above the block gas limit); this over-estimates rather than under-estimates, so it never OOGs — a wallet may cap it. Geth caps at the RPC gas cap.

Live MetaMask verification of the ERC-20 fee against a warm multi-peer daemon is the follow-up (the same peer-starvation that blocked the live eth_call applies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)