### PR TITLE
EL-C-5-3: CCIP-Read (ERC-3668) on the Rust engine

### DIFF
--- a/docs/reimplementation/07-el-implementation-plan.md
+++ b/docs/reimplementation/07-el-implementation-plan.md
@@ -441,8 +441,23 @@ Spec: doc 03 §§3–7, doc 04 §3. New crate `myotis-evm` (sans-I/O; revm gated
      divergence), `resolveAddress` honors the caller's root, records/reverse hardcode AUTO
      (JavaEnsApi parity). Cross-language goldens: `eljson::ens_record_json_shapes` ↔
      `RustEnsRecordJsonTest`. The daemon gained a `reverse-ens` CLI command (both engines).
-     *Still deferred to C-5-3:* CCIP-Read (offchain names error distinguishably meanwhile);
-     resolver-discovery caching (Java's static 5-min cache) is a later optimisation.
+     *Still deferred:* resolver-discovery caching (Java's static 5-min cache) — a later
+     optimisation.
+   - **Landed (EL-C-5-3): CCIP-Read (ERC-3668).** Split at the HTTP boundary: the NATIVE side
+     decodes the OffchainLookup 5-tuple (Java `OffchainLookupRevert` bounds: body ≥160, ≤32
+     URLs; unparseable → `lookup:None`, still distinguishable from no-record) and carries it +
+     the ENSIP-10 `wrapped` flag through `status:"offchain"` JSON; the HOST (`CcipDriver` in
+     `myotis-engines`) drives the gateway over the `HttpGateway` port — serial URLs, GET iff
+     `{data}` in the template (pre-substitution), else POST `{"sender","data"}`, lenient
+     `"data"` regex extraction, `HttpError` selector `0xca7a4e75` substring scan, per-URL
+     failure reasons — then re-enters via `method:"ccipCallback"` (same dispatch native, ABI
+     stays 12): the callback runs as a verified eth_call against the SAME root kind, its answer
+     is bytes-unwrapped when wrapped and decoded via the shared `decode_*_answer` helpers
+     (reverse claimed-names forward-verify inside the continuation). Recursion cap 1 (Java
+     `MAX_RECURSION_DEPTH`), enforced host-side. CCIP scope divergence (documented): the Java
+     engine's executor-level decorator would gateway ANY call in the walk; the Rust split
+     drives CCIP only for the record call itself (registry/supportsInterface reads never
+     legitimately revert OffchainLookup on-chain). No Rust HTTP dependency, per the plan.
 
 Milestone-C gate: on a SYNCED mainnet daemon with `-Pengine=rust`, a real ERC-20
 `balanceOf` `eth_call`, an `estimateGas` for a token transfer, and a `resolve-ens` of a

--- a/myotis-engines/src/main/java/io/myotis/engines/CcipDriver.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/CcipDriver.java
@@ -28,6 +28,13 @@ import java.util.regex.Pattern;
  * that gateway failing; ONE round only ({@code MAX_RECURSION_DEPTH = 1}) — a
  * second OffchainLookup from the callback is an error.
  *
+ * <p>Documented divergence from the Java engine: Java's per-callView depth
+ * counter lets an OFFCHAIN reverse record be forward-verified by an OFFCHAIN
+ * forward resolver (two independent gateway rounds). Here the forward-verify's
+ * OffchainLookup surfaces as a second offchain envelope and hits the cap — a
+ * rare Basenames-style setup reports the cap error instead of chaining;
+ * chained CCIP is a possible later refinement.
+ *
  * <p>Failures throw {@link EngineException}; {@link RustEnsApi} folds them into
  * the result's error field (it never throws).
  */
@@ -143,6 +150,13 @@ final class CcipDriver {
                     continue;
                 }
                 String dataHex = m.group(1);
+                // Odd-length hex can never decode (Java parity: parseHex throws
+                // inside the per-URL loop) — record and try the NEXT url rather
+                // than letting the native reject it after failover is gone.
+                if (dataHex.length() % 2 != 0) {
+                    reasons.add("odd-length data hex from " + template);
+                    continue;
+                }
                 if (containsHttpError(dataHex)) {
                     reasons.add("gateway HttpError from " + template);
                     continue;

--- a/myotis-engines/src/main/java/io/myotis/engines/CcipDriver.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/CcipDriver.java
@@ -1,0 +1,183 @@
+package io.myotis.engines;
+
+import com.eclipsesource.json.Json;
+import com.eclipsesource.json.JsonObject;
+import com.eclipsesource.json.JsonValue;
+import io.myotis.api.EngineException;
+import io.myotis.api.ports.HttpGateway;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.UnaryOperator;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * The host half of CCIP-Read (ERC-3668) for the Rust engine (EL-C-5-3): the
+ * native resolver reports {@code status:"offchain"} with the decoded
+ * OffchainLookup tuple; this drives the HTTP gateway round (the engine's ONLY
+ * HTTP, via the {@link HttpGateway} port) and re-enters the native resolver
+ * with {@code method:"ccipCallback"} so the callback runs as a verified
+ * eth_call and the answer is decoded with the original record semantics.
+ *
+ * <p>Java-engine parity ({@code CcipReadHandler}/{@code CcipReadEvmExecutor}):
+ * URLs tried SERIALLY, first parseable body wins; GET iff the template contains
+ * {@code {data}} (detected before substitution), else POST with
+ * {@code {"sender":"0x..","data":"0x.."}}; the response's {@code data} field is
+ * extracted with a lenient regex, not a JSON parser; response data containing
+ * the {@code HttpError} selector {@code 0xca7a4e75} at any offset counts as
+ * that gateway failing; ONE round only ({@code MAX_RECURSION_DEPTH = 1}) — a
+ * second OffchainLookup from the callback is an error.
+ *
+ * <p>Failures throw {@link EngineException}; {@link RustEnsApi} folds them into
+ * the result's error field (it never throws).
+ */
+final class CcipDriver {
+
+    /** Java {@code CcipReadHandler.MAX_RECURSION_DEPTH} twin. */
+    static final int MAX_ROUNDS = 1;
+
+    /** Lenient {@code "data":"0x…"} extraction — Java parity (not a JSON parser). */
+    private static final Pattern DATA_FIELD =
+            Pattern.compile("\"data\"\\s*:\\s*\"(0x[0-9a-fA-F]*)\"");
+
+    private CcipDriver() {
+    }
+
+    /**
+     * Drive CCIP rounds until the record JSON is not an offchain-with-tuple
+     * marker. Returns the final record JSON (which may still be a plain
+     * {@code offchain} without tuple fields — the parsers report that as the
+     * descriptive offchain error). {@code nativeCall} is the ccipCallback
+     * transport seam (the real one calls {@code nativeEnsRecordJson}).
+     */
+    static String drive(JsonObject originalParams, String json, HttpGateway gateway,
+            UnaryOperator<String> nativeCall) {
+        for (int round = 0; ; round++) {
+            JsonValue parsed;
+            try {
+                parsed = Json.parse(json);
+            } catch (RuntimeException e) {
+                return json; // let the record parsers fail closed on it
+            }
+            if (!parsed.isObject()) {
+                return json;
+            }
+            JsonObject o = parsed.asObject();
+            var status = o.get("status");
+            var sender = o.get("senderHex");
+            if (o.get("error") != null || status == null || !status.isString()
+                    || !"offchain".equals(status.asString())
+                    || sender == null || !sender.isString()) {
+                // Not an actionable offchain marker (includes the unparseable-
+                // tuple case: offchain without senderHex) — hand it back.
+                return json;
+            }
+            if (gateway == null) {
+                throw new EngineException(
+                        "name resolves offchain (ERC-3668) and no CCIP-Read HTTP gateway"
+                        + " is configured on this host");
+            }
+            if (round >= MAX_ROUNDS) {
+                // Java parity message shape (CcipReadEvmExecutor's cap).
+                throw new EngineException(
+                        "CCIP-Read recursion depth " + MAX_ROUNDS + " exceeds cap " + MAX_ROUNDS);
+            }
+            String senderHex = sender.asString();
+            String callDataHex = requireString(o, "callDataHex");
+            String callbackHex = requireString(o, "callbackFunctionHex");
+            String extraDataHex = requireString(o, "extraDataHex");
+            List<String> urls = new ArrayList<>();
+            var urlsVal = o.get("urls");
+            if (urlsVal != null && urlsVal.isArray()) {
+                urlsVal.asArray().forEach(u -> {
+                    if (u.isString()) {
+                        urls.add(u.asString());
+                    }
+                });
+            }
+            String responseHex = fetch(gateway, senderHex, callDataHex, urls);
+
+            JsonObject cb = Json.object();
+            for (String name : originalParams.names()) {
+                cb.add(name, originalParams.get(name));
+            }
+            cb.set("method", "ccipCallback");
+            cb.add("queryMethod", originalParams.getString("method", ""));
+            cb.add("senderHex", senderHex);
+            cb.add("callbackFunctionHex", callbackHex);
+            cb.add("responseHex", responseHex);
+            cb.add("extraDataHex", extraDataHex);
+            cb.add("wrapped", o.getBoolean("wrapped", false));
+            // The callback must run against the same root kind the offchain
+            // attempt did (verified == finalized in the record envelope).
+            cb.add("finalized", o.getBoolean("verified", false));
+            json = nativeCall.apply(cb.toString());
+        }
+    }
+
+    /**
+     * Try the gateway URLs serially; return the first parseable {@code data}
+     * payload. Throws {@link EngineException} with per-URL reasons when all
+     * fail (Java {@code CcipGatewayFailed} shape).
+     */
+    private static String fetch(HttpGateway gateway, String senderHex, String callDataHex,
+            List<String> urls) {
+        if (urls.isEmpty()) {
+            throw new EngineException("CCIP-Read gateway failed: OffchainLookup carried no URLs");
+        }
+        List<String> reasons = new ArrayList<>();
+        for (String template : urls) {
+            try {
+                // GET iff the template consumes the data inline — decided
+                // BEFORE substitution (Java parity).
+                boolean get = template.contains("{data}");
+                String url = template.replace("{sender}", senderHex)
+                        .replace("{data}", callDataHex);
+                String body = get ? null
+                        : "{\"sender\":\"" + senderHex + "\",\"data\":\"" + callDataHex + "\"}";
+                String response = gateway.request(
+                        get ? HttpGateway.Method.GET : HttpGateway.Method.POST, url, body);
+                Matcher m = response == null ? null : DATA_FIELD.matcher(response);
+                if (m == null || !m.find()) {
+                    reasons.add("non-200 or unparseable response from " + template);
+                    continue;
+                }
+                String dataHex = m.group(1);
+                if (containsHttpError(dataHex)) {
+                    reasons.add("gateway HttpError from " + template);
+                    continue;
+                }
+                return dataHex;
+            } catch (RuntimeException e) {
+                reasons.add(template + ": " + e.getClass().getSimpleName()
+                        + (e.getMessage() != null ? ": " + e.getMessage() : ""));
+            }
+        }
+        throw new EngineException("CCIP-Read gateway failed: " + String.join("; ", reasons));
+    }
+
+    /**
+     * The batch-gateway {@code HttpError} selector {@code 0xca7a4e75} at ANY
+     * even hex offset in the response data (Java's substring scan over the
+     * decoded bytes — scanning the hex at even offsets is byte-equivalent).
+     */
+    private static boolean containsHttpError(String dataHex) {
+        String bare = dataHex.startsWith("0x") ? dataHex.substring(2) : dataHex;
+        String needle = "ca7a4e75";
+        String lower = bare.toLowerCase(java.util.Locale.ROOT);
+        for (int i = 0; i + needle.length() <= lower.length(); i += 2) {
+            if (lower.startsWith(needle, i)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String requireString(JsonObject o, String key) {
+        var v = o.get(key);
+        if (v == null || !v.isString()) {
+            throw new EngineException("offchain JSON: missing " + key);
+        }
+        return v.asString();
+    }
+}

--- a/myotis-engines/src/main/java/io/myotis/engines/CcipDriver.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/CcipDriver.java
@@ -178,9 +178,10 @@ final class CcipDriver {
     private static boolean containsHttpError(String dataHex) {
         String bare = dataHex.startsWith("0x") ? dataHex.substring(2) : dataHex;
         String needle = "ca7a4e75";
-        String lower = bare.toLowerCase(java.util.Locale.ROOT);
-        for (int i = 0; i + needle.length() <= lower.length(); i += 2) {
-            if (lower.startsWith(needle, i)) {
+        // regionMatches(ignoreCase) scans in place — no lowercase copy of a
+        // potentially multi-MB L2-proof response.
+        for (int i = 0; i + needle.length() <= bare.length(); i += 2) {
+            if (bare.regionMatches(true, i, needle, 0, needle.length())) {
                 return true;
             }
         }

--- a/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
@@ -80,11 +80,24 @@ final class RustChainHandle implements ChainHandle, NodeStatusReads {
     private long lastHeadBlock = -1L;
     private long lastHeadAdvanceNanos;
 
+    /** CCIP-Read HTTP transport from EnginePorts; null = offchain names error. */
+    private final io.myotis.api.ports.HttpGateway httpGateway;
+
     RustChainHandle(long handle, String networkName, long chainId, int rpcPort) {
+        this(handle, networkName, chainId, rpcPort, null);
+    }
+
+    RustChainHandle(long handle, String networkName, long chainId, int rpcPort,
+            io.myotis.api.ports.HttpGateway httpGateway) {
         this.handle = handle;
         this.networkName = networkName;
         this.chainId = chainId;
         this.rpcPort = rpcPort;
+        this.httpGateway = httpGateway;
+    }
+
+    io.myotis.api.ports.HttpGateway httpGateway() {
+        return httpGateway;
     }
 
     @Override public String networkName() { return networkName; }

--- a/myotis-engines/src/main/java/io/myotis/engines/RustEnsApi.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustEnsApi.java
@@ -20,8 +20,12 @@ import io.myotis.api.EnsTextResult;
  * ONE generic dispatch native ({@code nativeEnsRecordJson}) — forward address,
  * text, contenthash, multi-coin, pubkey, ABI, dnsRecord, interfaceImplementer,
  * and reverse resolution with mandatory forward-verify (EL-C-5-2). CCIP-Read
- * (ERC-3668 offchain names) is the remaining slice (EL-C-5-3): an offchain name
- * reports a descriptive error, distinguishable from "no record".
+ * (ERC-3668, EL-C-5-3) is driven host-side: the native resolver surfaces the
+ * OffchainLookup tuple, {@link CcipDriver} performs the gateway round over the
+ * {@link io.myotis.api.ports.HttpGateway} port, and the callback re-enters the
+ * native resolver as a verified eth_call. Without a configured gateway (or on
+ * an unparseable tuple) an offchain name reports a descriptive error,
+ * distinguishable from "no record".
  *
  * <p>Roots: {@code resolveAddress} honors the caller's {@link EnsRoot} —
  * FINALIZED resolves against the beacon-FINALIZED execution root and fails
@@ -40,9 +44,13 @@ import io.myotis.api.EnsTextResult;
  */
 final class RustEnsApi implements EnsApi {
 
-    /** The offchain-name error until CCIP-Read lands (EL-C-5-3). */
+    /**
+     * The error for an offchain name that CCIP could NOT be driven for: the
+     * OffchainLookup tuple didn't parse (the driver only acts on a full tuple)
+     * — or a stale native returned offchain without one.
+     */
     private static final String OFFCHAIN =
-            "name resolves offchain (ERC-3668); CCIP-Read not yet supported on the rust engine";
+            "name resolves offchain (ERC-3668) but the OffchainLookup was not actionable";
 
     private final RustChainHandle handle;
 
@@ -59,7 +67,7 @@ final class RustEnsApi implements EnsApi {
         }
         try {
             JsonObject params = params("addr").add("name", name).add("root", rootParam(root));
-            return addressFromJson(name, handle.ensRecordJson(params.toString()));
+            return addressFromJson(name, exec(params));
         } catch (RuntimeException e) {
             return new EnsResolutionResult(name, null, -1, false, why(e));
         }
@@ -90,7 +98,7 @@ final class RustEnsApi implements EnsApi {
         String canonical = "0x" + bare;
         try {
             JsonObject params = params("reverse").add("addressHex", canonical);
-            return reverseFromJson(canonical, handle.ensRecordJson(params.toString()));
+            return reverseFromJson(canonical, exec(params));
         } catch (RuntimeException e) {
             return new EnsResolutionResult(null, canonical, -1, false, why(e));
         }
@@ -123,7 +131,7 @@ final class RustEnsApi implements EnsApi {
         }
         try {
             JsonObject params = params("text").add("name", name).add("key", key);
-            return textFromJson(name, key, handle.ensRecordJson(params.toString()));
+            return textFromJson(name, key, exec(params));
         } catch (RuntimeException e) {
             return new EnsTextResult(name, key, null, -1, false, why(e));
         }
@@ -147,7 +155,7 @@ final class RustEnsApi implements EnsApi {
         }
         try {
             JsonObject params = params("contenthash").add("name", name);
-            return contenthashFromJson(name, handle.ensRecordJson(params.toString()));
+            return contenthashFromJson(name, exec(params));
         } catch (RuntimeException e) {
             return new EnsContenthashResult(name, null, -1, false, why(e));
         }
@@ -174,7 +182,7 @@ final class RustEnsApi implements EnsApi {
         }
         try {
             JsonObject params = params("multicoin").add("name", name).add("coinType", coinType);
-            return multiCoinFromJson(name, coinType, handle.ensRecordJson(params.toString()));
+            return multiCoinFromJson(name, coinType, exec(params));
         } catch (RuntimeException e) {
             return new EnsMultiCoinResult(name, coinType, null, -1, false, why(e));
         }
@@ -199,7 +207,7 @@ final class RustEnsApi implements EnsApi {
         }
         try {
             JsonObject params = params("pubkey").add("name", name);
-            return pubkeyFromJson(name, handle.ensRecordJson(params.toString()));
+            return pubkeyFromJson(name, exec(params));
         } catch (RuntimeException e) {
             return new EnsPubkeyResult(name, null, null, -1, false, why(e));
         }
@@ -226,7 +234,7 @@ final class RustEnsApi implements EnsApi {
         }
         try {
             JsonObject params = params("abi").add("name", name).add("contentTypes", contentTypes);
-            return abiFromJson(name, handle.ensRecordJson(params.toString()));
+            return abiFromJson(name, exec(params));
         } catch (RuntimeException e) {
             return new EnsAbiResult(name, 0, null, -1, false, why(e));
         }
@@ -262,7 +270,7 @@ final class RustEnsApi implements EnsApi {
             JsonObject params = params("dnsRecord")
                     .add("name", name).add("dnsName", dnsName).add("resource", recordType);
             return dnsRecordFromJson(
-                    name, dnsName, recordType, handle.ensRecordJson(params.toString()));
+                    name, dnsName, recordType, exec(params));
         } catch (RuntimeException e) {
             return new EnsDnsRecordResult(name, dnsName, recordType, null, -1, false, why(e));
         }
@@ -301,7 +309,7 @@ final class RustEnsApi implements EnsApi {
         try {
             JsonObject params = params("interfaceImplementer")
                     .add("name", name).add("interfaceIdHex", idHex);
-            return interfaceFromJson(name, idHex, handle.ensRecordJson(params.toString()));
+            return interfaceFromJson(name, idHex, exec(params));
         } catch (RuntimeException e) {
             return new EnsInterfaceResult(name, idHex, null, -1, false, why(e));
         }
@@ -319,6 +327,18 @@ final class RustEnsApi implements EnsApi {
     }
 
     // ---- plumbing ----
+
+    /**
+     * One native record query + any CCIP-Read rounds it demands (EL-C-5-3):
+     * an offchain answer with a parsed tuple drives the HttpGateway via
+     * {@link CcipDriver} and re-enters the native callback path; everything
+     * else passes straight through to the record parsers.
+     */
+    private String exec(JsonObject params) {
+        String json = handle.ensRecordJson(params.toString());
+        return CcipDriver.drive(params, json, handle.httpGateway(),
+                p -> handle.ensRecordJson(p));
+    }
 
     private static JsonObject params(String method) {
         return Json.object().add("method", method);

--- a/myotis-engines/src/main/java/io/myotis/engines/RustMyotisEngine.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustMyotisEngine.java
@@ -130,7 +130,8 @@ public final class RustMyotisEngine implements MyotisEngine {
         // Mirror JavaMyotisEngine: honour a host-supplied RPC port, else the
         // network's catalog default (mainnet 8545, sepolia 8547, ...).
         int rpcPort = config.rpcPort() > 0 ? config.rpcPort() : net.defaultRpcPort();
-        RustChainHandle handle = new RustChainHandle(id, canonical, net.chainId(), rpcPort);
+        RustChainHandle handle = new RustChainHandle(id, canonical, net.chainId(), rpcPort,
+                ports != null ? ports.httpGateway() : null);
         // Atomic claim (mirrors JavaMyotisEngine.putIfAbsent): reject a re-create rather
         // than orphaning the previous handle's native entry. On a lost race, release the
         // native handle we just allocated so it doesn't leak a tokio/libp2p host.

--- a/myotis-engines/src/test/java/io/myotis/engines/CcipDriverTest.java
+++ b/myotis-engines/src/test/java/io/myotis/engines/CcipDriverTest.java
@@ -1,0 +1,163 @@
+package io.myotis.engines;
+
+import com.eclipsesource.json.Json;
+import com.eclipsesource.json.JsonObject;
+import io.myotis.api.EngineException;
+import io.myotis.api.ports.HttpGateway;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** The host half of CCIP-Read, driven with fakes — no JNI, no HTTP. */
+class CcipDriverTest {
+
+    private static final String SENDER = "0x" + "5e".repeat(20);
+
+    private static String offchainJson(String... urls) {
+        StringBuilder u = new StringBuilder();
+        for (String url : urls) {
+            if (u.length() > 0) {
+                u.append(',');
+            }
+            u.append('"').append(url).append('"');
+        }
+        return "{\"status\":\"offchain\",\"blockNumber\":21000010,\"verified\":true,"
+                + "\"wrapped\":true,\"senderHex\":\"" + SENDER + "\",\"urls\":[" + u + "],"
+                + "\"callDataHex\":\"0xca11\",\"callbackFunctionHex\":\"0xcbcbcbcb\","
+                + "\"extraDataHex\":\"0xeeeeee\"}";
+    }
+
+    private static JsonObject addrParams() {
+        return Json.object().add("method", "addr").add("name", "offchain.eth").add("root", "auto");
+    }
+
+    /** A scripted gateway recording each request. */
+    private static final class FakeGateway implements HttpGateway {
+        record Req(Method method, String url, String body) {}
+        final List<Req> requests = new ArrayList<>();
+        private final List<Object> outcomes; // String response or RuntimeException
+
+        FakeGateway(Object... outcomes) {
+            this.outcomes = List.of(outcomes);
+        }
+
+        @Override
+        public String request(Method method, String url, String bodyOrNull) {
+            requests.add(new Req(method, url, bodyOrNull));
+            Object o = outcomes.get(Math.min(requests.size() - 1, outcomes.size() - 1));
+            if (o instanceof RuntimeException e) {
+                throw e;
+            }
+            return (String) o;
+        }
+    }
+
+    @Test
+    void getWhenTemplateHasDataPlaceholderAndSubstitutes() {
+        var gw = new FakeGateway("{\"data\":\"0xaa\"}");
+        List<String> nativeCalls = new ArrayList<>();
+        String result = CcipDriver.drive(addrParams(),
+                offchainJson("https://gw.example/{sender}/{data}.json"), gw, p -> {
+                    nativeCalls.add(p);
+                    return "{\"status\":\"ok\",\"blockNumber\":21000010,\"verified\":true,"
+                            + "\"addressHex\":\"0x" + "d8".repeat(20) + "\"}";
+                });
+        assertEquals(1, gw.requests.size());
+        var req = gw.requests.get(0);
+        assertEquals(HttpGateway.Method.GET, req.method());
+        assertEquals("https://gw.example/" + SENDER + "/0xca11.json", req.url());
+        assertEquals(null, req.body());
+        // The callback params carry the original query + the tuple + the response.
+        JsonObject cb = Json.parse(nativeCalls.get(0)).asObject();
+        assertEquals("ccipCallback", cb.getString("method", null));
+        assertEquals("addr", cb.getString("queryMethod", null));
+        assertEquals("offchain.eth", cb.getString("name", null));
+        assertEquals(SENDER, cb.getString("senderHex", null));
+        assertEquals("0xaa", cb.getString("responseHex", null));
+        assertEquals("0xeeeeee", cb.getString("extraDataHex", null));
+        assertTrue(cb.getBoolean("wrapped", false));
+        assertTrue(cb.getBoolean("finalized", false)); // verified:true → same root
+        // And the driver returns the callback's final JSON.
+        assertTrue(result.contains("\"status\":\"ok\""));
+    }
+
+    @Test
+    void postWhenNoDataPlaceholder() {
+        var gw = new FakeGateway("{\"data\":\"0xaa\"}");
+        CcipDriver.drive(addrParams(), offchainJson("https://gw.example/query"), gw,
+                p -> "{\"status\":\"noRecord\",\"blockNumber\":1,\"verified\":false}");
+        var req = gw.requests.get(0);
+        assertEquals(HttpGateway.Method.POST, req.method());
+        assertEquals("{\"sender\":\"" + SENDER + "\",\"data\":\"0xca11\"}", req.body());
+    }
+
+    @Test
+    void urlsTriedSeriallyFirstParseableWins() {
+        var gw = new FakeGateway(
+                new RuntimeException("HTTP 503"),          // url1 transport failure
+                "not json at all",                          // url2 unparseable
+                "{\"data\":\"0x1234\"}");                   // url3 wins
+        List<String> nativeCalls = new ArrayList<>();
+        CcipDriver.drive(addrParams(), offchainJson("u1", "u2", "u3"), gw, p -> {
+            nativeCalls.add(p);
+            return "{\"status\":\"noRecord\",\"blockNumber\":1,\"verified\":false}";
+        });
+        assertEquals(3, gw.requests.size());
+        assertEquals(1, nativeCalls.size());
+        assertTrue(nativeCalls.get(0).contains("\"responseHex\":\"0x1234\""));
+    }
+
+    @Test
+    void httpErrorSelectorCountsAsGatewayFailure() {
+        // 0xca7a4e75 anywhere (even hex offset) in the data → that URL failed.
+        var gw = new FakeGateway("{\"data\":\"0x00ca7a4e7500\"}");
+        EngineException e = assertThrows(EngineException.class, () -> CcipDriver.drive(
+                addrParams(), offchainJson("only"), gw, p -> "unused"));
+        assertTrue(e.getMessage().contains("HttpError"), e.getMessage());
+    }
+
+    @Test
+    void allGatewaysFailingCarriesPerUrlReasons() {
+        var gw = new FakeGateway(new RuntimeException("boom"), "no data field here");
+        EngineException e = assertThrows(EngineException.class, () -> CcipDriver.drive(
+                addrParams(), offchainJson("u1", "u2"), gw, p -> "unused"));
+        assertTrue(e.getMessage().contains("u1"), e.getMessage());
+        assertTrue(e.getMessage().contains("unparseable response from u2"), e.getMessage());
+    }
+
+    @Test
+    void secondOffchainHitsTheRecursionCap() {
+        var gw = new FakeGateway("{\"data\":\"0xaa\"}");
+        // The callback itself reverts OffchainLookup again → cap 1 exceeded.
+        EngineException e = assertThrows(EngineException.class, () -> CcipDriver.drive(
+                addrParams(), offchainJson("u"), gw, p -> offchainJson("u")));
+        assertTrue(e.getMessage().contains("recursion depth"), e.getMessage());
+        assertEquals(1, gw.requests.size()); // no second gateway round
+    }
+
+    @Test
+    void nonActionableJsonPassesThrough() {
+        var gw = new FakeGateway("unused");
+        // ok / noRecord / error / offchain-without-tuple all pass through untouched.
+        for (String json : new String[] {
+                "{\"status\":\"ok\",\"blockNumber\":1,\"verified\":false,\"addressHex\":\"0xab\"}",
+                "{\"status\":\"noRecord\",\"blockNumber\":1,\"verified\":false}",
+                "{\"error\":\"no snap peer\"}",
+                "{\"status\":\"offchain\",\"blockNumber\":1,\"verified\":false,\"wrapped\":false}",
+                "not json"}) {
+            assertEquals(json, CcipDriver.drive(addrParams(), json, gw, p -> "unused"));
+        }
+        assertEquals(0, gw.requests.size());
+    }
+
+    @Test
+    void offchainWithoutGatewayIsAnError() {
+        EngineException e = assertThrows(EngineException.class, () -> CcipDriver.drive(
+                addrParams(), offchainJson("u"), null, p -> "unused"));
+        assertTrue(e.getMessage().contains("no CCIP-Read HTTP gateway"), e.getMessage());
+    }
+}

--- a/myotis-engines/src/test/java/io/myotis/engines/CcipDriverTest.java
+++ b/myotis-engines/src/test/java/io/myotis/engines/CcipDriverTest.java
@@ -17,6 +17,11 @@ class CcipDriverTest {
 
     private static final String SENDER = "0x" + "5e".repeat(20);
 
+    /**
+     * The exact envelope {@code eljson::ens_record_json} emits for a parsed
+     * OffchainLookup (its {@code ens_record_json_shapes} test pins the same
+     * literals — the two are the halves of the cross-language pin).
+     */
     private static String offchainJson(String... urls) {
         StringBuilder u = new StringBuilder();
         for (String url : urls) {
@@ -152,6 +157,31 @@ class CcipDriverTest {
             assertEquals(json, CcipDriver.drive(addrParams(), json, gw, p -> "unused"));
         }
         assertEquals(0, gw.requests.size());
+    }
+
+    @Test
+    void oddLengthDataHexFailsOverToNextUrl() {
+        // Odd-length hex can never decode natively — the driver must record it
+        // and try the NEXT url, not ship it to the native after failover ends.
+        var gw = new FakeGateway("{\"data\":\"0xabc\"}", "{\"data\":\"0xabcd\"}");
+        List<String> nativeCalls = new ArrayList<>();
+        CcipDriver.drive(addrParams(), offchainJson("u1", "u2"), gw, p -> {
+            nativeCalls.add(p);
+            return "{\"status\":\"noRecord\",\"blockNumber\":1,\"verified\":false}";
+        });
+        assertEquals(2, gw.requests.size());
+        assertTrue(nativeCalls.get(0).contains("\"responseHex\":\"0xabcd\""));
+    }
+
+    @Test
+    void senderOnlyTemplateIsPostWithSubstitution() {
+        var gw = new FakeGateway("{\"data\":\"0xaa\"}");
+        CcipDriver.drive(addrParams(), offchainJson("https://gw.example/{sender}"), gw,
+                p -> "{\"status\":\"noRecord\",\"blockNumber\":1,\"verified\":false}");
+        var req = gw.requests.get(0);
+        // No {data} in the template → POST, with {sender} still substituted.
+        assertEquals(HttpGateway.Method.POST, req.method());
+        assertEquals("https://gw.example/" + SENDER, req.url());
     }
 
     @Test

--- a/rust/myotis-engine/src/eljson.rs
+++ b/rust/myotis-engine/src/eljson.rs
@@ -706,6 +706,33 @@ mod tests {
         ))
         .unwrap();
         assert_eq!(off["status"], "offchain");
+        assert!(off.get("senderHex").is_none()); // unparseable tuple → no fields
+
+        // The FULL offchain envelope — the exact keys the Java CcipDriver reads
+        // (CcipDriverTest replays this literal as its input; the two are the
+        // halves of the cross-language pin).
+        let full: serde_json::Value = serde_json::from_str(&ens_record_json(
+            &EnsQueryOutcome::Offchain {
+                block_number: 21_000_010,
+                verified: true,
+                lookup: Some(Box::new(myotis_evm::OffchainLookup {
+                    sender: [0x5E; 20],
+                    urls: vec!["https://gw.example/{sender}/{data}.json".into()],
+                    call_data: vec![0xCA, 0x11],
+                    callback_function: [0xCB; 4],
+                    extra_data: vec![0xEE; 3],
+                })),
+                wrapped: true,
+            },
+        ))
+        .unwrap();
+        assert_eq!(full["senderHex"], format!("0x{}", "5e".repeat(20)));
+        assert_eq!(full["urls"][0], "https://gw.example/{sender}/{data}.json");
+        assert_eq!(full["callDataHex"], "0xca11");
+        assert_eq!(full["callbackFunctionHex"], "0xcbcbcbcb");
+        assert_eq!(full["extraDataHex"], "0xeeeeee");
+        assert_eq!(full["wrapped"], true);
+        assert_eq!(full["verified"], true);
     }
 
     fn sample_code() -> VerifiedCode {

--- a/rust/myotis-engine/src/eljson.rs
+++ b/rust/myotis-engine/src/eljson.rs
@@ -327,10 +327,28 @@ pub fn ens_record_json(outcome: &EnsQueryOutcome) -> String {
             obj.insert("blockNumber".into(), json_u64(*block_number));
             obj.insert("verified".into(), (*verified).into());
         }
-        EnsQueryOutcome::Offchain { block_number, verified } => {
+        EnsQueryOutcome::Offchain { block_number, verified, lookup, wrapped } => {
             obj.insert("status".into(), "offchain".into());
             obj.insert("blockNumber".into(), json_u64(*block_number));
             obj.insert("verified".into(), (*verified).into());
+            obj.insert("wrapped".into(), (*wrapped).into());
+            // The gateway tuple, when the revert body parsed — the host drives
+            // the CCIP round with these and re-enters via method:"ccipCallback".
+            if let Some(l) = lookup {
+                obj.insert("senderHex".into(), hex0x_var(&l.sender).into());
+                obj.insert(
+                    "urls".into(),
+                    serde_json::Value::Array(
+                        l.urls.iter().map(|u| u.as_str().into()).collect(),
+                    ),
+                );
+                obj.insert("callDataHex".into(), hex0x_var(&l.call_data).into());
+                obj.insert(
+                    "callbackFunctionHex".into(),
+                    hex0x_var(&l.callback_function).into(),
+                );
+                obj.insert("extraDataHex".into(), hex0x_var(&l.extra_data).into());
+            }
         }
     }
     serde_json::Value::Object(obj).to_string()
@@ -684,7 +702,7 @@ mod tests {
         assert!(none.get("dataHex").is_none());
 
         let off: serde_json::Value = serde_json::from_str(&ens_record_json(
-            &EnsQueryOutcome::Offchain { block_number: 21_000_010, verified: false },
+            &EnsQueryOutcome::Offchain { block_number: 21_000_010, verified: false, lookup: None, wrapped: false },
         ))
         .unwrap();
         assert_eq!(off["status"], "offchain");

--- a/rust/myotis-engine/src/host.rs
+++ b/rust/myotis-engine/src/host.rs
@@ -562,11 +562,12 @@ pub fn resolve_ens_json(handle: i64, name: &str) -> String {
 pub fn ens_record_json(handle: i64, params_json: &str) -> String {
     // Bound the native input like the other JSON natives. ccipCallback carries
     // gateway response payloads (L2-proof gateways return tens of KB), so it
-    // gets a wide bound sized to parse_hex_bytes' own 2 MiB-hex/field cap; the
-    // plain record queries keep the tight name-sized cap. The raw substring
-    // probe only widens the DoS-guard cap — the real method check follows.
-    let cap = if params_json.contains("\"ccipCallback\"") { 5 * 1024 * 1024 } else { 4096 };
-    if params_json.len() > cap {
+    // gets a wide bound sized to parse_hex_bytes' own 2 MiB-hex/field cap; all
+    // other methods keep the tight name-sized cap, enforced AFTER the method is
+    // known (an exact check — a "ccipCallback" substring in some unrelated
+    // field can't widen a record query's cap). Parsing up to the wide bound
+    // first is bounded work.
+    if params_json.len() > 5 * 1024 * 1024 {
         return eljson::error_json("ens params too long");
     }
     let params: serde_json::Value = match serde_json::from_str(params_json) {
@@ -580,6 +581,9 @@ pub fn ens_record_json(handle: i64, params_json: &str) -> String {
     let Some(method) = str_field("method") else {
         return eljson::error_json("missing method");
     };
+    if method != "ccipCallback" && params_json.len() > 4096 {
+        return eljson::error_json("ens params too long");
+    }
     // method:"ccipCallback" re-enters after a host-driven gateway round: the
     // ORIGINAL query travels as queryMethod + its usual fields (drives the
     // decode semantics + reverse forward-verify), plus the callback tuple.

--- a/rust/myotis-engine/src/host.rs
+++ b/rust/myotis-engine/src/host.rs
@@ -560,8 +560,13 @@ pub fn resolve_ens_json(handle: i64, name: &str) -> String {
 /// PEER_HEAD twin). Returns [`eljson::ens_record_json`] shapes or
 /// `{"error":"…"}`.
 pub fn ens_record_json(handle: i64, params_json: &str) -> String {
-    // Bound the native input like the other JSON natives.
-    if params_json.len() > 4096 {
+    // Bound the native input like the other JSON natives. ccipCallback carries
+    // gateway response payloads (L2-proof gateways return tens of KB), so it
+    // gets a wide bound sized to parse_hex_bytes' own 2 MiB-hex/field cap; the
+    // plain record queries keep the tight name-sized cap. The raw substring
+    // probe only widens the DoS-guard cap — the real method check follows.
+    let cap = if params_json.contains("\"ccipCallback\"") { 5 * 1024 * 1024 } else { 4096 };
+    if params_json.len() > cap {
         return eljson::error_json("ens params too long");
     }
     let params: serde_json::Value = match serde_json::from_str(params_json) {
@@ -570,20 +575,6 @@ pub fn ens_record_json(handle: i64, params_json: &str) -> String {
     };
     let str_field = |key: &str| -> Option<String> {
         params.get(key).and_then(|v| v.as_str()).map(str::to_string)
-    };
-    let u64_field = |key: &str| -> Option<u64> { params.get(key).and_then(|v| v.as_u64()) };
-    let name_field = |key: &str| -> Result<String, String> {
-        let Some(name) = str_field(key) else {
-            return Err(format!("missing {key}"));
-        };
-        let name = name.trim().to_string();
-        if name.is_empty() {
-            return Err(format!("empty {key}"));
-        }
-        if name.len() > 512 {
-            return Err(format!("{key} too long"));
-        }
-        Ok(name)
     };
 
     let Some(method) = str_field("method") else {
@@ -615,91 +606,9 @@ pub fn ens_record_json(handle: i64, params_json: &str) -> String {
         },
     };
 
-    let query = match query_method.as_str() {
-        "addr" | "contenthash" | "pubkey" => {
-            let name = match name_field("name") {
-                Ok(n) => n,
-                Err(e) => return eljson::error_json(&e),
-            };
-            match method.as_str() {
-                "addr" => EnsQuery::Addr { name },
-                "contenthash" => EnsQuery::Contenthash { name },
-                _ => EnsQuery::Pubkey { name },
-            }
-        }
-        "text" => {
-            let name = match name_field("name") {
-                Ok(n) => n,
-                Err(e) => return eljson::error_json(&e),
-            };
-            let Some(key) = str_field("key").filter(|k| !k.is_empty()) else {
-                return eljson::error_json("missing key");
-            };
-            if key.len() > 512 {
-                return eljson::error_json("key too long");
-            }
-            EnsQuery::Text { name, key }
-        }
-        "multicoin" => {
-            let name = match name_field("name") {
-                Ok(n) => n,
-                Err(e) => return eljson::error_json(&e),
-            };
-            let Some(coin_type) = u64_field("coinType") else {
-                return eljson::error_json("missing coinType");
-            };
-            EnsQuery::Multicoin { name, coin_type }
-        }
-        "abi" => {
-            let name = match name_field("name") {
-                Ok(n) => n,
-                Err(e) => return eljson::error_json(&e),
-            };
-            let Some(content_types) = u64_field("contentTypes") else {
-                return eljson::error_json("missing contentTypes");
-            };
-            EnsQuery::Abi { name, content_types }
-        }
-        "dnsRecord" => {
-            let name = match name_field("name") {
-                Ok(n) => n,
-                Err(e) => return eljson::error_json(&e),
-            };
-            let dns_name = match name_field("dnsName") {
-                Ok(n) => n,
-                Err(e) => return eljson::error_json(&e),
-            };
-            let resource = match u64_field("resource") {
-                Some(r) if r <= u64::from(u16::MAX) => r as u16,
-                Some(_) => return eljson::error_json("resource out of range (uint16)"),
-                None => return eljson::error_json("missing resource"),
-            };
-            EnsQuery::DnsRecord { name, dns_name, resource }
-        }
-        "interfaceImplementer" => {
-            let name = match name_field("name") {
-                Ok(n) => n,
-                Err(e) => return eljson::error_json(&e),
-            };
-            let Some(id_hex) = str_field("interfaceIdHex") else {
-                return eljson::error_json("missing interfaceIdHex");
-            };
-            let Some(id) = parse_hex_fixed::<4>(&id_hex) else {
-                return eljson::error_json("interfaceIdHex must be 4 bytes of hex");
-            };
-            EnsQuery::Interface { name, interface_id: id }
-        }
-        "reverse" => {
-            let Some(addr_hex) = str_field("addressHex") else {
-                return eljson::error_json("missing addressHex");
-            };
-            let Some(address) = parse_hex_fixed::<20>(&addr_hex) else {
-                // The Java EnsApi contract's message for a malformed reverse input.
-                return eljson::error_json("address must be a 20-byte hex string (40 hex chars)");
-            };
-            EnsQuery::Reverse { address }
-        }
-        other => return eljson::error_json(&format!("unknown ens method: {other}")),
+    let query = match parse_ens_query(&query_method, &params) {
+        Ok(q) => q,
+        Err(e) => return eljson::error_json(&e),
     };
 
     let Some(engine) = engine() else {
@@ -950,6 +859,91 @@ fn snapshot_reader_slots(
     }
 }
 
+/// Build the [`EnsQuery`] for one record method from the params JSON — shared
+/// by the direct dispatch AND the ccipCallback re-entry (which passes the
+/// ORIGINAL query's method as `queryMethod`), so the two paths can never
+/// disagree on decode semantics. `Err` is the user-facing message.
+fn parse_ens_query(query_method: &str, params: &serde_json::Value) -> Result<EnsQuery, String> {
+    let str_field = |key: &str| -> Option<String> {
+        params.get(key).and_then(|v| v.as_str()).map(str::to_string)
+    };
+    let u64_field = |key: &str| -> Option<u64> { params.get(key).and_then(|v| v.as_u64()) };
+    let name_field = |key: &str| -> Result<String, String> {
+        let Some(name) = str_field(key) else {
+            return Err(format!("missing {key}"));
+        };
+        let name = name.trim().to_string();
+        if name.is_empty() {
+            return Err(format!("empty {key}"));
+        }
+        if name.len() > 512 {
+            return Err(format!("{key} too long"));
+        }
+        Ok(name)
+    };
+
+    Ok(match query_method {
+        "addr" => EnsQuery::Addr { name: name_field("name")? },
+        "contenthash" => EnsQuery::Contenthash { name: name_field("name")? },
+        "pubkey" => EnsQuery::Pubkey { name: name_field("name")? },
+        "text" => {
+            let name = name_field("name")?;
+            let Some(key) = str_field("key").filter(|k| !k.is_empty()) else {
+                return Err("missing key".to_string());
+            };
+            if key.len() > 512 {
+                return Err("key too long".to_string());
+            }
+            EnsQuery::Text { name, key }
+        }
+        "multicoin" => {
+            let name = name_field("name")?;
+            let Some(coin_type) = u64_field("coinType") else {
+                return Err("missing coinType".to_string());
+            };
+            EnsQuery::Multicoin { name, coin_type }
+        }
+        "abi" => {
+            let name = name_field("name")?;
+            let Some(content_types) = u64_field("contentTypes") else {
+                return Err("missing contentTypes".to_string());
+            };
+            EnsQuery::Abi { name, content_types }
+        }
+        "dnsRecord" => {
+            let name = name_field("name")?;
+            let dns_name = name_field("dnsName")?;
+            let resource = match u64_field("resource") {
+                Some(r) if r <= u64::from(u16::MAX) => r as u16,
+                Some(_) => return Err("resource out of range (uint16)".to_string()),
+                None => return Err("missing resource".to_string()),
+            };
+            EnsQuery::DnsRecord { name, dns_name, resource }
+        }
+        "interfaceImplementer" => {
+            let name = name_field("name")?;
+            let Some(id_hex) = str_field("interfaceIdHex") else {
+                return Err("missing interfaceIdHex".to_string());
+            };
+            let Some(id) = parse_hex_fixed::<4>(&id_hex) else {
+                return Err("interfaceIdHex must be 4 bytes of hex".to_string());
+            };
+            EnsQuery::Interface { name, interface_id: id }
+        }
+        "reverse" => {
+            let Some(addr_hex) = str_field("addressHex") else {
+                return Err("missing addressHex".to_string());
+            };
+            let Some(address) = parse_hex_fixed::<20>(&addr_hex) else {
+                // The Java EnsApi contract's message for a malformed reverse input.
+                return Err("address must be a 20-byte hex string (40 hex chars)".to_string());
+            };
+            EnsQuery::Reverse { address }
+        }
+        other => return Err(format!("unknown ens method: {other}")),
+    })
+}
+
 /// Parse a `0x`-prefixed-or-bare hex string into exactly `N` bytes. Panic-free:
 /// `None` for any malformed input (JNI callers pass untrusted strings).
 fn parse_hex_fixed<const N: usize>(hex: &str) -> Option<[u8; N]> {
@@ -1104,6 +1098,39 @@ const NOT_STARTED_FALLBACK: &str = concat!(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_ens_query_maps_every_method_correctly() {
+        use myotis_net::el::evm::EnsQuery;
+        let q = |method: &str, extra: &str| {
+            let json: serde_json::Value =
+                serde_json::from_str(&format!(r#"{{"name":"a.eth"{extra}}}"#)).unwrap();
+            parse_ens_query(method, &json)
+        };
+        // The addr/contenthash/pubkey trio must NEVER collapse into one arm —
+        // the ccipCallback re-entry passes these as queryMethod, and a mis-map
+        // decodes an address answer with pubkey semantics (a real regression).
+        assert!(matches!(q("addr", "").unwrap(), EnsQuery::Addr { .. }));
+        assert!(matches!(q("contenthash", "").unwrap(), EnsQuery::Contenthash { .. }));
+        assert!(matches!(q("pubkey", "").unwrap(), EnsQuery::Pubkey { .. }));
+        assert!(matches!(q("text", r#","key":"url""#).unwrap(), EnsQuery::Text { .. }));
+        assert!(matches!(q("multicoin", r#","coinType":60"#).unwrap(), EnsQuery::Multicoin { coin_type: 60, .. }));
+        assert!(matches!(q("abi", r#","contentTypes":15"#).unwrap(), EnsQuery::Abi { .. }));
+        assert!(matches!(
+            q("dnsRecord", r#","dnsName":"a.eth","resource":1"#).unwrap(),
+            EnsQuery::DnsRecord { resource: 1, .. }
+        ));
+        assert!(matches!(
+            q("interfaceImplementer", r#","interfaceIdHex":"0x9061b923""#).unwrap(),
+            EnsQuery::Interface { interface_id: [0x90, 0x61, 0xb9, 0x23], .. }
+        ));
+        let rev: serde_json::Value =
+            serde_json::from_str(&format!(r#"{{"addressHex":"0x{}"}}"#, "d8".repeat(20))).unwrap();
+        assert!(matches!(parse_ens_query("reverse", &rev).unwrap(), EnsQuery::Reverse { .. }));
+        // ccipCallback can never be a queryMethod (no native recursion).
+        assert!(parse_ens_query("ccipCallback", &rev).is_err());
+        assert!(parse_ens_query("bogus", &rev).is_err());
+    }
 
     #[test]
     fn not_started_status_shape_is_stable() {

--- a/rust/myotis-engine/src/host.rs
+++ b/rust/myotis-engine/src/host.rs
@@ -589,6 +589,18 @@ pub fn ens_record_json(handle: i64, params_json: &str) -> String {
     let Some(method) = str_field("method") else {
         return eljson::error_json("missing method");
     };
+    // method:"ccipCallback" re-enters after a host-driven gateway round: the
+    // ORIGINAL query travels as queryMethod + its usual fields (drives the
+    // decode semantics + reverse forward-verify), plus the callback tuple.
+    let is_ccip = method == "ccipCallback";
+    let query_method = if is_ccip {
+        match str_field("queryMethod") {
+            Some(m) => m,
+            None => return eljson::error_json("missing queryMethod"),
+        }
+    } else {
+        method.clone()
+    };
     // Strict: a PRESENT root that isn't one of the known strings is an error
     // (a non-string value must not silently read as the default).
     let root = match params.get("root") {
@@ -603,7 +615,7 @@ pub fn ens_record_json(handle: i64, params_json: &str) -> String {
         },
     };
 
-    let query = match method.as_str() {
+    let query = match query_method.as_str() {
         "addr" | "contenthash" | "pubkey" => {
             let name = match name_field("name") {
                 Ok(n) => n,
@@ -697,6 +709,38 @@ pub fn ens_record_json(handle: i64, params_json: &str) -> String {
         Ok(snap) => snap,
         Err(msg) => return eljson::error_json(msg),
     };
+    if is_ccip {
+        let Some(sender) = str_field("senderHex").and_then(|h| parse_hex_fixed::<20>(&h)) else {
+            return eljson::error_json("missing/malformed senderHex");
+        };
+        let Some(callback) =
+            str_field("callbackFunctionHex").and_then(|h| parse_hex_fixed::<4>(&h))
+        else {
+            return eljson::error_json("missing/malformed callbackFunctionHex");
+        };
+        let Some(response) = str_field("responseHex").and_then(|h| parse_hex_bytes(&h)) else {
+            return eljson::error_json("missing/malformed responseHex");
+        };
+        let Some(extra) = str_field("extraDataHex").and_then(|h| parse_hex_bytes(&h)) else {
+            return eljson::error_json("missing/malformed extraDataHex");
+        };
+        let Some(wrapped) = params.get("wrapped").and_then(|v| v.as_bool()) else {
+            return eljson::error_json("missing wrapped");
+        };
+        let Some(finalized) = params.get("finalized").and_then(|v| v.as_bool()) else {
+            return eljson::error_json("missing finalized");
+        };
+        return match engine.rt.block_on(async {
+            reader
+                .ens_ccip_callback(
+                    query, chain_id, finalized, sender, callback, response, extra, wrapped,
+                )
+                .await
+        }) {
+            Ok(outcome) => eljson::ens_record_json(&outcome),
+            Err(e) => eljson::error_json(&e),
+        };
+    }
     match engine
         .rt
         .block_on(async { reader.resolve_ens_query(query, chain_id, root).await })

--- a/rust/myotis-evm/src/ens/abi.rs
+++ b/rust/myotis-evm/src/ens/abi.rs
@@ -188,6 +188,35 @@ pub fn decode_string(data: &[u8]) -> Option<String> {
     decode_dynamic_bytes(data, 0).map(|b| String::from_utf8_lossy(&b).into_owned())
 }
 
+/// Decode a `string[]` at the byte offset held in head slot `arg_index`:
+/// array length, then per-element offsets (relative to the array data start),
+/// each element length-prefixed UTF-8 (lossy). Capped at `max` elements; `None`
+/// on any out-of-bounds/oversized field.
+pub fn decode_string_array(data: &[u8], arg_index: usize, max: usize) -> Option<Vec<String>> {
+    let array = read_index(data, arg_index.checked_mul(32)?)?;
+    let len = read_index(data, array)?;
+    if len > max {
+        return None;
+    }
+    let base = array.checked_add(32)?;
+    let mut out = Vec::with_capacity(len);
+    for i in 0..len {
+        let rel = read_index(data, base.checked_add(i.checked_mul(32)?)?)?;
+        let elem = base.checked_add(rel)?;
+        let elen = read_index(data, elem)?;
+        let start = elem.checked_add(32)?;
+        let bytes = data.get(start..start.checked_add(elen)?)?;
+        out.push(String::from_utf8_lossy(bytes).into_owned());
+    }
+    Some(out)
+}
+
+/// Encode two dynamic `bytes` args head-tail (the ERC-3668 callback's
+/// `(response, extraData)` payload — appended after the callback selector).
+pub fn encode_two_bytes_args(a: &[u8], b: &[u8]) -> Vec<u8> {
+    encode_bytes_args(&[a, b])
+}
+
 /// Decode the two static 32-byte words of a `(bytes32,bytes32)` return
 /// (`pubkey(bytes32)` → x, y). `None` if shorter than 64 bytes.
 pub fn decode_two_words(data: &[u8]) -> Option<([u8; 32], [u8; 32])> {

--- a/rust/myotis-evm/src/ens/mod.rs
+++ b/rust/myotis-evm/src/ens/mod.rs
@@ -53,10 +53,13 @@ pub enum EnsError {
     /// The resolver reverted with ERC-3668 `OffchainLookup`: the record resolves
     /// OFFCHAIN via a CCIP-Read gateway. Carries the decoded 5-tuple (when the
     /// revert body parsed) so the HOST can drive the gateway and re-enter via
-    /// the callback (EL-C-5-3 — HTTP stays outside this crate by design), plus
-    /// whether the revert came from inside the ENSIP-10 `resolve()` wrap (the
-    /// callback's answer then needs the same bytes-unwrap). A tuple that fails
-    /// to parse is `lookup: None` — still distinguishable from "no record".
+    /// the callback (EL-C-5-3 — HTTP stays outside this crate by design).
+    /// `wrapped` = the ORIGINAL dispatch went through the ENSIP-10 `resolve()`
+    /// wrap, so whichever callback round finally answers must bytes-unwrap its
+    /// return; it describes the original call's decode contract, NOT where this
+    /// particular revert occurred, and is therefore carried unchanged through
+    /// callback rounds. A tuple that fails to parse is `lookup: None` — still
+    /// distinguishable from "no record".
     OffchainLookup { lookup: Option<Box<OffchainLookup>>, wrapped: bool },
     /// A resolution `eth_call` failed for a non-revert reason (state unavailable,
     /// halt, unsupported chain). A plain revert is treated as "no record", not an
@@ -442,6 +445,10 @@ pub fn ccip_callback(
                 Ok(Some(out))
             }
         }
+        // A second OffchainLookup carries the ORIGINAL `wrapped` forward: the
+        // flag is the original call's decode contract (see the variant doc),
+        // so a deeper round — if the cap were ever raised — still applies the
+        // right final unwrap.
         Err(EvmError::Reverted { data }) => revert_outcome(&data, wrapped),
         Err(e) => Err(EnsError::Call(e)),
     }

--- a/rust/myotis-evm/src/ens/mod.rs
+++ b/rust/myotis-evm/src/ens/mod.rs
@@ -50,23 +50,46 @@ const OFFCHAIN_LOOKUP_SELECTOR: [u8; 4] = [0x55, 0x6f, 0x18, 0x30];
 pub enum EnsError {
     /// The name is malformed (empty/oversized label).
     InvalidName(&'static str),
-    /// The resolver reverted with ERC-3668 `OffchainLookup`: the name resolves
-    /// OFFCHAIN via a CCIP-Read gateway, which this engine doesn't drive yet
-    /// (EL-C-5-3). Explicitly not "no record" — the record exists, offchain.
-    OffchainLookup,
+    /// The resolver reverted with ERC-3668 `OffchainLookup`: the record resolves
+    /// OFFCHAIN via a CCIP-Read gateway. Carries the decoded 5-tuple (when the
+    /// revert body parsed) so the HOST can drive the gateway and re-enter via
+    /// the callback (EL-C-5-3 — HTTP stays outside this crate by design), plus
+    /// whether the revert came from inside the ENSIP-10 `resolve()` wrap (the
+    /// callback's answer then needs the same bytes-unwrap). A tuple that fails
+    /// to parse is `lookup: None` — still distinguishable from "no record".
+    OffchainLookup { lookup: Option<Box<OffchainLookup>>, wrapped: bool },
     /// A resolution `eth_call` failed for a non-revert reason (state unavailable,
     /// halt, unsupported chain). A plain revert is treated as "no record", not an
     /// error.
     Call(EvmError),
 }
 
+/// The decoded ERC-3668 `OffchainLookup(address,string[],bytes,bytes4,bytes)`
+/// revert body (Java `OffchainLookupRevert` twin — same bounds: body ≥ 160
+/// bytes, ≤ 32 URLs).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OffchainLookup {
+    /// The callback TARGET (Java parity: the callback is sent to the tuple's
+    /// sender, and no sender==callee check is made — a lying resolver can only
+    /// redirect its own callback).
+    pub sender: [u8; 20],
+    /// Gateway URL templates (`{sender}` / `{data}` substitution — host-side).
+    pub urls: Vec<String>,
+    /// The data for the gateway request.
+    pub call_data: Vec<u8>,
+    /// The 4-byte callback selector on `sender`.
+    pub callback_function: [u8; 4],
+    /// Opaque state echoed into the callback.
+    pub extra_data: Vec<u8>,
+}
+
 impl std::fmt::Display for EnsError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             EnsError::InvalidName(why) => write!(f, "invalid ENS name: {why}"),
-            EnsError::OffchainLookup => write!(
+            EnsError::OffchainLookup { .. } => write!(
                 f,
-                "name resolves offchain (ERC-3668 OffchainLookup); CCIP-Read not yet supported"
+                "name resolves offchain (ERC-3668 OffchainLookup); a CCIP-Read gateway round is required"
             ),
             EnsError::Call(e) => write!(f, "ENS resolution call failed: {e}"),
         }
@@ -118,7 +141,7 @@ pub fn resolve_address(
     // A zero address is "no record", not an answer. decode_address is stricter
     // than the Java decoder (a dirty upper-12-byte word → None rather than
     // slicing the trailing 20) — deliberately fail-safe for a fund-destination.
-    Ok(abi::decode_address(&raw).filter(|a| a != &[0u8; 20]))
+    Ok(decode_address_answer(&raw))
 }
 
 /// Resolve a `text(bytes32,string)` record. `Ok(None)` = no record (absent
@@ -133,7 +156,7 @@ pub fn resolve_text(
     let Some(raw) = resolve_record(caller, name, &inner)? else {
         return Ok(None);
     };
-    Ok(abi::decode_string(&raw).filter(|s| !s.is_empty()))
+    Ok(decode_text_answer(&raw))
 }
 
 /// Resolve a `contenthash(bytes32)` record (raw multicodec bytes). `Ok(None)` =
@@ -147,7 +170,7 @@ pub fn resolve_contenthash(
     let Some(raw) = resolve_record(caller, name, &inner)? else {
         return Ok(None);
     };
-    Ok(abi::decode_dynamic_bytes(&raw, 0).filter(|b| !b.is_empty()))
+    Ok(decode_bytes_answer(&raw))
 }
 
 /// Resolve an ENSIP-9 multi-coin `addr(bytes32,uint256)` record (raw
@@ -162,7 +185,7 @@ pub fn resolve_multicoin(
     let Some(raw) = resolve_record(caller, name, &inner)? else {
         return Ok(None);
     };
-    Ok(abi::decode_dynamic_bytes(&raw, 0).filter(|b| !b.is_empty()))
+    Ok(decode_bytes_answer(&raw))
 }
 
 /// Resolve a `pubkey(bytes32)` record — a fixed `(bytes32 x, bytes32 y)` tuple,
@@ -176,7 +199,7 @@ pub fn resolve_pubkey(
     let Some(raw) = resolve_record(caller, name, &inner)? else {
         return Ok(None);
     };
-    Ok(abi::decode_two_words(&raw).filter(|(x, y)| x != &[0u8; 32] || y != &[0u8; 32]))
+    Ok(decode_pubkey_answer(&raw))
 }
 
 /// Resolve an `ABI(bytes32,uint256)` record → `(contentType, data)`. `Ok(None)`
@@ -192,7 +215,7 @@ pub fn resolve_abi(
     let Some(raw) = resolve_record(caller, name, &inner)? else {
         return Ok(None);
     };
-    Ok(abi::decode_uint_bytes(&raw).filter(|(_, data)| !data.is_empty()))
+    Ok(decode_abi_answer(&raw))
 }
 
 /// Resolve a `dnsRecord(bytes32,bytes,uint16)` record: `dns_name` is the DNS
@@ -216,7 +239,7 @@ pub fn resolve_dns_record(
     let Some(raw) = resolve_record(caller, name, &inner)? else {
         return Ok(None);
     };
-    Ok(abi::decode_dynamic_bytes(&raw, 0).filter(|b| !b.is_empty()))
+    Ok(decode_bytes_answer(&raw))
 }
 
 /// Resolve an `interfaceImplementer(bytes32,bytes4)` record (EIP-1820 over
@@ -235,7 +258,7 @@ pub fn resolve_interface_implementer(
     let Some(raw) = resolve_record(caller, name, &inner)? else {
         return Ok(None);
     };
-    Ok(abi::decode_address(&raw).filter(|a| a != &[0u8; 20]))
+    Ok(decode_address_answer(&raw))
 }
 
 /// Reverse-resolve `address` → its primary ENS name, **forward-verified**: the
@@ -279,14 +302,15 @@ pub fn reverse_resolve(
     let raw = match caller.eth_call(resolver, &name_call) {
         Ok(out) => out,
         Err(EvmError::Reverted { data }) => {
-            return match revert_outcome(&data) {
+            // name() is a direct legacy-style call — never ENSIP-10-wrapped.
+            return match revert_outcome(&data, false) {
                 Ok(_) => Ok(None),
                 Err(e) => Err(e),
             }
         }
         Err(e) => return Err(EnsError::Call(e)),
     };
-    let Some(claimed) = abi::decode_string(&raw).filter(|s| !s.is_empty()) else {
+    let Some(claimed) = decode_name_answer(&raw) else {
         return Ok(None);
     };
 
@@ -310,6 +334,40 @@ fn reverse_name(address: [u8; 20]) -> String {
     }
     s.push_str(".addr.reverse");
     s
+}
+
+/// Decode an address-shaped answer (addr / interfaceImplementer): strict
+/// (dirty upper 12 bytes → None) and zero → None. Shared by the direct path
+/// and the CCIP callback continuation.
+pub fn decode_address_answer(raw: &[u8]) -> Option<[u8; 20]> {
+    abi::decode_address(raw).filter(|a| a != &[0u8; 20])
+}
+
+/// Decode a text answer: dynamic string, empty → None.
+pub fn decode_text_answer(raw: &[u8]) -> Option<String> {
+    abi::decode_string(raw).filter(|s| !s.is_empty())
+}
+
+/// Decode a bytes answer (contenthash / multicoin / dnsRecord): empty → None.
+pub fn decode_bytes_answer(raw: &[u8]) -> Option<Vec<u8>> {
+    abi::decode_dynamic_bytes(raw, 0).filter(|b| !b.is_empty())
+}
+
+/// Decode a pubkey answer (fixed tuple): BOTH-zero → None.
+pub fn decode_pubkey_answer(raw: &[u8]) -> Option<([u8; 32], [u8; 32])> {
+    abi::decode_two_words(raw).filter(|(x, y)| x != &[0u8; 32] || y != &[0u8; 32])
+}
+
+/// Decode an ABI answer: `(contentType, data)`, empty data → None (the
+/// contentType word alone is NOT checked — Java parity).
+pub fn decode_abi_answer(raw: &[u8]) -> Option<(u64, Vec<u8>)> {
+    abi::decode_uint_bytes(raw).filter(|(_, data)| !data.is_empty())
+}
+
+/// Decode a reverse `name()` answer: dynamic string, empty → None. The caller
+/// must still forward-verify the claimed name.
+pub fn decode_name_answer(raw: &[u8]) -> Option<String> {
+    abi::decode_string(raw).filter(|s| !s.is_empty())
 }
 
 /// The shared resolution path every record type rides: find the (possibly
@@ -345,29 +403,83 @@ fn resolve_record(
         let call = abi::encode_resolve(&dns, inner_call);
         match caller.eth_call(info.resolver, &call) {
             Ok(out) => Ok(abi::decode_dynamic_bytes(&out, 0)),
-            Err(EvmError::Reverted { data }) => revert_outcome(&data),
+            Err(EvmError::Reverted { data }) => revert_outcome(&data, true),
             Err(e) => Err(EnsError::Call(e)),
         }
     } else {
         // Legacy exact resolver: dispatch the inner call directly.
         match caller.eth_call(info.resolver, inner_call) {
             Ok(out) => Ok(Some(out)),
-            Err(EvmError::Reverted { data }) => revert_outcome(&data),
+            Err(EvmError::Reverted { data }) => revert_outcome(&data, false),
             Err(e) => Err(EnsError::Call(e)),
         }
     }
 }
 
+/// Execute one ERC-3668 CALLBACK re-entry (EL-C-5-3): the host drove the
+/// gateway and hands back its response; this calls
+/// `sender.callbackFunction(response, extraData)` as a verified eth_call and
+/// returns the raw answer bytes (bytes-unwrapped when the original revert came
+/// from inside the ENSIP-10 wrap). A plain revert is "no record" (Java
+/// `decodeOutcome` parity); ANOTHER OffchainLookup revert surfaces
+/// distinguishably so the host can enforce the recursion cap (Java
+/// `MAX_RECURSION_DEPTH = 1`).
+pub fn ccip_callback(
+    caller: &dyn EthCaller,
+    sender: [u8; 20],
+    callback_function: [u8; 4],
+    response: &[u8],
+    extra_data: &[u8],
+    wrapped: bool,
+) -> Result<Option<Vec<u8>>, EnsError> {
+    let mut call = callback_function.to_vec();
+    call.extend_from_slice(&abi::encode_two_bytes_args(response, extra_data));
+    match caller.eth_call(sender, &call) {
+        Ok(out) => {
+            if wrapped {
+                Ok(abi::decode_dynamic_bytes(&out, 0))
+            } else {
+                Ok(Some(out))
+            }
+        }
+        Err(EvmError::Reverted { data }) => revert_outcome(&data, wrapped),
+        Err(e) => Err(EnsError::Call(e)),
+    }
+}
+
 /// Classify a resolver-call revert: an ERC-3668 `OffchainLookup` is a
-/// distinguishable "resolves offchain" failure (never folded into "no record");
-/// any other revert is "no record".
-fn revert_outcome(data: &[u8]) -> Result<Option<Vec<u8>>, EnsError> {
+/// distinguishable "resolves offchain" failure carrying the decoded gateway
+/// tuple (never folded into "no record"); any other revert is "no record".
+fn revert_outcome(data: &[u8], wrapped: bool) -> Result<Option<Vec<u8>>, EnsError> {
     if data.len() >= 4 && data[..4] == OFFCHAIN_LOOKUP_SELECTOR {
-        Err(EnsError::OffchainLookup)
+        Err(EnsError::OffchainLookup {
+            lookup: decode_offchain_lookup(&data[4..]).map(Box::new),
+            wrapped,
+        })
     } else {
         Ok(None)
     }
 }
+
+/// Decode the `OffchainLookup` revert BODY (after the selector): head slots are
+/// sender, urls offset, callData offset, callbackFunction (bytes4
+/// left-aligned), extraData offset (Java `OffchainLookupRevert.parseBody`
+/// bounds: ≥ 160 bytes, ≤ 32 URLs). `None` on any malformed field — the host
+/// then reports "offchain, but unparseable" instead of calling a gateway.
+fn decode_offchain_lookup(body: &[u8]) -> Option<OffchainLookup> {
+    if body.len() < 160 {
+        return None;
+    }
+    let sender = abi::decode_address(body)?;
+    let urls = abi::decode_string_array(body, 1, MAX_CCIP_URLS)?;
+    let call_data = abi::decode_dynamic_bytes(body, 2)?;
+    let callback_function: [u8; 4] = body.get(96..100)?.try_into().ok()?;
+    let extra_data = abi::decode_dynamic_bytes(body, 4)?;
+    Some(OffchainLookup { sender, urls, call_data, callback_function, extra_data })
+}
+
+/// Java `OffchainLookupRevert.MAX_URLS` twin.
+const MAX_CCIP_URLS: usize = 32;
 
 /// Walk the registry from the full name up through its ancestors (the root node
 /// itself is NOT queried — Java's `walkResolver` stops at the last label, and the
@@ -511,7 +623,12 @@ mod tests {
                     Err(EvmError::Reverted { data })
                 })
             });
-        assert_eq!(resolve_address(&caller, "offchain.eth"), Err(EnsError::OffchainLookup));
+        // A truncated body decodes to lookup:None but the WRAPPED flag and the
+        // offchain classification survive.
+        assert!(matches!(
+            resolve_address(&caller, "offchain.eth"),
+            Err(EnsError::OffchainLookup { lookup: None, wrapped: true })
+        ));
         // A plain revert stays "no record".
         let plain = MockCaller::new()
             .on(move |t, cd| (t == REGISTRY && sel(cd) == resolver_sel).then(|| Ok(addr_word(RESOLVER))))
@@ -848,6 +965,120 @@ mod tests {
         // Resolver set but name() returns an empty string.
         let caller = reverse_caller("", VITALIK);
         assert_eq!(reverse_resolve(&caller, VITALIK).unwrap(), None);
+    }
+
+    // ---- CCIP-Read (EL-C-5-3) ----
+
+    /// Hand-build a full OffchainLookup revert body (selector + 5-tuple).
+    fn offchain_revert_body(urls: &[&str]) -> Vec<u8> {
+        let word = |v: u64| {
+            let mut w = [0u8; 32];
+            w[24..].copy_from_slice(&v.to_be_bytes());
+            w
+        };
+        let dyn_bytes = |b: &[u8]| {
+            let mut out = word(b.len() as u64).to_vec();
+            out.extend_from_slice(b);
+            out.extend(std::iter::repeat_n(0u8, (32 - (b.len() % 32)) % 32));
+            out
+        };
+        // Tail parts: urls array, callData, extraData — offsets from body start.
+        let mut urls_tail = word(urls.len() as u64).to_vec();
+        let mut elems = Vec::new();
+        let mut rel = urls.len() * 32;
+        for u in urls {
+            urls_tail.extend_from_slice(&word(rel as u64));
+            let e = dyn_bytes(u.as_bytes());
+            rel += e.len();
+            elems.extend_from_slice(&e);
+        }
+        urls_tail.extend_from_slice(&elems);
+        let call_data = dyn_bytes(&[0xCA, 0x11]);
+        let extra_data = dyn_bytes(&[0xEE; 3]);
+
+        let urls_off = 160u64;
+        let calldata_off = urls_off + urls_tail.len() as u64;
+        let extra_off = calldata_off + call_data.len() as u64;
+
+        let mut body = OFFCHAIN_LOOKUP_SELECTOR.to_vec();
+        body.extend_from_slice(&addr_word([0x5E; 20])); // sender
+        body.extend_from_slice(&word(urls_off));
+        body.extend_from_slice(&word(calldata_off));
+        let mut cb = [0u8; 32];
+        cb[..4].copy_from_slice(&[0xCB, 0xCB, 0xCB, 0xCB]); // left-aligned bytes4
+        body.extend_from_slice(&cb);
+        body.extend_from_slice(&word(extra_off));
+        body.extend_from_slice(&urls_tail);
+        body.extend_from_slice(&call_data);
+        body.extend_from_slice(&extra_data);
+        body
+    }
+
+    #[test]
+    fn offchain_lookup_tuple_round_trips() {
+        let body = offchain_revert_body(&["https://gw.example/{sender}/{data}", "https://b.example"]);
+        let got = decode_offchain_lookup(&body[4..]).expect("decodes");
+        assert_eq!(got.sender, [0x5E; 20]);
+        assert_eq!(got.urls, vec!["https://gw.example/{sender}/{data}", "https://b.example"]);
+        assert_eq!(got.call_data, vec![0xCA, 0x11]);
+        assert_eq!(got.callback_function, [0xCB, 0xCB, 0xCB, 0xCB]);
+        assert_eq!(got.extra_data, vec![0xEE; 3]);
+
+        // The resolver path carries the tuple out through the error.
+        let resolver_sel = abi::selector("resolver(bytes32)");
+        let supports_sel = abi::selector("supportsInterface(bytes4)");
+        let body2 = body.clone();
+        let caller = MockCaller::new()
+            .on(move |t, cd| (t == REGISTRY && sel(cd) == resolver_sel).then(|| Ok(addr_word(RESOLVER))))
+            .on(move |t, cd| (t == RESOLVER && sel(cd) == supports_sel).then(revert))
+            .on(move |t, _cd| (t == RESOLVER).then(|| Err(EvmError::Reverted { data: body2.clone() })));
+        match resolve_address(&caller, "offchain.eth") {
+            Err(EnsError::OffchainLookup { lookup: Some(l), wrapped: false }) => {
+                assert_eq!(l.sender, [0x5E; 20]);
+                assert_eq!(l.urls.len(), 2);
+            }
+            other => panic!("expected carried tuple, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn oversized_url_list_is_rejected() {
+        let urls: Vec<String> = (0..33).map(|i| format!("https://{i}.example")).collect();
+        let refs: Vec<&str> = urls.iter().map(String::as_str).collect();
+        let body = offchain_revert_body(&refs);
+        assert!(decode_offchain_lookup(&body[4..]).is_none()); // > MAX_CCIP_URLS
+    }
+
+    #[test]
+    fn ccip_callback_calls_sender_and_unwraps() {
+        const SENDER: [u8; 20] = [0x5E; 20];
+        let caller = MockCaller::new().on(move |t, cd| {
+            if t != SENDER || cd[..4] != [0xCB, 0xCB, 0xCB, 0xCB] {
+                return None;
+            }
+            // (response, extraData) arrive head-tail after the selector.
+            let resp = abi::decode_dynamic_bytes(&cd[4..], 0).unwrap();
+            let extra = abi::decode_dynamic_bytes(&cd[4..], 1).unwrap();
+            assert_eq!(resp, vec![0xAA]);
+            assert_eq!(extra, vec![0xEE; 3]);
+            // Return bytes-wrapping of an addr word (the wrapped path unwraps).
+            Some(Ok(dyn_bytes_return(&addr_word(VITALIK))))
+        });
+        let out = ccip_callback(&caller, SENDER, [0xCB; 4], &[0xAA], &[0xEE; 3], true)
+            .unwrap()
+            .unwrap();
+        assert_eq!(abi::decode_address(&out), Some(VITALIK));
+        // A second OffchainLookup revert from the callback stays distinguishable
+        // (the host enforces the recursion cap).
+        let again = MockCaller::new().on(move |t, _cd| {
+            (t == SENDER).then(|| {
+                Err(EvmError::Reverted { data: OFFCHAIN_LOOKUP_SELECTOR.to_vec() })
+            })
+        });
+        assert!(matches!(
+            ccip_callback(&again, SENDER, [0xCB; 4], &[0xAA], &[], false),
+            Err(EnsError::OffchainLookup { .. })
+        ));
     }
 
     #[test]

--- a/rust/myotis-evm/src/lib.rs
+++ b/rust/myotis-evm/src/lib.rs
@@ -54,9 +54,10 @@ pub use cache::{
 };
 pub use database::OracleDatabase;
 pub use ens::{
-    resolve_abi, resolve_address, resolve_contenthash, resolve_dns_record,
+    ccip_callback, decode_abi_answer, decode_address_answer, decode_bytes_answer,
+    decode_name_answer, decode_pubkey_answer, decode_text_answer, resolve_abi, resolve_address, resolve_contenthash, resolve_dns_record,
     resolve_interface_implementer, resolve_multicoin, resolve_pubkey, resolve_text,
-    reverse_resolve, EnsError, EthCaller, ExecutorCaller,
+    reverse_resolve, EnsError, EthCaller, ExecutorCaller, OffchainLookup,
 };
 pub use error::EvmError;
 pub use executor::EvmExecutor;

--- a/rust/myotis-net/src/el/evm.rs
+++ b/rust/myotis-net/src/el/evm.rs
@@ -142,9 +142,17 @@ pub enum EnsQueryOutcome {
     Value { value: EnsRecordValue, block_number: u64, verified: bool },
     /// Successfully determined there is no record.
     NoRecord { block_number: u64, verified: bool },
-    /// The record resolves OFFCHAIN (ERC-3668) — needs a CCIP-Read gateway
-    /// (EL-C-5-3). Distinguishable from `NoRecord` by design.
-    Offchain { block_number: u64, verified: bool },
+    /// The record resolves OFFCHAIN (ERC-3668): the host must drive a CCIP-Read
+    /// gateway round with the carried tuple, then re-enter via the callback
+    /// (`method:"ccipCallback"`). `lookup` is `None` when the revert's tuple was
+    /// unparseable (still distinguishable from `NoRecord`); `wrapped` = the
+    /// revert came from inside the ENSIP-10 `resolve()` wrap.
+    Offchain {
+        block_number: u64,
+        verified: bool,
+        lookup: Option<Box<myotis_evm::OffchainLookup>>,
+        wrapped: bool,
+    },
 }
 
 /// Build a [`BlockContext`] from a verified head header. `chain_id` comes from the

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -746,7 +746,7 @@ impl ElReader {
         match joined {
             Ok(Some(address)) => Ok(EnsOutcome::Resolved { address, block_number }),
             Ok(None) => Ok(EnsOutcome::NoRecord { block_number }),
-            Err(EnsError::OffchainLookup) => Ok(EnsOutcome::Offchain { block_number }),
+            Err(EnsError::OffchainLookup { .. }) => Ok(EnsOutcome::Offchain { block_number }),
             Err(e) => Err(e.to_string()),
         }
     }
@@ -791,6 +791,70 @@ impl ElReader {
             .map_err(|_| "resolve-ens timed out".to_string())?
     }
 
+    /// One ERC-3668 CALLBACK re-entry (EL-C-5-3): the host drove the gateway;
+    /// this executes `sender.callbackFunction(response, extraData)` against the
+    /// SAME root kind as the original attempt and decodes the answer with the
+    /// original query's record semantics. A second `OffchainLookup` from the
+    /// callback surfaces as `Offchain` again — the HOST enforces the recursion
+    /// cap (Java `MAX_RECURSION_DEPTH = 1`). For a `Reverse` query the decoded
+    /// claimed name is forward-verified here, exactly like the direct path.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn ens_ccip_callback(
+        &self,
+        query: EnsQuery,
+        chain_id: u64,
+        finalized: bool,
+        sender: [u8; 20],
+        callback_function: [u8; 4],
+        response: Vec<u8>,
+        extra_data: Vec<u8>,
+        wrapped: bool,
+    ) -> Result<EnsQueryOutcome, String> {
+        let attempt = async {
+            let (ctx, executor) = if finalized {
+                self.evm_setup_finalized(chain_id, "resolve-ens").await?
+            } else {
+                self.evm_setup(chain_id, "resolve-ens").await?
+            };
+            let block_number = ctx.block_number;
+            let walk = tokio::task::spawn_blocking(move || {
+                let caller = ExecutorCaller { executor: &executor, ctx: &ctx };
+                let raw = myotis_evm::ccip_callback(
+                    &caller,
+                    sender,
+                    callback_function,
+                    &response,
+                    &extra_data,
+                    wrapped,
+                )?;
+                let Some(raw) = raw else { return Ok(None) };
+                decode_ccip_answer(&caller, &query, &raw)
+            });
+            let joined = tokio::time::timeout(RESOLVE_ENS_ATTEMPT_DEADLINE, walk)
+                .await
+                .map_err(|_| "resolve-ens attempt timed out".to_string())?
+                .map_err(|e| format!("resolve-ens task join error: {e}"))?;
+            match joined {
+                Ok(Some(value)) => {
+                    Ok(EnsQueryOutcome::Value { value, block_number, verified: finalized })
+                }
+                Ok(None) => Ok(EnsQueryOutcome::NoRecord { block_number, verified: finalized }),
+                Err(EnsError::OffchainLookup { lookup, wrapped }) => {
+                    Ok(EnsQueryOutcome::Offchain {
+                        block_number,
+                        verified: finalized,
+                        lookup,
+                        wrapped,
+                    })
+                }
+                Err(e) => Err(e.to_string()),
+            }
+        };
+        tokio::time::timeout(RESOLVE_ENS_DEADLINE, attempt)
+            .await
+            .map_err(|_| "resolve-ens timed out".to_string())?
+    }
+
     /// One resolution attempt against one root (finalized or optimistic).
     async fn ens_attempt(
         &self,
@@ -819,9 +883,12 @@ impl ElReader {
         match joined {
             Ok(Some(value)) => Ok(EnsQueryOutcome::Value { value, block_number, verified: finalized }),
             Ok(None) => Ok(EnsQueryOutcome::NoRecord { block_number, verified: finalized }),
-            Err(EnsError::OffchainLookup) => {
-                Ok(EnsQueryOutcome::Offchain { block_number, verified: finalized })
-            }
+            Err(EnsError::OffchainLookup { lookup, wrapped }) => Ok(EnsQueryOutcome::Offchain {
+                block_number,
+                verified: finalized,
+                lookup,
+                wrapped,
+            }),
             Err(e) => Err(e.to_string()),
         }
     }
@@ -1326,6 +1393,38 @@ fn run_ens_query(
         EnsQuery::Reverse { address } => {
             myotis_evm::reverse_resolve(caller, *address)?.map(EnsRecordValue::Name)
         }
+    })
+}
+
+/// Decode a CCIP callback's raw answer with the ORIGINAL query's record
+/// semantics (single source: the myotis-evm `decode_*_answer` helpers). A
+/// `Reverse` claimed name is forward-verified here, exactly like the direct
+/// path (the forward walk may itself surface `OffchainLookup` — propagated).
+fn decode_ccip_answer(
+    caller: &dyn myotis_evm::EthCaller,
+    query: &EnsQuery,
+    raw: &[u8],
+) -> Result<Option<EnsRecordValue>, EnsError> {
+    Ok(match query {
+        EnsQuery::Addr { .. } | EnsQuery::Interface { .. } => {
+            myotis_evm::decode_address_answer(raw).map(EnsRecordValue::Address)
+        }
+        EnsQuery::Text { .. } => myotis_evm::decode_text_answer(raw).map(EnsRecordValue::Text),
+        EnsQuery::Contenthash { .. } | EnsQuery::Multicoin { .. } | EnsQuery::DnsRecord { .. } => {
+            myotis_evm::decode_bytes_answer(raw).map(EnsRecordValue::Bytes)
+        }
+        EnsQuery::Pubkey { .. } => {
+            myotis_evm::decode_pubkey_answer(raw).map(|(x, y)| EnsRecordValue::Pubkey { x, y })
+        }
+        EnsQuery::Abi { .. } => myotis_evm::decode_abi_answer(raw)
+            .map(|(content_type, data)| EnsRecordValue::Abi { content_type, data }),
+        EnsQuery::Reverse { address } => match myotis_evm::decode_name_answer(raw) {
+            None => None,
+            Some(claimed) => match myotis_evm::resolve_address(caller, &claimed)? {
+                Some(fwd) if fwd == *address => Some(EnsRecordValue::Name(claimed)),
+                _ => None,
+            },
+        },
     })
 }
 

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -1420,9 +1420,13 @@ fn decode_ccip_answer(
             .map(|(content_type, data)| EnsRecordValue::Abi { content_type, data }),
         EnsQuery::Reverse { address } => match myotis_evm::decode_name_answer(raw) {
             None => None,
-            Some(claimed) => match myotis_evm::resolve_address(caller, &claimed)? {
-                Some(fwd) if fwd == *address => Some(EnsRecordValue::Name(claimed)),
-                _ => None,
+            // Same hardening as the direct reverse path: a MALFORMED claimed
+            // name (adversarial gateway data) is a failed verify, never an
+            // error a malicious resolver can force.
+            Some(claimed) => match myotis_evm::resolve_address(caller, &claimed) {
+                Ok(Some(fwd)) if fwd == *address => Some(EnsRecordValue::Name(claimed)),
+                Ok(_) | Err(EnsError::InvalidName(_)) => None,
+                Err(e) => return Err(e),
             },
         },
     })
@@ -1431,6 +1435,74 @@ fn decode_ccip_answer(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    struct ScriptedCaller(Vec<([u8; 20], Vec<u8>)>);
+    impl myotis_evm::EthCaller for ScriptedCaller {
+        fn eth_call(
+            &self,
+            target: [u8; 20],
+            calldata: &[u8],
+        ) -> Result<Vec<u8>, myotis_evm::EvmError> {
+            for (t, out) in &self.0 {
+                if *t == target {
+                    let _ = calldata;
+                    return Ok(out.clone());
+                }
+            }
+            Ok(vec![0u8; 32])
+        }
+    }
+
+    fn addr_word(a: [u8; 20]) -> Vec<u8> {
+        let mut w = vec![0u8; 32];
+        w[12..].copy_from_slice(&a);
+        w
+    }
+
+    #[test]
+    fn ccip_answer_decodes_per_query_kind() {
+        // Addr answers decode as addresses — NOT pubkey/bytes (the queryMethod
+        // mis-map regression class).
+        let caller = ScriptedCaller(Vec::new());
+        let addr = decode_ccip_answer(
+            &caller,
+            &EnsQuery::Addr { name: "a.eth".into() },
+            &addr_word([0xd8; 20]),
+        )
+        .unwrap();
+        assert_eq!(addr, Some(EnsRecordValue::Address([0xd8; 20])));
+        // The same 32-byte answer under a pubkey query is None (needs 64) —
+        // proving the kinds are NOT interchangeable.
+        let pk = decode_ccip_answer(
+            &caller,
+            &EnsQuery::Pubkey { name: "a.eth".into() },
+            &addr_word([0xd8; 20]),
+        )
+        .unwrap();
+        assert_eq!(pk, None);
+    }
+
+    #[test]
+    fn ccip_reverse_malformed_claimed_name_is_none_not_error() {
+        // A gateway-supplied claimed name with an interior empty label must be
+        // a failed forward-verify (None), never an InvalidName error.
+        let mut claimed = vec![0u8; 32];
+        claimed[31] = 0x20;
+        let name = b"a..eth";
+        let mut len = vec![0u8; 32];
+        len[31] = name.len() as u8;
+        claimed.extend_from_slice(&len);
+        claimed.extend_from_slice(name);
+        claimed.extend_from_slice(&[0u8; 26]);
+        let caller = ScriptedCaller(Vec::new());
+        let out = decode_ccip_answer(
+            &caller,
+            &EnsQuery::Reverse { address: [0xd8; 20] },
+            &claimed,
+        )
+        .unwrap();
+        assert_eq!(out, None);
+    }
 
     #[test]
     fn next_base_fee_at_target_is_unchanged() {


### PR DESCRIPTION
Stacked on #200 (base = `rust/el-c5-2-ens-records`; will retarget to `rust-engine` when #200 merges). Completes the last ENS feature gap: offchain (CCIP-Read) names now resolve on the Rust engine.

## Design: split at the HTTP boundary

The Rust workspace keeps zero HTTP dependencies (per the plan). The **native side** decodes the ERC-3668 `OffchainLookup` revert 5-tuple (Java `OffchainLookupRevert` bounds: body ≥160 bytes, ≤32 URLs; unparseable → still distinguishable from no-record) and carries it through the `status:"offchain"` JSON envelope, plus the ENSIP-10 `wrapped` flag. The **host side** (`CcipDriver` in `myotis-engines`) drives the gateway over the `EnginePorts.httpGateway` port with Java `CcipReadHandler` parity — serial URLs, GET iff `{data}` in the template (pre-substitution), POST `{"sender","data"}` body, lenient `data`-field regex, `HttpError` selector `0xca7a4e75` scan, per-URL failure reasons, recursion cap 1 — then re-enters via `method:"ccipCallback"` on the SAME dispatch native (ABI stays 12): the callback executes as a verified eth_call against the same root kind, its answer bytes-unwrapped when wrapped and decoded with the original record semantics via shared `decode_*_answer` helpers (reverse claimed-names forward-verify inside the continuation, with the malformed-name hardening from #200 applied there too).

Documented divergences: CCIP fires for the record call itself, not every walk-internal call (Java's executor-level decorator technically covers registry reads — never legitimately offchain on-chain); an offchain reverse record forward-verified by an offchain forward resolver hits the cap here instead of chaining a second round (Java's per-callView depth allows it; rare Basenames-style setups).

## Review note

The independent no-context review caught a **critical** bug the tests missed: the `ccipCallback` re-entry decoded offchain `addr`/`contenthash` queries with pubkey semantics (an inner match keyed on the wrong variable) — every offchain address would have read "no record" (fail-safe, but feature-defeating). Fixed by extracting `parse_ens_query` so the direct dispatch and the re-entry share one construction path, pinned by a unit test that fails on the old code. Its other findings (reverse InvalidName hardening regressed on the continuation path, 4 KiB params cap strangling L2-proof gateways, odd-length gateway hex killing URL failover, missing cross-language envelope pins) are all fixed with tests in the same commit.

## Testing

- 265 Rust tests green (tuple round-trip incl. oversized-URL rejection, callback encode/unwrap, second-offchain distinguishability, per-kind continuation decode, malformed-claimed-name hardening, parser-mapping pins); `:myotis-engines:test` green (CcipDriverTest: GET/POST routing + substitution, serial first-wins, HttpError, per-URL reasons, cap, odd-hex failover, pass-through, no-gateway).
- Cross-language pin: `eljson::ens_record_json_shapes` emits the full offchain envelope; `CcipDriverTest` replays the same literals.
- **Live check is peer-bound**: CCIP demo names (`ens.cb.id`) exist only on mainnet, and this host's mainnet daemon reaches SYNCED but holds a single snap peer that fails header serves (the same environmental wall that moved EL-C validation to sepolia). Retried over ~30 min without a served window. The stack underneath (walk, wildcard wrap, eth_call, root ladder) is live-validated on sepolia in #200; the CCIP delta is covered by the driver/native suites + the cross-language envelope pin. Happy to rerun the live smoke on a machine/time with healthier mainnet snap supply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PP9WX3oschsX9T4AAKpdim