### PR TITLE
LC finality poll: parallel fan-out + serve-recency ordering (both engines)

### DIFF
--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
@@ -1944,6 +1944,15 @@ public class BeaconLightClient implements AutoCloseable {
         // sorts it most-recently-served first (winners get promoted to the
         // tier below), so a known-live server stays inside the fan-out window.
         final int POLL_FINALITY_FANOUT = 16;
+        // Heal a late winner from a PREVIOUS round: if its BLS verify outlasted
+        // that round's 12s deadline, the store advanced but the poll thread had
+        // moved on, skipping updateSyncState/persistSnapshot — and re-polling the
+        // same update reports "no advance", so the lag would otherwise persist
+        // until a NEW update publishes.
+        if (store.isInitialized() && store.getFinalizedSlot() > syncState.getFinalizedSlot()) {
+            updateSyncState();
+            persistSnapshot();
+        }
         List<String> peers = copyPeers();
         if (peers.size() > POLL_FINALITY_FANOUT) {
             peers = peers.subList(0, POLL_FINALITY_FANOUT);
@@ -2038,11 +2047,17 @@ public class BeaconLightClient implements AutoCloseable {
             // re-fires either way.
             win = winner.get(12, TimeUnit.SECONDS);
         } catch (Exception e) {
+            // Future.get can surface InterruptedException: restore the flag so
+            // shutdown propagation isn't silently swallowed (the sync loop's
+            // sleep then exits promptly).
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
             // A late winner (a BLS verify outlasting the deadline on the
             // catch-up executor) must still void the round's strikes — strikes
             // are only for rounds that truly found no server. Its follow-ups
-            // are skipped; the store already advanced and the next winning
-            // round re-syncs BeaconSyncState/snapshot.
+            // are skipped; the store already advanced and the store-ahead check
+            // at the top of the next poll heals BeaconSyncState/snapshot.
             boolean lateWin = winner.isDone() && !winner.isCompletedExceptionally();
             if (!lateWin) {
                 for (String p : roundFailures) notifyPeerFailure(p);

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
@@ -1935,94 +1935,155 @@ public class BeaconLightClient implements AutoCloseable {
         // Honor the Lodestar exclusion — finality polling is part of the
         // debug surface for Lighthouse/Teku/Prysm reliability.
         //
-        // Cap the per-cycle iteration. Without this, when every peer's
-        // finality update fails (typical when the committee is stale and
-        // can't be advanced because peers pruned the LC updates we'd
-        // need), we'd serially iterate ~1000 peers at up to 10s each =
-        // burning hours per cycle. That starves the syncLoop's
-        // wall-clock catchUpSyncCommittee retry at the top of the next
-        // call and locks the daemon in CATCHING_UP indefinitely. 16 is
-        // enough to find a working peer when one exists; the syncLoop
-        // re-fires every 12s so we cycle through fresh selections fast.
-        final int POLL_FINALITY_PEER_LIMIT = 16;
-        int tried = 0;
-        for (String peer : copyPeers()) {
+        // Parallel fan-out, first VERIFIED apply wins — the Rust engine's
+        // poll_finality shape, replacing the old sequential loop. Sequentially,
+        // a round burned 1-10s per dead candidate before reaching a live server
+        // (on-device: ~28s rounds, verified-head age spiking past 2 minutes
+        // whenever a round found no server at all). The cap still bounds the
+        // per-cycle dial count; copyPeers() orders proven + recently-served
+        // servers first so they're always inside the fan-out window.
+        final int POLL_FINALITY_FANOUT = 16;
+        List<String> peers = copyPeers();
+        if (peers.size() > POLL_FINALITY_FANOUT) {
+            peers = peers.subList(0, POLL_FINALITY_FANOUT);
+        }
+        if (peers.isEmpty()) return;
+
+        final CompletableFuture<FinalityPollWin> winner = new CompletableFuture<>();
+        final java.util.concurrent.atomic.AtomicInteger remaining =
+                new java.util.concurrent.atomic.AtomicInteger(peers.size());
+        // Round-scoped strike buffer (parity with the Rust poll_finality
+        // accounting, which learned this on-device): a parallel fan-out mints
+        // up to N-1 speculative losses per round, and feeding each into the
+        // host's strike-based cache eviction empties it of every proven server.
+        // The sequential loop never dialed peers behind the winner, so they
+        // accrued no strikes. Reproduce the OUTCOME: a round WITH a winner
+        // discards the buffered failures (the losers merely raced a success);
+        // a fully-failed round strikes every failed peer once (the sequential
+        // analog dialed the whole list and struck each).
+        final java.util.Queue<String> roundFailures = new java.util.concurrent.ConcurrentLinkedQueue<>();
+
+        for (String peer : peers) {
             if (!running) return;
-            if (tried++ >= POLL_FINALITY_PEER_LIMIT) {
-                log.debug("[beacon] pollFinalityUpdate: tried {} peers, no advance — will retry next cycle",
-                        POLL_FINALITY_PEER_LIMIT);
-                return;
-            }
-            try {
-                byte[] response = p2pService
-                        .requestFinalityUpdate(peer)
-                        .get(10, TimeUnit.SECONDS);
-                // Relay-cache the raw SSZ so peers who query us get the
-                // latest finality update we just received, without having to
-                // re-ask upstream.
-                p2pService.cacheFinalityUpdate(response);
+            // Per-attempt deadline via the req/resp layer (closes the stream on
+            // expiry — an outer orTimeout would leave it accumulating; see the
+            // requestFinalityUpdate javadoc).
+            p2pService.requestFinalityUpdate(peer, 10_000L)
+                    .whenComplete((response, ex) -> {
+                        // A finished round ignores stragglers entirely: no strike
+                        // (they raced a success), no apply (the winner advanced us).
+                        if (winner.isDone()) return;
+                        if (ex != null) {
+                            Throwable root = ex;
+                            while (root.getCause() != null) root = root.getCause();
+                            log.debug("[beacon] Finality update failed from {}: {}", peer,
+                                    root.getMessage() != null ? root.getMessage()
+                                            : root.getClass().getSimpleName());
+                            roundFailures.add(peer);
+                        } else {
+                            try {
+                                // Relay-cache the raw SSZ so peers who query us get the
+                                // latest finality update we just received, without having
+                                // to re-ask upstream.
+                                p2pService.cacheFinalityUpdate(response);
+                                com.jaeckel.ethp2p.consensus.lightclient.VectorDump.maybeDump("finality", response);
+                                LightClientFinalityUpdate update = LightClientFinalityUpdate.decode(response);
 
-                com.jaeckel.ethp2p.consensus.lightclient.VectorDump.maybeDump("finality", response);
-                LightClientFinalityUpdate update = LightClientFinalityUpdate.decode(response);
-
-                final boolean finalityApplied;
-                // Writers serialize on catchUpApplyLock (see its javadoc): without this a
-                // straggler catch-up applier's gate-check→store-next sequence can interleave
-                // with this finality apply's rotation and re-arm a stale next committee.
-                synchronized (catchUpApplyLock) {
-                    finalityApplied = store.isInitialized() && processor.processFinalityUpdate(update);
-                }
-                if (finalityApplied) {
-                    updateSyncState();
-                    fillChainStateRoots(peer, true);
-                    notifyPeerSuccess(peer);
-                    // Steady-state advance — persist so a restart resumes here
-                    // (no-op unless the committee period actually moved).
-                    persistSnapshot();
-                    log.debug("[beacon] Finality update applied from {}, finalizedSlot={}",
-                            peer, store.getFinalizedSlot());
-                    return;
-                }
-
-                // Seeded mode: update sync state directly from finality update
-                if (!store.isInitialized()) {
-                    LightClientHeader fh = update.finalizedHeader();
-                    byte[] sr = fh.execution().stateRoot();
-                    if (sr != null && sr.length == 32) {
-                        long slot = fh.beacon().slot();
-                        syncState.recordStateRoot(slot, sr, false);
-                        // Also record the attested header's execution state root
-                        long attestedSlot = update.attestedHeader().beacon().slot();
-                        byte[] attestedRoot = update.attestedHeader().execution().stateRoot();
-                        if (attestedRoot != null && attestedRoot.length == 32) {
-                            syncState.recordStateRoot(attestedSlot, attestedRoot, false);
+                                final boolean finalityApplied;
+                                // Writers serialize on catchUpApplyLock (see its javadoc): without
+                                // this a straggler catch-up applier's gate-check→store-next sequence
+                                // can interleave with this finality apply's rotation and re-arm a
+                                // stale next committee. Two same-round appliers also serialize here;
+                                // the second usually reports no-advance and simply doesn't win.
+                                synchronized (catchUpApplyLock) {
+                                    finalityApplied = store.isInitialized()
+                                            && processor.processFinalityUpdate(update);
+                                }
+                                if (finalityApplied) {
+                                    winner.complete(new FinalityPollWin(peer, update, true));
+                                    return;
+                                }
+                                if (!store.isInitialized()) {
+                                    // Seeded mode: any decodable update with a plausible exec
+                                    // state root wins; the poll thread runs the seed branch.
+                                    byte[] sr = update.finalizedHeader().execution().stateRoot();
+                                    if (sr != null && sr.length == 32) {
+                                        winner.complete(new FinalityPollWin(peer, update, false));
+                                        return;
+                                    }
+                                }
+                                // Decoded but did not advance: not a strike (sequential parity —
+                                // the old loop just moved on), simply not a win either.
+                                log.debug("[beacon] Finality update from {} did not advance state", peer);
+                            } catch (Exception e) {
+                                log.debug("[beacon] Finality update decode/apply failed from {}: {}",
+                                        peer, e.getMessage());
+                                roundFailures.add(peer);
+                            }
                         }
-                        // Fill intermediate blocks to cover recent state roots
-                        byte[] attestedBlockRoot = update.attestedHeader().beacon().hashTreeRoot();
-                        log.debug("[beacon] Seeded poll: finalizedSlot={}, attestedSlot={}, filling {} slots",
-                                slot, attestedSlot, attestedSlot - slot);
-                        fillChainStateRoots(peer, false, slot, attestedSlot, attestedBlockRoot);
-                        notifyPeerSuccess(peer);
-                        if (slot > syncState.getFinalizedSlot()) {
-                            long execBlockNum = fh.execution().blockNumber();
-                            byte[] execBlockHash = fh.execution().blockHash();
-                            syncState.update(slot, sr, update.signatureSlot(), execBlockNum, execBlockHash);
-                            log.debug("[beacon] Finality update refreshed from {}, finalizedSlot={}", peer, slot);
+                        if (remaining.decrementAndGet() == 0 && !winner.isDone()) {
+                            winner.completeExceptionally(new java.util.concurrent.TimeoutException(
+                                    "no finality advance from " + roundFailures.size() + " failed peers"));
                         }
-                        return;
-                    }
-                }
+                    });
+        }
 
-                log.debug("[beacon] Finality update from {} did not advance state", peer);
-            } catch (Exception e) {
-                String msg = e.getMessage() != null ? e.getMessage()
-                        : e.getClass().getSimpleName()
-                          + (e.getCause() != null ? ": " + e.getCause().getMessage() : "");
-                log.debug("[beacon] Finality update failed from {}: {}", peer, msg);
-                notifyPeerFailure(peer);
-            }
+        final FinalityPollWin win;
+        try {
+            // 10s per-request timeout + decode/apply slack; the 12s sync cycle
+            // re-fires either way.
+            win = winner.get(12, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            for (String p : roundFailures) notifyPeerFailure(p);
+            log.debug("[beacon] pollFinalityUpdate: fan-out of {} peer(s), no advance — will retry next cycle",
+                    peers.size());
+            return;
+        }
+
+        // Winner follow-ups run HERE, on the poll thread: fillChainStateRoots does
+        // its own blocking req/resp round-trips, which must stay off libp2p
+        // callback threads (the fan-out callbacks above only decode + apply).
+        if (win.applied()) {
+            updateSyncState();
+            fillChainStateRoots(win.peer(), true);
+            notifyPeerSuccess(win.peer());
+            // Steady-state advance — persist so a restart resumes here
+            // (no-op unless the committee period actually moved).
+            persistSnapshot();
+            log.debug("[beacon] Finality update applied from {}, finalizedSlot={}",
+                    win.peer(), store.getFinalizedSlot());
+            return;
+        }
+
+        // Seeded mode: update sync state directly from the winning finality update.
+        LightClientHeader fh = win.update().finalizedHeader();
+        byte[] sr = fh.execution().stateRoot();
+        long slot = fh.beacon().slot();
+        syncState.recordStateRoot(slot, sr, false);
+        // Also record the attested header's execution state root
+        long attestedSlot = win.update().attestedHeader().beacon().slot();
+        byte[] attestedRoot = win.update().attestedHeader().execution().stateRoot();
+        if (attestedRoot != null && attestedRoot.length == 32) {
+            syncState.recordStateRoot(attestedSlot, attestedRoot, false);
+        }
+        // Fill intermediate blocks to cover recent state roots
+        byte[] attestedBlockRoot = win.update().attestedHeader().beacon().hashTreeRoot();
+        log.debug("[beacon] Seeded poll: finalizedSlot={}, attestedSlot={}, filling {} slots",
+                slot, attestedSlot, attestedSlot - slot);
+        fillChainStateRoots(win.peer(), false, slot, attestedSlot, attestedBlockRoot);
+        notifyPeerSuccess(win.peer());
+        if (slot > syncState.getFinalizedSlot()) {
+            long execBlockNum = fh.execution().blockNumber();
+            byte[] execBlockHash = fh.execution().blockHash();
+            syncState.update(slot, sr, win.update().signatureSlot(), execBlockNum, execBlockHash);
+            log.debug("[beacon] Finality update refreshed from {}, finalizedSlot={}", win.peer(), slot);
         }
     }
+
+    /** A finality-poll round's winning response: the peer, its decoded update, and
+     *  whether it was a VERIFIED store apply ({@code applied}) or a seeded-mode
+     *  candidate the poll thread still has to run the seed branch for. */
+    private record FinalityPollWin(String peer, LightClientFinalityUpdate update, boolean applied) {}
 
     /**
      * Push the current store state into the shared {@link BeaconSyncState}.
@@ -2247,7 +2308,11 @@ public class BeaconLightClient implements AutoCloseable {
     }
 
     /** Confirmed light_client servers first, proven non-LC peers last, rest in between —
-     *  so finality polls / bootstrap hit peers that actually serve light-client first. */
+     *  so finality polls / bootstrap hit peers that actually serve light-client first.
+     *  Within the confirmed tier, most-recently-served first: a server that answered
+     *  seconds ago is almost certainly still good, so any bounded slice (the finality
+     *  fan-out window, catch-up batches) contains it even when the proven set is large
+     *  and littered with servers that are flagged LC-capable but currently at capacity. */
     private List<String> orderByLightClient(List<String> peers) {
         if (provenLightClient.isEmpty() && peersNoLcUpdates.isEmpty()) return peers;
         List<String> first = new ArrayList<>(), mid = new ArrayList<>(), last = new ArrayList<>();
@@ -2255,6 +2320,16 @@ public class BeaconLightClient implements AutoCloseable {
             if (provenLightClient.contains(p)) first.add(p);
             else if (peersNoLcUpdates.contains(p)) last.add(p);
             else mid.add(p);
+        }
+        if (first.size() > 1 && !recentServes.isEmpty()) {
+            // recentServes prunes to a 60s window, so "recently served" decays on its
+            // own; never-served proven peers sort after all recent servers, keeping
+            // their existing relative order (sort is stable).
+            first.sort(java.util.Comparator.comparingLong((String p) -> {
+                String pid = peerIdOf(p);
+                Long t = recentServes.get(pid != null ? pid : p);
+                return t == null ? Long.MIN_VALUE : t;
+            }).reversed());
         }
         List<String> out = new ArrayList<>(peers.size());
         out.addAll(first); out.addAll(mid); out.addAll(last);

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
@@ -1940,8 +1940,9 @@ public class BeaconLightClient implements AutoCloseable {
         // a round burned 1-10s per dead candidate before reaching a live server
         // (on-device: ~28s rounds, verified-head age spiking past 2 minutes
         // whenever a round found no server at all). The cap still bounds the
-        // per-cycle dial count; copyPeers() orders proven + recently-served
-        // servers first so they're always inside the fan-out window.
+        // per-cycle dial count; copyPeers() puts the proven tier first and
+        // sorts it most-recently-served first (winners get promoted to the
+        // tier below), so a known-live server stays inside the fan-out window.
         final int POLL_FINALITY_FANOUT = 16;
         List<String> peers = copyPeers();
         if (peers.size() > POLL_FINALITY_FANOUT) {
@@ -1956,20 +1957,27 @@ public class BeaconLightClient implements AutoCloseable {
         // accounting, which learned this on-device): a parallel fan-out mints
         // up to N-1 speculative losses per round, and feeding each into the
         // host's strike-based cache eviction empties it of every proven server.
-        // The sequential loop never dialed peers behind the winner, so they
-        // accrued no strikes. Reproduce the OUTCOME: a round WITH a winner
-        // discards the buffered failures (the losers merely raced a success);
-        // a fully-failed round strikes every failed peer once (the sequential
-        // analog dialed the whole list and struck each).
+        // A round WITH a winner discards the buffered failures (the losers
+        // merely raced a success); a fully-failed round strikes every failed
+        // peer once. Deliberate divergence from the OLD sequential loop, same
+        // trade the Rust side made: a dead peer AHEAD of the winner used to
+        // accrue a strike per round and cache-evict in ~3 polls; now it is
+        // never struck while rounds keep winning — the recency sort in
+        // orderByLightClient demotes it instead.
         final java.util.Queue<String> roundFailures = new java.util.concurrent.ConcurrentLinkedQueue<>();
 
         for (String peer : peers) {
             if (!running) return;
             // Per-attempt deadline via the req/resp layer (closes the stream on
             // expiry — an outer orTimeout would leave it accumulating; see the
-            // requestFinalityUpdate javadoc).
+            // requestFinalityUpdate javadoc). Completion hops to catchUpExecutor:
+            // the BLS sync-aggregate verify inside processFinalityUpdate must NOT
+            // run on a netty event loop thread (see the catchUpExecutor comment —
+            // the catch-up fan-out honors the same rule), and its single thread
+            // both serializes the up-to-16 verifies and makes the isDone bail
+            // free for every response behind the winner.
             p2pService.requestFinalityUpdate(peer, 10_000L)
-                    .whenComplete((response, ex) -> {
+                    .whenCompleteAsync((response, ex) -> {
                         // A finished round ignores stragglers entirely: no strike
                         // (they raced a success), no apply (the winner advanced us).
                         if (winner.isDone()) return;
@@ -1982,10 +1990,6 @@ public class BeaconLightClient implements AutoCloseable {
                             roundFailures.add(peer);
                         } else {
                             try {
-                                // Relay-cache the raw SSZ so peers who query us get the
-                                // latest finality update we just received, without having
-                                // to re-ask upstream.
-                                p2pService.cacheFinalityUpdate(response);
                                 com.jaeckel.ethp2p.consensus.lightclient.VectorDump.maybeDump("finality", response);
                                 LightClientFinalityUpdate update = LightClientFinalityUpdate.decode(response);
 
@@ -2000,7 +2004,7 @@ public class BeaconLightClient implements AutoCloseable {
                                             && processor.processFinalityUpdate(update);
                                 }
                                 if (finalityApplied) {
-                                    winner.complete(new FinalityPollWin(peer, update, true));
+                                    winner.complete(new FinalityPollWin(peer, response, update, true));
                                     return;
                                 }
                                 if (!store.isInitialized()) {
@@ -2008,7 +2012,7 @@ public class BeaconLightClient implements AutoCloseable {
                                     // state root wins; the poll thread runs the seed branch.
                                     byte[] sr = update.finalizedHeader().execution().stateRoot();
                                     if (sr != null && sr.length == 32) {
-                                        winner.complete(new FinalityPollWin(peer, update, false));
+                                        winner.complete(new FinalityPollWin(peer, response, update, false));
                                         return;
                                     }
                                 }
@@ -2025,27 +2029,45 @@ public class BeaconLightClient implements AutoCloseable {
                             winner.completeExceptionally(new java.util.concurrent.TimeoutException(
                                     "no finality advance from " + roundFailures.size() + " failed peers"));
                         }
-                    });
+                    }, catchUpExecutor);
         }
 
-        final FinalityPollWin win;
+        FinalityPollWin win;
         try {
             // 10s per-request timeout + decode/apply slack; the 12s sync cycle
             // re-fires either way.
             win = winner.get(12, TimeUnit.SECONDS);
         } catch (Exception e) {
-            for (String p : roundFailures) notifyPeerFailure(p);
-            log.debug("[beacon] pollFinalityUpdate: fan-out of {} peer(s), no advance — will retry next cycle",
-                    peers.size());
+            // A late winner (a BLS verify outlasting the deadline on the
+            // catch-up executor) must still void the round's strikes — strikes
+            // are only for rounds that truly found no server. Its follow-ups
+            // are skipped; the store already advanced and the next winning
+            // round re-syncs BeaconSyncState/snapshot.
+            boolean lateWin = winner.isDone() && !winner.isCompletedExceptionally();
+            if (!lateWin) {
+                for (String p : roundFailures) notifyPeerFailure(p);
+            }
+            log.debug("[beacon] pollFinalityUpdate: fan-out of {} peer(s), no advance this cycle{}",
+                    peers.size(), lateWin ? " (late winner, follow-ups next round)" : "");
             return;
         }
 
         // Winner follow-ups run HERE, on the poll thread: fillChainStateRoots does
-        // its own blocking req/resp round-trips, which must stay off libp2p
-        // callback threads (the fan-out callbacks above only decode + apply).
+        // its own blocking req/resp round-trips, which must stay off the (single)
+        // catch-up executor thread the fan-out callbacks run on.
+        // Relay-cache the WINNER's raw SSZ (last write wins in the relay cache, so
+        // caching per-response from concurrent callbacks could leave a losing,
+        // staler update as what we serve peers — the sequential loop always ended
+        // on the winner's bytes).
+        p2pService.cacheFinalityUpdate(win.raw());
         if (win.applied()) {
             updateSyncState();
             fillChainStateRoots(win.peer(), true);
+            // The winner just demonstrably served light-client data: promote it to
+            // the proven tier (the Rust pool's mark_proven analog) so the recency
+            // ordering applies to it even if Identify never flagged it.
+            provenLightClient.add(win.peer());
+            peersNoLcUpdates.remove(win.peer());
             notifyPeerSuccess(win.peer());
             // Steady-state advance — persist so a restart resumes here
             // (no-op unless the committee period actually moved).
@@ -2080,10 +2102,13 @@ public class BeaconLightClient implements AutoCloseable {
         }
     }
 
-    /** A finality-poll round's winning response: the peer, its decoded update, and
-     *  whether it was a VERIFIED store apply ({@code applied}) or a seeded-mode
-     *  candidate the poll thread still has to run the seed branch for. */
-    private record FinalityPollWin(String peer, LightClientFinalityUpdate update, boolean applied) {}
+    /** A finality-poll round's winning response: the peer, the raw SSZ (for the
+     *  relay cache — cached on the poll thread so the winner's bytes are what we
+     *  serve), the decoded update, and whether it was a VERIFIED store apply
+     *  ({@code applied}) or a seeded-mode candidate the poll thread still has to
+     *  run the seed branch for. */
+    private record FinalityPollWin(
+            String peer, byte[] raw, LightClientFinalityUpdate update, boolean applied) {}
 
     /**
      * Push the current store state into the shared {@link BeaconSyncState}.
@@ -2324,12 +2349,18 @@ public class BeaconLightClient implements AutoCloseable {
         if (first.size() > 1 && !recentServes.isEmpty()) {
             // recentServes prunes to a 60s window, so "recently served" decays on its
             // own; never-served proven peers sort after all recent servers, keeping
-            // their existing relative order (sort is stable).
-            first.sort(java.util.Comparator.comparingLong((String p) -> {
+            // their existing relative order (sort is stable). Snapshot the timestamps
+            // BEFORE sorting: recentServes mutates concurrently (bootstrap-callback
+            // successes, status-thread prunes), and a comparator over live state can
+            // trip TimSort's consistency check mid-sort.
+            final java.util.HashMap<String, Long> at = new java.util.HashMap<>();
+            for (String p : first) {
                 String pid = peerIdOf(p);
                 Long t = recentServes.get(pid != null ? pid : p);
-                return t == null ? Long.MIN_VALUE : t;
-            }).reversed());
+                if (t != null) at.put(p, t);
+            }
+            first.sort(java.util.Comparator.comparingLong(
+                    (String p) -> at.getOrDefault(p, Long.MIN_VALUE)).reversed());
         }
         List<String> out = new ArrayList<>(peers.size());
         out.addAll(first); out.addAll(mid); out.addAll(last);

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/libp2p/BeaconP2PService.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/libp2p/BeaconP2PService.java
@@ -980,8 +980,20 @@ public class BeaconP2PService implements AutoCloseable {
     }
 
     public CompletableFuture<byte[]> requestFinalityUpdate(String peerMultiaddr) {
+        return requestFinalityUpdate(peerMultiaddr, 0L);
+    }
+
+    /**
+     * Variant with a per-attempt deadline; {@code timeoutMs <= 0} means none.
+     * Same rationale as {@link #requestUpdatesByRange(String, long, int, long)}:
+     * the deadline closes the underlying libp2p stream, where an {@code orTimeout}
+     * on the returned future would only complete the wrapper and leave the
+     * stream accumulating — that matters for the finality poll's parallel
+     * fan-out, which opens up to 16 streams per round.
+     */
+    public CompletableFuture<byte[]> requestFinalityUpdate(String peerMultiaddr, long timeoutMs) {
         // No request body for finality_update — send nothing, just close write side
-        return doReqResp(peerMultiaddr, FINALITY, new byte[0])
+        return doReqResp(peerMultiaddr, FINALITY, new byte[0], timeoutMs)
                 .thenApply(BeaconP2PService::decodeSingleResponse);
     }
 

--- a/consensus/src/test/java/com/jaeckel/ethp2p/consensus/BeaconLightClientPeerPoolTest.java
+++ b/consensus/src/test/java/com/jaeckel/ethp2p/consensus/BeaconLightClientPeerPoolTest.java
@@ -116,4 +116,35 @@ class BeaconLightClientPeerPoolTest {
         assertEquals(false, pool(c).contains(addr(1)), "tail-most old peer should be evicted");
         assertTrue(c.addPeer(addr(1)), "an evicted peer must be re-addable");
     }
+
+    /** The proven tier sorts most-recently-served first (so the finality fan-out
+     *  window always contains the server that answered seconds ago); never-served
+     *  proven peers follow, unproven peers last — the Rust
+     *  {@code proven_tier_orders_by_serve_recency} twin. */
+    @Test
+    @SuppressWarnings("unchecked")
+    void provenTierOrdersByServeRecency() throws Exception {
+        BeaconLightClient c = newClient();
+        String never = addr(1), old = addr(2), recent = addr(3), unproven = addr(4);
+        c.addPeer(never);
+        c.addPeer(old);
+        c.addPeer(recent);
+        c.addPeer(unproven);
+        c.setProvenLightClient(List.of(never, old, recent));
+
+        // recentServes keys by peerId (the /p2p/ suffix of addr()).
+        Field f = BeaconLightClient.class.getDeclaredField("recentServes");
+        f.setAccessible(true);
+        Map<String, Long> serves = (Map<String, Long>) f.get(c);
+        serves.put("16Uiu2HAm2", System.nanoTime() - 1_000_000L);
+        serves.put("16Uiu2HAm3", System.nanoTime());
+
+        var m = BeaconLightClient.class.getDeclaredMethod("copyPeers");
+        m.setAccessible(true);
+        List<String> ordered = (List<String>) m.invoke(c);
+        assertEquals(recent, ordered.get(0), "most recently served proven peer first");
+        assertEquals(old, ordered.get(1), "older served proven peer second");
+        assertEquals(never, ordered.get(2), "never-served proven peer after servers");
+        assertEquals(unproven, ordered.get(3), "unproven peer last");
+    }
 }

--- a/rust/myotis-net/src/sync.rs
+++ b/rust/myotis-net/src/sync.rs
@@ -650,16 +650,34 @@ impl PeerPool {
                 && (!respect_cooldown || pool.cooled_down(id))
         };
         let mut out: Vec<Peer> = Vec::with_capacity(n);
-        // Tier 1: peers that actually served light-client data before.
+        // Tier 1: peers that actually served light-client data before —
+        // most-recently-served first (recent_serves already backs the
+        // served-last-minute metric). A server that answered seconds ago is
+        // almost certainly still good, so a bounded batch always contains it
+        // even when the proven set outgrows `n` and carries servers that are
+        // flagged capable but currently at capacity. Never-served proven
+        // peers keep their pool order after the recent ones (stable sort).
+        let mut tier1: Vec<&Peer> = self
+            .peers
+            .iter()
+            .filter(|p| self.proven.contains(&p.id) && ok(self, &p.id))
+            .collect();
+        tier1.sort_by_key(|p| std::cmp::Reverse(self.recent_serves.get(&p.id).copied()));
+        for p in tier1 {
+            if out.len() >= n {
+                break;
+            }
+            if !out.iter().any(|q| q.id == p.id) {
+                out.push(p.clone());
+            }
+        }
         // Tier 2: positive-signal peers (Identify-confirmed LC servers).
-        for tier in [&self.proven, prefer] {
-            for p in &self.peers {
-                if out.len() >= n {
-                    break;
-                }
-                if tier.contains(&p.id) && ok(self, &p.id) && !out.iter().any(|q| q.id == p.id) {
-                    out.push(p.clone());
-                }
+        for p in &self.peers {
+            if out.len() >= n {
+                break;
+            }
+            if prefer.contains(&p.id) && ok(self, &p.id) && !out.iter().any(|q| q.id == p.id) {
+                out.push(p.clone());
             }
         }
         // Fill from a rotating window of the rest.
@@ -2037,6 +2055,34 @@ mod tests {
         // than none — catch_up bounces to rediscovery instead of thrashing).
         let all_skip: HashSet<PeerId> = ids.iter().copied().collect();
         assert!(pool.candidates(4, true, false, &HashSet::new(), &all_skip).is_empty());
+    }
+
+    #[test]
+    fn proven_tier_orders_by_serve_recency() {
+        let mut pool = PeerPool::new();
+        let mut ids = Vec::new();
+        for i in 0..4u8 {
+            let kp = libp2p::identity::Keypair::generate_secp256k1();
+            let id = kp.public().to_peer_id();
+            ids.push(id);
+            pool.add(id, format!("/ip4/10.0.1.{i}/tcp/9000").parse().unwrap());
+        }
+        // Three proven servers; ids[1] served longest ago, ids[3] most recently,
+        // ids[0] is proven but never served (Identify-confirmed only via
+        // mark_proven from an earlier session's cache seed, say).
+        for id in [ids[0], ids[1], ids[3]] {
+            pool.mark_proven(id);
+        }
+        pool.note_served(ids[1]);
+        pool.note_served(ids[3]); // later ⇒ more recent
+
+        let c = pool.candidates(4, false, false, &HashSet::new(), &HashSet::new());
+        // Most-recently-served proven first, then older serves, then the
+        // never-served proven peer, then the unproven rest.
+        assert_eq!(c[0].id, ids[3], "most recent server leads the batch");
+        assert_eq!(c[1].id, ids[1], "older server second");
+        assert_eq!(c[2].id, ids[0], "never-served proven after recent servers");
+        assert_eq!(c[3].id, ids[2], "unproven peer last");
     }
 
     #[test]

--- a/rust/myotis-net/src/sync.rs
+++ b/rust/myotis-net/src/sync.rs
@@ -1631,7 +1631,8 @@ fn apply_staged_step(
 }
 
 /// One finality-poll pass: try peers until one update verifies and applies —
-/// the Java `pollFinalityUpdate` steady-state branch (POLL_FINALITY_PEER_LIMIT=16).
+/// the Java `pollFinalityUpdate` steady-state branch (POLL_FINALITY_FANOUT=16,
+/// which now mirrors this fan-out shape and round accounting).
 /// Returns true when an update verified AND applied (the resume guard's
 /// confirmation signal).
 async fn poll_finality(
@@ -1660,21 +1661,16 @@ async fn poll_finality(
             }
         })
         .collect();
-    // Round-scoped cache accounting. The Java poll is SEQUENTIAL, proven-first,
-    // stop-at-first-success: live proven servers usually answer first try, so
-    // peers behind the winner are never dialed and accrue no strikes, while a
-    // DEAD tier-0 peer is tried at the head of every poll and evicted from the
-    // persistent cache after 3 polls. This parallel fan-out must reproduce
-    // those OUTCOMES, not the per-dial mechanics: dialing 16 at once mints up
-    // to 15 speculative losses per 12 s round, and feeding each into the
-    // cache's 3-strike eviction emptied it of every proven server on-device
-    // (peers=209, catch_up_servers=0). So: failures are buffered per round;
-    // a round WITH a winner discards them (the losers raced a success — the
-    // Java analog was never dialed); a fully-failed round strikes every failed
-    // peer once (the Java analog dialed the whole list and struck each). Dead
-    // proven servers thus still evict in ~3 fully-failed encounters, and the
-    // cache can't accumulate them unboundedly. Session-pool note_failure stays
-    // per-dial: it exists precisely to rotate the live fan-out.
+    // Round-scoped cache accounting (the Java poll now fans out with the same
+    // rule). Dialing 16 at once mints up to 15 speculative losses per 12 s
+    // round, and feeding each into the cache's 3-strike eviction emptied it of
+    // every proven server on-device (peers=209, catch_up_servers=0). So:
+    // failures are buffered per round; a round WITH a winner discards them
+    // (the losers raced a success); a fully-failed round strikes every failed
+    // peer once. Dead proven servers thus still evict in ~3 fully-failed
+    // encounters, and the cache can't accumulate them unboundedly.
+    // Session-pool note_failure stays per-dial: it exists precisely to rotate
+    // the live fan-out.
     let mut round_failures: Vec<String> = Vec::new();
     let mut applied = false;
     while let Some((peer, res)) = in_flight.next().await {
@@ -2074,7 +2070,13 @@ mod tests {
             pool.mark_proven(id);
         }
         pool.note_served(ids[1]);
-        pool.note_served(ids[3]); // later ⇒ more recent
+        // Instant::now() can be coarse (Windows ~15ms ticks); equal timestamps
+        // would stable-sort back to pool order and flake the assertion below.
+        let t0 = std::time::Instant::now();
+        while std::time::Instant::now() == t0 {
+            std::hint::spin_loop();
+        }
+        pool.note_served(ids[3]); // strictly later ⇒ more recent
 
         let c = pool.candidates(4, false, false, &HashSet::new(), &HashSet::new());
         // Most-recently-served proven first, then older serves, then the


### PR DESCRIPTION
## Why

The verified head only advances when a finality-update poll succeeds, and the Java poll was sequential: up to 16 candidates, 1–10 s each, stop at first success. On-device (mobile NAT; ~2 usable mainnet LC servers among a dozen flagged-capable-but-at-capacity candidates) a round burned ~28 s before reaching a live server, and rounds that found none pushed the verified-head age past **2 minutes**.

## What

**Java (\`BeaconLightClient\`)** — brings the poll to the shape the Rust engine already had:
- \`pollFinalityUpdate\`: parallel fan-out of up to 16 requests, first **verified** apply wins. Callbacks hop to \`catchUpExecutor\` (the BLS verify must not run on netty event loops — same invariant the catch-up fan-out honors); winner follow-ups (\`fillChainStateRoots\`, persist, relay-cache) stay on the poll thread. Worst-case cycle time drops from 16×10 s to a hard 12 s cap.
- **Round-scoped strike accounting**, ported from Rust (which learned it on-device): a round with a winner discards the speculative losses; only a fully-failed round strikes each failed peer. Deliberate divergence from the sequential loop, same trade as Rust: dead proven peers demote via recency ordering instead of accruing per-round strikes — called out in the comment.
- \`orderByLightClient\`: most-recently-served first within the proven tier (over a pre-sort snapshot of \`recentServes\` — the live-map comparator could trip TimSort). Finality winners get promoted to the proven tier (Rust \`mark_proven\` analog).
- \`BeaconP2PService.requestFinalityUpdate(peer, timeoutMs)\`: deadline variant that closes the stream on expiry (per the \`requestUpdatesByRange\` precedent) — an outer \`orTimeout\` would leave up to 16 streams accumulating per round.

**Rust (\`myotis-net\`)** — already had the fan-out + strike model; \`candidates()\` now also orders its proven tier by \`recent_serves\` recency (tier-pick order only; strike/cooldown accounting untouched).

**Tests**: twin unit tests pin the ordering on both sides (\`proven_tier_orders_by_serve_recency\` / \`provenTierOrdersByServeRecency\`); the Rust test spins past coarse-clock granularity.

## Verified on-device (Pixel 7)

- Finality updates now apply within **~1–6 s of each 12 s cycle on all three chains** (before: every 30–60 s with multi-minute droughts)
- A cold verified-head RPC demand fills in **< 10 s** (verified \`eth_getBalance\` served)
- \`:consensus:build\` green; \`cargo test -p myotis-net\` 118/118

Independent no-context review run before opening (1 major — BLS verify was still landing on netty threads via the callbacks — plus hardening: late-winner strike handling, relay-cache winner bytes, TimSort-safe sort; all addressed in the second commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017MUyVxaEcPKwfgya4FZptF