### PR TITLE
ci: build the Android Rust jniLibs from source in the APK workflow

### DIFF
--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -43,6 +43,39 @@ jobs:
       - name: Make gradlew executable
         run: chmod +x gradlew
 
+      # Build the Rust engine jniLibs FROM SOURCE so the published APK can
+      # never ship the committed binaries stale (a recurring failure mode:
+      # ABI-compatible but feature-stale .so files pass the version handshake
+      # silently). The committed jniLibs remain the fallback for local builds
+      # without cargo. The runner's preinstalled NDK is found via
+      # ANDROID_NDK_HOME / $ANDROID_HOME/ndk by the cargoNdkAndroid task.
+      - name: Set up Rust (Android targets)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-linux-android,x86_64-linux-android
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust
+
+      - name: Install cargo-ndk
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-ndk
+
+      # Explicit + guarded: cargoNdkAndroid self-skips when its toolchain is
+      # missing — in CI that must FAIL, not silently fall back to the committed
+      # binaries. The newer-than check catches any silent skip.
+      - name: Build Rust jniLibs from source
+        run: |
+          ./gradlew cargoNdkAndroid --stacktrace
+          for abi in arm64-v8a x86_64; do
+            lib="android-app/src/main/jniLibs/$abi/libmyotis_engine.so"
+            [ "$lib" -nt gradlew ] \
+              || { echo "::error::$lib was NOT rebuilt (cargoNdkAndroid self-skipped?)"; exit 1; }
+          done
+
       # The ubuntu-latest runner ships an Android SDK via $ANDROID_HOME, which
       # AGP picks up automatically when local.properties is absent. No extra
       # sdkmanager calls needed for compileSdk 34.


### PR DESCRIPTION
Kills the stale-jniLibs failure mode structurally (user request). The committed binaries repeatedly went feature-stale while staying ABI-compatible — the version handshake passes and the shipped Rust engine silently lacks recent work; three manual refresh PRs so far (#196, #202, #205), and the pending pre-release would have needed a fourth.

The APK workflow now sets up the Rust toolchain (with both Android targets), `cargo-ndk` (prebuilt via install-action), and a Rust build cache, then runs `cargoNdkAndroid` before assembling — every CI-built APK (PR builds, main pushes, and the `v*` release publishing job, which reuses this build's artifact) carries a Rust engine built from the checked-out source. A newer-than guard fails the job if the task self-skips, so CI can never silently fall back to the committed binaries.

The committed jniLibs stay in the repo as the documented fallback for local builds without cargo. The PR build of this very workflow doubles as its own end-to-end test (the guard proves the rebuild happened).

Note for the pre-release: with this merged, the tag-published APK is automatically current — no refresh PR needed for CI artifacts (a final refresh for local-dev parity is optional).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PP9WX3oschsX9T4AAKpdim