### PR TITLE
Merge main into rust-engine: sepolia CL ground truth + Android readiness notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,6 +664,8 @@ Ethereum's weak-subjectivity window is only ~28 hours of stake-weighted safety, 
 
 The task queries `/eth/v2/beacon/blocks/finalized` on three independent mainnet checkpoint providers (beaconstate.info, sync-mainnet.beaconcha.in, mainnet-checkpoint-sync.attestant.io), normalizes to the oldest observed finalized slot, re-queries each provider for the canonical block root at that slot, and requires byte-for-byte agreement before writing. Any disagreement aborts without modifying the source.
 
+The same machinery serves the other networks: `./gradlew refreshSepoliaCheckpoint` refreshes the `@checkpoint:sepolia` region from the eth-clients sepolia checkpoint providers, and `./gradlew refreshGnosisCheckpoint` refreshes `@checkpoint:gnosis` (its own task — Gnosis exposes a different API slice and fewer providers).
+
 ### Verification flow
 
 1. The beacon light client obtains a finalized execution state root (BLS-verified via sync committee signatures)

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -516,11 +516,17 @@ public final class NodeService extends Service {
      *  on a poor network still completes first. */
     private static final long SYNC_RUN_CEILING_MS = 30 * 60_000L;
     private volatile java.util.concurrent.ScheduledExecutorService idleTicker;
-    /** The notification's current "title\ntext" content, so we re-notify only when it changes. */
+    /** The notification's current "title\ntext" content, so we re-notify only when it changes.
+     *  Guarded by {@link #notifLock} for an atomic diff-and-notify across the idle ticker,
+     *  boot threads, and the connectivity callback. */
     private volatile String notifiedContent;
+    private final Object notifLock = new Object();
     /** Default-network callback: refreshes the notification the moment connectivity changes,
      *  so "No network connection" appears/clears without waiting for the 30 s idle reconcile. */
     private volatile ConnectivityManager.NetworkCallback notifNetCallback;
+    /** Last device connectivity seen by the callback, so a capability jitter that doesn't flip
+     *  up↔down skips the (per-stack) readiness poll. */
+    private volatile Boolean lastNetworkUp;
 
     /** Note UI-originated activity so the idle controller keeps the node awake. */
     public void noteUiActivity() {
@@ -820,13 +826,17 @@ public final class NodeService extends Service {
     private void updateNotification() {
         if (!RUNNING.get()) return;
         try {
+            // Poll live state OUTSIDE the lock (status()/lifecycle() are blocking engine calls).
             String[] tt = notificationText();
             String key = tt[0] + "\n" + tt[1];
-            String shown = notifiedContent;
-            if (shown != null && shown.equals(key)) return;   // unchanged → skip the re-notify
-            notifiedContent = key;
-            NotificationManager nm = getSystemService(NotificationManager.class);
-            if (nm != null) nm.notify(NOTIFICATION_ID, buildNotification(tt[0], tt[1]));
+            // Diff-and-notify atomically so concurrent callers can't post out of order or both
+            // re-notify the same content; building the Notification is cheap (no engine calls).
+            synchronized (notifLock) {
+                if (key.equals(notifiedContent)) return;   // unchanged → skip the re-notify
+                notifiedContent = key;
+                NotificationManager nm = getSystemService(NotificationManager.class);
+                if (nm != null) nm.notify(NOTIFICATION_ID, buildNotification(tt[0], tt[1]));
+            }
         } catch (Throwable t) {
             LogBuffer.w(TAG, "notification update failed: " + t);
         }
@@ -886,17 +896,29 @@ public final class NodeService extends Service {
         try {
             ConnectivityManager cm = getSystemService(ConnectivityManager.class);
             if (cm == null) return;
+            lastNetworkUp = networkAvailable();   // seed so the first callback doesn't spuriously poll
             ConnectivityManager.NetworkCallback cb = new ConnectivityManager.NetworkCallback() {
-                @Override public void onAvailable(Network network) { updateNotification(); }
-                @Override public void onLost(Network network) { updateNotification(); }
+                @Override public void onAvailable(Network network) { onNotifConnectivityChanged(); }
+                @Override public void onLost(Network network) { onNotifConnectivityChanged(); }
                 @Override public void onCapabilitiesChanged(
-                        Network network, android.net.NetworkCapabilities caps) { updateNotification(); }
+                        Network network, android.net.NetworkCapabilities caps) { onNotifConnectivityChanged(); }
             };
             notifNetCallback = cb;
             cm.registerDefaultNetworkCallback(cb);
         } catch (Throwable t) {
             LogBuffer.w(TAG, "notification network callback registration failed: " + t);
         }
+    }
+
+    /** Refresh the notification only when device connectivity actually flipped up↔down —
+     *  capability callbacks fire often (signal / metering / validation changes) and each would
+     *  otherwise trigger a full per-stack readiness poll. */
+    private void onNotifConnectivityChanged() {
+        boolean up = networkAvailable();
+        Boolean prev = lastNetworkUp;
+        if (prev != null && prev == up) return;   // no real change → skip the readiness poll
+        lastNetworkUp = up;
+        updateNotification();
     }
 
     private void unregisterNotifNetworkCallback() {
@@ -1713,12 +1735,6 @@ public final class NodeService extends Service {
         unregisterNotifNetworkCallback();
         new Thread(this::doShutdown, "ethp2p-shutdown").start();
         super.onDestroy();
-    }
-
-    /** Build the ongoing notification from the current live state. */
-    private Notification buildNotification() {
-        String[] tt = notificationText();
-        return buildNotification(tt[0], tt[1]);
     }
 
     private Notification buildNotification(String title, String text) {

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -924,8 +924,11 @@ public final class NodeService extends Service {
                 @Override public void onCapabilitiesChanged(
                         Network network, android.net.NetworkCapabilities caps) { onNotifConnectivityChanged(); }
             };
-            notifNetCallback = cb;
             cm.registerDefaultNetworkCallback(cb);
+            // Publish only AFTER registration succeeded: if register throws, the
+            // field stays null so the top-of-method guard lets a later call retry
+            // (a pre-assignment would wedge connectivity refreshes until restart).
+            notifNetCallback = cb;
         } catch (Throwable t) {
             LogBuffer.w(TAG, "notification network callback registration failed: " + t);
         }
@@ -1283,7 +1286,9 @@ public final class NodeService extends Service {
         // to match the manifest's <service android:foregroundServiceType="...">
         // declaration. API 29-33 ignore the third arg. minSdk is 29.
         String[] tt0 = notificationText();
-        notifiedContent = tt0[0] + "\n" + tt0[1];   // prime the diff key to the initial content
+        synchronized (notifLock) {   // the field's documented guard — keep the prime
+            notifiedContent = tt0[0] + "\n" + tt0[1];   // ordered with any concurrent diff-and-notify
+        }
         startForeground(NOTIFICATION_ID, buildNotification(tt0[0], tt0[1]),
                 ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC);
         startIdleTicker();

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -912,13 +912,21 @@ public final class NodeService extends Service {
 
     /** Refresh the notification only when device connectivity actually flipped up↔down —
      *  capability callbacks fire often (signal / metering / validation changes) and each would
-     *  otherwise trigger a full per-stack readiness poll. */
+     *  otherwise trigger a full per-stack readiness poll.
+     *
+     *  <p>NetworkCallback runs on the system's shared connectivity thread, so the blocking
+     *  readiness poll (h.status()) must NOT run here — offload to {@link #QUERY_POOL}. The
+     *  up↔down gate is checked under {@link #notifLock} so concurrent callbacks don't both poll. */
     private void onNotifConnectivityChanged() {
-        boolean up = networkAvailable();
-        Boolean prev = lastNetworkUp;
-        if (prev != null && prev == up) return;   // no real change → skip the readiness poll
-        lastNetworkUp = up;
-        updateNotification();
+        QUERY_POOL.execute(() -> {
+            boolean up = networkAvailable();
+            synchronized (notifLock) {
+                Boolean prev = lastNetworkUp;
+                if (prev != null && prev == up) return;   // no real change → skip the readiness poll
+                lastNetworkUp = up;
+            }
+            updateNotification();
+        });
     }
 
     private void unregisterNotifNetworkCallback() {

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -516,8 +516,11 @@ public final class NodeService extends Service {
      *  on a poor network still completes first. */
     private static final long SYNC_RUN_CEILING_MS = 30 * 60_000L;
     private volatile java.util.concurrent.ScheduledExecutorService idleTicker;
-    /** What the notification currently shows, to notify() only on transitions. */
-    private volatile Boolean notifiedSleeping;
+    /** The notification's current "title\ntext" content, so we re-notify only when it changes. */
+    private volatile String notifiedContent;
+    /** Default-network callback: refreshes the notification the moment connectivity changes,
+     *  so "No network connection" appears/clears without waiting for the 30 s idle reconcile. */
+    private volatile ConnectivityManager.NetworkCallback notifNetCallback;
 
     /** Note UI-originated activity so the idle controller keeps the node awake. */
     public void noteUiActivity() {
@@ -812,20 +815,98 @@ public final class NodeService extends Service {
         }
     }
 
-    /** Re-issue the foreground notification when the sleeping/active state changed —
-     *  including engine-initiated wakes (an RPC request resumed a paused stack). */
+    /** Re-issue the foreground notification when its content changed — the sleeping/active
+     *  state (incl. engine-initiated wakes), the per-network readiness, or connectivity. */
     private void updateNotification() {
         if (!RUNNING.get()) return;
-        boolean sleeping = allStacksPaused();
-        Boolean shown = notifiedSleeping;
-        if (shown != null && shown == sleeping) return;
-        notifiedSleeping = sleeping;
         try {
+            String[] tt = notificationText();
+            String key = tt[0] + "\n" + tt[1];
+            String shown = notifiedContent;
+            if (shown != null && shown.equals(key)) return;   // unchanged → skip the re-notify
+            notifiedContent = key;
             NotificationManager nm = getSystemService(NotificationManager.class);
-            if (nm != null) nm.notify(NOTIFICATION_ID, buildNotification(sleeping));
+            if (nm != null) nm.notify(NOTIFICATION_ID, buildNotification(tt[0], tt[1]));
         } catch (Throwable t) {
             LogBuffer.w(TAG, "notification update failed: " + t);
         }
+    }
+
+    /**
+     * The ongoing notification's {@code [title, text]}, derived from live node + connectivity
+     * state. Priority: idle-sleep (networking intentionally off) → no device network → per-network
+     * readiness. Readiness mirrors the in-app {@code ReadinessStrip} tiers.
+     */
+    private String[] notificationText() {
+        if (allStacksPaused()) {
+            return new String[]{"ethp2p node sleeping", "Networking off — a wallet request wakes it"};
+        }
+        if (!networkAvailable()) {
+            // Actively meant to be running, but the device has no connectivity — surface it: the
+            // node can't discover peers or sync until a network returns.
+            return new String[]{"ethp2p node running", "No network connection"};
+        }
+        return new String[]{"ethp2p node running", readinessSummary()};
+    }
+
+    /** Per-network readiness on one line, e.g. {@code "mainnet ready · gnosis syncing"}; sorted by
+     *  network name so the text is stable across polls. Empty (pre-boot) → {@code "Starting…"}. */
+    private String readinessSummary() {
+        java.util.List<String> names = new java.util.ArrayList<>(handles.keySet());
+        java.util.Collections.sort(names);
+        StringBuilder sb = new StringBuilder();
+        for (String n : names) {
+            ChainHandle h = handles.get(n);
+            if (h == null) continue;
+            if (sb.length() > 0) sb.append(" · ");
+            sb.append(n).append(' ').append(readinessWord(h));
+        }
+        return sb.length() == 0 ? "Starting…" : sb.toString();
+    }
+
+    /** One-word readiness for a stack, mirroring the app's {@code ReadinessStrip} tiers:
+     *  {@code sleeping} (paused) → {@code syncing} (beacon not SYNCED) → {@code warming up}
+     *  (SYNCED but no verified head yet, so reads would 503) → {@code ready}. */
+    private static String readinessWord(ChainHandle h) {
+        try {
+            if (h.lifecycle() == io.myotis.api.LifecycleState.PAUSED) return "sleeping";
+            StatusSnapshot s = h.status();
+            if (s.beaconState() != BeaconState.SYNCED) return "syncing";
+            if (s.verifiedHeadAgeMs() == Long.MAX_VALUE) return "warming up";
+            return "ready";
+        } catch (Throwable t) {
+            return "…";
+        }
+    }
+
+    /** Register a default-network callback that refreshes the notification on connectivity
+     *  changes, so the "No network connection" line appears/clears promptly. Best-effort. */
+    private void registerNotifNetworkCallback() {
+        if (notifNetCallback != null) return;
+        try {
+            ConnectivityManager cm = getSystemService(ConnectivityManager.class);
+            if (cm == null) return;
+            ConnectivityManager.NetworkCallback cb = new ConnectivityManager.NetworkCallback() {
+                @Override public void onAvailable(Network network) { updateNotification(); }
+                @Override public void onLost(Network network) { updateNotification(); }
+                @Override public void onCapabilitiesChanged(
+                        Network network, android.net.NetworkCapabilities caps) { updateNotification(); }
+            };
+            notifNetCallback = cb;
+            cm.registerDefaultNetworkCallback(cb);
+        } catch (Throwable t) {
+            LogBuffer.w(TAG, "notification network callback registration failed: " + t);
+        }
+    }
+
+    private void unregisterNotifNetworkCallback() {
+        ConnectivityManager.NetworkCallback cb = notifNetCallback;
+        notifNetCallback = null;
+        if (cb == null) return;
+        try {
+            ConnectivityManager cm = getSystemService(ConnectivityManager.class);
+            if (cm != null) cm.unregisterNetworkCallback(cb);
+        } catch (Throwable ignored) {}
     }
 
     // Runs the BLOCKING engine-API calls (requestAccount, ens().resolveAddress) off the
@@ -1145,10 +1226,12 @@ public final class NodeService extends Service {
         // API 34+ requires the foregroundServiceType to be passed here and
         // to match the manifest's <service android:foregroundServiceType="...">
         // declaration. API 29-33 ignore the third arg. minSdk is 29.
-        notifiedSleeping = false;
-        startForeground(NOTIFICATION_ID, buildNotification(false),
+        String[] tt0 = notificationText();
+        notifiedContent = tt0[0] + "\n" + tt0[1];   // prime the diff key to the initial content
+        startForeground(NOTIFICATION_ID, buildNotification(tt0[0], tt0[1]),
                 ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC);
         startIdleTicker();
+        registerNotifNetworkCallback();
 
         // Boot every enabled network as its own stack (Step 9). Each Netty/libp2p boot is
         // blocking-ish, so build + start each on its own worker; they bind distinct ports
@@ -1627,21 +1710,26 @@ public final class NodeService extends Service {
         // tears every stack down under each network's bootLock, so a subsequent
         // service start can't race with a half-finished close.
         RUNNING.set(false);
+        unregisterNotifNetworkCallback();
         new Thread(this::doShutdown, "ethp2p-shutdown").start();
         super.onDestroy();
     }
 
-    private Notification buildNotification(boolean sleeping) {
+    /** Build the ongoing notification from the current live state. */
+    private Notification buildNotification() {
+        String[] tt = notificationText();
+        return buildNotification(tt[0], tt[1]);
+    }
+
+    private Notification buildNotification(String title, String text) {
         NotificationManager nm = getSystemService(NotificationManager.class);
         NotificationChannel channel = new NotificationChannel(
                 CHANNEL_ID, "ethp2p node",
                 NotificationManager.IMPORTANCE_LOW);
         nm.createNotificationChannel(channel);
         return new Notification.Builder(this, CHANNEL_ID)
-                .setContentTitle(sleeping ? "ethp2p node sleeping" : "ethp2p node running")
-                .setContentText(sleeping
-                        ? "Networking off — a wallet request wakes it"
-                        : null)
+                .setContentTitle(title)
+                .setContentText(text)
                 .setSmallIcon(android.R.drawable.stat_sys_download)
                 .setOngoing(true)
                 .build();

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -1746,11 +1746,16 @@ public final class NodeService extends Service {
     }
 
     private Notification buildNotification(String title, String text) {
+        // Guard the channel creation like updateNotification() treats the manager as nullable —
+        // this also runs on the startForeground() path, which isn't wrapped in try/catch, so a
+        // (practically impossible) null manager must not NPE the service start.
         NotificationManager nm = getSystemService(NotificationManager.class);
-        NotificationChannel channel = new NotificationChannel(
-                CHANNEL_ID, "ethp2p node",
-                NotificationManager.IMPORTANCE_LOW);
-        nm.createNotificationChannel(channel);
+        if (nm != null) {
+            NotificationChannel channel = new NotificationChannel(
+                    CHANNEL_ID, "ethp2p node",
+                    NotificationManager.IMPORTANCE_LOW);
+            nm.createNotificationChannel(channel);
+        }
         return new Notification.Builder(this, CHANNEL_ID)
                 .setContentTitle(title)
                 .setContentText(text)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -150,7 +150,8 @@ fun registerCheckpointRefresh(taskName: String, network: String, endpoints: List
         val finalRoot = distinct.single().removePrefix("0x")
         val period = minSlot / 8192
         // Shared with the Java-side genesis constants via gradle.properties
-        val genesis = (project.property(genesisTimeProperty) as String).toLong()
+        val genesis = (project.findProperty(genesisTimeProperty) as? String)?.takeIf { it.isNotBlank() }?.toLongOrNull()
+            ?: throw GradleException("Property '$genesisTimeProperty' is missing, blank, or not a valid Long")
         val ts = Instant.ofEpochSecond(genesis + minSlot * 12)
         val date = DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneOffset.UTC).format(ts)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,24 +69,19 @@ subprojects {
 }
 
 // -------------------------------------------------------------------------
-// Trust anchor refresh: fetch the current mainnet finalized block root from
-// multiple independent public checkpoint endpoints, cross-validate, and
-// rewrite the `@checkpoint:mainnet` region in NetworkConfig.java.
+// Trust anchor refresh: fetch the current finalized block root from multiple
+// independent public checkpoint endpoints, cross-validate, and rewrite the
+// `@checkpoint:<network>` region in NetworkConfig.java. Shared by the mainnet
+// and sepolia tasks (identical Beacon API shape and mainnet-preset slot math);
+// Gnosis has its own task below (different API surface, scarce endpoints).
 // -------------------------------------------------------------------------
 
-tasks.register("refreshMainnetCheckpoint") {
+fun registerCheckpointRefresh(taskName: String, network: String, endpoints: List<String>, genesisTimeProperty: String) =
+    tasks.register(taskName) {
     group = "trust"
-    description = "Fetch the finalized mainnet block root from 3 public checkpoint providers, cross-validate, and update NetworkConfig.java. Use -Pdry to preview the diff without writing."
+    description = "Fetch the finalized $network block root from ${endpoints.size} public checkpoint providers, cross-validate, and update NetworkConfig.java. Use -Pdry to preview the diff without writing."
 
     doLast {
-        // Three independent mainnet checkpoint-sync endpoints. These serve only a narrow
-        // slice of the Beacon API (/eth/v1/beacon/blocks/{id}/root + /eth/v2/beacon/blocks/{id}),
-        // which is enough for what we need here.
-        val endpoints = listOf(
-            "https://beaconstate.info",
-            "https://sync-mainnet.beaconcha.in",
-            "https://mainnet-checkpoint-sync.attestant.io",
-        )
         val dryRun = project.hasProperty("dry")
         val client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build()
 
@@ -154,20 +149,20 @@ tasks.register("refreshMainnetCheckpoint") {
 
         val finalRoot = distinct.single().removePrefix("0x")
         val period = minSlot / 8192
-        // Shared with BeaconChainSpec.MAINNET_GENESIS_TIME via gradle.properties
-        val genesis = (project.property("ethp2p.mainnet.genesisTime") as String).toLong()
+        // Shared with the Java-side genesis constants via gradle.properties
+        val genesis = (project.property(genesisTimeProperty) as String).toLong()
         val ts = Instant.ofEpochSecond(genesis + minSlot * 12)
         val date = DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneOffset.UTC).format(ts)
 
         val file = project(":networking").projectDir.resolve(
             "src/main/java/com/jaeckel/ethp2p/networking/NetworkConfig.java")
         val original = file.readText()
-        val beginMarker = "// @checkpoint:mainnet:begin"
-        val endMarker = "// @checkpoint:mainnet:end"
+        val beginMarker = "// @checkpoint:$network:begin"
+        val endMarker = "// @checkpoint:$network:end"
         val beginIdx = original.indexOf(beginMarker)
         val endIdx = original.indexOf(endMarker)
         if (beginIdx < 0 || endIdx < 0 || endIdx < beginIdx) {
-            throw GradleException("Could not find @checkpoint:mainnet:begin/end markers in NetworkConfig.java")
+            throw GradleException("Could not find @checkpoint:$network:begin/end markers in NetworkConfig.java")
         }
         // Preserve whatever line ending the source file uses so we don't mix CRLF/LF
         // when running on Windows.
@@ -179,11 +174,11 @@ tasks.register("refreshMainnetCheckpoint") {
         val indent = original.substring(beginLineStart, beginIdx)
 
         val replacement = buildString {
-            append(indent).append("// @checkpoint:mainnet:begin — managed by `./gradlew refreshMainnetCheckpoint`").append(eol)
-            append(indent).append("// trusted checkpoint: recent finalized mainnet block root (slot $minSlot, $date, period $period)").append(eol)
+            append(indent).append("// @checkpoint:$network:begin — managed by `./gradlew $taskName`").append(eol)
+            append(indent).append("// trusted checkpoint: recent finalized $network block root (slot $minSlot, $date, period $period)").append(eol)
             append(indent).append("Bytes.fromHexString(\"$finalRoot\").toArrayUnsafe(),").append(eol)
             append(indent).append("${minSlot}L, // checkpoint slot (epoch = slot/32). Must stay in sync with the root above.").append(eol)
-            append(indent).append("// @checkpoint:mainnet:end")
+            append(indent).append("// @checkpoint:$network:end")
         }
         val updated = original.substring(0, beginLineStart) + replacement + original.substring(endMarkerEnd)
 
@@ -214,6 +209,30 @@ tasks.register("refreshMainnetCheckpoint") {
         }
     }
 }
+
+// Independent checkpoint-sync endpoints per network. These serve only a narrow
+// slice of the Beacon API (/eth/v1/beacon/blocks/{id}/root + /eth/v2/beacon/blocks/{id}),
+// which is enough for what we need here.
+registerCheckpointRefresh(
+    "refreshMainnetCheckpoint", "mainnet",
+    listOf(
+        "https://beaconstate.info",
+        "https://sync-mainnet.beaconcha.in",
+        "https://mainnet-checkpoint-sync.attestant.io",
+    ),
+    "ethp2p.mainnet.genesisTime",
+)
+// The full eth-clients/checkpoint-sync-endpoints sepolia list; the task needs
+// any 2 of them live for cross-validation.
+registerCheckpointRefresh(
+    "refreshSepoliaCheckpoint", "sepolia",
+    listOf(
+        "https://sepolia.beaconstate.info",
+        "https://checkpoint-sync.sepolia.ethpandaops.io",
+        "https://beaconstate-sepolia.chainsafe.io",
+    ),
+    "ethp2p.sepolia.genesisTime",
+)
 
 // -------------------------------------------------------------------------
 // Gnosis checkpoint refresh. Public Gnosis beacon endpoints serving the

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,9 @@ ethp2p.mainnet.genesisTime=1606824023
 # Gnosis Beacon Chain genesis time (2021-12-08 19:55:40 UTC); read by
 # refreshGnosisCheckpoint for the checkpoint-date comment.
 ethp2p.gnosis.genesisTime=1638993340
+# Sepolia beacon genesis time (2022-06-20 14:00:00 UTC); read by
+# refreshSepoliaCheckpoint for the checkpoint-date comment.
+ethp2p.sepolia.genesisTime=1655733600
 
 # Required by the Compose / Activity artifacts pulled in by :android-app.
 android.useAndroidX=true

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/NetworkConfig.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/NetworkConfig.java
@@ -184,22 +184,48 @@ public record NetworkConfig(
             ),
             // genesis_validators_root (sepolia)
             Bytes.fromHexString("d8ea171f3c94aea21ebc42a1ed61052acf3f9209c00e4efbaaddac09ed9b8078").toArrayUnsafe(),
-            // trusted checkpoint: a recent finalized sepolia block root
-            Bytes.fromHexString("1f7c15e7e1a7be27b4e7e9b7bdb0e5e9b2aa5aebd33498ec04b58ef2adb5e9ce").toArrayUnsafe(),
-            0L, // checkpoint slot — unknown for sepolia, use 0 (spec-default). refresh job should fill this.
-            // current fork version: Electra on sepolia (0x90000073)
-            new byte[]{(byte) 0x90, 0x00, 0x00, 0x73},
-            0L, 0L, // no BPO active on sepolia
-            null, // prior fork version not pinned for sepolia
+            // @checkpoint:sepolia:begin — managed by `./gradlew refreshSepoliaCheckpoint`
+            // trusted checkpoint: recent finalized sepolia block root (slot 10657440, 2026-07-09, period 1300)
+            Bytes.fromHexString("8c3bc10ed8e1567dbdb60da360091c9af38e6b64e7de553a1ba2b0a5ffdfa5f6").toArrayUnsafe(),
+            10657440L, // checkpoint slot (epoch = slot/32). Must stay in sync with the root above.
+            // @checkpoint:sepolia:end
+            // current fork version: Fulu on sepolia (0x90000075) — activated at epoch 272640 (2025-10-14)
+            new byte[]{(byte) 0x90, 0x00, 0x00, 0x75},
+            // EIP-7892 BLOB_SCHEDULE — latest active entry on sepolia:
+            // BPO2 at epoch 275712, MAX_BLOBS_PER_BLOCK=21 (2025-10-28). Folds into
+            // the fork digest XOR — see activeBlobParams.
+            275712L, 21L,
+            // No prior-fork fallback (same rationale as mainnet: stale digests
+            // wouldn't help us sync to the current head anyway).
+            null,
             // CL peer multiaddrs for sepolia
             List.of(
                     "/ip4/18.185.193.198/tcp/9000/p2p/16Uiu2HAm3mfkjmLPtqnSJzNtKxbDuVjVRXidz5UinaZNpjCCKAkS"
             ),
             null,
             1655733600L, // sepolia beacon genesis: 2022-06-20 14:00:00 UTC
-            List.of(), // EL ENR trees — not pinned
-            List.of(), // CL ENR trees — not pinned
-            List.of()  // CL discv5 bootnodes — not pinned for sepolia this PR
+            // EL: Ethereum Foundation canonical sepolia tree (same EF signing key
+            // as the mainnet tree; the resolver verifies the signature).
+            List.of("enrtree://AKA3AM6LPBYEUDMVNU3BSVQJ5AD45Y7YPOHJLEF6W26QOE4VTUDPE@all.sepolia.ethdisco.net"),
+            List.of(), // CL ENR trees — no canonical single tree (same as mainnet)
+            // CL discv5 bootnodes — the canonical seed set for the sepolia beacon DHT.
+            // Mirrors eth-clients/sepolia metadata/bootstrap_nodes.yaml (EF, Teku,
+            // Lodestar). Seeds only: discv5's Kademlia loop expands beyond them.
+            List.of(
+                    // EF
+                    "enr:-Ku4QDZ_rCowZFsozeWr60WwLgOfHzv1Fz2cuMvJqN5iJzLxKtVjoIURY42X_YTokMi3IGstW5v32uSYZyGUXj9Q_IECh2F0dG5ldHOIAAAAAAAAAACEZXRoMpCo_ujukAAAaf__________gmlkgnY0gmlwhIpEe5iJc2VjcDI1NmsxoQNHTpFdaNSCEWiN_QqT396nb0PzcUpLe3OVtLph-AciBYN1ZHCCIy0",
+                    "enr:-Ku4QHRyRwEPT7s0XLYzJ_EeeWvZTXBQb4UCGy1F_3m-YtCNTtDlGsCMr4UTgo4uR89pv11uM-xq4w6GKfKhqU31hTgCh2F0dG5ldHOIAAAAAAAAAACEZXRoMpCo_ujukAAAaf__________gmlkgnY0gmlwhIrFM7WJc2VjcDI1NmsxoQI4diTwChN3zAAkarf7smOHCdFb1q3DSwdiQ_Lc_FdzFIN1ZHCCIy0",
+                    "enr:-Ku4QOkvvf0u5Hg4-HhY-SJmEyft77G5h3rUM8VF_e-Hag5cAma3jtmFoX4WElLAqdILCA-UWFRN1ZCDJJVuEHrFeLkDh2F0dG5ldHOIAAAAAAAAAACEZXRoMpCo_ujukAAAaf__________gmlkgnY0gmlwhJK-AWeJc2VjcDI1NmsxoQLFcT5VE_NMiIC8Ll7GypWDnQ4UEmuzD7hF_Hf4veDJwIN1ZHCCIy0",
+                    "enr:-Ku4QH6tYsHKITYeHUu5kdfXgEZWI18EWk_2RtGOn1jBPlx2UlS_uF3Pm5Dx7tnjOvla_zs-wwlPgjnEOcQDWXey51QCh2F0dG5ldHOIAAAAAAAAAACEZXRoMpCo_ujukAAAaf__________gmlkgnY0gmlwhIs7Mc6Jc2VjcDI1NmsxoQIET4Mlv9YzhrYhX_H9D7aWMemUrvki6W4J2Qo0YmFMp4N1ZHCCIy0",
+                    "enr:-Ku4QDmz-4c1InchGitsgNk4qzorWMiFUoaPJT4G0IiF8r2UaevrekND1o7fdoftNucirj7sFFTTn2-JdC2Ej0p1Mn8Ch2F0dG5ldHOIAAAAAAAAAACEZXRoMpCo_ujukAAAaf__________gmlkgnY0gmlwhKpA-liJc2VjcDI1NmsxoQMpHP5U1DK8O_JQU6FadmWbE42qEdcGlllR8HcSkkfWq4N1ZHCCIy0",
+                    // Teku
+                    "enr:-Iu4QKvMF7Ne_RSQoZGvavTuZ1QA5_Pgeb0nq_hrjhU8s0UDV3KhcMXJkGwOWhsDGZL3ISjL0CTP-hfoTjZtEtCEwR4BgmlkgnY0gmlwhAOAaySJc2VjcDI1NmsxoQNta5b_bexSSwwrGW2Re24MjfMntzFd0f2SAxQtMj3ueYN0Y3CCIyiDdWRwgiMo",
+                    // Lodestar
+                    "enr:-KG4QJejf8KVtMeAPWFhN_P0c4efuwu1pZHELTveiXUeim6nKYcYcMIQpGxxdgT2Xp9h-M5pr9gn2NbbwEAtxzu50Y8BgmlkgnY0gmlwhEEVkQCDaXA2kCoBBPnAEJg4AAAAAAAAAAGJc2VjcDI1NmsxoQLEh_eVvk07AQABvLkTGBQTrrIOQkzouMgSBtNHIRUxOIN1ZHCCIyiEdWRwNoIjKA",
+                    // remaining bootstrap_nodes.yaml entries (unattributed)
+                    "enr:-Iq4QMCTfIMXnow27baRUb35Q8iiFHSIDBJh6hQM5Axohhf4b6Kr_cOCu0htQ5WvVqKvFgY28893DHAg8gnBAXsAVqmGAX53x8JggmlkgnY0gmlwhLKAlv6Jc2VjcDI1NmsxoQK6S-Cii_KmfFdUJL2TANL3ksaKUnNXvTCv1tLwXs0QgIN1ZHCCIyk",
+                    "enr:-L64QC9Hhov4DhQ7mRukTOz4_jHm4DHlGL726NWH4ojH1wFgEwSin_6H95Gs6nW2fktTWbPachHJ6rUFu0iJNgA0SB2CARqHYXR0bmV0c4j__________4RldGgykDb6UBOQAABx__________-CaWSCdjSCaXCEA-2vzolzZWNwMjU2azGhA17lsUg60R776rauYMdrAz383UUgESoaHEzMkvm4K6k6iHN5bmNuZXRzD4N0Y3CCIyiDdWRwgiMo"
+            )
     );
 
     // Gnosis Chain (xDai). EL chainId 100; its own Consensus Layer (Gnosis Beacon

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/EthHandler.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/EthHandler.java
@@ -1056,10 +1056,11 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
                 return;
             }
             long blockNum = headers.get(0).header().number;
-            // Reject obviously stale headers. We use a static minimum rather than
-            // chainHead because chainHead can be poisoned by malicious peers.
-            // Mainnet is ~24.6M as of March 2026; 20M gives ample margin.
-            if (blockNum < 20_000_000) {
+            // Reject obviously stale headers. We use a static per-network minimum
+            // rather than chainHead because chainHead can be poisoned by malicious
+            // peers. (A flat mainnet-scale literal here rejected EVERY honest
+            // sepolia peer — sepolia's head is far below mainnet's.)
+            if (blockNum < network.minSensibleHeadBlock()) {
                 log.warn("[snap] Peer {} returned stale header (block #{}), skipping",
                         remoteAddress, blockNum);
                 result.completeExceptionally(new RuntimeException(
@@ -1166,7 +1167,8 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
                 return;
             }
             long blockNum = headers.get(0).header().number;
-            if (blockNum < 1_000_000) {
+            // Same per-network staleness floor as the account path above.
+            if (blockNum < network.minSensibleHeadBlock()) {
                 log.warn("[snap] Peer {} returned stale header (block #{}), skipping for storage query",
                     remoteAddress, blockNum);
                 result.completeExceptionally(new RuntimeException(

--- a/networking/src/test/java/com/jaeckel/ethp2p/networking/discv5/DiscV5ReseedTest.java
+++ b/networking/src/test/java/com/jaeckel/ethp2p/networking/discv5/DiscV5ReseedTest.java
@@ -49,7 +49,7 @@ class DiscV5ReseedTest {
 
     @Test
     void noBootnodesMeansNeverDue() {
-        // Sepolia pins clDiscv5Bootnodes to List.of(): with nothing to ping, a
+        // A network with no pinned CL bootnodes: with nothing to ping, a
         // re-seed must never fire (it would log "re-pinged 0 bootnode(s)"
         // every minute forever, reading as recovery where none is possible).
         DiscV5Service s = new DiscV5Service(NodeKey.generate(), List.of(), enr -> { });


### PR DESCRIPTION
Brings `rust-engine` up to date with `main` (9 commits) before the multichain milestone starts. Highlights of what comes in:

- **PR #192 — sepolia CL discovery + trust anchor**: the corrected sepolia ground truth the Rust multichain work will mirror — real `@checkpoint:sepolia` markers (slot 10657440, 2026-07-09) + a `refreshSepoliaCheckpoint` task (mainnet task refactored into a shared `registerCheckpointRefresh` helper), and the fixed CL fork version (**Fulu `0x90000075`**, replacing the wrong `0x90000073`/Deneb placeholder). This unblocks `ChainConfig::sepolia()` on the Rust side.
- **PR #189 — Android readiness + no-network in the foreground notification.**

## Conflict resolution
One conflict, `build.gradle.kts`: rust-engine's optional-Rust-build block (ToolProbe/cargo tasks) sat directly above the old mainnet-only "Trust anchor refresh" comment header, which main replaced with the new shared mainnet+sepolia header for the refactored helper. Resolved by keeping the entire Rust block and adopting main's new header verbatim — no functional code was in conflict.

## Validation
Full `./gradlew build` green (6m12s): every module's main + test sources compile (the failure mode of the previous main-merge), all Java/Kotlin suites, `cargoTest` (full Rust workspace), and the new `:ui:desktopTest`.

Next (after this merges): MC-1 — `ChainConfig::sepolia()` / `ElConfig::sepolia()` + lifting the Rust engine's mainnet-only gates, mirroring the #192 values; then Gnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PP9WX3oschsX9T4AAKpdim