### PR TITLE
EL-C-3-2: speculative prefetch convergence loop + parallel batch fan-out

### DIFF
--- a/docs/reimplementation/07-el-implementation-plan.md
+++ b/docs/reimplementation/07-el-implementation-plan.md
@@ -487,10 +487,16 @@ Java engine's.
   fail-closed `IterationLimitExceeded` (pinned by the cap=1 twin of Java's
   `iterationCapOfOneAlwaysExceeds`). `estimateGas` bypasses the loop (Java parity).
   The wave rides `SnapStateOracle::prefetch_batch` (default no-op for fixtures):
-  `PoolOracle` chunks 64 path-sets (Java `BATCH_PATHSET_CHUNK`), pins each chunk to one
-  peer (chunk-level rotation), fans account+slot fetches out concurrently (≤48 in
-  flight, Java `PREFETCH_MAX_IN_FLIGHT`), writes verified results into the cross-call
-  sinks, and feeds chunk-level reputation. Bytecode fans out content-addressed.
+  `PoolOracle` chunks 64 path-sets (Java `BATCH_PATHSET_CHUNK` — here rotation
+  granularity, NOT message coalescing: this transport sends one request per
+  account/slot, matching the Java EthHandlerSnapPeer fan-out; the win is
+  concurrency), runs ALL chunks concurrently, pins each chunk to one peer per
+  attempt with retry rotation (3 attempts, Java `DEFAULT_MAX_ATTEMPTS`), bounds
+  wire requests with a shared 48-permit semaphore (Java `PREFETCH_MAX_IN_FLIGHT`,
+  per REQUEST) and the whole wave at 30 s (Java `PREFETCH_WAVE_TIMEOUT_SEC`),
+  writes verified results into the cross-call sinks + the account-leaf memo, and
+  feeds chunk-level reputation (cache-skips carry no signal). Bytecode fans out
+  content-addressed.
   *Still deferred (EL-C-3-3):* lanes (heavy/small + the SnapLaneGate semaphore),
   in-flight dedup for concurrent calls, the whole-result RPC cache.
 

--- a/docs/reimplementation/07-el-implementation-plan.md
+++ b/docs/reimplementation/07-el-implementation-plan.md
@@ -474,11 +474,25 @@ Java engine's.
   (c) Snap-quality reputation now flows from the EVM oracle path: `PoolOracle` records
   per-peer serve/failure into the same `ElPeerCache` sinks the block path feeds (via the
   new cloneable `SnapQualitySink`), so eth_call outcomes shape the next run's dial order.
-- **Next (EL-C-3-2): batch fan-out + speculative prefetch.** Port PrefetchingEvmExecutor's
-  sentinel convergence loop (cap 4, last-two-real, prime-target, hit-only fast path,
-  fail-closed IterationLimitExceeded) + the 64-path-set batch (concurrent per-peer
-  fan-out, one verify+cache pass, chunk-level rotation, best-effort). Lanes (heavy/small
-  + SnapLaneGate semaphore) after.
+- **Landed (EL-C-3-2): speculative prefetch + batch fan-out.** The Java
+  `PrefetchingEvmExecutor.runConvergent` twin lives in `EvmExecutor::call`: ONE
+  `OracleDatabase` shared across iterations (per-call view now includes BYTECODE — a
+  sentinel pass must execute the primed code, not a placeholder); prime-target
+  (untracked); sentinel passes return zero-shaped placeholders UNCACHED while recording
+  every access at the DB layer (Java's tracer+view collapse — every revm read passes
+  through `basic_ref`/`storage_ref`/`code_by_hash_ref`); per-iteration access diffs
+  drive best-effort parallel waves; hit-only fast path (no fresh accesses + no sentinel
+  misses → the sentinel run IS the answer); sentinel reverts tolerated; last two
+  iterations always real; real-run reverts propagate (they're the answer); cap 4 →
+  fail-closed `IterationLimitExceeded` (pinned by the cap=1 twin of Java's
+  `iterationCapOfOneAlwaysExceeds`). `estimateGas` bypasses the loop (Java parity).
+  The wave rides `SnapStateOracle::prefetch_batch` (default no-op for fixtures):
+  `PoolOracle` chunks 64 path-sets (Java `BATCH_PATHSET_CHUNK`), pins each chunk to one
+  peer (chunk-level rotation), fans account+slot fetches out concurrently (≤48 in
+  flight, Java `PREFETCH_MAX_IN_FLIGHT`), writes verified results into the cross-call
+  sinks, and feeds chunk-level reputation. Bytecode fans out content-addressed.
+  *Still deferred (EL-C-3-3):* lanes (heavy/small + the SnapLaneGate semaphore),
+  in-flight dedup for concurrent calls, the whole-result RPC cache.
 
 ## Multichain (post-Milestone-C)
 

--- a/rust/myotis-evm/src/database.rs
+++ b/rust/myotis-evm/src/database.rs
@@ -52,6 +52,10 @@ struct ViewCache {
 /// consecutive snapshots to find newly-discovered dependencies (the Java
 /// `AccessTracker` twin, collapsed to the DB layer: every revm read passes
 /// through here, so no separate opcode tracer is needed).
+/// Growth is gas-bounded, not attacker-controlled: cold reads cost revm gas
+/// regardless of what this DB returns (sentinel zeros included), so one 30 M
+/// run tops out around ~14k distinct slots / ~11k accounts; `seen` accumulates
+/// ≤4 largely-overlapping iterations and dies with the per-call database.
 #[derive(Debug, Default, Clone)]
 pub struct AccessSet {
     pub accounts: std::collections::HashSet<[u8; 20]>,
@@ -138,10 +142,6 @@ impl OracleDatabase {
         std::mem::take(&mut self.track.lock().unwrap().set)
     }
 
-    /// The state root this database is pinned to.
-    pub fn state_root(&self) -> [u8; 32] {
-        self.state_root
-    }
 
     /// Resolve an account through the three tiers. Returns the cached/ fetched
     /// account, or `None` when proven absent.

--- a/rust/myotis-evm/src/database.rs
+++ b/rust/myotis-evm/src/database.rs
@@ -41,6 +41,54 @@ struct ViewCache {
     /// `None` marks an address proven absent — cached so we don't re-fetch it.
     accounts: HashMap<[u8; 20], Option<OracleAccount>>,
     storage: HashMap<([u8; 20], U256), U256>,
+    /// Per-call bytecode (the Java `SyncStateView` holds code too): keeps the
+    /// primed/fetched code alive across the convergence loop's iterations even
+    /// when the shared bytecode cache is a Noop — a sentinel pass must execute
+    /// the REAL primed code, not an empty placeholder.
+    code: HashMap<[u8; 32], Bytes>,
+}
+
+/// Everything one execution TOUCHED (hit or miss) — the prefetch loop diffs
+/// consecutive snapshots to find newly-discovered dependencies (the Java
+/// `AccessTracker` twin, collapsed to the DB layer: every revm read passes
+/// through here, so no separate opcode tracer is needed).
+#[derive(Debug, Default, Clone)]
+pub struct AccessSet {
+    pub accounts: std::collections::HashSet<[u8; 20]>,
+    pub slots: std::collections::HashSet<([u8; 20], U256)>,
+    pub code_hashes: std::collections::HashSet<[u8; 32]>,
+}
+
+impl AccessSet {
+    pub fn is_empty(&self) -> bool {
+        self.accounts.is_empty() && self.slots.is_empty() && self.code_hashes.is_empty()
+    }
+
+    /// The entries of `self` not present in `seen`.
+    pub fn minus(&self, seen: &AccessSet) -> AccessSet {
+        AccessSet {
+            accounts: self.accounts.difference(&seen.accounts).copied().collect(),
+            slots: self.slots.difference(&seen.slots).copied().collect(),
+            code_hashes: self.code_hashes.difference(&seen.code_hashes).copied().collect(),
+        }
+    }
+
+    pub fn merge(&mut self, other: AccessSet) {
+        self.accounts.extend(other.accounts);
+        self.slots.extend(other.slots);
+        self.code_hashes.extend(other.code_hashes);
+    }
+}
+
+/// Sentinel-mode + access-tracking state (the Java `SyncStateView` sentinel
+/// semantics): with sentinel ON, a read that would need the network (tier 3)
+/// instead returns a zero-shaped placeholder WITHOUT caching it and bumps the
+/// miss counter — one cheap discovery pass per data-dependency hop.
+#[derive(Default)]
+struct Track {
+    sentinel: bool,
+    misses: u64,
+    set: AccessSet,
 }
 
 /// A `revm` state source backed by a verified oracle + the caches, pinned to one
@@ -51,6 +99,7 @@ pub struct OracleDatabase {
     proof_cache: Arc<dyn StateProofCache>,
     bytecode_cache: Arc<dyn BytecodeCache>,
     view: Mutex<ViewCache>,
+    track: Mutex<Track>,
 }
 
 impl OracleDatabase {
@@ -68,12 +117,36 @@ impl OracleDatabase {
             proof_cache,
             bytecode_cache,
             view: Mutex::new(ViewCache::default()),
+            track: Mutex::new(Track::default()),
         }
+    }
+
+    /// Toggle sentinel mode (prefetch discovery passes). OFF by default.
+    pub fn set_sentinel(&self, on: bool) {
+        self.track.lock().unwrap().sentinel = on;
+    }
+
+    /// Cumulative count of sentinel placeholders handed out — if a run finishes
+    /// with this unchanged, every read was a verified hit and the run is
+    /// byte-identical to a real one (the hit-only fast path).
+    pub fn sentinel_misses(&self) -> u64 {
+        self.track.lock().unwrap().misses
+    }
+
+    /// Snapshot AND clear the per-iteration access set (misses stay cumulative).
+    pub fn take_access_set(&self) -> AccessSet {
+        std::mem::take(&mut self.track.lock().unwrap().set)
+    }
+
+    /// The state root this database is pinned to.
+    pub fn state_root(&self) -> [u8; 32] {
+        self.state_root
     }
 
     /// Resolve an account through the three tiers. Returns the cached/ fetched
     /// account, or `None` when proven absent.
     fn account(&self, addr: [u8; 20]) -> Result<Option<OracleAccount>, OracleError> {
+        self.track.lock().unwrap().set.accounts.insert(addr);
         // Tier 1 — this call.
         if let Some(cached) = self.view.lock().unwrap().accounts.get(&addr) {
             return Ok(cached.clone());
@@ -87,6 +160,16 @@ impl OracleDatabase {
                 .accounts
                 .insert(addr, maybe_acc.clone());
             return Ok(maybe_acc);
+        }
+        // Sentinel: a would-be network fetch instead hands out a zero-shaped
+        // placeholder (revm sees a nonexistent account), UNCACHED so a later
+        // real pass re-fetches, and counts the miss.
+        {
+            let mut track = self.track.lock().unwrap();
+            if track.sentinel {
+                track.misses += 1;
+                return Ok(None);
+            }
         }
         // Tier 3 — a fresh verified fetch. The lock is NOT held across it: the
         // oracle may block on the network, and a call runs single-threaded so
@@ -148,10 +231,25 @@ impl DatabaseRef for OracleDatabase {
         if hash == EMPTY_CODE_HASH {
             return Ok(Bytecode::default());
         }
+        self.track.lock().unwrap().set.code_hashes.insert(hash);
+        // Tier 1 — this call's view (primed target code lives here).
+        if let Some(bytes) = self.view.lock().unwrap().code.get(&hash) {
+            return Ok(to_bytecode(bytes.clone()));
+        }
         // A cache hit was verified (below) when first stored, and the cache is
         // keyed by hash, so it needs no re-check.
         if let Some(bytes) = self.bytecode_cache.get(&hash) {
+            self.view.lock().unwrap().code.insert(hash, bytes.clone());
             return Ok(to_bytecode(bytes));
+        }
+        // Sentinel: empty code, uncached, counted — nested CALLs short-circuit
+        // in discovery passes (expected; the real pass executes them).
+        {
+            let mut track = self.track.lock().unwrap();
+            if track.sentinel {
+                track.misses += 1;
+                return Ok(Bytecode::default());
+            }
         }
         let bytes: Bytes = self.oracle.fetch_bytecode(&hash)?.into();
         // Defense-in-depth at the trust boundary: bytecode is content-addressed,
@@ -174,11 +272,13 @@ impl DatabaseRef for OracleDatabase {
             });
         }
         self.bytecode_cache.put(&hash, bytes.clone());
+        self.view.lock().unwrap().code.insert(hash, bytes.clone());
         Ok(to_bytecode(bytes))
     }
 
     fn storage_ref(&self, address: Address, index: U256) -> Result<U256, Self::Error> {
         let addr = address.into_array();
+        self.track.lock().unwrap().set.slots.insert((addr, index));
         // Tier 1.
         if let Some(v) = self.view.lock().unwrap().storage.get(&(addr, index)) {
             return Ok(*v);
@@ -190,6 +290,14 @@ impl DatabaseRef for OracleDatabase {
         {
             self.view.lock().unwrap().storage.insert((addr, index), v);
             return Ok(v);
+        }
+        // Sentinel: placeholder zero, uncached, counted (see `account`).
+        {
+            let mut track = self.track.lock().unwrap();
+            if track.sentinel {
+                track.misses += 1;
+                return Ok(U256::ZERO);
+            }
         }
         // Tier 3 — verified fetch (the oracle handles the account/storage-root and
         // empty-trie short-circuit internally). Lock released across it as above.

--- a/rust/myotis-evm/src/error.rs
+++ b/rust/myotis-evm/src/error.rs
@@ -32,6 +32,10 @@ pub enum EvmError {
     /// revm rejected the transaction envelope itself (should not happen for a
     /// well-formed view call — surfaced rather than swallowed).
     Transaction { detail: String },
+    /// The speculative prefetch convergence loop didn't settle within its
+    /// iteration cap (Java `IterationLimitExceeded` twin) — fail closed rather
+    /// than answer from a run that was still discovering state.
+    IterationLimitExceeded { cap: usize },
 }
 
 impl From<OracleError> for EvmError {
@@ -57,6 +61,10 @@ impl std::fmt::Display for EvmError {
                 write!(f, "unsupported chain id {chain_id} (executor is mainnet-only)")
             }
             EvmError::Transaction { detail } => write!(f, "invalid transaction: {detail}"),
+            EvmError::IterationLimitExceeded { cap } => write!(
+                f,
+                "call did not converge within {cap} prefetch iterations"
+            ),
         }
     }
 }

--- a/rust/myotis-evm/src/executor.rs
+++ b/rust/myotis-evm/src/executor.rs
@@ -31,7 +31,7 @@ use revm::{Context, ExecuteEvm, MainBuilder, MainContext};
 
 use crate::block::BlockContext;
 use crate::cache::{BytecodeCache, StateProofCache};
-use crate::database::OracleDatabase;
+use crate::database::{AccessSet, OracleDatabase};
 use crate::error::EvmError;
 use crate::fork::spec_for;
 use crate::oracle::{OracleError, SnapStateOracle};
@@ -40,6 +40,20 @@ use crate::oracle::{OracleError, SnapStateOracle};
 /// per-tx gas cap so revm's spec-default cap (2²⁴ on the latest fork, EIP-7825)
 /// doesn't clip an `eth_call` that legitimately wants the full block budget.
 pub const VIEW_CALL_GAS: u64 = 30_000_000;
+
+/// Speculative-prefetch convergence cap (Java `DEFAULT_ITERATION_CAP` — plan-
+/// mandated 4): at most two sentinel discovery passes, then real runs; a call
+/// still discovering at the cap fails closed.
+const PREFETCH_ITERATION_CAP: usize = 4;
+
+/// Interpret a converged real run for the call path.
+fn finish_call(result: ExecutionResult) -> Result<Vec<u8>, EvmError> {
+    match result {
+        ExecutionResult::Success { output, .. } => Ok(output_bytes(output)),
+        ExecutionResult::Revert { output, .. } => Err(EvmError::Reverted { data: output.to_vec() }),
+        ExecutionResult::Halt { reason, .. } => Err(map_halt(reason)),
+    }
+}
 
 /// The exact intrinsic cost of a plain value transfer — the empty-calldata
 /// no-code estimate short-circuit's answer (unbuffered; Java parity).
@@ -138,14 +152,33 @@ impl EvmExecutor {
         // rules — the chain id itself is set via cfg.chain_id, and every chain
         // spec_for knows (mainnet, sepolia) is rule-identical at a given SpecId.
         let spec = spec_for(ctx.chain_id, ctx.block_number, ctx.timestamp)?;
+        let db = self.database_for(ctx);
+        self.execute_with_db(&db, spec, caller, target, calldata, value, ctx)
+    }
 
-        let db = OracleDatabase::new(
+    fn database_for(&self, ctx: &BlockContext) -> OracleDatabase {
+        OracleDatabase::new(
             Arc::clone(&self.oracle),
             ctx.state_root,
             Arc::clone(&self.proof_cache),
             Arc::clone(&self.bytecode_cache),
-        );
+        )
+    }
 
+    /// One `transact` against a caller-owned database (the convergence loop
+    /// shares ONE database — and thus one per-call view cache — across all of
+    /// its iterations, so fetched state carries forward).
+    #[allow(clippy::too_many_arguments)]
+    fn execute_with_db(
+        &self,
+        db: &OracleDatabase,
+        spec: revm::primitives::hardfork::SpecId,
+        caller: Address,
+        target: [u8; 20],
+        calldata: &[u8],
+        value: U256,
+        ctx: &BlockContext,
+    ) -> Result<ExecutionResult, EvmError> {
         let mut cfg = CfgEnv::new_with_spec(spec);
         cfg.chain_id = ctx.chain_id;
         // Not a real tx: relax the transaction-level checks (see the module docs).
@@ -179,7 +212,13 @@ impl EvmExecutor {
         Ok(evm.transact(tx).map_err(map_evm_error)?.result)
     }
 
-    /// Run a call and return its output bytes (revert/halt → `Err`).
+    /// Run a call and return its output bytes (revert/halt → `Err`), via the
+    /// speculative prefetch CONVERGENCE LOOP (the Java `PrefetchingEvmExecutor.
+    /// runConvergent` twin): sentinel discovery passes hand out zero-shaped
+    /// placeholders for network misses while recording every access; each pass
+    /// discovers one data-dependency hop, whose fresh accesses are batch-warmed
+    /// in one parallel wave; the last two iterations always run REAL. Fails
+    /// closed with [`EvmError::IterationLimitExceeded`] at the cap.
     fn call(
         &self,
         caller: Address,
@@ -188,13 +227,103 @@ impl EvmExecutor {
         value: U256,
         ctx: &BlockContext,
     ) -> Result<Vec<u8>, EvmError> {
-        match self.execute(caller, target, calldata, value, ctx)? {
-            ExecutionResult::Success { output, .. } => Ok(output_bytes(output)),
-            ExecutionResult::Revert { output, .. } => {
-                Err(EvmError::Reverted { data: output.to_vec() })
-            }
-            ExecutionResult::Halt { reason, .. } => Err(map_halt(reason)),
+        self.call_capped(caller, target, calldata, value, ctx, PREFETCH_ITERATION_CAP)
+    }
+
+    /// [`Self::call`] with an explicit iteration cap (tests pin the fail-closed
+    /// cap behavior with cap=1, mirroring Java's `iterationCapOfOneAlwaysExceeds`).
+    #[allow(clippy::too_many_arguments)]
+    fn call_capped(
+        &self,
+        caller: Address,
+        target: [u8; 20],
+        calldata: &[u8],
+        value: U256,
+        ctx: &BlockContext,
+        cap: usize,
+    ) -> Result<Vec<u8>, EvmError> {
+        let spec = spec_for(ctx.chain_id, ctx.block_number, ctx.timestamp)?;
+        let db = self.database_for(ctx);
+
+        // Prime the target's account + code synchronously (sentinel OFF, not
+        // access-tracked — Java parity) so iteration 0 executes real top-level
+        // code instead of a sentinel empty account.
+        if let Some(acc) = db.basic_ref(Address::from(target))? {
+            db.code_by_hash_ref(acc.code_hash)?;
         }
+        let _ = db.take_access_set(); // the prime is not part of any snapshot
+
+        let mut seen = AccessSet::default();
+        let mut discovering = true;
+        for iter in 0..cap {
+            // Sentinel while still discovering, but the LAST TWO iterations are
+            // always real (one final wave + one warm real run).
+            let sentinel = discovering && iter + 2 < cap;
+            db.set_sentinel(sentinel);
+            let misses_before = db.sentinel_misses();
+            let outcome = self.execute_with_db(&db, spec, caller, target, calldata, value, ctx);
+            db.set_sentinel(false);
+            let fresh = db.take_access_set().minus(&seen);
+
+            if sentinel {
+                // A sentinel run that discovered nothing new AND handed out no
+                // placeholder was all verified hits — byte-identical to a real
+                // run: return it (the hit-only fast path). A sentinel failure
+                // (zeroes tripping a require()) is tolerated; its partial
+                // access set still drives the wave.
+                if fresh.is_empty() {
+                    if db.sentinel_misses() == misses_before {
+                        if let Ok(result) = outcome {
+                            return finish_call(result);
+                        }
+                    }
+                    discovering = false;
+                } else {
+                    self.prefetch_wave(ctx, &fresh);
+                    let mut merged = seen;
+                    merged.merge(fresh);
+                    seen = merged;
+                }
+            } else {
+                // Real-run outcomes are authoritative: errors (incl. reverts —
+                // they ARE the answer, callers key on the revert data) propagate.
+                let result = outcome?;
+                if fresh.is_empty() {
+                    return finish_call(result); // converged
+                }
+                // Still discovering under real mode (a sentinel zero had hidden
+                // a branch): warm the stragglers and run again.
+                self.prefetch_wave(ctx, &fresh);
+                let mut merged = seen;
+                merged.merge(fresh);
+                seen = merged;
+            }
+        }
+        Err(EvmError::IterationLimitExceeded { cap })
+    }
+
+    /// One best-effort parallel warm-up wave over freshly-discovered accesses:
+    /// slots grouped per account + the touched accounts + code hashes, handed to
+    /// the oracle's batch primitive (concurrent per-peer fan-out on the network
+    /// oracle; no-op on fixtures).
+    fn prefetch_wave(&self, ctx: &BlockContext, fresh: &AccessSet) {
+        let mut by_account: std::collections::HashMap<[u8; 20], Vec<U256>> =
+            std::collections::HashMap::new();
+        for addr in &fresh.accounts {
+            by_account.entry(*addr).or_default();
+        }
+        for (addr, slot) in &fresh.slots {
+            by_account.entry(*addr).or_default().push(*slot);
+        }
+        let items: Vec<([u8; 20], Vec<U256>)> = by_account.into_iter().collect();
+        let code_hashes: Vec<[u8; 32]> = fresh.code_hashes.iter().copied().collect();
+        self.oracle.prefetch_batch(
+            &ctx.state_root,
+            &items,
+            &code_hashes,
+            &*self.proof_cache,
+            &*self.bytecode_cache,
+        );
     }
 
     /// Run a call and return the gas-limit estimate (revert/halt → `Err`).
@@ -571,6 +700,98 @@ mod tests {
             .estimate_gas([0x42; 20], TARGET, &[0xFFu8; 8], U256::ZERO, &ctx(19_500_000, CANCUN_TIME + 1))
             .unwrap();
         assert!(est > 21_000, "calldata must not short-circuit, was {est}");
+    }
+
+    #[test]
+    fn iteration_cap_of_one_always_exceeds() {
+        // Java iterationCapOfOneAlwaysExceeds twin: any state-reading call needs
+        // ≥2 iterations to converge (discover, then confirm), so cap=1 must fail
+        // CLOSED — never answer from a run that was still discovering.
+        let code = vec![0x60u8, 0x00, 0x54, 0x60, 0x00, 0x52, 0x60, 0x20, 0x60, 0x00, 0xf3];
+        let exec = executor_with(code, Some(U256::from(7u64)));
+        let got = exec.call_capped(
+            Address::from([0u8; 20]), TARGET, &[], U256::ZERO,
+            &ctx(19_500_000, CANCUN_TIME + 1), 1,
+        );
+        assert!(
+            matches!(got, Err(EvmError::IterationLimitExceeded { cap: 1 })),
+            "cap=1 must fail closed, got {got:?}"
+        );
+    }
+
+    #[test]
+    fn sentinel_revert_is_tolerated_and_real_run_answers() {
+        // The contract REVERTs when slot0 == 0 — exactly what the sentinel pass
+        // sees (placeholder zero). The revert must be swallowed, the discovered
+        // slot warmed, and the REAL run (slot0 = 7) return successfully.
+        // PUSH1 0 SLOAD PUSH1 0x0b JUMPI PUSH1 0 PUSH1 0 REVERT JUMPDEST
+        // PUSH1 0 SLOAD PUSH1 0 MSTORE PUSH1 0x20 PUSH1 0 RETURN
+        let code = vec![
+            0x60u8, 0x00, 0x54, 0x60, 0x0b, 0x57, 0x60, 0x00, 0x60, 0x00, 0xfd, 0x5b,
+            0x60, 0x00, 0x54, 0x60, 0x00, 0x52, 0x60, 0x20, 0x60, 0x00, 0xf3,
+        ];
+        let exec = executor_with(code, Some(U256::from(7u64)));
+        let out = exec
+            .call_view(TARGET, &[], &ctx(19_500_000, CANCUN_TIME + 1))
+            .expect("sentinel revert must not surface; the real run answers");
+        assert_eq!(U256::from_be_slice(&out), U256::from(7u64));
+    }
+
+    #[test]
+    fn prefetch_wave_carries_the_discovered_slot() {
+        // A recording oracle: the wave must fire with the SLOAD-discovered slot
+        // grouped under the target account.
+        #[derive(Default)]
+        struct Recording {
+            inner: FixtureSnapStateOracle,
+            waves: std::sync::Mutex<Vec<Vec<([u8; 20], Vec<U256>)>>>,
+        }
+        impl crate::oracle::SnapStateOracle for Recording {
+            fn fetch_account(
+                &self, r: &[u8; 32], a: [u8; 20],
+            ) -> Result<Option<OracleAccount>, crate::oracle::OracleError> {
+                self.inner.fetch_account(r, a)
+            }
+            fn fetch_storage(
+                &self, r: &[u8; 32], a: [u8; 20], s: U256,
+            ) -> Result<U256, crate::oracle::OracleError> {
+                self.inner.fetch_storage(r, a, s)
+            }
+            fn fetch_bytecode(&self, h: &[u8; 32]) -> Result<Vec<u8>, crate::oracle::OracleError> {
+                self.inner.fetch_bytecode(h)
+            }
+            fn prefetch_batch(
+                &self,
+                _root: &[u8; 32],
+                accounts: &[([u8; 20], Vec<U256>)],
+                _code: &[[u8; 32]],
+                _ps: &dyn crate::cache::StateProofCache,
+                _cs: &dyn crate::cache::BytecodeCache,
+            ) {
+                self.waves.lock().unwrap().push(accounts.to_vec());
+            }
+        }
+        let code = vec![0x60u8, 0x00, 0x54, 0x60, 0x00, 0x52, 0x60, 0x20, 0x60, 0x00, 0xf3];
+        let ch = keccak256(&code);
+        let mut fx = FixtureSnapStateOracle::new().with_account(
+            ROOT, TARGET,
+            OracleAccount { nonce: 1, balance: U256::ZERO, code_hash: ch, storage_root: [0x9; 32] },
+        );
+        assert_eq!(fx.with_bytecode(code), ch);
+        let fx = fx.with_storage(ROOT, TARGET, [0u8; 32], U256::from(7u64));
+        let rec = Arc::new(Recording { inner: fx, waves: std::sync::Mutex::new(Vec::new()) });
+        let exec = EvmExecutor::new(
+            Arc::clone(&rec) as Arc<dyn crate::oracle::SnapStateOracle>,
+            Arc::new(NoopStateProofCache),
+            Arc::new(NoopBytecodeCache),
+        );
+        let out = exec.call_view(TARGET, &[], &ctx(19_500_000, CANCUN_TIME + 1)).unwrap();
+        assert_eq!(U256::from_be_slice(&out), U256::from(7u64));
+        let waves = rec.waves.lock().unwrap();
+        assert!(!waves.is_empty(), "the sentinel pass must trigger a wave");
+        let first = &waves[0];
+        let target_item = first.iter().find(|(a, _)| *a == TARGET).expect("target in wave");
+        assert!(target_item.1.contains(&U256::ZERO), "slot 0 must ride the wave");
     }
 
     #[test]

--- a/rust/myotis-evm/src/executor.rs
+++ b/rust/myotis-evm/src/executor.rs
@@ -271,6 +271,15 @@ impl EvmExecutor {
                 // run: return it (the hit-only fast path). A sentinel failure
                 // (zeroes tripping a require()) is tolerated; its partial
                 // access set still drives the wave.
+                //
+                // Two deliberate deviations from Java here: (1) the access diff
+                // includes CODE hashes (Java diffs only accounts+slots) — a
+                // code-only discovery keeps the wave warm instead of going
+                // serial, and determinism over verified state still guarantees
+                // convergence; (2) a hit-only run's REVERT returns immediately
+                // (Java re-derives the identical revert from the next real run
+                // — all-verified reads make the outcome deterministic, so this
+                // is the same answer one iteration sooner).
                 if fresh.is_empty() {
                     if db.sentinel_misses() == misses_before {
                         if let Ok(result) = outcome {
@@ -700,6 +709,148 @@ mod tests {
             .estimate_gas([0x42; 20], TARGET, &[0xFFu8; 8], U256::ZERO, &ctx(19_500_000, CANCUN_TIME + 1))
             .unwrap();
         assert!(est > 21_000, "calldata must not short-circuit, was {est}");
+    }
+
+    #[test]
+    fn prefetched_and_direct_agree() {
+        // The Java prefetchedAndDirectAgree differential: the convergence loop
+        // and a direct single execution must return byte-identical results —
+        // the no-sentinel-leak invariant, pinned end-to-end.
+        let code = vec![0x60u8, 0x00, 0x54, 0x60, 0x00, 0x52, 0x60, 0x20, 0x60, 0x00, 0xf3];
+        let exec = executor_with(code, Some(U256::from(1234u64)));
+        let c = ctx(19_500_000, CANCUN_TIME + 1);
+        let looped = exec.call_view(TARGET, &[], &c).unwrap();
+        let direct = {
+            let spec = spec_for(c.chain_id, c.block_number, c.timestamp).unwrap();
+            let db = exec.database_for(&c);
+            match exec
+                .execute_with_db(&db, spec, Address::from([0u8; 20]), TARGET, &[], U256::ZERO, &c)
+                .unwrap()
+            {
+                ExecutionResult::Success { output, .. } => output_bytes(output),
+                other => panic!("direct run must succeed, got {other:?}"),
+            }
+        };
+        assert_eq!(looped, direct);
+    }
+
+    #[test]
+    fn warm_cache_converges_with_zero_oracle_fetches() {
+        // Hit-only fast path: with REAL shared caches warmed by a first call,
+        // the second identical call must touch the oracle ZERO times.
+        #[derive(Default)]
+        struct Counting {
+            inner: FixtureSnapStateOracle,
+            fetches: std::sync::atomic::AtomicUsize,
+        }
+        impl crate::oracle::SnapStateOracle for Counting {
+            fn fetch_account(
+                &self, r: &[u8; 32], a: [u8; 20],
+            ) -> Result<Option<OracleAccount>, crate::oracle::OracleError> {
+                self.fetches.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                self.inner.fetch_account(r, a)
+            }
+            fn fetch_storage(
+                &self, r: &[u8; 32], a: [u8; 20], s: U256,
+            ) -> Result<U256, crate::oracle::OracleError> {
+                self.fetches.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                self.inner.fetch_storage(r, a, s)
+            }
+            fn fetch_bytecode(&self, h: &[u8; 32]) -> Result<Vec<u8>, crate::oracle::OracleError> {
+                self.fetches.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                self.inner.fetch_bytecode(h)
+            }
+        }
+        let code = vec![0x60u8, 0x00, 0x54, 0x60, 0x00, 0x52, 0x60, 0x20, 0x60, 0x00, 0xf3];
+        let ch = keccak256(&code);
+        let mut fx = FixtureSnapStateOracle::new().with_account(
+            ROOT, TARGET,
+            OracleAccount { nonce: 1, balance: U256::ZERO, code_hash: ch, storage_root: [0x9; 32] },
+        );
+        assert_eq!(fx.with_bytecode(code), ch);
+        let fx = fx.with_storage(ROOT, TARGET, [0u8; 32], U256::from(7u64));
+        let oracle = Arc::new(Counting { inner: fx, fetches: Default::default() });
+        let exec = EvmExecutor::new(
+            Arc::clone(&oracle) as Arc<dyn crate::oracle::SnapStateOracle>,
+            Arc::new(crate::cache::InMemoryStateProofCache::new(1024)),
+            Arc::new(crate::cache::InMemoryBytecodeCache::default()),
+        );
+        let c = ctx(19_500_000, CANCUN_TIME + 1);
+        assert_eq!(
+            U256::from_be_slice(&exec.call_view(TARGET, &[], &c).unwrap()),
+            U256::from(7u64)
+        );
+        let after_first = oracle.fetches.load(std::sync::atomic::Ordering::SeqCst);
+        assert_eq!(
+            U256::from_be_slice(&exec.call_view(TARGET, &[], &c).unwrap()),
+            U256::from(7u64)
+        );
+        let after_second = oracle.fetches.load(std::sync::atomic::Ordering::SeqCst);
+        assert_eq!(after_first, after_second, "warm second call must not touch the oracle");
+    }
+
+    #[test]
+    fn two_hop_dependency_converges_with_two_waves() {
+        // slot0 holds K; the contract then SLOADs K — the loop's raison d'être:
+        // hop 1 discovers slot0, hop 2 discovers slot K, two waves, converge.
+        // PUSH1 0 SLOAD SLOAD PUSH1 0 MSTORE PUSH1 0x20 PUSH1 0 RETURN
+        #[derive(Default)]
+        struct Recording {
+            inner: FixtureSnapStateOracle,
+            waves: std::sync::Mutex<Vec<Vec<([u8; 20], Vec<U256>)>>>,
+        }
+        impl crate::oracle::SnapStateOracle for Recording {
+            fn fetch_account(
+                &self, r: &[u8; 32], a: [u8; 20],
+            ) -> Result<Option<OracleAccount>, crate::oracle::OracleError> {
+                self.inner.fetch_account(r, a)
+            }
+            fn fetch_storage(
+                &self, r: &[u8; 32], a: [u8; 20], s: U256,
+            ) -> Result<U256, crate::oracle::OracleError> {
+                self.inner.fetch_storage(r, a, s)
+            }
+            fn fetch_bytecode(&self, h: &[u8; 32]) -> Result<Vec<u8>, crate::oracle::OracleError> {
+                self.inner.fetch_bytecode(h)
+            }
+            fn prefetch_batch(
+                &self,
+                _root: &[u8; 32],
+                accounts: &[([u8; 20], Vec<U256>)],
+                _code: &[[u8; 32]],
+                _ps: &dyn crate::cache::StateProofCache,
+                _cs: &dyn crate::cache::BytecodeCache,
+            ) {
+                self.waves.lock().unwrap().push(accounts.to_vec());
+            }
+        }
+        let code = vec![0x60u8, 0x00, 0x54, 0x54, 0x60, 0x00, 0x52, 0x60, 0x20, 0x60, 0x00, 0xf3];
+        let ch = keccak256(&code);
+        let mut fx = FixtureSnapStateOracle::new().with_account(
+            ROOT, TARGET,
+            OracleAccount { nonce: 1, balance: U256::ZERO, code_hash: ch, storage_root: [0x9; 32] },
+        );
+        assert_eq!(fx.with_bytecode(code), ch);
+        let mut k = [0u8; 32];
+        k[31] = 5;
+        let fx = fx
+            .with_storage(ROOT, TARGET, [0u8; 32], U256::from(5u64)) // slot0 → K=5
+            .with_storage(ROOT, TARGET, k, U256::from(42u64)); // slot5 → 42
+        let rec = Arc::new(Recording { inner: fx, waves: Default::default() });
+        let exec = EvmExecutor::new(
+            Arc::clone(&rec) as Arc<dyn crate::oracle::SnapStateOracle>,
+            Arc::new(NoopStateProofCache),
+            Arc::new(NoopBytecodeCache),
+        );
+        let out = exec.call_view(TARGET, &[], &ctx(19_500_000, CANCUN_TIME + 1)).unwrap();
+        assert_eq!(U256::from_be_slice(&out), U256::from(42u64));
+        let waves = rec.waves.lock().unwrap();
+        assert!(waves.len() >= 2, "two dependency hops need two waves, got {}", waves.len());
+        let slot_in = |w: &Vec<([u8; 20], Vec<U256>)>, s: U256| {
+            w.iter().any(|(a, slots)| *a == TARGET && slots.contains(&s))
+        };
+        assert!(slot_in(&waves[0], U256::ZERO), "hop 1 discovers slot 0");
+        assert!(slot_in(&waves[1], U256::from(5u64)), "hop 2 discovers slot K");
     }
 
     #[test]

--- a/rust/myotis-evm/src/executor.rs
+++ b/rust/myotis-evm/src/executor.rs
@@ -289,9 +289,7 @@ impl EvmExecutor {
                     discovering = false;
                 } else {
                     self.prefetch_wave(ctx, &fresh);
-                    let mut merged = seen;
-                    merged.merge(fresh);
-                    seen = merged;
+                    seen.merge(fresh);
                 }
             } else {
                 // Real-run outcomes are authoritative: errors (incl. reverts —
@@ -303,9 +301,7 @@ impl EvmExecutor {
                 // Still discovering under real mode (a sentinel zero had hidden
                 // a branch): warm the stragglers and run again.
                 self.prefetch_wave(ctx, &fresh);
-                let mut merged = seen;
-                merged.merge(fresh);
-                seen = merged;
+                seen.merge(fresh);
             }
         }
         Err(EvmError::IterationLimitExceeded { cap })

--- a/rust/myotis-evm/src/oracle.rs
+++ b/rust/myotis-evm/src/oracle.rs
@@ -151,6 +151,22 @@ pub trait SnapStateOracle: Send + Sync {
     /// Bytecode whose `keccak256` equals `code_hash` (content-addressed, so not
     /// tied to a state root). Empty for the empty-code hash.
     fn fetch_bytecode(&self, code_hash: &[u8; 32]) -> Result<Vec<u8>, OracleError>;
+
+    /// Best-effort BATCH warm-up (the Java `fetchBatch` twin, EL-C-3-2): fetch +
+    /// verify every `(account, slots…)` item and every code hash CONCURRENTLY
+    /// where the transport allows, writing verified results into the sinks.
+    /// Silent on failure — the per-item path re-fetches whatever is missing, so
+    /// batching can never weaken correctness. Default: no-op (a fixture needs
+    /// no warm-up; its per-item fetches are free).
+    fn prefetch_batch(
+        &self,
+        _state_root: &[u8; 32],
+        _accounts: &[([u8; 20], Vec<U256>)],
+        _code_hashes: &[[u8; 32]],
+        _proof_sink: &dyn crate::cache::StateProofCache,
+        _code_sink: &dyn crate::cache::BytecodeCache,
+    ) {
+    }
 }
 
 #[cfg(any(test, feature = "fixture"))]

--- a/rust/myotis-net/src/el/evm.rs
+++ b/rust/myotis-net/src/el/evm.rs
@@ -28,7 +28,10 @@ use tokio::runtime::Handle;
 
 use myotis_core::header::BlockHeader;
 use myotis_core::trie::{AccountLeaf, EMPTY_TRIE_ROOT};
-use myotis_evm::{BlockContext, OracleAccount, OracleError, SnapStateOracle, U256};
+use myotis_evm::{
+    BlockContext, BytecodeCache, OracleAccount, OracleError, SnapStateOracle, StateProofCache,
+    U256,
+};
 
 use crate::el::peer::ManagedPeer;
 use crate::el::snap::fetch::AccountOutcome;
@@ -179,6 +182,18 @@ pub fn block_context(header: &BlockHeader, chain_id: u64) -> Result<BlockContext
     })
 }
 
+/// Map a proof-verified account leaf to the oracle's account shape; `None` when
+/// the balance scalar is oversized (an adversarial leaf can't reach here, but
+/// stay panic-free).
+fn leaf_account(leaf: &AccountLeaf) -> Option<OracleAccount> {
+    Some(OracleAccount {
+        nonce: leaf.nonce,
+        balance: u256_be(&leaf.balance)?,
+        code_hash: leaf.code_hash,
+        storage_root: leaf.storage_root,
+    })
+}
+
 /// A minimal big-endian scalar → `u64`, saturating rather than panicking. Base
 /// fee never approaches `u64::MAX` on mainnet; a longer/oversized scalar (which a
 /// proof-verified header can't produce) saturates instead of aborting.
@@ -293,24 +308,130 @@ impl SnapStateOracle for PoolOracle {
         address: [u8; 20],
     ) -> Result<Option<OracleAccount>, OracleError> {
         match self.leaf(state_root, address)? {
-            Some(leaf) => {
-                let balance = u256_be(&leaf.balance).ok_or_else(|| OracleError::InvalidProof {
+            Some(leaf) => leaf_account(&leaf)
+                .ok_or_else(|| OracleError::InvalidProof {
                     state_root: *state_root,
                     address,
                     detail: format!(
                         "account balance scalar too long ({} bytes)",
                         leaf.balance.len()
                     ),
-                })?;
-                Ok(Some(OracleAccount {
-                    nonce: leaf.nonce,
-                    balance,
-                    code_hash: leaf.code_hash,
-                    storage_root: leaf.storage_root,
-                }))
-            }
+                })
+                .map(Some),
             None => Ok(None),
         }
+    }
+
+    /// Best-effort batch warm-up (EL-C-3-2; the Java `fetchBatch` twin adapted to
+    /// this transport): chunk the account items at 64 path-sets, pin each chunk
+    /// to ONE peer (rotating per chunk), fan its account+slot fetches out
+    /// CONCURRENTLY (≤48 in flight — the Java `PREFETCH_MAX_IN_FLIGHT`), and
+    /// write verified results straight into the cross-call sinks. Failures are
+    /// silent per item; the per-item path re-fetches whatever is missing.
+    /// Bytecode (content-addressed) fans out over rotating peers the same way.
+    fn prefetch_batch(
+        &self,
+        state_root: &[u8; 32],
+        accounts: &[([u8; 20], Vec<U256>)],
+        code_hashes: &[[u8; 32]],
+        proof_sink: &dyn StateProofCache,
+        code_sink: &dyn BytecodeCache,
+    ) {
+        use futures::stream::{self, StreamExt};
+        const BATCH_PATHSET_CHUNK: usize = 64; // Java SnapBackedStateOracle parity
+        const MAX_IN_FLIGHT: usize = 48; // Java PREFETCH_MAX_IN_FLIGHT
+
+        if self.peers.is_empty() || (accounts.is_empty() && code_hashes.is_empty()) {
+            return;
+        }
+        let quality = self.quality.clone();
+        self.handle.block_on(async {
+            for (chunk_idx, chunk) in accounts.chunks(BATCH_PATHSET_CHUNK).enumerate() {
+                let peer = &self.peers[chunk_idx % self.peers.len()];
+                let served: Vec<bool> = stream::iter(chunk.iter().map(|(addr, slots)| {
+                    let peer = Arc::clone(peer);
+                    async move {
+                        // Skip items another call already proved at this root.
+                        if proof_sink.get_account(state_root, addr).is_some()
+                            && slots.iter().all(|s| {
+                                proof_sink.get_storage(state_root, addr, s).is_some()
+                            })
+                        {
+                            return true;
+                        }
+                        let leaf = match peer.snap_get_account(state_root, addr).await {
+                            Ok(AccountOutcome::Present(leaf)) => leaf,
+                            Ok(AccountOutcome::Absent) => {
+                                proof_sink.put_account(state_root, addr, None);
+                                // Every slot of a proven-absent account is zero.
+                                for slot in slots {
+                                    proof_sink.put_storage(state_root, addr, slot, U256::ZERO);
+                                }
+                                return true;
+                            }
+                            Err(_) => return false,
+                        };
+                        let Some(account) = leaf_account(&leaf) else {
+                            return false; // oversized balance scalar — not cacheable
+                        };
+                        proof_sink.put_account(state_root, addr, Some(account));
+                        if leaf.storage_root == EMPTY_TRIE_ROOT {
+                            for slot in slots {
+                                proof_sink.put_storage(state_root, addr, slot, U256::ZERO);
+                            }
+                            return true;
+                        }
+                        // The item's slots, concurrently on the SAME peer.
+                        let values = futures::future::join_all(slots.iter().map(|slot| {
+                            let position = slot.to_be_bytes::<32>();
+                            let peer = Arc::clone(&peer);
+                            let leaf = leaf.clone();
+                            async move {
+                                peer.snap_get_storage(state_root, addr, &leaf, &position)
+                                    .await
+                                    .ok()
+                                    .and_then(|bytes| u256_be(&bytes))
+                            }
+                        }))
+                        .await;
+                        for (slot, value) in slots.iter().zip(values) {
+                            if let Some(v) = value {
+                                proof_sink.put_storage(state_root, addr, slot, v);
+                            }
+                        }
+                        true
+                    }
+                }))
+                .buffer_unordered(MAX_IN_FLIGHT)
+                .collect()
+                .await;
+                // Chunk-level reputation: any served item confirms the peer; a
+                // chunk where EVERYTHING failed strikes it.
+                if let Some(q) = &quality {
+                    if served.iter().any(|&ok| ok) {
+                        q.served(peer.addr()).await;
+                    } else if !served.is_empty() {
+                        q.failed(peer.addr()).await;
+                    }
+                }
+            }
+            // Bytecode: content-addressed, verified by hash inside the peer call.
+            let code_fetches = code_hashes.iter().enumerate().map(|(i, hash)| {
+                let peer = Arc::clone(&self.peers[i % self.peers.len()]);
+                async move {
+                    if code_sink.get(hash).is_some() {
+                        return;
+                    }
+                    if let Ok(code) = peer.snap_get_bytecode(hash).await {
+                        code_sink.put(hash, code.into());
+                    }
+                }
+            });
+            stream::iter(code_fetches)
+                .buffer_unordered(MAX_IN_FLIGHT)
+                .collect::<Vec<()>>()
+                .await;
+        });
     }
 
     fn fetch_storage(

--- a/rust/myotis-net/src/el/evm.rs
+++ b/rust/myotis-net/src/el/evm.rs
@@ -368,26 +368,49 @@ impl SnapStateOracle for PoolOracle {
         let fetch_item = |peer: Arc<ManagedPeer>, addr: [u8; 20], slots: Vec<U256>| {
             let sem = Arc::clone(&sem);
             async move {
-                if proof_sink.get_account(state_root, &addr).is_some()
-                    && slots
-                        .iter()
-                        .all(|s| proof_sink.get_storage(state_root, &addr, s).is_some())
-                {
+                // Only the slots this root doesn't already have — a RETRY after
+                // a partial failure re-fetches just the gaps, and a fully-cached
+                // item skips without touching the peer (no reputation signal).
+                let missing: Vec<U256> = slots
+                    .iter()
+                    .filter(|s| proof_sink.get_storage(state_root, &addr, s).is_none())
+                    .copied()
+                    .collect();
+                let account_cached = proof_sink.get_account(state_root, &addr).is_some();
+                if account_cached && missing.is_empty() {
                     return ItemOutcome::Skipped;
                 }
-                let leaf = {
-                    let _permit = sem.acquire().await;
-                    match peer.snap_get_account(state_root, &addr).await {
-                        Ok(AccountOutcome::Present(leaf)) => leaf,
-                        Ok(AccountOutcome::Absent) => {
-                            proof_sink.put_account(state_root, &addr, None);
-                            for slot in &slots {
-                                proof_sink.put_storage(state_root, &addr, slot, U256::ZERO);
-                            }
-                            self.leaf_memo.lock().unwrap().insert(addr, None);
-                            return ItemOutcome::Served;
+                // The account leaf: reuse this call's memo (primed target /
+                // earlier iterations) before spending a round-trip.
+                let memoed = self.leaf_memo.lock().unwrap().get(&addr).cloned();
+                let leaf = match memoed {
+                    Some(None) => {
+                        // Proven absent already — every slot is zero, no request.
+                        proof_sink.put_account(state_root, &addr, None);
+                        for slot in &missing {
+                            proof_sink.put_storage(state_root, &addr, slot, U256::ZERO);
                         }
-                        Err(_) => return ItemOutcome::Failed,
+                        return ItemOutcome::Skipped;
+                    }
+                    Some(Some(leaf)) => leaf,
+                    None => {
+                        // A closed semaphore (impossible in practice — nothing
+                        // closes it) must FAIL the item, never bypass the bound.
+                        let Ok(_permit) = sem.acquire().await else {
+                            return ItemOutcome::Failed;
+                        };
+                        match peer.snap_get_account(state_root, &addr).await {
+                            Ok(AccountOutcome::Present(leaf)) => leaf,
+                            Ok(AccountOutcome::Absent) => {
+                                proof_sink.put_account(state_root, &addr, None);
+                                for slot in &missing {
+                                    proof_sink.put_storage(state_root, &addr, slot, U256::ZERO);
+                                }
+                                self.leaf_memo.lock().unwrap().insert(addr, None);
+                                return ItemOutcome::Served;
+                            }
+                            Err(_) => return ItemOutcome::Failed,
+                        }
                     }
                 };
                 let Some(account) = leaf_account(&leaf) else {
@@ -396,18 +419,20 @@ impl SnapStateOracle for PoolOracle {
                 proof_sink.put_account(state_root, &addr, Some(account));
                 self.leaf_memo.lock().unwrap().insert(addr, Some(leaf.clone()));
                 if leaf.storage_root == EMPTY_TRIE_ROOT {
-                    for slot in &slots {
+                    for slot in &missing {
                         proof_sink.put_storage(state_root, &addr, slot, U256::ZERO);
                     }
                     return ItemOutcome::Served;
                 }
-                let values = futures::future::join_all(slots.iter().map(|slot| {
+                let values = futures::future::join_all(missing.iter().map(|slot| {
                     let position = slot.to_be_bytes::<32>();
                     let peer = Arc::clone(&peer);
                     let leaf = leaf.clone();
                     let sem = Arc::clone(&sem);
                     async move {
-                        let _permit = sem.acquire().await;
+                        let Ok(_permit) = sem.acquire().await else {
+                            return None; // closed semaphore = local failure
+                        };
                         peer.snap_get_storage(state_root, &addr, &leaf, &position)
                             .await
                             .ok()
@@ -415,12 +440,21 @@ impl SnapStateOracle for PoolOracle {
                     }
                 }))
                 .await;
-                for (slot, value) in slots.iter().zip(values) {
-                    if let Some(v) = value {
-                        proof_sink.put_storage(state_root, &addr, slot, v);
+                let mut any_slot_failed = false;
+                for (slot, value) in missing.iter().zip(values) {
+                    match value {
+                        Some(v) => proof_sink.put_storage(state_root, &addr, slot, v),
+                        None => any_slot_failed = true,
                     }
                 }
-                ItemOutcome::Served
+                // A partial slot failure fails the ITEM so the rotation retries
+                // it on the next peer — the retry only re-fetches the gaps
+                // (cached slots are filtered out above). Successful puts keep.
+                if any_slot_failed {
+                    ItemOutcome::Failed
+                } else {
+                    ItemOutcome::Served
+                }
             }
         };
 
@@ -484,7 +518,9 @@ impl SnapStateOracle for PoolOracle {
                     if code_sink.get(hash).is_some() {
                         return;
                     }
-                    let _permit = sem.acquire().await;
+                    let Ok(_permit) = sem.acquire().await else {
+                        return; // closed semaphore — never bypass the bound
+                    };
                     if let Ok(code) = peer.snap_get_bytecode(hash).await {
                         code_sink.put(hash, code.into());
                     }

--- a/rust/myotis-net/src/el/evm.rs
+++ b/rust/myotis-net/src/el/evm.rs
@@ -322,13 +322,19 @@ impl SnapStateOracle for PoolOracle {
         }
     }
 
-    /// Best-effort batch warm-up (EL-C-3-2; the Java `fetchBatch` twin adapted to
-    /// this transport): chunk the account items at 64 path-sets, pin each chunk
-    /// to ONE peer (rotating per chunk), fan its account+slot fetches out
-    /// CONCURRENTLY (≤48 in flight — the Java `PREFETCH_MAX_IN_FLIGHT`), and
-    /// write verified results straight into the cross-call sinks. Failures are
-    /// silent per item; the per-item path re-fetches whatever is missing.
-    /// Bytecode (content-addressed) fans out over rotating peers the same way.
+    /// Best-effort batch warm-up (EL-C-3-2; the Java `fetchBatch` +
+    /// `prefetchInParallel` twin adapted to this transport): chunk the account
+    /// items at 64 path-sets, pin each chunk to ONE peer per attempt (rotating
+    /// on retry — failed items get up to 3 attempts across peers, Java
+    /// `DEFAULT_MAX_ATTEMPTS`), run ALL chunks concurrently under one
+    /// per-REQUEST 48-permit semaphore (Java `PREFETCH_MAX_IN_FLIGHT` — bounds
+    /// wire requests, not items, so a 1000-slot item can't flood a peer), and
+    /// bound the WHOLE wave at 30 s (Java `PREFETCH_WAVE_TIMEOUT_SEC`).
+    /// Verified results go straight into the cross-call sinks (and the account
+    /// leaf memo, so the serial fallback needn't re-fetch). Failures are silent
+    /// per item; the per-item path re-fetches whatever is missing. Note: unlike
+    /// Java's one-getTrieNodes-per-chunk framing, this transport sends one
+    /// request per account/slot — the win is concurrency, not fewer messages.
     fn prefetch_batch(
         &self,
         state_root: &[u8; 32],
@@ -339,89 +345,146 @@ impl SnapStateOracle for PoolOracle {
     ) {
         use futures::stream::{self, StreamExt};
         const BATCH_PATHSET_CHUNK: usize = 64; // Java SnapBackedStateOracle parity
-        const MAX_IN_FLIGHT: usize = 48; // Java PREFETCH_MAX_IN_FLIGHT
+        const MAX_IN_FLIGHT: usize = 48; // Java PREFETCH_MAX_IN_FLIGHT (per request)
+        const MAX_ATTEMPTS: usize = 3; // Java DEFAULT_MAX_ATTEMPTS
+        const WAVE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
         if self.peers.is_empty() || (accounts.is_empty() && code_hashes.is_empty()) {
             return;
         }
+        let sem = Arc::new(tokio::sync::Semaphore::new(MAX_IN_FLIGHT));
         let quality = self.quality.clone();
-        self.handle.block_on(async {
-            for (chunk_idx, chunk) in accounts.chunks(BATCH_PATHSET_CHUNK).enumerate() {
-                let peer = &self.peers[chunk_idx % self.peers.len()];
-                let served: Vec<bool> = stream::iter(chunk.iter().map(|(addr, slots)| {
-                    let peer = Arc::clone(peer);
+
+        /// One item's outcome for retry + reputation bookkeeping.
+        enum ItemOutcome {
+            Skipped, // already cached — no request sent, no reputation signal
+            Served,
+            Failed,
+        }
+
+        // One (account, slots) item against one peer: account leaf first (its
+        // proof also decides absent/empty-trie zero-slots), then the slots
+        // concurrently — every wire request behind its own semaphore permit.
+        let fetch_item = |peer: Arc<ManagedPeer>, addr: [u8; 20], slots: Vec<U256>| {
+            let sem = Arc::clone(&sem);
+            async move {
+                if proof_sink.get_account(state_root, &addr).is_some()
+                    && slots
+                        .iter()
+                        .all(|s| proof_sink.get_storage(state_root, &addr, s).is_some())
+                {
+                    return ItemOutcome::Skipped;
+                }
+                let leaf = {
+                    let _permit = sem.acquire().await;
+                    match peer.snap_get_account(state_root, &addr).await {
+                        Ok(AccountOutcome::Present(leaf)) => leaf,
+                        Ok(AccountOutcome::Absent) => {
+                            proof_sink.put_account(state_root, &addr, None);
+                            for slot in &slots {
+                                proof_sink.put_storage(state_root, &addr, slot, U256::ZERO);
+                            }
+                            self.leaf_memo.lock().unwrap().insert(addr, None);
+                            return ItemOutcome::Served;
+                        }
+                        Err(_) => return ItemOutcome::Failed,
+                    }
+                };
+                let Some(account) = leaf_account(&leaf) else {
+                    return ItemOutcome::Failed; // oversized balance scalar
+                };
+                proof_sink.put_account(state_root, &addr, Some(account));
+                self.leaf_memo.lock().unwrap().insert(addr, Some(leaf.clone()));
+                if leaf.storage_root == EMPTY_TRIE_ROOT {
+                    for slot in &slots {
+                        proof_sink.put_storage(state_root, &addr, slot, U256::ZERO);
+                    }
+                    return ItemOutcome::Served;
+                }
+                let values = futures::future::join_all(slots.iter().map(|slot| {
+                    let position = slot.to_be_bytes::<32>();
+                    let peer = Arc::clone(&peer);
+                    let leaf = leaf.clone();
+                    let sem = Arc::clone(&sem);
                     async move {
-                        // Skip items another call already proved at this root.
-                        if proof_sink.get_account(state_root, addr).is_some()
-                            && slots.iter().all(|s| {
-                                proof_sink.get_storage(state_root, addr, s).is_some()
-                            })
-                        {
-                            return true;
-                        }
-                        let leaf = match peer.snap_get_account(state_root, addr).await {
-                            Ok(AccountOutcome::Present(leaf)) => leaf,
-                            Ok(AccountOutcome::Absent) => {
-                                proof_sink.put_account(state_root, addr, None);
-                                // Every slot of a proven-absent account is zero.
-                                for slot in slots {
-                                    proof_sink.put_storage(state_root, addr, slot, U256::ZERO);
-                                }
-                                return true;
-                            }
-                            Err(_) => return false,
-                        };
-                        let Some(account) = leaf_account(&leaf) else {
-                            return false; // oversized balance scalar — not cacheable
-                        };
-                        proof_sink.put_account(state_root, addr, Some(account));
-                        if leaf.storage_root == EMPTY_TRIE_ROOT {
-                            for slot in slots {
-                                proof_sink.put_storage(state_root, addr, slot, U256::ZERO);
-                            }
-                            return true;
-                        }
-                        // The item's slots, concurrently on the SAME peer.
-                        let values = futures::future::join_all(slots.iter().map(|slot| {
-                            let position = slot.to_be_bytes::<32>();
-                            let peer = Arc::clone(&peer);
-                            let leaf = leaf.clone();
-                            async move {
-                                peer.snap_get_storage(state_root, addr, &leaf, &position)
-                                    .await
-                                    .ok()
-                                    .and_then(|bytes| u256_be(&bytes))
-                            }
-                        }))
-                        .await;
-                        for (slot, value) in slots.iter().zip(values) {
-                            if let Some(v) = value {
-                                proof_sink.put_storage(state_root, addr, slot, v);
-                            }
-                        }
-                        true
+                        let _permit = sem.acquire().await;
+                        peer.snap_get_storage(state_root, &addr, &leaf, &position)
+                            .await
+                            .ok()
+                            .and_then(|bytes| u256_be(&bytes))
                     }
                 }))
-                .buffer_unordered(MAX_IN_FLIGHT)
-                .collect()
                 .await;
-                // Chunk-level reputation: any served item confirms the peer; a
-                // chunk where EVERYTHING failed strikes it.
-                if let Some(q) = &quality {
-                    if served.iter().any(|&ok| ok) {
-                        q.served(peer.addr()).await;
-                    } else if !served.is_empty() {
-                        q.failed(peer.addr()).await;
+                for (slot, value) in slots.iter().zip(values) {
+                    if let Some(v) = value {
+                        proof_sink.put_storage(state_root, &addr, slot, v);
                     }
                 }
+                ItemOutcome::Served
             }
+        };
+
+        let wave = async {
+            // ALL chunks concurrently (each pinned to its own rotating peer).
+            let chunk_runs = accounts.chunks(BATCH_PATHSET_CHUNK).enumerate().map(
+                |(chunk_idx, chunk)| {
+                    let quality = quality.clone();
+                    let fetch_item = &fetch_item;
+                    async move {
+                        // Items still needing a fetch; failed ones retry on the
+                        // next peer (Java tryWithRetries chunk rotation).
+                        let mut pending: Vec<&([u8; 20], Vec<U256>)> = chunk.iter().collect();
+                        let attempts = MAX_ATTEMPTS.min(self.peers.len()).max(1);
+                        for attempt in 0..attempts {
+                            if pending.is_empty() {
+                                break;
+                            }
+                            let peer =
+                                &self.peers[(chunk_idx + attempt) % self.peers.len()];
+                            let outcomes = futures::future::join_all(pending.iter().map(
+                                |(addr, slots)| {
+                                    fetch_item(Arc::clone(peer), *addr, slots.clone())
+                                },
+                            ))
+                            .await;
+                            let mut still_failed = Vec::new();
+                            let mut served_any = false;
+                            let mut asked_any = false;
+                            for (item, outcome) in pending.into_iter().zip(outcomes) {
+                                match outcome {
+                                    ItemOutcome::Served => served_any = true,
+                                    ItemOutcome::Failed => {
+                                        asked_any = true;
+                                        still_failed.push(item);
+                                    }
+                                    // Cache-skips carry NO reputation signal —
+                                    // the peer was never asked.
+                                    ItemOutcome::Skipped => {}
+                                }
+                            }
+                            if let Some(q) = &quality {
+                                if served_any {
+                                    q.served(peer.addr()).await;
+                                } else if asked_any {
+                                    q.failed(peer.addr()).await;
+                                }
+                            }
+                            pending = still_failed;
+                        }
+                    }
+                },
+            );
+            futures::future::join_all(chunk_runs).await;
+
             // Bytecode: content-addressed, verified by hash inside the peer call.
             let code_fetches = code_hashes.iter().enumerate().map(|(i, hash)| {
                 let peer = Arc::clone(&self.peers[i % self.peers.len()]);
+                let sem = Arc::clone(&sem);
                 async move {
                     if code_sink.get(hash).is_some() {
                         return;
                     }
+                    let _permit = sem.acquire().await;
                     if let Ok(code) = peer.snap_get_bytecode(hash).await {
                         code_sink.put(hash, code.into());
                     }
@@ -431,6 +494,12 @@ impl SnapStateOracle for PoolOracle {
                 .buffer_unordered(MAX_IN_FLIGHT)
                 .collect::<Vec<()>>()
                 .await;
+        };
+        // The whole wave is bounded (Java PREFETCH_WAVE_TIMEOUT_SEC): on timeout
+        // whatever landed is kept and the loop's next iteration proceeds — an
+        // eth_call must never hang on a slow warm-up.
+        self.handle.block_on(async {
+            let _ = tokio::time::timeout(WAVE_TIMEOUT, wave).await;
         });
     }
 


### PR DESCRIPTION
The substantive half of EL-C-3: storage-heavy `eth_call`s stop paying one round-trip per SLOAD. Port of the Java `PrefetchingEvmExecutor.runConvergent` machinery, collapsed to the database layer (every revm read passes through `OracleDatabase`, so no opcode tracer is needed).

## How it works

- **Sentinel discovery passes**: reads that would need the network return zero-shaped placeholders — UNCACHED, counted — while every access is recorded. Each pass discovers one data-dependency hop; its fresh accesses are batch-warmed in one parallel wave. The last two iterations always run real; cap 4 fails closed with the new `EvmError::IterationLimitExceeded` (Java `DEFAULT_ITERATION_CAP`).
- **The no-sentinel-leak invariant**: sentinel values are never written to any cache, and the hit-only fast path (return a sentinel-mode run) additionally requires zero fresh accesses AND an unmoved miss counter — every read of that run was verified. Pinned end-to-end by the `prefetched_and_direct_agree` differential (Java twin), and the whole pre-existing call/ENS suite rides the loop with byte-identical outputs.
- **The wave** (`PoolOracle::prefetch_batch`, trait default no-op for fixtures): 64 path-sets per chunk (rotation granularity — this transport sends one request per account/slot like Java's `EthHandlerSnapPeer` fan-out; the win is concurrency), ALL chunks concurrent, per-chunk peer pinning with 3-attempt retry rotation, a shared 48-permit **per-request** semaphore, a 30 s whole-wave bound, verified results written into the cross-call sinks + leaf memo, chunk-level snap reputation (cache-skips carry no signal).
- `estimateGas` bypasses the loop (Java parity). Found & fixed along the way: bytecode had no per-call view tier, so sentinel passes under Noop caches executed empty code instead of the primed target (Java `SyncStateView` holds code; now the Rust view does too).
- Two documented deviations from Java, both safe and commented at the loop: code hashes participate in the convergence diff (keeps the wave warm for code-only discoveries), and a hit-only run's revert returns one iteration sooner (deterministic either way).

## Testing

280 Rust tests green. New pins: `prefetched_and_direct_agree` (differential), `warm_cache_converges_with_zero_oracle_fetches` (hit-only fast path, zero oracle touches on a warm cache), `two_hop_dependency_converges_with_two_waves` (ordered wave contents), `iteration_cap_of_one_always_exceeds` (fail-closed cap, Java twin), `sentinel_revert_is_tolerated_and_real_run_answers`, `prefetch_wave_carries_the_discovered_slot`. `:myotis-engines:test` green.

## Review note

An independent no-context review traced every return path and verified the no-sentinel-leak invariant airtight, and compared the loop line-by-line against Java. Its findings — no wave budget + sequential chunks (unbounded eth_call latency under slow peers), per-item instead of per-request in-flight cap (single-peer flood), no chunk retry rotation (silent serial fallback), the three missing test pins, and several nits — are all addressed in the second commit.

Remaining EL-C-3 tail (optional polish, tracked in the plan doc): lanes/`SnapLaneGate`, in-flight dedup for concurrent calls, the whole-result RPC cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PP9WX3oschsX9T4AAKpdim