### PR TITLE
EL-C-3-1: oracle quick wins — cache parity, 21000 short-circuit, snap reputation

### DIFF
--- a/docs/reimplementation/07-el-implementation-plan.md
+++ b/docs/reimplementation/07-el-implementation-plan.md
@@ -464,6 +464,22 @@ Milestone-C gate: on a SYNCED mainnet daemon with `-Pengine=rust`, a real ERC-20
 known name (including one CCIP-Read/offchain name) all return verified results matching the
 Java engine's.
 
+## EL-C-3 (dispatch fairness / performance parity) — in progress
+
+- **Landed (EL-C-3-1): oracle quick wins.** (a) The cross-call state-proof cache grows
+  8 192 → 65 536 entries/kind (Java `STATE_PROOF_CACHE_MAX` parity — sized for a
+  ~1000-token sweep). (b) `estimateGas` gains the Java `rpcEstimateGas` short-circuit:
+  empty calldata + codeless (or proven-absent) recipient → exactly 21 000, no EVM run,
+  NO 1.15 buffer; an account WITH code (contract / EIP-7702-delegated EOA) falls through.
+  (c) Snap-quality reputation now flows from the EVM oracle path: `PoolOracle` records
+  per-peer serve/failure into the same `ElPeerCache` sinks the block path feeds (via the
+  new cloneable `SnapQualitySink`), so eth_call outcomes shape the next run's dial order.
+- **Next (EL-C-3-2): batch fan-out + speculative prefetch.** Port PrefetchingEvmExecutor's
+  sentinel convergence loop (cap 4, last-two-real, prime-target, hit-only fast path,
+  fail-closed IterationLimitExceeded) + the 64-path-set batch (concurrent per-peer
+  fan-out, one verify+cache pass, chunk-level rotation, best-effort). Lanes (heavy/small
+  + SnapLaneGate semaphore) after.
+
 ## Multichain (post-Milestone-C)
 
 - **MC-1 (landed): sepolia hosted by the Rust engine.** `ChainConfig::sepolia()` /

--- a/rust/myotis-evm/src/cache.rs
+++ b/rust/myotis-evm/src/cache.rs
@@ -201,6 +201,11 @@ impl<K: std::hash::Hash + Eq + Clone, V> Lru<K, V> {
         // Lowest tick == least recently touched. Ticks are monotonic within the
         // map's lifetime; a `wrapping_add` overflow would need 2^64 operations,
         // far beyond any process lifetime, so ordering is effectively total.
+        //
+        // O(len) scan per eviction: sub-millisecond even at the 65 536-entry
+        // cap and dwarfed by the network fetch that precedes every insert —
+        // but if EL-C-3-2's batch fan-out makes inserts burst (64/chunk), move
+        // to an ordered/amortized structure before raising capacity again.
         if let Some(victim) = self
             .map
             .iter()

--- a/rust/myotis-evm/src/executor.rs
+++ b/rust/myotis-evm/src/executor.rs
@@ -196,7 +196,11 @@ impl EvmExecutor {
         // CODELESS account costs exactly 21000 — no EVM run and NO 1.15 buffer
         // (it's exact). One verified account fetch through the caching database
         // decides it; an account WITH code (contract, or an EIP-7702-delegated
-        // EOA) falls through to the full estimate.
+        // EOA) falls through to the full estimate. Fork/chain validation still
+        // runs FIRST — an unsupported chain or too-old fork fails closed here
+        // exactly like the full path, never answering 21000 for a context the
+        // executor wouldn't execute.
+        spec_for(ctx.chain_id, ctx.block_number, ctx.timestamp)?;
         if calldata.is_empty() {
             let db = OracleDatabase::new(
                 Arc::clone(&self.oracle),
@@ -463,6 +467,46 @@ mod tests {
             .estimate_gas([0x42; 20], TARGET, &[], U256::ZERO, &ctx(19_500_000, CANCUN_TIME + 1))
             .unwrap();
         assert_eq!(est, 21_000);
+    }
+
+    #[test]
+    fn oracle_failure_during_short_circuit_is_an_error_not_21000() {
+        // State unavailable must NEVER read as "no code → 21000" — that would
+        // hand out a plausible number for a recipient we couldn't verify.
+        struct FailingOracle;
+        impl crate::oracle::SnapStateOracle for FailingOracle {
+            fn fetch_account(
+                &self,
+                state_root: &[u8; 32],
+                address: [u8; 20],
+            ) -> Result<Option<OracleAccount>, crate::oracle::OracleError> {
+                Err(crate::oracle::OracleError::StateUnavailable {
+                    state_root: *state_root,
+                    address,
+                    slot: None,
+                })
+            }
+            fn fetch_storage(
+                &self,
+                _: &[u8; 32],
+                _: [u8; 20],
+                _: U256,
+            ) -> Result<U256, crate::oracle::OracleError> {
+                unreachable!("short-circuit only fetches the account")
+            }
+            fn fetch_bytecode(&self, _: &[u8; 32]) -> Result<Vec<u8>, crate::oracle::OracleError> {
+                unreachable!("short-circuit only fetches the account")
+            }
+        }
+        let exec = EvmExecutor::new(
+            Arc::new(FailingOracle),
+            Arc::new(NoopStateProofCache),
+            Arc::new(NoopBytecodeCache),
+        );
+        let got = exec.estimate_gas(
+            [0x42; 20], TARGET, &[], U256::ZERO, &ctx(19_500_000, CANCUN_TIME + 1),
+        );
+        assert!(got.is_err(), "state-unavailable must be an error, got {got:?}");
     }
 
     #[test]

--- a/rust/myotis-evm/src/executor.rs
+++ b/rust/myotis-evm/src/executor.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 
 use revm::context::result::{ExecutionResult, HaltReason, Output};
 use revm::context::{CfgEnv, TxEnv};
-use revm::database_interface::DBErrorMarker;
+use revm::database_interface::{DBErrorMarker, DatabaseRef};
 use revm::primitives::{Address, TxKind, U256};
 use revm::{Context, ExecuteEvm, MainBuilder, MainContext};
 
@@ -40,6 +40,10 @@ use crate::oracle::{OracleError, SnapStateOracle};
 /// per-tx gas cap so revm's spec-default cap (2²⁴ on the latest fork, EIP-7825)
 /// doesn't clip an `eth_call` that legitimately wants the full block budget.
 pub const VIEW_CALL_GAS: u64 = 30_000_000;
+
+/// The exact intrinsic cost of a plain value transfer — the empty-calldata
+/// no-code estimate short-circuit's answer (unbuffered; Java parity).
+const PLAIN_TRANSFER_GAS: u64 = 21_000;
 
 /// The from-less `eth_call` sender: the zero address (Geth's default). A caller
 /// that needs `msg.sender` set (ERC-20 `transfer`/`approve`) uses [`EvmExecutor::call_view_from`].
@@ -188,6 +192,25 @@ impl EvmExecutor {
         value: U256,
         ctx: &BlockContext,
     ) -> Result<u64, EvmError> {
+        // Java `rpcEstimateGas` parity: a plain transfer (empty calldata) to a
+        // CODELESS account costs exactly 21000 — no EVM run and NO 1.15 buffer
+        // (it's exact). One verified account fetch through the caching database
+        // decides it; an account WITH code (contract, or an EIP-7702-delegated
+        // EOA) falls through to the full estimate.
+        if calldata.is_empty() {
+            let db = OracleDatabase::new(
+                Arc::clone(&self.oracle),
+                ctx.state_root,
+                Arc::clone(&self.proof_cache),
+                Arc::clone(&self.bytecode_cache),
+            );
+            let no_code = db
+                .basic_ref(Address::from(target))?
+                .is_none_or(|a| a.code_hash.0 == myotis_core::trie::EMPTY_CODE_HASH);
+            if no_code {
+                return Ok(PLAIN_TRANSFER_GAS);
+            }
+        }
         match self.execute(caller, target, calldata, value, ctx)? {
             ExecutionResult::Success { gas, .. } => {
                 // The gas-limit base must cover BOTH the gross execution draw
@@ -399,6 +422,72 @@ mod tests {
             .call_view(TARGET, &[], &ctx(19_500_000, CANCUN_TIME + 1))
             .unwrap_err();
         assert!(matches!(err, EvmError::OutOfGas), "got {err:?}");
+    }
+
+    #[test]
+    fn plain_transfer_to_codeless_account_is_exactly_21000() {
+        // Empty calldata + no code → the short-circuit answers 21000 EXACTLY
+        // (no 1.15 buffer, no EVM run — Java rpcEstimateGas parity).
+        let fx = FixtureSnapStateOracle::new().with_account(
+            ROOT,
+            TARGET,
+            OracleAccount {
+                nonce: 1,
+                balance: U256::from(1_000_000u64),
+                code_hash: myotis_core::trie::EMPTY_CODE_HASH,
+                storage_root: [0x9; 32],
+            },
+        );
+        let exec = EvmExecutor::new(
+            Arc::new(fx),
+            Arc::new(NoopStateProofCache),
+            Arc::new(NoopBytecodeCache),
+        );
+        let est = exec
+            .estimate_gas([0x42; 20], TARGET, &[], U256::from(1u64), &ctx(19_500_000, CANCUN_TIME + 1))
+            .unwrap();
+        assert_eq!(est, 21_000);
+    }
+
+    #[test]
+    fn plain_transfer_to_absent_account_is_exactly_21000() {
+        // A proven-absent recipient has no code either — same exact answer.
+        // The fixture treats any un-added account as proven ABSENT.
+        let fx = FixtureSnapStateOracle::new();
+        let exec = EvmExecutor::new(
+            Arc::new(fx),
+            Arc::new(NoopStateProofCache),
+            Arc::new(NoopBytecodeCache),
+        );
+        let est = exec
+            .estimate_gas([0x42; 20], TARGET, &[], U256::ZERO, &ctx(19_500_000, CANCUN_TIME + 1))
+            .unwrap();
+        assert_eq!(est, 21_000);
+    }
+
+    #[test]
+    fn calldata_to_codeless_account_skips_the_short_circuit() {
+        // Non-empty calldata must NOT short-circuit (EIP-7623 floor + intrinsic
+        // calldata gas apply) — the estimate is buffered and above 21000.
+        let fx = FixtureSnapStateOracle::new().with_account(
+            ROOT,
+            TARGET,
+            OracleAccount {
+                nonce: 1,
+                balance: U256::ZERO,
+                code_hash: myotis_core::trie::EMPTY_CODE_HASH,
+                storage_root: [0x9; 32],
+            },
+        );
+        let exec = EvmExecutor::new(
+            Arc::new(fx),
+            Arc::new(NoopStateProofCache),
+            Arc::new(NoopBytecodeCache),
+        );
+        let est = exec
+            .estimate_gas([0x42; 20], TARGET, &[0xFFu8; 8], U256::ZERO, &ctx(19_500_000, CANCUN_TIME + 1))
+            .unwrap();
+        assert!(est > 21_000, "calldata must not short-circuit, was {est}");
     }
 
     #[test]

--- a/rust/myotis-evm/src/executor.rs
+++ b/rust/myotis-evm/src/executor.rs
@@ -45,6 +45,20 @@ pub const VIEW_CALL_GAS: u64 = 30_000_000;
 /// no-code estimate short-circuit's answer (unbuffered; Java parity).
 const PLAIN_TRANSFER_GAS: u64 = 21_000;
 
+/// Precompiles are CODELESS in state yet execute logic — an empty-calldata
+/// call to one still charges its base gas, so the 21000 short-circuit must
+/// not claim it. Conservatively covers 0x…0001 ..= 0x…01ff (mainnet uses
+/// 0x01..0x11 through Prague; the headroom absorbs future forks and
+/// RIP-7212-style 0x100 assignments — a stray fall-through only costs a full
+/// estimate run). NOTE: the Java engine's rpcEstimateGas short-circuits these
+/// today (same under-estimate) — flagged for the same fix there.
+fn in_precompile_range(addr: &[u8; 20]) -> bool {
+    addr[..18].iter().all(|&b| b == 0) && {
+        let low = u16::from_be_bytes([addr[18], addr[19]]);
+        (1..=0x01FF).contains(&low)
+    }
+}
+
 /// The from-less `eth_call` sender: the zero address (Geth's default). A caller
 /// that needs `msg.sender` set (ERC-20 `transfer`/`approve`) uses [`EvmExecutor::call_view_from`].
 const VIEW_CALLER: Address = Address::ZERO;
@@ -201,7 +215,7 @@ impl EvmExecutor {
         // exactly like the full path, never answering 21000 for a context the
         // executor wouldn't execute.
         spec_for(ctx.chain_id, ctx.block_number, ctx.timestamp)?;
-        if calldata.is_empty() {
+        if calldata.is_empty() && !in_precompile_range(&target) {
             let db = OracleDatabase::new(
                 Arc::clone(&self.oracle),
                 ctx.state_root,
@@ -467,6 +481,31 @@ mod tests {
             .estimate_gas([0x42; 20], TARGET, &[], U256::ZERO, &ctx(19_500_000, CANCUN_TIME + 1))
             .unwrap();
         assert_eq!(est, 21_000);
+    }
+
+    #[test]
+    fn precompile_target_is_never_short_circuited() {
+        // Precompiles are codeless in state but still execute: the identity
+        // precompile (0x04) with empty calldata costs 21000 + its base gas, so
+        // answering a bare 21000 would under-estimate. The guard forces the
+        // full metered path (which prices the precompile via revm).
+        let mut precompile = [0u8; 20];
+        precompile[19] = 0x04;
+        let fx = FixtureSnapStateOracle::new(); // absent everywhere, like real state
+        let exec = EvmExecutor::new(
+            Arc::new(fx),
+            Arc::new(NoopStateProofCache),
+            Arc::new(NoopBytecodeCache),
+        );
+        let est = exec
+            .estimate_gas([0x42; 20], precompile, &[], U256::ZERO, &ctx(19_500_000, CANCUN_TIME + 1))
+            .unwrap();
+        assert!(est > 21_000, "a precompile call must be metered, was {est}");
+        // The zero address is NOT a precompile — burns short-circuit normally.
+        let est0 = exec
+            .estimate_gas([0x42; 20], [0u8; 20], &[], U256::ZERO, &ctx(19_500_000, CANCUN_TIME + 1))
+            .unwrap();
+        assert_eq!(est0, 21_000);
     }
 
     #[test]

--- a/rust/myotis-net/src/el/evm.rs
+++ b/rust/myotis-net/src/el/evm.rs
@@ -207,6 +207,10 @@ fn u256_be(bytes: &[u8]) -> Option<U256> {
 pub struct PoolOracle {
     peers: Vec<Arc<ManagedPeer>>,
     handle: Handle,
+    /// Snap-quality reputation sink (None in tests): serves confirm a peer,
+    /// failures count toward DENIED — the same sinks the block path feeds, so
+    /// eth_call fetch outcomes shape the next run's dial order too (EL-C-3).
+    quality: Option<crate::el::pool::SnapQualitySink>,
     /// Per-call memo of fetched account leaves (keyed by address; the state root
     /// is fixed for the call). Dedups the account fetch that both `fetch_account`
     /// and every `fetch_storage` on the same contract need. `Some(None)` caches a
@@ -215,11 +219,27 @@ pub struct PoolOracle {
 }
 
 impl PoolOracle {
-    pub fn new(peers: Vec<Arc<ManagedPeer>>, handle: Handle) -> PoolOracle {
+    pub fn new(
+        peers: Vec<Arc<ManagedPeer>>,
+        handle: Handle,
+        quality: Option<crate::el::pool::SnapQualitySink>,
+    ) -> PoolOracle {
         PoolOracle {
             peers,
             handle,
+            quality,
             leaf_memo: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Record one per-peer fetch outcome (no-op without a sink).
+    async fn record(quality: &Option<crate::el::pool::SnapQualitySink>, peer: &ManagedPeer, served: bool) {
+        if let Some(q) = quality {
+            if served {
+                q.served(peer.addr()).await;
+            } else {
+                q.failed(peer.addr()).await;
+            }
         }
     }
 
@@ -234,13 +254,20 @@ impl PoolOracle {
             return Ok(cached.clone());
         }
         // No lock held across the network fetch.
+        let quality = self.quality.clone();
         let fetched = self.handle.block_on(async {
             for peer in &self.peers {
                 match peer.snap_get_account(state_root, &address).await {
-                    Ok(AccountOutcome::Present(leaf)) => return Some(Some(leaf)),
-                    Ok(AccountOutcome::Absent) => return Some(None),
+                    Ok(AccountOutcome::Present(leaf)) => {
+                        Self::record(&quality, peer, true).await;
+                        return Some(Some(leaf));
+                    }
+                    Ok(AccountOutcome::Absent) => {
+                        Self::record(&quality, peer, true).await;
+                        return Some(None);
+                    }
                     // Bad proof / transport for this peer — try the next.
-                    Err(_) => continue,
+                    Err(_) => Self::record(&quality, peer, false).await,
                 }
             }
             None
@@ -301,14 +328,18 @@ impl SnapStateOracle for PoolOracle {
             return Ok(U256::ZERO);
         }
         let position = slot.to_be_bytes::<32>();
+        let quality = self.quality.clone();
         let fetched = self.handle.block_on(async {
             for peer in &self.peers {
                 match peer
                     .snap_get_storage(state_root, &address, &leaf, &position)
                     .await
                 {
-                    Ok(value) => return Some(value),
-                    Err(_) => continue,
+                    Ok(value) => {
+                        Self::record(&quality, peer, true).await;
+                        return Some(value);
+                    }
+                    Err(_) => Self::record(&quality, peer, false).await,
                 }
             }
             None
@@ -331,11 +362,15 @@ impl SnapStateOracle for PoolOracle {
     fn fetch_bytecode(&self, code_hash: &[u8; 32]) -> Result<Vec<u8>, OracleError> {
         // Content-addressed: snap_get_bytecode checks keccak(code) == code_hash,
         // so any peer's bytes are trusted iff they hash correctly.
+        let quality = self.quality.clone();
         let fetched = self.handle.block_on(async {
             for peer in &self.peers {
                 match peer.snap_get_bytecode(code_hash).await {
-                    Ok(code) => return Some(code),
-                    Err(_) => continue,
+                    Ok(code) => {
+                        Self::record(&quality, peer, true).await;
+                        return Some(code);
+                    }
+                    Err(_) => Self::record(&quality, peer, false).await,
                 }
             }
             None

--- a/rust/myotis-net/src/el/pool.rs
+++ b/rust/myotis-net/src/el/pool.rs
@@ -87,6 +87,18 @@ struct PoolInner {
 }
 
 impl PoolInner {
+    /// The single quality-recording path (dirty-gated flush inside) — shared by
+    /// the pool's public sinks and [`SnapQualitySink`] so behavior can't drift.
+    async fn record_quality(&self, addr: SocketAddr, served: bool) {
+        let mut cache = self.cache.lock().await;
+        if served {
+            cache.record_snap_served(addr);
+        } else {
+            cache.record_snap_failure(addr);
+        }
+        cache.flush();
+    }
+
     /// Drop closed peers, freeing their addresses for a future re-dial. Returns
     /// the number of remaining live peers (so callers avoid a second `peers`
     /// lock just to read the count).
@@ -270,17 +282,13 @@ impl PeerPool {
     /// cached peer CONFIRMED (dial-first next run). Persists only on a quality
     /// transition (dirty-gated flush), so repeated serves don't re-write.
     pub async fn record_snap_served(&self, addr: SocketAddr) {
-        let mut cache = self.inner.cache.lock().await;
-        cache.record_snap_served(addr);
-        cache.flush();
+        self.inner.record_quality(addr, true).await;
     }
 
     /// A snap fetch against `addr` failed — after the failure threshold the
     /// cached peer is marked DENIED (deprioritized next run). Dirty-gated flush.
     pub async fn record_snap_failure(&self, addr: SocketAddr) {
-        let mut cache = self.inner.cache.lock().await;
-        cache.record_snap_failure(addr);
-        cache.flush();
+        self.inner.record_quality(addr, false).await;
     }
 
     /// A cloneable, task-safe handle onto the snap-quality sinks — hands the
@@ -456,6 +464,26 @@ fn to_pubkey(node_id: &[u8]) -> Option<[u8; 64]> {
     node_id.try_into().ok()
 }
 
+/// See [`PeerPool::quality_sink`]. The Java `SnapQualitySink` twin: serves
+/// confirm a peer (dial-first next run), failures count toward DENIED after
+/// the cache's consecutive-failure threshold. Dirty-gated flush inside.
+#[derive(Clone)]
+pub struct SnapQualitySink {
+    inner: Arc<PoolInner>,
+}
+
+impl SnapQualitySink {
+    /// A snap fetch against `addr` returned usable proof material.
+    pub async fn served(&self, addr: SocketAddr) {
+        self.inner.record_quality(addr, true).await;
+    }
+
+    /// A snap fetch against `addr` failed (bad proof / transport / timeout).
+    pub async fn failed(&self, addr: SocketAddr) {
+        self.inner.record_quality(addr, false).await;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -605,26 +633,4 @@ mod tests {
     }
 }
 
-/// See [`PeerPool::quality_sink`]. The Java `SnapQualitySink` twin: serves
-/// confirm a peer (dial-first next run), failures count toward DENIED after
-/// the cache's consecutive-failure threshold. Dirty-gated flush inside.
-#[derive(Clone)]
-pub struct SnapQualitySink {
-    inner: Arc<PoolInner>,
-}
 
-impl SnapQualitySink {
-    /// A snap fetch against `addr` returned usable proof material.
-    pub async fn served(&self, addr: std::net::SocketAddr) {
-        let mut cache = self.inner.cache.lock().await;
-        cache.record_snap_served(addr);
-        cache.flush();
-    }
-
-    /// A snap fetch against `addr` failed (bad proof / transport / timeout).
-    pub async fn failed(&self, addr: std::net::SocketAddr) {
-        let mut cache = self.inner.cache.lock().await;
-        cache.record_snap_failure(addr);
-        cache.flush();
-    }
-}

--- a/rust/myotis-net/src/el/pool.rs
+++ b/rust/myotis-net/src/el/pool.rs
@@ -283,6 +283,14 @@ impl PeerPool {
         cache.flush();
     }
 
+    /// A cloneable, task-safe handle onto the snap-quality sinks — hands the
+    /// EVM oracle's fetch loops the same reputation recording the block path
+    /// uses, without holding the whole pool (the pool owns task handles and is
+    /// deliberately not Clone).
+    pub fn quality_sink(&self) -> SnapQualitySink {
+        SnapQualitySink { inner: Arc::clone(&self.inner) }
+    }
+
     /// Stop the pool: flush the peer cache, abort the background tasks, and drop
     /// all held peers (closing them).
     pub async fn stop(self) {
@@ -594,5 +602,29 @@ mod tests {
 
         pool.stop().await;
         let _ = std::fs::remove_file(&path);
+    }
+}
+
+/// See [`PeerPool::quality_sink`]. The Java `SnapQualitySink` twin: serves
+/// confirm a peer (dial-first next run), failures count toward DENIED after
+/// the cache's consecutive-failure threshold. Dirty-gated flush inside.
+#[derive(Clone)]
+pub struct SnapQualitySink {
+    inner: Arc<PoolInner>,
+}
+
+impl SnapQualitySink {
+    /// A snap fetch against `addr` returned usable proof material.
+    pub async fn served(&self, addr: std::net::SocketAddr) {
+        let mut cache = self.inner.cache.lock().await;
+        cache.record_snap_served(addr);
+        cache.flush();
+    }
+
+    /// A snap fetch against `addr` failed (bad proof / transport / timeout).
+    pub async fn failed(&self, addr: std::net::SocketAddr) {
+        let mut cache = self.inner.cache.lock().await;
+        cache.record_snap_failure(addr);
+        cache.flush();
     }
 }

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -275,8 +275,10 @@ pub struct ElReader {
 }
 
 /// Per-kind bound for the cross-call state-proof cache (accounts and storage
-/// slots each). Generous — entries are small and eviction only trims the oldest.
-const EVM_PROOF_CACHE_ENTRIES: usize = 8192;
+/// slots each) — Java `STATE_PROOF_CACHE_MAX` parity: sized so a ~1000-token
+/// balance sweep's slots survive across the prefetch convergence loop and
+/// repeat calls (~64k small entries ≈ a few MB; eviction is LRU).
+const EVM_PROOF_CACHE_ENTRIES: usize = 65_536;
 
 /// Overall deadline for one ENS resolution walk (mirrors the Java
 /// `JavaEnsApi.RESOLVE_TIMEOUT_SEC` order of magnitude — the EnsApi contract
@@ -987,7 +989,11 @@ impl ElReader {
         if peers.is_empty() {
             return Err(format!("no snap peer available for {what}"));
         }
-        let oracle = Arc::new(PoolOracle::new(peers, tokio::runtime::Handle::current()));
+        let oracle = Arc::new(PoolOracle::new(
+            peers,
+            tokio::runtime::Handle::current(),
+            Some(self.pool.quality_sink()),
+        ));
         // Bind the concrete Arc types first, then let the unsizing coercion to the
         // trait objects happen at the constructor call (a coercion directly on
         // `Arc::clone` would instead infer `Arc<dyn Trait>` and fail to type-check).

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -277,7 +277,11 @@ pub struct ElReader {
 /// Per-kind bound for the cross-call state-proof cache (accounts and storage
 /// slots each) — Java `STATE_PROOF_CACHE_MAX` parity: sized so a ~1000-token
 /// balance sweep's slots survive across the prefetch convergence loop and
-/// repeat calls (~64k small entries ≈ a few MB; eviction is LRU).
+/// repeat calls. Honest ceiling: BOTH kinds fully populated cost ~40 MB
+/// (hashbrown buckets: accounts ~176 B, storage ~128 B × 128k buckets each),
+/// and full population is reachable on a long-running daemon because keys
+/// include the state_root (every new head re-proves). Same order as the Java
+/// cache at the same count; eviction is LRU.
 const EVM_PROOF_CACHE_ENTRIES: usize = 65_536;
 
 /// Overall deadline for one ENS resolution walk (mirrors the Java


### PR DESCRIPTION
First slice of EL-C-3 (EVM-read performance parity with the Java engine). Three independent, small wins:

1. **Cross-call proof-cache parity** — 8 192 → 65 536 entries/kind (Java `STATE_PROOF_CACHE_MAX`), sized so a ~1000-token sweep survives across the coming prefetch convergence loop and repeat calls. The doc comment carries the honest ceiling (~40 MB with both kinds fully populated — reachable on a long daemon since keys include the state_root; same order as Java's cache at the same count).
2. **The 21000 estimateGas short-circuit** (Java `rpcEstimateGas` parity) — empty calldata + codeless **or proven-absent** recipient → exactly 21 000: no EVM run, no 1.15 buffer. An account WITH code (contract, or EIP-7702-delegated EOA) falls through. Fork/chain validation still runs first (an unsupported chain fails closed, never answers 21 000), the single account fetch rides the caching database (not wasted on fall-through), and a state-unavailable oracle is an error — pinned by a dedicated test so a refactor can't regress it into a plausible-but-unverified number.
3. **Snap reputation from the EVM path** — `PoolOracle` now records per-peer serve/failure into the same `ElPeerCache` sinks the block path feeds (new cloneable `PeerPool::quality_sink()`, deduped through one `PoolInner::record_quality` so dirty-gated flushing can't drift). eth_call fetch outcomes now shape the next run's dial order: 3 consecutive failures → DENIED (dial-last), any serve → CONFIRMED (dial-first).

## Testing
273 Rust tests green (new: exact-21000, absent-recipient-21000, calldata-falls-through, oracle-failure-is-error); `:myotis-engines:test` green.

## Review note
An independent no-context review verified Java parity for the subtle absent-account arm against the Java oracle contract, confirmed the `block_on` bridge is deadlock-free (blocking-pool thread, no lock inversion), and confirmed the flush is dirty-gated. Its findings (fail-closed ordering of the short-circuit, honest cache-memory math, sink duplication, the untested oracle-failure edge, O(len) LRU note for the next slice) are all addressed in the second commit.

Next slice (EL-C-3-2): the 64-path-set batch fan-out + the sentinel prefetch convergence loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PP9WX3oschsX9T4AAKpdim