### PR TITLE
MC-2: host Gnosis Chain on the Rust engine

### DIFF
--- a/docs/reimplementation/07-el-implementation-plan.md
+++ b/docs/reimplementation/07-el-implementation-plan.md
@@ -442,10 +442,23 @@ Java engine's.
   `fork_digest_bpo`). Sepolia checkpoint refreshes (`refreshSepoliaCheckpoint`) must be
   hand-mirrored into `ChainConfig::sepolia()` like mainnet's, until the plan-PR7 task
   rewrite covers the Rust constants.
-- **MC-2 (next): gnosis.** Own beacon chain (5s slots / 16-slot epochs — the Rust
-  `ChainConfig` fields are already generic), `refreshGnosisCheckpoint` mirroring, gnosis
-  `ElConfig` + EVM fork table, per-chain tip floor (gnosis 0.001 gwei vs 0.1), no ENS
-  (`has_ens=false` must gate `RustChainHandle.ens()` to null).
+- **MC-2 (landed): gnosis hosted by the Rust engine.** `ChainConfig::gnosis()` /
+  `ElConfig::gnosis()` mirror the Java `NetworkConfig.GNOSIS` (own beacon chain: 5s slots,
+  16-slot epochs, gvr `f5dcb556…`, Fulu fork `0x06000064` / prior Electra `0x05000064`,
+  blob params 1337856/2, checkpoint slot 28516336; EL network_id 100, genesis `4f1dd231…`,
+  fork-id `0xcfca387c`, 6 bootnodes, port 30304). The sync-committee period stays 8192
+  slots — gnosis uses `EPOCHS_PER_SYNC_COMMITTEE_PERIOD=512`, so 512×16 = 8192, numerically
+  identical to mainnet's 256×32 (checkpoint slot 28516336 → period 3480). The per-network
+  `min_suggested_tip_wei` floor became an `ElConfig`/`ElReader` field (gnosis 0.001 gwei =
+  1_000_000; mainnet/sepolia keep 0.1 gwei). EVM fork table gained the gnosis cascade
+  (Shanghai `0x64c8edbc` / Cancun `0x65ef4dbc` / Prague `0x68122dbc`, all timestamp-gated,
+  fail-closed below Shanghai) pinned to the nethermind `gnosis.json` hex. Gnosis has no ENS:
+  catalog `has_ens=false` threads through `RustMyotisEngine.create` → `RustChainHandle` so
+  `ens()` returns null. Parity tests pin the CL config incl. both fork digests (current Fulu+BPO
+  `0x3237dab6`, prior Electra `0x7d5aab40`). Validated live: the gnosis checkpoint bootstrap
+  discovered a CL peer (fork-digest correct) and verified against the genesis validators root
+  (`period=3480`, state `CATCHING_UP`); full SYNCED is peer-supply-bound on the dev host, as with
+  mainnet. `refreshGnosisCheckpoint` is hand-mirrored into `ChainConfig::gnosis()` like the others.
 - **Known gap (both engines, deliberately mirrored): fork tables cap at PRAGUE** even
   though mainnet + sepolia have activated Osaka/Fusaka (sepolia `osakaTime` 1760427360,
   go-ethereum `SepoliaChainConfig`). Adding OSAKA is a cross-engine follow-up so the two

--- a/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
@@ -80,11 +80,13 @@ final class RustChainHandle implements ChainHandle, NodeStatusReads {
     private long lastHeadBlock = -1L;
     private long lastHeadAdvanceNanos;
 
-    RustChainHandle(long handle, String networkName, long chainId, int rpcPort) {
+    RustChainHandle(long handle, String networkName, long chainId, int rpcPort, boolean hasEns) {
         this.handle = handle;
         this.networkName = networkName;
         this.chainId = chainId;
         this.rpcPort = rpcPort;
+        // Networks without ENS (e.g. gnosis) get no EnsApi — ens() returns null.
+        this.ensApi = hasEns ? new RustEnsApi(this) : null;
     }
 
     @Override public String networkName() { return networkName; }
@@ -271,12 +273,12 @@ final class RustChainHandle implements ChainHandle, NodeStatusReads {
      * Package-private test seam: exercises the JSON→snapshot mapping without JNI.
      */
     static StatusSnapshot statusFromJson(String network, String json) {
-        return new RustChainHandle(0L, network, 1L, 0).status(ParsedStatus.parse(json));
+        return new RustChainHandle(0L, network, 1L, 0, false).status(ParsedStatus.parse(json));
     }
 
     /** Package-private test seam: JSON→{@link BeaconStatus} without JNI. */
     static BeaconStatus beaconStatusFromJson(String network, String json) {
-        return new RustChainHandle(0L, network, 1L, 0).beaconStatus(ParsedStatus.parse(json));
+        return new RustChainHandle(0L, network, 1L, 0, false).beaconStatus(ParsedStatus.parse(json));
     }
 
     /** Package-private test seam: map a status JSON on THIS handle (so head-age
@@ -420,7 +422,10 @@ final class RustChainHandle implements ChainHandle, NodeStatusReads {
 
     @Override public VerifiedReads reads() { return rpcServer != null ? verifiedReads : null; }
 
-    private final EnsApi ensApi = new RustEnsApi(this);
+    // Non-null only for ENS-capable networks (gnosis has no ENS registry — the
+    // ChainHandle contract returns null there). Assigned in the constructor since
+    // it depends on hasEns.
+    private final EnsApi ensApi;
 
     @Override public EnsApi ens() { return ensApi; }
 

--- a/myotis-engines/src/main/java/io/myotis/engines/RustMyotisEngine.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustMyotisEngine.java
@@ -130,7 +130,7 @@ public final class RustMyotisEngine implements MyotisEngine {
         // Mirror JavaMyotisEngine: honour a host-supplied RPC port, else the
         // network's catalog default (mainnet 8545, sepolia 8547, ...).
         int rpcPort = config.rpcPort() > 0 ? config.rpcPort() : net.defaultRpcPort();
-        RustChainHandle handle = new RustChainHandle(id, canonical, net.chainId(), rpcPort);
+        RustChainHandle handle = new RustChainHandle(id, canonical, net.chainId(), rpcPort, net.hasEns());
         // Atomic claim (mirrors JavaMyotisEngine.putIfAbsent): reject a re-create rather
         // than orphaning the previous handle's native entry. On a lost race, release the
         // native handle we just allocated so it doesn't leak a tokio/libp2p host.

--- a/myotis-engines/src/main/java/io/myotis/engines/RustMyotisEngine.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustMyotisEngine.java
@@ -116,8 +116,8 @@ public final class RustMyotisEngine implements MyotisEngine {
         }
         // The native side is the single source of truth for which networks it
         // hosts: nativeCreate returns UNSUPPORTED_NETWORK for a canonical network
-        // whose Rust config hasn't landed (today: gnosis), and auto mode falls
-        // back to Java on the exception.
+        // whose Rust config hasn't landed yet, and auto mode falls back to Java
+        // on the exception.
         long id = RustEngineNative.nativeCreate(canonical, config.dataDir());
         if (id == RustEngineNative.UNSUPPORTED_NETWORK) {
             throw new EngineException(

--- a/myotis-engines/src/test/java/io/myotis/engines/RustCatalogParityTest.java
+++ b/myotis-engines/src/test/java/io/myotis/engines/RustCatalogParityTest.java
@@ -56,20 +56,18 @@ class RustCatalogParityTest {
     }
 
     @Test
-    void createRejectsUnhostedNetwork() {
-        // The native side is the source of truth for hosted networks: gnosis is
-        // canonical but has no Rust config yet, so nativeCreate returns
-        // UNSUPPORTED_NETWORK and create() raises a named EngineException (auto
-        // mode falls back to Java on it). Mainnet + sepolia pass this gate.
-        assumeTrue(RustMyotisEngine.isAvailable(),
-                "libmyotis_engine not on java.library.path — skipping native gate test");
+    void createRejectsUnknownNetwork() {
+        // All three CANONICAL networks (mainnet, sepolia, gnosis) are now hosted,
+        // so the remaining rejection path is a truly-unknown network name: it
+        // never reaches nativeCreate — canonicalNetworkName() rejects it first,
+        // raising a named EngineException (auto mode falls back to Java).
         RustMyotisEngine rust = new RustMyotisEngine();
         EngineConfig cfg = new EngineConfig(
-                "gnosis", 0, 0, 0, null, false, 0, true, "/tmp/myotis-test");
+                "not-a-real-network", 0, 0, 0, null, false, 0, true, "/tmp/myotis-test");
         EngineException e = assertThrows(EngineException.class,
                 () -> rust.create(cfg, null));
         org.junit.jupiter.api.Assertions.assertTrue(
-                e.getMessage().contains("does not host gnosis"),
+                e.getMessage().contains("not-a-real-network"),
                 "unexpected message: " + e.getMessage());
     }
 }

--- a/myotis-engines/src/test/java/io/myotis/engines/RustEnsApiTest.java
+++ b/myotis-engines/src/test/java/io/myotis/engines/RustEnsApiTest.java
@@ -17,12 +17,11 @@ class RustEnsApiTest {
         return new RustEnsApi(new RustChainHandle(0L, "mainnet", 1L, 0, true));
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void ensIsNullOnNetworksWithoutEns() {
         // gnosis (hasEns=false) → ChainHandle.ens() is null; mainnet (true) → non-null.
         assertNull(new RustChainHandle(0L, "gnosis", 100L, 0, false).ens());
-        org.junit.jupiter.api.Assertions.assertNotNull(
-                new RustChainHandle(0L, "mainnet", 1L, 0, true).ens());
+        assertNotNull(new RustChainHandle(0L, "mainnet", 1L, 0, true).ens());
     }
 
     @Test

--- a/myotis-engines/src/test/java/io/myotis/engines/RustEnsApiTest.java
+++ b/myotis-engines/src/test/java/io/myotis/engines/RustEnsApiTest.java
@@ -14,7 +14,15 @@ class RustEnsApiTest {
 
     private static RustEnsApi api() {
         // A never-started handle: only the pre-native guard paths are exercised.
-        return new RustEnsApi(new RustChainHandle(0L, "mainnet", 1L, 0));
+        return new RustEnsApi(new RustChainHandle(0L, "mainnet", 1L, 0, true));
+    }
+
+    @org.junit.jupiter.api.Test
+    void ensIsNullOnNetworksWithoutEns() {
+        // gnosis (hasEns=false) → ChainHandle.ens() is null; mainnet (true) → non-null.
+        assertNull(new RustChainHandle(0L, "gnosis", 100L, 0, false).ens());
+        org.junit.jupiter.api.Assertions.assertNotNull(
+                new RustChainHandle(0L, "mainnet", 1L, 0, true).ens());
     }
 
     @Test

--- a/myotis-engines/src/test/java/io/myotis/engines/RustStatusJsonTest.java
+++ b/myotis-engines/src/test/java/io/myotis/engines/RustStatusJsonTest.java
@@ -127,7 +127,7 @@ class RustStatusJsonTest {
     @Test
     void verifiedHeadAgeGrowsBetweenBlocksAndResetsOnAdvance() throws InterruptedException {
         // One persistent handle polled repeatedly — the real on-device behavior.
-        RustChainHandle h = new RustChainHandle(0L, "mainnet", 1L, 0);
+        RustChainHandle h = new RustChainHandle(0L, "mainnet", 1L, 0, true);
         String synced = CATCHING_UP_JSON.replace("CATCHING_UP", "SYNCED"); // optimisticBlockNumber 21000010
         long age1 = h.statusFromJsonOnThisHandle(synced).verifiedHeadAgeMs();
         assertEquals(0L, age1);                       // just observed the head

--- a/rust/myotis-engine/src/host.rs
+++ b/rust/myotis-engine/src/host.rs
@@ -95,6 +95,7 @@ fn config_for(network_name: &str) -> Option<ChainConfig> {
     match crate::catalog::canonical_network_name(network_name) {
         Some("mainnet") => Some(ChainConfig::mainnet()),
         Some("sepolia") => Some(ChainConfig::sepolia()),
+        Some("gnosis") => Some(ChainConfig::gnosis()),
         _ => None,
     }
 }
@@ -191,6 +192,7 @@ pub fn start(handle: i64) -> bool {
     let el_config = match config.name {
         "mainnet" => Some(myotis_net::el::reader::ElConfig::mainnet()),
         "sepolia" => Some(myotis_net::el::reader::ElConfig::sepolia()),
+        "gnosis" => Some(myotis_net::el::reader::ElConfig::gnosis()),
         other => {
             tracing::warn!(handle, network = other, "no EL config for this network; CL runs without EL");
             None

--- a/rust/myotis-evm/src/executor.rs
+++ b/rust/myotis-evm/src/executor.rs
@@ -464,10 +464,10 @@ mod tests {
         ];
         let exec = executor_with(code, None);
         let mut c = ctx(19_500_000, CANCUN_TIME + 1);
-        c.chain_id = 100; // Gnosis — no fork table yet, spec_for must fail closed
+        c.chain_id = 137; // Polygon — no fork table here, spec_for must fail closed
         let err = exec.call_view(TARGET, &[], &c).unwrap_err();
         assert!(
-            matches!(err, EvmError::UnsupportedChain { chain_id: 100 }),
+            matches!(err, EvmError::UnsupportedChain { chain_id: 137 }),
             "got {err:?}"
         );
     }

--- a/rust/myotis-evm/src/fork.rs
+++ b/rust/myotis-evm/src/fork.rs
@@ -51,6 +51,7 @@ pub fn spec_for(chain_id: u64, block_number: u64, timestamp: u64) -> Result<Spec
     match chain_id {
         1 => mainnet_spec(block_number, timestamp),
         11_155_111 => sepolia_spec(block_number, timestamp),
+        100 => gnosis_spec(block_number, timestamp),
         other => Err(EvmError::UnsupportedChain { chain_id: other }),
     }
 }
@@ -84,6 +85,31 @@ fn sepolia_spec(block_number: u64, timestamp: u64) -> Result<SpecId, EvmError> {
     } else if timestamp >= SEPOLIA_CANCUN_TIME {
         Ok(SpecId::CANCUN)
     } else if timestamp >= SEPOLIA_SHANGHAI_TIME {
+        Ok(SpecId::SHANGHAI)
+    } else {
+        Err(EvmError::ForkTooOld {
+            block_number,
+            timestamp,
+        })
+    }
+}
+
+/// Gnosis Shanghai activation timestamp (nethermind gnosis.json
+/// eip3855TransitionTimestamp 0x64c8edbc = 2023-08-01). Gnosis merged before
+/// Shanghai, so anything a beacon-anchored engine can serve is at/after it.
+pub const GNOSIS_SHANGHAI_TIME: u64 = 1_690_889_660;
+/// Gnosis Cancun activation timestamp (0x65ef4dbc = 2024-03-11).
+pub const GNOSIS_CANCUN_TIME: u64 = 1_710_181_820;
+/// Gnosis Prague activation timestamp (0x68122dbc = 2025-04-30).
+pub const GNOSIS_PRAGUE_TIME: u64 = 1_746_021_820;
+
+/// The gnosis cascade — all timestamp-gated (gnosis merged before Shanghai).
+fn gnosis_spec(block_number: u64, timestamp: u64) -> Result<SpecId, EvmError> {
+    if timestamp >= GNOSIS_PRAGUE_TIME {
+        Ok(SpecId::PRAGUE)
+    } else if timestamp >= GNOSIS_CANCUN_TIME {
+        Ok(SpecId::CANCUN)
+    } else if timestamp >= GNOSIS_SHANGHAI_TIME {
         Ok(SpecId::SHANGHAI)
     } else {
         Err(EvmError::ForkTooOld {
@@ -144,10 +170,32 @@ mod tests {
     }
 
     #[test]
+    fn gnosis_fork_times_pin_the_nethermind_hex() {
+        // Guards against a decimal-conversion slip: these MUST equal the
+        // nethermind gnosis.json hex activation timestamps, not a paraphrase.
+        assert_eq!(GNOSIS_SHANGHAI_TIME, 0x64c8_edbc); // 1_690_889_660
+        assert_eq!(GNOSIS_CANCUN_TIME, 0x65ef_4dbc); // 1_710_181_820
+        assert_eq!(GNOSIS_PRAGUE_TIME, 0x6812_2dbc); // 1_746_021_820
+    }
+
+    #[test]
+    fn gnosis_boundaries_map_to_their_specs() {
+        let g = 100u64;
+        assert_eq!(spec_for(g, 30_000_000, GNOSIS_PRAGUE_TIME).unwrap(), SpecId::PRAGUE);
+        assert_eq!(spec_for(g, 30_000_000, GNOSIS_PRAGUE_TIME - 1).unwrap(), SpecId::CANCUN);
+        assert_eq!(spec_for(g, 30_000_000, GNOSIS_CANCUN_TIME).unwrap(), SpecId::CANCUN);
+        assert_eq!(spec_for(g, 30_000_000, GNOSIS_SHANGHAI_TIME).unwrap(), SpecId::SHANGHAI);
+        assert!(matches!(
+            spec_for(g, 30_000_000, GNOSIS_SHANGHAI_TIME - 1),
+            Err(EvmError::ForkTooOld { .. })
+        ));
+    }
+
+    #[test]
     fn unknown_chain_is_unsupported() {
         assert!(matches!(
-            spec_for(100, 20_000_000, SEPOLIA_PRAGUE_TIME),
-            Err(EvmError::UnsupportedChain { chain_id: 100 })
+            spec_for(137, 20_000_000, SEPOLIA_PRAGUE_TIME),
+            Err(EvmError::UnsupportedChain { chain_id: 137 })
         ));
     }
 

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -59,6 +59,9 @@ pub struct ElConfig {
     /// Path to the EL peer cache (`dataDir/peers.cache`) for warm-start; `None`
     /// runs without persistence.
     pub cache_path: Option<std::path::PathBuf>,
+    /// Network floor for the suggested priority fee (wei) — the Java
+    /// `NetworkConfig.minSuggestedTipWei` (mainnet/sepolia 0.1 gwei; gnosis 0.001).
+    pub min_suggested_tip_wei: u128,
 }
 
 impl ElConfig {
@@ -82,6 +85,7 @@ impl ElConfig {
             listen_port: 30303,
             pool_config: PoolConfig::default(),
             cache_path: None,
+            min_suggested_tip_wei: 100_000_000, // 0.1 gwei
         }
     }
 
@@ -108,6 +112,31 @@ impl ElConfig {
             listen_port: 30305,
             pool_config: PoolConfig::default(),
             cache_path: None,
+            min_suggested_tip_wei: 100_000_000, // 0.1 gwei
+        }
+    }
+    /// Gnosis EL parameters — verbatim from the Java `NetworkConfig.GNOSIS`. The
+    /// fork-id is the pinned Fulu/Osaka-head hash from live gnosis peers' eth Status.
+    pub fn gnosis() -> ElConfig {
+        const GNOSIS_BOOTNODES: &[&str] = &[
+            "65.109.103.148:30303",
+            "65.109.103.149:30303",
+            "141.94.97.22:30303",
+            "141.94.97.74:30303",
+            "141.94.97.84:30303",
+            "51.68.39.206:30303",
+        ];
+        ElConfig {
+            network_id: 100,
+            genesis_hash: hex32("4f1dd23188aab3a76b463e4af801b52b1248ef073c648cbdc4c9333d3da79756"),
+            fork_id_hash: [0xcf, 0xca, 0x38, 0x7c],
+            fork_next: 0,
+            bootnodes: GNOSIS_BOOTNODES.iter().filter_map(|s| s.parse().ok()).collect(),
+            discv4_port: 0,
+            listen_port: 30304, // gnosis conventional EL port (Java defaultElPort)
+            pool_config: PoolConfig::default(),
+            cache_path: None,
+            min_suggested_tip_wei: 1_000_000, // 0.001 gwei — cheap-chain floor
         }
     }
 }
@@ -214,11 +243,6 @@ const BLOCK_LOOKBACK_MAX: u64 = 256;
 /// (mirrors the Java `TIP_SUGGEST_BLOCKS`).
 const TIP_SUGGEST_BLOCKS: u64 = 3;
 
-/// Mainnet floor for the suggested tip: 0.1 gwei (mirrors the Java `MIN_SUGGESTED_TIP`).
-/// The Rust engine is mainnet-only, so this is a constant here rather than the
-/// network-aware `minSuggestedTipWei`.
-const MIN_SUGGESTED_TIP_WEI: u128 = 100_000_000;
-
 /// A verified fee suggestion (`eth_gasPrice` + `eth_maxPriorityFeePerGas`), both
 /// in wei. The tip is the median effective priority fee over the last
 /// `TIP_SUGGEST_BLOCKS` verified blocks (floored); the gas price is the next
@@ -234,6 +258,8 @@ pub struct ElReader {
     discovery: Discv4Service,
     pool: PeerPool,
     anchor: Arc<ExecAnchor>,
+    /// Network floor for the suggested tip (from `ElConfig::min_suggested_tip_wei`).
+    min_suggested_tip_wei: u128,
     /// Cross-call EVM caches, shared across every `eth_call` on this reader. Both
     /// hold `stateRoot`-keyed / content-addressed cryptographic facts, so reuse is
     /// sound. Because a call pins to the CURRENT head (whose root advances ~every
@@ -314,6 +340,7 @@ impl ElReader {
             discovery,
             pool,
             anchor,
+            min_suggested_tip_wei: cfg.min_suggested_tip_wei,
             evm_proof_cache: Arc::new(InMemoryStateProofCache::new(EVM_PROOF_CACHE_ENTRIES)),
             evm_bytecode_cache: Arc::new(InMemoryBytecodeCache::new()),
         })
@@ -871,7 +898,7 @@ impl ElReader {
 
     /// Verified fee suggestion (`eth_gasPrice` + `eth_maxPriorityFeePerGas`). Samples
     /// the last `TIP_SUGGEST_BLOCKS` beacon-anchored blocks: median per-tx effective
-    /// tip (floored at `MIN_SUGGESTED_TIP_WEI`) as the priority fee, and next-block
+    /// tip (floored at the network's `min_suggested_tip_wei`) as the priority fee, and next-block
     /// base fee + that tip as the legacy gas price. `Err` when it can't verify.
     pub async fn fee_estimate(&self) -> Result<FeeEstimate, String> {
         let head_num = self.anchor.optimistic_block_number();
@@ -955,10 +982,10 @@ impl ElReader {
             }
         }
         let tip = if tips.is_empty() {
-            MIN_SUGGESTED_TIP_WEI
+            self.min_suggested_tip_wei
         } else {
             tips.sort_unstable();
-            tips[tips.len() / 2].max(MIN_SUGGESTED_TIP_WEI)
+            tips[tips.len() / 2].max(self.min_suggested_tip_wei)
         };
         // Gas price = the NEXT block's base fee (from the head header) + the tip.
         let head_header = &window[window.len() - 1].header;
@@ -1240,5 +1267,21 @@ mod tests {
         assert_eq!(cfg.fork_next, 0);
         assert_eq!(cfg.bootnodes.len(), 5, "all five sepolia bootnodes must parse");
         assert_eq!(cfg.listen_port, 30305);
+        assert_eq!(cfg.min_suggested_tip_wei, 100_000_000);
+    }
+
+    #[test]
+    fn gnosis_config_pins_known_values() {
+        let cfg = ElConfig::gnosis();
+        assert_eq!(cfg.network_id, 100);
+        assert_eq!(
+            cfg.genesis_hash,
+            super::hex32("4f1dd23188aab3a76b463e4af801b52b1248ef073c648cbdc4c9333d3da79756")
+        );
+        assert_eq!(cfg.fork_id_hash, [0xcf, 0xca, 0x38, 0x7c]);
+        assert_eq!(cfg.fork_next, 0);
+        assert_eq!(cfg.bootnodes.len(), 6, "all six gnosis bootnodes must parse");
+        assert_eq!(cfg.listen_port, 30304);
+        assert_eq!(cfg.min_suggested_tip_wei, 1_000_000, "gnosis cheap-chain tip floor");
     }
 }

--- a/rust/myotis-net/src/sync.rs
+++ b/rust/myotis-net/src/sync.rs
@@ -145,6 +145,45 @@ impl ChainConfig {
         }
     }
 
+    /// Gnosis Chain — values duplicated verbatim from the Java
+    /// `NetworkConfig.GNOSIS`. Its own beacon chain: 5 s slots, 16-slot epochs
+    /// (still 8192 slots per sync-committee period: 512 epochs × 16), and a
+    /// prior-fork digest fallback (Electra) accepted alongside the Fulu digest.
+    pub fn gnosis() -> Self {
+        Self {
+            name: "gnosis",
+            chain_id: 100,
+            // Fulu on Gnosis (0x06000064), active since 2026-04-14.
+            fork_version: [0x06, 0x00, 0x00, 0x64],
+            // Electra — accepted as a discv5 fork-digest fallback.
+            prior_fork_version: Some([0x05, 0x00, 0x00, 0x64]),
+            genesis_validators_root: hex32(
+                "f5dcb5564e829aab27264b9becd5dfaa017085611224cb3036f573368dbb9d47",
+            ),
+            genesis_time: 1_638_993_340, // 2021-12-08 19:55:40 UTC
+            seconds_per_slot: 5,
+            slots_per_epoch: 16,
+            // EIP-7892: Gnosis has no explicit BLOB_SCHEDULE — clients fold the
+            // Electra-baseline params (ELECTRA_FORK_EPOCH=1337856, MAX_BLOBS=2)
+            // into the Fulu digest. Yields the live-verified digest 0x3237dab6.
+            blob_params_epoch: 1_337_856,
+            blob_params_max_blobs: 2,
+            // Copied verbatim from the @checkpoint:gnosis:begin/end region of
+            // NetworkConfig.java (slot 28516336, 2026-06-16, period 3480 —
+            // deliberately one period behind head, see refreshGnosisCheckpoint).
+            // A refresh must be mirrored here by hand until plan PR7.
+            checkpoint_root: hex32(
+                "dc1ce049946173d38463595f907f19893e4fd956c740913fb70d94d34e07e789",
+            ),
+            checkpoint_slot: 28_516_336,
+            static_peers: Vec::new(), // none pinned — discv5 bootnodes seed discovery
+            bootstrap_enrs: GNOSIS_BOOTSTRAP_ENRS.iter().map(|s| s.to_string()).collect(),
+            discv5_port: 0,
+            snapshot_path: None,
+            cl_peer_cache_path: None,
+        }
+    }
+
     /// Fork digests accepted when filtering discv5 ENRs — current first, then
     /// the prior fork's when configured (`NetworkConfig.acceptedForkDigests`).
     pub fn accepted_fork_digests(&self) -> Vec<[u8; 4]> {
@@ -212,6 +251,19 @@ const SEPOLIA_BOOTSTRAP_ENRS: &[&str] = &[
     // remaining bootstrap_nodes.yaml entries (unattributed)
     "enr:-Iq4QMCTfIMXnow27baRUb35Q8iiFHSIDBJh6hQM5Axohhf4b6Kr_cOCu0htQ5WvVqKvFgY28893DHAg8gnBAXsAVqmGAX53x8JggmlkgnY0gmlwhLKAlv6Jc2VjcDI1NmsxoQK6S-Cii_KmfFdUJL2TANL3ksaKUnNXvTCv1tLwXs0QgIN1ZHCCIyk",
     "enr:-L64QC9Hhov4DhQ7mRukTOz4_jHm4DHlGL726NWH4ojH1wFgEwSin_6H95Gs6nW2fktTWbPachHJ6rUFu0iJNgA0SB2CARqHYXR0bmV0c4j__________4RldGgykDb6UBOQAABx__________-CaWSCdjSCaXCEA-2vzolzZWNwMjU2azGhA17lsUg60R776rauYMdrAz383UUgESoaHEzMkvm4K6k6iHN5bmNuZXRzD4N0Y3CCIyiDdWRwgiMo",
+];
+
+/// Gnosis CL discv5 bootstrap ENRs (Java `NetworkConfig.GNOSIS.clDiscv5Bootnodes`
+/// — gnosischain/configs bootstrap_nodes.txt).
+const GNOSIS_BOOTSTRAP_ENRS: &[&str] = &[
+    "enr:-Ly4QIAhiTHk6JdVhCdiLwT83wAolUFo5J4nI5HrF7-zJO_QEw3cmEGxC1jvqNNUN64Vu-xxqDKSM528vKRNCehZAfEBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpCCS-QxAgAAZP__________gmlkgnY0gmlwhEFtZ5SJc2VjcDI1NmsxoQJwgL5C-30E8RJmW8gCb7sfwWvvfre7wGcCeV4X1G2wJYhzeW5jbmV0cwCDdGNwgiMog3VkcIIjKA",
+    "enr:-Ly4QDhEjlkf8fwO5uWAadexy88GXZneTuUCIPHhv98v8ZfXMtC0S1S_8soiT0CMEgoeLe9Db01dtkFQUnA9YcnYC_8Bh2F0dG5ldHOIAAAAAAAAAACEZXRoMpCCS-QxAgAAZP__________gmlkgnY0gmlwhEFtZ5WJc2VjcDI1NmsxoQMRSho89q2GKx_l2FZhR1RmnSiQr6o_9hfXfQUuW6bjMohzeW5jbmV0cwCDdGNwgiMog3VkcIIjKA",
+    "enr:-Ly4QLKgv5M2D4DYJgo6s4NG_K4zu4sk5HOLCfGCdtgoezsbfRbfGpQ4iSd31M88ec3DHA5FWVbkgIas9EaJeXia0nwBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpCCS-QxAgAAZP__________gmlkgnY0gmlwhI1eYRaJc2VjcDI1NmsxoQLpK_A47iNBkVjka9Mde1F-Kie-R0sq97MCNKCxt2HwOIhzeW5jbmV0cwCDdGNwgiMog3VkcIIjKA",
+    "enr:-Ly4QF_0qvji6xqXrhQEhwJR1W9h5dXV7ZjVCN_NlosKxcgZW6emAfB_KXxEiPgKr_-CZG8CWvTiojEohG1ewF7P368Bh2F0dG5ldHOIAAAAAAAAAACEZXRoMpCCS-QxAgAAZP__________gmlkgnY0gmlwhI1eYUqJc2VjcDI1NmsxoQIpNRUT6llrXqEbjkAodsZOyWv8fxQkyQtSvH4sg2D7n4hzeW5jbmV0cwCDdGNwgiMog3VkcIIjKA",
+    "enr:-Ly4QCD5D99p36WafgTSxB6kY7D2V1ca71C49J4VWI2c8UZCCPYBvNRWiv0-HxOcbpuUdwPVhyWQCYm1yq2ZH0ukCbQBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpCCS-QxAgAAZP__________gmlkgnY0gmlwhI1eYVSJc2VjcDI1NmsxoQJJMSV8iSZ8zvkgbi8cjIGEUVJeekLqT0LQha_co-siT4hzeW5jbmV0cwCDdGNwgiMog3VkcIIjKA",
+    "enr:-KK4QKXJq1QOVWuJAGige4uaT8LRPQGCVRf3lH3pxjaVScMRUfFW1eiiaz8RwOAYvw33D4EX-uASGJ5QVqVCqwccxa-Bi4RldGgykCGm-DYDAABk__________-CaWSCdjSCaXCEM0QnzolzZWNwMjU2azGhAhNvrRkpuK4MWTf3WqiOXSOePL8Zc-wKVpZ9FQx_BDadg3RjcIIjKIN1ZHCCIyg",
+    "enr:-LO4QO87Rn2ejN3SZdXkx7kv8m11EZ3KWWqoIN5oXwQ7iXR9CVGd1dmSyWxOL1PGsdIqeMf66OZj4QGEJckSi6okCdWBpIdhdHRuZXRziAAAAABgAAAAhGV0aDKQPr_UhAQAAGT__________4JpZIJ2NIJpcIQj0iX1iXNlY3AyNTZrMaEDd-_eqFlWWJrUfEp8RhKT9NxdYaZoLHvsp3bbejPyOoeDdGNwgiMog3VkcIIjKA",
+    "enr:-LK4QIJUAxX9uNgW4ACkq8AixjnSTcs9sClbEtWRq9F8Uy9OEExsr4ecpBTYpxX66cMk6pUHejCSX3wZkK2pOCCHWHEBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpA-v9SEBAAAZP__________gmlkgnY0gmlwhCPSnDuJc2VjcDI1NmsxoQNuaAjFE-ANkH3pbeBdPiEIwjR5kxFuKaBWxHkqFuPz5IN0Y3CCIyiDdWRwgiMo",
 ];
 
 /// Known light-client-serving mainnet peers — the Java `NetworkConfig.MAINNET`
@@ -1897,6 +1949,37 @@ mod tests {
         assert_eq!(c.accepted_fork_digests(), vec![[0x74, 0xD0, 0x14, 0x59]]);
         assert_eq!(c.static_peers.len(), 1);
         assert_eq!(c.bootstrap_enrs.len(), 9);
+    }
+
+    #[test]
+    fn gnosis_config_matches_networkconfig_java() {
+        let c = ChainConfig::gnosis();
+        assert_eq!(c.chain_id, 100);
+        assert_eq!(c.fork_version, [0x06, 0x00, 0x00, 0x64]); // Fulu on Gnosis
+        assert_eq!(c.prior_fork_version, Some([0x05, 0x00, 0x00, 0x64])); // Electra
+        assert_eq!(c.checkpoint_slot, 28_516_336);
+        assert_eq!(
+            hex_str(&c.checkpoint_root),
+            "dc1ce049946173d38463595f907f19893e4fd956c740913fb70d94d34e07e789"
+        );
+        assert_eq!(
+            hex_str(&c.genesis_validators_root),
+            "f5dcb5564e829aab27264b9becd5dfaa017085611224cb3036f573368dbb9d47"
+        );
+        assert_eq!(c.genesis_time, 1_638_993_340);
+        assert_eq!((c.seconds_per_slot, c.slots_per_epoch), (5, 16));
+        assert_eq!((c.blob_params_epoch, c.blob_params_max_blobs), (1_337_856, 2));
+        // 512 epochs x 16 slots = the same 8192-slot period as mainnet-preset.
+        assert_eq!(spec::compute_sync_committee_period(c.checkpoint_slot), 3480);
+        // Live-verified digests the Java computes (NetworkConfig.GNOSIS
+        // currentForkDigest / acceptedForkDigests): Fulu first, Electra fallback.
+        assert_eq!(c.current_fork_digest(), [0x32, 0x37, 0xDA, 0xB6]);
+        assert_eq!(
+            c.accepted_fork_digests(),
+            vec![[0x32, 0x37, 0xDA, 0xB6], [0x7D, 0x5A, 0xAB, 0x40]]
+        );
+        assert!(c.static_peers.is_empty());
+        assert_eq!(c.bootstrap_enrs.len(), 8);
     }
 
     #[test]


### PR DESCRIPTION
Enables **Gnosis Chain** (chainId 100) on the Rust engine, completing the multichain pair started by MC-1 (sepolia, #197). Gnosis has its own beacon chain, so this exercises every generic slot in the CL/EL config that mainnet + sepolia (both mainnet-preset) never did.

## What changed

- **CL config** — `ChainConfig::gnosis()` mirrors `NetworkConfig.GNOSIS` char-for-char: 5s slots / 16-slot epochs, gvr `f5dcb556…`, Fulu fork `0x06000064` / prior Electra `0x05000064`, blob params 1337856/2, checkpoint slot 28516336, all 8 CL ENRs. Parity test pins both fork digests (current Fulu+BPO `0x3237dab6`, prior Electra `0x7d5aab40`).
- **Sync-committee period** — stays 8192 slots: gnosis uses `EPOCHS_PER_SYNC_COMMITTEE_PERIOD=512`, so 512×16 == mainnet's 256×32 (checkpoint 28516336 → period 3480). No code change needed; documented + tested.
- **EL config** — `ElConfig::gnosis()`: network_id 100, genesis `4f1dd231…`, fork-id `0xcfca387c`, 6 bootnodes, listen port 30304. `min_suggested_tip_wei` becomes a per-network field (gnosis 0.001 gwei; mainnet/sepolia keep 0.1 gwei).
- **EVM fork table** — gnosis cascade, timestamp-gated, pinned to nethermind `gnosis.json` hex: Shanghai `0x64c8edbc` (2023-08-01) / Cancun `0x65ef4dbc` (2024-03-11) / Prague `0x68122dbc` (2025-04-30); fails closed below Shanghai. A dedicated test asserts the decimals against the hex.
- **No ENS** — catalog `has_ens=false` threads through `RustMyotisEngine.create` → `RustChainHandle`, so `ens()` returns null on gnosis (`ensIsNullOnNetworksWithoutEns` pins both directions).
- **Host routing** — `config_for` + EL-config match route gnosis; per-network cache/snapshot paths as with sepolia.

## Testing

- Rust suites green: myotis-net (incl. gnosis parity), myotis-evm (incl. corrected fork-time pins), myotis-engine.
- Java `:myotis-engines:test` green.
- **Live**: a gnosis daemon on `-Pengine=rust` discovered a CL peer (fork digest `0x3237dab6` correct) and the checkpoint bootstrap **verified against the genesis validators root** — `period=3480`, `state=CATCHING_UP`, `finalizedSlot=28516336`. Full SYNCED is peer-supply-bound on this host (same as mainnet); every gnosis-specific constant is validated by the successful bootstrap verification.

## Review note

An independent no-context review of the diff caught three wrong gnosis EVM fork timestamps (a decimal-conversion slip — they decoded to non-existent fork dates); corrected to the nethermind hex values before this PR, and a hex-pin test added so it can't recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)