### PR TITLE
Java EvmFactory: per-chain fork cascades (the Rust spec_for twin)

### DIFF
--- a/docs/evm/besu-extraction.md
+++ b/docs/evm/besu-extraction.md
@@ -81,7 +81,7 @@ not exercise that path; Phase 2 will, against real ERC-20 contracts.)
 
 `EvmFactory.buildForBlock(BlockContext)` selects between London / Paris
 (post-merge, block-keyed) / Shanghai / Cancun / Prague / Osaka (timestamp-keyed)
-using mainnet's published transition values. Pre-London is intentionally
+using each hosted chain's own published transition values (per-chain cascades; unknown chain ids fail closed). Pre-London is intentionally
 unsupported — the wallet only operates on recent finalised heads. Add a
 test per fork transition (one block before, one block after) before any
 upgrade.

--- a/docs/reimplementation/07-el-implementation-plan.md
+++ b/docs/reimplementation/07-el-implementation-plan.md
@@ -539,11 +539,11 @@ Java engine's.
   1764798551 / sepolia 1760427360 (go-ethereum ChainConfig) / gnosis 1776168380
   (0x69de2dbc, nethermind — hex-pinned like the other gnosis times), boundary-tested on
   both sides (`osaka_boundaries_map_on_every_chain` ↔ `OsakaBoundaryTest`, which also
-  pins P256VERIFY present under Osaka and absent under Prague). Known residuals: the
-  Java table stays MAINNET-times-for-all-chains — harmless TODAY (every hosted chain is
-  past both schedules' boundaries) but time-contingent: the next fork's rollout re-opens
-  a head-reachable divergence window on sepolia/gnosis, so Java chain-awareness MUST
-  land before the next fork constant is added to either table; estimateGas's 30 M view
+  pins P256VERIFY present under Osaka and absent under Prague). Known residuals: (RESOLVED
+  in the follow-up chain-awareness change: the Java EvmFactory now carries per-chain
+  cascades — mainnet/sepolia/gnosis, unknown chain ids fail closed like Rust's
+  UnsupportedChain — twinned by ChainAwareForkTest and cross-base-pinned by
+  ForkTimePinsTest); estimateGas's 30 M view
   ceiling exceeds Osaka's EIP-7825 2^24 per-tx cap (an estimate >16.7 M can't be a
   valid post-Osaka tx — shared semantics, both engines).
 

--- a/myotis-evm/src/main/java/io/myotis/evm/besu/EvmFactory.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/besu/EvmFactory.java
@@ -77,12 +77,14 @@ public final class EvmFactory {
      * rather than silently getting mainnet fork times).
      */
     public static EvmAndPrecompiles buildForBlock(BlockContext ctx) {
+        java.util.Objects.requireNonNull(ctx, "ctx");
         final long chainId;
         try {
             chainId = ctx.chainId().longValueExact();
-        } catch (ArithmeticException | NullPointerException e) {
+        } catch (ArithmeticException e) {
             // Same friendly type as the unknown-id path — never leak the raw
             // ArithmeticException (module convention, see AbiDecoder).
+            // BlockContext enforces a non-null chainId, so only overflow lands here.
             throw new IllegalArgumentException("unsupported chain id " + ctx.chainId(), e);
         }
         if (chainId == 1L) {

--- a/myotis-evm/src/main/java/io/myotis/evm/besu/EvmFactory.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/besu/EvmFactory.java
@@ -48,58 +48,130 @@ public final class EvmFactory {
     public static final long CANCUN_TIME    = 1_710_338_135L;
     public static final long PRAGUE_TIME    = 1_746_612_311L;
     /** Fusaka's EL fork (CLZ, P256VERIFY, ModExp repricing) — go-ethereum
-     *  MainnetChainConfig.OsakaTime (2025-12-03). NOTE the known asymmetry:
-     *  this table uses MAINNET times for every chain (the Rust engine's
-     *  spec_for is per-chain); harmless at the beacon-anchored head since all
-     *  hosted chains activated Osaka long ago, and the ≤256-block historical
-     *  window can no longer straddle the boundary — full chain-awareness here
-     *  remains a tracked follow-up. */
+     *  MainnetChainConfig.OsakaTime (2025-12-03). */
     public static final long OSAKA_TIME     = 1_764_798_551L;
+
+    // Sepolia fork-activation timestamps (go-ethereum SepoliaChainConfig).
+    // Sepolia merged before Shanghai; below Shanghai fails closed as too old.
+    public static final long SEPOLIA_SHANGHAI_TIME = 1_677_557_088L;
+    public static final long SEPOLIA_CANCUN_TIME   = 1_706_655_072L;
+    public static final long SEPOLIA_PRAGUE_TIME   = 1_741_159_776L;
+    public static final long SEPOLIA_OSAKA_TIME    = 1_760_427_360L;
+
+    // Gnosis fork-activation timestamps (nethermind gnosis.json, hex-sourced:
+    // 0x64c8edbc / 0x65ef4dbc / 0x68122dbc / 0x69de2dbc — pinned cross-base in
+    // ForkTimePinsTest like every other constant here).
+    public static final long GNOSIS_SHANGHAI_TIME = 1_690_889_660L;
+    public static final long GNOSIS_CANCUN_TIME   = 1_710_181_820L;
+    public static final long GNOSIS_PRAGUE_TIME   = 1_746_021_820L;
+    public static final long GNOSIS_OSAKA_TIME    = 1_776_168_380L;
 
     private EvmFactory() {}
 
-    /** Build an {@link EVM} instance whose rules match the active fork at {@code ctx}. */
+    /**
+     * Build an {@link EVM} instance whose rules match the active fork at {@code ctx} —
+     * PER CHAIN (the Rust {@code spec_for} twin, one cascade per hosted chain; an
+     * unknown chain id fails closed exactly like the Rust engine's UnsupportedChain
+     * rather than silently getting mainnet fork times).
+     */
     public static EvmAndPrecompiles buildForBlock(BlockContext ctx) {
-        EvmConfiguration cfg = EvmConfiguration.DEFAULT;
-        java.math.BigInteger chainId = ctx.chainId();
-        long blockNumber = ctx.blockNumber();
-        long ts = ctx.timestamp();
-
-        if (ts >= OSAKA_TIME) {
-            EVM evm = MainnetEVMs.osaka(chainId, cfg);
-            GasCalculator gc = new OsakaGasCalculator();
-            return new EvmAndPrecompiles(evm, MainnetPrecompiledContracts.osaka(gc), gc, EvmSpecVersion.OSAKA);
+        long chainId = ctx.chainId().longValueExact();
+        if (chainId == 1L) {
+            return mainnetSpec(ctx);
         }
-        if (ts >= PRAGUE_TIME) {
-            EVM evm = MainnetEVMs.prague(chainId, cfg);
-            GasCalculator gc = new PragueGasCalculator();
-            return new EvmAndPrecompiles(evm, MainnetPrecompiledContracts.prague(gc), gc, EvmSpecVersion.PRAGUE);
+        if (chainId == 11_155_111L) {
+            return sepoliaSpec(ctx);
         }
-        if (ts >= CANCUN_TIME) {
-            EVM evm = MainnetEVMs.cancun(chainId, cfg);
-            GasCalculator gc = new CancunGasCalculator();
-            return new EvmAndPrecompiles(evm, MainnetPrecompiledContracts.cancun(gc), gc, EvmSpecVersion.CANCUN);
-        }
-        if (ts >= SHANGHAI_TIME) {
-            EVM evm = MainnetEVMs.shanghai(chainId, cfg);
-            GasCalculator gc = new ShanghaiGasCalculator();
-            // Shanghai uses Istanbul-vintage precompiles; cancun() includes the
-            // post-merge surface but adds KZG point-evaluation, which is
-            // post-Shanghai. Use istanbul() here to stay correct.
-            return new EvmAndPrecompiles(evm, MainnetPrecompiledContracts.istanbul(gc), gc, EvmSpecVersion.SHANGHAI);
-        }
-        if (blockNumber >= PARIS_BLOCK) {
-            EVM evm = MainnetEVMs.paris(chainId, cfg);
-            GasCalculator gc = new LondonGasCalculator();
-            return new EvmAndPrecompiles(evm, MainnetPrecompiledContracts.istanbul(gc), gc, EvmSpecVersion.PARIS);
-        }
-        if (blockNumber >= LONDON_BLOCK) {
-            EVM evm = MainnetEVMs.london(chainId, cfg);
-            GasCalculator gc = new LondonGasCalculator();
-            return new EvmAndPrecompiles(evm, MainnetPrecompiledContracts.istanbul(gc), gc, EvmSpecVersion.LONDON);
+        if (chainId == 100L) {
+            return gnosisSpec(ctx);
         }
         throw new IllegalArgumentException(
-                "pre-London blocks are not supported (blockNumber=" + blockNumber
+                "unsupported chain id " + chainId + " (no fork table — failing closed, "
+                        + "never silently applying mainnet fork rules)");
+    }
+
+    /** Mainnet: pre-merge forks by block number, post-merge by timestamp. */
+    private static EvmAndPrecompiles mainnetSpec(BlockContext ctx) {
+        long ts = ctx.timestamp();
+        long blockNumber = ctx.blockNumber();
+        java.math.BigInteger chainId = ctx.chainId();
+        EvmConfiguration cfg = EvmConfiguration.DEFAULT;
+        if (ts >= OSAKA_TIME) return osaka(chainId, cfg);
+        if (ts >= PRAGUE_TIME) return prague(chainId, cfg);
+        if (ts >= CANCUN_TIME) return cancun(chainId, cfg);
+        if (ts >= SHANGHAI_TIME) return shanghai(chainId, cfg);
+        if (blockNumber >= PARIS_BLOCK) return paris(chainId, cfg);
+        if (blockNumber >= LONDON_BLOCK) return london(chainId, cfg);
+        throw tooOld(blockNumber, ts);
+    }
+
+    /** Sepolia: all timestamp-gated (merged pre-Shanghai; older is unservable). */
+    private static EvmAndPrecompiles sepoliaSpec(BlockContext ctx) {
+        long ts = ctx.timestamp();
+        java.math.BigInteger chainId = ctx.chainId();
+        EvmConfiguration cfg = EvmConfiguration.DEFAULT;
+        if (ts >= SEPOLIA_OSAKA_TIME) return osaka(chainId, cfg);
+        if (ts >= SEPOLIA_PRAGUE_TIME) return prague(chainId, cfg);
+        if (ts >= SEPOLIA_CANCUN_TIME) return cancun(chainId, cfg);
+        if (ts >= SEPOLIA_SHANGHAI_TIME) return shanghai(chainId, cfg);
+        throw tooOld(ctx.blockNumber(), ts);
+    }
+
+    /** Gnosis: all timestamp-gated (merged pre-Shanghai; older is unservable). */
+    private static EvmAndPrecompiles gnosisSpec(BlockContext ctx) {
+        long ts = ctx.timestamp();
+        java.math.BigInteger chainId = ctx.chainId();
+        EvmConfiguration cfg = EvmConfiguration.DEFAULT;
+        if (ts >= GNOSIS_OSAKA_TIME) return osaka(chainId, cfg);
+        if (ts >= GNOSIS_PRAGUE_TIME) return prague(chainId, cfg);
+        if (ts >= GNOSIS_CANCUN_TIME) return cancun(chainId, cfg);
+        if (ts >= GNOSIS_SHANGHAI_TIME) return shanghai(chainId, cfg);
+        throw tooOld(ctx.blockNumber(), ts);
+    }
+
+    // ---- one builder per rung (gas-calculator/precompile pairings unchanged) ----
+
+    private static EvmAndPrecompiles osaka(java.math.BigInteger chainId, EvmConfiguration cfg) {
+        GasCalculator gc = new OsakaGasCalculator();
+        return new EvmAndPrecompiles(MainnetEVMs.osaka(chainId, cfg),
+                MainnetPrecompiledContracts.osaka(gc), gc, EvmSpecVersion.OSAKA);
+    }
+
+    private static EvmAndPrecompiles prague(java.math.BigInteger chainId, EvmConfiguration cfg) {
+        GasCalculator gc = new PragueGasCalculator();
+        return new EvmAndPrecompiles(MainnetEVMs.prague(chainId, cfg),
+                MainnetPrecompiledContracts.prague(gc), gc, EvmSpecVersion.PRAGUE);
+    }
+
+    private static EvmAndPrecompiles cancun(java.math.BigInteger chainId, EvmConfiguration cfg) {
+        GasCalculator gc = new CancunGasCalculator();
+        return new EvmAndPrecompiles(MainnetEVMs.cancun(chainId, cfg),
+                MainnetPrecompiledContracts.cancun(gc), gc, EvmSpecVersion.CANCUN);
+    }
+
+    private static EvmAndPrecompiles shanghai(java.math.BigInteger chainId, EvmConfiguration cfg) {
+        GasCalculator gc = new ShanghaiGasCalculator();
+        // Shanghai uses Istanbul-vintage precompiles; cancun() would add KZG
+        // point-evaluation, which is post-Shanghai.
+        return new EvmAndPrecompiles(MainnetEVMs.shanghai(chainId, cfg),
+                MainnetPrecompiledContracts.istanbul(gc), gc, EvmSpecVersion.SHANGHAI);
+    }
+
+    private static EvmAndPrecompiles paris(java.math.BigInteger chainId, EvmConfiguration cfg) {
+        GasCalculator gc = new LondonGasCalculator();
+        return new EvmAndPrecompiles(MainnetEVMs.paris(chainId, cfg),
+                MainnetPrecompiledContracts.istanbul(gc), gc, EvmSpecVersion.PARIS);
+    }
+
+    private static EvmAndPrecompiles london(java.math.BigInteger chainId, EvmConfiguration cfg) {
+        GasCalculator gc = new LondonGasCalculator();
+        return new EvmAndPrecompiles(MainnetEVMs.london(chainId, cfg),
+                MainnetPrecompiledContracts.istanbul(gc), gc, EvmSpecVersion.LONDON);
+    }
+
+    private static IllegalArgumentException tooOld(long blockNumber, long ts) {
+        return new IllegalArgumentException(
+                "pre-fork-floor blocks are not supported (blockNumber=" + blockNumber
                         + ", timestamp=" + ts + ")");
     }
 

--- a/myotis-evm/src/main/java/io/myotis/evm/besu/EvmFactory.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/besu/EvmFactory.java
@@ -15,11 +15,13 @@ import org.hyperledger.besu.evm.precompile.MainnetPrecompiledContracts;
 import org.hyperledger.besu.evm.precompile.PrecompileContractRegistry;
 
 /**
- * Builds Besu {@link EVM} instances configured for the correct mainnet hard
- * fork at a given block.
+ * Builds Besu {@link EVM} instances configured for the correct hard fork of
+ * the TARGET CHAIN at a given block — per-chain cascades for mainnet, sepolia
+ * and gnosis (the Rust {@code spec_for} twin); unknown chain ids fail closed.
  *
  * <p>Mainnet fork boundaries (block-number-keyed up through the Merge,
- * timestamp-keyed afterwards):
+ * timestamp-keyed afterwards; sepolia/gnosis schedules live on their own
+ * constants below, cross-base-pinned in ForkTimePinsTest):
  * <ul>
  *   <li>London — {@code 12_965_000}
  *   <li>Paris (Merge) — {@code 15_537_394}
@@ -75,7 +77,14 @@ public final class EvmFactory {
      * rather than silently getting mainnet fork times).
      */
     public static EvmAndPrecompiles buildForBlock(BlockContext ctx) {
-        long chainId = ctx.chainId().longValueExact();
+        final long chainId;
+        try {
+            chainId = ctx.chainId().longValueExact();
+        } catch (ArithmeticException | NullPointerException e) {
+            // Same friendly type as the unknown-id path — never leak the raw
+            // ArithmeticException (module convention, see AbiDecoder).
+            throw new IllegalArgumentException("unsupported chain id " + ctx.chainId(), e);
+        }
         if (chainId == 1L) {
             return mainnetSpec(ctx);
         }

--- a/myotis-evm/src/test/java/io/myotis/evm/besu/ChainAwareForkTest.java
+++ b/myotis-evm/src/test/java/io/myotis/evm/besu/ChainAwareForkTest.java
@@ -32,8 +32,13 @@ class ChainAwareForkTest {
         long s = 11_155_111L;
         assertEquals(EvmSpecVersion.OSAKA, spec(s, 9_000_000, EvmFactory.SEPOLIA_OSAKA_TIME));
         assertEquals(EvmSpecVersion.PRAGUE, spec(s, 9_000_000, EvmFactory.SEPOLIA_OSAKA_TIME - 1));
+        // Exact activation instants (Rust twin parity — a >= flipped to > on
+        // any rung diverges the engines for one second per fork):
+        assertEquals(EvmSpecVersion.PRAGUE, spec(s, 9_000_000, EvmFactory.SEPOLIA_PRAGUE_TIME));
         assertEquals(EvmSpecVersion.CANCUN, spec(s, 9_000_000, EvmFactory.SEPOLIA_PRAGUE_TIME - 1));
+        assertEquals(EvmSpecVersion.CANCUN, spec(s, 9_000_000, EvmFactory.SEPOLIA_CANCUN_TIME));
         assertEquals(EvmSpecVersion.SHANGHAI, spec(s, 9_000_000, EvmFactory.SEPOLIA_CANCUN_TIME - 1));
+        assertEquals(EvmSpecVersion.SHANGHAI, spec(s, 9_000_000, EvmFactory.SEPOLIA_SHANGHAI_TIME));
         // THE case the old mainnet-times-for-all table got wrong: sepolia's
         // Osaka window before mainnet's activation.
         assertEquals(EvmSpecVersion.OSAKA, spec(s, 9_000_000, EvmFactory.OSAKA_TIME - 1_000_000));
@@ -46,8 +51,11 @@ class ChainAwareForkTest {
         long g = 100L;
         assertEquals(EvmSpecVersion.OSAKA, spec(g, 30_000_000, EvmFactory.GNOSIS_OSAKA_TIME));
         assertEquals(EvmSpecVersion.PRAGUE, spec(g, 30_000_000, EvmFactory.GNOSIS_OSAKA_TIME - 1));
+        assertEquals(EvmSpecVersion.PRAGUE, spec(g, 30_000_000, EvmFactory.GNOSIS_PRAGUE_TIME));
         assertEquals(EvmSpecVersion.CANCUN, spec(g, 30_000_000, EvmFactory.GNOSIS_PRAGUE_TIME - 1));
+        assertEquals(EvmSpecVersion.CANCUN, spec(g, 30_000_000, EvmFactory.GNOSIS_CANCUN_TIME));
         assertEquals(EvmSpecVersion.SHANGHAI, spec(g, 30_000_000, EvmFactory.GNOSIS_CANCUN_TIME - 1));
+        assertEquals(EvmSpecVersion.SHANGHAI, spec(g, 30_000_000, EvmFactory.GNOSIS_SHANGHAI_TIME));
         // The flip side: mainnet's Osaka time must NOT flip gnosis early.
         assertEquals(EvmSpecVersion.PRAGUE, spec(g, 30_000_000, EvmFactory.OSAKA_TIME));
         assertThrows(IllegalArgumentException.class,
@@ -58,6 +66,9 @@ class ChainAwareForkTest {
     void mainnetCascadeUnchanged() {
         assertEquals(EvmSpecVersion.OSAKA, spec(1, 21_000_000, EvmFactory.OSAKA_TIME));
         assertEquals(EvmSpecVersion.PRAGUE, spec(1, 21_000_000, EvmFactory.OSAKA_TIME - 1));
+        assertEquals(EvmSpecVersion.PRAGUE, spec(1, 21_000_000, EvmFactory.PRAGUE_TIME));
+        assertEquals(EvmSpecVersion.CANCUN, spec(1, 21_000_000, EvmFactory.CANCUN_TIME));
+        assertEquals(EvmSpecVersion.SHANGHAI, spec(1, 19_000_000, EvmFactory.SHANGHAI_TIME));
         assertEquals(EvmSpecVersion.PARIS, spec(1, 15_537_394, EvmFactory.SHANGHAI_TIME - 1));
         assertEquals(EvmSpecVersion.LONDON, spec(1, 12_965_000, EvmFactory.SHANGHAI_TIME - 1));
     }

--- a/myotis-evm/src/test/java/io/myotis/evm/besu/ChainAwareForkTest.java
+++ b/myotis-evm/src/test/java/io/myotis/evm/besu/ChainAwareForkTest.java
@@ -1,0 +1,72 @@
+package io.myotis.evm.besu;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.myotis.evm.BlockContext;
+import java.math.BigInteger;
+import org.hyperledger.besu.evm.EvmSpecVersion;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Per-chain fork selection — the Java twin of the Rust {@code spec_for} tests
+ * ({@code osaka_boundaries_map_on_every_chain} and the per-chain cascades), so
+ * the two engines can never diverge on (chainId, block, timestamp) → spec.
+ */
+class ChainAwareForkTest {
+
+    private static BlockContext ctx(final long chainId, final long block, final long ts) {
+        return new BlockContext(
+                new byte[32], block, ts, BigInteger.valueOf(1_000_000_000L),
+                io.myotis.evm.Address.ZERO, new byte[32],
+                BigInteger.valueOf(chainId), 30_000_000L);
+    }
+
+    private static EvmSpecVersion spec(final long chainId, final long block, final long ts) {
+        return EvmFactory.buildForBlock(ctx(chainId, block, ts)).specVersion();
+    }
+
+    @Test
+    void sepoliaUsesItsOwnSchedule() {
+        long s = 11_155_111L;
+        assertEquals(EvmSpecVersion.OSAKA, spec(s, 9_000_000, EvmFactory.SEPOLIA_OSAKA_TIME));
+        assertEquals(EvmSpecVersion.PRAGUE, spec(s, 9_000_000, EvmFactory.SEPOLIA_OSAKA_TIME - 1));
+        assertEquals(EvmSpecVersion.CANCUN, spec(s, 9_000_000, EvmFactory.SEPOLIA_PRAGUE_TIME - 1));
+        assertEquals(EvmSpecVersion.SHANGHAI, spec(s, 9_000_000, EvmFactory.SEPOLIA_CANCUN_TIME - 1));
+        // THE case the old mainnet-times-for-all table got wrong: sepolia's
+        // Osaka window before mainnet's activation.
+        assertEquals(EvmSpecVersion.OSAKA, spec(s, 9_000_000, EvmFactory.OSAKA_TIME - 1_000_000));
+        assertThrows(IllegalArgumentException.class,
+                () -> spec(s, 9_000_000, EvmFactory.SEPOLIA_SHANGHAI_TIME - 1));
+    }
+
+    @Test
+    void gnosisUsesItsOwnSchedule() {
+        long g = 100L;
+        assertEquals(EvmSpecVersion.OSAKA, spec(g, 30_000_000, EvmFactory.GNOSIS_OSAKA_TIME));
+        assertEquals(EvmSpecVersion.PRAGUE, spec(g, 30_000_000, EvmFactory.GNOSIS_OSAKA_TIME - 1));
+        assertEquals(EvmSpecVersion.CANCUN, spec(g, 30_000_000, EvmFactory.GNOSIS_PRAGUE_TIME - 1));
+        assertEquals(EvmSpecVersion.SHANGHAI, spec(g, 30_000_000, EvmFactory.GNOSIS_CANCUN_TIME - 1));
+        // The flip side: mainnet's Osaka time must NOT flip gnosis early.
+        assertEquals(EvmSpecVersion.PRAGUE, spec(g, 30_000_000, EvmFactory.OSAKA_TIME));
+        assertThrows(IllegalArgumentException.class,
+                () -> spec(g, 30_000_000, EvmFactory.GNOSIS_SHANGHAI_TIME - 1));
+    }
+
+    @Test
+    void mainnetCascadeUnchanged() {
+        assertEquals(EvmSpecVersion.OSAKA, spec(1, 21_000_000, EvmFactory.OSAKA_TIME));
+        assertEquals(EvmSpecVersion.PRAGUE, spec(1, 21_000_000, EvmFactory.OSAKA_TIME - 1));
+        assertEquals(EvmSpecVersion.PARIS, spec(1, 15_537_394, EvmFactory.SHANGHAI_TIME - 1));
+        assertEquals(EvmSpecVersion.LONDON, spec(1, 12_965_000, EvmFactory.SHANGHAI_TIME - 1));
+    }
+
+    @Test
+    void unknownChainFailsClosed() {
+        // Never silently mainnet rules (Rust UnsupportedChain twin).
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> spec(137, 21_000_000, EvmFactory.OSAKA_TIME));
+        assertTrue(e.getMessage().contains("unsupported chain id 137"), e.getMessage());
+    }
+}

--- a/myotis-evm/src/test/java/io/myotis/evm/besu/ForkTimePinsTest.java
+++ b/myotis-evm/src/test/java/io/myotis/evm/besu/ForkTimePinsTest.java
@@ -20,4 +20,20 @@ class ForkTimePinsTest {
         assertEquals(0x681b_3057L, EvmFactory.PRAGUE_TIME);
         assertEquals(0x6930_b057L, EvmFactory.OSAKA_TIME);
     }
+
+    @Test
+    void sepoliaForkTimesMatchTheirHexForms() {
+        assertEquals(0x63fd_7d60L, EvmFactory.SEPOLIA_SHANGHAI_TIME);
+        assertEquals(0x65b9_7d60L, EvmFactory.SEPOLIA_CANCUN_TIME);
+        assertEquals(0x67c7_fd60L, EvmFactory.SEPOLIA_PRAGUE_TIME);
+        assertEquals(0x68ed_fd60L, EvmFactory.SEPOLIA_OSAKA_TIME);
+    }
+
+    @Test
+    void gnosisForkTimesMatchTheNethermindHex() {
+        assertEquals(0x64c8_edbcL, EvmFactory.GNOSIS_SHANGHAI_TIME);
+        assertEquals(0x65ef_4dbcL, EvmFactory.GNOSIS_CANCUN_TIME);
+        assertEquals(0x6812_2dbcL, EvmFactory.GNOSIS_PRAGUE_TIME);
+        assertEquals(0x69de_2dbcL, EvmFactory.GNOSIS_OSAKA_TIME);
+    }
 }

--- a/rust/myotis-evm/src/fork.rs
+++ b/rust/myotis-evm/src/fork.rs
@@ -46,13 +46,9 @@ pub const SEPOLIA_OSAKA_TIME: u64 = 1_760_427_360;
 /// [`EvmError::UnsupportedChain`] for a chain with no table here (e.g. Gnosis
 /// until its slice lands), [`EvmError::ForkTooOld`] below each chain's floor.
 ///
-/// KNOWN GAP vs the Java `EvmFactory` (cross-engine follow-up): Java applies
-/// the MAINNET timestamps to every chain, while this table is per-chain. The
-/// divergence windows are all in the past today (every hosted chain is beyond
-/// both schedules' last boundary), BUT the argument is time-contingent: the
-/// next fork's rollout re-opens a window on sepolia/gnosis between their
-/// activation and mainnet's. Java chain-awareness MUST land before the next
-/// fork constant is added to either table.
+/// The Java `EvmFactory` mirrors this table PER CHAIN (its per-chain cascades
+/// and the ChainAwareForkTest are the twins of this function and its tests) —
+/// keep the two in lockstep whenever a fork constant is added.
 pub fn spec_for(chain_id: u64, block_number: u64, timestamp: u64) -> Result<SpecId, EvmError> {
     match chain_id {
         1 => mainnet_spec(block_number, timestamp),

--- a/rust/myotis-evm/src/fork.rs
+++ b/rust/myotis-evm/src/fork.rs
@@ -43,8 +43,8 @@ pub const SEPOLIA_PRAGUE_TIME: u64 = 1_741_159_776;
 pub const SEPOLIA_OSAKA_TIME: u64 = 1_760_427_360;
 
 /// The revm `SpecId` a `(chain_id, block_number, timestamp)` activates:
-/// [`EvmError::UnsupportedChain`] for a chain with no table here (e.g. Gnosis
-/// until its slice lands), [`EvmError::ForkTooOld`] below each chain's floor.
+/// [`EvmError::UnsupportedChain`] for a chain with no table here,
+/// [`EvmError::ForkTooOld`] below each chain's floor.
 ///
 /// The Java `EvmFactory` mirrors this table PER CHAIN (its per-chain cascades
 /// and the ChainAwareForkTest are the twins of this function and its tests) —


### PR DESCRIPTION
Closes the last spec-selection asymmetry between the engines, flagged in #209: the Java table applied MAINNET timestamps to every chain while Rust was per-chain — harmless only until the next fork's rollout re-opened a head-reachable divergence window.

## What changed

- `buildForBlock` switches on chainId with one cascade per hosted chain, mirroring `rust/myotis-evm/src/fork.rs` rung for rung: mainnet (block-keyed pre-merge, timestamp-keyed after), sepolia and gnosis (all timestamp-keyed, failing closed below their own Shanghai floors). The per-rung EVM/gas-calculator/precompile pairings are extracted into shared builders — verified byte-identical to the pre-refactor inline versions (Shanghai keeps `istanbul()` precompiles).
- **Unknown chain ids fail closed** (the Rust `UnsupportedChain` twin) instead of silently receiving mainnet fork rules — deliberate behavior change; the review confirmed no real caller is affected (both `BlockContext` production sites use `NetworkConfig` ids, which only defines the three hosted chains; the holesky `EnsResolver.forChainId` path selects addresses only, never builds an EVM context).
- Sepolia/gnosis constants source-pinned cross-base in `ForkTimePinsTest` (12 hex↔decimal pins — the review recomputed every one independently and re-verified all constants against go-ethereum and nethermind masters).
- `ChainAwareForkTest` twins the Rust boundary tests, including the two directional cases the old table got wrong (sepolia's Osaka window before mainnet's → OSAKA; mainnet's Osaka time on gnosis → still PRAGUE) and — per the review — the **exact activation-instant** assertions on every middle rung of all three chains, so a `>=` flipped to `>` anywhere fails the suite.
- `chainId` extraction wraps `ArithmeticException`/NPE into the friendly `IllegalArgumentException`; stale mainnet-times docs swept (EvmFactory javadoc, besu-extraction.md, a leftover fork.rs parenthetical); the "must land before the next fork" warning is retired for a lockstep note.

With this, the next fork (Amsterdam) needs exactly one constant per chain per engine, each caught by the existing cross-base pins and boundary twins if mistyped.

## Testing

Full `myotis-evm` + engines + app suites green both engines (88 Rust). The independent no-context review found no input where the engines disagree, and its findings (six missing exact-boundary pins, three stale doc spots, the exception-type nit) are all addressed in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PP9WX3oschsX9T4AAKpdim