### PR TITLE
EL-C-5-2: every ENS record type + reverse resolution + root modes on the Rust engine

### DIFF
--- a/app/src/main/java/com/jaeckel/ethp2p/app/CommandHandler.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/CommandHandler.java
@@ -67,6 +67,7 @@ public class CommandHandler {
                 case "get-account"             -> handleGetAccount(jsonLine);
                 case "get-storage"             -> handleGetStorage(jsonLine);
                 case "resolve-ens"             -> handleResolveEns(jsonLine);
+                case "reverse-ens"             -> handleReverseEns(jsonLine);
                 case "resolve-ens-text"        -> handleResolveEnsText(jsonLine);
                 case "resolve-ens-contenthash" -> handleResolveEnsContenthash(jsonLine);
                 case "resolve-ens-addr-coin"   -> handleResolveEnsAddrCoin(jsonLine);
@@ -339,6 +340,30 @@ public class CommandHandler {
             if (r.error() == null) {
                 return "{\"ok\":true,\"resolved\":false"
                         + ",\"name\":\"" + escapeJson(name) + "\""
+                        + ",\"beaconVerified\":false"
+                        + ",\"blockNumber\":" + r.blockNumber() + "}";
+            }
+            return jsonError(r.error());
+        } catch (EngineException | IllegalStateException e) {
+            return jsonError(e.getMessage());
+        }
+    }
+
+    private String handleReverseEns(String jsonLine) {
+        String address = extractString(jsonLine, "address");
+        try {
+            EnsResolutionResult r = ens().reverseResolve(address);
+            if (r.name() != null) {
+                return "{\"ok\":true,\"resolved\":true"
+                        + ",\"address\":\"" + escapeJson(address) + "\""
+                        + ",\"name\":\"" + escapeJson(r.name()) + "\""
+                        + ",\"beaconVerified\":" + r.verified()
+                        + ",\"blockNumber\":" + r.blockNumber() + "}";
+            }
+            // name==null && error==null = no (forward-verified) reverse record.
+            if (r.error() == null) {
+                return "{\"ok\":true,\"resolved\":false"
+                        + ",\"address\":\"" + escapeJson(address) + "\""
                         + ",\"beaconVerified\":false"
                         + ",\"blockNumber\":" + r.blockNumber() + "}";
             }

--- a/app/src/main/java/com/jaeckel/ethp2p/app/DaemonClient.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/DaemonClient.java
@@ -117,6 +117,10 @@ public class DaemonClient {
                 if (args.length < 2) throw new IllegalArgumentException("Usage: resolve-ens <name.eth>");
                 yield "{\"cmd\":\"resolve-ens\",\"name\":\"" + esc(args[1]) + "\"}";
             }
+            case "reverse-ens" -> {
+                if (args.length < 2) throw new IllegalArgumentException("Usage: reverse-ens <0xaddress>");
+                yield "{\"cmd\":\"reverse-ens\",\"address\":\"" + esc(args[1]) + "\"}";
+            }
             case "resolve-ens-text" -> {
                 if (args.length < 3) throw new IllegalArgumentException(
                     "Usage: resolve-ens-text <name.eth> <key>");

--- a/docs/reimplementation/07-el-implementation-plan.md
+++ b/docs/reimplementation/07-el-implementation-plan.md
@@ -419,6 +419,30 @@ Spec: doc 03 §§3–7, doc 04 §3. New crate `myotis-evm` (sans-I/O; revm gated
      namehash/DNS vectors. *Deferred:* reverse + forward-verify (C-5-2), CCIP-Read offchain
      (C-5-3, HTTP via an injected `CcipGateway` port — no Rust HTTP dep), and the JNI/Java `EnsApi`
      wiring (C-5-1b, replacing `RustChainHandle.ens() { return null; }`).
+   - **Landed (EL-C-5-2): every ENS record type + reverse + root modes.** The walk generalized
+     into `resolve_record` (shared registry-walk → ENSIP-10-wrap-or-legacy dispatch → raw inner
+     bytes); typed wrappers `resolve_text` / `resolve_contenthash` / `resolve_multicoin` /
+     `resolve_pubkey` (fixed tuple, no offsets) / `resolve_abi` (contentType word NOT checked —
+     Java `decodeAbiResult` parity) / `resolve_dns_record` / `resolve_interface_implementer`, with
+     Java empty-record semantics per type. **dnsRecord ports the JAVA engine's signature
+     `dnsRecord(bytes32,bytes,uint16)` = `0xee8de1f7` (raw DNS wire name), which differs from the
+     mainnet PublicResolver ABI (`bytes32` name-hash, `0xa8fa5682`) — flagged upstream, ported
+     byte-for-byte.** `reverse_resolve`: EXACT `<hex>.addr.reverse` lookup (no walk / no
+     supportsInterface / no wrap — Java `resolveName` parity), `name(bytes32)`, then MANDATORY
+     forward-verify through the full forward path; empty record / no resolver / failed verify are
+     one indistinguishable `None`. Root modes (`EnsRootMode`): `Finalized` anchors the context at
+     `ExecAnchor::finalized_execution()` (header fetched over the verified window, then pinned to
+     the finalized hash + state root; fails closed — peers may prune the ~2-epoch-old root),
+     `Auto` = finalized-first-then-optimistic (Java AUTO-ladder shape; a finalized Value/Offchain
+     is returned, NoRecord/error falls back), `Optimistic` = the Java PEER_HEAD twin
+     (beacon-anchored here, strictly stronger). `verified` in results = "ran against the
+     finalized root". JNI: ONE generic `nativeEnsRecordJson(handle, paramsJson)` dispatch
+     (ABI 11 → 12); `RustEnsApi` implements the full `EnsApi` over it (never throws — documented
+     divergence), `resolveAddress` honors the caller's root, records/reverse hardcode AUTO
+     (JavaEnsApi parity). Cross-language goldens: `eljson::ens_record_json_shapes` ↔
+     `RustEnsRecordJsonTest`. The daemon gained a `reverse-ens` CLI command (both engines).
+     *Still deferred to C-5-3:* CCIP-Read (offchain names error distinguishably meanwhile);
+     resolver-discovery caching (Java's static 5-min cache) is a later optimisation.
 
 Milestone-C gate: on a SYNCED mainnet daemon with `-Pengine=rust`, a real ERC-20
 `balanceOf` `eth_call`, an `estimateGas` for a token transfer, and a `resolve-ens` of a

--- a/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
@@ -557,6 +557,16 @@ final class RustChainHandle implements ChainHandle, NodeStatusReads {
         return ensResolutionFromJson(name, RustEngineNative.nativeResolveEnsJson(handle, name));
     }
 
+    /**
+     * One generic ENS record query (EL-C-5-2): raw params JSON in, raw record
+     * JSON out. Parsing/typing lives in {@link RustEnsApi} (its per-record
+     * fromJson seams are the golden-tested halves); this is only the native
+     * transport hop.
+     */
+    String ensRecordJson(String paramsJson) {
+        return RustEngineNative.nativeEnsRecordJson(handle, paramsJson);
+    }
+
     /** Package-private test seam: ENS JSON → {@link EnsResolutionResult} without JNI. */
     static EnsResolutionResult ensResolutionFromJson(String name, String json) {
         JsonObject o = parseResultOrThrow(json, "resolve-ens");

--- a/myotis-engines/src/main/java/io/myotis/engines/RustEngineNative.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustEngineNative.java
@@ -23,7 +23,7 @@ final class RustEngineNative {
     private static final Logger log = LoggerFactory.getLogger(RustEngineNative.class);
 
     /** Must match {@code ABI_VERSION} in rust/myotis-engine/src/lib.rs. */
-    static final int EXPECTED_ABI_VERSION = 11; // 11: + nativeResolveEnsJson
+    static final int EXPECTED_ABI_VERSION = 12; // 12: + nativeEnsRecordJson (EL-C-5-2)
 
     private static final boolean AVAILABLE = load();
 
@@ -176,6 +176,13 @@ final class RustEngineNative {
      * or {@code {"error":"…"}} on a transport/bad-input failure).
      */
     static native String nativeResolveEnsJson(long handle, String name);
+
+    /**
+     * One generic ENS record dispatch (EL-C-5-2): the method and its args travel
+     * in {@code paramsJson} (see the Rust {@code host::ens_record_json} doc for
+     * the exact shapes); returns the record JSON or {@code {"error": "..."}}.
+     */
+    static native String nativeEnsRecordJson(long handle, String paramsJson);
 
     /**
      * Verified {@code eth_getBlockByNumber} (transactions as hashes) for a running

--- a/myotis-engines/src/main/java/io/myotis/engines/RustEnsApi.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustEnsApi.java
@@ -395,10 +395,15 @@ final class RustEnsApi implements EnsApi {
             }
         }
 
-        /** A mandatory string value field — absence is shape drift, fail closed. */
+        /**
+         * A mandatory string value field — absence is shape drift, fail closed.
+         * Only EMPTINESS is drift (the Rust side never emits an empty value):
+         * a whitespace-only text record is legitimate on-chain data and must
+         * pass through, so no isBlank() here.
+         */
         String requireString(String key) {
             var v = o.get(key);
-            if (v == null || v.isNull() || !v.isString() || v.asString().isBlank()) {
+            if (v == null || v.isNull() || !v.isString() || v.asString().isEmpty()) {
                 throw new EngineException("ens-record JSON: status=ok without " + key);
             }
             return v.asString();

--- a/myotis-engines/src/main/java/io/myotis/engines/RustEnsApi.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustEnsApi.java
@@ -1,5 +1,8 @@
 package io.myotis.engines;
 
+import com.eclipsesource.json.Json;
+import com.eclipsesource.json.JsonObject;
+import io.myotis.api.EngineException;
 import io.myotis.api.EnsAbiResult;
 import io.myotis.api.EnsApi;
 import io.myotis.api.EnsContenthashResult;
@@ -12,32 +15,34 @@ import io.myotis.api.EnsRoot;
 import io.myotis.api.EnsTextResult;
 
 /**
- * The Rust engine's {@link EnsApi}: forward address resolution is served by the
- * native resolver (registry walk + {@code addr}/ENSIP-10 dispatch over verified
- * eth_calls — EL-C-5-1); every other record type returns a graceful
- * "not implemented" error result until its slice lands (reverse+forward-verify
- * EL-C-5-2, CCIP-Read EL-C-5-3, further record types after). Resolution failures
- * are reported in the result record's {@code error}; this impl never throws (see
- * the divergence note below).
+ * The Rust engine's {@link EnsApi}: every record type is served by the native
+ * resolver (registry walk + ENSIP-10 dispatch over verified eth_calls) through
+ * ONE generic dispatch native ({@code nativeEnsRecordJson}) — forward address,
+ * text, contenthash, multi-coin, pubkey, ABI, dnsRecord, interfaceImplementer,
+ * and reverse resolution with mandatory forward-verify (EL-C-5-2). CCIP-Read
+ * (ERC-3668 offchain names) is the remaining slice (EL-C-5-3): an offchain name
+ * reports a descriptive error, distinguishable from "no record".
  *
- * <p>The native resolver always runs against the beacon-anchored optimistic head
- * (AUTO-like freshness), so {@code verified} is reported {@code false} — the
- * resolution IS proof-verified against the anchored head, but not against a
- * beacon-FINALIZED root, which is what {@code verified} means in this API. An
- * explicit {@link EnsRoot#FINALIZED} request is therefore rejected with an error
- * result (never silently downgraded); finalized-root pinning is a later refinement.
+ * <p>Roots: {@code resolveAddress} honors the caller's {@link EnsRoot} —
+ * FINALIZED resolves against the beacon-FINALIZED execution root and fails
+ * closed; AUTO tries finalized first and falls back to the beacon-anchored
+ * optimistic head; PEER_HEAD maps to the optimistic head (this engine has no
+ * peer-claimed-head mode — its fallback is beacon-anchored, strictly stronger).
+ * All other record lookups and reverse hardcode AUTO, mirroring JavaEnsApi.
+ * {@code verified} in results = "resolved against the finalized root".
  *
  * <p>Deliberate divergence from {@code JavaEnsApi}: that impl throws
- * {@link io.myotis.api.EngineException} for the not-running state (per the EnsApi
- * javadoc), while this one folds EVERY failure — including not-running — into the
- * record's {@code error}. The native layer reports not-running as an error JSON,
- * and distinguishing it by message string would be brittle; IPC consumers handle
- * both shapes identically.
+ * {@link EngineException} for not-running / malformed-input states (per the
+ * EnsApi javadoc), while this one folds EVERY failure — including not-running
+ * and bad arguments — into the record's {@code error}. The native layer reports
+ * not-running as an error JSON, and distinguishing it by message string would
+ * be brittle; IPC consumers handle both shapes identically.
  */
 final class RustEnsApi implements EnsApi {
 
-    private static final String NOT_IMPLEMENTED =
-            "not implemented on the rust engine yet (later EL-C-5 slice)";
+    /** The offchain-name error until CCIP-Read lands (EL-C-5-3). */
+    private static final String OFFCHAIN =
+            "name resolves offchain (ERC-3668); CCIP-Read not yet supported on the rust engine";
 
     private final RustChainHandle handle;
 
@@ -45,62 +50,236 @@ final class RustEnsApi implements EnsApi {
         this.handle = handle;
     }
 
+    // ---- forward address (root-aware) ----
+
     @Override
     public EnsResolutionResult resolveAddress(String name, EnsRoot root) {
         if (name == null || name.isBlank()) {
             return new EnsResolutionResult(name, null, -1, false, "empty ENS name");
         }
-        if (root == EnsRoot.FINALIZED) {
-            // Fail closed rather than silently serving a weaker root than demanded:
-            // this engine resolves against the beacon-anchored OPTIMISTIC head only.
-            return new EnsResolutionResult(name, null, -1, false,
-                    "finalized-root resolution not supported on the rust engine yet"
-                    + " (resolves against the beacon-anchored optimistic head; use AUTO)");
-        }
         try {
-            return handle.resolveEnsVerified(name);
+            JsonObject params = params("addr").add("name", name).add("root", rootParam(root));
+            return addressFromJson(name, handle.ensRecordJson(params.toString()));
         } catch (RuntimeException e) {
-            // EngineException (transport / not running) or any unchecked failure:
-            // THIS impl folds every failure into the record's error (a deliberate
-            // divergence from the interface's throw-allowance — class javadoc).
-            String why = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
-            return new EnsResolutionResult(name, null, -1, false, why);
+            return new EnsResolutionResult(name, null, -1, false, why(e));
         }
     }
+
+    /** Package-private JSON seam: record JSON → forward-resolution result. */
+    static EnsResolutionResult addressFromJson(String name, String json) {
+        Parsed p = Parsed.of(json);
+        return switch (p.status) {
+            case "ok" -> new EnsResolutionResult(
+                    name, p.requireString("addressHex"), p.block, p.verified, null);
+            case "noRecord" -> new EnsResolutionResult(name, null, p.block, p.verified, null);
+            case "offchain" -> new EnsResolutionResult(name, null, p.block, p.verified, OFFCHAIN);
+            default -> throw p.unknownStatus();
+        };
+    }
+
+    // ---- reverse (forward-verified by the native side) ----
 
     @Override
     public EnsResolutionResult reverseResolve(String hexAddress) {
-        return new EnsResolutionResult(null, hexAddress, -1, false, NOT_IMPLEMENTED);
+        String bare = normalizeAddress(hexAddress);
+        if (bare == null) {
+            // JavaEnsApi throws this message; this impl folds it (class javadoc).
+            return new EnsResolutionResult(null, hexAddress, -1, false,
+                    "address must be a 20-byte hex string (40 hex chars)");
+        }
+        String canonical = "0x" + bare;
+        try {
+            JsonObject params = params("reverse").add("addressHex", canonical);
+            return reverseFromJson(canonical, handle.ensRecordJson(params.toString()));
+        } catch (RuntimeException e) {
+            return new EnsResolutionResult(null, canonical, -1, false, why(e));
+        }
     }
+
+    /** Package-private JSON seam: record JSON → reverse-resolution result. */
+    static EnsResolutionResult reverseFromJson(String addressHex, String json) {
+        Parsed p = Parsed.of(json);
+        return switch (p.status) {
+            // The name is forward-verified on the native side; an empty record,
+            // no reverse resolver, and a failed verify are all "noRecord"
+            // (Java parity — indistinguishable, no special error token).
+            case "ok" -> new EnsResolutionResult(
+                    p.requireString("name"), addressHex, p.block, p.verified, null);
+            case "noRecord" -> new EnsResolutionResult(null, addressHex, p.block, p.verified, null);
+            case "offchain" -> new EnsResolutionResult(null, addressHex, p.block, p.verified, OFFCHAIN);
+            default -> throw p.unknownStatus();
+        };
+    }
+
+    // ---- record types (AUTO root, JavaEnsApi parity) ----
 
     @Override
     public EnsTextResult resolveText(String name, String key) {
-        return new EnsTextResult(name, key, null, -1, false, NOT_IMPLEMENTED);
+        if (name == null || name.isBlank()) {
+            return new EnsTextResult(name, key, null, -1, false, "empty ENS name");
+        }
+        if (key == null || key.isBlank()) {
+            return new EnsTextResult(name, key, null, -1, false, "empty text key");
+        }
+        try {
+            JsonObject params = params("text").add("name", name).add("key", key);
+            return textFromJson(name, key, handle.ensRecordJson(params.toString()));
+        } catch (RuntimeException e) {
+            return new EnsTextResult(name, key, null, -1, false, why(e));
+        }
+    }
+
+    static EnsTextResult textFromJson(String name, String key, String json) {
+        Parsed p = Parsed.of(json);
+        return switch (p.status) {
+            case "ok" -> new EnsTextResult(
+                    name, key, p.requireString("value"), p.block, p.verified, null);
+            case "noRecord" -> new EnsTextResult(name, key, null, p.block, p.verified, null);
+            case "offchain" -> new EnsTextResult(name, key, null, p.block, p.verified, OFFCHAIN);
+            default -> throw p.unknownStatus();
+        };
     }
 
     @Override
     public EnsContenthashResult resolveContenthash(String name) {
-        return new EnsContenthashResult(name, null, -1, false, NOT_IMPLEMENTED);
+        if (name == null || name.isBlank()) {
+            return new EnsContenthashResult(name, null, -1, false, "empty ENS name");
+        }
+        try {
+            JsonObject params = params("contenthash").add("name", name);
+            return contenthashFromJson(name, handle.ensRecordJson(params.toString()));
+        } catch (RuntimeException e) {
+            return new EnsContenthashResult(name, null, -1, false, why(e));
+        }
+    }
+
+    static EnsContenthashResult contenthashFromJson(String name, String json) {
+        Parsed p = Parsed.of(json);
+        return switch (p.status) {
+            case "ok" -> new EnsContenthashResult(
+                    name, p.requireString("dataHex"), p.block, p.verified, null);
+            case "noRecord" -> new EnsContenthashResult(name, null, p.block, p.verified, null);
+            case "offchain" -> new EnsContenthashResult(name, null, p.block, p.verified, OFFCHAIN);
+            default -> throw p.unknownStatus();
+        };
     }
 
     @Override
     public EnsMultiCoinResult resolveMultiCoinAddr(String name, long coinType) {
-        return new EnsMultiCoinResult(name, coinType, null, -1, false, NOT_IMPLEMENTED);
+        if (name == null || name.isBlank()) {
+            return new EnsMultiCoinResult(name, coinType, null, -1, false, "empty ENS name");
+        }
+        if (coinType < 0) {
+            return new EnsMultiCoinResult(name, coinType, null, -1, false, "negative coinType");
+        }
+        try {
+            JsonObject params = params("multicoin").add("name", name).add("coinType", coinType);
+            return multiCoinFromJson(name, coinType, handle.ensRecordJson(params.toString()));
+        } catch (RuntimeException e) {
+            return new EnsMultiCoinResult(name, coinType, null, -1, false, why(e));
+        }
+    }
+
+    static EnsMultiCoinResult multiCoinFromJson(String name, long coinType, String json) {
+        Parsed p = Parsed.of(json);
+        return switch (p.status) {
+            case "ok" -> new EnsMultiCoinResult(
+                    name, coinType, p.requireString("dataHex"), p.block, p.verified, null);
+            case "noRecord" -> new EnsMultiCoinResult(name, coinType, null, p.block, p.verified, null);
+            case "offchain" -> new EnsMultiCoinResult(
+                    name, coinType, null, p.block, p.verified, OFFCHAIN);
+            default -> throw p.unknownStatus();
+        };
     }
 
     @Override
     public EnsPubkeyResult resolvePubkey(String name) {
-        return new EnsPubkeyResult(name, null, null, -1, false, NOT_IMPLEMENTED);
+        if (name == null || name.isBlank()) {
+            return new EnsPubkeyResult(name, null, null, -1, false, "empty ENS name");
+        }
+        try {
+            JsonObject params = params("pubkey").add("name", name);
+            return pubkeyFromJson(name, handle.ensRecordJson(params.toString()));
+        } catch (RuntimeException e) {
+            return new EnsPubkeyResult(name, null, null, -1, false, why(e));
+        }
+    }
+
+    static EnsPubkeyResult pubkeyFromJson(String name, String json) {
+        Parsed p = Parsed.of(json);
+        return switch (p.status) {
+            case "ok" -> new EnsPubkeyResult(name, p.requireString("pubkeyXHex"),
+                    p.requireString("pubkeyYHex"), p.block, p.verified, null);
+            case "noRecord" -> new EnsPubkeyResult(name, null, null, p.block, p.verified, null);
+            case "offchain" -> new EnsPubkeyResult(name, null, null, p.block, p.verified, OFFCHAIN);
+            default -> throw p.unknownStatus();
+        };
     }
 
     @Override
     public EnsAbiResult resolveAbi(String name, long contentTypes) {
-        return new EnsAbiResult(name, 0, null, -1, false, NOT_IMPLEMENTED);
+        if (name == null || name.isBlank()) {
+            return new EnsAbiResult(name, 0, null, -1, false, "empty ENS name");
+        }
+        if (contentTypes < 0) {
+            return new EnsAbiResult(name, 0, null, -1, false, "negative contentTypes mask");
+        }
+        try {
+            JsonObject params = params("abi").add("name", name).add("contentTypes", contentTypes);
+            return abiFromJson(name, handle.ensRecordJson(params.toString()));
+        } catch (RuntimeException e) {
+            return new EnsAbiResult(name, 0, null, -1, false, why(e));
+        }
+    }
+
+    static EnsAbiResult abiFromJson(String name, String json) {
+        Parsed p = Parsed.of(json);
+        return switch (p.status) {
+            // contentType=0 when absent — JavaEnsApi parity.
+            case "ok" -> new EnsAbiResult(name, p.requireLong("contentType"),
+                    p.requireString("dataHex"), p.block, p.verified, null);
+            case "noRecord" -> new EnsAbiResult(name, 0, null, p.block, p.verified, null);
+            case "offchain" -> new EnsAbiResult(name, 0, null, p.block, p.verified, OFFCHAIN);
+            default -> throw p.unknownStatus();
+        };
     }
 
     @Override
     public EnsDnsRecordResult resolveDnsRecord(String name, String dnsName, int recordType) {
-        return new EnsDnsRecordResult(name, dnsName, recordType, null, -1, false, NOT_IMPLEMENTED);
+        if (name == null || name.isBlank()) {
+            return new EnsDnsRecordResult(
+                    name, dnsName, recordType, null, -1, false, "empty ENS name");
+        }
+        if (dnsName == null || dnsName.isBlank()) {
+            return new EnsDnsRecordResult(
+                    name, dnsName, recordType, null, -1, false, "empty DNS name");
+        }
+        if (recordType < 0 || recordType > 0xFFFF) {
+            return new EnsDnsRecordResult(name, dnsName, recordType, null, -1, false,
+                    "recordType out of range (uint16)");
+        }
+        try {
+            JsonObject params = params("dnsRecord")
+                    .add("name", name).add("dnsName", dnsName).add("resource", recordType);
+            return dnsRecordFromJson(
+                    name, dnsName, recordType, handle.ensRecordJson(params.toString()));
+        } catch (RuntimeException e) {
+            return new EnsDnsRecordResult(name, dnsName, recordType, null, -1, false, why(e));
+        }
+    }
+
+    static EnsDnsRecordResult dnsRecordFromJson(
+            String name, String dnsName, int recordType, String json) {
+        Parsed p = Parsed.of(json);
+        return switch (p.status) {
+            case "ok" -> new EnsDnsRecordResult(
+                    name, dnsName, recordType, p.requireString("dataHex"), p.block, p.verified, null);
+            case "noRecord" -> new EnsDnsRecordResult(
+                    name, dnsName, recordType, null, p.block, p.verified, null);
+            case "offchain" -> new EnsDnsRecordResult(
+                    name, dnsName, recordType, null, p.block, p.verified, OFFCHAIN);
+            default -> throw p.unknownStatus();
+        };
     }
 
     @Override
@@ -115,6 +294,131 @@ final class RustEnsApi implements EnsApi {
         for (byte b : interfaceId4) {
             hex.append(String.format("%02x", b));
         }
-        return new EnsInterfaceResult(name, hex.toString(), null, -1, false, NOT_IMPLEMENTED);
+        String idHex = hex.toString();
+        if (name == null || name.isBlank()) {
+            return new EnsInterfaceResult(name, idHex, null, -1, false, "empty ENS name");
+        }
+        try {
+            JsonObject params = params("interfaceImplementer")
+                    .add("name", name).add("interfaceIdHex", idHex);
+            return interfaceFromJson(name, idHex, handle.ensRecordJson(params.toString()));
+        } catch (RuntimeException e) {
+            return new EnsInterfaceResult(name, idHex, null, -1, false, why(e));
+        }
+    }
+
+    static EnsInterfaceResult interfaceFromJson(String name, String idHex, String json) {
+        Parsed p = Parsed.of(json);
+        return switch (p.status) {
+            case "ok" -> new EnsInterfaceResult(
+                    name, idHex, p.requireString("addressHex"), p.block, p.verified, null);
+            case "noRecord" -> new EnsInterfaceResult(name, idHex, null, p.block, p.verified, null);
+            case "offchain" -> new EnsInterfaceResult(name, idHex, null, p.block, p.verified, OFFCHAIN);
+            default -> throw p.unknownStatus();
+        };
+    }
+
+    // ---- plumbing ----
+
+    private static JsonObject params(String method) {
+        return Json.object().add("method", method);
+    }
+
+    private static String rootParam(EnsRoot root) {
+        if (root == null) {
+            return "auto";
+        }
+        return switch (root) {
+            case AUTO -> "auto";
+            case FINALIZED -> "finalized";
+            // This engine has no peer-claimed-head mode; PEER_HEAD maps to the
+            // beacon-anchored optimistic head (strictly stronger, same "don't
+            // wait for finality" intent).
+            case PEER_HEAD -> "optimistic";
+        };
+    }
+
+    /** Lowercase bare 40-hex form of an address input, or null when malformed. */
+    private static String normalizeAddress(String hexAddress) {
+        if (hexAddress == null) {
+            return null;
+        }
+        String bare = hexAddress.startsWith("0x") || hexAddress.startsWith("0X")
+                ? hexAddress.substring(2) : hexAddress;
+        if (bare.length() != 40 || !bare.chars().allMatch(c -> Character.digit(c, 16) >= 0)) {
+            return null;
+        }
+        return bare.toLowerCase(java.util.Locale.ROOT);
+    }
+
+    private static String why(RuntimeException e) {
+        return e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
+    }
+
+    /**
+     * The pinned envelope of every record JSON: status + blockNumber + verified
+     * (all mandatory — a missing one is native shape drift and fails closed as
+     * an {@link EngineException}, which the public methods fold into the
+     * result's error).
+     */
+    private record Parsed(JsonObject o, String status, long block, boolean verified) {
+        static Parsed of(String json) {
+            if (json == null || json.isBlank()) {
+                throw new EngineException((json == null ? "null" : "blank")
+                        + " ens-record JSON from the Rust engine (native failure?)");
+            }
+            JsonObject o;
+            try {
+                o = Json.parse(json).asObject();
+            } catch (RuntimeException e) {
+                throw new EngineException(
+                        "malformed ens-record JSON from the Rust engine: " + e.getMessage(), e);
+            }
+            var error = o.get("error");
+            if (error != null && !error.isNull()) {
+                throw new EngineException(error.isString() ? error.asString() : error.toString());
+            }
+            try {
+                var status = o.get("status");
+                var bn = o.get("blockNumber");
+                var verified = o.get("verified");
+                if (status == null || bn == null || bn.isNull() || verified == null) {
+                    throw new EngineException(
+                            "ens-record JSON: missing status/blockNumber/verified");
+                }
+                return new Parsed(o, status.asString(), bn.asLong(), verified.asBoolean());
+            } catch (EngineException e) {
+                throw e;
+            } catch (RuntimeException e) {
+                throw new EngineException(
+                        "malformed ens-record JSON from the Rust engine: " + e.getMessage(), e);
+            }
+        }
+
+        /** A mandatory string value field — absence is shape drift, fail closed. */
+        String requireString(String key) {
+            var v = o.get(key);
+            if (v == null || v.isNull() || !v.isString() || v.asString().isBlank()) {
+                throw new EngineException("ens-record JSON: status=ok without " + key);
+            }
+            return v.asString();
+        }
+
+        /** A mandatory numeric value field — absence is shape drift, fail closed. */
+        long requireLong(String key) {
+            var v = o.get(key);
+            if (v == null || v.isNull()) {
+                throw new EngineException("ens-record JSON: status=ok without " + key);
+            }
+            try {
+                return v.asLong();
+            } catch (RuntimeException e) {
+                throw new EngineException("ens-record JSON: non-numeric " + key, e);
+            }
+        }
+
+        EngineException unknownStatus() {
+            return new EngineException("ens-record JSON: unknown status '" + status + "'");
+        }
     }
 }

--- a/myotis-engines/src/test/java/io/myotis/engines/RustEnsApiTest.java
+++ b/myotis-engines/src/test/java/io/myotis/engines/RustEnsApiTest.java
@@ -9,7 +9,11 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/** The RustEnsApi paths that need no native library (guards + graceful stubs). */
+/**
+ * The RustEnsApi paths that need no native library — the pre-native input
+ * guards, which must fold into error results (this impl never throws). The
+ * JSON→record mapping is covered by {@link RustEnsRecordJsonTest}.
+ */
 class RustEnsApiTest {
 
     private static RustEnsApi api() {
@@ -18,40 +22,54 @@ class RustEnsApiTest {
     }
 
     @Test
-    void finalizedRootIsRejectedNotDowngraded() {
-        EnsResolutionResult r = api().resolveAddress("vitalik.eth", EnsRoot.FINALIZED);
-        assertNull(r.addressHex());
-        assertNotNull(r.error());
-        assertTrue(r.error().contains("finalized"), r.error());
-    }
-
-    @Test
     void blankNameIsAnErrorResult() {
         EnsResolutionResult r = api().resolveAddress("  ", EnsRoot.AUTO);
         assertNull(r.addressHex());
         assertNotNull(r.error());
+        // FINALIZED is a supported root now (EL-C-5-2) — the blank-name guard is
+        // root-independent and must not mention finalized.
+        EnsResolutionResult fin = api().resolveAddress("  ", EnsRoot.FINALIZED);
+        assertNotNull(fin.error());
     }
 
     @Test
-    void unimplementedRecordTypesReturnGracefulErrors() {
-        // Never throws; error set, no value fields populated as answers.
+    void blankInputsFoldToErrorResultsForEveryRecordType() {
+        // Never throws; error set, no value fields populated as answers. These
+        // all stop at the input guard — no native call on a never-started handle.
         var api = api();
-        assertNotNull(api.resolveText("a.eth", "url").error());
-        assertNotNull(api.resolveContenthash("a.eth").error());
-        assertNotNull(api.resolveMultiCoinAddr("a.eth", 60).error());
-        assertNotNull(api.resolvePubkey("a.eth").error());
-        assertNotNull(api.resolveAbi("a.eth", 1).error());
-        assertNotNull(api.resolveDnsRecord("a.eth", "a.eth.", 1).error());
-        assertNotNull(api.resolveInterfaceImplementer("a.eth", new byte[] {1, 2, 3, 4}).error());
-        assertNotNull(api.reverseResolve("0x" + "11".repeat(20)).error());
+        assertNotNull(api.resolveText(" ", "url").error());
+        assertNotNull(api.resolveText("a.eth", " ").error());
+        assertNotNull(api.resolveContenthash(" ").error());
+        assertNotNull(api.resolveMultiCoinAddr(" ", 60).error());
+        assertNotNull(api.resolveMultiCoinAddr("a.eth", -1).error());
+        assertNotNull(api.resolvePubkey(" ").error());
+        assertNotNull(api.resolveAbi(" ", 1).error());
+        assertNotNull(api.resolveAbi("a.eth", -1).error());
+        assertNotNull(api.resolveDnsRecord(" ", "a.eth.", 1).error());
+        assertNotNull(api.resolveDnsRecord("a.eth", " ", 1).error());
+        assertNotNull(api.resolveDnsRecord("a.eth", "a.eth.", -1).error());
+        assertNotNull(api.resolveDnsRecord("a.eth", "a.eth.", 0x10000).error());
+    }
+
+    @Test
+    void malformedReverseAddressIsAnErrorResult() {
+        // JavaEnsApi THROWS for this; this impl folds it (documented divergence).
+        var api = api();
+        var bad = api.reverseResolve("0x1234");
+        assertNull(bad.name());
+        assertTrue(bad.error().contains("40 hex chars"), bad.error());
+        assertNotNull(api.reverseResolve(null).error());
+        assertNotNull(api.reverseResolve("zz".repeat(20)).error());
     }
 
     @Test
     void interfaceImplementerEchoesQueriedIdAndValidatesLength() {
         var api = api();
-        // The queried id is echoed (JavaEnsApi parity) even on the stub error result.
-        var ok = api.resolveInterfaceImplementer("a.eth", new byte[] {(byte) 0x90, 0x61, (byte) 0xb9, 0x23});
+        // The queried id is echoed (JavaEnsApi parity) even on a guard error
+        // result (blank name keeps this on the no-native path).
+        var ok = api.resolveInterfaceImplementer(" ", new byte[] {(byte) 0x90, 0x61, (byte) 0xb9, 0x23});
         assertEquals("0x9061b923", ok.interfaceIdHex());
+        assertNotNull(ok.error());
         // A malformed id is its own error result, never an echo or a throw.
         var bad = api.resolveInterfaceImplementer("a.eth", new byte[] {1, 2, 3});
         assertNull(bad.interfaceIdHex());

--- a/myotis-engines/src/test/java/io/myotis/engines/RustEnsRecordJsonTest.java
+++ b/myotis-engines/src/test/java/io/myotis/engines/RustEnsRecordJsonTest.java
@@ -1,0 +1,130 @@
+package io.myotis.engines;
+
+import io.myotis.api.EngineException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Golden JSON→record vectors for the RustEnsApi parsers (the Java half of the
+ * cross-language pin — the Rust half is {@code eljson::ens_record_json_shapes},
+ * which emits these exact literals). No JNI.
+ */
+class RustEnsRecordJsonTest {
+
+    private static final String ADDR40 = "0x" + "d8".repeat(20);
+
+    private static String ok(String valueFields) {
+        return "{\"status\":\"ok\",\"blockNumber\":21000010,\"verified\":true," + valueFields + "}";
+    }
+
+    private static final String NO_RECORD =
+            "{\"status\":\"noRecord\",\"blockNumber\":21000010,\"verified\":false}";
+    private static final String OFFCHAIN =
+            "{\"status\":\"offchain\",\"blockNumber\":21000010,\"verified\":false}";
+
+    @Test
+    void addressOkNoRecordAndOffchain() {
+        var okR = RustEnsApi.addressFromJson("vitalik.eth", ok("\"addressHex\":\"" + ADDR40 + "\""));
+        assertEquals(ADDR40, okR.addressHex());
+        assertEquals(21000010, okR.blockNumber());
+        assertTrue(okR.verified());
+        assertNull(okR.error());
+
+        var none = RustEnsApi.addressFromJson("gone.eth", NO_RECORD);
+        assertNull(none.addressHex());
+        assertNull(none.error()); // successful "no record"
+        assertFalse(none.verified());
+
+        var off = RustEnsApi.addressFromJson("cb.id", OFFCHAIN);
+        assertNull(off.addressHex());
+        assertTrue(off.error().contains("offchain"));
+    }
+
+    @Test
+    void reverseCarriesForwardVerifiedName() {
+        var r = RustEnsApi.reverseFromJson(ADDR40, ok("\"name\":\"vitalik.eth\""));
+        assertEquals("vitalik.eth", r.name());
+        assertEquals(ADDR40, r.addressHex());
+        assertTrue(r.verified());
+        // Empty record / failed forward-verify / no reverse resolver are ONE
+        // shape: noRecord with a null name and NO error (Java parity).
+        var none = RustEnsApi.reverseFromJson(ADDR40, NO_RECORD);
+        assertNull(none.name());
+        assertEquals(ADDR40, none.addressHex());
+        assertNull(none.error());
+    }
+
+    @Test
+    void textValueAndNoRecord() {
+        var r = RustEnsApi.textFromJson("vitalik.eth", "url", ok("\"value\":\"https://vitalik.ca\""));
+        assertEquals("https://vitalik.ca", r.value());
+        assertEquals("url", r.key());
+        var none = RustEnsApi.textFromJson("vitalik.eth", "url", NO_RECORD);
+        assertNull(none.value());
+        assertNull(none.error());
+    }
+
+    @Test
+    void bytesShapedRecords() {
+        var ch = RustEnsApi.contenthashFromJson("a.eth", ok("\"dataHex\":\"0xc0ffee\""));
+        assertEquals("0xc0ffee", ch.contenthashHex());
+        var mc = RustEnsApi.multiCoinFromJson("a.eth", 0, ok("\"dataHex\":\"0xc0ffee\""));
+        assertEquals("0xc0ffee", mc.addressHex());
+        assertEquals(0, mc.coinType());
+        var dns = RustEnsApi.dnsRecordFromJson("a.eth", "a.eth.", 1, ok("\"dataHex\":\"0xc0ffee\""));
+        assertEquals("0xc0ffee", dns.dataHex());
+        assertEquals(1, dns.recordType());
+    }
+
+    @Test
+    void pubkeyAndAbi() {
+        String x = "0x" + "0a".repeat(32);
+        String y = "0x" + "0b".repeat(32);
+        var pk = RustEnsApi.pubkeyFromJson(
+                "a.eth", ok("\"pubkeyXHex\":\"" + x + "\",\"pubkeyYHex\":\"" + y + "\""));
+        assertEquals(x, pk.pubkeyXHex());
+        assertEquals(y, pk.pubkeyYHex());
+
+        var abi = RustEnsApi.abiFromJson("a.eth", ok("\"contentType\":1,\"dataHex\":\"0x7b7d\""));
+        assertEquals(1, abi.contentType());
+        assertEquals("0x7b7d", abi.dataHex());
+        // contentType folds to 0 on noRecord (JavaEnsApi parity).
+        assertEquals(0, RustEnsApi.abiFromJson("a.eth", NO_RECORD).contentType());
+    }
+
+    @Test
+    void interfaceImplementerAddressShape() {
+        var r = RustEnsApi.interfaceFromJson(
+                "a.eth", "0x9061b923", ok("\"addressHex\":\"" + ADDR40 + "\""));
+        assertEquals(ADDR40, r.implementerHex());
+        assertEquals("0x9061b923", r.interfaceIdHex());
+    }
+
+    @Test
+    void shapeDriftFailsClosed() {
+        // status=ok without its value field must throw (→ folded into an error
+        // result by the API layer), never read as a successful no-record.
+        assertThrows(EngineException.class,
+                () -> RustEnsApi.addressFromJson("a.eth", ok("\"unrelated\":1")));
+        assertThrows(EngineException.class,
+                () -> RustEnsApi.textFromJson("a.eth", "url", ok("\"dataHex\":\"0x00\"")));
+        assertThrows(EngineException.class,
+                () -> RustEnsApi.pubkeyFromJson("a.eth", ok("\"pubkeyXHex\":\"0x0a\"")));
+        assertThrows(EngineException.class, () -> RustEnsApi.abiFromJson(
+                "a.eth", ok("\"contentType\":\"NaN\",\"dataHex\":\"0x7b7d\"")));
+        // Missing envelope fields are drift too.
+        assertThrows(EngineException.class, () -> RustEnsApi.addressFromJson(
+                "a.eth", "{\"status\":\"ok\",\"addressHex\":\"" + ADDR40 + "\"}"));
+        assertThrows(EngineException.class, () -> RustEnsApi.addressFromJson(
+                "a.eth", "{\"status\":\"weird\",\"blockNumber\":1,\"verified\":false}"));
+        // An error object throws with the native's message.
+        EngineException e = assertThrows(EngineException.class,
+                () -> RustEnsApi.addressFromJson("a.eth", "{\"error\":\"no snap peer\"}"));
+        assertTrue(e.getMessage().contains("no snap peer"));
+    }
+}

--- a/rust/myotis-engine/src/eljson.rs
+++ b/rust/myotis-engine/src/eljson.rs
@@ -8,7 +8,7 @@
 //! serializes `{"error": "..."}`, which the Java side raises as an
 //! `EngineException`.
 
-use myotis_net::el::evm::{CallOutcome, EnsOutcome, GasOutcome};
+use myotis_net::el::evm::{CallOutcome, EnsOutcome, EnsQueryOutcome, EnsRecordValue, GasOutcome};
 use myotis_net::el::reader::{
     FeeEstimate, VerifiedAccount, VerifiedBlock, VerifiedCode, VerifiedStorage,
 };
@@ -277,6 +277,60 @@ pub fn ens_json(outcome: &EnsOutcome) -> String {
         EnsOutcome::Offchain { block_number } => {
             obj.insert("status".into(), "offchain".into());
             obj.insert("blockNumber".into(), json_u64(*block_number));
+        }
+    }
+    serde_json::Value::Object(obj).to_string()
+}
+
+/// ENS record-query result (EL-C-5-2, all record types + reverse). Shapes:
+/// - `{"status":"ok","blockNumber":N,"verified":b, <value keys>}` where the
+///   value keys are per record type: `addressHex` (addr / interfaceImplementer),
+///   `value` (text), `dataHex` (contenthash / multicoin / dnsRecord),
+///   `pubkeyXHex`+`pubkeyYHex` (pubkey), `contentType`+`dataHex` (ABI), or
+///   `name` (reverse).
+/// - `{"status":"noRecord","blockNumber":N,"verified":b}`
+/// - `{"status":"offchain","blockNumber":N,"verified":b}`
+///
+/// `verified` = the resolution ran against the beacon-FINALIZED root.
+pub fn ens_record_json(outcome: &EnsQueryOutcome) -> String {
+    let mut obj = serde_json::Map::new();
+    match outcome {
+        EnsQueryOutcome::Value { value, block_number, verified } => {
+            obj.insert("status".into(), "ok".into());
+            obj.insert("blockNumber".into(), json_u64(*block_number));
+            obj.insert("verified".into(), (*verified).into());
+            match value {
+                EnsRecordValue::Address(a) => {
+                    obj.insert("addressHex".into(), hex0x_var(a).into());
+                }
+                EnsRecordValue::Text(s) => {
+                    obj.insert("value".into(), s.as_str().into());
+                }
+                EnsRecordValue::Bytes(b) => {
+                    obj.insert("dataHex".into(), hex0x_var(b).into());
+                }
+                EnsRecordValue::Pubkey { x, y } => {
+                    obj.insert("pubkeyXHex".into(), hex0x_var(x).into());
+                    obj.insert("pubkeyYHex".into(), hex0x_var(y).into());
+                }
+                EnsRecordValue::Abi { content_type, data } => {
+                    obj.insert("contentType".into(), json_u64(*content_type));
+                    obj.insert("dataHex".into(), hex0x_var(data).into());
+                }
+                EnsRecordValue::Name(n) => {
+                    obj.insert("name".into(), n.as_str().into());
+                }
+            }
+        }
+        EnsQueryOutcome::NoRecord { block_number, verified } => {
+            obj.insert("status".into(), "noRecord".into());
+            obj.insert("blockNumber".into(), json_u64(*block_number));
+            obj.insert("verified".into(), (*verified).into());
+        }
+        EnsQueryOutcome::Offchain { block_number, verified } => {
+            obj.insert("status".into(), "offchain".into());
+            obj.insert("blockNumber".into(), json_u64(*block_number));
+            obj.insert("verified".into(), (*verified).into());
         }
     }
     serde_json::Value::Object(obj).to_string()
@@ -582,6 +636,57 @@ mod tests {
         let off: serde_json::Value =
             serde_json::from_str(&ens_json(&EnsOutcome::Offchain { block_number: 21_000_010 }))
                 .unwrap();
+        assert_eq!(off["status"], "offchain");
+    }
+
+    #[test]
+    fn ens_record_json_shapes() {
+        // One pin per value shape (the Java RustEnsApi parsers replay the same
+        // literals — the two halves of the cross-language golden).
+        let v = |value: EnsRecordValue| {
+            serde_json::from_str::<serde_json::Value>(&ens_record_json(&EnsQueryOutcome::Value {
+                value,
+                block_number: 21_000_010,
+                verified: true,
+            }))
+            .unwrap()
+        };
+
+        let addr = v(EnsRecordValue::Address([0xd8; 20]));
+        assert_eq!(addr["status"], "ok");
+        assert_eq!(addr["addressHex"], "0xd8d8d8d8d8d8d8d8d8d8d8d8d8d8d8d8d8d8d8d8");
+        assert_eq!(addr["blockNumber"], 21_000_010);
+        assert_eq!(addr["verified"], true);
+
+        let text = v(EnsRecordValue::Text("https://vitalik.ca".into()));
+        assert_eq!(text["value"], "https://vitalik.ca");
+
+        let bytes = v(EnsRecordValue::Bytes(vec![0xC0, 0xFF, 0xEE]));
+        assert_eq!(bytes["dataHex"], "0xc0ffee");
+
+        let pk = v(EnsRecordValue::Pubkey { x: [0x0A; 32], y: [0x0B; 32] });
+        assert_eq!(pk["pubkeyXHex"], format!("0x{}", "0a".repeat(32)));
+        assert_eq!(pk["pubkeyYHex"], format!("0x{}", "0b".repeat(32)));
+
+        let abi = v(EnsRecordValue::Abi { content_type: 1, data: b"{}".to_vec() });
+        assert_eq!(abi["contentType"], 1);
+        assert_eq!(abi["dataHex"], "0x7b7d");
+
+        let name = v(EnsRecordValue::Name("vitalik.eth".into()));
+        assert_eq!(name["name"], "vitalik.eth");
+
+        let none: serde_json::Value = serde_json::from_str(&ens_record_json(
+            &EnsQueryOutcome::NoRecord { block_number: 21_000_010, verified: false },
+        ))
+        .unwrap();
+        assert_eq!(none["status"], "noRecord");
+        assert_eq!(none["verified"], false);
+        assert!(none.get("dataHex").is_none());
+
+        let off: serde_json::Value = serde_json::from_str(&ens_record_json(
+            &EnsQueryOutcome::Offchain { block_number: 21_000_010, verified: false },
+        ))
+        .unwrap();
         assert_eq!(off["status"], "offchain");
     }
 

--- a/rust/myotis-engine/src/host.rs
+++ b/rust/myotis-engine/src/host.rs
@@ -589,13 +589,18 @@ pub fn ens_record_json(handle: i64, params_json: &str) -> String {
     let Some(method) = str_field("method") else {
         return eljson::error_json("missing method");
     };
-    let root = match str_field("root").as_deref() {
-        None | Some("auto") => EnsRootMode::Auto,
-        Some("finalized") => EnsRootMode::Finalized,
-        // The Java EnsRoot.PEER_HEAD twin: don't wait for finality (here still
-        // beacon-anchored — this engine has no peer-claimed-head mode).
-        Some("optimistic") => EnsRootMode::Optimistic,
-        Some(other) => return eljson::error_json(&format!("unknown root mode: {other}")),
+    // Strict: a PRESENT root that isn't one of the known strings is an error
+    // (a non-string value must not silently read as the default).
+    let root = match params.get("root") {
+        None => EnsRootMode::Auto,
+        Some(v) => match v.as_str() {
+            Some("auto") => EnsRootMode::Auto,
+            Some("finalized") => EnsRootMode::Finalized,
+            // The Java EnsRoot.PEER_HEAD twin: don't wait for finality (here
+            // still beacon-anchored — no peer-claimed-head mode).
+            Some("optimistic") => EnsRootMode::Optimistic,
+            _ => return eljson::error_json(&format!("unknown root mode: {v}")),
+        },
     };
 
     let query = match method.as_str() {
@@ -618,6 +623,9 @@ pub fn ens_record_json(handle: i64, params_json: &str) -> String {
             let Some(key) = str_field("key").filter(|k| !k.is_empty()) else {
                 return eljson::error_json("missing key");
             };
+            if key.len() > 512 {
+                return eljson::error_json("key too long");
+            }
             EnsQuery::Text { name, key }
         }
         "multicoin" => {

--- a/rust/myotis-engine/src/host.rs
+++ b/rust/myotis-engine/src/host.rs
@@ -24,6 +24,7 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 
+use myotis_net::el::evm::{EnsQuery, EnsRootMode};
 use myotis_net::el::reader::ElReader;
 use myotis_net::{ChainConfig, SyncHandle, SyncState, SyncStatus};
 use myotis_evm::U256;
@@ -540,6 +541,163 @@ pub fn resolve_ens_json(handle: i64, name: &str) -> String {
     }
 }
 
+/// `nativeEnsRecordJson`: one generic dispatch for every ENS record query
+/// (EL-C-5-2) — the "one RPC dispatch layer" shape, so record types don't
+/// multiply natives. `params_json` carries the method and its args:
+///
+/// ```json
+/// {"method":"text","name":"a.eth","key":"url","root":"auto"}
+/// {"method":"addr"|"contenthash"|"pubkey","name":"a.eth","root":"finalized"}
+/// {"method":"multicoin","name":"a.eth","coinType":0}
+/// {"method":"abi","name":"a.eth","contentTypes":15}
+/// {"method":"dnsRecord","name":"a.eth","dnsName":"a.eth","resource":1}
+/// {"method":"interfaceImplementer","name":"a.eth","interfaceIdHex":"0x5b5e139f"}
+/// {"method":"reverse","addressHex":"0x…40-hex"}
+/// ```
+///
+/// `root` is optional: `"auto"` (default — finalized first, optimistic
+/// fallback), `"finalized"` (fails closed), or `"optimistic"` (the Java
+/// PEER_HEAD twin). Returns [`eljson::ens_record_json`] shapes or
+/// `{"error":"…"}`.
+pub fn ens_record_json(handle: i64, params_json: &str) -> String {
+    // Bound the native input like the other JSON natives.
+    if params_json.len() > 4096 {
+        return eljson::error_json("ens params too long");
+    }
+    let params: serde_json::Value = match serde_json::from_str(params_json) {
+        Ok(v) => v,
+        Err(e) => return eljson::error_json(&format!("bad ens params JSON: {e}")),
+    };
+    let str_field = |key: &str| -> Option<String> {
+        params.get(key).and_then(|v| v.as_str()).map(str::to_string)
+    };
+    let u64_field = |key: &str| -> Option<u64> { params.get(key).and_then(|v| v.as_u64()) };
+    let name_field = |key: &str| -> Result<String, String> {
+        let Some(name) = str_field(key) else {
+            return Err(format!("missing {key}"));
+        };
+        let name = name.trim().to_string();
+        if name.is_empty() {
+            return Err(format!("empty {key}"));
+        }
+        if name.len() > 512 {
+            return Err(format!("{key} too long"));
+        }
+        Ok(name)
+    };
+
+    let Some(method) = str_field("method") else {
+        return eljson::error_json("missing method");
+    };
+    let root = match str_field("root").as_deref() {
+        None | Some("auto") => EnsRootMode::Auto,
+        Some("finalized") => EnsRootMode::Finalized,
+        // The Java EnsRoot.PEER_HEAD twin: don't wait for finality (here still
+        // beacon-anchored — this engine has no peer-claimed-head mode).
+        Some("optimistic") => EnsRootMode::Optimistic,
+        Some(other) => return eljson::error_json(&format!("unknown root mode: {other}")),
+    };
+
+    let query = match method.as_str() {
+        "addr" | "contenthash" | "pubkey" => {
+            let name = match name_field("name") {
+                Ok(n) => n,
+                Err(e) => return eljson::error_json(&e),
+            };
+            match method.as_str() {
+                "addr" => EnsQuery::Addr { name },
+                "contenthash" => EnsQuery::Contenthash { name },
+                _ => EnsQuery::Pubkey { name },
+            }
+        }
+        "text" => {
+            let name = match name_field("name") {
+                Ok(n) => n,
+                Err(e) => return eljson::error_json(&e),
+            };
+            let Some(key) = str_field("key").filter(|k| !k.is_empty()) else {
+                return eljson::error_json("missing key");
+            };
+            EnsQuery::Text { name, key }
+        }
+        "multicoin" => {
+            let name = match name_field("name") {
+                Ok(n) => n,
+                Err(e) => return eljson::error_json(&e),
+            };
+            let Some(coin_type) = u64_field("coinType") else {
+                return eljson::error_json("missing coinType");
+            };
+            EnsQuery::Multicoin { name, coin_type }
+        }
+        "abi" => {
+            let name = match name_field("name") {
+                Ok(n) => n,
+                Err(e) => return eljson::error_json(&e),
+            };
+            let Some(content_types) = u64_field("contentTypes") else {
+                return eljson::error_json("missing contentTypes");
+            };
+            EnsQuery::Abi { name, content_types }
+        }
+        "dnsRecord" => {
+            let name = match name_field("name") {
+                Ok(n) => n,
+                Err(e) => return eljson::error_json(&e),
+            };
+            let dns_name = match name_field("dnsName") {
+                Ok(n) => n,
+                Err(e) => return eljson::error_json(&e),
+            };
+            let resource = match u64_field("resource") {
+                Some(r) if r <= u64::from(u16::MAX) => r as u16,
+                Some(_) => return eljson::error_json("resource out of range (uint16)"),
+                None => return eljson::error_json("missing resource"),
+            };
+            EnsQuery::DnsRecord { name, dns_name, resource }
+        }
+        "interfaceImplementer" => {
+            let name = match name_field("name") {
+                Ok(n) => n,
+                Err(e) => return eljson::error_json(&e),
+            };
+            let Some(id_hex) = str_field("interfaceIdHex") else {
+                return eljson::error_json("missing interfaceIdHex");
+            };
+            let Some(id) = parse_hex_fixed::<4>(&id_hex) else {
+                return eljson::error_json("interfaceIdHex must be 4 bytes of hex");
+            };
+            EnsQuery::Interface { name, interface_id: id }
+        }
+        "reverse" => {
+            let Some(addr_hex) = str_field("addressHex") else {
+                return eljson::error_json("missing addressHex");
+            };
+            let Some(address) = parse_hex_fixed::<20>(&addr_hex) else {
+                // The Java EnsApi contract's message for a malformed reverse input.
+                return eljson::error_json("address must be a 20-byte hex string (40 hex chars)");
+            };
+            EnsQuery::Reverse { address }
+        }
+        other => return eljson::error_json(&format!("unknown ens method: {other}")),
+    };
+
+    let Some(engine) = engine() else {
+        return eljson::error_json("engine unavailable");
+    };
+    let (reader, chain_id) = match snapshot_reader_evm(engine, handle) {
+        Ok(snap) => snap,
+        Err(msg) => return eljson::error_json(msg),
+    };
+    match engine
+        .rt
+        .block_on(async { reader.resolve_ens_query(query, chain_id, root).await })
+    {
+        Ok(outcome) => eljson::ens_record_json(&outcome),
+        Err(e) => eljson::error_json(&e),
+    }
+}
+
 /// `nativeEstimateGasJson`: verified `eth_estimateGas` for a call (`to` set) over the
 /// revm executor. Args as for [`eth_call_json`] minus the block (estimate always runs
 /// against the verified head). Returns the estimate JSON (`ok`/`unavailable`, see
@@ -738,6 +896,20 @@ fn snapshot_reader_slots(
         Some(ChainEntry::Created(_)) => Err("handle not started"),
         None => Err("unknown handle"),
     }
+}
+
+/// Parse a `0x`-prefixed-or-bare hex string into exactly `N` bytes. Panic-free:
+/// `None` for any malformed input (JNI callers pass untrusted strings).
+fn parse_hex_fixed<const N: usize>(hex: &str) -> Option<[u8; N]> {
+    let hex = hex.strip_prefix("0x").or_else(|| hex.strip_prefix("0X")).unwrap_or(hex);
+    if hex.len() != 2 * N || !hex.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return None;
+    }
+    let mut out = [0u8; N];
+    for (i, byte) in out.iter_mut().enumerate() {
+        *byte = u8::from_str_radix(hex.get(i * 2..i * 2 + 2)?, 16).ok()?;
+    }
+    Some(out)
 }
 
 /// Parse a `0x`-prefixed-or-bare 40-char hex address into 20 bytes. Panic-free:

--- a/rust/myotis-engine/src/lib.rs
+++ b/rust/myotis-engine/src/lib.rs
@@ -27,7 +27,9 @@ pub mod ringlog;
 /// v9: added nativeEthCallJson (eth_call over verified state via the revm executor).
 /// v10: added nativeEstimateGasJson (eth_estimateGas over the revm executor).
 /// v11: added nativeResolveEnsJson (ENS forward resolution over verified eth_calls).
-pub const ABI_VERSION: i32 = 11;
+/// v12: added nativeEnsRecordJson (all ENS record types + reverse + root modes,
+///      one generic dispatch — EL-C-5-2).
+pub const ABI_VERSION: i32 = 12;
 
 // Keep the workspace edge alive so `cargo build -p myotis-engine` type-checks the
 // consensus crate too.
@@ -331,6 +333,25 @@ mod jni_shim {
     ) -> jstring {
         let name = read_string(&mut env, &name).unwrap_or_default();
         let json = crate::host::resolve_ens_json(handle, &name);
+        match env.new_string(json) {
+            Ok(s) => s.into_raw(),
+            Err(_) => std::ptr::null_mut(),
+        }
+    }
+
+    /// `RustEngineNative.nativeEnsRecordJson(long handle, String paramsJson)` —
+    /// one generic dispatch for every ENS record query (text, contenthash,
+    /// multi-coin, pubkey, ABI, dnsRecord, interfaceImplementer, reverse, and
+    /// root-aware addr). The method + args travel in `paramsJson`.
+    #[no_mangle]
+    pub extern "system" fn Java_io_myotis_engines_RustEngineNative_nativeEnsRecordJson(
+        mut env: JNIEnv,
+        _class: JClass,
+        handle: jlong,
+        params_json: JString,
+    ) -> jstring {
+        let params = read_string(&mut env, &params_json).unwrap_or_default();
+        let json = crate::host::ens_record_json(handle, &params);
         match env.new_string(json) {
             Ok(s) => s.into_raw(),
             Err(_) => std::ptr::null_mut(),

--- a/rust/myotis-evm/src/ens/abi.rs
+++ b/rust/myotis-evm/src/ens/abi.rs
@@ -51,6 +51,68 @@ pub fn encode_resolve(dns_name: &[u8], inner_call: &[u8]) -> Vec<u8> {
     out
 }
 
+/// `selector ‖ bytes32 ‖ head-tail(string)` — one static node + one dynamic
+/// string arg (`text(bytes32,string)`). The string's offset is relative to the
+/// start of the args (after the selector), so with one static word ahead of it
+/// the offset is 0x40.
+pub fn encode_call_bytes32_string(signature: &str, node: &[u8; 32], s: &str) -> Vec<u8> {
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(4 + 32 * 3 + bytes.len().next_multiple_of(32));
+    out.extend_from_slice(&selector(signature));
+    out.extend_from_slice(node);
+    out.extend_from_slice(&word(0x40)); // offset: past node word + offset word
+    out.extend_from_slice(&word(bytes.len() as u64));
+    out.extend_from_slice(bytes);
+    let pad = (32 - (bytes.len() % 32)) % 32;
+    out.extend(std::iter::repeat_n(0u8, pad));
+    out
+}
+
+/// `selector ‖ bytes32 ‖ uint256(v)` — one static node + one static uint arg
+/// (`addr(bytes32,uint256)` multi-coin, `ABI(bytes32,uint256)`).
+pub fn encode_call_bytes32_u64(signature: &str, node: &[u8; 32], v: u64) -> Vec<u8> {
+    let mut out = Vec::with_capacity(4 + 64);
+    out.extend_from_slice(&selector(signature));
+    out.extend_from_slice(node);
+    out.extend_from_slice(&word(v));
+    out
+}
+
+/// `selector ‖ bytes32 ‖ offset ‖ uint(v) ‖ len‖data‖pad` — one static node, one
+/// dynamic `bytes`, one static uint (`dnsRecord(bytes32,bytes,uint16)` — the
+/// JAVA ENGINE's signature, selector 0xee8de1f7, taking the RAW DNS wire name;
+/// note this differs from the mainnet PublicResolver ABI, which takes
+/// `keccak256(wireName)` as `bytes32` — ported byte-for-byte for parity).
+pub fn encode_call_bytes32_bytes_u64(
+    signature: &str,
+    node: &[u8; 32],
+    dyn_bytes: &[u8],
+    v: u64,
+) -> Vec<u8> {
+    let pad = (32 - (dyn_bytes.len() % 32)) % 32;
+    let mut out = Vec::with_capacity(4 + 32 * 4 + dyn_bytes.len() + pad);
+    out.extend_from_slice(&selector(signature));
+    out.extend_from_slice(node);
+    out.extend_from_slice(&word(0x60)); // offset: past the three head words
+    out.extend_from_slice(&word(v));
+    out.extend_from_slice(&word(dyn_bytes.len() as u64));
+    out.extend_from_slice(dyn_bytes);
+    out.extend(std::iter::repeat_n(0u8, pad));
+    out
+}
+
+/// `selector ‖ bytes32 ‖ bytes4-left-aligned` —
+/// `interfaceImplementer(bytes32,bytes4)`.
+pub fn encode_call_bytes32_bytes4(signature: &str, node: &[u8; 32], id: [u8; 4]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(4 + 64);
+    out.extend_from_slice(&selector(signature));
+    out.extend_from_slice(node);
+    let mut w = [0u8; 32];
+    w[..4].copy_from_slice(&id);
+    out.extend_from_slice(&w);
+    out
+}
+
 /// Head-tail encoding of N dynamic `bytes` args: N offset words, then each arg as
 /// `length ‖ data ‖ zero-pad-to-32`.
 fn encode_bytes_args(args: &[&[u8]]) -> Vec<u8> {
@@ -120,6 +182,33 @@ pub fn decode_dynamic_bytes(data: &[u8], arg_index: usize) -> Option<Vec<u8>> {
     data.get(start..end).map(<[u8]>::to_vec)
 }
 
+/// Decode the dynamic `string` at head slot 0 (offset → length → UTF-8 data,
+/// invalid sequences replaced — Java `new String(bytes, UTF_8)` parity).
+pub fn decode_string(data: &[u8]) -> Option<String> {
+    decode_dynamic_bytes(data, 0).map(|b| String::from_utf8_lossy(&b).into_owned())
+}
+
+/// Decode the two static 32-byte words of a `(bytes32,bytes32)` return
+/// (`pubkey(bytes32)` → x, y). `None` if shorter than 64 bytes.
+pub fn decode_two_words(data: &[u8]) -> Option<([u8; 32], [u8; 32])> {
+    let x: [u8; 32] = data.get(..32)?.try_into().ok()?;
+    let y: [u8; 32] = data.get(32..64)?.try_into().ok()?;
+    Some((x, y))
+}
+
+/// Decode a `(uint256, bytes)` return (`ABI(bytes32,uint256)` → contentType,
+/// data). The uint must fit u64 (ENS content types are a small bitmask —
+/// anything larger is not a real record). `None` on malformed data.
+pub fn decode_uint_bytes(data: &[u8]) -> Option<(u64, Vec<u8>)> {
+    let word = data.get(..32)?;
+    if word[..24].iter().any(|&b| b != 0) {
+        return None;
+    }
+    let v = u64::from_be_bytes(word[24..32].try_into().ok()?);
+    let bytes = decode_dynamic_bytes(data, 1)?;
+    Some((v, bytes))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -171,6 +260,80 @@ mod tests {
         let enc = encode_bytes_args(&[a, b]);
         assert_eq!(decode_dynamic_bytes(&enc, 0).unwrap(), a);
         assert_eq!(decode_dynamic_bytes(&enc, 1).unwrap(), b);
+    }
+
+    #[test]
+    fn record_selectors_are_correct() {
+        // The ENSIP record-profile selectors, pinned against their published ids.
+        assert_eq!(selector("text(bytes32,string)"), [0x59, 0xd1, 0xd4, 0x3c]);
+        assert_eq!(selector("contenthash(bytes32)"), [0xbc, 0x1c, 0x58, 0xd1]);
+        assert_eq!(selector("addr(bytes32,uint256)"), [0xf1, 0xcb, 0x7e, 0x06]);
+        assert_eq!(selector("pubkey(bytes32)"), [0xc8, 0x69, 0x02, 0x33]);
+        assert_eq!(selector("ABI(bytes32,uint256)"), [0x22, 0x03, 0xab, 0x56]);
+        // The JAVA ENGINE's dnsRecord signature (raw wire name as `bytes`) — NOT
+        // the mainnet PublicResolver's dnsRecord(bytes32,bytes32,uint16) 0xa8fa5682.
+        assert_eq!(selector("dnsRecord(bytes32,bytes,uint16)"), [0xee, 0x8d, 0xe1, 0xf7]);
+        assert_eq!(selector("interfaceImplementer(bytes32,bytes4)"), [0x12, 0x4a, 0x31, 0x9c]);
+    }
+
+    #[test]
+    fn encode_bytes32_string_shape() {
+        let node = [0xABu8; 32];
+        let enc = encode_call_bytes32_string("text(bytes32,string)", &node, "avatar");
+        assert_eq!(&enc[..4], &[0x59, 0xd1, 0xd4, 0x3c]);
+        assert_eq!(&enc[4..36], &node);
+        assert_eq!(enc[36..68], word(0x40)); // offset past the two head words
+        assert_eq!(enc[68..100], word(6)); // "avatar".len()
+        assert_eq!(&enc[100..106], b"avatar");
+        assert_eq!(enc.len(), 4 + 32 * 3 + 32); // padded to a full word
+        assert!(enc[106..].iter().all(|&b| b == 0));
+    }
+
+    #[test]
+    fn encode_bytes32_u64_and_bytes4_shapes() {
+        let node = [0x11u8; 32];
+        let mc = encode_call_bytes32_u64("addr(bytes32,uint256)", &node, 60);
+        assert_eq!(&mc[..4], &[0xf1, 0xcb, 0x7e, 0x06]);
+        assert_eq!(mc[36..68], word(60));
+
+        let ii = encode_call_bytes32_bytes4(
+            "interfaceImplementer(bytes32,bytes4)",
+            &node,
+            [0x5b, 0x5e, 0x13, 0x9f],
+        );
+        assert_eq!(&ii[..4], &[0x12, 0x4a, 0x31, 0x9c]);
+        assert_eq!(&ii[36..40], &[0x5b, 0x5e, 0x13, 0x9f]); // left-aligned
+        assert!(ii[40..68].iter().all(|&b| b == 0));
+
+        // dnsRecord: node ‖ offset(0x60) ‖ resource ‖ len ‖ wire ‖ pad
+        let wire = [0x07u8, b'v', b'i', b't', b'a', b'l', b'i', b'k', 0x03, b'e', b't', b'h', 0x00];
+        let dr = encode_call_bytes32_bytes_u64("dnsRecord(bytes32,bytes,uint16)", &node, &wire, 1);
+        assert_eq!(&dr[..4], &[0xee, 0x8d, 0xe1, 0xf7]);
+        assert_eq!(dr[36..68], word(0x60));
+        assert_eq!(dr[68..100], word(1)); // A record
+        assert_eq!(dr[100..132], word(wire.len() as u64));
+        assert_eq!(&dr[132..132 + wire.len()], &wire);
+        assert_eq!(dr.len(), 132 + 32); // wire padded to one word
+    }
+
+    #[test]
+    fn decode_two_words_and_uint_bytes() {
+        let mut pk = vec![0x0Au8; 32];
+        pk.extend_from_slice(&[0x0Bu8; 32]);
+        assert_eq!(decode_two_words(&pk), Some(([0x0A; 32], [0x0B; 32])));
+        assert_eq!(decode_two_words(&pk[..40]), None);
+
+        // (uint256=1, bytes="hi")
+        let mut ab = word(1).to_vec();
+        ab.extend_from_slice(&word(0x40)); // offset of the bytes
+        ab.extend_from_slice(&word(2));
+        ab.extend_from_slice(b"hi");
+        ab.extend_from_slice(&[0u8; 30]);
+        assert_eq!(decode_uint_bytes(&ab), Some((1, b"hi".to_vec())));
+        // dirty high bytes in the uint word → None
+        let mut dirty = ab.clone();
+        dirty[0] = 1;
+        assert_eq!(decode_uint_bytes(&dirty), None);
     }
 
     #[test]

--- a/rust/myotis-evm/src/ens/abi.rs
+++ b/rust/myotis-evm/src/ens/abi.rs
@@ -199,6 +199,9 @@ pub fn decode_two_words(data: &[u8]) -> Option<([u8; 32], [u8; 32])> {
 /// Decode a `(uint256, bytes)` return (`ABI(bytes32,uint256)` → contentType,
 /// data). The uint must fit u64 (ENS content types are a small bitmask —
 /// anything larger is not a real record). `None` on malformed data.
+/// Known micro-divergence: a contentType in [2^63, 2^64) decodes here but makes
+/// Java's `longValueExact()` throw → empty there vs an error result here; only
+/// an adversarial resolver can produce it and no wrong value is delivered.
 pub fn decode_uint_bytes(data: &[u8]) -> Option<(u64, Vec<u8>)> {
     let word = data.get(..32)?;
     if word[..24].iter().any(|&b| b != 0) {

--- a/rust/myotis-evm/src/ens/mod.rs
+++ b/rust/myotis-evm/src/ens/mod.rs
@@ -248,6 +248,13 @@ pub fn resolve_interface_implementer(
 /// `resolveName` parity): the resolver is looked up at the EXACT
 /// `<hex>.addr.reverse` node — no ancestor walk, no `supportsInterface` probe,
 /// no ENSIP-10 wrap — and `name(bytes32)` is called directly on it.
+///
+/// One deliberate divergence from the Java reverse path: a plain REVERT during
+/// the reverse lookup (registry or `name()`) folds to `Ok(None)` here, where
+/// Java surfaces it as an error record — this matches the FORWARD path's
+/// revert-is-no-record classification on both engines, and a reverse resolver
+/// without a `name(bytes32)` function simply has no reverse record to give.
+/// Non-revert failures (state unavailable) still propagate as errors.
 pub fn reverse_resolve(
     caller: &dyn EthCaller,
     address: [u8; 20],
@@ -313,6 +320,12 @@ fn resolve_record(
     name: &str,
     inner_call: &[u8],
 ) -> Result<Option<Vec<u8>>, EnsError> {
+    // DNS-encode BEFORE the walk (Java `dispatchResolve` ordering): a malformed
+    // name (empty / oversized label) is always an InvalidName error — never a
+    // "no record" — even when the walk would find no resolver or the legacy
+    // path wouldn't need the wire form.
+    let dns = dns_encode(name)?;
+
     let Some(info) = find_resolver(caller, name)? else {
         return Ok(None);
     };
@@ -321,11 +334,6 @@ fn resolve_record(
     if !info.exact && !info.extended {
         return Ok(None);
     }
-
-    // DNS-encode eagerly on BOTH paths (Java `dispatchResolve` parity): a
-    // malformed name (empty / oversized label) is rejected even when the legacy
-    // path wouldn't need the wire form.
-    let dns = dns_encode(name)?;
 
     if info.extended {
         // ENSIP-10: resolver.resolve(dnsEncode(name), inner) → bytes wrapping
@@ -586,6 +594,18 @@ mod tests {
         // Registry returns zero for every suffix → no resolver anywhere.
         let caller = MockCaller::new().on(|_t, _cd| Some(Ok(vec![0u8; 32])));
         assert_eq!(resolve_address(&caller, "nonexistent.eth").unwrap(), None);
+    }
+
+    #[test]
+    fn malformed_name_errors_even_without_a_resolver() {
+        // DNS-encoding runs BEFORE the walk (Java dispatchResolve ordering): an
+        // interior empty label is InvalidName, never a clean "no record" — even
+        // when the registry has no resolver for any suffix.
+        let caller = MockCaller::new().on(|_t, _cd| Some(Ok(vec![0u8; 32])));
+        assert!(matches!(
+            resolve_address(&caller, "a..eth"),
+            Err(EnsError::InvalidName(_))
+        ));
     }
 
     #[test]

--- a/rust/myotis-evm/src/ens/mod.rs
+++ b/rust/myotis-evm/src/ens/mod.rs
@@ -292,9 +292,13 @@ pub fn reverse_resolve(
 
     // Forward-verify through the FULL forward path (registry walk + ENSIP-10):
     // the claimed name must resolve back to the queried address, byte-equal.
-    match resolve_address(caller, &claimed)? {
-        Some(fwd) if fwd == address => Ok(Some(claimed)),
-        _ => Ok(None),
+    // A MALFORMED claimed name is a failed verify (no record), not an error —
+    // a malicious reverse record must not be able to force an error result
+    // where "no verified reverse record" is the truthful answer.
+    match resolve_address(caller, &claimed) {
+        Ok(Some(fwd)) if fwd == address => Ok(Some(claimed)),
+        Ok(_) | Err(EnsError::InvalidName(_)) => Ok(None),
+        Err(e) => Err(e),
     }
 }
 
@@ -825,6 +829,14 @@ mod tests {
         // The reverse record claims "vitalik.eth" but the forward resolution of
         // that name points at a DIFFERENT address → the claim is discarded.
         let caller = reverse_caller("vitalik.eth", [0xBA; 20]);
+        assert_eq!(reverse_resolve(&caller, VITALIK).unwrap(), None);
+    }
+
+    #[test]
+    fn reverse_malformed_claimed_name_is_none_not_error() {
+        // A malicious reverse record claiming a malformed name ("a..eth") must
+        // read as a failed forward-verify (None) — not surface InvalidName.
+        let caller = reverse_caller("a..eth", VITALIK);
         assert_eq!(reverse_resolve(&caller, VITALIK).unwrap(), None);
     }
 

--- a/rust/myotis-evm/src/ens/mod.rs
+++ b/rust/myotis-evm/src/ens/mod.rs
@@ -110,6 +110,209 @@ pub fn resolve_address(
     caller: &dyn EthCaller,
     name: &str,
 ) -> Result<Option<[u8; 20]>, EnsError> {
+    let node = namehash(name);
+    let inner = abi::encode_call_bytes32("addr(bytes32)", &node);
+    let Some(raw) = resolve_record(caller, name, &inner)? else {
+        return Ok(None);
+    };
+    // A zero address is "no record", not an answer. decode_address is stricter
+    // than the Java decoder (a dirty upper-12-byte word → None rather than
+    // slicing the trailing 20) — deliberately fail-safe for a fund-destination.
+    Ok(abi::decode_address(&raw).filter(|a| a != &[0u8; 20]))
+}
+
+/// Resolve a `text(bytes32,string)` record. `Ok(None)` = no record (absent
+/// name/resolver, empty string — Java `decodeStringResult` parity).
+pub fn resolve_text(
+    caller: &dyn EthCaller,
+    name: &str,
+    key: &str,
+) -> Result<Option<String>, EnsError> {
+    let node = namehash(name);
+    let inner = abi::encode_call_bytes32_string("text(bytes32,string)", &node, key);
+    let Some(raw) = resolve_record(caller, name, &inner)? else {
+        return Ok(None);
+    };
+    Ok(abi::decode_string(&raw).filter(|s| !s.is_empty()))
+}
+
+/// Resolve a `contenthash(bytes32)` record (raw multicodec bytes). `Ok(None)` =
+/// no record (empty bytes).
+pub fn resolve_contenthash(
+    caller: &dyn EthCaller,
+    name: &str,
+) -> Result<Option<Vec<u8>>, EnsError> {
+    let node = namehash(name);
+    let inner = abi::encode_call_bytes32("contenthash(bytes32)", &node);
+    let Some(raw) = resolve_record(caller, name, &inner)? else {
+        return Ok(None);
+    };
+    Ok(abi::decode_dynamic_bytes(&raw, 0).filter(|b| !b.is_empty()))
+}
+
+/// Resolve an ENSIP-9 multi-coin `addr(bytes32,uint256)` record (raw
+/// coin-specific address bytes). `Ok(None)` = no record (empty bytes).
+pub fn resolve_multicoin(
+    caller: &dyn EthCaller,
+    name: &str,
+    coin_type: u64,
+) -> Result<Option<Vec<u8>>, EnsError> {
+    let node = namehash(name);
+    let inner = abi::encode_call_bytes32_u64("addr(bytes32,uint256)", &node, coin_type);
+    let Some(raw) = resolve_record(caller, name, &inner)? else {
+        return Ok(None);
+    };
+    Ok(abi::decode_dynamic_bytes(&raw, 0).filter(|b| !b.is_empty()))
+}
+
+/// Resolve a `pubkey(bytes32)` record — a fixed `(bytes32 x, bytes32 y)` tuple,
+/// NO dynamic offsets. `Ok(None)` = no record (short return or both words zero).
+pub fn resolve_pubkey(
+    caller: &dyn EthCaller,
+    name: &str,
+) -> Result<Option<([u8; 32], [u8; 32])>, EnsError> {
+    let node = namehash(name);
+    let inner = abi::encode_call_bytes32("pubkey(bytes32)", &node);
+    let Some(raw) = resolve_record(caller, name, &inner)? else {
+        return Ok(None);
+    };
+    Ok(abi::decode_two_words(&raw).filter(|(x, y)| x != &[0u8; 32] || y != &[0u8; 32]))
+}
+
+/// Resolve an `ABI(bytes32,uint256)` record → `(contentType, data)`. `Ok(None)`
+/// = no record (empty data — the contentType word alone is NOT checked, Java
+/// `decodeAbiResult` parity).
+pub fn resolve_abi(
+    caller: &dyn EthCaller,
+    name: &str,
+    content_types: u64,
+) -> Result<Option<(u64, Vec<u8>)>, EnsError> {
+    let node = namehash(name);
+    let inner = abi::encode_call_bytes32_u64("ABI(bytes32,uint256)", &node, content_types);
+    let Some(raw) = resolve_record(caller, name, &inner)? else {
+        return Ok(None);
+    };
+    Ok(abi::decode_uint_bytes(&raw).filter(|(_, data)| !data.is_empty()))
+}
+
+/// Resolve a `dnsRecord(bytes32,bytes,uint16)` record: `dns_name` is the DNS
+/// name queried (its RAW wire encoding is the second arg — the Java engine's
+/// signature, selector 0xee8de1f7; see [`abi::encode_call_bytes32_bytes_u64`]),
+/// `resource` the DNS record type (1 = A, 16 = TXT, …). `Ok(None)` = no record.
+pub fn resolve_dns_record(
+    caller: &dyn EthCaller,
+    name: &str,
+    dns_name: &str,
+    resource: u16,
+) -> Result<Option<Vec<u8>>, EnsError> {
+    let node = namehash(name);
+    let wire = dns_encode(dns_name)?;
+    let inner = abi::encode_call_bytes32_bytes_u64(
+        "dnsRecord(bytes32,bytes,uint16)",
+        &node,
+        &wire,
+        u64::from(resource),
+    );
+    let Some(raw) = resolve_record(caller, name, &inner)? else {
+        return Ok(None);
+    };
+    Ok(abi::decode_dynamic_bytes(&raw, 0).filter(|b| !b.is_empty()))
+}
+
+/// Resolve an `interfaceImplementer(bytes32,bytes4)` record (EIP-1820 over
+/// ENS). `Ok(None)` = no record (zero address).
+pub fn resolve_interface_implementer(
+    caller: &dyn EthCaller,
+    name: &str,
+    interface_id: [u8; 4],
+) -> Result<Option<[u8; 20]>, EnsError> {
+    let node = namehash(name);
+    let inner = abi::encode_call_bytes32_bytes4(
+        "interfaceImplementer(bytes32,bytes4)",
+        &node,
+        interface_id,
+    );
+    let Some(raw) = resolve_record(caller, name, &inner)? else {
+        return Ok(None);
+    };
+    Ok(abi::decode_address(&raw).filter(|a| a != &[0u8; 20]))
+}
+
+/// Reverse-resolve `address` → its primary ENS name, **forward-verified**: the
+/// claimed name is forward-resolved and must map back to `address`, or the
+/// answer is discarded. Empty reverse record, no reverse resolver, and a failed
+/// forward-verify are all indistinguishable `Ok(None)` (Java parity — no
+/// special error token).
+///
+/// The reverse side is deliberately simpler than forward resolution (Java
+/// `resolveName` parity): the resolver is looked up at the EXACT
+/// `<hex>.addr.reverse` node — no ancestor walk, no `supportsInterface` probe,
+/// no ENSIP-10 wrap — and `name(bytes32)` is called directly on it.
+pub fn reverse_resolve(
+    caller: &dyn EthCaller,
+    address: [u8; 20],
+) -> Result<Option<String>, EnsError> {
+    let rev_name = reverse_name(address);
+    let rev_node = namehash(&rev_name);
+
+    // Exact resolver lookup; a zero resolver (or a revert) is "no reverse record".
+    let call = abi::encode_call_bytes32("resolver(bytes32)", &rev_node);
+    let out = match caller.eth_call(REGISTRY, &call) {
+        Ok(out) => out,
+        Err(EvmError::Reverted { .. }) => return Ok(None),
+        Err(e) => return Err(EnsError::Call(e)),
+    };
+    let Some(resolver) = abi::decode_address(&out).filter(|a| a != &[0u8; 20]) else {
+        return Ok(None);
+    };
+
+    // name(node) → the claimed primary name (empty/malformed → no record). An
+    // OffchainLookup revert stays distinguishable, like every resolver call.
+    let name_call = abi::encode_call_bytes32("name(bytes32)", &rev_node);
+    let raw = match caller.eth_call(resolver, &name_call) {
+        Ok(out) => out,
+        Err(EvmError::Reverted { data }) => {
+            return match revert_outcome(&data) {
+                Ok(_) => Ok(None),
+                Err(e) => Err(e),
+            }
+        }
+        Err(e) => return Err(EnsError::Call(e)),
+    };
+    let Some(claimed) = abi::decode_string(&raw).filter(|s| !s.is_empty()) else {
+        return Ok(None);
+    };
+
+    // Forward-verify through the FULL forward path (registry walk + ENSIP-10):
+    // the claimed name must resolve back to the queried address, byte-equal.
+    match resolve_address(caller, &claimed)? {
+        Some(fwd) if fwd == address => Ok(Some(claimed)),
+        _ => Ok(None),
+    }
+}
+
+/// `<lowercase-hex-no-0x>.addr.reverse` (EIP-181; Java `ReverseLookup.nameFor`).
+fn reverse_name(address: [u8; 20]) -> String {
+    let mut s = String::with_capacity(40 + 13);
+    for b in address {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s.push_str(".addr.reverse");
+    s
+}
+
+/// The shared resolution path every record type rides: find the (possibly
+/// wildcard) resolver for `name`, dispatch `inner_call` to it — wrapped in
+/// ENSIP-10 `resolve(bytes,bytes)` for an extended resolver, direct for a legacy
+/// one — and return the raw inner return bytes. `Ok(None)` = no resolver / a
+/// non-wildcard ancestor / a plain revert / an unwrappable extended return;
+/// per-record "empty answer" semantics (zero address, empty string, …) belong to
+/// the typed wrappers on top.
+fn resolve_record(
+    caller: &dyn EthCaller,
+    name: &str,
+    inner_call: &[u8],
+) -> Result<Option<Vec<u8>>, EnsError> {
     let Some(info) = find_resolver(caller, name)? else {
         return Ok(None);
     };
@@ -119,44 +322,34 @@ pub fn resolve_address(
         return Ok(None);
     }
 
-    let node = namehash(name);
-    let inner = abi::encode_call_bytes32("addr(bytes32)", &node);
     // DNS-encode eagerly on BOTH paths (Java `dispatchResolve` parity): a
     // malformed name (empty / oversized label) is rejected even when the legacy
     // path wouldn't need the wire form.
     let dns = dns_encode(name)?;
 
-    let raw = if info.extended {
-        // ENSIP-10: resolver.resolve(dnsEncode(name), addr(node)) → bytes wrapping
+    if info.extended {
+        // ENSIP-10: resolver.resolve(dnsEncode(name), inner) → bytes wrapping
         // the inner return.
-        let call = abi::encode_resolve(&dns, &inner);
+        let call = abi::encode_resolve(&dns, inner_call);
         match caller.eth_call(info.resolver, &call) {
-            Ok(out) => match abi::decode_dynamic_bytes(&out, 0) {
-                Some(unwrapped) => unwrapped,
-                None => return Ok(None),
-            },
-            Err(EvmError::Reverted { data }) => return revert_outcome(&data),
-            Err(e) => return Err(EnsError::Call(e)),
+            Ok(out) => Ok(abi::decode_dynamic_bytes(&out, 0)),
+            Err(EvmError::Reverted { data }) => revert_outcome(&data),
+            Err(e) => Err(EnsError::Call(e)),
         }
     } else {
-        // Legacy exact resolver: resolver.addr(node) directly.
-        match caller.eth_call(info.resolver, &inner) {
-            Ok(out) => out,
-            Err(EvmError::Reverted { data }) => return revert_outcome(&data),
-            Err(e) => return Err(EnsError::Call(e)),
+        // Legacy exact resolver: dispatch the inner call directly.
+        match caller.eth_call(info.resolver, inner_call) {
+            Ok(out) => Ok(Some(out)),
+            Err(EvmError::Reverted { data }) => revert_outcome(&data),
+            Err(e) => Err(EnsError::Call(e)),
         }
-    };
-
-    // A zero address is "no record", not an answer. decode_address is stricter
-    // than the Java decoder (a dirty upper-12-byte word → None rather than
-    // slicing the trailing 20) — deliberately fail-safe for a fund-destination.
-    Ok(abi::decode_address(&raw).filter(|a| a != &[0u8; 20]))
+    }
 }
 
 /// Classify a resolver-call revert: an ERC-3668 `OffchainLookup` is a
 /// distinguishable "resolves offchain" failure (never folded into "no record");
 /// any other revert is "no record".
-fn revert_outcome(data: &[u8]) -> Result<Option<[u8; 20]>, EnsError> {
+fn revert_outcome(data: &[u8]) -> Result<Option<Vec<u8>>, EnsError> {
     if data.len() >= 4 && data[..4] == OFFCHAIN_LOOKUP_SELECTOR {
         Err(EnsError::OffchainLookup)
     } else {
@@ -426,5 +619,210 @@ mod tests {
             .on(move |t, cd| (t == RESOLVER && sel(cd) == supports_sel).then(revert))
             .on(move |t, cd| (t == RESOLVER && sel(cd) == addr_sel).then(|| Ok(vec![0u8; 32]))); // zero addr
         assert_eq!(resolve_address(&caller, "vitalik.eth").unwrap(), None);
+    }
+
+    // ---- record types (EL-C-5-2) ----
+
+    /// A legacy exact resolver answering `record_sel` with `response`.
+    fn legacy_resolver_caller(
+        record_sel: [u8; 4],
+        response: Vec<u8>,
+    ) -> MockCaller {
+        let resolver_sel = abi::selector("resolver(bytes32)");
+        let supports_sel = abi::selector("supportsInterface(bytes4)");
+        MockCaller::new()
+            .on(move |t, cd| (t == REGISTRY && sel(cd) == resolver_sel).then(|| Ok(addr_word(RESOLVER))))
+            .on(move |t, cd| (t == RESOLVER && sel(cd) == supports_sel).then(revert))
+            .on(move |t, cd| (t == RESOLVER && sel(cd) == record_sel).then(|| Ok(response.clone())))
+    }
+
+    /// `bytes`/`string` head-tail wrapping of `payload` (offset ‖ len ‖ data ‖ pad).
+    fn dyn_bytes_return(payload: &[u8]) -> Vec<u8> {
+        let mut o = vec![0u8; 32];
+        o[31] = 0x20;
+        let mut len = vec![0u8; 32];
+        len[24..].copy_from_slice(&(payload.len() as u64).to_be_bytes());
+        o.extend_from_slice(&len);
+        o.extend_from_slice(payload);
+        o.extend(std::iter::repeat_n(0u8, (32 - (payload.len() % 32)) % 32));
+        o
+    }
+
+    #[test]
+    fn text_record_resolves_and_empty_is_none() {
+        let text_sel = abi::selector("text(bytes32,string)");
+        let caller = legacy_resolver_caller(text_sel, dyn_bytes_return(b"https://vitalik.ca"));
+        assert_eq!(
+            resolve_text(&caller, "vitalik.eth", "url").unwrap(),
+            Some("https://vitalik.ca".to_string())
+        );
+        // The queried key must be inside the calldata (dynamic string arg).
+        let empty = legacy_resolver_caller(text_sel, dyn_bytes_return(b""));
+        assert_eq!(resolve_text(&empty, "vitalik.eth", "url").unwrap(), None);
+        // Short return (< offset+len words) → None, not an error.
+        let short = legacy_resolver_caller(text_sel, vec![0u8; 32]);
+        assert_eq!(resolve_text(&short, "vitalik.eth", "url").unwrap(), None);
+    }
+
+    #[test]
+    fn contenthash_and_multicoin_and_dnsrecord_empty_bytes_are_none() {
+        for (sel4, run) in [
+            (abi::selector("contenthash(bytes32)"),
+             Box::new(|c: &dyn EthCaller| resolve_contenthash(c, "a.eth").unwrap())
+                 as Box<dyn Fn(&dyn EthCaller) -> Option<Vec<u8>>>),
+            (abi::selector("addr(bytes32,uint256)"),
+             Box::new(|c: &dyn EthCaller| resolve_multicoin(c, "a.eth", 0).unwrap())),
+            (abi::selector("dnsRecord(bytes32,bytes,uint16)"),
+             Box::new(|c: &dyn EthCaller| resolve_dns_record(c, "a.eth", "a.eth", 1).unwrap())),
+        ] {
+            let payload = vec![0xC0u8, 0xFF, 0xEE];
+            let full = legacy_resolver_caller(sel4, dyn_bytes_return(&payload));
+            assert_eq!(run(&full), Some(payload), "selector {sel4:02x?}");
+            let empty = legacy_resolver_caller(sel4, dyn_bytes_return(b""));
+            assert_eq!(run(&empty), None, "selector {sel4:02x?}");
+        }
+    }
+
+    #[test]
+    fn pubkey_fixed_tuple_and_zero_is_none() {
+        let pk_sel = abi::selector("pubkey(bytes32)");
+        let mut xy = vec![0x0A; 32];
+        xy.extend_from_slice(&[0x0B; 32]);
+        let caller = legacy_resolver_caller(pk_sel, xy);
+        assert_eq!(
+            resolve_pubkey(&caller, "a.eth").unwrap(),
+            Some(([0x0A; 32], [0x0B; 32]))
+        );
+        let zero = legacy_resolver_caller(pk_sel, vec![0u8; 64]);
+        assert_eq!(resolve_pubkey(&zero, "a.eth").unwrap(), None);
+        let short = legacy_resolver_caller(pk_sel, vec![0u8; 32]);
+        assert_eq!(resolve_pubkey(&short, "a.eth").unwrap(), None);
+    }
+
+    #[test]
+    fn abi_record_returns_content_type_and_data() {
+        let abi_sel = abi::selector("ABI(bytes32,uint256)");
+        // (uint256 contentType=1, bytes data="{}") — offset 0x40 (after 2 head words).
+        let mut ret = vec![0u8; 32];
+        ret[31] = 1;
+        let mut off = vec![0u8; 32];
+        off[31] = 0x40;
+        ret.extend_from_slice(&off);
+        let mut len = vec![0u8; 32];
+        len[31] = 2;
+        ret.extend_from_slice(&len);
+        ret.extend_from_slice(b"{}");
+        ret.extend_from_slice(&[0u8; 30]);
+        let caller = legacy_resolver_caller(abi_sel, ret);
+        assert_eq!(resolve_abi(&caller, "a.eth", 0xF).unwrap(), Some((1, b"{}".to_vec())));
+        // Empty data → None even with a non-zero contentType word shape.
+        let mut empty = vec![0u8; 32];
+        empty[31] = 1;
+        let mut off2 = vec![0u8; 32];
+        off2[31] = 0x40;
+        empty.extend_from_slice(&off2);
+        empty.extend_from_slice(&[0u8; 32]); // len 0
+        let caller2 = legacy_resolver_caller(abi_sel, empty);
+        assert_eq!(resolve_abi(&caller2, "a.eth", 0xF).unwrap(), None);
+    }
+
+    #[test]
+    fn interface_implementer_zero_is_none() {
+        let ii_sel = abi::selector("interfaceImplementer(bytes32,bytes4)");
+        let caller = legacy_resolver_caller(ii_sel, addr_word([0x77; 20]));
+        assert_eq!(
+            resolve_interface_implementer(&caller, "a.eth", [0x5b, 0x5e, 0x13, 0x9f]).unwrap(),
+            Some([0x77; 20])
+        );
+        let zero = legacy_resolver_caller(ii_sel, vec![0u8; 32]);
+        assert_eq!(
+            resolve_interface_implementer(&zero, "a.eth", [0x5b, 0x5e, 0x13, 0x9f]).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn records_ride_the_ensip10_wrap() {
+        // A WILDCARD resolver: the text() inner call must arrive wrapped in
+        // resolve(bytes,bytes) and the answer is bytes-unwrapped.
+        let resolver_sel = abi::selector("resolver(bytes32)");
+        let supports_sel = abi::selector("supportsInterface(bytes4)");
+        let resolve_sel = abi::selector("resolve(bytes,bytes)");
+        let text_sel = abi::selector("text(bytes32,string)");
+        let caller = MockCaller::new()
+            .on(move |t, cd| (t == REGISTRY && sel(cd) == resolver_sel).then(|| Ok(addr_word(RESOLVER))))
+            .on(move |t, cd| (t == RESOLVER && sel(cd) == supports_sel).then(|| Ok(bool_word(true))))
+            .on(move |t, cd| {
+                if t != RESOLVER || sel(cd) != resolve_sel {
+                    return None;
+                }
+                // The inner call (2nd dynamic arg) must be the text() call.
+                let inner = abi::decode_dynamic_bytes(&cd[4..], 1).unwrap();
+                assert_eq!(&inner[..4], &text_sel);
+                // Return bytes-wrapping of the inner string return.
+                Some(Ok(dyn_bytes_return(&dyn_bytes_return(b"wrapped!"))))
+            });
+        assert_eq!(
+            resolve_text(&caller, "sub.gateway.eth", "url").unwrap(),
+            Some("wrapped!".to_string())
+        );
+    }
+
+    // ---- reverse resolution (EL-C-5-2) ----
+
+    /// registry.resolver(REVERSE node) → REV_RESOLVER; name(node) → `claimed`;
+    /// then the forward path for `claimed` → `forward_addr`.
+    fn reverse_caller(claimed: &str, forward_addr: [u8; 20]) -> MockCaller {
+        const REV_RESOLVER: [u8; 20] = [0x55; 20];
+        let resolver_sel = abi::selector("resolver(bytes32)");
+        let name_sel = abi::selector("name(bytes32)");
+        let supports_sel = abi::selector("supportsInterface(bytes4)");
+        let addr_sel = abi::selector("addr(bytes32)");
+        let rev_node = namehash(&reverse_name(VITALIK));
+        let claimed_ret = dyn_bytes_return(claimed.as_bytes());
+        MockCaller::new()
+            .on(move |t, cd| {
+                (t == REGISTRY && sel(cd) == resolver_sel && cd[4..36] == rev_node)
+                    .then(|| Ok(addr_word(REV_RESOLVER)))
+            })
+            .on(move |t, cd| {
+                (t == REV_RESOLVER && sel(cd) == name_sel).then(|| Ok(claimed_ret.clone()))
+            })
+            // forward path: exact resolver for the claimed name, legacy.
+            .on(move |t, cd| (t == REGISTRY && sel(cd) == resolver_sel).then(|| Ok(addr_word(RESOLVER))))
+            .on(move |t, cd| (t == RESOLVER && sel(cd) == supports_sel).then(revert))
+            .on(move |t, cd| (t == RESOLVER && sel(cd) == addr_sel).then(|| Ok(addr_word(forward_addr))))
+    }
+
+    #[test]
+    fn reverse_resolves_with_forward_verify() {
+        let caller = reverse_caller("vitalik.eth", VITALIK);
+        assert_eq!(reverse_resolve(&caller, VITALIK).unwrap(), Some("vitalik.eth".to_string()));
+    }
+
+    #[test]
+    fn reverse_impersonation_is_rejected() {
+        // The reverse record claims "vitalik.eth" but the forward resolution of
+        // that name points at a DIFFERENT address → the claim is discarded.
+        let caller = reverse_caller("vitalik.eth", [0xBA; 20]);
+        assert_eq!(reverse_resolve(&caller, VITALIK).unwrap(), None);
+    }
+
+    #[test]
+    fn reverse_empty_record_and_no_resolver_are_none() {
+        // No resolver at the reverse node.
+        let no_resolver = MockCaller::new().on(|_t, _cd| Some(Ok(vec![0u8; 32])));
+        assert_eq!(reverse_resolve(&no_resolver, VITALIK).unwrap(), None);
+        // Resolver set but name() returns an empty string.
+        let caller = reverse_caller("", VITALIK);
+        assert_eq!(reverse_resolve(&caller, VITALIK).unwrap(), None);
+    }
+
+    #[test]
+    fn reverse_name_is_lowercase_hex() {
+        assert_eq!(
+            reverse_name([0xd8; 20]),
+            format!("{}.addr.reverse", "d8".repeat(20))
+        );
     }
 }

--- a/rust/myotis-evm/src/lib.rs
+++ b/rust/myotis-evm/src/lib.rs
@@ -53,7 +53,11 @@ pub use cache::{
     NoopStateProofCache, StateProofCache,
 };
 pub use database::OracleDatabase;
-pub use ens::{resolve_address, EnsError, EthCaller, ExecutorCaller};
+pub use ens::{
+    resolve_abi, resolve_address, resolve_contenthash, resolve_dns_record,
+    resolve_interface_implementer, resolve_multicoin, resolve_pubkey, resolve_text,
+    reverse_resolve, EnsError, EthCaller, ExecutorCaller,
+};
 pub use error::EvmError;
 pub use executor::EvmExecutor;
 pub use oracle::{OracleAccount, OracleError, SnapStateOracle};

--- a/rust/myotis-net/src/el/evm.rs
+++ b/rust/myotis-net/src/el/evm.rs
@@ -76,6 +76,77 @@ pub enum EnsOutcome {
     Offchain { block_number: u64 },
 }
 
+/// Which state root an ENS query resolves against (the Java `EnsRoot` twin —
+/// this engine has no PEER_HEAD mode; its non-finalized root is the
+/// beacon-anchored OPTIMISTIC head, strictly stronger than a peer-claimed head).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EnsRootMode {
+    /// Try the beacon-FINALIZED root first; fall back to the optimistic head if
+    /// the finalized attempt errors or finds no record (Java AUTO-ladder parity).
+    Auto,
+    /// The beacon-FINALIZED root only — a failure is an error, never a silent
+    /// downgrade.
+    Finalized,
+    /// The beacon-anchored optimistic head only (the Java `PEER_HEAD` twin —
+    /// "don't wait for finality"; here it is still beacon-anchored, not
+    /// peer-claimed). Reports `verified=false`.
+    Optimistic,
+}
+
+/// One ENS query — every record type the resolver serves (EL-C-5-2).
+#[derive(Debug, Clone)]
+pub enum EnsQuery {
+    /// Forward `name → address` (the EL-C-5-1 read, now root-aware).
+    Addr { name: String },
+    /// `text(bytes32,string)`.
+    Text { name: String, key: String },
+    /// `contenthash(bytes32)`.
+    Contenthash { name: String },
+    /// ENSIP-9 `addr(bytes32,uint256)`.
+    Multicoin { name: String, coin_type: u64 },
+    /// `pubkey(bytes32)`.
+    Pubkey { name: String },
+    /// `ABI(bytes32,uint256)`.
+    Abi { name: String, content_types: u64 },
+    /// `dnsRecord(bytes32,bytes,uint16)` (the Java engine's signature).
+    DnsRecord { name: String, dns_name: String, resource: u16 },
+    /// `interfaceImplementer(bytes32,bytes4)`.
+    Interface { name: String, interface_id: [u8; 4] },
+    /// Reverse `address → name`, forward-verified.
+    Reverse { address: [u8; 20] },
+}
+
+/// A resolved record value, shaped per query type.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EnsRecordValue {
+    /// `Addr` / `Interface` answers.
+    Address([u8; 20]),
+    /// `Text` answers.
+    Text(String),
+    /// `Contenthash` / `Multicoin` / `DnsRecord` answers (raw bytes).
+    Bytes(Vec<u8>),
+    /// `Pubkey` answers.
+    Pubkey { x: [u8; 32], y: [u8; 32] },
+    /// `Abi` answers.
+    Abi { content_type: u64, data: Vec<u8> },
+    /// `Reverse` answers (the forward-verified primary name).
+    Name(String),
+}
+
+/// The outcome of an [`EnsQuery`]. `verified` = the resolution ran against the
+/// beacon-FINALIZED root (the API's meaning of "verified"); the optimistic-head
+/// path reports `false`.
+#[derive(Debug, Clone)]
+pub enum EnsQueryOutcome {
+    /// The record resolved to this value.
+    Value { value: EnsRecordValue, block_number: u64, verified: bool },
+    /// Successfully determined there is no record.
+    NoRecord { block_number: u64, verified: bool },
+    /// The record resolves OFFCHAIN (ERC-3668) — needs a CCIP-Read gateway
+    /// (EL-C-5-3). Distinguishable from `NoRecord` by design.
+    Offchain { block_number: u64, verified: bool },
+}
+
 /// Build a [`BlockContext`] from a verified head header. `chain_id` comes from the
 /// chain config (the header carries no chain id).
 pub fn block_context(header: &BlockHeader, chain_id: u64) -> Result<BlockContext, String> {

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -257,6 +257,14 @@ const EVM_PROOF_CACHE_ENTRIES: usize = 8192;
 /// promises a bounded worst case of ~2 min).
 const RESOLVE_ENS_DEADLINE: std::time::Duration = std::time::Duration::from_secs(120);
 
+/// Per-ATTEMPT deadline inside the ENS root ladder (the Java
+/// `VerifiedRpcBackend.ENS_TIMEOUT_SEC` twin): AUTO runs up to two attempts
+/// (finalized, then optimistic), each bounded here, with
+/// [`RESOLVE_ENS_DEADLINE`] as the outer cap on the whole query — so a stalled
+/// finalized attempt can't consume the optimistic attempt's budget, and the
+/// JNI caller's total block time stays within the API's ~2 min contract.
+const RESOLVE_ENS_ATTEMPT_DEADLINE: std::time::Duration = std::time::Duration::from_secs(60);
+
 impl ElReader {
     /// Start a mainnet reader with a freshly-generated ephemeral node key (the
     /// CL side generates its libp2p identity per run too; a persistent EL
@@ -756,23 +764,31 @@ impl ElReader {
         chain_id: u64,
         root: EnsRootMode,
     ) -> Result<EnsQueryOutcome, String> {
-        match root {
-            EnsRootMode::Finalized => self.ens_attempt(query, chain_id, true).await,
-            EnsRootMode::Optimistic => self.ens_attempt(query, chain_id, false).await,
-            EnsRootMode::Auto => {
-                match self.ens_attempt(query.clone(), chain_id, true).await {
-                    // A finalized value / offchain marker is the answer (an
-                    // offchain gateway response won't change with the root).
-                    Ok(out @ EnsQueryOutcome::Value { .. })
-                    | Ok(out @ EnsQueryOutcome::Offchain { .. }) => Ok(out),
-                    // No record at the finalized root, or the finalized attempt
-                    // itself failed → the optimistic head decides.
-                    Ok(EnsQueryOutcome::NoRecord { .. }) | Err(_) => {
-                        self.ens_attempt(query, chain_id, false).await
+        // ONE outer deadline over the whole query — including context setups and
+        // both AUTO attempts — so the (synchronously blocking) JNI caller's worst
+        // case stays within the API's ~2 min contract regardless of root mode.
+        let ladder = async {
+            match root {
+                EnsRootMode::Finalized => self.ens_attempt(query, chain_id, true).await,
+                EnsRootMode::Optimistic => self.ens_attempt(query, chain_id, false).await,
+                EnsRootMode::Auto => {
+                    match self.ens_attempt(query.clone(), chain_id, true).await {
+                        // A finalized value / offchain marker is the answer (an
+                        // offchain gateway response won't change with the root).
+                        Ok(out @ EnsQueryOutcome::Value { .. })
+                        | Ok(out @ EnsQueryOutcome::Offchain { .. }) => Ok(out),
+                        // No record at the finalized root, or the finalized attempt
+                        // itself failed → the optimistic head decides.
+                        Ok(EnsQueryOutcome::NoRecord { .. }) | Err(_) => {
+                            self.ens_attempt(query, chain_id, false).await
+                        }
                     }
                 }
             }
-        }
+        };
+        tokio::time::timeout(RESOLVE_ENS_DEADLINE, ladder)
+            .await
+            .map_err(|_| "resolve-ens timed out".to_string())?
     }
 
     /// One resolution attempt against one root (finalized or optimistic).
@@ -792,11 +808,13 @@ impl ElReader {
             let caller = ExecutorCaller { executor: &executor, ctx: &ctx };
             run_ens_query(&caller, &query)
         });
-        // Same overall deadline as resolve_ens — the walk is a chain of
-        // per-request-bounded peer calls that must not multiply unbounded.
-        let joined = tokio::time::timeout(RESOLVE_ENS_DEADLINE, walk)
+        // Per-attempt deadline (Java ENS_TIMEOUT_SEC twin): a stalled finalized
+        // walk must leave budget for AUTO's optimistic attempt under the outer
+        // cap. The timed-out spawn_blocking closure still runs out its in-flight
+        // peer call (can't be cancelled) — only the caller is released.
+        let joined = tokio::time::timeout(RESOLVE_ENS_ATTEMPT_DEADLINE, walk)
             .await
-            .map_err(|_| "resolve-ens timed out".to_string())?
+            .map_err(|_| "resolve-ens attempt timed out".to_string())?
             .map_err(|e| format!("resolve-ens task join error: {e}"))?;
         match joined {
             Ok(Some(value)) => Ok(EnsQueryOutcome::Value { value, block_number, verified: finalized }),

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -35,7 +35,10 @@ use myotis_evm::{
 use crate::el::anchor::ExecAnchor;
 use crate::el::discv4::{Discv4Config, Discv4Service};
 use crate::el::eth::session::EthConfig;
-use crate::el::evm::{block_context, CallOutcome, EnsOutcome, GasOutcome, PoolOracle};
+use crate::el::evm::{
+    block_context, CallOutcome, EnsOutcome, EnsQuery, EnsQueryOutcome, EnsRecordValue,
+    EnsRootMode, GasOutcome, PoolOracle,
+};
 use crate::el::peer::ManagedPeer;
 use crate::el::pool::{PeerPool, PoolConfig};
 use crate::el::snap::fetch::AccountOutcome;
@@ -740,6 +743,111 @@ impl ElReader {
         }
     }
 
+    /// One [`EnsQuery`] against the root the caller demands (EL-C-5-2). `Auto`
+    /// mirrors the Java ladder: attempt the beacon-FINALIZED root first and
+    /// return its answer when it produced a value or an offchain marker;
+    /// otherwise (no record, or the finalized attempt failed — e.g. no peer
+    /// still serves that root) retry against the optimistic head. `Finalized`
+    /// fails closed instead of downgrading. `verified` in the outcome = "ran
+    /// against the finalized root".
+    pub async fn resolve_ens_query(
+        &self,
+        query: EnsQuery,
+        chain_id: u64,
+        root: EnsRootMode,
+    ) -> Result<EnsQueryOutcome, String> {
+        match root {
+            EnsRootMode::Finalized => self.ens_attempt(query, chain_id, true).await,
+            EnsRootMode::Optimistic => self.ens_attempt(query, chain_id, false).await,
+            EnsRootMode::Auto => {
+                match self.ens_attempt(query.clone(), chain_id, true).await {
+                    // A finalized value / offchain marker is the answer (an
+                    // offchain gateway response won't change with the root).
+                    Ok(out @ EnsQueryOutcome::Value { .. })
+                    | Ok(out @ EnsQueryOutcome::Offchain { .. }) => Ok(out),
+                    // No record at the finalized root, or the finalized attempt
+                    // itself failed → the optimistic head decides.
+                    Ok(EnsQueryOutcome::NoRecord { .. }) | Err(_) => {
+                        self.ens_attempt(query, chain_id, false).await
+                    }
+                }
+            }
+        }
+    }
+
+    /// One resolution attempt against one root (finalized or optimistic).
+    async fn ens_attempt(
+        &self,
+        query: EnsQuery,
+        chain_id: u64,
+        finalized: bool,
+    ) -> Result<EnsQueryOutcome, String> {
+        let (ctx, executor) = if finalized {
+            self.evm_setup_finalized(chain_id, "resolve-ens").await?
+        } else {
+            self.evm_setup(chain_id, "resolve-ens").await?
+        };
+        let block_number = ctx.block_number;
+        let walk = tokio::task::spawn_blocking(move || {
+            let caller = ExecutorCaller { executor: &executor, ctx: &ctx };
+            run_ens_query(&caller, &query)
+        });
+        // Same overall deadline as resolve_ens — the walk is a chain of
+        // per-request-bounded peer calls that must not multiply unbounded.
+        let joined = tokio::time::timeout(RESOLVE_ENS_DEADLINE, walk)
+            .await
+            .map_err(|_| "resolve-ens timed out".to_string())?
+            .map_err(|e| format!("resolve-ens task join error: {e}"))?;
+        match joined {
+            Ok(Some(value)) => Ok(EnsQueryOutcome::Value { value, block_number, verified: finalized }),
+            Ok(None) => Ok(EnsQueryOutcome::NoRecord { block_number, verified: finalized }),
+            Err(EnsError::OffchainLookup) => {
+                Ok(EnsQueryOutcome::Offchain { block_number, verified: finalized })
+            }
+            Err(e) => Err(e.to_string()),
+        }
+    }
+
+    /// [`Self::evm_setup`], anchored at the beacon-FINALIZED execution block
+    /// instead of the optimistic head. The header is fetched over the verified
+    /// hash-chain window and then CROSS-CHECKED against the finalized anchor's
+    /// own hash + state root, so the context provably IS the finalized state.
+    /// Note the servable-edge caveat: execution peers prune state, so a
+    /// finalized root (~2 epochs back) can be unservable — that fails closed
+    /// here or in the oracle, and AUTO falls back to the optimistic head.
+    async fn evm_setup_finalized(
+        &self,
+        chain_id: u64,
+        what: &str,
+    ) -> Result<(myotis_evm::BlockContext, EvmExecutor), String> {
+        let Some(fin) = self.anchor.finalized_execution() else {
+            return Err(format!("no beacon-finalized execution block for {what}"));
+        };
+        let Some(block) = self.get_block_by_number(Some(fin.block_number)).await? else {
+            return Err(format!(
+                "finalized block {} not fetchable for {what}",
+                fin.block_number
+            ));
+        };
+        // The window walk verified hash-linkage to the optimistic head; also pin
+        // the header to the finalized anchor itself (belt and braces — the
+        // finalized payload is the trust anchor this mode advertises).
+        if block.hash != fin.block_hash {
+            return Err(format!(
+                "finalized-block hash mismatch at {} for {what}",
+                fin.block_number
+            ));
+        }
+        if block.header.state_root != fin.state_root {
+            return Err(format!(
+                "finalized-block state-root mismatch at {} for {what}",
+                fin.block_number
+            ));
+        }
+        let ctx = block_context(&block.header, chain_id)?;
+        self.evm_executor_for(ctx, what).await
+    }
+
     /// Shared setup for the EVM reads: a [`BlockContext`](myotis_evm::BlockContext)
     /// from the verified head + an [`EvmExecutor`] over a fresh snap-peer snapshot and
     /// the reader's cross-call caches. `what` names the caller in the error messages.
@@ -752,6 +860,16 @@ impl ElReader {
             return Err(format!("no verified head to run {what} against"));
         };
         let ctx = block_context(&block.header, chain_id)?;
+        self.evm_executor_for(ctx, what).await
+    }
+
+    /// The executor half of the EVM setup: a fresh snap-peer snapshot + the
+    /// reader's cross-call caches bound over the given context.
+    async fn evm_executor_for(
+        &self,
+        ctx: myotis_evm::BlockContext,
+        what: &str,
+    ) -> Result<(myotis_evm::BlockContext, EvmExecutor), String> {
         // Snapshot the snap peers once: one consistent set for the whole call.
         let peers = self.pool.snap_peers().await;
         if peers.is_empty() {
@@ -1151,6 +1269,46 @@ fn next_base_fee_calc(base: u128, gas_limit: u64, gas_used: u64) -> u128 {
         let delta = base.saturating_mul((gas_target - gas_used) as u128) / target / 8;
         base.saturating_sub(delta)
     }
+}
+
+/// Dispatch one [`EnsQuery`] to its `myotis_evm::ens` resolver function,
+/// folding each typed answer into [`EnsRecordValue`]. Runs on a blocking
+/// thread (every step's oracle fetch bridges via `block_on`).
+fn run_ens_query(
+    caller: &dyn myotis_evm::EthCaller,
+    query: &EnsQuery,
+) -> Result<Option<EnsRecordValue>, EnsError> {
+    Ok(match query {
+        EnsQuery::Addr { name } => {
+            myotis_evm::resolve_address(caller, name)?.map(EnsRecordValue::Address)
+        }
+        EnsQuery::Text { name, key } => {
+            myotis_evm::resolve_text(caller, name, key)?.map(EnsRecordValue::Text)
+        }
+        EnsQuery::Contenthash { name } => {
+            myotis_evm::resolve_contenthash(caller, name)?.map(EnsRecordValue::Bytes)
+        }
+        EnsQuery::Multicoin { name, coin_type } => {
+            myotis_evm::resolve_multicoin(caller, name, *coin_type)?.map(EnsRecordValue::Bytes)
+        }
+        EnsQuery::Pubkey { name } => myotis_evm::resolve_pubkey(caller, name)?
+            .map(|(x, y)| EnsRecordValue::Pubkey { x, y }),
+        EnsQuery::Abi { name, content_types } => {
+            myotis_evm::resolve_abi(caller, name, *content_types)?
+                .map(|(content_type, data)| EnsRecordValue::Abi { content_type, data })
+        }
+        EnsQuery::DnsRecord { name, dns_name, resource } => {
+            myotis_evm::resolve_dns_record(caller, name, dns_name, *resource)?
+                .map(EnsRecordValue::Bytes)
+        }
+        EnsQuery::Interface { name, interface_id } => {
+            myotis_evm::resolve_interface_implementer(caller, name, *interface_id)?
+                .map(EnsRecordValue::Address)
+        }
+        EnsQuery::Reverse { address } => {
+            myotis_evm::reverse_resolve(caller, *address)?.map(EnsRecordValue::Name)
+        }
+    })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes the largest remaining ENS gap on the Rust engine: all record types, reverse resolution, and real root modes — leaving only CCIP-Read (EL-C-5-3) as a follow-up.

## What changed

**Rust resolver (`myotis-evm::ens`)**
- The walk is generalized into `resolve_record` (registry walk → ENSIP-10 wrap-or-legacy dispatch → raw inner bytes); `resolve_address` is refactored onto it with behavior preserved.
- Typed wrappers with Java empty-record parity: `text` (empty string→none), `contenthash`/`multicoin`/`dnsRecord` (empty bytes→none), `pubkey` (fixed tuple, BOTH-zero→none), `ABI` (empty data→none, contentType word unchecked — `decodeAbiResult` parity), `interfaceImplementer` (zero address→none).
- **dnsRecord deliberately ports the JAVA engine's signature** `dnsRecord(bytes32,bytes,uint16)` = `0xee8de1f7` (raw DNS wire name) — byte-for-byte parity with `EnsResolver`. Note: this differs from the deployed mainnet PublicResolver ABI (`dnsRecord(bytes32,bytes32,uint16)` = `0xa8fa5682`, keccak of the wire name), so DNS-record lookups likely miss against real resolvers on BOTH engines — flagged in the plan doc as an upstream (Java-first) fix.
- `reverse_resolve`: EXACT `<hex>.addr.reverse` lookup (no walk / no supportsInterface / no wrap — `resolveName` parity), `name(bytes32)`, then **mandatory forward-verify** through the full forward path; empty record / no resolver / failed verify are one indistinguishable none. Documented divergence: plain reverts during the reverse lookup fold to no-record (Java errors) — consistent with the forward path's revert classification.
- New ABI helpers (mixed static/dynamic encoders, string/tuple/uint-bytes decoders), all bounds-checked and panic-free; selectors pinned incl. `0xee8de1f7` and `interfaceImplementer` `0x124a319c`.

**Root modes (reader)**
- `Finalized`: `BlockContext` anchored at `ExecAnchor::finalized_execution()` — header fetched over the verified window, then pinned to the finalized block hash + state root; fails closed (peers may prune the ~2-epoch-old root).
- `Auto`: finalized-first ladder (a finalized Value/Offchain is returned; NoRecord or attempt error falls back to the optimistic head) — the Java `resolveRecordWithMode` shape.
- `Optimistic`: the Java `PEER_HEAD` twin (beacon-anchored here — strictly stronger than a peer-claimed head).
- `verified` in results now means what the API says: "resolved against the beacon-FINALIZED root".
- Deadlines: one outer 120 s cap over the whole query (setups + both AUTO attempts), 60 s per attempt (the Java `ENS_TIMEOUT_SEC` twin).

**JNI + Java**
- ONE generic `nativeEnsRecordJson(handle, paramsJson)` dispatch — record types don't multiply natives (ABI 11 → 12; jniLibs refresh follows as a separate PR like #196).
- `RustEnsApi` implements the full `EnsApi` over it: never throws (documented divergence — every failure folds into the result's `error`), `resolveAddress` honors the caller's root, records/reverse hardcode AUTO (JavaEnsApi parity), fail-closed envelope parsing (`status`/`blockNumber`/`verified` mandatory; `status=ok` without its value field is shape drift, never a silent no-record).
- Cross-language goldens: `eljson::ens_record_json_shapes` ↔ `RustEnsRecordJsonTest` (same literals both sides).
- The daemon gains a `reverse-ens` CLI command (works on both engines).

## Testing

- 258 Rust tests green (new: per-record mock-walk tests, ENSIP-10 wrap-for-records, reverse forward-verify + impersonation rejection, malformed-name ordering, ABI encoder/decoder shapes + adversarial bounds); `:myotis-engines:test` green; full `./gradlew build` green.
- **Live on a SYNCED sepolia daemon with `-Pengine=rust`**: forward addr resolved **against the finalized root** (`beaconVerified:true`, block 11242016 — the first finalized-root ENS resolution on this engine); multicoin (coinType 60) returned the real record; text/contenthash/interfaceImplementer/reverse returned clean full-walk no-records; `get-account` regression gate passed.

## Review note

An independent no-context review confirmed the ABI encoders byte-identical to the Java `AbiEncoder`, decoders panic-free, and empty-record semantics per record; its findings (whitespace text values wrongly rejected by the Java parser; AUTO exceeding the ~2 min contract; dns_encode ordering; reverse-revert divergence undocumented) are all fixed/documented in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PP9WX3oschsX9T4AAKpdim