### PR TITLE
desktop: bundle the Rust engine into packaged apps (+ fix DOA packaged launch)

### DIFF
--- a/.github/workflows/desktop-dmg.yml
+++ b/.github/workflows/desktop-dmg.yml
@@ -114,8 +114,11 @@ jobs:
       # Retry to ride out transient repo-resolution blips.
       - name: Build macOS .dmg (${{ matrix.arch }})
         env:
-          # Cross-compile the Rust engine on the Rosetta leg (see Set up Rust).
-          RUST_TARGET: ${{ matrix.arch == 'x64' && 'x86_64-apple-darwin' || '' }}
+          # Explicit triple on BOTH legs (the arm64 value equals the host, so
+          # it's a no-op there) — an empty-string env var is NOT null and
+          # would otherwise flow into `--target ""` (this exact failure took
+          # down the arm64 leg's first CI run).
+          RUST_TARGET: ${{ matrix.arch == 'x64' && 'x86_64-apple-darwin' || 'aarch64-apple-darwin' }}
         run: |
           GRADLE_ARGS="-Porg.gradle.java.installations.auto-detect=false -Porg.gradle.java.installations.auto-download=false -Porg.gradle.java.installations.paths=$JAVA_HOME"
           for attempt in 1 2 3; do

--- a/.github/workflows/desktop-dmg.yml
+++ b/.github/workflows/desktop-dmg.yml
@@ -83,6 +83,12 @@ jobs:
       # missing, so this step is REQUIRED, not optional.
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          # Both matrix legs run on arm64 macos-14; the x64 leg is a Rosetta
+          # cross-build. cargo builds its HOST triple regardless of the JVM's
+          # arch, so the x64 leg must cross-compile explicitly or the x64 dmg
+          # would bundle an arm64 dylib (dead engine toggle on Intel Macs).
+          targets: ${{ matrix.arch == 'x64' && 'x86_64-apple-darwin' || 'aarch64-apple-darwin' }}
 
       - name: Cache Rust build
         uses: Swatinem/rust-cache@v2
@@ -107,6 +113,9 @@ jobs:
       # right-click → Open the first time; notarization (Apple Developer ID) is a follow-up.
       # Retry to ride out transient repo-resolution blips.
       - name: Build macOS .dmg (${{ matrix.arch }})
+        env:
+          # Cross-compile the Rust engine on the Rosetta leg (see Set up Rust).
+          RUST_TARGET: ${{ matrix.arch == 'x64' && 'x86_64-apple-darwin' || '' }}
         run: |
           GRADLE_ARGS="-Porg.gradle.java.installations.auto-detect=false -Porg.gradle.java.installations.auto-download=false -Porg.gradle.java.installations.paths=$JAVA_HOME"
           for attempt in 1 2 3; do
@@ -157,6 +166,16 @@ jobs:
           echo "$archs" | tr ' ' '\n' | grep -qx "$want" \
             || { echo "::error::arch mismatch: expected $want, got [$archs] for the ${{ matrix.arch }} dmg"; exit 1; }
           echo "OK: ${{ matrix.arch }} dmg launcher is $want"
+          # The bundled Rust engine must exist AND match the dmg's arch — a
+          # wrong-arch dylib loads nothing and leaves the engine toggle dead
+          # (invisible to the launcher check above).
+          rustlib=$(find "$mnt" -type f -name 'libmyotis_engine.dylib' | head -n1 || true)
+          [ -n "$rustlib" ] || { echo "::error::libmyotis_engine.dylib missing from the dmg"; exit 1; }
+          rustarchs=$(lipo -archs "$rustlib")
+          echo "bundled rust engine: $rustlib -> [$rustarchs]"
+          echo "$rustarchs" | tr ' ' '\n' | grep -qx "$want" \
+            || { echo "::error::rust engine arch mismatch: expected $want, got [$rustarchs]"; exit 1; }
+          echo "OK: bundled rust engine is $want"
 
       - name: Upload DMG
         uses: actions/upload-artifact@v4

--- a/.github/workflows/desktop-dmg.yml
+++ b/.github/workflows/desktop-dmg.yml
@@ -78,6 +78,17 @@ jobs:
           distribution: 'temurin'
           architecture: ${{ matrix.java-arch }}
 
+      # The packaged app bundles the Rust engine (appResources): build it from
+      # source here. prepareRustAppResources fails the build if the lib is
+      # missing, so this step is REQUIRED, not optional.
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust
+
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
 

--- a/.github/workflows/desktop-linux-deb.yml
+++ b/.github/workflows/desktop-linux-deb.yml
@@ -60,6 +60,17 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
 
+      # The packaged app bundles the Rust engine (appResources): build it from
+      # source here. prepareRustAppResources fails the build if the lib is
+      # missing, so this step is REQUIRED, not optional.
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust
+
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
 

--- a/.github/workflows/desktop-linux-deb.yml
+++ b/.github/workflows/desktop-linux-deb.yml
@@ -132,7 +132,16 @@ jobs:
           echo "bundled libjvm: $info"
           echo "$info" | grep -q "$want_elf" \
             || { echo "::error::ELF arch mismatch: expected $want_elf in: $info"; exit 1; }
-          echo "OK: ${{ matrix.arch }} deb is $want_deb/$want_elf"
+          # The bundled Rust engine must exist AND match (both legs build on
+          # native-arch runners so cargo's host triple is already right; this
+          # assertion keeps that assumption honest).
+          rustlib=$(find "$ex" -type f -name 'libmyotis_engine.so' | head -n1 || true)
+          [ -n "$rustlib" ] || { echo "::error::libmyotis_engine.so missing from the deb"; exit 1; }
+          rustinfo=$(file -b "$rustlib")
+          echo "bundled rust engine: $rustinfo"
+          echo "$rustinfo" | grep -q "$want_elf" \
+            || { echo "::error::rust engine ELF arch mismatch: expected $want_elf in: $rustinfo"; exit 1; }
+          echo "OK: ${{ matrix.arch }} deb is $want_deb/$want_elf (rust engine bundled)"
 
       - name: Upload DEB
         uses: actions/upload-artifact@v4

--- a/app-desktop/build.gradle.kts
+++ b/app-desktop/build.gradle.kts
@@ -32,6 +32,14 @@ kotlin { jvmToolchain(21) }
 // the fork (reaches SYNCED), so it's safe to do the same here.
 configurations.all {
     exclude(group = "io.tmio")
+    // Besu 26.4 pulls tuweni under its POST-RENAME coordinates
+    // (io.consensys.tuweni) — the same Bytes classes as our Kotlin fork but
+    // WITHOUT the Kotlin Companion. The gradle-run daemon happened to
+    // classload the fork first; jpackage's flattened classpath let the Java
+    // jar win and the PACKAGED app died at launch with
+    // NoSuchFieldError: Bytes.Companion (found by launching the app image).
+    // The fork supplies these classes; exclude the upstream twins.
+    exclude(group = "io.consensys.tuweni")
     exclude(group = "io.netty")
 }
 
@@ -73,6 +81,65 @@ tasks.register<JavaExec>("syncSmoke") {
     systemProperty("myotis.logfile", rootProject.file("devp2p.log").absolutePath)
 }
 
+// ---------------------------------------------------------------------------
+// Bundle the Rust engine into PACKAGED desktop apps (dmg/deb/distributable):
+// cargoBuildHost's host lib is staged into Compose's appResources under the
+// current os-arch subdir; jpackage ships that dir inside the app and exposes
+// it at runtime via the `compose.application.resources.dir` system property,
+// which Main.kt forwards to the engine loader (-Dmyotis.engine.lib). Dev
+// `run`/`syncSmoke` keep their absolute-path wiring below and never bake a
+// path into packages. FAIL-LOUD: packaging without cargo must error, never
+// silently ship a Java-only app with a dead engine toggle (same philosophy
+// as the APK workflow's self-skip guard).
+// ---------------------------------------------------------------------------
+val rustHostLibName = run {
+    val os = System.getProperty("os.name").lowercase()
+    when {
+        os.contains("mac") -> "libmyotis_engine.dylib"
+        os.contains("win") -> "myotis_engine.dll"
+        else -> "libmyotis_engine.so"
+    }
+}
+val composeOsArchDir = run {
+    val os = System.getProperty("os.name").lowercase()
+    val arch = System.getProperty("os.arch").lowercase()
+    val osPart = when {
+        os.contains("mac") -> "macos"
+        os.contains("win") -> "windows"
+        else -> "linux"
+    }
+    val archPart = if (arch == "aarch64" || arch == "arm64") "arm64" else "x64"
+    "$osPart-$archPart"
+}
+
+val prepareRustAppResources = tasks.register<Copy>("prepareRustAppResources") {
+    group = "build"
+    description = "Stage the Rust engine host lib into Compose appResources for packaging"
+    dependsOn(rootProject.tasks.named("cargoBuildHost"))
+    from(rootProject.file("rust/target/release/$rustHostLibName"))
+    into(layout.buildDirectory.dir("rustAppResources/$composeOsArchDir"))
+    doLast {
+        val staged = layout.buildDirectory
+            .file("rustAppResources/$composeOsArchDir/$rustHostLibName").get().asFile
+        check(staged.isFile) {
+            "Rust engine lib missing ($staged) — packaging requires cargo " +
+                "(cargoBuildHost self-skipped?). A packaged app must never " +
+                "silently ship without the Rust engine."
+        }
+    }
+}
+
+// Compose's own internal prepareAppResources task copies appResourcesRootDir
+// into the image — our staging must run before IT (depending only on the
+// package*/createDistributable* umbrella tasks is too late: the internal copy
+// consumes the dir first).
+tasks.matching {
+    it.name == "prepareAppResources"
+        || it.name.startsWith("package") || it.name.startsWith("createDistributable")
+        || it.name.startsWith("createReleaseDistributable")
+        || it.name.startsWith("runDistributable") || it.name.startsWith("runRelease")
+}.configureEach { dependsOn(prepareRustAppResources) }
+
 compose.desktop {
     application {
         mainClass = "io.myotis.desktop.MainKt"
@@ -90,6 +157,8 @@ compose.desktop {
             languageVersion.set(JavaLanguageVersion.of(21))
         }.get().metadata.installationPath.asFile.absolutePath
         nativeDistributions {
+            // The staged Rust engine lib (see prepareRustAppResources above).
+            appResourcesRootDir.set(layout.buildDirectory.dir("rustAppResources"))
             // jpackage is host-OS-bound: the .dmg can only be produced on macOS, the .deb only
             // on Linux. CI builds each on its matching runner (desktop-dmg.yml /
             // desktop-linux-deb.yml); locally you get the format for your OS. Msi when a

--- a/app-desktop/build.gradle.kts
+++ b/app-desktop/build.gradle.kts
@@ -136,12 +136,17 @@ val prepareRustAppResources = tasks.register("prepareRustAppResources") {
 // into the image — our staging must run before IT (depending only on the
 // package*/createDistributable* umbrella tasks is too late: the internal copy
 // consumes the dir first).
-tasks.matching {
-    it.name == "prepareAppResources"
-        || it.name.startsWith("package") || it.name.startsWith("createDistributable")
-        || it.name.startsWith("createReleaseDistributable")
-        || it.name.startsWith("runDistributable") || it.name.startsWith("runRelease")
-}.configureEach { dependsOn(prepareRustAppResources) }
+tasks.configureEach {
+    // configureEach (not tasks.matching{}, which realizes every task eagerly):
+    // the name check runs lazily as each task is configured.
+    if (name == "prepareAppResources"
+        || name.startsWith("package") || name.startsWith("createDistributable")
+        || name.startsWith("createReleaseDistributable")
+        || name.startsWith("runDistributable") || name.startsWith("runRelease")
+    ) {
+        dependsOn(prepareRustAppResources)
+    }
+}
 
 compose.desktop {
     application {

--- a/app-desktop/build.gradle.kts
+++ b/app-desktop/build.gradle.kts
@@ -92,14 +92,8 @@ tasks.register<JavaExec>("syncSmoke") {
 // silently ship a Java-only app with a dead engine toggle (same philosophy
 // as the APK workflow's self-skip guard).
 // ---------------------------------------------------------------------------
-val rustHostLibName = run {
-    val os = System.getProperty("os.name").lowercase()
-    when {
-        os.contains("mac") -> "libmyotis_engine.dylib"
-        os.contains("win") -> "myotis_engine.dll"
-        else -> "libmyotis_engine.so"
-    }
-}
+val rustHostLibName = rootProject.extra["rustEngineLibName"] as String
+val rustReleaseDir = rootProject.extra["rustReleaseDir"] as String
 val composeOsArchDir = run {
     val os = System.getProperty("os.name").lowercase()
     val arch = System.getProperty("os.arch").lowercase()
@@ -112,19 +106,28 @@ val composeOsArchDir = run {
     "$osPart-$archPart"
 }
 
-val prepareRustAppResources = tasks.register<Copy>("prepareRustAppResources") {
+val prepareRustAppResources = tasks.register("prepareRustAppResources") {
     group = "build"
     description = "Stage the Rust engine host lib into Compose appResources for packaging"
     dependsOn(rootProject.tasks.named("cargoBuildHost"))
-    from(rootProject.file("rust/target/release/$rustHostLibName"))
-    into(layout.buildDirectory.dir("rustAppResources/$composeOsArchDir"))
+    val src = rootProject.file("$rustReleaseDir/$rustHostLibName")
+    val destDir = layout.buildDirectory.dir("rustAppResources/$composeOsArchDir")
+    inputs.files(src).optional() // optional so the ACTION runs even when absent
+    outputs.dir(destDir)
+    // A plain task, NOT Copy: a Copy with a missing source is skipped as
+    // NO-SOURCE — actions included — so its doLast guard never fires and
+    // packaging silently ships a Java-only app (empirically reproduced in
+    // review). Plain-task actions always run; the check below is the real
+    // fail-loud gate.
     doLast {
-        val staged = layout.buildDirectory
-            .file("rustAppResources/$composeOsArchDir/$rustHostLibName").get().asFile
-        check(staged.isFile) {
-            "Rust engine lib missing ($staged) — packaging requires cargo " +
+        check(src.isFile) {
+            "Rust engine lib missing ($src) — packaging requires cargo " +
                 "(cargoBuildHost self-skipped?). A packaged app must never " +
                 "silently ship without the Rust engine."
+        }
+        copy {
+            from(src)
+            into(destDir)
         }
     }
 }

--- a/app-desktop/src/main/kotlin/io/myotis/desktop/Main.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/Main.kt
@@ -12,6 +12,23 @@ import java.nio.file.Path
  * view fills in as they sync.
  */
 fun main() {
+    // PACKAGED apps: Compose ships appResources inside the bundle and exposes
+    // the dir via this property — point the engine loader at the bundled Rust
+    // lib BEFORE anything touches Engines. Dev runs pass an explicit
+    // -Dmyotis.engine.lib (absolute path) and win; a missing lib leaves the
+    // property unset, and the selector's Java fallback still works.
+    if (System.getProperty("myotis.engine.lib") == null) {
+        System.getProperty("compose.application.resources.dir")?.let { dir ->
+            val os = System.getProperty("os.name").lowercase()
+            val lib = when {
+                os.contains("mac") -> "libmyotis_engine.dylib"
+                os.contains("win") -> "myotis_engine.dll"
+                else -> "libmyotis_engine.so"
+            }
+            val f = Path.of(dir, lib).toFile()
+            if (f.isFile) System.setProperty("myotis.engine.lib", f.absolutePath)
+        }
+    }
     val dataDir = Path.of(System.getProperty("user.home"), ".myotis")
     // settings first: the controller reads it at boot (configured RPC port + snap target).
     val settings = DesktopSettings()

--- a/app-desktop/src/main/kotlin/io/myotis/desktop/Main.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/Main.kt
@@ -18,7 +18,9 @@ fun main() {
     // -Dmyotis.engine.lib (absolute path) and win; a missing lib leaves the
     // property unset, and the selector's Java fallback still works.
     if (System.getProperty("myotis.engine.lib") == null) {
-        System.getProperty("compose.application.resources.dir")?.let { dir ->
+        System.getProperty("compose.application.resources.dir")
+            ?.takeIf { it.isNotBlank() } // blank would resolve against the CWD
+            ?.let { dir ->
             val os = System.getProperty("os.name").lowercase()
             val lib = when {
                 os.contains("mac") -> "libmyotis_engine.dylib"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -190,24 +190,52 @@ val hostLibNames = run {
     val os = System.getProperty("os.name").lowercase()
     listOf("myotis_bls", "myotis_engine").map {
         when {
-            os.contains("win") -> "$it.dll"
+            // mac first, matching the copies in app-desktop/Main.kt — the
+            // branch ORDER is harmless today but consistent ordering is how
+            // copy-paste drift stays visible.
             os.contains("mac") -> "lib$it.dylib"
+            os.contains("win") -> "$it.dll"
             else -> "lib$it.so"
         }
     }
 }
+
+// Optional cross-target triple (-PrustTarget=… or RUST_TARGET env): needed by
+// the x64 dmg CI leg, which runs on arm64 runners under Rosetta — cargo builds
+// its HOST triple regardless of the JVM's arch, so without an explicit
+// --target the x64 dmg would bundle an arm64 dylib (dead engine toggle on
+// Intel Macs, invisible to a launcher-only arch check).
+val rustTargetTriple: String? =
+    (findProperty("rustTarget") as String?) ?: System.getenv("RUST_TARGET")
+
+// Where cargo puts the host libs: target/release, or target/<triple>/release
+// when cross-compiling. Exposed (with the lib names) for :app-desktop's
+// packaging staging.
+val rustReleaseDir = if (rustTargetTriple != null) {
+    "rust/target/$rustTargetTriple/release"
+} else {
+    "rust/target/release"
+}
+extra["rustReleaseDir"] = rustReleaseDir
+extra["rustEngineLibName"] = hostLibNames.last() // lib?myotis_engine.{dylib,so,dll}
 
 tasks.register<Exec>("cargoBuildHost") {
     group = "rust"
     description = "cargo build --release for the host OS (self-skips when cargo is missing)"
     onlyIf { rustAvailable }
     workingDir = file("rust")
-    commandLine("cargo", "build", "--release", "--workspace")
+    commandLine(
+        buildList {
+            addAll(listOf("cargo", "build", "--release", "--workspace"))
+            rustTargetTriple?.let { addAll(listOf("--target", it)) }
+        }
+    )
     inputs.files(rustSources).withPathSensitivity(PathSensitivity.RELATIVE)
     // Toolchain identity is an input: a rustc upgrade with unchanged sources
     // must rebuild, or stale artifacts survive UP-TO-DATE checks.
     inputs.property("cargoVersion", cargoVersion)
-    outputs.files(hostLibNames.map { file("rust/target/release/$it") })
+    inputs.property("rustTarget", rustTargetTriple ?: "host")
+    outputs.files(hostLibNames.map { file("$rustReleaseDir/$it") })
 }
 
 val cargoTest = tasks.register<Exec>("cargoTest") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,6 +61,15 @@ subprojects {
         exclude(group = "io.netty", module = "netty-transport-native-epoll")
         exclude(group = "io.netty", module = "netty-transport-native-kqueue")
         exclude(group = "io.netty", module = "netty-transport-native-unix-common")
+        // Besu 26.4 pulls tuweni under its post-rename coordinates
+        // (io.consensys.tuweni) — the same org.apache.tuweni classes as our
+        // Kotlin fork but WITHOUT the Kotlin Companion objects. Whichever jar
+        // classloads first wins: gradle-run happened to pick the fork, but
+        // jpackage's flattened classpath picked the upstream jar and the
+        // packaged desktop app died at launch (NoSuchFieldError:
+        // Bytes.Companion). The fork supplies these classes everywhere —
+        // exclude the upstream twins for every JVM module.
+        exclude(group = "io.consensys.tuweni")
     }
 
     tasks.test {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -206,7 +206,8 @@ val hostLibNames = run {
 // --target the x64 dmg would bundle an arm64 dylib (dead engine toggle on
 // Intel Macs, invisible to a launcher-only arch check).
 val rustTargetTriple: String? =
-    (findProperty("rustTarget") as String?) ?: System.getenv("RUST_TARGET")
+    ((findProperty("rustTarget") as? String) ?: System.getenv("RUST_TARGET"))
+        ?.takeIf { it.isNotBlank() } // an empty env var must mean "host", never --target ""
 
 // Where cargo puts the host libs: target/release, or target/<triple>/release
 // when cross-compiling. Exposed (with the lib names) for :app-desktop's


### PR DESCRIPTION
Closes the last engine-availability gap (user request): packaged dmg/deb apps shipped Java-only — the Rust engine toggle was dead in installed apps.

## What changed

- **Bundling**: `prepareRustAppResources` stages `cargoBuildHost`'s lib into Compose `appResources` (per os-arch subdir, wired ahead of Compose's internal copy task); jpackage ships it; `Main.kt` forwards the runtime resources dir to `-Dmyotis.engine.lib` before anything touches `Engines` (explicit `-D` from dev runs still wins).
- **Real fail-loud guard**: a plain task whose action `check()`s the lib then copies — NOT a `Copy` task, whose missing-source NO-SOURCE skip silently bypasses `doLast` (the review reproduced this; the fix is proven with `--no-daemon` + cargo masked: `cargoBuildHost SKIPPED → "Rust engine lib missing" → BUILD FAILED`).
- **Cross-arch correctness (review HIGH)**: the x64 dmg leg is a Rosetta cross-build on arm64 runners, and cargo builds its *host* triple regardless of the JVM's arch — without handling, the x64 dmg would bundle an **arm64** dylib (dead toggle for exactly the Intel users this targets, invisible to the launcher-only arch check). `cargoBuildHost` now honors `-PrustTarget`/`RUST_TARGET`, the x64 leg cross-compiles `x86_64-apple-darwin`, and **both** desktop verify steps assert the bundled Rust lib's presence *and* architecture inside the produced image.
- Both desktop workflows gain the Rust toolchain + cache; the Gradle os→libname mapping is defined once at the root.

## The launch-crash fix that rode along

Launching the packaged app (which current `main` cannot do) surfaced that the image **dies at startup**: `NoSuchFieldError: Bytes.Companion`. Besu 26.4 pulls tuweni under its post-rename `io.consensys.tuweni` coordinates, whose Java `Bytes` shadowed the Kotlin fork's in jpackage's flattened classpath — gradle-run classload order had hidden it, and the daemon's classpath carried 13 of the same jars working by luck. Excluded at the root for every JVM module (the review verified Besu's real tuweni needs — `bytes`+`units` only — are fully covered by the fork, and `:myotis-evm:test` is green). **Without this, the prerelease dmg/deb would have shipped dead on arrival.**

## Verified

Dylib ships at `Contents/app/resources/`, passes an arch/linkage load probe, and the packaged app boots the full stack and syncs (arm64 local; the x64 leg is covered by the new in-image CI assertion). Release-notes residual: `libmyotis_bls` is still not bundled, so the BLS-backend toggle remains dead in installed desktop apps (pre-existing; follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PP9WX3oschsX9T4AAKpdim