### PR TITLE
EL-C-5-1b: wire ENS resolution to the host (native + Java EnsApi)

### DIFF
--- a/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
@@ -13,6 +13,7 @@ import io.myotis.api.DialResult;
 import io.myotis.api.DiscoveredPeer;
 import io.myotis.api.EngineException;
 import io.myotis.api.EnsApi;
+import io.myotis.api.EnsResolutionResult;
 import io.myotis.api.HeadersResult;
 import io.myotis.api.LifecycleState;
 import io.myotis.api.NodeStatusReads;
@@ -407,17 +408,21 @@ final class RustChainHandle implements ChainHandle, NodeStatusReads {
     // to decide whether verified RPC is available. So: null before start(), when
     // rpcPort<=0, or on a bind failure; non-null once serving.
     //
-    // ens() still returns null (no ENS registry served yet) — that IS the ChainHandle
-    // contract ("or null when this network has no ENS registry"), and callers
-    // null-check it. The EL QUERY methods further down (getHeaders/getBlockVerified/
-    // dialPeer) still throw EngineException: the contract reserves exceptions for
-    // malformed input / not running, and an unimplemented EL surface is a capability
-    // error (no verification to report a failReason for) — a failReason record would
-    // misrepresent "we can't" as "we tried and failed".
+    // ens() serves forward resolution via the native resolver (EL-C-5-1); the
+    // Rust engine is mainnet-only and mainnet has ENS, so it is always non-null.
+    // Unimplemented record types report a graceful error RESULT per the EnsApi
+    // contract (see RustEnsApi). The EL QUERY methods further down
+    // (getHeaders/getBlockVerified/dialPeer) still throw EngineException: the
+    // contract reserves exceptions for malformed input / not running, and an
+    // unimplemented EL surface is a capability error (no verification to report
+    // a failReason for) — a failReason record would misrepresent "we can't" as
+    // "we tried and failed".
 
     @Override public VerifiedReads reads() { return rpcServer != null ? verifiedReads : null; }
 
-    @Override public EnsApi ens() { return null; }
+    private final EnsApi ensApi = new RustEnsApi(this);
+
+    @Override public EnsApi ens() { return ensApi; }
 
     @Override
     public List<DiscoveredPeer> discoveredPeers() { return List.of(); }
@@ -540,6 +545,44 @@ final class RustChainHandle implements ChainHandle, NodeStatusReads {
             return null;
         } catch (RuntimeException e) {
             throw new EngineException("malformed call JSON from the Rust engine: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * One verified ENS forward resolution: {@code name} → its
+     * {@link EnsResolutionResult}. Throws {@link EngineException} on a transport /
+     * not-running failure (the RustEnsApi adapter maps that to an error result).
+     */
+    EnsResolutionResult resolveEnsVerified(String name) {
+        return ensResolutionFromJson(name, RustEngineNative.nativeResolveEnsJson(handle, name));
+    }
+
+    /** Package-private test seam: ENS JSON → {@link EnsResolutionResult} without JNI. */
+    static EnsResolutionResult ensResolutionFromJson(String name, String json) {
+        JsonObject o = parseResultOrThrow(json, "resolve-ens");
+        try {
+            String status = stringOrNull(o, "status");
+            long block = o.getLong("blockNumber", -1L);
+            // verified=false: the resolution IS proof-verified against the
+            // beacon-anchored optimistic head, but "verified" in this API means a
+            // beacon-FINALIZED root (see RustEnsApi) — don't overclaim.
+            return switch (status == null ? "" : status) {
+                case "ok" -> new EnsResolutionResult(
+                        name, stringOrNull(o, "addressHex"), block, false, null);
+                // API convention: addressHex==null && error==null is a SUCCESSFUL
+                // "name has no record".
+                case "noRecord" -> new EnsResolutionResult(name, null, block, false, null);
+                case "offchain" -> new EnsResolutionResult(name, null, block, false,
+                        "name resolves offchain (ERC-3668); CCIP-Read not yet supported"
+                        + " on the rust engine");
+                default -> throw new EngineException(
+                        "resolve-ens JSON: unknown status '" + status + "'");
+            };
+        } catch (EngineException e) {
+            throw e;
+        } catch (RuntimeException e) {
+            throw new EngineException(
+                    "malformed resolve-ens JSON from the Rust engine: " + e.getMessage(), e);
         }
     }
 

--- a/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
@@ -562,7 +562,13 @@ final class RustChainHandle implements ChainHandle, NodeStatusReads {
         JsonObject o = parseResultOrThrow(json, "resolve-ens");
         try {
             String status = stringOrNull(o, "status");
-            long block = o.getLong("blockNumber", -1L);
+            // blockNumber is part of the pinned native shape for ALL statuses; a
+            // missing one is shape drift -> fail closed (like ok-without-address).
+            var bn = o.get("blockNumber");
+            if (bn == null || bn.isNull()) {
+                throw new EngineException("resolve-ens JSON: missing blockNumber");
+            }
+            long block = bn.asLong();
             // verified=false: the resolution IS proof-verified against the
             // beacon-anchored optimistic head, but "verified" in this API means a
             // beacon-FINALIZED root (see RustEnsApi) — don't overclaim.

--- a/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
@@ -567,8 +567,18 @@ final class RustChainHandle implements ChainHandle, NodeStatusReads {
             // beacon-anchored optimistic head, but "verified" in this API means a
             // beacon-FINALIZED root (see RustEnsApi) — don't overclaim.
             return switch (status == null ? "" : status) {
-                case "ok" -> new EnsResolutionResult(
-                        name, stringOrNull(o, "addressHex"), block, false, null);
+                // status=ok MUST carry an address; a missing one is native shape
+                // drift -> fail closed (EngineException), NOT a silent result that
+                // would read as the API's successful "no record" (same convention
+                // as estimateGasFromJson's ok-without-gas).
+                case "ok" -> {
+                    String addressHex = stringOrNull(o, "addressHex");
+                    if (addressHex == null || addressHex.isBlank()) {
+                        throw new EngineException(
+                                "resolve-ens JSON: status=ok without an addressHex");
+                    }
+                    yield new EnsResolutionResult(name, addressHex, block, false, null);
+                }
                 // API convention: addressHex==null && error==null is a SUCCESSFUL
                 // "name has no record".
                 case "noRecord" -> new EnsResolutionResult(name, null, block, false, null);

--- a/myotis-engines/src/main/java/io/myotis/engines/RustEngineNative.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustEngineNative.java
@@ -23,7 +23,7 @@ final class RustEngineNative {
     private static final Logger log = LoggerFactory.getLogger(RustEngineNative.class);
 
     /** Must match {@code ABI_VERSION} in rust/myotis-engine/src/lib.rs. */
-    static final int EXPECTED_ABI_VERSION = 10; // 10: + nativeEstimateGasJson
+    static final int EXPECTED_ABI_VERSION = 11; // 11: + nativeResolveEnsJson
 
     private static final boolean AVAILABLE = load();
 
@@ -162,6 +162,15 @@ final class RustEngineNative {
      */
     static native String nativeEstimateGasJson(
             long handle, String from, String to, String data, String value);
+
+    /**
+     * Verified ENS forward resolution (name → address record) over the revm
+     * executor, as JSON ({@code {"status":"ok","addressHex":"0x…","blockNumber":N}},
+     * {@code {"status":"noRecord",…}} for a successfully-determined absent record,
+     * {@code {"status":"offchain",…}} for an ERC-3668 name (exists, needs CCIP-Read),
+     * or {@code {"error":"…"}} on a transport/bad-input failure).
+     */
+    static native String nativeResolveEnsJson(long handle, String name);
 
     /**
      * Verified {@code eth_getBlockByNumber} (transactions as hashes) for a running

--- a/myotis-engines/src/main/java/io/myotis/engines/RustEnsApi.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustEnsApi.java
@@ -1,0 +1,95 @@
+package io.myotis.engines;
+
+import io.myotis.api.EnsAbiResult;
+import io.myotis.api.EnsApi;
+import io.myotis.api.EnsContenthashResult;
+import io.myotis.api.EnsDnsRecordResult;
+import io.myotis.api.EnsInterfaceResult;
+import io.myotis.api.EnsMultiCoinResult;
+import io.myotis.api.EnsPubkeyResult;
+import io.myotis.api.EnsResolutionResult;
+import io.myotis.api.EnsRoot;
+import io.myotis.api.EnsTextResult;
+
+/**
+ * The Rust engine's {@link EnsApi}: forward address resolution is served by the
+ * native resolver (registry walk + {@code addr}/ENSIP-10 dispatch over verified
+ * eth_calls — EL-C-5-1); every other record type returns a graceful
+ * "not implemented" error result until its slice lands (reverse+forward-verify
+ * EL-C-5-2, CCIP-Read EL-C-5-3, further record types after). Per the
+ * {@link EnsApi} contract, failures are reported in the result record's
+ * {@code error} — methods never throw.
+ *
+ * <p>The {@code root} parameter is currently advisory: the native resolver always
+ * runs against the beacon-anchored optimistic head (AUTO-like freshness), so
+ * {@code verified} is reported {@code false} — the resolution IS proof-verified
+ * against the anchored head, but not against a beacon-FINALIZED root, which is
+ * what {@code verified} means in this API. Finalized-root pinning is a later
+ * refinement.
+ */
+final class RustEnsApi implements EnsApi {
+
+    private static final String NOT_IMPLEMENTED =
+            "not implemented on the rust engine yet (later EL-C-5 slice)";
+
+    private final RustChainHandle handle;
+
+    RustEnsApi(RustChainHandle handle) {
+        this.handle = handle;
+    }
+
+    @Override
+    public EnsResolutionResult resolveAddress(String name, EnsRoot root) {
+        if (name == null || name.isBlank()) {
+            return new EnsResolutionResult(name, null, -1, false, "empty ENS name");
+        }
+        try {
+            return handle.resolveEnsVerified(name);
+        } catch (RuntimeException e) {
+            // EngineException (transport / not running) or any unchecked failure:
+            // the EnsApi contract reports failures in the record, never throws.
+            String why = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
+            return new EnsResolutionResult(name, null, -1, false, why);
+        }
+    }
+
+    @Override
+    public EnsResolutionResult reverseResolve(String hexAddress) {
+        return new EnsResolutionResult(null, hexAddress, -1, false, NOT_IMPLEMENTED);
+    }
+
+    @Override
+    public EnsTextResult resolveText(String name, String key) {
+        return new EnsTextResult(name, key, null, -1, false, NOT_IMPLEMENTED);
+    }
+
+    @Override
+    public EnsContenthashResult resolveContenthash(String name) {
+        return new EnsContenthashResult(name, null, -1, false, NOT_IMPLEMENTED);
+    }
+
+    @Override
+    public EnsMultiCoinResult resolveMultiCoinAddr(String name, long coinType) {
+        return new EnsMultiCoinResult(name, coinType, null, -1, false, NOT_IMPLEMENTED);
+    }
+
+    @Override
+    public EnsPubkeyResult resolvePubkey(String name) {
+        return new EnsPubkeyResult(name, null, null, -1, false, NOT_IMPLEMENTED);
+    }
+
+    @Override
+    public EnsAbiResult resolveAbi(String name, long contentTypes) {
+        return new EnsAbiResult(name, 0, null, -1, false, NOT_IMPLEMENTED);
+    }
+
+    @Override
+    public EnsDnsRecordResult resolveDnsRecord(String name, String dnsName, int recordType) {
+        return new EnsDnsRecordResult(name, dnsName, recordType, null, -1, false, NOT_IMPLEMENTED);
+    }
+
+    @Override
+    public EnsInterfaceResult resolveInterfaceImplementer(String name, byte[] interfaceId4) {
+        return new EnsInterfaceResult(name, null, null, -1, false, NOT_IMPLEMENTED);
+    }
+}

--- a/myotis-engines/src/main/java/io/myotis/engines/RustEnsApi.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustEnsApi.java
@@ -16,16 +16,23 @@ import io.myotis.api.EnsTextResult;
  * native resolver (registry walk + {@code addr}/ENSIP-10 dispatch over verified
  * eth_calls — EL-C-5-1); every other record type returns a graceful
  * "not implemented" error result until its slice lands (reverse+forward-verify
- * EL-C-5-2, CCIP-Read EL-C-5-3, further record types after). Per the
- * {@link EnsApi} contract, failures are reported in the result record's
- * {@code error} — methods never throw.
+ * EL-C-5-2, CCIP-Read EL-C-5-3, further record types after). Resolution failures
+ * are reported in the result record's {@code error}; this impl never throws (see
+ * the divergence note below).
  *
- * <p>The {@code root} parameter is currently advisory: the native resolver always
- * runs against the beacon-anchored optimistic head (AUTO-like freshness), so
- * {@code verified} is reported {@code false} — the resolution IS proof-verified
- * against the anchored head, but not against a beacon-FINALIZED root, which is
- * what {@code verified} means in this API. Finalized-root pinning is a later
- * refinement.
+ * <p>The native resolver always runs against the beacon-anchored optimistic head
+ * (AUTO-like freshness), so {@code verified} is reported {@code false} — the
+ * resolution IS proof-verified against the anchored head, but not against a
+ * beacon-FINALIZED root, which is what {@code verified} means in this API. An
+ * explicit {@link EnsRoot#FINALIZED} request is therefore rejected with an error
+ * result (never silently downgraded); finalized-root pinning is a later refinement.
+ *
+ * <p>Deliberate divergence from {@code JavaEnsApi}: that impl throws
+ * {@link io.myotis.api.EngineException} for the not-running state (per the EnsApi
+ * javadoc), while this one folds EVERY failure — including not-running — into the
+ * record's {@code error}. The native layer reports not-running as an error JSON,
+ * and distinguishing it by message string would be brittle; IPC consumers handle
+ * both shapes identically.
  */
 final class RustEnsApi implements EnsApi {
 
@@ -42,6 +49,13 @@ final class RustEnsApi implements EnsApi {
     public EnsResolutionResult resolveAddress(String name, EnsRoot root) {
         if (name == null || name.isBlank()) {
             return new EnsResolutionResult(name, null, -1, false, "empty ENS name");
+        }
+        if (root == EnsRoot.FINALIZED) {
+            // Fail closed rather than silently serving a weaker root than demanded:
+            // this engine resolves against the beacon-anchored OPTIMISTIC head only.
+            return new EnsResolutionResult(name, null, -1, false,
+                    "finalized-root resolution not supported on the rust engine yet"
+                    + " (resolves against the beacon-anchored optimistic head; use AUTO)");
         }
         try {
             return handle.resolveEnsVerified(name);

--- a/myotis-engines/src/main/java/io/myotis/engines/RustEnsApi.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustEnsApi.java
@@ -61,7 +61,8 @@ final class RustEnsApi implements EnsApi {
             return handle.resolveEnsVerified(name);
         } catch (RuntimeException e) {
             // EngineException (transport / not running) or any unchecked failure:
-            // the EnsApi contract reports failures in the record, never throws.
+            // THIS impl folds every failure into the record's error (a deliberate
+            // divergence from the interface's throw-allowance — class javadoc).
             String why = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
             return new EnsResolutionResult(name, null, -1, false, why);
         }
@@ -104,6 +105,16 @@ final class RustEnsApi implements EnsApi {
 
     @Override
     public EnsInterfaceResult resolveInterfaceImplementer(String name, byte[] interfaceId4) {
-        return new EnsInterfaceResult(name, null, null, -1, false, NOT_IMPLEMENTED);
+        // Echo the queried id like JavaEnsApi does; a malformed id is its own error
+        // result (this impl never throws).
+        if (interfaceId4 == null || interfaceId4.length != 4) {
+            return new EnsInterfaceResult(name, null, null, -1, false,
+                    "interfaceId must be exactly 4 bytes");
+        }
+        StringBuilder hex = new StringBuilder("0x");
+        for (byte b : interfaceId4) {
+            hex.append(String.format("%02x", b));
+        }
+        return new EnsInterfaceResult(name, hex.toString(), null, -1, false, NOT_IMPLEMENTED);
     }
 }

--- a/myotis-engines/src/test/java/io/myotis/engines/RustEnsApiTest.java
+++ b/myotis-engines/src/test/java/io/myotis/engines/RustEnsApiTest.java
@@ -4,6 +4,7 @@ import io.myotis.api.EnsResolutionResult;
 import io.myotis.api.EnsRoot;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -43,5 +44,18 @@ class RustEnsApiTest {
         assertNotNull(api.resolveDnsRecord("a.eth", "a.eth.", 1).error());
         assertNotNull(api.resolveInterfaceImplementer("a.eth", new byte[] {1, 2, 3, 4}).error());
         assertNotNull(api.reverseResolve("0x" + "11".repeat(20)).error());
+    }
+
+    @Test
+    void interfaceImplementerEchoesQueriedIdAndValidatesLength() {
+        var api = api();
+        // The queried id is echoed (JavaEnsApi parity) even on the stub error result.
+        var ok = api.resolveInterfaceImplementer("a.eth", new byte[] {(byte) 0x90, 0x61, (byte) 0xb9, 0x23});
+        assertEquals("0x9061b923", ok.interfaceIdHex());
+        // A malformed id is its own error result, never an echo or a throw.
+        var bad = api.resolveInterfaceImplementer("a.eth", new byte[] {1, 2, 3});
+        assertNull(bad.interfaceIdHex());
+        assertTrue(bad.error().contains("4 bytes"));
+        assertNull(api.resolveInterfaceImplementer("a.eth", null).interfaceIdHex());
     }
 }

--- a/myotis-engines/src/test/java/io/myotis/engines/RustEnsApiTest.java
+++ b/myotis-engines/src/test/java/io/myotis/engines/RustEnsApiTest.java
@@ -1,0 +1,47 @@
+package io.myotis.engines;
+
+import io.myotis.api.EnsResolutionResult;
+import io.myotis.api.EnsRoot;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** The RustEnsApi paths that need no native library (guards + graceful stubs). */
+class RustEnsApiTest {
+
+    private static RustEnsApi api() {
+        // A never-started handle: only the pre-native guard paths are exercised.
+        return new RustEnsApi(new RustChainHandle(0L, "mainnet", 1L, 0));
+    }
+
+    @Test
+    void finalizedRootIsRejectedNotDowngraded() {
+        EnsResolutionResult r = api().resolveAddress("vitalik.eth", EnsRoot.FINALIZED);
+        assertNull(r.addressHex());
+        assertNotNull(r.error());
+        assertTrue(r.error().contains("finalized"), r.error());
+    }
+
+    @Test
+    void blankNameIsAnErrorResult() {
+        EnsResolutionResult r = api().resolveAddress("  ", EnsRoot.AUTO);
+        assertNull(r.addressHex());
+        assertNotNull(r.error());
+    }
+
+    @Test
+    void unimplementedRecordTypesReturnGracefulErrors() {
+        // Never throws; error set, no value fields populated as answers.
+        var api = api();
+        assertNotNull(api.resolveText("a.eth", "url").error());
+        assertNotNull(api.resolveContenthash("a.eth").error());
+        assertNotNull(api.resolveMultiCoinAddr("a.eth", 60).error());
+        assertNotNull(api.resolvePubkey("a.eth").error());
+        assertNotNull(api.resolveAbi("a.eth", 1).error());
+        assertNotNull(api.resolveDnsRecord("a.eth", "a.eth.", 1).error());
+        assertNotNull(api.resolveInterfaceImplementer("a.eth", new byte[] {1, 2, 3, 4}).error());
+        assertNotNull(api.reverseResolve("0x" + "11".repeat(20)).error());
+    }
+}

--- a/myotis-engines/src/test/java/io/myotis/engines/RustVerifiedReadJsonTest.java
+++ b/myotis-engines/src/test/java/io/myotis/engines/RustVerifiedReadJsonTest.java
@@ -310,6 +310,14 @@ class RustVerifiedReadJsonTest {
     }
 
     @Test
+    void okEnsWithoutAddressFailsClosed() {
+        // status=ok without an addressHex is native shape drift -> EngineException,
+        // never a silent "no record" (same convention as okEstimateWithoutGasFailsClosed).
+        assertThrows(EngineException.class, () -> RustChainHandle.ensResolutionFromJson(
+                "vitalik.eth", "{\"status\":\"ok\",\"blockNumber\":21000010}"));
+    }
+
+    @Test
     void unknownEnsStatusFailsClosed() {
         assertThrows(EngineException.class, () -> RustChainHandle.ensResolutionFromJson(
                 "vitalik.eth", "{\"status\":\"weird\"}"));

--- a/myotis-engines/src/test/java/io/myotis/engines/RustVerifiedReadJsonTest.java
+++ b/myotis-engines/src/test/java/io/myotis/engines/RustVerifiedReadJsonTest.java
@@ -272,6 +272,49 @@ class RustVerifiedReadJsonTest {
                 () -> RustChainHandle.estimateGasFromJson("{\"status\":\"ok\"}"));
     }
 
+    // ---- resolve-ens (ensResolutionFromJson) ----
+
+    @Test
+    void okEnsResolutionCarriesAddressAndBlock() {
+        var r = RustChainHandle.ensResolutionFromJson("vitalik.eth",
+                "{\"status\":\"ok\",\"addressHex\":\"0xd8da6bf26964af9d7eed9e03e53415d37aa96045\","
+                + "\"blockNumber\":21000010}");
+        assertEquals("vitalik.eth", r.name());
+        assertEquals("0xd8da6bf26964af9d7eed9e03e53415d37aa96045", r.addressHex());
+        assertEquals(21000010L, r.blockNumber());
+        assertNull(r.error());
+    }
+
+    @Test
+    void noRecordEnsResolutionIsSuccessfulNull() {
+        // API convention: addressHex==null && error==null = successful "no record".
+        var r = RustChainHandle.ensResolutionFromJson("nonexistent.eth",
+                "{\"status\":\"noRecord\",\"blockNumber\":21000010}");
+        assertNull(r.addressHex());
+        assertNull(r.error());
+        assertEquals(21000010L, r.blockNumber());
+    }
+
+    @Test
+    void offchainEnsResolutionCarriesError() {
+        var r = RustChainHandle.ensResolutionFromJson("offchain.cb.id",
+                "{\"status\":\"offchain\",\"blockNumber\":21000010}");
+        assertNull(r.addressHex());
+        assertTrue(r.error().contains("offchain"));
+    }
+
+    @Test
+    void ensErrorObjectBecomesEngineException() {
+        assertThrows(EngineException.class, () -> RustChainHandle.ensResolutionFromJson(
+                "vitalik.eth", "{\"error\":\"no snap peer available\"}"));
+    }
+
+    @Test
+    void unknownEnsStatusFailsClosed() {
+        assertThrows(EngineException.class, () -> RustChainHandle.ensResolutionFromJson(
+                "vitalik.eth", "{\"status\":\"weird\"}"));
+    }
+
     // ---- eth_getStorageAt (storageValueFromJson) ----
 
     @Test

--- a/myotis-engines/src/test/java/io/myotis/engines/RustVerifiedReadJsonTest.java
+++ b/myotis-engines/src/test/java/io/myotis/engines/RustVerifiedReadJsonTest.java
@@ -318,6 +318,16 @@ class RustVerifiedReadJsonTest {
     }
 
     @Test
+    void ensWithoutBlockNumberFailsClosed() {
+        // blockNumber is part of the pinned shape for every status — missing = drift.
+        assertThrows(EngineException.class, () -> RustChainHandle.ensResolutionFromJson(
+                "vitalik.eth",
+                "{\"status\":\"ok\",\"addressHex\":\"0xd8da6bf26964af9d7eed9e03e53415d37aa96045\"}"));
+        assertThrows(EngineException.class, () -> RustChainHandle.ensResolutionFromJson(
+                "vitalik.eth", "{\"status\":\"noRecord\"}"));
+    }
+
+    @Test
     void unknownEnsStatusFailsClosed() {
         assertThrows(EngineException.class, () -> RustChainHandle.ensResolutionFromJson(
                 "vitalik.eth", "{\"status\":\"weird\"}"));

--- a/rust/myotis-engine/src/eljson.rs
+++ b/rust/myotis-engine/src/eljson.rs
@@ -257,10 +257,6 @@ pub fn call_json(outcome: &CallOutcome) -> String {
     serde_json::Value::Object(obj).to_string()
 }
 
-/// `estimateGas` result: `{"status":"ok","gas":N}` (the buffered gas-limit estimate
-/// as a JSON number — the 1.15 buffer can put it slightly above the 30 M base) or
-/// `{"status":"unavailable","reason":"…"}`. The Java side returns the number for
-/// `ok` and null otherwise (a reverting/unverifiable estimate has no number).
 /// ENS forward-resolution result: `{"status":"ok","addressHex":"0x…","blockNumber":N}`,
 /// `{"status":"noRecord","blockNumber":N}` (successfully determined absent — the
 /// Java side maps it to addressHex null + error null, the API's "no record"
@@ -286,6 +282,10 @@ pub fn ens_json(outcome: &EnsOutcome) -> String {
     serde_json::Value::Object(obj).to_string()
 }
 
+/// `estimateGas` result: `{"status":"ok","gas":N}` (the buffered gas-limit estimate
+/// as a JSON number — the 1.15 buffer can put it slightly above the 30 M base) or
+/// `{"status":"unavailable","reason":"…"}`. The Java side returns the number for
+/// `ok` and null otherwise (a reverting/unverifiable estimate has no number).
 pub fn estimate_json(outcome: &GasOutcome) -> String {
     let mut obj = serde_json::Map::new();
     match outcome {

--- a/rust/myotis-engine/src/eljson.rs
+++ b/rust/myotis-engine/src/eljson.rs
@@ -8,7 +8,7 @@
 //! serializes `{"error": "..."}`, which the Java side raises as an
 //! `EngineException`.
 
-use myotis_net::el::evm::{CallOutcome, GasOutcome};
+use myotis_net::el::evm::{CallOutcome, EnsOutcome, GasOutcome};
 use myotis_net::el::reader::{
     FeeEstimate, VerifiedAccount, VerifiedBlock, VerifiedCode, VerifiedStorage,
 };
@@ -261,6 +261,31 @@ pub fn call_json(outcome: &CallOutcome) -> String {
 /// as a JSON number — the 1.15 buffer can put it slightly above the 30 M base) or
 /// `{"status":"unavailable","reason":"…"}`. The Java side returns the number for
 /// `ok` and null otherwise (a reverting/unverifiable estimate has no number).
+/// ENS forward-resolution result: `{"status":"ok","addressHex":"0x…","blockNumber":N}`,
+/// `{"status":"noRecord","blockNumber":N}` (successfully determined absent — the
+/// Java side maps it to addressHex null + error null, the API's "no record"
+/// convention), or `{"status":"offchain","blockNumber":N}` (ERC-3668 name; the
+/// Java side sets a descriptive error — the record exists but needs CCIP-Read).
+pub fn ens_json(outcome: &EnsOutcome) -> String {
+    let mut obj = serde_json::Map::new();
+    match outcome {
+        EnsOutcome::Resolved { address, block_number } => {
+            obj.insert("status".into(), "ok".into());
+            obj.insert("addressHex".into(), hex0x_var(address).into());
+            obj.insert("blockNumber".into(), json_u64(*block_number));
+        }
+        EnsOutcome::NoRecord { block_number } => {
+            obj.insert("status".into(), "noRecord".into());
+            obj.insert("blockNumber".into(), json_u64(*block_number));
+        }
+        EnsOutcome::Offchain { block_number } => {
+            obj.insert("status".into(), "offchain".into());
+            obj.insert("blockNumber".into(), json_u64(*block_number));
+        }
+    }
+    serde_json::Value::Object(obj).to_string()
+}
+
 pub fn estimate_json(outcome: &GasOutcome) -> String {
     let mut obj = serde_json::Map::new();
     match outcome {
@@ -535,6 +560,29 @@ mod tests {
         .unwrap();
         assert_eq!(un["status"], "unavailable");
         assert_eq!(un["reason"], "execution reverted");
+    }
+
+    #[test]
+    fn ens_json_shapes() {
+        let ok: serde_json::Value = serde_json::from_str(&ens_json(&EnsOutcome::Resolved {
+            address: [0xd8; 20],
+            block_number: 21_000_010,
+        }))
+        .unwrap();
+        assert_eq!(ok["status"], "ok");
+        assert_eq!(ok["addressHex"], "0xd8d8d8d8d8d8d8d8d8d8d8d8d8d8d8d8d8d8d8d8");
+        assert_eq!(ok["blockNumber"], 21_000_010);
+
+        let none: serde_json::Value =
+            serde_json::from_str(&ens_json(&EnsOutcome::NoRecord { block_number: 21_000_010 }))
+                .unwrap();
+        assert_eq!(none["status"], "noRecord");
+        assert!(none.get("addressHex").is_none());
+
+        let off: serde_json::Value =
+            serde_json::from_str(&ens_json(&EnsOutcome::Offchain { block_number: 21_000_010 }))
+                .unwrap();
+        assert_eq!(off["status"], "offchain");
     }
 
     fn sample_code() -> VerifiedCode {

--- a/rust/myotis-engine/src/host.rs
+++ b/rust/myotis-engine/src/host.rs
@@ -490,6 +490,40 @@ pub fn eth_call_json(
     }
 }
 
+/// `nativeResolveEnsJson`: verified ENS forward resolution for a running handle.
+/// `name` is the ENS name (e.g. "vitalik.eth"); resolution runs the registry
+/// resolver-walk + addr/ENSIP-10 dispatch over verified eth_calls against the
+/// current head. Returns the ENS JSON (`ok`/`noRecord`/`offchain`, see
+/// [`eljson::ens_json`]) or `{"error": "..."}`.
+pub fn resolve_ens_json(handle: i64, name: &str) -> String {
+    let name = name.trim();
+    if name.is_empty() {
+        return eljson::error_json("empty ENS name");
+    }
+    // Bound the native input: real names are short; DNS-encoding caps labels at
+    // 63 bytes anyway, and an unbounded string shouldn't cross into the walk.
+    if name.len() > 512 {
+        return eljson::error_json("ENS name too long");
+    }
+    let Some(engine) = engine() else {
+        return eljson::error_json("engine unavailable");
+    };
+    let reader = match snapshot_reader(engine, handle) {
+        Ok((reader, _, _)) => reader,
+        Err(msg) => return eljson::error_json(msg),
+    };
+    // Mainnet-only, like the other EVM reads (the executor rejects any other chain).
+    const MAINNET_CHAIN_ID: u64 = 1;
+    let owned = name.to_string();
+    match engine
+        .rt
+        .block_on(async { reader.resolve_ens(owned, MAINNET_CHAIN_ID).await })
+    {
+        Ok(outcome) => eljson::ens_json(&outcome),
+        Err(e) => eljson::error_json(&e),
+    }
+}
+
 /// `nativeEstimateGasJson`: verified `eth_estimateGas` for a call (`to` set) over the
 /// revm executor. Args as for [`eth_call_json`] minus the block (estimate always runs
 /// against the verified head). Returns the estimate JSON (`ok`/`unavailable`, see

--- a/rust/myotis-engine/src/lib.rs
+++ b/rust/myotis-engine/src/lib.rs
@@ -26,7 +26,8 @@ pub mod ringlog;
 ///     running Java engine treats as stale.
 /// v9: added nativeEthCallJson (eth_call over verified state via the revm executor).
 /// v10: added nativeEstimateGasJson (eth_estimateGas over the revm executor).
-pub const ABI_VERSION: i32 = 10;
+/// v11: added nativeResolveEnsJson (ENS forward resolution over verified eth_calls).
+pub const ABI_VERSION: i32 = 11;
 
 // Keep the workspace edge alive so `cargo build -p myotis-engine` type-checks the
 // consensus crate too.
@@ -313,6 +314,23 @@ mod jni_shim {
         let data = read_string(&mut env, &data).unwrap_or_default();
         let value = read_string(&mut env, &value).unwrap_or_default();
         let json = crate::host::estimate_gas_json(handle, &from, &to, &data, &value);
+        match env.new_string(json) {
+            Ok(s) => s.into_raw(),
+            Err(_) => std::ptr::null_mut(),
+        }
+    }
+
+    /// `RustEngineNative.nativeResolveEnsJson(long handle, String name)` — verified
+    /// ENS forward resolution (name → address record) over the revm executor.
+    #[no_mangle]
+    pub extern "system" fn Java_io_myotis_engines_RustEngineNative_nativeResolveEnsJson(
+        mut env: JNIEnv,
+        _class: JClass,
+        handle: jlong,
+        name: JString,
+    ) -> jstring {
+        let name = read_string(&mut env, &name).unwrap_or_default();
+        let json = crate::host::resolve_ens_json(handle, &name);
         match env.new_string(json) {
             Ok(s) => s.into_raw(),
             Err(_) => std::ptr::null_mut(),

--- a/rust/myotis-net/src/el/evm.rs
+++ b/rust/myotis-net/src/el/evm.rs
@@ -60,6 +60,22 @@ pub enum GasOutcome {
     Unavailable(String),
 }
 
+/// The outcome of an ENS forward resolution. `block_number` is the verified head
+/// the resolution ran against. A hard failure (state unavailable, invalid name)
+/// travels the `Err(String)` channel instead, like the other reads.
+#[derive(Debug, Clone)]
+pub enum EnsOutcome {
+    /// The name resolved to this address record.
+    Resolved { address: [u8; 20], block_number: u64 },
+    /// Successfully determined that the name has NO address record (absent name,
+    /// zero-address record, or a non-wildcard ancestor resolver).
+    NoRecord { block_number: u64 },
+    /// The name resolves OFFCHAIN (ERC-3668 `OffchainLookup`) — the record exists
+    /// but needs a CCIP-Read gateway, which this engine doesn't drive yet
+    /// (EL-C-5-3). Distinguishable from `NoRecord` by design.
+    Offchain { block_number: u64 },
+}
+
 /// Build a [`BlockContext`] from a verified head header. `chain_id` comes from the
 /// chain config (the header carries no chain id).
 pub fn block_context(header: &BlockHeader, chain_id: u64) -> Result<BlockContext, String> {

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -223,6 +223,11 @@ pub struct ElReader {
 /// slots each). Generous — entries are small and eviction only trims the oldest.
 const EVM_PROOF_CACHE_ENTRIES: usize = 8192;
 
+/// Overall deadline for one ENS resolution walk (mirrors the Java
+/// `JavaEnsApi.RESOLVE_TIMEOUT_SEC` order of magnitude — the EnsApi contract
+/// promises a bounded worst case of ~2 min).
+const RESOLVE_ENS_DEADLINE: std::time::Duration = std::time::Duration::from_secs(120);
+
 impl ElReader {
     /// Start a mainnet reader with a freshly-generated ephemeral node key (the
     /// CL side generates its libp2p identity per run too; a persistent EL
@@ -677,12 +682,19 @@ impl ElReader {
     pub async fn resolve_ens(&self, name: String, chain_id: u64) -> Result<EnsOutcome, String> {
         let (ctx, executor) = self.evm_setup(chain_id, "resolve-ens").await?;
         let block_number = ctx.block_number;
-        let joined = tokio::task::spawn_blocking(move || {
+        let walk = tokio::task::spawn_blocking(move || {
             let caller = ExecutorCaller { executor: &executor, ctx: &ctx };
             myotis_evm::resolve_address(&caller, &name)
-        })
-        .await
-        .map_err(|e| format!("resolve-ens task join error: {e}"))?;
+        });
+        // Overall deadline (the EnsApi contract promises a bounded worst case): the
+        // walk is a chain of per-request-bounded peer calls, but a many-label name
+        // against stalling peers could multiply far past that. On timeout the
+        // abandoned closure still runs out its in-flight peer call on the blocking
+        // thread (spawn_blocking can't be cancelled) — only the caller is released.
+        let joined = tokio::time::timeout(RESOLVE_ENS_DEADLINE, walk)
+            .await
+            .map_err(|_| "resolve-ens timed out".to_string())?
+            .map_err(|e| format!("resolve-ens task join error: {e}"))?;
         match joined {
             Ok(Some(address)) => Ok(EnsOutcome::Resolved { address, block_number }),
             Ok(None) => Ok(EnsOutcome::NoRecord { block_number }),

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -27,12 +27,15 @@ use myotis_core::nodekey::NodeKey;
 use myotis_core::trie::{EMPTY_CODE_HASH, EMPTY_TRIE_ROOT};
 use myotis_core::triehash;
 
-use myotis_evm::{EvmError, EvmExecutor, InMemoryBytecodeCache, InMemoryStateProofCache, U256};
+use myotis_evm::{
+    EnsError, EvmError, EvmExecutor, ExecutorCaller, InMemoryBytecodeCache,
+    InMemoryStateProofCache, U256,
+};
 
 use crate::el::anchor::ExecAnchor;
 use crate::el::discv4::{Discv4Config, Discv4Service};
 use crate::el::eth::session::EthConfig;
-use crate::el::evm::{block_context, CallOutcome, GasOutcome, PoolOracle};
+use crate::el::evm::{block_context, CallOutcome, EnsOutcome, GasOutcome, PoolOracle};
 use crate::el::peer::ManagedPeer;
 use crate::el::pool::{PeerPool, PoolConfig};
 use crate::el::snap::fetch::AccountOutcome;
@@ -662,6 +665,30 @@ impl ElReader {
             Ok(gas) => GasOutcome::Estimate(gas),
             Err(e) => GasOutcome::Unavailable(e.to_string()),
         })
+    }
+
+    /// Verified ENS forward resolution: `name` → its address record, resolved
+    /// entirely over verified `eth_call`s against the current head (the registry
+    /// resolver-walk + `addr`/ENSIP-10 `resolve` in `myotis_evm::ens`). Runs the
+    /// whole walk on one blocking thread (each step's oracle fetch bridges via
+    /// `block_on`, same as [`Self::eth_call`]). An invalid name or a state failure
+    /// is `Err`; an offchain (CCIP) name is the distinguishable
+    /// [`EnsOutcome::Offchain`].
+    pub async fn resolve_ens(&self, name: String, chain_id: u64) -> Result<EnsOutcome, String> {
+        let (ctx, executor) = self.evm_setup(chain_id, "resolve-ens").await?;
+        let block_number = ctx.block_number;
+        let joined = tokio::task::spawn_blocking(move || {
+            let caller = ExecutorCaller { executor: &executor, ctx: &ctx };
+            myotis_evm::resolve_address(&caller, &name)
+        })
+        .await
+        .map_err(|e| format!("resolve-ens task join error: {e}"))?;
+        match joined {
+            Ok(Some(address)) => Ok(EnsOutcome::Resolved { address, block_number }),
+            Ok(None) => Ok(EnsOutcome::NoRecord { block_number }),
+            Err(EnsError::OffchainLookup) => Ok(EnsOutcome::Offchain { block_number }),
+            Err(e) => Err(e.to_string()),
+        }
     }
 
     /// Shared setup for the EVM reads: a [`BlockContext`](myotis_evm::BlockContext)


### PR DESCRIPTION
Makes the EL-C-5-1 resolver **reachable**: `resolve-ens vitalik.eth` now works on the Rust engine — IPC → `EnsApi` → JNI → the registry walk over verified `eth_call`s. No `CommandHandler` changes needed (the `resolve-ens` verb already routes through `ChainHandle.ens()`, which previously returned `null` on the Rust engine).

## What lands
**Rust**
- `ElReader::resolve_ens`: the shared `evm_setup` (verified-head `BlockContext` + `PoolOracle` + executor), then the whole registry walk on one `spawn_blocking` thread via `ExecutorCaller` (each step's oracle fetch bridges with `block_on`, same as `eth_call`). **Overall 120 s deadline** (`RESOLVE_ENS_DEADLINE`, the EnsApi contract's bounded-worst-case promise).
- `EnsOutcome { Resolved | NoRecord | Offchain }` — the ERC-3668 case stays **distinguishable** end-to-end (record exists, needs CCIP-Read).
- `eljson::ens_json` (`ok`/`noRecord`/`offchain` + `blockNumber`), `host::resolve_ens_json` (trim/empty/512-byte bound), `nativeResolveEnsJson`. **ABI 10→11.**

**Java**
- `RustEnsApi` (new): forward resolution real; the other 8 record types return graceful "not implemented (later EL-C-5 slice)" results. Never throws (documented as a deliberate divergence from `JavaEnsApi`'s throw-on-not-running). An explicit `EnsRoot.FINALIZED` request is **rejected with an error result** rather than silently served from the weaker optimistic-head root.
- `RustChainHandle.ens()` returns the cached `RustEnsApi` (was `null`); `ensResolutionFromJson` parse seam — `ok`→address, `noRecord`→the API's successful-no-record convention (`addressHex==null && error==null`), `offchain`→descriptive error, unknown status / `ok`-without-address → `EngineException` (fail closed on shape drift).
- `verified=false` deliberately: resolution is proof-verified against the beacon-anchored **optimistic** head, but `verified` in this API means a beacon-**finalized** root — finalized-root pinning is a later refinement.

## Validation
Rust: `ens_json` shape test; engine 25 / net 111 green; full workspace green. Java: golden tests for every JSON status (`ok`/`noRecord`/`offchain`/`error`/unknown-status/`ok`-without-address → fail closed) + `RustEnsApiTest` (FINALIZED rejection, blank-name guard, graceful stubs). Broad Java compile green.

An independent no-context review verified the async→sync bridge (no nested-runtime hazard, concurrency-safe), all 9 record arities, and that **no path can yield a non-null address that isn't the verified record**. Its findings (fail-open `ok` parse, FINALIZED downgrade, missing overall deadline, doc accuracy) are fixed in the last commit.

Live check once merged (Milestone-C gate item): `./gradlew :app:run -Pengine=rust -Pargs="resolve-ens vitalik.eth"` on a synced daemon.

Next after this: the multichain milestone (Sepolia, then Gnosis), per plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PP9WX3oschsX9T4AAKpdim