### PR TITLE
build: Besu 24.12.2 → 26.4.0 (final-Fusaka EVM) + Android ART fork rebase

### DIFF
--- a/android-app/build.gradle.kts
+++ b/android-app/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
 // Caffeine) and publishes them via JitPack. See besu-android-fork/README.md.
 // We swap only these two modules to the fork — scoped to :android-app so the
 // JVM daemon stays on upstream Besu, where those APIs work.
-val besuForkVersion = "24.12.2-android.2"
+val besuForkVersion = "26.4.0-android.1"
 
 // The JitPack netty-kotlin fork republishes netty-common/buffer/etc. with the
 // same fully-qualified classes; the JVM tolerates the shadowing but the dexer
@@ -34,10 +34,13 @@ configurations.all {
     // JitPack); everything else stays upstream. Eager `all` so AGP's classpaths
     // pick up the resolutionStrategy before they resolve.
     resolutionStrategy.dependencySubstitution {
-        substitute(module("org.hyperledger.besu:evm"))
-            .using(module("com.github.biafra23.besu:evm:$besuForkVersion"))
-        substitute(module("org.hyperledger.besu.internal:algorithms"))
-            .using(module("com.github.biafra23.besu:algorithms:$besuForkVersion"))
+        substitute(module("org.hyperledger.besu:besu-evm"))
+            .using(module("com.github.biafra23.besu:besu-evm:$besuForkVersion"))
+        // 26.4 renamed the crypto module's distribution artifact; our vendored
+        // repo serves it as besu-crypto-algorithms — swap THAT to the fork's
+        // algorithms module (same sources, ART-patched BesuProvider ctor).
+        substitute(module("org.hyperledger.besu.internal:besu-crypto-algorithms"))
+            .using(module("com.github.biafra23.besu:besu-crypto-algorithms:$besuForkVersion"))
         // The fork's POMs import org.hyperledger.besu:bom:24.12.2, which Besu
         // never publishes to Maven Central; redirect it to the fork-published
         // bom. The fork is pinned to version 24.12.2, so its other sibling refs
@@ -47,13 +50,15 @@ configurations.all {
         substitute(platform(module("org.hyperledger.besu:bom")))
             .using(platform(module("com.github.biafra23.besu:bom:$besuForkVersion")))
     }
-    // Besu (via :myotis-evm) pulls the pre-rename tuweni coordinates
-    // io.tmio:tuweni-* 2.4.2, whose org.apache.tuweni.* classes collide with
-    // our JitPack fork (com.github.biafra23.tuweni-kotlin 2.7.2-jvm17.1) —
-    // D8 rejects the duplicates. Strip io.tmio and route Besu's tuweni to the
-    // fork (same package, newer version; API-compatible for the units/bytes
-    // Besu uses).
+    // Historical: Besu ≤24.12 pulled the pre-rename io.tmio:tuweni-* 2.4.2,
+    // colliding with our tuweni fork. Besu 26.4 targets tuweni 2.7.2 (the
+    // fork's exact version) so nothing pulls io.tmio anymore — the exclude
+    // stays as a cheap guard against a transitive reintroducing it.
     exclude(group = "io.tmio")
+    // tuweni's post-rename coordinates (io.consensys.tuweni, pulled by the
+    // Besu 26.4 fork's POM) collide with our Kotlin fork the same way io.tmio
+    // did — same classes, D8 rejects the duplicates. The fork supplies them.
+    exclude(group = "io.consensys.tuweni")
     // Requesting the STANDARD_JVM Guava variant (below) clashes with the
     // `android` variant that Besu pulls transitively — both provide the guava
     // capability. Resolve the conflict toward the JRE variant, which is the one
@@ -70,9 +75,10 @@ configurations.all {
             }
         }
     }
-    // (No Caffeine pin needed: the fork's CodeCache drops Caffeine, so nothing
-    // on the EVM path loads a Caffeine class — its StripedBuffer/System.Logger
-    // Android incompatibilities never trigger.)
+    // (No Caffeine pin needed: the fork drops Caffeine from
+    // JumpDestOnlyCodeCache AND nulls the 14 static precompile result caches
+    // 26.4 added — nothing on the EVM path constructs a Caffeine cache, so its
+    // StripedBuffer/System.Logger ART incompatibilities never trigger.)
 }
 
 // Optional JSON-RPC upstream-proxy URL (DEBUG/dev only) read from local.properties

--- a/app-desktop/build.gradle.kts
+++ b/app-desktop/build.gradle.kts
@@ -12,7 +12,9 @@ plugins {
 
 kotlin { jvmToolchain(21) }
 
-// Besu (via :myotis-evm) drags in the pre-rename tuweni coordinates io.tmio:tuweni-* 2.4.2,
+// Historical (Besu ≤24.12; 26.4 targets tuweni 2.7.2 so io.tmio is gone from the
+// graph — the exclude stays as a cheap guard):
+// Besu (via :myotis-evm) dragged in the pre-rename tuweni coordinates io.tmio:tuweni-* 2.4.2,
 // whose org.apache.tuweni.bytes.Bytes collides with the JitPack Kotlin fork we use
 // (com.github.biafra23.tuweni-kotlin 2.7.2). A single classloader loads only ONE Bytes for
 // that FQN: tuweni-rlp 2.7.2 (BytesRLPWriter.kt) needs the 2.7.2 Bytes' Kotlin `Companion`,

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,6 +67,15 @@ subprojects {
         useJUnitPlatform()
     }
 
+    // Besu 26.4's imported BOM pins junit-platform 1.13 onto every test
+    // classpath that (transitively) sees :myotis-evm; without a matching
+    // launcher the engine fails discovery ("unaligned versions of the
+    // junit-platform-engine and junit-platform-launcher jars"). One aligned
+    // launcher for every JVM module.
+    dependencies {
+        "testRuntimeOnly"("org.junit.platform:junit-platform-launcher")
+    }
+
     tasks.withType<JavaCompile> {
         options.encoding = "UTF-8"
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,10 +18,13 @@ jblst = "0.3.15"
 jvm-libp2p = "1.3.2-RELEASE"
 trueblocks-kotlin = "main-SNAPSHOT"
 dnsjava = "3.6.2"
-# Hyperledger Besu, used by myotis-evm. Pinned to a recent stable that ships
-# all currently-active mainnet precompiles. Bumping requires a fork-rule audit
-# in EvmFactory and a pass over docs/besu-extraction.md.
-besu = "24.12.2"
+# Hyperledger Besu (myotis-evm). NOTE: 25.7+ RENAMED the maven artifactIds
+# (evm → besu-evm; internal:algorithms → internal:besu-crypto-algorithms) —
+# probing the old names 404s and looks like publishing stopped; it didn't.
+# Bumping requires a fork-rule audit in EvmFactory, a pass over
+# docs/besu-extraction.md, AND rebasing the Android ART fork
+# (biafra23/besu, tag <ver>-android.N — android-app substitutes it in).
+besu = "26.4.0"
 agp = "8.7.3"
 kotlin = "2.0.21"
 compose-bom = "2024.11.00"
@@ -79,12 +82,9 @@ jvm-libp2p          = { module = "io.libp2p:jvm-libp2p",                   versi
 trueblocks-kotlin   = { module = "com.github.biafra23:trueblocks-kotlin", version.ref = "trueblocks-kotlin" }
 dnsjava             = { module = "dnsjava:dnsjava",                       version.ref = "dnsjava" }
 discovery           = { module = "io.consensys.protocols:discovery",       version.ref = "discovery" }
-
-# Besu EVM module. The standalone `evm` artifact is the heart of the Phase 0
-# spike — a hand-rolled WorldUpdater plugs into it. `besu-datatypes` carries
-# the Address/Wei/Hash value types the EVM expects on its API.
-besu-evm            = { module = "org.hyperledger.besu:evm",              version.ref = "besu" }
+besu-evm            = { module = "org.hyperledger.besu:besu-evm",         version.ref = "besu" }
 besu-datatypes      = { module = "org.hyperledger.besu:besu-datatypes",   version.ref = "besu" }
+
 
 androidx-compose-bom              = { module = "androidx.compose:compose-bom", version.ref = "compose-bom" }
 androidx-activity-compose         = { module = "androidx.activity:activity-compose", version.ref = "activity-compose" }

--- a/myotis-evm/build.gradle.kts
+++ b/myotis-evm/build.gradle.kts
@@ -27,17 +27,6 @@ dependencies {
     // flow from the real POMs.
     implementation(libs.besu.evm)
     implementation(libs.besu.datatypes)
-    // Former POM-transitives of besu:evm, now explicit (versions from the
-    // 26.4.0 release tarball's lib/):
-    implementation("com.github.ben-manes.caffeine:caffeine:3.2.3")
-    implementation("com.google.guava:guava:33.5.0-jre")
-    implementation("net.java.dev.jna:jna:5.18.1")
-    // besu-native crypto (secp256k1/r1 + gnark precompile backends) — still
-    // published publicly:
-    implementation("org.hyperledger.besu:secp256k1:1.5.0")
-    implementation("org.hyperledger.besu:secp256r1:1.5.0")
-    implementation("org.hyperledger.besu:gnark:1.5.0")
-    implementation("org.hyperledger.besu:arithmetic:1.5.0")
 
     // Tuweni Bytes/UInt256 are part of Besu's public API surface, so we use
     // the same coordinates here for ABI codec inputs/outputs.

--- a/myotis-evm/build.gradle.kts
+++ b/myotis-evm/build.gradle.kts
@@ -20,10 +20,24 @@ java {
 dependencies {
     implementation(project(":core"))
 
-    // Besu EVM. Brings in besu-datatypes transitively, but pin both so the
-    // version catalog is the single bump-point.
+    // Besu EVM 26.4.0 — the final-Fusaka EVM (CLZ, P256VERIFY, EOF removed).
+    // 25.7+ renamed the artifactIds (evm → besu-evm); transitives (tuweni
+    // 2.7.2 — the same version as our Kotlin fork, killing the old io.tmio
+    // collision at the source — caffeine, guava, jna, besu-native, jc-kzg)
+    // flow from the real POMs.
     implementation(libs.besu.evm)
     implementation(libs.besu.datatypes)
+    // Former POM-transitives of besu:evm, now explicit (versions from the
+    // 26.4.0 release tarball's lib/):
+    implementation("com.github.ben-manes.caffeine:caffeine:3.2.3")
+    implementation("com.google.guava:guava:33.5.0-jre")
+    implementation("net.java.dev.jna:jna:5.18.1")
+    // besu-native crypto (secp256k1/r1 + gnark precompile backends) — still
+    // published publicly:
+    implementation("org.hyperledger.besu:secp256k1:1.5.0")
+    implementation("org.hyperledger.besu:secp256r1:1.5.0")
+    implementation("org.hyperledger.besu:gnark:1.5.0")
+    implementation("org.hyperledger.besu:arithmetic:1.5.0")
 
     // Tuweni Bytes/UInt256 are part of Besu's public API surface, so we use
     // the same coordinates here for ABI codec inputs/outputs.

--- a/myotis-evm/src/main/java/io/myotis/evm/DefaultEvmExecutor.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/DefaultEvmExecutor.java
@@ -151,7 +151,7 @@ public final class DefaultEvmExecutor implements EvmExecutor {
                 .blockValues(new BlockContextValues(blockContext))
                 .completer(f -> {})
                 .miningBeneficiary(besuCoinbase)
-                .blockHashLookup(n -> {
+                .blockHashLookup((bhFrame, n) -> {
                     throw new UnsupportedOperationException(
                             "BLOCKHASH not implemented; needs a verified block-hash provider");
                 })
@@ -210,7 +210,7 @@ public final class DefaultEvmExecutor implements EvmExecutor {
             contractCode = delegateAccount == null ? Bytes.EMPTY : delegateAccount.getCode();
             contractCodeHash = delegateAccount == null ? Hash.EMPTY : delegateAccount.getCodeHash();
         }
-        return evm.getCode(contractCodeHash, contractCode);
+        return evm.getOrCreateCachedJumpDest(contractCodeHash, contractCode);
     }
 
     /**
@@ -294,7 +294,7 @@ public final class DefaultEvmExecutor implements EvmExecutor {
                 // it as a "weak randomness" source). Fail fast instead; the
                 // EVM will surface this as PRECOMPILE_ERROR / opaque halt and
                 // we relabel it via the halt-reason mapping below.
-                .blockHashLookup(n -> {
+                .blockHashLookup((bhFrame, n) -> {
                     throw new UnsupportedOperationException(
                             "BLOCKHASH not implemented; needs a verified block-hash provider");
                 })

--- a/myotis-evm/src/main/java/io/myotis/evm/prefetch/PrefetchingTracer.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/prefetch/PrefetchingTracer.java
@@ -84,7 +84,7 @@ public final class PrefetchingTracer implements OperationTracer {
             case OP_SLOAD -> {
                 UInt256 slot = UInt256.fromBytes(Bytes32.leftPad(frame.getStackItem(0)));
                 io.myotis.evm.Address owner = io.myotis.evm.Address.of(
-                        frame.getRecipientAddress().toArrayUnsafe());
+                        frame.getRecipientAddress().getBytes().toArrayUnsafe());
                 tracker.recordStorage(owner, slot.toUnsignedBigInteger());
                 tracker.recordAccount(owner);
             }

--- a/myotis-evm/src/main/java/io/myotis/evm/world/SnapAccount.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/world/SnapAccount.java
@@ -69,7 +69,7 @@ final class SnapAccount implements MutableAccount {
         this(besuAddress, view);
         this.nonce = 0L;
         this.balance = Wei.ZERO;
-        this.codeHash = Hash.EMPTY.getBytes().toArrayUnsafe();
+        this.codeHash = Hash.EMPTY.getBytes().toArray();
         this.loadedCode = Bytes.EMPTY;
     }
 
@@ -77,7 +77,7 @@ final class SnapAccount implements MutableAccount {
         SnapAccount a = new SnapAccount(src.getAddress(), view);
         a.nonce = src.getNonce();
         a.balance = src.getBalance();
-        a.codeHash = src.getCodeHash().getBytes().toArrayUnsafe();
+        a.codeHash = src.getCodeHash().getBytes().toArray();
         a.loadedCode = src.getCode();
         // Inherit storage journals from the parent so writes performed
         // earlier in the same transaction are visible inside nested calls.
@@ -225,6 +225,6 @@ final class SnapAccount implements MutableAccount {
     }
 
     private boolean codeHashIsEmpty() {
-        return java.util.Arrays.equals(codeHash, Hash.EMPTY.getBytes().toArrayUnsafe());
+        return java.util.Arrays.equals(codeHash, Hash.EMPTY.getBytes().toArray());
     }
 }

--- a/myotis-evm/src/main/java/io/myotis/evm/world/SnapAccount.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/world/SnapAccount.java
@@ -69,7 +69,7 @@ final class SnapAccount implements MutableAccount {
         this(besuAddress, view);
         this.nonce = 0L;
         this.balance = Wei.ZERO;
-        this.codeHash = Hash.EMPTY.toArrayUnsafe();
+        this.codeHash = Hash.EMPTY.getBytes().toArrayUnsafe();
         this.loadedCode = Bytes.EMPTY;
     }
 
@@ -77,7 +77,7 @@ final class SnapAccount implements MutableAccount {
         SnapAccount a = new SnapAccount(src.getAddress(), view);
         a.nonce = src.getNonce();
         a.balance = src.getBalance();
-        a.codeHash = src.getCodeHash().toArrayUnsafe();
+        a.codeHash = src.getCodeHash().getBytes().toArrayUnsafe();
         a.loadedCode = src.getCode();
         // Inherit storage journals from the parent so writes performed
         // earlier in the same transaction are visible inside nested calls.
@@ -99,7 +99,7 @@ final class SnapAccount implements MutableAccount {
 
     @Override
     public Hash getAddressHash() {
-        return Hash.hash(besuAddress);
+        return Hash.hash(besuAddress.getBytes());
     }
 
     @Override
@@ -145,7 +145,7 @@ final class SnapAccount implements MutableAccount {
         if (v != null) return v;
         UInt256 orig = originalStorage.get(slot);
         if (orig != null) return orig;
-        UInt256 fetched = view.storage(Address.of(besuAddress.toArrayUnsafe()), slot);
+        UInt256 fetched = view.storage(Address.of(besuAddress.getBytes().toArrayUnsafe()), slot);
         originalStorage.put(slot, fetched);
         return fetched;
     }
@@ -154,7 +154,7 @@ final class SnapAccount implements MutableAccount {
     public UInt256 getOriginalStorageValue(UInt256 slot) {
         UInt256 cached = originalStorage.get(slot);
         if (cached != null) return cached;
-        UInt256 fetched = view.storage(Address.of(besuAddress.toArrayUnsafe()), slot);
+        UInt256 fetched = view.storage(Address.of(besuAddress.getBytes().toArrayUnsafe()), slot);
         originalStorage.put(slot, fetched);
         return fetched;
     }
@@ -194,7 +194,7 @@ final class SnapAccount implements MutableAccount {
         // Lazily seed the original-value cache so a subsequent getOriginalStorageValue
         // returns the pre-write value rather than the journalled write.
         originalStorage.computeIfAbsent(key,
-                k -> view.storage(Address.of(besuAddress.toArrayUnsafe()), k));
+                k -> view.storage(Address.of(besuAddress.getBytes().toArrayUnsafe()), k));
         updatedStorage.put(key, value);
     }
 
@@ -225,6 +225,6 @@ final class SnapAccount implements MutableAccount {
     }
 
     private boolean codeHashIsEmpty() {
-        return java.util.Arrays.equals(codeHash, Hash.EMPTY.toArrayUnsafe());
+        return java.util.Arrays.equals(codeHash, Hash.EMPTY.getBytes().toArrayUnsafe());
     }
 }

--- a/myotis-evm/src/main/java/io/myotis/evm/world/SnapWorldUpdater.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/world/SnapWorldUpdater.java
@@ -94,7 +94,7 @@ public final class SnapWorldUpdater implements WorldUpdater {
         // EVM-side account record — the EVM treats absent accounts as
         // empty (nonce=0, balance=0, no code) and the AccountState the
         // oracle returns for a miss already encodes that.
-        Address own = Address.of(address.toArrayUnsafe());
+        Address own = Address.of(address.getBytes().toArrayUnsafe());
         AccountState state = baseView.account(own);
         SnapAccount a = SnapAccount.fromState(state, baseView);
         touched.put(address, a);

--- a/myotis-evm/src/test/java/io/myotis/evm/besu/PragueLayoutTest.java
+++ b/myotis-evm/src/test/java/io/myotis/evm/besu/PragueLayoutTest.java
@@ -1,0 +1,50 @@
+package io.myotis.evm.besu;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigInteger;
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.evm.gascalculator.PragueGasCalculator;
+import org.hyperledger.besu.evm.precompile.MainnetPrecompiledContracts;
+import org.hyperledger.besu.evm.precompile.PrecompileContractRegistry;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the PRAGUE precompile layout after the Besu 26.4.0 bump: the FINAL
+ * EIP-2537 mainnet set (0x0b..0x11, 7 contracts) — Besu 24.12.2 shipped the
+ * pre-final draft (9 contracts through 0x13 with separate G1MUL/G2MUL), so the
+ * bump is a live-correctness fix, not a neutral swap. Also guards the coming
+ * Osaka flip: P256VERIFY (0x100) must NOT be registered under Prague.
+ */
+class PragueLayoutTest {
+
+    private static Address addr(final int lastByte) {
+        byte[] b = new byte[20];
+        b[19] = (byte) lastByte;
+        return Address.wrap(org.apache.tuweni.bytes.Bytes.wrap(b));
+    }
+
+    @Test
+    void pragueHasFinalBlsLayoutAndNoOsakaPrecompiles() {
+        PrecompileContractRegistry reg =
+                MainnetPrecompiledContracts.prague(new PragueGasCalculator());
+        // Final EIP-2537: 0x0b..0x11 present…
+        for (int a = 0x0b; a <= 0x11; a++) {
+            assertTrue(reg.get(addr(a)) != null, "0x" + Integer.toHexString(a) + " must exist");
+        }
+        // …and the pre-final draft's 0x12/0x13 gone.
+        assertFalse(reg.get(addr(0x12)) != null, "0x12 is not in the final EIP-2537 layout");
+        assertFalse(reg.get(addr(0x13)) != null, "0x13 is not in the final EIP-2537 layout");
+        // Osaka's P256VERIFY (0x100) must not leak into Prague.
+        byte[] p256 = new byte[20];
+        p256[18] = 0x01;
+        assertFalse(reg.get(Address.wrap(org.apache.tuweni.bytes.Bytes.wrap(p256))) != null,
+                "P256VERIFY is Osaka-only");
+        // KZG point-eval (0x0a, Cancun+) still registered.
+        assertTrue(reg.get(addr(0x0a)) != null, "KZG point-eval must exist");
+        // Sanity: chain-id-flavored factory agrees.
+        BigInteger one = BigInteger.ONE;
+        assertTrue(one.signum() > 0);
+    }
+}

--- a/myotis-evm/src/test/java/io/myotis/evm/besu/PragueLayoutTest.java
+++ b/myotis-evm/src/test/java/io/myotis/evm/besu/PragueLayoutTest.java
@@ -3,7 +3,6 @@ package io.myotis.evm.besu;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.math.BigInteger;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.gascalculator.PragueGasCalculator;
 import org.hyperledger.besu.evm.precompile.MainnetPrecompiledContracts;
@@ -43,8 +42,10 @@ class PragueLayoutTest {
                 "P256VERIFY is Osaka-only");
         // KZG point-eval (0x0a, Cancun+) still registered.
         assertTrue(reg.get(addr(0x0a)) != null, "KZG point-eval must exist");
-        // Sanity: chain-id-flavored factory agrees.
-        BigInteger one = BigInteger.ONE;
-        assertTrue(one.signum() > 0);
+        // Sanity: the hand-built P256 address really is 0x…0100.
+        assertTrue(
+                Address.wrap(org.apache.tuweni.bytes.Bytes.wrap(p256))
+                        .equals(Address.fromHexString("0x0000000000000000000000000000000000000100")),
+                "p256 byte array must encode address 0x100");
     }
 }


### PR DESCRIPTION
Step 1 of the Osaka fix (user-approved): bring the Java engine's embedded EVM to a line that carries the **final Fusaka Osaka** (CLZ/EIP-7939, P256VERIFY/EIP-7951, EOF removed). Spec selection **stays at Prague** here; the twin fork-table PR flips both engines to OSAKA together.

## Key findings baked into this PR

- **Besu 25.7+ renamed its maven artifactIds** (`evm` → `besu-evm`; `internal:algorithms` → `internal:besu-crypto-algorithms`). Probing the old names 404s and looks exactly like "publishing stopped after 25.6.0" — it didn't. The bump uses the real public coordinates on hyperledger.jfrog.io, with transitives from the real POMs. (An earlier vendored-jar approach was fully built and then discarded once this surfaced.)
- **Not behavior-neutral, deliberately**: 24.12.2's Prague carried the *pre-final* EIP-2537 draft (9 BLS precompiles through 0x13, separate G1MUL/G2MUL); 26.4.0 has the final mainnet layout (7 through 0x11) — a live correctness fix for a trust-minimized wallet, pinned by the new `PragueLayoutTest` (which also asserts P256VERIFY stays out of Prague, guarding the coming Osaka flip).
- **The io.tmio collision dies at the source**: Besu 26.4 targets tuweni 2.7.2 — the exact version of this repo's Kotlin fork. Excludes stay as cheap guards; Android adds the post-rename `io.consensys.tuweni` to the same guard.
- **Android (first-class)**: the ART fork is rebased onto genuine 26.4.0 (`biafra23/besu` tag `26.4.0-android.1`, JitPack-built): the BesuProvider API-1 ctor patch, Caffeine dropped from `JumpDestOnlyCodeCache`, and a **new third patch** — 26.4 added static-final Caffeine result caches to 14 precompile classes whose class-init alone crashes ART; they're nulled (every use is behind the never-enabled `enableResultCaching` flag). `android-app` substitutes the renamed coordinates to the fork.
- API drift ported (`BytesHolder` accessors, BiFunction `BlockHashLookup`, `getOrCreateCachedJumpDest`) — verified semantically neutral against both jars' bytecode. Root build adds one aligned `junit-platform-launcher` for all JVM modules (Besu's BOM pins junit-platform 1.13; engines fail discovery without it).

## Testing

Full `./gradlew build` green (all modules incl. Android via the JitPack fork); `PragueLayoutTest` pins the final BLS layout; an independent no-context review drove this shape — its critical finding (the original `files()` vendoring silently bypassed Android's fork substitution → ART crash at first EVM call) is what surfaced the rename and led to the coordinate-based solution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PP9WX3oschsX9T4AAKpdim