### PR TITLE
UI: decouple Status Start/Stop from the Settings network-enable switches

### DIFF
--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -376,8 +376,7 @@ public final class NodeService extends Service {
             return;
         }
         if (handles.containsKey(n)) return;
-        long gen = stopGen(n);
-        new Thread(() -> runBoot(n, gen), "ethp2p-boot-" + n).start();
+        spawnBoot(n, stopGen(n), null, "ethp2p-boot-" + n);
     }
 
     /**
@@ -420,13 +419,13 @@ public final class NodeService extends Service {
         // to SYNCED again before the idle controller may pause it. buildAndStart re-stamps the
         // start clocks. (rebootNetwork doesn't go through forgetStack, so clear it explicitly here.)
         reachedSynced.remove(n);
-        long gen = stopGen(n);
-        new Thread(() -> {
+        // preBoot tears the old instance down; buildAndStart then re-acquires
+        // bootLock(n) for its start() — the teardown frees the ports first.
+        spawnBoot(n, stopGen(n), () -> {
             synchronized (bootLock(n)) {
                 try { ENGINE.stop(n); } catch (Throwable ignored) {}
             }
-            runBoot(n, gen);   // re-acquires bootLock(n) for its start() — frees ports first
-        }, "ethp2p-reboot-" + n).start();
+        }, "ethp2p-reboot-" + n);
     }
 
     /** Drop all NodeService-side bookkeeping for a network (the engine-side stop happens separately). */
@@ -450,7 +449,8 @@ public final class NodeService extends Service {
         return false;
     }
 
-    /** Boots currently inside {@link #runBoot} — guards {@link #stopIfNoStacksLeft}
+    /** Boots claimed by {@link #spawnBoot} (on the calling thread, before the worker
+     *  starts) and released in the worker's finally — guards {@link #stopIfNoStacksLeft}
      *  against the transiently-empty {@link #handles} map while a chain is still
      *  spinning up (a boot only registers its handle once start() succeeds). */
     private final java.util.concurrent.atomic.AtomicInteger bootsInFlight =
@@ -466,25 +466,33 @@ public final class NodeService extends Service {
     }
 
     /**
-     * The boot-thread entry around {@link #buildAndStart}: counts the boot in flight,
-     * and once it finishes (success, bail, or failure) gives the service-stop check
-     * one shot. The gen comparison finishes a runtime stop that raced this boot: the
-     * stop's own check ran while this boot was still in flight and skipped.
+     * Spawn a boot worker for {@code n}: runs {@code preBoot} (nullable — reboot's
+     * old-instance teardown), then {@link #buildAndStart}, and once the worker
+     * finishes (success, bail, or failure) gives the service-stop check one shot.
+     * The in-flight count is claimed HERE, on the CALLING thread, before start():
+     * claimed inside the worker there'd be a scheduling gap in which a concurrent
+     * user stop sees zero boots in flight over an empty map and tears the service
+     * down under the pending boot. The gen comparison in the finally finishes a
+     * runtime stop that raced this boot: the stop's own check ran while this boot
+     * was still in flight and skipped.
      */
-    private void runBoot(String n, long gen) {
+    private void spawnBoot(String n, long gen, Runnable preBoot, String threadName) {
         bootsInFlight.incrementAndGet();
-        try {
-            buildAndStart(n, gen);
-        } finally {
-            bootsInFlight.decrementAndGet();
-            stopIfNoStacksLeft(stopGen(n) != gen);
-        }
+        new Thread(() -> {
+            try {
+                if (preBoot != null) preBoot.run();
+                buildAndStart(n, gen);
+            } finally {
+                bootsInFlight.decrementAndGet();
+                stopIfNoStacksLeft(stopGen(n) != gen);
+            }
+        }, threadName).start();
     }
 
     /**
      * Stop the whole foreground service once the last stack is gone and no boot is in
      * flight. {@code userStop} (Status Stop / Settings disable, incl. one racing a boot —
-     * see {@link #runBoot}) makes the empty map decisive even while networks are still
+     * see {@link #spawnBoot}) makes the empty map decisive even while networks are still
      * ENABLED: a runtime stop keeps the flags on by design, and a zero-stack service has
      * nothing to host (its notification would read "Starting…" forever). Start cold-starts
      * the service again and onStartCommand boots the enabled set. Non-user callers
@@ -1336,8 +1344,7 @@ public final class NodeService extends Service {
         // blocking-ish, so build + start each on its own worker; they bind distinct ports
         // (NetworkConfig.defaultElPort/Discv5Port/RpcPort) so they never collide.
         for (String n : enabledNetworks(this)) {
-            long gen = stopGen(n);
-            new Thread(() -> runBoot(n, gen), "ethp2p-boot-" + n).start();
+            spawnBoot(n, stopGen(n), null, "ethp2p-boot-" + n);
         }
         return START_NOT_STICKY;
     }
@@ -1370,7 +1377,7 @@ public final class NodeService extends Service {
             // network). A whole-service Stop, a per-network disable, or a runtime stopNetwork
             // (which bumps the stop generation instead of the enabled flag) could race this
             // boot, so bail if any says the chain is no longer wanted — re-checked after
-            // start() too, since start() blocks and the race window spans it. runBoot fires
+            // start() too, since start() blocks and the race window spans it. spawnBoot's worker fires
             // the service-stop check after every bail/return path.
             synchronized (bootLock(n)) {
                 if (!RUNNING.get() || !isNetworkEnabled(this, n) || stopGen(n) != gen) {
@@ -1460,7 +1467,7 @@ public final class NodeService extends Service {
                     }
                 }
             }
-            // service-stop check happens in runBoot's finally, after the in-flight count drops
+            // service-stop check happens in the boot worker's finally, after the in-flight count drops
         }
     }
 

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -342,14 +342,35 @@ public final class NodeService extends Service {
     }
 
     /**
-     * Enable a network: persist the flag and bring its stack up. If the service isn't
-     * running yet, start it (onStartCommand boots the whole enabled-set); otherwise build
-     * and start just this stack on a worker. No-op if it's already live.
+     * Enable a network (Settings semantics): persist the flag AND bring its stack up
+     * via {@link #startNetwork}.
      */
     public void enableNetwork(String name) {
-        noteUiActivity();
         String n = canonicalNetwork(name);
         setNetworkEnabled(this, n, true);
+        startNetwork(n);
+    }
+
+    /**
+     * Disable a network (Settings semantics): persist the flag off AND shut its stack
+     * down via {@link #stopNetwork}.
+     */
+    public void disableNetwork(String name) {
+        String n = canonicalNetwork(name);
+        setNetworkEnabled(this, n, false);
+        stopNetwork(n);
+    }
+
+    /**
+     * Runtime-only start (the Status page's Start button): bring the stack up WITHOUT
+     * touching the persisted enabled flag. If the service isn't running yet, start it
+     * (onStartCommand boots the whole enabled-set — callers ensure the network is in it,
+     * or go through {@link #enableNetwork}); otherwise build and start just this stack
+     * on a worker. No-op if it's already live.
+     */
+    public void startNetwork(String name) {
+        noteUiActivity();
+        String n = canonicalNetwork(name);
         if (!RUNNING.get()) {
             startForegroundService(new Intent(this, NodeService.class));
             return;
@@ -359,19 +380,20 @@ public final class NodeService extends Service {
     }
 
     /**
-     * Disable a network: persist the flag, remove and shut down its stack on a worker. If it
-     * was the last live stack, the whole service stops (mirrors a Stop-node tap).
+     * Runtime-only stop (the Status page's Stop button): remove and shut down the stack
+     * on a worker WITHOUT touching the persisted enabled flag — the chain stays enabled
+     * and boots again on the next service start. If it was the last live stack, the
+     * whole service stops (mirrors a Stop-node tap).
      */
-    public void disableNetwork(String name) {
+    public void stopNetwork(String name) {
         String n = canonicalNetwork(name);
-        setNetworkEnabled(this, n, false);
         forgetStack(n);   // drop from the UI's live map immediately
         new Thread(() -> {
             synchronized (bootLock(n)) {
                 try { ENGINE.stop(n); } catch (Throwable ignored) {}
             }
             stopIfNoStacksLeft();
-        }, "ethp2p-disable-" + n).start();
+        }, "ethp2p-stop-" + n).start();
     }
 
     /**

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -376,23 +376,31 @@ public final class NodeService extends Service {
             return;
         }
         if (handles.containsKey(n)) return;
-        new Thread(() -> buildAndStart(n), "ethp2p-boot-" + n).start();
+        long gen = stopGen(n);
+        new Thread(() -> runBoot(n, gen), "ethp2p-boot-" + n).start();
     }
 
     /**
      * Runtime-only stop (the Status page's Stop button): remove and shut down the stack
      * on a worker WITHOUT touching the persisted enabled flag — the chain stays enabled
      * and boots again on the next service start. If it was the last live stack, the
-     * whole service stops (mirrors a Stop-node tap).
+     * whole service stops (mirrors a Stop-node tap): a service with zero stacks has
+     * nothing to host, and its notification would read "Starting…" forever.
      */
     public void stopNetwork(String name) {
         String n = canonicalNetwork(name);
+        // Invalidate any queued/in-flight boot of this chain. The old disable path got
+        // this for free from buildAndStart's enabled-flag re-check; a runtime stop
+        // leaves the flag on, so without the generation bump a boot that loses the
+        // bootLock race would resurrect the chain the user just stopped.
+        stopGens.computeIfAbsent(n, k -> new java.util.concurrent.atomic.AtomicLong()).incrementAndGet();
         forgetStack(n);   // drop from the UI's live map immediately
         new Thread(() -> {
             synchronized (bootLock(n)) {
                 try { ENGINE.stop(n); } catch (Throwable ignored) {}
             }
-            stopIfNoStacksLeft();
+            // userStop=true: an empty map is decisive even though flags stay enabled.
+            stopIfNoStacksLeft(true);
         }, "ethp2p-stop-" + n).start();
     }
 
@@ -412,11 +420,12 @@ public final class NodeService extends Service {
         // to SYNCED again before the idle controller may pause it. buildAndStart re-stamps the
         // start clocks. (rebootNetwork doesn't go through forgetStack, so clear it explicitly here.)
         reachedSynced.remove(n);
+        long gen = stopGen(n);
         new Thread(() -> {
             synchronized (bootLock(n)) {
                 try { ENGINE.stop(n); } catch (Throwable ignored) {}
             }
-            buildAndStart(n);   // re-acquires bootLock(n) for its start() — frees ports first
+            runBoot(n, gen);   // re-acquires bootLock(n) for its start() — frees ports first
         }, "ethp2p-reboot-" + n).start();
     }
 
@@ -441,15 +450,53 @@ public final class NodeService extends Service {
         return false;
     }
 
+    /** Boots currently inside {@link #runBoot} — guards {@link #stopIfNoStacksLeft}
+     *  against the transiently-empty {@link #handles} map while a chain is still
+     *  spinning up (a boot only registers its handle once start() succeeds). */
+    private final java.util.concurrent.atomic.AtomicInteger bootsInFlight =
+            new java.util.concurrent.atomic.AtomicInteger();
+
+    /** Per-network stop generation, bumped by {@link #stopNetwork}. Boot threads
+     *  snapshot it at spawn and bail if it moved — see the stopNetwork comment. */
+    private final java.util.concurrent.ConcurrentHashMap<String, java.util.concurrent.atomic.AtomicLong> stopGens =
+            new java.util.concurrent.ConcurrentHashMap<>();
+
+    private long stopGen(String n) {
+        return stopGens.computeIfAbsent(n, k -> new java.util.concurrent.atomic.AtomicLong()).get();
+    }
+
     /**
-     * Stop the whole foreground service once the last stack is gone AND no network is still
-     * enabled — i.e. the user disabled the last chain. The enabled-set guard matters because a
-     * boot-bail can see the map transiently empty while other enabled chains are still spinning
-     * up; without it, disabling one chain mid-boot could wrongly stop the whole service.
+     * The boot-thread entry around {@link #buildAndStart}: counts the boot in flight,
+     * and once it finishes (success, bail, or failure) gives the service-stop check
+     * one shot. The gen comparison finishes a runtime stop that raced this boot: the
+     * stop's own check ran while this boot was still in flight and skipped.
      */
-    private void stopIfNoStacksLeft() {
-        if (handles.isEmpty() && !anyNetworkEnabled() && RUNNING.compareAndSet(true, false)) {
-            LogBuffer.i(TAG, "no networks left enabled; stopping service");
+    private void runBoot(String n, long gen) {
+        bootsInFlight.incrementAndGet();
+        try {
+            buildAndStart(n, gen);
+        } finally {
+            bootsInFlight.decrementAndGet();
+            stopIfNoStacksLeft(stopGen(n) != gen);
+        }
+    }
+
+    /**
+     * Stop the whole foreground service once the last stack is gone and no boot is in
+     * flight. {@code userStop} (Status Stop / Settings disable, incl. one racing a boot —
+     * see {@link #runBoot}) makes the empty map decisive even while networks are still
+     * ENABLED: a runtime stop keeps the flags on by design, and a zero-stack service has
+     * nothing to host (its notification would read "Starting…" forever). Start cold-starts
+     * the service again and onStartCommand boots the enabled set. Non-user callers
+     * (boot-bail/failure paths) keep the old enabled-set guard, so a failed boot with
+     * enabled chains leaves the service up exactly as before. The boots-in-flight guard
+     * covers the transiently-empty map while another chain is still spinning up.
+     */
+    private void stopIfNoStacksLeft(boolean userStop) {
+        if (handles.isEmpty() && bootsInFlight.get() == 0
+                && (userStop || !anyNetworkEnabled())
+                && RUNNING.compareAndSet(true, false)) {
+            LogBuffer.i(TAG, "no stacks left; stopping service");
             stopForeground(STOP_FOREGROUND_REMOVE);
             stopSelf();
         }
@@ -1289,7 +1336,8 @@ public final class NodeService extends Service {
         // blocking-ish, so build + start each on its own worker; they bind distinct ports
         // (NetworkConfig.defaultElPort/Discv5Port/RpcPort) so they never collide.
         for (String n : enabledNetworks(this)) {
-            new Thread(() -> buildAndStart(n), "ethp2p-boot-" + n).start();
+            long gen = stopGen(n);
+            new Thread(() -> runBoot(n, gen), "ethp2p-boot-" + n).start();
         }
         return START_NOT_STICKY;
     }
@@ -1301,7 +1349,7 @@ public final class NodeService extends Service {
      * internally, so a fast disable→enable (or rebootNetwork) of the same chain waits for
      * its own ports to free. Stops the service only if the very last stack fails to come up.
      */
-    private void buildAndStart(String netName) {
+    private void buildAndStart(String netName, long gen) {
         String n = canonicalNetwork(netName);
         ChainHandle created = null;
         try {
@@ -1319,14 +1367,15 @@ public final class NodeService extends Service {
             // create() + start() under the per-network bootLock: a Stop→Start / disable→enable
             // has this boot wait for the old instance's teardown (which holds the same lock) to
             // free the ports AND unregister from the engine (create() throws on a still-hosted
-            // network). A whole-service Stop or a per-network disable could race this boot, so
-            // bail if either says the chain is no longer wanted — re-checked after start() too,
-            // since start() blocks and the race window spans it.
+            // network). A whole-service Stop, a per-network disable, or a runtime stopNetwork
+            // (which bumps the stop generation instead of the enabled flag) could race this
+            // boot, so bail if any says the chain is no longer wanted — re-checked after
+            // start() too, since start() blocks and the race window spans it. runBoot fires
+            // the service-stop check after every bail/return path.
             synchronized (bootLock(n)) {
-                if (!RUNNING.get() || !isNetworkEnabled(this, n)) {
+                if (!RUNNING.get() || !isNetworkEnabled(this, n) || stopGen(n) != gen) {
                     LogBuffer.i(TAG, "[" + n + "] stop/disable raced boot; skipping");
                     forgetStack(n);
-                    stopIfNoStacksLeft();
                     return;
                 }
                 if (ENGINE.get(n) != null) {
@@ -1382,14 +1431,12 @@ public final class NodeService extends Service {
                     LogBuffer.e(TAG, "[" + n + "] node stack failed to start");
                     forgetStack(n);
                     try { ENGINE.stop(n); } catch (Throwable ignored) {}
-                    stopIfNoStacksLeft();
                     return;
                 }
-                if (!RUNNING.get() || !isNetworkEnabled(this, n)) {
+                if (!RUNNING.get() || !isNetworkEnabled(this, n) || stopGen(n) != gen) {
                     LogBuffer.i(TAG, "[" + n + "] stop/disable raced start; tearing down");
                     forgetStack(n);
                     try { ENGINE.stop(n); } catch (Throwable ignored) {}
-                    stopIfNoStacksLeft();
                     return;
                 }
             }
@@ -1413,7 +1460,7 @@ public final class NodeService extends Service {
                     }
                 }
             }
-            stopIfNoStacksLeft();
+            // service-stop check happens in runBoot's finally, after the in-flight count drops
         }
     }
 

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/cmp/AndroidNodeBridge.kt
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/cmp/AndroidNodeBridge.kt
@@ -71,6 +71,20 @@ class AndroidNodeController(
         }
     }
     override fun disableNetwork(name: String) { serviceProvider()?.disableNetwork(name) }
+
+    override fun startNetwork(name: String) {
+        // Runtime-only start — same isRunning gate as enableNetwork, but the cold path must
+        // NOT persist the enabled flag. onStartService boots the persisted enabled set; the
+        // Status page only offers runtime Start for enabled chains (a disabled chain routes
+        // through enableNetwork), so the started set includes [name].
+        val svc = serviceProvider()
+        if (svc != null && NodeService.isRunning()) {
+            svc.startNetwork(name)
+        } else {
+            onStartService()
+        }
+    }
+    override fun stopNetwork(name: String) { serviceProvider()?.stopNetwork(name) }
     override fun rebootNetwork(name: String) { serviceProvider()?.rebootNetwork(name) }
     override fun shutdown() { serviceProvider()?.shutdown() }
     override fun setTargetSnapPeers(target: Int) { serviceProvider()?.setTargetSnapPeers(target) }

--- a/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
@@ -65,6 +65,15 @@ class DesktopNodeController(
         get() = engine.hostedNetworks().any { engine.get(it)?.isRunning == true }
 
     override fun enableNetwork(name: String) {
+        // Settings semantics: persist the enabled flag, then the runtime start. (The shared
+        // SettingsTab also persists before calling this — idempotent — but hosts must not
+        // rely on that: the interface contract is that enableNetwork persists.)
+        settings.setNetworkEnabled(engine.canonicalNetworkName(name), true)
+        startNetwork(name)
+    }
+
+    override fun startNetwork(name: String) {
+        // Runtime-only start (Status page): never touches the persisted enabled flag.
         // Resolve the canonical name up front (xdai/gbc → gnosis, case-folds): the boot lock
         // and the key/cache filenames must use the canonical form, or an alias would
         // double-boot and leak.
@@ -124,13 +133,22 @@ class DesktopNodeController(
     }
 
     override fun disableNetwork(name: String) {
+        // Settings semantics: persist the flag off, then the runtime stop.
+        settings.setNetworkEnabled(engine.canonicalNetworkName(name), false)
+        stopNetwork(name)
+    }
+
+    override fun stopNetwork(name: String) {
+        // Runtime-only stop (Status page): never touches the persisted enabled flag.
         val canonical = engine.canonicalNetworkName(name)
         synchronized(bootLock(canonical)) { dropNetwork(canonical) }
     }
 
     override fun rebootNetwork(name: String) {
-        disableNetwork(name)
-        enableNetwork(name)
+        // stop+start, NOT disable+enable: a reboot (e.g. RPC-port change) must not
+        // rewrite the persisted enabled flags.
+        stopNetwork(name)
+        startNetwork(name)
     }
 
     override fun shutdown() {

--- a/app-desktop/src/main/kotlin/io/myotis/desktop/Main.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/Main.kt
@@ -7,8 +7,9 @@ import java.nio.file.Path
 
 /**
  * Desktop GUI entry: the SAME shared `:ui` NodeScreen Android renders, driven by the
- * in-process Java backend via [DesktopNodeController]. Starts the primary network on
- * launch so the Status view fills in as it syncs.
+ * in-process Java backend via [DesktopNodeController]. Starts the enabled networks on
+ * launch (runtime start — booting must not rewrite the enabled flags) so the Status
+ * view fills in as they sync.
  */
 fun main() {
     val dataDir = Path.of(System.getProperty("user.home"), ".myotis")
@@ -16,7 +17,7 @@ fun main() {
     val settings = DesktopSettings()
     val controller = DesktopNodeController(dataDir, settings)
     val history = DesktopQueryHistory(dataDir.resolve("query-history.tsv"))
-    controller.enableNetwork(settings.primaryNetwork())
+    settings.enabledNetworks().forEach(controller::startNetwork)
 
     application {
         Window(

--- a/docs/multichain-android-phase-b.md
+++ b/docs/multichain-android-phase-b.md
@@ -86,8 +86,9 @@ new Thread(() -> { if (!stack.start()) stacks.remove(n); }, "ethp2p-boot-" + n).
   **Move the all-stacks-down `stopForeground/stopSelf` here** — today the single-stack
   boot-failure path calls it (~1332); per-stack failures must NOT stop the service.
 - Delete `switchNetwork`/`restartWithCurrentSettings`/`restartAfterShutdown` (~254–276,
-  174). An RPC-port change for `n` = `disableNetwork(n); enableNetwork(n)` (only that
-  stack reboots). Keep the **Stop→Start race** safety: `ChainStack.start()`/`shutdown()`
+  174). An RPC-port change for `n` = `rebootNetwork(n)` (only that stack reboots; NOT
+  disable+enable — those persist the enabled flag, a reboot must never rewrite it).
+  Keep the **Stop→Start race** safety: `ChainStack.start()`/`shutdown()`
   are already `synchronized` together, so a fast disable→enable on one stack serializes
   on that stack's monitor (this replaces the old service-wide `restartAfterShutdown`
   dance — verify on device that a port-change reboot of one chain doesn't flap the

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeController.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeController.kt
@@ -27,8 +27,9 @@ interface NodeController {
     /**
      * Runtime-only start: bring the stack up WITHOUT touching the persisted enabled
      * flag. The Status page's Start button — starting a stopped chain there must not
-     * flip its Settings switch. Callers ensure the network is enabled (or the service
-     * already running); a cold host boots the enabled set, which then includes it.
+     * flip its Settings switch. Callers ensure the network is ENABLED (a disabled
+     * chain routes through [enableNetwork] instead): hosts may boot only the enabled
+     * set (Android's cold service does) or refuse disabled chains outright.
      */
     fun startNetwork(name: String)
 

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeController.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeController.kt
@@ -15,8 +15,30 @@ interface NodeController {
     /** Live per-network snapshots, keyed by network name, for the UI to render. */
     fun snapshots(): Flow<Map<String, NodeSnapshot>>
 
+    /**
+     * Settings semantics: persist the network's enabled flag AND bring its stack up.
+     * The enabled flag is what boots on the next app/service start.
+     */
     fun enableNetwork(name: String)
+
+    /** Settings semantics: persist the enabled flag off AND tear the stack down. */
     fun disableNetwork(name: String)
+
+    /**
+     * Runtime-only start: bring the stack up WITHOUT touching the persisted enabled
+     * flag. The Status page's Start button — starting a stopped chain there must not
+     * flip its Settings switch. Callers ensure the network is enabled (or the service
+     * already running); a cold host boots the enabled set, which then includes it.
+     */
+    fun startNetwork(name: String)
+
+    /**
+     * Runtime-only stop: tear the stack down WITHOUT touching the persisted enabled
+     * flag. The Status page's Stop button — the chain stays enabled and comes back
+     * on the next app/service start.
+     */
+    fun stopNetwork(name: String)
+
     fun rebootNetwork(name: String)
     fun shutdown()
 

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
@@ -108,7 +108,10 @@ fun NodeScreen(
     // still-live stack. Sourcing from settings rather than the live map keeps a
     // runtime-stopped chain's chip visible — Stop on the Status page is decoupled from
     // the Settings enable switch, so an enabled-but-stopped chain stays selectable and
-    // can be started again from Status.
+    // can be started again from Status. enabledNetworks() is a plain read (no snapshot
+    // state): a Settings toggle re-derives it via the boot/stop it triggers changing
+    // `snapshots` within one 2s poll (or via any tab switch), so chips may lag a toggle
+    // by a beat but self-heal.
     val chains = (settings.enabledNetworks() + snapshots.keys).distinct()
     var selected by remember { mutableStateOf<String?>(null) }
     val network = selected?.takeIf { it in chains } ?: chains.firstOrNull() ?: settings.primaryNetwork()

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
@@ -109,10 +109,12 @@ fun NodeScreen(
     // runtime-stopped chain's chip visible — Stop on the Status page is decoupled from
     // the Settings enable switch, so an enabled-but-stopped chain stays selectable and
     // can be started again from Status. enabledNetworks() is a plain read (no snapshot
-    // state): a Settings toggle re-derives it via the boot/stop it triggers changing
-    // `snapshots` within one 2s poll (or via any tab switch), so chips may lag a toggle
-    // by a beat but self-heal.
-    val chains = (settings.enabledNetworks() + snapshots.keys).distinct()
+    // state), so SettingsTab bumps enabledRev on every toggle to re-derive the chips
+    // immediately — without it they'd lag until the boot/stop lands in `snapshots`.
+    var enabledRev by remember { mutableStateOf(0) }
+    val chains = remember(enabledRev, snapshots) {
+        (settings.enabledNetworks() + snapshots.keys).distinct()
+    }
     var selected by remember { mutableStateOf<String?>(null) }
     val network = selected?.takeIf { it in chains } ?: chains.firstOrNull() ?: settings.primaryNetwork()
     val current = snapshots[network]
@@ -144,7 +146,7 @@ fun NodeScreen(
                 0 -> StatusTab(controller, settings, current, network, online, onOpenNetworkSettings)
                 1 -> QueryTab(controller, settings, current, network, history)
                 2 -> LogsTab(logs)
-                3 -> SettingsTab(controller, settings, snapshots)
+                3 -> SettingsTab(controller, settings, snapshots, onEnabledChanged = { enabledRev++ })
             }
         }
     }
@@ -228,6 +230,9 @@ private fun SettingsTab(
     controller: NodeController,
     settings: Settings,
     snapshots: Map<String, NodeSnapshot>,
+    // Notifies the screen that the persisted enabled set changed, so the network
+    // chips (derived from settings, not snapshot state) re-derive immediately.
+    onEnabledChanged: () -> Unit = {},
 ) {
     val networks = remember { settings.allNetworks() }
     // Per-network enabled toggle + RPC-port text, seeded from persisted settings. Toggling a
@@ -274,6 +279,7 @@ private fun SettingsTab(
                             enabled[id] = on
                             settings.setNetworkEnabled(id, on)
                             if (on) controller.enableNetwork(id) else controller.disableNetwork(id)
+                            onEnabledChanged()
                         },
                     )
                 }

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
@@ -104,9 +104,12 @@ fun NodeScreen(
     val online by onlineFlow.collectAsState(initial = true)
     var tab by remember { mutableStateOf(0) }
 
-    // Network selector: chips over the live stacks (or the enabled-set when stopped) drive which
-    // chain Status + Query operate on, so a 2nd enabled chain (e.g. gnosis) is visible/queryable.
-    val chains = snapshots.keys.toList().ifEmpty { settings.enabledNetworks() }
+    // Network selector: chips over the ENABLED set (the Settings switches), plus any
+    // still-live stack. Sourcing from settings rather than the live map keeps a
+    // runtime-stopped chain's chip visible — Stop on the Status page is decoupled from
+    // the Settings enable switch, so an enabled-but-stopped chain stays selectable and
+    // can be started again from Status.
+    val chains = (settings.enabledNetworks() + snapshots.keys).distinct()
     var selected by remember { mutableStateOf<String?>(null) }
     val network = selected?.takeIf { it in chains } ?: chains.firstOrNull() ?: settings.primaryNetwork()
     val current = snapshots[network]
@@ -115,7 +118,7 @@ fun NodeScreen(
         Column(Modifier.fillMaxSize().padding(16.dp)) {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text("Myotis", style = MaterialTheme.typography.headlineSmall)
-                if (chains.size > 1) {
+                if (chains.isNotEmpty()) {
                     Spacer(Modifier.width(12.dp))
                     NetworkChips(chains, network, onSelect = { selected = it })
                 }
@@ -135,7 +138,7 @@ fun NodeScreen(
             Spacer(Modifier.height(16.dp))
 
             when (tab) {
-                0 -> StatusTab(controller, current, network, online, onOpenNetworkSettings)
+                0 -> StatusTab(controller, settings, current, network, online, onOpenNetworkSettings)
                 1 -> QueryTab(controller, settings, current, network, history)
                 2 -> LogsTab(logs)
                 3 -> SettingsTab(controller, settings, snapshots)
@@ -144,7 +147,7 @@ fun NodeScreen(
     }
 }
 
-/** Horizontally-scrolling chips to pick the chain Status + Query act on (shown when >1 enabled). */
+/** Horizontally-scrolling chips over the enabled chains — picks the chain Status + Query act on. */
 @Composable
 private fun NetworkChips(chains: List<String>, selected: String, onSelect: (String) -> Unit) {
     Row(
@@ -420,6 +423,7 @@ private fun SwitchRow(label: String, checked: Boolean, onChange: (Boolean) -> Un
 @Composable
 private fun StatusTab(
     controller: NodeController,
+    settings: Settings,
     snap: NodeSnapshot?,
     primary: String,
     online: Boolean,
@@ -440,18 +444,25 @@ private fun StatusTab(
 
         Spacer(Modifier.height(16.dp))
         // A snapshot for `primary` exists only while its stack is registered (running or
-        // mid-boot): Start disabled once up, Stop only while it is. Stop the primary network
-        // specifically so the pairing reads correctly once more networks are added.
+        // mid-boot): Start disabled once up, Stop only while it is. Start/Stop here are
+        // RUNTIME-only (startNetwork/stopNetwork) — deliberately decoupled from the
+        // Settings enable switches, so stopping a chain from Status does not flip its
+        // switch off. The one exception: Start on a chain that isn't enabled at all
+        // (e.g. fresh install, nothing on) goes through enableNetwork so a cold host
+        // has an enabled set to boot.
         val primaryActive = snap != null
         Row {
             Button(
-                onClick = { controller.enableNetwork(primary) },
+                onClick = {
+                    if (settings.isNetworkEnabled(primary)) controller.startNetwork(primary)
+                    else controller.enableNetwork(primary)
+                },
                 // Don't offer Start while offline — discovery can't reach any peer.
                 enabled = !primaryActive && online,
             ) { Text("Start $primary") }
             Spacer(Modifier.width(8.dp))
             OutlinedButton(
-                onClick = { controller.disableNetwork(primary) },
+                onClick = { controller.stopNetwork(primary) },
                 enabled = primaryActive,
             ) { Text("Stop") }
         }


### PR DESCRIPTION
## Why

Stop on the Status page called \`disableNetwork\`, which persists the network's enabled flag off — stopping a chain silently flipped its Settings switch. Requested behavior: Start/Stop are runtime controls; the Settings switches own the persisted enabled set; the enabled networks show as chips.

## What

**\`NodeController\`** — two pairs with distinct contracts:
- \`startNetwork\`/\`stopNetwork\`: runtime-only, never touch the persisted flag (Status page)
- \`enableNetwork\`/\`disableNetwork\`: persist AND start/stop (Settings switches)

**Status page**: Start/Stop use the runtime pair. A stopped chain stays enabled and boots again on the next app/service start. Start on a never-enabled chain (fresh install) routes through \`enableNetwork\` so a cold host has an enabled set to boot.

**Chips**: derived from the enabled set (settings) ∪ live stacks — an enabled-but-stopped chain keeps its chip and stays selectable. The row now shows whenever any chain is enabled (previously only >1 live): deliberate, per the request to show enabled networks as chips.

**Android \`NodeService\`**: \`enable\`/\`disable\` delegate to new \`startNetwork\`/\`stopNetwork\`; flag writes only in enable/disable. Two lifecycle fixes that fell out of review:
- \`stopIfNoStacksLeft\` used to require \`!anyNetworkEnabled()\` — a runtime stop of the last chain (flags stay on by design) would leave a zombie foreground service with a "Starting…" notification forever. Now \`stopIfNoStacksLeft(userStop)\`: a user stop makes the empty map decisive (service exits; Start cold-boots the enabled set); boot-bail/failure paths keep the old guard, and a \`bootsInFlight\` counter covers the transiently-empty map while another chain spins up.
- A runtime stop racing a queued boot could be silently overridden (the old protection was \`buildAndStart\`'s enabled-flag re-check, which a flag-preserving stop never trips). Per-network stop generations: bumped on stop, snapshotted at boot spawn, re-checked under the bootLock.

**Desktop**: \`enable\`/\`disable\` now persist (interface contract) and delegate to runtime start/stop; \`rebootNetwork\` is stop+start so a port-change reboot can't rewrite flags; launch boots the enabled set via \`startNetwork\` (was: force-enable primary).

## Verified on-device (Pixel 7, Kohaku host app)

- Stop mainnet from Status → \`enabled_mainnet\` stays \`true\`, chip stays, Settings switch stays ON; Start brings it back
- Stop **all three** chains one by one → after the last: "no stacks left; stopping service" in app logs, \`startRequested=false\`, foreground notification gone — while all three \`enabled_*\` prefs stay \`true\` and all chips remain
- \`:ui:build :app-desktop:build :android-app:assembleDebug\` green

Independent no-context review run before opening (1 major + minors — all addressed in the second commit; the major was the zombie-service finding above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017MUyVxaEcPKwfgya4FZptF