### PR TITLE
fork tables: OSAKA on both engines (Fusaka EL — CLZ, P256VERIFY, ModExp repricing)

### DIFF
--- a/docs/evm/besu-extraction.md
+++ b/docs/evm/besu-extraction.md
@@ -80,7 +80,7 @@ not exercise that path; Phase 2 will, against real ERC-20 contracts.)
 ## Hard-fork awareness
 
 `EvmFactory.buildForBlock(BlockContext)` selects between London / Paris
-(post-merge, block-keyed) / Shanghai / Cancun / Prague (timestamp-keyed)
+(post-merge, block-keyed) / Shanghai / Cancun / Prague / Osaka (timestamp-keyed)
 using mainnet's published transition values. Pre-London is intentionally
 unsupported — the wallet only operates on recent finalised heads. Add a
 test per fork transition (one block before, one block after) before any
@@ -93,6 +93,7 @@ Precompile sets are paired with the fork:
 - Shanghai → `istanbul(gc)` again (KZG point-evaluation arrives in Cancun)
 - Cancun → `cancun(gc)` (adds 0x0a)
 - Prague → `prague(gc)` (BLS12-381 precompiles)
+- Osaka → `osaka(gc)` (adds P256VERIFY at 0x100; ModExp repriced per EIP-7883)
 
 ## Determinism audit
 

--- a/docs/reimplementation/07-el-implementation-plan.md
+++ b/docs/reimplementation/07-el-implementation-plan.md
@@ -540,8 +540,10 @@ Java engine's.
   (0x69de2dbc, nethermind — hex-pinned like the other gnosis times), boundary-tested on
   both sides (`osaka_boundaries_map_on_every_chain` ↔ `OsakaBoundaryTest`, which also
   pins P256VERIFY present under Osaka and absent under Prague). Known residuals: the
-  Java table stays MAINNET-times-for-all-chains (chain-awareness follow-up — harmless
-  now that every hosted chain is long past both boundaries); estimateGas's 30 M view
+  Java table stays MAINNET-times-for-all-chains — harmless TODAY (every hosted chain is
+  past both schedules' boundaries) but time-contingent: the next fork's rollout re-opens
+  a head-reachable divergence window on sepolia/gnosis, so Java chain-awareness MUST
+  land before the next fork constant is added to either table; estimateGas's 30 M view
   ceiling exceeds Osaka's EIP-7825 2^24 per-tx cap (an estimate >16.7 M can't be a
   valid post-Osaka tx — shared semantics, both engines).
 

--- a/docs/reimplementation/07-el-implementation-plan.md
+++ b/docs/reimplementation/07-el-implementation-plan.md
@@ -534,10 +534,16 @@ Java engine's.
   discovered a CL peer (fork-digest correct) and verified against the genesis validators root
   (`period=3480`, state `CATCHING_UP`); full SYNCED is peer-supply-bound on the dev host, as with
   mainnet. `refreshGnosisCheckpoint` is hand-mirrored into `ChainConfig::gnosis()` like the others.
-- **Known gap (both engines, deliberately mirrored): fork tables cap at PRAGUE** even
-  though mainnet + sepolia have activated Osaka/Fusaka (sepolia `osakaTime` 1760427360,
-  go-ethereum `SepoliaChainConfig`). Adding OSAKA is a cross-engine follow-up so the two
-  engines never diverge on spec selection.
+- **CLOSED: OSAKA on both engines** (after the Besu 26.4.0 bump made the Java side
+  capable). Both fork tables gained the Osaka rung in ONE coordinated change: mainnet
+  1764798551 / sepolia 1760427360 (go-ethereum ChainConfig) / gnosis 1776168380
+  (0x69de2dbc, nethermind — hex-pinned like the other gnosis times), boundary-tested on
+  both sides (`osaka_boundaries_map_on_every_chain` ↔ `OsakaBoundaryTest`, which also
+  pins P256VERIFY present under Osaka and absent under Prague). Known residuals: the
+  Java table stays MAINNET-times-for-all-chains (chain-awareness follow-up — harmless
+  now that every hosted chain is long past both boundaries); estimateGas's 30 M view
+  ceiling exceeds Osaka's EIP-7825 2^24 per-tx cap (an estimate >16.7 M can't be a
+  valid post-Osaka tx — shared semantics, both engines).
 
 ## Cross-cutting rules & risks
 

--- a/myotis-evm/src/main/java/io/myotis/evm/besu/EvmFactory.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/besu/EvmFactory.java
@@ -26,6 +26,8 @@ import org.hyperledger.besu.evm.precompile.PrecompileContractRegistry;
  *   <li>Shanghai — timestamp {@code 1_681_338_455} (block ~17_034_870)
  *   <li>Cancun — timestamp {@code 1_710_338_135} (block ~19_426_587)
  *   <li>Prague — timestamp {@code 1_746_612_311} (block ~22_431_084)
+ *   <li>Osaka — timestamp {@code 1_764_798_551} (Fusaka's EL half: CLZ,
+ *       P256VERIFY at 0x100, ModExp repricing)
  * </ul>
  *
  * <p>For pre-merge ranges we use the block number; for post-merge we use the

--- a/myotis-evm/src/main/java/io/myotis/evm/besu/EvmFactory.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/besu/EvmFactory.java
@@ -8,6 +8,7 @@ import org.hyperledger.besu.evm.gascalculator.CancunGasCalculator;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.gascalculator.LondonGasCalculator;
 import org.hyperledger.besu.evm.gascalculator.PragueGasCalculator;
+import org.hyperledger.besu.evm.gascalculator.OsakaGasCalculator;
 import org.hyperledger.besu.evm.gascalculator.ShanghaiGasCalculator;
 import org.hyperledger.besu.evm.internal.EvmConfiguration;
 import org.hyperledger.besu.evm.precompile.MainnetPrecompiledContracts;
@@ -44,6 +45,14 @@ public final class EvmFactory {
     public static final long SHANGHAI_TIME  = 1_681_338_455L;
     public static final long CANCUN_TIME    = 1_710_338_135L;
     public static final long PRAGUE_TIME    = 1_746_612_311L;
+    /** Fusaka's EL fork (CLZ, P256VERIFY, ModExp repricing) — go-ethereum
+     *  MainnetChainConfig.OsakaTime (2025-12-03). NOTE the known asymmetry:
+     *  this table uses MAINNET times for every chain (the Rust engine's
+     *  spec_for is per-chain); harmless at the beacon-anchored head since all
+     *  hosted chains activated Osaka long ago, and the ≤256-block historical
+     *  window can no longer straddle the boundary — full chain-awareness here
+     *  remains a tracked follow-up. */
+    public static final long OSAKA_TIME     = 1_764_798_551L;
 
     private EvmFactory() {}
 
@@ -54,6 +63,11 @@ public final class EvmFactory {
         long blockNumber = ctx.blockNumber();
         long ts = ctx.timestamp();
 
+        if (ts >= OSAKA_TIME) {
+            EVM evm = MainnetEVMs.osaka(chainId, cfg);
+            GasCalculator gc = new OsakaGasCalculator();
+            return new EvmAndPrecompiles(evm, MainnetPrecompiledContracts.osaka(gc), gc, EvmSpecVersion.OSAKA);
+        }
         if (ts >= PRAGUE_TIME) {
             EVM evm = MainnetEVMs.prague(chainId, cfg);
             GasCalculator gc = new PragueGasCalculator();

--- a/myotis-evm/src/test/java/io/myotis/evm/besu/ForkTimePinsTest.java
+++ b/myotis-evm/src/test/java/io/myotis/evm/besu/ForkTimePinsTest.java
@@ -1,0 +1,23 @@
+package io.myotis.evm.besu;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Cross-BASE pins for the fork-boundary constants (hex vs the decimal
+ * definitions): a transposition typo in either form cannot survive both
+ * representations. Twin of the Rust {@code osaka_times_pin_their_sources} —
+ * these constants are trust-critical (a wrong one silently mis-selects EVM
+ * rules) and previously had no pin at all on the Java side.
+ */
+class ForkTimePinsTest {
+
+    @Test
+    void forkTimesMatchTheirHexForms() {
+        assertEquals(0x6437_3057L, EvmFactory.SHANGHAI_TIME);
+        assertEquals(0x65f1_b057L, EvmFactory.CANCUN_TIME);
+        assertEquals(0x681b_3057L, EvmFactory.PRAGUE_TIME);
+        assertEquals(0x6930_b057L, EvmFactory.OSAKA_TIME);
+    }
+}

--- a/myotis-evm/src/test/java/io/myotis/evm/besu/OsakaBoundaryTest.java
+++ b/myotis-evm/src/test/java/io/myotis/evm/besu/OsakaBoundaryTest.java
@@ -1,0 +1,50 @@
+package io.myotis.evm.besu;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import io.myotis.evm.BlockContext;
+import java.math.BigInteger;
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.evm.EvmSpecVersion;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The OSAKA fork boundary (Fusaka's EL half), twinned with the Rust engine's
+ * `osaka_boundaries_map_on_every_chain` so spec selection can't diverge:
+ * timestamps at/after go-ethereum's MainnetChainConfig.OsakaTime select the
+ * Osaka EVM (P256VERIFY at 0x100), a second earlier stays Prague.
+ */
+class OsakaBoundaryTest {
+
+    private static final Address P256 =
+            Address.fromHexString("0x0000000000000000000000000000000000000100");
+
+    private static BlockContext ctx(final long ts) {
+        return new BlockContext(
+                new byte[32],
+                /* blockNumber */ 21_000_000L,
+                /* timestamp   */ ts,
+                /* baseFee     */ BigInteger.valueOf(1_000_000_000L),
+                /* coinbase    */ io.myotis.evm.Address.ZERO,
+                /* prevRandao  */ new byte[32],
+                /* chainId     */ BigInteger.ONE,
+                /* gasLimit    */ 30_000_000L);
+    }
+
+    @Test
+    void osakaTimestampSelectsOsakaWithP256() {
+        EvmFactory.EvmAndPrecompiles built = EvmFactory.buildForBlock(ctx(EvmFactory.OSAKA_TIME));
+        assertEquals(EvmSpecVersion.OSAKA, built.specVersion());
+        assertNotNull(built.precompiles().get(P256), "P256VERIFY must be registered under Osaka");
+    }
+
+    @Test
+    void secondBeforeOsakaStaysPragueWithoutP256() {
+        EvmFactory.EvmAndPrecompiles built =
+                EvmFactory.buildForBlock(ctx(EvmFactory.OSAKA_TIME - 1));
+        assertEquals(EvmSpecVersion.PRAGUE, built.specVersion());
+        assertNull(built.precompiles().get(P256), "P256VERIFY is Osaka-only");
+    }
+}

--- a/rust/myotis-evm/src/executor.rs
+++ b/rust/myotis-evm/src/executor.rs
@@ -62,8 +62,8 @@ const PLAIN_TRANSFER_GAS: u64 = 21_000;
 /// Precompiles are CODELESS in state yet execute logic — an empty-calldata
 /// call to one still charges its base gas, so the 21000 short-circuit must
 /// not claim it. Conservatively covers 0x…0001 ..= 0x…01ff (mainnet uses
-/// 0x01..0x11 through Prague; the headroom absorbs future forks and
-/// RIP-7212-style 0x100 assignments — a stray fall-through only costs a full
+/// 0x01..0x11 through Prague, 0x100 = P256VERIFY since Osaka; the headroom
+/// absorbs future assignments — a stray fall-through only costs a full
 /// estimate run). NOTE: the Java engine's rpcEstimateGas short-circuits these
 /// today (same under-estimate) — flagged for the same fix there.
 fn in_precompile_range(addr: &[u8; 20]) -> bool {

--- a/rust/myotis-evm/src/fork.rs
+++ b/rust/myotis-evm/src/fork.rs
@@ -26,6 +26,10 @@ pub const CANCUN_TIME: u64 = 1_710_338_135;
 /// Prague activation timestamp (EIP-7702, …).
 pub const PRAGUE_TIME: u64 = 1_746_612_311;
 
+/// Mainnet Osaka (Fusaka's EL fork: CLZ, P256VERIFY, ModExp repricing) —
+/// go-ethereum MainnetChainConfig.OsakaTime (2025-12-03).
+pub const OSAKA_TIME: u64 = 1_764_798_551;
+
 /// Sepolia fork-activation timestamps (go-ethereum `SepoliaChainConfig`).
 /// Sepolia launched with London active and merged in mid-2022, so anything the
 /// beacon-anchored engine can serve is far past Shanghai; below Shanghai fails
@@ -35,6 +39,8 @@ pub const SEPOLIA_SHANGHAI_TIME: u64 = 1_677_557_088;
 pub const SEPOLIA_CANCUN_TIME: u64 = 1_706_655_072;
 /// Sepolia Prague activation timestamp.
 pub const SEPOLIA_PRAGUE_TIME: u64 = 1_741_159_776;
+/// Sepolia Osaka — go-ethereum SepoliaChainConfig.OsakaTime (2025-10-14).
+pub const SEPOLIA_OSAKA_TIME: u64 = 1_760_427_360;
 
 /// The revm `SpecId` a `(chain_id, block_number, timestamp)` activates:
 /// [`EvmError::UnsupportedChain`] for a chain with no table here (e.g. Gnosis
@@ -59,6 +65,9 @@ pub fn spec_for(chain_id: u64, block_number: u64, timestamp: u64) -> Result<Spec
 /// The mainnet cascade: pre-merge forks by block number, post-merge by timestamp
 /// (timestamp checked first — a post-merge block is always past the merge block).
 fn mainnet_spec(block_number: u64, timestamp: u64) -> Result<SpecId, EvmError> {
+    if timestamp >= OSAKA_TIME {
+        return Ok(SpecId::OSAKA);
+    }
     if timestamp >= PRAGUE_TIME {
         Ok(SpecId::PRAGUE)
     } else if timestamp >= CANCUN_TIME {
@@ -80,6 +89,9 @@ fn mainnet_spec(block_number: u64, timestamp: u64) -> Result<SpecId, EvmError> {
 /// The sepolia cascade — all timestamp-gated (sepolia merged before Shanghai, and
 /// nothing pre-Shanghai is servable by a beacon-anchored engine).
 fn sepolia_spec(block_number: u64, timestamp: u64) -> Result<SpecId, EvmError> {
+    if timestamp >= SEPOLIA_OSAKA_TIME {
+        return Ok(SpecId::OSAKA);
+    }
     if timestamp >= SEPOLIA_PRAGUE_TIME {
         Ok(SpecId::PRAGUE)
     } else if timestamp >= SEPOLIA_CANCUN_TIME {
@@ -102,9 +114,15 @@ pub const GNOSIS_SHANGHAI_TIME: u64 = 1_690_889_660;
 pub const GNOSIS_CANCUN_TIME: u64 = 1_710_181_820;
 /// Gnosis Prague activation timestamp (0x68122dbc = 2025-04-30).
 pub const GNOSIS_PRAGUE_TIME: u64 = 1_746_021_820;
+/// Gnosis Osaka activation timestamp (0x69de2dbc = 2026-04-14, nethermind
+/// gnosis.json — hex-pinned like the other gnosis fork times).
+pub const GNOSIS_OSAKA_TIME: u64 = 1_776_168_380;
 
 /// The gnosis cascade — all timestamp-gated (gnosis merged before Shanghai).
 fn gnosis_spec(block_number: u64, timestamp: u64) -> Result<SpecId, EvmError> {
+    if timestamp >= GNOSIS_OSAKA_TIME {
+        return Ok(SpecId::OSAKA);
+    }
     if timestamp >= GNOSIS_PRAGUE_TIME {
         Ok(SpecId::PRAGUE)
     } else if timestamp >= GNOSIS_CANCUN_TIME {
@@ -167,6 +185,31 @@ mod tests {
             spec_for(s, 9_000_000, SEPOLIA_SHANGHAI_TIME - 1),
             Err(EvmError::ForkTooOld { .. })
         ));
+    }
+
+    #[test]
+    fn osaka_boundaries_map_on_every_chain() {
+        // Mainnet
+        assert_eq!(spec_for(1, 21_000_000, OSAKA_TIME).unwrap(), SpecId::OSAKA);
+        assert_eq!(spec_for(1, 21_000_000, OSAKA_TIME - 1).unwrap(), SpecId::PRAGUE);
+        // Sepolia
+        let s = 11_155_111u64;
+        assert_eq!(spec_for(s, 9_000_000, SEPOLIA_OSAKA_TIME).unwrap(), SpecId::OSAKA);
+        assert_eq!(spec_for(s, 9_000_000, SEPOLIA_OSAKA_TIME - 1).unwrap(), SpecId::PRAGUE);
+        // Gnosis
+        let g = 100u64;
+        assert_eq!(spec_for(g, 30_000_000, GNOSIS_OSAKA_TIME).unwrap(), SpecId::OSAKA);
+        assert_eq!(spec_for(g, 30_000_000, GNOSIS_OSAKA_TIME - 1).unwrap(), SpecId::PRAGUE);
+    }
+
+    #[test]
+    fn osaka_times_pin_their_sources() {
+        // go-ethereum MainnetChainConfig / SepoliaChainConfig OsakaTime; the
+        // gnosis value is the nethermind hex (decimal-conversion-slip guard,
+        // like the other gnosis pins).
+        assert_eq!(OSAKA_TIME, 1_764_798_551);
+        assert_eq!(SEPOLIA_OSAKA_TIME, 1_760_427_360);
+        assert_eq!(GNOSIS_OSAKA_TIME, 0x69de_2dbc);
     }
 
     #[test]

--- a/rust/myotis-evm/src/fork.rs
+++ b/rust/myotis-evm/src/fork.rs
@@ -46,13 +46,13 @@ pub const SEPOLIA_OSAKA_TIME: u64 = 1_760_427_360;
 /// [`EvmError::UnsupportedChain`] for a chain with no table here (e.g. Gnosis
 /// until its slice lands), [`EvmError::ForkTooOld`] below each chain's floor.
 ///
-/// KNOWN GAPS vs the Java `EvmFactory` (cross-engine follow-ups):
-/// * both tables cap at PRAGUE even though mainnet and sepolia have since
-///   activated Osaka/Fusaka — Java stops at Prague too; add OSAKA to both.
-/// * Java applies the MAINNET timestamps to every chain, so a historical sepolia
-///   call in a window where the two schedules disagree (e.g. sepolia's
-///   [Prague, mainnet-Prague) gap) picks a different spec there — this table is
-///   the more correct side, and head-of-chain calls agree on both.
+/// KNOWN GAP vs the Java `EvmFactory` (cross-engine follow-up): Java applies
+/// the MAINNET timestamps to every chain, while this table is per-chain. The
+/// divergence windows are all in the past today (every hosted chain is beyond
+/// both schedules' last boundary), BUT the argument is time-contingent: the
+/// next fork's rollout re-opens a window on sepolia/gnosis between their
+/// activation and mainnet's. Java chain-awareness MUST land before the next
+/// fork constant is added to either table.
 pub fn spec_for(chain_id: u64, block_number: u64, timestamp: u64) -> Result<SpecId, EvmError> {
     match chain_id {
         1 => mainnet_spec(block_number, timestamp),
@@ -203,13 +203,34 @@ mod tests {
     }
 
     #[test]
+    fn osaka_wires_p256verify_and_prague_does_not() {
+        // Twin of the Java OsakaBoundaryTest's registry assertions: don't just
+        // trust revm's wiring across future bumps — pin that the OSAKA
+        // precompile set serves 0x…0100 (EIP-7951) and PRAGUE's does not.
+        use revm::precompile::{PrecompileSpecId, Precompiles};
+        let mut p256 = [0u8; 20];
+        p256[18] = 0x01;
+        let addr = revm::primitives::Address::from(p256);
+        assert!(
+            Precompiles::new(PrecompileSpecId::OSAKA).get(&addr).is_some(),
+            "P256VERIFY must be in the OSAKA set"
+        );
+        assert!(
+            Precompiles::new(PrecompileSpecId::PRAGUE).get(&addr).is_none(),
+            "P256VERIFY is Osaka-only"
+        );
+    }
+
+    #[test]
     fn osaka_times_pin_their_sources() {
-        // go-ethereum MainnetChainConfig / SepoliaChainConfig OsakaTime; the
-        // gnosis value is the nethermind hex (decimal-conversion-slip guard,
-        // like the other gnosis pins).
-        assert_eq!(OSAKA_TIME, 1_764_798_551);
-        assert_eq!(SEPOLIA_OSAKA_TIME, 1_760_427_360);
-        assert_eq!(GNOSIS_OSAKA_TIME, 0x69de_2dbc);
+        // Cross-BASE pins (hex vs the decimal constants): a transposition typo
+        // in either form can't survive both representations — the guard that
+        // caught the gnosis decimal-slip bug, now applied to every chain.
+        // Sources: go-ethereum MainnetChainConfig / SepoliaChainConfig
+        // OsakaTime; nethermind gnosis.json eip*TransitionTimestamps.
+        assert_eq!(OSAKA_TIME, 0x6930_b057); // 1_764_798_551, 2025-12-03
+        assert_eq!(SEPOLIA_OSAKA_TIME, 0x68ed_fd60); // 1_760_427_360, 2025-10-14
+        assert_eq!(GNOSIS_OSAKA_TIME, 0x69de_2dbc); // 1_776_168_380, 2026-04-14
     }
 
     #[test]


### PR DESCRIPTION
Step 2 (final) of the Osaka fix: both engines' fork tables gain the OSAKA rung in one coordinated change, so head-anchored `eth_call`s on every hosted chain now run **real Osaka semantics** instead of silently using Prague rules — closing the shared debt tracked since the multichain milestone.

## What changed

- **Rust** `spec_for`: OSAKA arms on mainnet, sepolia, gnosis. **Java** `EvmFactory`: the OSAKA branch (`MainnetEVMs.osaka` + `OsakaGasCalculator` + the osaka precompile registry — bytecode-verified to be exactly the gas-calculator pairing Besu uses internally).
- **Timestamps, independently re-verified by the no-context review against geth master and nethermind master**: mainnet `1764798551` (2025-12-03), sepolia `1760427360` (2025-10-14), gnosis `1776168380` = `0x69de2dbc` (2026-04-14, all eight nethermind Osaka-era transitions).
- **Cross-base pins on BOTH engines** (review hardening — the original mainnet/sepolia pins were circular and Java had none): Rust asserts all three constants against their hex forms; new Java `ForkTimePinsTest` pins Shanghai→Osaka the same way. Writing them re-proved the point: two hand-typed hex forms were wrong until computed — a typo'd constant would previously have passed every test and silently diverged the engines.
- **Twinned boundary + wiring tests**: `osaka_boundaries_map_on_every_chain` + a new Rust assertion that revm's OSAKA precompile set serves `0x…0100` and Prague's doesn't ↔ Java `OsakaBoundaryTest` (spec version + P256VERIFY registry presence/absence), complementing #208's `PragueLayoutTest`.
- **EIP-7825 verified harmless**: Rust's explicit `tx_gas_limit_cap` override keeps 30 M view calls working under OSAKA (revm's cap resolution prefers the override); Java drives `MessageCallProcessor` directly (no tx validation). Residual, symmetric on both engines: an estimate in (2²⁴, 30 M] can't be a valid post-Osaka transaction — the network rejects it, not this code.

## The one sharpened warning

The Java table still applies MAINNET timestamps to every chain (Rust is per-chain). All divergence windows are closed **today**, but the argument is time-contingent — the next fork's rollout re-opens a head-reachable window on sepolia/gnosis between their activation and mainnet's. The code and plan doc now state explicitly: **Java chain-awareness must land before the next fork constant is added to either table.**

## Testing

288 Rust + full Java suites green. The independent review confirmed every constant against upstream sources, the rung order/`>=` semantics on both engines, that revm 41.0.0 and Besu 26.4.0 genuinely implement what the tables now select (CLZ gating, P256VERIFY wiring incl. the non-optional `p256` dep under our `default-features=false` build, EIP-7883 modexp), and quantified the asymmetry-unreachability claim (~13 min max reachback vs boundaries months in the past).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PP9WX3oschsX9T4AAKpdim