### PR TITLE
Sepolia: working CL discovery, fork digest, trust anchor, and snap staleness floors

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,6 +664,8 @@ Ethereum's weak-subjectivity window is only ~28 hours of stake-weighted safety, 
 
 The task queries `/eth/v2/beacon/blocks/finalized` on three independent mainnet checkpoint providers (beaconstate.info, sync-mainnet.beaconcha.in, mainnet-checkpoint-sync.attestant.io), normalizes to the oldest observed finalized slot, re-queries each provider for the canonical block root at that slot, and requires byte-for-byte agreement before writing. Any disagreement aborts without modifying the source.
 
+The same machinery serves the other networks: `./gradlew refreshSepoliaCheckpoint` refreshes the `@checkpoint:sepolia` region from the eth-clients sepolia checkpoint providers, and `./gradlew refreshGnosisCheckpoint` refreshes `@checkpoint:gnosis` (its own task — Gnosis exposes a different API slice and fewer providers).
+
 ### Verification flow
 
 1. The beacon light client obtains a finalized execution state root (BLS-verified via sync committee signatures)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -150,7 +150,8 @@ fun registerCheckpointRefresh(taskName: String, network: String, endpoints: List
         val finalRoot = distinct.single().removePrefix("0x")
         val period = minSlot / 8192
         // Shared with the Java-side genesis constants via gradle.properties
-        val genesis = (project.property(genesisTimeProperty) as String).toLong()
+        val genesis = (project.findProperty(genesisTimeProperty) as? String)?.takeIf { it.isNotBlank() }?.toLongOrNull()
+            ?: throw GradleException("Property '$genesisTimeProperty' is missing, blank, or not a valid Long")
         val ts = Instant.ofEpochSecond(genesis + minSlot * 12)
         val date = DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneOffset.UTC).format(ts)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,24 +69,19 @@ subprojects {
 }
 
 // -------------------------------------------------------------------------
-// Trust anchor refresh: fetch the current mainnet finalized block root from
-// multiple independent public checkpoint endpoints, cross-validate, and
-// rewrite the `@checkpoint:mainnet` region in NetworkConfig.java.
+// Trust anchor refresh: fetch the current finalized block root from multiple
+// independent public checkpoint endpoints, cross-validate, and rewrite the
+// `@checkpoint:<network>` region in NetworkConfig.java. Shared by the mainnet
+// and sepolia tasks (identical Beacon API shape and mainnet-preset slot math);
+// Gnosis has its own task below (different API surface, scarce endpoints).
 // -------------------------------------------------------------------------
 
-tasks.register("refreshMainnetCheckpoint") {
+fun registerCheckpointRefresh(taskName: String, network: String, endpoints: List<String>, genesisTimeProperty: String) =
+    tasks.register(taskName) {
     group = "trust"
-    description = "Fetch the finalized mainnet block root from 3 public checkpoint providers, cross-validate, and update NetworkConfig.java. Use -Pdry to preview the diff without writing."
+    description = "Fetch the finalized $network block root from ${endpoints.size} public checkpoint providers, cross-validate, and update NetworkConfig.java. Use -Pdry to preview the diff without writing."
 
     doLast {
-        // Three independent mainnet checkpoint-sync endpoints. These serve only a narrow
-        // slice of the Beacon API (/eth/v1/beacon/blocks/{id}/root + /eth/v2/beacon/blocks/{id}),
-        // which is enough for what we need here.
-        val endpoints = listOf(
-            "https://beaconstate.info",
-            "https://sync-mainnet.beaconcha.in",
-            "https://mainnet-checkpoint-sync.attestant.io",
-        )
         val dryRun = project.hasProperty("dry")
         val client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build()
 
@@ -154,20 +149,20 @@ tasks.register("refreshMainnetCheckpoint") {
 
         val finalRoot = distinct.single().removePrefix("0x")
         val period = minSlot / 8192
-        // Shared with BeaconChainSpec.MAINNET_GENESIS_TIME via gradle.properties
-        val genesis = (project.property("ethp2p.mainnet.genesisTime") as String).toLong()
+        // Shared with the Java-side genesis constants via gradle.properties
+        val genesis = (project.property(genesisTimeProperty) as String).toLong()
         val ts = Instant.ofEpochSecond(genesis + minSlot * 12)
         val date = DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneOffset.UTC).format(ts)
 
         val file = project(":networking").projectDir.resolve(
             "src/main/java/com/jaeckel/ethp2p/networking/NetworkConfig.java")
         val original = file.readText()
-        val beginMarker = "// @checkpoint:mainnet:begin"
-        val endMarker = "// @checkpoint:mainnet:end"
+        val beginMarker = "// @checkpoint:$network:begin"
+        val endMarker = "// @checkpoint:$network:end"
         val beginIdx = original.indexOf(beginMarker)
         val endIdx = original.indexOf(endMarker)
         if (beginIdx < 0 || endIdx < 0 || endIdx < beginIdx) {
-            throw GradleException("Could not find @checkpoint:mainnet:begin/end markers in NetworkConfig.java")
+            throw GradleException("Could not find @checkpoint:$network:begin/end markers in NetworkConfig.java")
         }
         // Preserve whatever line ending the source file uses so we don't mix CRLF/LF
         // when running on Windows.
@@ -179,11 +174,11 @@ tasks.register("refreshMainnetCheckpoint") {
         val indent = original.substring(beginLineStart, beginIdx)
 
         val replacement = buildString {
-            append(indent).append("// @checkpoint:mainnet:begin — managed by `./gradlew refreshMainnetCheckpoint`").append(eol)
-            append(indent).append("// trusted checkpoint: recent finalized mainnet block root (slot $minSlot, $date, period $period)").append(eol)
+            append(indent).append("// @checkpoint:$network:begin — managed by `./gradlew $taskName`").append(eol)
+            append(indent).append("// trusted checkpoint: recent finalized $network block root (slot $minSlot, $date, period $period)").append(eol)
             append(indent).append("Bytes.fromHexString(\"$finalRoot\").toArrayUnsafe(),").append(eol)
             append(indent).append("${minSlot}L, // checkpoint slot (epoch = slot/32). Must stay in sync with the root above.").append(eol)
-            append(indent).append("// @checkpoint:mainnet:end")
+            append(indent).append("// @checkpoint:$network:end")
         }
         val updated = original.substring(0, beginLineStart) + replacement + original.substring(endMarkerEnd)
 
@@ -214,6 +209,30 @@ tasks.register("refreshMainnetCheckpoint") {
         }
     }
 }
+
+// Independent checkpoint-sync endpoints per network. These serve only a narrow
+// slice of the Beacon API (/eth/v1/beacon/blocks/{id}/root + /eth/v2/beacon/blocks/{id}),
+// which is enough for what we need here.
+registerCheckpointRefresh(
+    "refreshMainnetCheckpoint", "mainnet",
+    listOf(
+        "https://beaconstate.info",
+        "https://sync-mainnet.beaconcha.in",
+        "https://mainnet-checkpoint-sync.attestant.io",
+    ),
+    "ethp2p.mainnet.genesisTime",
+)
+// The full eth-clients/checkpoint-sync-endpoints sepolia list; the task needs
+// any 2 of them live for cross-validation.
+registerCheckpointRefresh(
+    "refreshSepoliaCheckpoint", "sepolia",
+    listOf(
+        "https://sepolia.beaconstate.info",
+        "https://checkpoint-sync.sepolia.ethpandaops.io",
+        "https://beaconstate-sepolia.chainsafe.io",
+    ),
+    "ethp2p.sepolia.genesisTime",
+)
 
 // -------------------------------------------------------------------------
 // Gnosis checkpoint refresh. Public Gnosis beacon endpoints serving the

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,9 @@ ethp2p.mainnet.genesisTime=1606824023
 # Gnosis Beacon Chain genesis time (2021-12-08 19:55:40 UTC); read by
 # refreshGnosisCheckpoint for the checkpoint-date comment.
 ethp2p.gnosis.genesisTime=1638993340
+# Sepolia beacon genesis time (2022-06-20 14:00:00 UTC); read by
+# refreshSepoliaCheckpoint for the checkpoint-date comment.
+ethp2p.sepolia.genesisTime=1655733600
 
 # Required by the Compose / Activity artifacts pulled in by :android-app.
 android.useAndroidX=true

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/NetworkConfig.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/NetworkConfig.java
@@ -184,22 +184,48 @@ public record NetworkConfig(
             ),
             // genesis_validators_root (sepolia)
             Bytes.fromHexString("d8ea171f3c94aea21ebc42a1ed61052acf3f9209c00e4efbaaddac09ed9b8078").toArrayUnsafe(),
-            // trusted checkpoint: a recent finalized sepolia block root
-            Bytes.fromHexString("1f7c15e7e1a7be27b4e7e9b7bdb0e5e9b2aa5aebd33498ec04b58ef2adb5e9ce").toArrayUnsafe(),
-            0L, // checkpoint slot — unknown for sepolia, use 0 (spec-default). refresh job should fill this.
-            // current fork version: Electra on sepolia (0x90000073)
-            new byte[]{(byte) 0x90, 0x00, 0x00, 0x73},
-            0L, 0L, // no BPO active on sepolia
-            null, // prior fork version not pinned for sepolia
+            // @checkpoint:sepolia:begin — managed by `./gradlew refreshSepoliaCheckpoint`
+            // trusted checkpoint: recent finalized sepolia block root (slot 10657440, 2026-07-09, period 1300)
+            Bytes.fromHexString("8c3bc10ed8e1567dbdb60da360091c9af38e6b64e7de553a1ba2b0a5ffdfa5f6").toArrayUnsafe(),
+            10657440L, // checkpoint slot (epoch = slot/32). Must stay in sync with the root above.
+            // @checkpoint:sepolia:end
+            // current fork version: Fulu on sepolia (0x90000075) — activated at epoch 272640 (2025-10-14)
+            new byte[]{(byte) 0x90, 0x00, 0x00, 0x75},
+            // EIP-7892 BLOB_SCHEDULE — latest active entry on sepolia:
+            // BPO2 at epoch 275712, MAX_BLOBS_PER_BLOCK=21 (2025-10-28). Folds into
+            // the fork digest XOR — see activeBlobParams.
+            275712L, 21L,
+            // No prior-fork fallback (same rationale as mainnet: stale digests
+            // wouldn't help us sync to the current head anyway).
+            null,
             // CL peer multiaddrs for sepolia
             List.of(
                     "/ip4/18.185.193.198/tcp/9000/p2p/16Uiu2HAm3mfkjmLPtqnSJzNtKxbDuVjVRXidz5UinaZNpjCCKAkS"
             ),
             null,
             1655733600L, // sepolia beacon genesis: 2022-06-20 14:00:00 UTC
-            List.of(), // EL ENR trees — not pinned
-            List.of(), // CL ENR trees — not pinned
-            List.of()  // CL discv5 bootnodes — not pinned for sepolia this PR
+            // EL: Ethereum Foundation canonical sepolia tree (same EF signing key
+            // as the mainnet tree; the resolver verifies the signature).
+            List.of("enrtree://AKA3AM6LPBYEUDMVNU3BSVQJ5AD45Y7YPOHJLEF6W26QOE4VTUDPE@all.sepolia.ethdisco.net"),
+            List.of(), // CL ENR trees — no canonical single tree (same as mainnet)
+            // CL discv5 bootnodes — the canonical seed set for the sepolia beacon DHT.
+            // Mirrors eth-clients/sepolia metadata/bootstrap_nodes.yaml (EF, Teku,
+            // Lodestar). Seeds only: discv5's Kademlia loop expands beyond them.
+            List.of(
+                    // EF
+                    "enr:-Ku4QDZ_rCowZFsozeWr60WwLgOfHzv1Fz2cuMvJqN5iJzLxKtVjoIURY42X_YTokMi3IGstW5v32uSYZyGUXj9Q_IECh2F0dG5ldHOIAAAAAAAAAACEZXRoMpCo_ujukAAAaf__________gmlkgnY0gmlwhIpEe5iJc2VjcDI1NmsxoQNHTpFdaNSCEWiN_QqT396nb0PzcUpLe3OVtLph-AciBYN1ZHCCIy0",
+                    "enr:-Ku4QHRyRwEPT7s0XLYzJ_EeeWvZTXBQb4UCGy1F_3m-YtCNTtDlGsCMr4UTgo4uR89pv11uM-xq4w6GKfKhqU31hTgCh2F0dG5ldHOIAAAAAAAAAACEZXRoMpCo_ujukAAAaf__________gmlkgnY0gmlwhIrFM7WJc2VjcDI1NmsxoQI4diTwChN3zAAkarf7smOHCdFb1q3DSwdiQ_Lc_FdzFIN1ZHCCIy0",
+                    "enr:-Ku4QOkvvf0u5Hg4-HhY-SJmEyft77G5h3rUM8VF_e-Hag5cAma3jtmFoX4WElLAqdILCA-UWFRN1ZCDJJVuEHrFeLkDh2F0dG5ldHOIAAAAAAAAAACEZXRoMpCo_ujukAAAaf__________gmlkgnY0gmlwhJK-AWeJc2VjcDI1NmsxoQLFcT5VE_NMiIC8Ll7GypWDnQ4UEmuzD7hF_Hf4veDJwIN1ZHCCIy0",
+                    "enr:-Ku4QH6tYsHKITYeHUu5kdfXgEZWI18EWk_2RtGOn1jBPlx2UlS_uF3Pm5Dx7tnjOvla_zs-wwlPgjnEOcQDWXey51QCh2F0dG5ldHOIAAAAAAAAAACEZXRoMpCo_ujukAAAaf__________gmlkgnY0gmlwhIs7Mc6Jc2VjcDI1NmsxoQIET4Mlv9YzhrYhX_H9D7aWMemUrvki6W4J2Qo0YmFMp4N1ZHCCIy0",
+                    "enr:-Ku4QDmz-4c1InchGitsgNk4qzorWMiFUoaPJT4G0IiF8r2UaevrekND1o7fdoftNucirj7sFFTTn2-JdC2Ej0p1Mn8Ch2F0dG5ldHOIAAAAAAAAAACEZXRoMpCo_ujukAAAaf__________gmlkgnY0gmlwhKpA-liJc2VjcDI1NmsxoQMpHP5U1DK8O_JQU6FadmWbE42qEdcGlllR8HcSkkfWq4N1ZHCCIy0",
+                    // Teku
+                    "enr:-Iu4QKvMF7Ne_RSQoZGvavTuZ1QA5_Pgeb0nq_hrjhU8s0UDV3KhcMXJkGwOWhsDGZL3ISjL0CTP-hfoTjZtEtCEwR4BgmlkgnY0gmlwhAOAaySJc2VjcDI1NmsxoQNta5b_bexSSwwrGW2Re24MjfMntzFd0f2SAxQtMj3ueYN0Y3CCIyiDdWRwgiMo",
+                    // Lodestar
+                    "enr:-KG4QJejf8KVtMeAPWFhN_P0c4efuwu1pZHELTveiXUeim6nKYcYcMIQpGxxdgT2Xp9h-M5pr9gn2NbbwEAtxzu50Y8BgmlkgnY0gmlwhEEVkQCDaXA2kCoBBPnAEJg4AAAAAAAAAAGJc2VjcDI1NmsxoQLEh_eVvk07AQABvLkTGBQTrrIOQkzouMgSBtNHIRUxOIN1ZHCCIyiEdWRwNoIjKA",
+                    // remaining bootstrap_nodes.yaml entries (unattributed)
+                    "enr:-Iq4QMCTfIMXnow27baRUb35Q8iiFHSIDBJh6hQM5Axohhf4b6Kr_cOCu0htQ5WvVqKvFgY28893DHAg8gnBAXsAVqmGAX53x8JggmlkgnY0gmlwhLKAlv6Jc2VjcDI1NmsxoQK6S-Cii_KmfFdUJL2TANL3ksaKUnNXvTCv1tLwXs0QgIN1ZHCCIyk",
+                    "enr:-L64QC9Hhov4DhQ7mRukTOz4_jHm4DHlGL726NWH4ojH1wFgEwSin_6H95Gs6nW2fktTWbPachHJ6rUFu0iJNgA0SB2CARqHYXR0bmV0c4j__________4RldGgykDb6UBOQAABx__________-CaWSCdjSCaXCEA-2vzolzZWNwMjU2azGhA17lsUg60R776rauYMdrAz383UUgESoaHEzMkvm4K6k6iHN5bmNuZXRzD4N0Y3CCIyiDdWRwgiMo"
+            )
     );
 
     // Gnosis Chain (xDai). EL chainId 100; its own Consensus Layer (Gnosis Beacon

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/EthHandler.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/EthHandler.java
@@ -1056,10 +1056,11 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
                 return;
             }
             long blockNum = headers.get(0).header().number;
-            // Reject obviously stale headers. We use a static minimum rather than
-            // chainHead because chainHead can be poisoned by malicious peers.
-            // Mainnet is ~24.6M as of March 2026; 20M gives ample margin.
-            if (blockNum < 20_000_000) {
+            // Reject obviously stale headers. We use a static per-network minimum
+            // rather than chainHead because chainHead can be poisoned by malicious
+            // peers. (A flat mainnet-scale literal here rejected EVERY honest
+            // sepolia peer — sepolia's head is far below mainnet's.)
+            if (blockNum < network.minSensibleHeadBlock()) {
                 log.warn("[snap] Peer {} returned stale header (block #{}), skipping",
                         remoteAddress, blockNum);
                 result.completeExceptionally(new RuntimeException(
@@ -1166,7 +1167,8 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
                 return;
             }
             long blockNum = headers.get(0).header().number;
-            if (blockNum < 1_000_000) {
+            // Same per-network staleness floor as the account path above.
+            if (blockNum < network.minSensibleHeadBlock()) {
                 log.warn("[snap] Peer {} returned stale header (block #{}), skipping for storage query",
                     remoteAddress, blockNum);
                 result.completeExceptionally(new RuntimeException(

--- a/networking/src/test/java/com/jaeckel/ethp2p/networking/discv5/DiscV5ReseedTest.java
+++ b/networking/src/test/java/com/jaeckel/ethp2p/networking/discv5/DiscV5ReseedTest.java
@@ -49,7 +49,7 @@ class DiscV5ReseedTest {
 
     @Test
     void noBootnodesMeansNeverDue() {
-        // Sepolia pins clDiscv5Bootnodes to List.of(): with nothing to ping, a
+        // A network with no pinned CL bootnodes: with nothing to ping, a
         // re-seed must never fire (it would log "re-pinged 0 bootnode(s)"
         // every minute forever, reading as recovery where none is possible).
         DiscV5Service s = new DiscV5Service(NodeKey.generate(), List.of(), enr -> { });


### PR DESCRIPTION
## Why

Sepolia support existed on paper (\`NetworkConfig.SEPOLIA\`, \`-Pnetwork=sepolia\`) but could not sync: the beacon light client never completed a bootstrap, and \`get-account\`/\`get-storage\` could never verify. Needed working for the Kohaku integration.

## Root causes fixed (4)

1. **No CL discv5 bootnodes** — \`clDiscv5Bootnodes\` was \`List.of()\` ("not pinned this PR"), so discv5 had zero entry points into the sepolia beacon DHT (\`seen-total=0\` forever), and the re-seed recovery had nothing to ping. The only fallback was one hardcoded, dead CL multiaddr. → Pinned the canonical eth-clients/sepolia \`bootstrap_nodes.yaml\` set (EF ×5, Teku, Lodestar, +2), byte-identical to upstream, plus the EF sepolia EL enrtree (\`all.sepolia.ethdisco.net\`, same EF signing key as mainnet's — signature-verified by the resolver).

2. **Wrong fork digest** — the entry pinned "Electra (0x90000073)" (actually **Deneb's** version number) with no BPO params. Sepolia has been on **Fulu 0x90000075** since epoch 272640 (2025-10-14) with BPO2 (epoch 275712, max 21 blobs) folded into the digest per EIP-7892. With the wrong digest, every real sepolia CL peer would be rejected by the \`acceptedForkDigests\` filter even after discovery was fixed.

3. **Placeholder trust anchor** — checkpoint root was a stale/unknown value at slot 0. → Added \`refreshSepoliaCheckpoint\` by parameterizing the mainnet task into a shared \`registerCheckpointRefresh()\` (mainnet task behavior unchanged: same endpoints, markers, messages; Gnosis keeps its own task — different API slice). Pinned a cross-validated anchor (slot 10657440, period 1300, agreed byte-for-byte by ethpandaops + chainsafe; endpoints mirror eth-clients/checkpoint-sync-endpoints).

4. **Latent \`EthHandler\` staleness-floor bug** — the snap fresh-header check used hardcoded literals: \`blockNum < 20_000_000\` (account path) and \`< 1_000_000\` (storage path). Sepolia's head is ~11.24M, so **every honest sepolia peer was rejected as "stale"** and \`get-account\` could never succeed; gnosis passes only because its 5s blocks put its head ~43M. → Both sites now use the existing per-network \`NetworkConfig.minSensibleHeadBlock()\` (mainnet 20M / sepolia 5M / gnosis 40M), which was documented for exactly this purpose but never wired in here.

## Behavior notes (beyond the sepolia intent)

- **Gnosis floors tightened**: account path 20M → 40M, storage path 1M → 40M. Safe (gnosis head ~43M, monotonic) and now consistent with \`minSensibleHeadBlock()\`'s documented margins.
- **Unknown networks**: storage-path floor goes 1M → 0 (disabled) — per the method's javadoc ("better to try than to refuse"); unreachable today with 3 defined networks.
- The extracted Gradle function keeps the original body indentation to keep this diff reviewable; happy to re-indent in a follow-up.

## Verification (live, CLI daemon)

- discv5: \`live=0 seen-total=0\` → **1300+ live nodes**, 40–70 eth2-matching per tick; only rejects are stale-ENR digests (\`0xa8fee8ee\`)
- LC bootstrap: **complete at slot 10657440** (period 1300); warm restart re-bootstraps in ~11s from \`cl-peers-sepolia.cache\`
- \`beacon-status\` → \`"state":"SYNCED"\`, finalized slot tracking head
- \`get-account 0xd8dA…6045\` → \`"ok":true\`, full MPT proof, \`"verifyMethod":"headerChain"\`, \`"blsVerified":true\`
- \`get-storage\` (sepolia WETH) → \`"ok":true\` with verified proof (exercises the second fixed floor)
- \`sync-state-sepolia.snapshot\` persisted (26KB, period 1300)
- Fork-digest correctness is proven by the above: a wrong digest admits zero CL peers, so no bootstrap could have happened
- \`./gradlew build\` green; independent no-context review run before opening this PR (findings addressed in the second commit; no blockers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017MUyVxaEcPKwfgya4FZptF