### PR TITLE
chore: fix the two unused_mut warnings

### DIFF
--- a/rust/myotis-engine/src/lib.rs
+++ b/rust/myotis-engine/src/lib.rs
@@ -381,7 +381,7 @@ mod jni_shim {
     /// `{"gasPriceWei","maxPriorityFeePerGasWei"}` or `{"error": "..."}`.
     #[no_mangle]
     pub extern "system" fn Java_io_myotis_engines_RustEngineNative_nativeFeeEstimateJson(
-        mut env: JNIEnv,
+        env: JNIEnv,
         _class: JClass,
         handle: jlong,
     ) -> jstring {

--- a/rust/myotis-net/src/sync.rs
+++ b/rust/myotis-net/src/sync.rs
@@ -1074,7 +1074,7 @@ async fn try_bootstrap(
     // cache unboundedly and — once they filled the 8-candidate proven tier —
     // wedge a fresh bootstrap forever on the same dead dials every round.
     let mut round_failures: Vec<String> = Vec::new();
-    let mut fail = |pool: &mut PeerPool, buf: &mut Vec<String>, id: PeerId| {
+    let fail = |pool: &mut PeerPool, buf: &mut Vec<String>, id: PeerId| {
         pool.note_failure(id);
         if let Some(p) = peers.iter().find(|p| p.id == id) {
             buf.push(format!("{}/p2p/{}", p.addr, p.id));


### PR DESCRIPTION
Two compiler-verified one-char removals so `cargo build --workspace` is warning-clean again (a tolerated warning is where the next real one hides). Workspace builds with 0 warnings; myotis-net + myotis-engine tests green. Trivial enough that no separate no-context review was run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PP9WX3oschsX9T4AAKpdim