### PR TITLE
fix: desktop Logs tab dead in packaged app — evict Besu's competing slf4j provider

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,17 +44,17 @@ subprojects {
             exclude(group = "io.netty", module = "netty-transport-native-epoll")
             exclude(group = "io.netty", module = "netty-transport-native-kqueue")
             exclude(group = "io.netty", module = "netty-transport-native-unix-common")
-        // Besu 26.4 drags log4j-slf4j2-impl — a SECOND slf4j provider — plus
-        // log4j-core. Whichever provider classloads first gets ALL logging;
-        // jpackage's flattened classpath deterministically picked log4j and the
-        // desktop app's Logs tab (a LOGBACK appender) went dark. Logback is
-        // this repo's one true backend: drop the competing provider + core
-        // everywhere; Besu's log4j-api calls route into slf4j via the
-        // log4j-to-slf4j bridge (added in :myotis-evm).
-        exclude(group = "org.apache.logging.log4j", module = "log4j-slf4j2-impl")
-        exclude(group = "org.apache.logging.log4j", module = "log4j-slf4j-impl")
-        exclude(group = "org.apache.logging.log4j", module = "log4j-slf4j18-impl")
-        exclude(group = "org.apache.logging.log4j", module = "log4j-core")
+            // Besu 26.4 drags log4j-slf4j2-impl — a SECOND slf4j provider — plus
+            // log4j-core. Whichever provider classloads first gets ALL logging;
+            // jpackage's flattened classpath deterministically picked log4j and the
+            // desktop app's Logs tab (a LOGBACK appender) went dark. Logback is
+            // this repo's one true backend: drop the competing provider + core
+            // everywhere; Besu's log4j-api calls route into slf4j via the
+            // log4j-to-slf4j bridge (added in :myotis-evm).
+            exclude(group = "org.apache.logging.log4j", module = "log4j-slf4j2-impl")
+            exclude(group = "org.apache.logging.log4j", module = "log4j-slf4j-impl")
+            exclude(group = "org.apache.logging.log4j", module = "log4j-slf4j18-impl")
+            exclude(group = "org.apache.logging.log4j", module = "log4j-core")
         }
         return@subprojects
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,23 +39,26 @@ subprojects {
     //   android-app  → com.android.application
     //   ui           → kotlin-multiplatform + com.android.library + compose
     //   app-desktop  → kotlin.jvm + compose (desktop)
+    // Excludes shared by EVERY module (Android plugin modules included):
+    // - native Netty transports, for Android compatibility;
+    // - Besu 26.4's log4j: it drags log4j-slf4j2-impl — a SECOND slf4j
+    //   provider — plus log4j-core. Whichever provider classloads first gets
+    //   ALL logging; jpackage's flattened classpath deterministically picked
+    //   log4j and the desktop app's Logs tab (a LOGBACK appender) went dark.
+    //   Logback is this repo's one true backend: drop the competing provider
+    //   + core everywhere; Besu's log4j-api calls route into slf4j via the
+    //   log4j-to-slf4j bridge (added in :myotis-evm).
+    configurations.all {
+        exclude(group = "io.netty", module = "netty-transport-native-epoll")
+        exclude(group = "io.netty", module = "netty-transport-native-kqueue")
+        exclude(group = "io.netty", module = "netty-transport-native-unix-common")
+        exclude(group = "org.apache.logging.log4j", module = "log4j-slf4j2-impl")
+        exclude(group = "org.apache.logging.log4j", module = "log4j-slf4j-impl")
+        exclude(group = "org.apache.logging.log4j", module = "log4j-slf4j18-impl")
+        exclude(group = "org.apache.logging.log4j", module = "log4j-core")
+    }
+
     if (name in setOf("android-app", "ui", "app-desktop")) {
-        configurations.all {
-            exclude(group = "io.netty", module = "netty-transport-native-epoll")
-            exclude(group = "io.netty", module = "netty-transport-native-kqueue")
-            exclude(group = "io.netty", module = "netty-transport-native-unix-common")
-            // Besu 26.4 drags log4j-slf4j2-impl — a SECOND slf4j provider — plus
-            // log4j-core. Whichever provider classloads first gets ALL logging;
-            // jpackage's flattened classpath deterministically picked log4j and the
-            // desktop app's Logs tab (a LOGBACK appender) went dark. Logback is
-            // this repo's one true backend: drop the competing provider + core
-            // everywhere; Besu's log4j-api calls route into slf4j via the
-            // log4j-to-slf4j bridge (added in :myotis-evm).
-            exclude(group = "org.apache.logging.log4j", module = "log4j-slf4j2-impl")
-            exclude(group = "org.apache.logging.log4j", module = "log4j-slf4j-impl")
-            exclude(group = "org.apache.logging.log4j", module = "log4j-slf4j18-impl")
-            exclude(group = "org.apache.logging.log4j", module = "log4j-core")
-        }
         return@subprojects
     }
 
@@ -67,11 +70,7 @@ subprojects {
         }
     }
 
-    // Exclude native Netty transports for Android compatibility
     configurations.all {
-        exclude(group = "io.netty", module = "netty-transport-native-epoll")
-        exclude(group = "io.netty", module = "netty-transport-native-kqueue")
-        exclude(group = "io.netty", module = "netty-transport-native-unix-common")
         // Besu 26.4 pulls tuweni under its post-rename coordinates
         // (io.consensys.tuweni) — the same org.apache.tuweni classes as our
         // Kotlin fork but WITHOUT the Kotlin Companion objects. Whichever jar
@@ -81,17 +80,6 @@ subprojects {
         // Bytes.Companion). The fork supplies these classes everywhere —
         // exclude the upstream twins for every JVM module.
         exclude(group = "io.consensys.tuweni")
-        // Besu 26.4 drags log4j-slf4j2-impl — a SECOND slf4j provider — plus
-        // log4j-core. Whichever provider classloads first gets ALL logging;
-        // jpackage's flattened classpath deterministically picked log4j and the
-        // desktop app's Logs tab (a LOGBACK appender) went dark. Logback is
-        // this repo's one true backend: drop the competing provider + core
-        // everywhere; Besu's log4j-api calls route into slf4j via the
-        // log4j-to-slf4j bridge (added in :myotis-evm).
-        exclude(group = "org.apache.logging.log4j", module = "log4j-slf4j2-impl")
-        exclude(group = "org.apache.logging.log4j", module = "log4j-slf4j-impl")
-        exclude(group = "org.apache.logging.log4j", module = "log4j-slf4j18-impl")
-        exclude(group = "org.apache.logging.log4j", module = "log4j-core")
     }
 
     tasks.test {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,6 +44,17 @@ subprojects {
             exclude(group = "io.netty", module = "netty-transport-native-epoll")
             exclude(group = "io.netty", module = "netty-transport-native-kqueue")
             exclude(group = "io.netty", module = "netty-transport-native-unix-common")
+        // Besu 26.4 drags log4j-slf4j2-impl — a SECOND slf4j provider — plus
+        // log4j-core. Whichever provider classloads first gets ALL logging;
+        // jpackage's flattened classpath deterministically picked log4j and the
+        // desktop app's Logs tab (a LOGBACK appender) went dark. Logback is
+        // this repo's one true backend: drop the competing provider + core
+        // everywhere; Besu's log4j-api calls route into slf4j via the
+        // log4j-to-slf4j bridge (added in :myotis-evm).
+        exclude(group = "org.apache.logging.log4j", module = "log4j-slf4j2-impl")
+        exclude(group = "org.apache.logging.log4j", module = "log4j-slf4j-impl")
+        exclude(group = "org.apache.logging.log4j", module = "log4j-slf4j18-impl")
+        exclude(group = "org.apache.logging.log4j", module = "log4j-core")
         }
         return@subprojects
     }
@@ -70,6 +81,17 @@ subprojects {
         // Bytes.Companion). The fork supplies these classes everywhere —
         // exclude the upstream twins for every JVM module.
         exclude(group = "io.consensys.tuweni")
+        // Besu 26.4 drags log4j-slf4j2-impl — a SECOND slf4j provider — plus
+        // log4j-core. Whichever provider classloads first gets ALL logging;
+        // jpackage's flattened classpath deterministically picked log4j and the
+        // desktop app's Logs tab (a LOGBACK appender) went dark. Logback is
+        // this repo's one true backend: drop the competing provider + core
+        // everywhere; Besu's log4j-api calls route into slf4j via the
+        // log4j-to-slf4j bridge (added in :myotis-evm).
+        exclude(group = "org.apache.logging.log4j", module = "log4j-slf4j2-impl")
+        exclude(group = "org.apache.logging.log4j", module = "log4j-slf4j-impl")
+        exclude(group = "org.apache.logging.log4j", module = "log4j-slf4j18-impl")
+        exclude(group = "org.apache.logging.log4j", module = "log4j-core")
     }
 
     tasks.test {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ netty-kotlin = "main-SNAPSHOT"
 bouncycastle = "1.78.1"
 junit = "5.10.0"
 slf4j = "2.0.12"
+log4j = "2.25.3"  # matches Besu 26.4's log4j-bom; bump in lockstep with Besu
 logback = "1.5.6"
 snappy = "0.4"
 milagro = "0.4.0"
@@ -69,6 +70,7 @@ netty-handler       = { module = "com.github.biafra23.netty-kotlin:netty-handler
 bouncycastle        = { module = "org.bouncycastle:bcprov-jdk18on",        version.ref = "bouncycastle" }
 
 slf4j-api           = { module = "org.slf4j:slf4j-api",                   version.ref = "slf4j" }
+log4j-to-slf4j      = { module = "org.apache.logging.log4j:log4j-to-slf4j", version.ref = "log4j" }
 logback-classic     = { module = "ch.qos.logback:logback-classic",         version.ref = "logback" }
 
 snappy              = { module = "org.iq80.snappy:snappy",                  version.ref = "snappy" }

--- a/myotis-evm/build.gradle.kts
+++ b/myotis-evm/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
     // log4j-core are excluded repo-wide (see the root build) so Logback stays
     // the single backend — this bridge routes Besu's log4j-api calls into
     // slf4j/Logback instead of dropping them.
-    runtimeOnly("org.apache.logging.log4j:log4j-to-slf4j:2.25.3")
+    runtimeOnly(libs.log4j.to.slf4j)
 
     // Tuweni Bytes/UInt256 are part of Besu's public API surface, so we use
     // the same coordinates here for ABI codec inputs/outputs.

--- a/myotis-evm/build.gradle.kts
+++ b/myotis-evm/build.gradle.kts
@@ -27,6 +27,11 @@ dependencies {
     // flow from the real POMs.
     implementation(libs.besu.evm)
     implementation(libs.besu.datatypes)
+    // Besu logs against log4j-api; the competing log4j slf4j PROVIDER and
+    // log4j-core are excluded repo-wide (see the root build) so Logback stays
+    // the single backend — this bridge routes Besu's log4j-api calls into
+    // slf4j/Logback instead of dropping them.
+    runtimeOnly("org.apache.logging.log4j:log4j-to-slf4j:2.25.3")
 
     // Tuweni Bytes/UInt256 are part of Besu's public API surface, so we use
     // the same coordinates here for ABI codec inputs/outputs.

--- a/networking/build.gradle.kts
+++ b/networking/build.gradle.kts
@@ -11,6 +11,10 @@ java {
 }
 
 dependencies {
+    // discv5 logs through log4j-api; log4j-core is excluded repo-wide (root
+    // build — Logback is the single backend), so bridge it for this module's
+    // tests/dnsSmoke too. Version floats on Besu's log4j-bom elsewhere; pin here.
+    testRuntimeOnly("org.apache.logging.log4j:log4j-to-slf4j:2.25.3")
     implementation(project(":core"))
     implementation(libs.tuweni.bytes)
     implementation(libs.tuweni.rlp)

--- a/networking/build.gradle.kts
+++ b/networking/build.gradle.kts
@@ -13,8 +13,8 @@ java {
 dependencies {
     // discv5 logs through log4j-api; log4j-core is excluded repo-wide (root
     // build — Logback is the single backend), so bridge it for this module's
-    // tests/dnsSmoke too. Version floats on Besu's log4j-bom elsewhere; pin here.
-    testRuntimeOnly("org.apache.logging.log4j:log4j-to-slf4j:2.25.3")
+    // tests/dnsSmoke too.
+    testRuntimeOnly(libs.log4j.to.slf4j)
     implementation(project(":core"))
     implementation(libs.tuweni.bytes)
     implementation(libs.tuweni.rlp)


### PR DESCRIPTION
## Problem
The Logs screen in the latest main-built desktop app is dark (reported with the rust engine; the java engine's lines were equally lost in packaged builds).

Besu 26.4 (since #208) drags in `log4j-slf4j2-impl` — a **second SLF4J provider** — plus `log4j-core`. Whichever provider classloads first receives ALL logging; jpackage's flattened classpath deterministically picks log4j, so nothing reaches Logback and the Logs tab's `DesktopLogAppender` (and the rust-log drain feeding slf4j) goes dark. Gradle-run had hidden it by winning the provider race for Logback. Same classpath-order-roulette family as the `io.consensys.tuweni` shadow fixed in #212.

## Fix
- Exclude `log4j-slf4j2-impl` (+ legacy `log4j-slf4j-impl`/`-slf4j18-impl`) and `log4j-core` in both root `subprojects` branches — Logback stays the single backend.
- Keep `log4j-api` (Besu links against it) and add the `log4j-to-slf4j` bridge as `runtimeOnly` in `:myotis-evm` so Besu's log4j-api calls route into Logback; it flows transitively to `:app` and `:app-desktop`. Version 2.25.3 matches Besu's `log4j-bom` and floats with it on future bumps.
- `:networking` gets the bridge as `testRuntimeOnly` (discv5 logs via log4j-api; its `log4j-core` came from the same exclude).
- Android already excluded the whole log4j group (its own earlier fix of this same problem) — unaffected; the group exclude also strips the bridge, so no collision with its log4j shim.

## Verification (packaged app, rust engine forced)
Rebuilt `createDistributable` and launched `Myotis.app` with `-Dmyotis.engine=rust`:
- no "multiple SLF4J providers" warning — logback-classic is the sole provider on the resolved runtime classpath (verified via dependency tree too),
- rust engine loaded from the bundle (ABI 12),
- 29 `[rust]`-prefixed drain lines flowing through the Logback pipeline the Logs tab reads.

`:myotis-evm:test`, `:app:test`, `:myotis-engines:test`, `:networking:test` green. No-context review: no HIGH/MED; both LOW nits (indent, `:networking` test bridge) addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PP9WX3oschsX9T4AAKpdim