### PR TITLE
CL peer classification: harvest fan-out verdicts, background Identify sweep, honest cache buckets

### DIFF
--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/CacheFileStats.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/CacheFileStats.java
@@ -92,16 +92,18 @@ final class CacheFileStats {
             // Per-PEER flags, not per-token: the loader merges multiple
             // range/legacy tokens on one line into a single served range
             // (widening), so counting per token could show proven > total.
-            // Proven now includes Identify-confirmed `lc` peers, not just
-            // catch-up servers — and beats nolc — so the three buckets
-            // (proven / nolc / untried-remainder) always sum to total.
+            // Proven = ANY positive LC signal: a served catch-up range, an
+            // Identify-confirmed `lc`, or a served bootstrap (`b<period>` —
+            // bootstrap IS a light-client protocol). Proven beats nolc, so
+            // the three buckets (proven / nolc / untried-remainder) always
+            // sum to total.
             boolean hasLcSignal = false;
             boolean hasNolc = false;
             String[] tokens = trimmed.split("\t");
             for (int i = 1; i < tokens.length; i++) {
                 String tok = tokens[i];
                 if (tok.equals("nolc")) hasNolc = true;
-                else if (tok.equals("lc") || isServedRange(tok)) hasLcSignal = true;
+                else if (tok.equals("lc") || isBootstrapToken(tok) || isServedRange(tok)) hasLcSignal = true;
             }
             if (hasLcSignal) proven++;
             else if (hasNolc) nolc++;
@@ -143,6 +145,11 @@ final class CacheFileStats {
         if (dash < 0) return allDigits(tok); // legacy bare floor
         return dash > 0 && dash < tok.length() - 1
                 && allDigits(tok.substring(0, dash)) && allDigits(tok.substring(dash + 1));
+    }
+
+    /** {@code b<period>} — the peer served a light_client_bootstrap at that period. */
+    private static boolean isBootstrapToken(String tok) {
+        return tok.length() > 1 && tok.charAt(0) == 'b' && allDigits(tok.substring(1));
     }
 
     private static boolean allDigits(String s) {

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/CacheFileStats.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/CacheFileStats.java
@@ -22,7 +22,9 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 final class CacheFileStats {
 
-    /** CL: total cached peers, proven catch-up servers (served-range token), nolc-flagged. */
+    /** CL: total cached peers, proven LC servers (served-range or {@code lc} token),
+     *  nolc-flagged. Buckets are mutually exclusive (proven wins over nolc), so
+     *  {@code total - proven - nolc} is the untried remainder the UI shows. */
     record ClStats(int total, int proven, int nolc) {
         static final ClStats EMPTY = new ClStats(0, 0, 0);
     }
@@ -90,16 +92,19 @@ final class CacheFileStats {
             // Per-PEER flags, not per-token: the loader merges multiple
             // range/legacy tokens on one line into a single served range
             // (widening), so counting per token could show proven > total.
-            boolean hasRange = false;
+            // Proven now includes Identify-confirmed `lc` peers, not just
+            // catch-up servers — and beats nolc — so the three buckets
+            // (proven / nolc / untried-remainder) always sum to total.
+            boolean hasLcSignal = false;
             boolean hasNolc = false;
             String[] tokens = trimmed.split("\t");
             for (int i = 1; i < tokens.length; i++) {
                 String tok = tokens[i];
                 if (tok.equals("nolc")) hasNolc = true;
-                else if (isServedRange(tok)) hasRange = true;
+                else if (tok.equals("lc") || isServedRange(tok)) hasLcSignal = true;
             }
-            if (hasRange) proven++;
-            if (hasNolc) nolc++;
+            if (hasLcSignal) proven++;
+            else if (hasNolc) nolc++;
         }
         return new ClStats(total, proven, nolc);
     }

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/CacheFileStats.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/CacheFileStats.java
@@ -22,7 +22,7 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 final class CacheFileStats {
 
-    /** CL: total cached peers, proven LC servers (served-range or {@code lc} token),
+    /** CL: total cached peers, proven LC servers (served catch-up range, served bootstrap {@code b<period>}, or {@code lc} token),
      *  nolc-flagged. Buckets are mutually exclusive (proven wins over nolc), so
      *  {@code total - proven - nolc} is the untried remainder the UI shows. */
     record ClStats(int total, int proven, int nolc) {

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -1094,8 +1094,8 @@ public final class NodeService extends Service {
                                       // short-lived, so clPeersConnected is usually 0
                                       // and THIS is the "are we being fed?" signal
             int clPeersCached,         // CL peers in cl-peers[-net].cache (live file count)
-            int clCachedProven,        // …of which proven catch-up servers (served-range token)
-            int clCachedNolc,          // …of which known non-LC (nolc token)
+            int clCachedProven,        // …of which proven LC servers (served-range or lc token)
+            int clCachedNolc,          // …of which known non-LC (nolc token; proven wins on conflict)
             long finalizedSlot,
             long executionBlockNumber,
             String executionBlockHashHex, // null until first finality update

--- a/android-app/src/test/java/com/jaeckel/ethp2p/android/CacheFileStatsTest.java
+++ b/android-app/src/test/java/com/jaeckel/ethp2p/android/CacheFileStatsTest.java
@@ -19,17 +19,25 @@ public class CacheFileStatsTest {
                 "/ip4/1.1.1.1/tcp/9000/p2p/16Ua\t1770-1795\tb1480\tlc",   // proven (range)
                 "/ip4/2.2.2.2/tcp/9000/p2p/16Ub\t1777",                    // proven (legacy bare floor)
                 "/ip4/3.3.3.3/tcp/9000/p2p/16Uc\tnolc",
-                "/ip4/4.4.4.4/tcp/9000/p2p/16Ud\tb1480\tlc",              // bootstrap+lc, NOT proven
-                "/ip4/5.5.5.5/tcp/9000/p2p/16Ue",
+                "/ip4/4.4.4.4/tcp/9000/p2p/16Ud\tb1480\tlc",              // proven (bootstrap-served + lc)
+                "/ip4/5.5.5.5/tcp/9000/p2p/16Ue",                          // untried (no verdict tokens)
                 // Multi-token line the loader accepts by WIDENING into one
                 // range — must count as ONE proven peer, never two (the
                 // per-token bug showed proven > total).
                 "/ip4/6.6.6.6/tcp/9000/p2p/16Uf\t1770-1795\t1777",
+                // Conflict line: buckets are mutually exclusive, proven wins —
+                // the status row's three buckets must always sum to total.
+                "/ip4/7.7.7.7/tcp/9000/p2p/16Ug\t1770-1795\tnolc",
+                // Bare bootstrap token: served a light_client_bootstrap ⇒ proven,
+                // not "untried" (bootstrap IS a light-client protocol).
+                "/ip4/8.8.8.8/tcp/9000/p2p/16Uh\tb1500",
                 "# comment / stray line",
                 ""));
-        assertEquals(6, s.total());
-        assertEquals(3, s.proven());
+        assertEquals(8, s.total());
+        assertEquals(6, s.proven());
         assertEquals(1, s.nolc());
+        // untried = total - proven - nolc, the row's derived third bucket
+        assertEquals(1, s.total() - s.proven() - s.nolc());
     }
 
     @Test

--- a/app-desktop/src/main/kotlin/io/myotis/desktop/CacheFileStats.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/CacheFileStats.kt
@@ -33,19 +33,28 @@ object CacheFileStats {
             if (!t.startsWith("/")) continue
             total++
             // Per-PEER flags (loader merges multiple range tokens by widening).
-            var hasRange = false; var hasNolc = false
+            // Mirror of the Android CacheFileStats.parseCl: proven = ANY positive
+            // LC signal (served catch-up range, Identify-confirmed `lc`, or served
+            // bootstrap `b<period>`), and proven beats nolc — mutually exclusive
+            // buckets so the shared NodeScreen row's derived
+            // `untried = total - proven - nolc` always sums and never goes negative.
+            var hasLcSignal = false; var hasNolc = false
             val tokens = t.split('\t')
             for (i in 1 until tokens.size) {
                 when {
                     tokens[i] == "nolc" -> hasNolc = true
-                    isServedRange(tokens[i]) -> hasRange = true
+                    tokens[i] == "lc" || isBootstrapToken(tokens[i]) ||
+                        isServedRange(tokens[i]) -> hasLcSignal = true
                 }
             }
-            if (hasRange) proven++
-            if (hasNolc) nolc++
+            if (hasLcSignal) proven++ else if (hasNolc) nolc++
         }
         ClStats(total, proven, nolc)
     }
+
+    /** `b<period>` — the peer served a light_client_bootstrap at that period. */
+    private fun isBootstrapToken(tok: String): Boolean =
+        tok.length > 1 && tok[0] == 'b' && tok.substring(1).all { it in '0'..'9' }
 
     fun el(file: Path): ElStats = memoized(file, ElStats.EMPTY) { lines ->
         var total = 0; var snapOk = 0; var snapBad = 0

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
@@ -179,7 +179,7 @@ public class BeaconLightClient implements AutoCloseable {
     // servers instead of re-Identifying the whole fork-matched set (most of which are
     // full nodes without the light-client server).
     private final Set<String> provenLightClient = java.util.concurrent.ConcurrentHashMap.newKeySet();
-    /** Notified (confirmedLcMultiaddrs, deniedLcMultiaddrs) once per Identify round, batched so
+    /** Notified (confirmedLcMultiaddrs, deniedLcMultiaddrs) once per Identify round or finality-poll round, batched so
      *  the host persists the whole round in a single rewrite rather than once per peer. */
     private volatile java.util.function.BiConsumer<java.util.Collection<String>, java.util.Collection<String>> onLightClientVerdict;
 
@@ -722,6 +722,9 @@ public class BeaconLightClient implements AutoCloseable {
                 // whether LC-capable peers are accumulating or bleeding off.
                 if (++cycleCount % 5 == 0) logPeerPoolStats();
                 pollFinalityUpdate();
+                // Background classification of untried pool peers (fire-and-forget;
+                // never blocks the cycle) — drains the cache's untried bucket.
+                classifyUntriedPeers();
                 Thread.sleep(pollIntervalMs);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
@@ -868,9 +871,17 @@ public class BeaconLightClient implements AutoCloseable {
             }
         }
 
-        // Record each peer's light_client verdict (keyed by multiaddr) for in-session
-        // prioritization + cache persistence, so a restart dials known light-client
-        // servers first. Identify is per-peerId; map it back to our multiaddrs.
+        applyIdentifyVerdicts(connected);
+    }
+
+    /**
+     * Record each connected peer's light_client verdict (keyed by multiaddr) for
+     * in-session prioritization + cache persistence, so a restart dials known
+     * light-client servers first. Identify is per-peerId; map it back to our
+     * multiaddrs. Shared by the boot Identify round and the steady-state
+     * {@link #classifyUntriedPeers} sweep.
+     */
+    private void applyIdentifyVerdicts(List<BeaconP2PService.PeerInfo> connected) {
         java.util.Map<String, Boolean> lcByPeerId = new java.util.HashMap<>();
         for (BeaconP2PService.PeerInfo pi : connected) {
             lcByPeerId.put(pi.peerId(), pi.supportsLightClient());
@@ -891,6 +902,48 @@ public class BeaconLightClient implements AutoCloseable {
         if (verdictCb != null && (!newConfirmed.isEmpty() || !newDenied.isEmpty())) {
             verdictCb.accept(newConfirmed, newDenied);
         }
+    }
+
+    /** Untried peers Identified per sync cycle by the background classification
+     *  sweep — small enough to be invisible next to the fan-out's dials, big
+     *  enough to classify the whole in-pool backlog in tens of minutes. */
+    private static final int CLASSIFY_SWEEP_BATCH = 4;
+    /** Rotating cursor over the untried peers so consecutive sweeps walk the
+     *  backlog instead of re-probing the same head. */
+    private int classifySweepCursor = 0;
+
+    /**
+     * Steady-state classification sweep: Identify a small rotating batch of
+     * UNTRIED pool peers (no lc/nolc verdict yet) per sync cycle, so the cache's
+     * untried mass drains into proven/nolc instead of waiting for a fan-out
+     * probe to happen to hit each peer. Fire-and-forget: the Identify batch runs
+     * async and applies verdicts on the catch-up executor; the sync loop never
+     * blocks on it. Verdicts persist through the same batched callback the boot
+     * Identify round uses.
+     */
+    private void classifyUntriedPeers() {
+        List<String> untried = new ArrayList<>();
+        for (String ma : copyPeers(false)) {
+            if (!provenLightClient.contains(ma) && !peersNoLcUpdates.contains(ma)) {
+                untried.add(ma);
+            }
+        }
+        if (untried.isEmpty()) return;
+        List<CompletableFuture<Void>> batch = new ArrayList<>(CLASSIFY_SWEEP_BATCH);
+        int start = classifySweepCursor % untried.size();
+        classifySweepCursor += CLASSIFY_SWEEP_BATCH;
+        for (int i = 0; i < Math.min(CLASSIFY_SWEEP_BATCH, untried.size()); i++) {
+            if (!running) return;
+            String peer = untried.get((start + i) % untried.size());
+            batch.add(p2pService.queryIdentify(peer).handle((v, ex) -> null));
+        }
+        CompletableFuture.allOf(batch.toArray(new CompletableFuture[0]))
+                .whenCompleteAsync((v, ex) -> {
+                    if (!running) return;
+                    // A failed/timed-out Identify yields no PeerInfo entry and stays
+                    // untried — deliberately: unreachable ≠ not-an-LC-server.
+                    applyIdentifyVerdicts(p2pService.getConnectedPeers());
+                }, catchUpExecutor);
     }
 
     /**
@@ -1941,8 +1994,9 @@ public class BeaconLightClient implements AutoCloseable {
         // (on-device: ~28s rounds, verified-head age spiking past 2 minutes
         // whenever a round found no server at all). The cap still bounds the
         // per-cycle dial count; copyPeers() puts the proven tier first and
-        // sorts it most-recently-served first (winners get promoted to the
-        // tier below), so a known-live server stays inside the fan-out window.
+        // sorts it most-recently-served first (every decodable responder gets
+        // confirmed into the tier — see the classification harvest below), so
+        // a known-live server stays inside the fan-out window.
         final int POLL_FINALITY_FANOUT = 16;
         // Heal a late winner from a PREVIOUS round: if its BLS verify outlasted
         // that round's 12s deadline, the store advanced but the poll thread had
@@ -1981,6 +2035,9 @@ public class BeaconLightClient implements AutoCloseable {
         // proves the peer serves light-client data; a NoSuchRemoteProtocol
         // rejection proves it doesn't (deliberately NOT the connection-closed /
         // timeout failures — that's how genuine-but-at-capacity servers fail).
+        // NOTE cross-engine divergence: the Rust poll treats UnsupportedProtocol
+        // as neutral and never persists lc for decode-only responders — both
+        // engines share the cache file, so align Rust when it grows a sweep.
         final java.util.Queue<String> lcConfirmed = new java.util.concurrent.ConcurrentLinkedQueue<>();
         final java.util.Queue<String> lcDenied = new java.util.concurrent.ConcurrentLinkedQueue<>();
 
@@ -2072,6 +2129,13 @@ public class BeaconLightClient implements AutoCloseable {
             if (e instanceof InterruptedException) {
                 Thread.currentThread().interrupt();
             }
+            // Close the round BEFORE harvesting: on a get() timeout the winner
+            // future is still open, so straggler callbacks would pass the
+            // isDone gate and enqueue verdicts into queues we've already
+            // drained — silently losing exactly the classifications this
+            // harvest exists to keep. completeExceptionally is a no-op if a
+            // late winner already completed it, preserving the lateWin check.
+            winner.completeExceptionally(new java.util.concurrent.TimeoutException("round closed"));
             // A late winner (a BLS verify outlasting the deadline on the
             // catch-up executor) must still void the round's strikes — strikes
             // are only for rounds that truly found no server. Its follow-ups
@@ -2096,7 +2160,9 @@ public class BeaconLightClient implements AutoCloseable {
         // on the winner's bytes).
         p2pService.cacheFinalityUpdate(win.raw());
         // Classification harvest (covers the winner too — a decodable response
-        // queued it as confirmed, which is the Rust mark_proven analog).
+        // queued it as confirmed — dial-priority signal only, unlike Rust's
+        // verified-apply-gated mark_proven; Java's provenLightClient is the
+        // Identify-grade tier).
         recordLcVerdicts(lcConfirmed, lcDenied);
         if (win.applied()) {
             updateSyncState();
@@ -2158,10 +2224,15 @@ public class BeaconLightClient implements AutoCloseable {
         java.util.Set<String> confirmedSet = new java.util.HashSet<>();
         for (String p; (p = confirmed.poll()) != null; ) {
             confirmedSet.add(p);
-            peersNoLcUpdates.remove(p);
-            if (provenLightClient.add(p)) newConfirmed.add(p);
-            String pid = peerIdOf(p);
-            recentServes.put(pid != null ? pid : p, System.nanoTime());
+            // Deliberately NO recentServes stamp here: that map means "last
+            // SUCCESSFUL (verified) light-client response" — it backs the
+            // servedPeersLastMinute health signal and the recency ordering.
+            // Stamping decode-only losers would show ~16 peers "serving"
+            // during a stale-committee stall (the exact stall the metric
+            // exists to expose) and recency-rank unverifiable responders
+            // first. The round's WINNER gets its stamp via notifyPeerSuccess.
+            boolean changed = peersNoLcUpdates.remove(p) | provenLightClient.add(p);
+            if (changed) newConfirmed.add(p);
         }
         for (String p; (p = denied.poll()) != null; ) {
             if (confirmedSet.contains(p)) continue;

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
@@ -892,8 +892,19 @@ public class BeaconLightClient implements AutoCloseable {
             String pid = peerIdOf(ma);
             Boolean lc = pid != null ? lcByPeerId.get(pid) : null;
             if (lc == null) continue; // not Identified this round
-            if (lc) { provenLightClient.add(ma); peersNoLcUpdates.remove(ma); newConfirmed.add(ma); }
-            else { peersNoLcUpdates.add(ma); provenLightClient.remove(ma); newDenied.add(ma); }
+            if (lc) {
+                // Non-short-circuit |: apply both set updates, report only CHANGES —
+                // the classification sweep runs this every cycle, so unconditional
+                // reporting would fire the persistence callback with no-op payloads
+                // each round.
+                if (peersNoLcUpdates.remove(ma) | provenLightClient.add(ma)) newConfirmed.add(ma);
+            } else if (!provenLightClient.contains(ma)) {
+                // Mirror the cache's stickiness IN MEMORY: an Identify list lacking
+                // light_client never demotes a peer that demonstrably served us —
+                // without this the per-cycle sweep would re-demote a serve-proven
+                // peer every 12s and wedge it out of the fan-out window.
+                if (peersNoLcUpdates.add(ma)) newDenied.add(ma);
+            }
         }
         // Persist the whole round's verdicts in one shot — a per-peer callback would
         // trigger a disk rewrite for each of dozens of peers identified in parallel.
@@ -2236,8 +2247,11 @@ public class BeaconLightClient implements AutoCloseable {
         }
         for (String p; (p = denied.poll()) != null; ) {
             if (confirmedSet.contains(p)) continue;
-            provenLightClient.remove(p);
-            if (peersNoLcUpdates.add(p)) newDenied.add(p);
+            // A hard protocol rejection DOES demote a proven peer in memory (unlike
+            // the Identify sweep's weaker list-absence signal): the peer's mux just
+            // said it no longer speaks the protocol. Non-short-circuit | for the
+            // same report-only-changes gating as the confirm arm.
+            if (provenLightClient.remove(p) | peersNoLcUpdates.add(p)) newDenied.add(p);
         }
         java.util.function.BiConsumer<java.util.Collection<String>, java.util.Collection<String>> cb =
                 onLightClientVerdict;

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
@@ -886,32 +886,34 @@ public class BeaconLightClient implements AutoCloseable {
         for (BeaconP2PService.PeerInfo pi : connected) {
             lcByPeerId.put(pi.peerId(), pi.supportsLightClient());
         }
-        List<String> newConfirmed = new ArrayList<>();
-        List<String> newDenied = new ArrayList<>();
-        for (String ma : copyPeers(false)) {
-            String pid = peerIdOf(ma);
-            Boolean lc = pid != null ? lcByPeerId.get(pid) : null;
-            if (lc == null) continue; // not Identified this round
-            if (lc) {
-                // Non-short-circuit |: apply both set updates, report only CHANGES —
-                // the classification sweep runs this every cycle, so unconditional
-                // reporting would fire the persistence callback with no-op payloads
-                // each round.
-                if (peersNoLcUpdates.remove(ma) | provenLightClient.add(ma)) newConfirmed.add(ma);
-            } else if (!provenLightClient.contains(ma)) {
-                // Mirror the cache's stickiness IN MEMORY: an Identify list lacking
-                // light_client never demotes a peer that demonstrably served us —
-                // without this the per-cycle sweep would re-demote a serve-proven
-                // peer every 12s and wedge it out of the fan-out window.
-                if (peersNoLcUpdates.add(ma)) newDenied.add(ma);
+        synchronized (lcVerdictLock) {
+            List<String> newConfirmed = new ArrayList<>();
+            List<String> newDenied = new ArrayList<>();
+            for (String ma : copyPeers(false)) {
+                String pid = peerIdOf(ma);
+                Boolean lc = pid != null ? lcByPeerId.get(pid) : null;
+                if (lc == null) continue; // not Identified this round
+                if (lc) {
+                    // Non-short-circuit |: apply both set updates, report only CHANGES —
+                    // the classification sweep runs this every cycle, so unconditional
+                    // reporting would fire the persistence callback with no-op payloads
+                    // each round.
+                    if (peersNoLcUpdates.remove(ma) | provenLightClient.add(ma)) newConfirmed.add(ma);
+                } else if (!provenLightClient.contains(ma)) {
+                    // Mirror the cache's stickiness IN MEMORY: an Identify list lacking
+                    // light_client never demotes a peer that demonstrably served us —
+                    // without this the per-cycle sweep would re-demote a serve-proven
+                    // peer every 12s and wedge it out of the fan-out window.
+                    if (peersNoLcUpdates.add(ma)) newDenied.add(ma);
+                }
             }
-        }
-        // Persist the whole round's verdicts in one shot — a per-peer callback would
-        // trigger a disk rewrite for each of dozens of peers identified in parallel.
-        java.util.function.BiConsumer<java.util.Collection<String>, java.util.Collection<String>> verdictCb =
-                onLightClientVerdict;
-        if (verdictCb != null && (!newConfirmed.isEmpty() || !newDenied.isEmpty())) {
-            verdictCb.accept(newConfirmed, newDenied);
+            // Persist the whole round's verdicts in one shot — a per-peer callback would
+            // trigger a disk rewrite for each of dozens of peers identified in parallel.
+            java.util.function.BiConsumer<java.util.Collection<String>, java.util.Collection<String>> verdictCb =
+                    onLightClientVerdict;
+            if (verdictCb != null && (!newConfirmed.isEmpty() || !newDenied.isEmpty())) {
+                verdictCb.accept(newConfirmed, newDenied);
+            }
         }
     }
 
@@ -941,7 +943,7 @@ public class BeaconLightClient implements AutoCloseable {
         }
         if (untried.isEmpty()) return;
         List<CompletableFuture<Void>> batch = new ArrayList<>(CLASSIFY_SWEEP_BATCH);
-        int start = classifySweepCursor % untried.size();
+        int start = Math.floorMod(classifySweepCursor, untried.size()); // floorMod: survives cursor overflow
         classifySweepCursor += CLASSIFY_SWEEP_BATCH;
         for (int i = 0; i < Math.min(CLASSIFY_SWEEP_BATCH, untried.size()); i++) {
             if (!running) return;
@@ -2230,35 +2232,48 @@ public class BeaconLightClient implements AutoCloseable {
      * queues counts as confirmed (it served; the rejection was transient).
      */
     private void recordLcVerdicts(java.util.Queue<String> confirmed, java.util.Queue<String> denied) {
-        List<String> newConfirmed = new ArrayList<>();
-        List<String> newDenied = new ArrayList<>();
-        java.util.Set<String> confirmedSet = new java.util.HashSet<>();
-        for (String p; (p = confirmed.poll()) != null; ) {
-            confirmedSet.add(p);
-            // Deliberately NO recentServes stamp here: that map means "last
-            // SUCCESSFUL (verified) light-client response" — it backs the
-            // servedPeersLastMinute health signal and the recency ordering.
-            // Stamping decode-only losers would show ~16 peers "serving"
-            // during a stale-committee stall (the exact stall the metric
-            // exists to expose) and recency-rank unverifiable responders
-            // first. The round's WINNER gets its stamp via notifyPeerSuccess.
-            boolean changed = peersNoLcUpdates.remove(p) | provenLightClient.add(p);
-            if (changed) newConfirmed.add(p);
-        }
-        for (String p; (p = denied.poll()) != null; ) {
-            if (confirmedSet.contains(p)) continue;
-            // A hard protocol rejection DOES demote a proven peer in memory (unlike
-            // the Identify sweep's weaker list-absence signal): the peer's mux just
-            // said it no longer speaks the protocol. Non-short-circuit | for the
-            // same report-only-changes gating as the confirm arm.
-            if (provenLightClient.remove(p) | peersNoLcUpdates.add(p)) newDenied.add(p);
-        }
-        java.util.function.BiConsumer<java.util.Collection<String>, java.util.Collection<String>> cb =
-                onLightClientVerdict;
-        if (cb != null && (!newConfirmed.isEmpty() || !newDenied.isEmpty())) {
-            cb.accept(newConfirmed, newDenied);
+        synchronized (lcVerdictLock) {
+            List<String> newConfirmed = new ArrayList<>();
+            List<String> newDenied = new ArrayList<>();
+            java.util.Set<String> confirmedSet = new java.util.HashSet<>();
+            for (String p; (p = confirmed.poll()) != null; ) {
+                confirmedSet.add(p);
+                // Deliberately NO recentServes stamp here: that map means "last
+                // SUCCESSFUL (verified) light-client response" — it backs the
+                // servedPeersLastMinute health signal and the recency ordering.
+                // Stamping decode-only losers would show ~16 peers "serving"
+                // during a stale-committee stall (the exact stall the metric
+                // exists to expose) and recency-rank unverifiable responders
+                // first. The round's WINNER gets its stamp via notifyPeerSuccess.
+                boolean changed = peersNoLcUpdates.remove(p) | provenLightClient.add(p);
+                if (changed) newConfirmed.add(p);
+            }
+            for (String p; (p = denied.poll()) != null; ) {
+                if (confirmedSet.contains(p)) continue;
+                // A hard protocol rejection DOES demote a proven peer in memory (unlike
+                // the Identify sweep's weaker list-absence signal): the peer's mux just
+                // said it no longer speaks the protocol. Non-short-circuit | for the
+                // same report-only-changes gating as the confirm arm.
+                if (provenLightClient.remove(p) | peersNoLcUpdates.add(p)) newDenied.add(p);
+            }
+            java.util.function.BiConsumer<java.util.Collection<String>, java.util.Collection<String>> cb =
+                    onLightClientVerdict;
+            if (cb != null && (!newConfirmed.isEmpty() || !newDenied.isEmpty())) {
+                cb.accept(newConfirmed, newDenied);
+            }
         }
     }
+
+    /**
+     * Serializes the two verdict appliers ({@link #recordLcVerdicts} on the poll
+     * thread, {@link #applyIdentifyVerdicts} on the catch-up executor): their
+     * check-then-act sequences over the proven/nolc set PAIR aren't atomic on
+     * their own, so an interleaving could transiently leave a peer in both sets
+     * (or neither) and mis-gate the change-only persistence reports. Dedicated
+     * lock (not {@code this}, which other lifecycle paths monitor) — both bodies
+     * are cheap set ops plus an at-most-once-per-change cache write.
+     */
+    private final Object lcVerdictLock = new Object();
 
     /**
      * Push the current store state into the shared {@link BeaconSyncState}.

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
@@ -1974,6 +1974,15 @@ public class BeaconLightClient implements AutoCloseable {
         // never struck while rounds keep winning — the recency sort in
         // orderByLightClient demotes it instead.
         final java.util.Queue<String> roundFailures = new java.util.concurrent.ConcurrentLinkedQueue<>();
+        // Classification harvest — independent of the round outcome and of the
+        // strike buffer above. With few proven servers the fan-out fills with
+        // UNTRIED cache candidates anyway; record what each dial teaches us so
+        // the probe isn't wasted: a decodable finality update (winner or loser)
+        // proves the peer serves light-client data; a NoSuchRemoteProtocol
+        // rejection proves it doesn't (deliberately NOT the connection-closed /
+        // timeout failures — that's how genuine-but-at-capacity servers fail).
+        final java.util.Queue<String> lcConfirmed = new java.util.concurrent.ConcurrentLinkedQueue<>();
+        final java.util.Queue<String> lcDenied = new java.util.concurrent.ConcurrentLinkedQueue<>();
 
         for (String peer : peers) {
             if (!running) return;
@@ -1996,11 +2005,21 @@ public class BeaconLightClient implements AutoCloseable {
                             log.debug("[beacon] Finality update failed from {}: {}", peer,
                                     root.getMessage() != null ? root.getMessage()
                                             : root.getClass().getSimpleName());
+                            // Definitive non-server: the peer's mux said it has no such
+                            // protocol. Matched by simple name to avoid pinning libp2p's
+                            // internal package layout.
+                            if ("NoSuchRemoteProtocolException".equals(root.getClass().getSimpleName())) {
+                                lcDenied.add(peer);
+                            }
                             roundFailures.add(peer);
                         } else {
                             try {
                                 com.jaeckel.ethp2p.consensus.lightclient.VectorDump.maybeDump("finality", response);
                                 LightClientFinalityUpdate update = LightClientFinalityUpdate.decode(response);
+                                // Decodable update ⇒ the peer serves the LC protocol,
+                                // whether or not it wins the round. Dial-priority signal
+                                // only — trust still requires the verified apply below.
+                                lcConfirmed.add(peer);
 
                                 final boolean finalityApplied;
                                 // Writers serialize on catchUpApplyLock (see its javadoc): without
@@ -2062,6 +2081,7 @@ public class BeaconLightClient implements AutoCloseable {
             if (!lateWin) {
                 for (String p : roundFailures) notifyPeerFailure(p);
             }
+            recordLcVerdicts(lcConfirmed, lcDenied);
             log.debug("[beacon] pollFinalityUpdate: fan-out of {} peer(s), no advance this cycle{}",
                     peers.size(), lateWin ? " (late winner, follow-ups next round)" : "");
             return;
@@ -2075,14 +2095,12 @@ public class BeaconLightClient implements AutoCloseable {
         // staler update as what we serve peers — the sequential loop always ended
         // on the winner's bytes).
         p2pService.cacheFinalityUpdate(win.raw());
+        // Classification harvest (covers the winner too — a decodable response
+        // queued it as confirmed, which is the Rust mark_proven analog).
+        recordLcVerdicts(lcConfirmed, lcDenied);
         if (win.applied()) {
             updateSyncState();
             fillChainStateRoots(win.peer(), true);
-            // The winner just demonstrably served light-client data: promote it to
-            // the proven tier (the Rust pool's mark_proven analog) so the recency
-            // ordering applies to it even if Identify never flagged it.
-            provenLightClient.add(win.peer());
-            peersNoLcUpdates.remove(win.peer());
             notifyPeerSuccess(win.peer());
             // Steady-state advance — persist so a restart resumes here
             // (no-op unless the committee period actually moved).
@@ -2124,6 +2142,38 @@ public class BeaconLightClient implements AutoCloseable {
      *  run the seed branch for. */
     private record FinalityPollWin(
             String peer, byte[] raw, LightClientFinalityUpdate update, boolean applied) {}
+
+    /**
+     * Apply a poll round's classification harvest (poll thread, once per round):
+     * confirmed peers join the proven tier (recency-ordered by copyPeers) and
+     * denied peers the nolc tier — mirroring the Identify-round verdicts — and
+     * ONLY the peers whose state actually changed are pushed to the host's
+     * verdict callback, so a round that merely re-confirms the same winner
+     * doesn't trigger a cache-file rewrite every 12s. A peer somehow in both
+     * queues counts as confirmed (it served; the rejection was transient).
+     */
+    private void recordLcVerdicts(java.util.Queue<String> confirmed, java.util.Queue<String> denied) {
+        List<String> newConfirmed = new ArrayList<>();
+        List<String> newDenied = new ArrayList<>();
+        java.util.Set<String> confirmedSet = new java.util.HashSet<>();
+        for (String p; (p = confirmed.poll()) != null; ) {
+            confirmedSet.add(p);
+            peersNoLcUpdates.remove(p);
+            if (provenLightClient.add(p)) newConfirmed.add(p);
+            String pid = peerIdOf(p);
+            recentServes.put(pid != null ? pid : p, System.nanoTime());
+        }
+        for (String p; (p = denied.poll()) != null; ) {
+            if (confirmedSet.contains(p)) continue;
+            provenLightClient.remove(p);
+            if (peersNoLcUpdates.add(p)) newDenied.add(p);
+        }
+        java.util.function.BiConsumer<java.util.Collection<String>, java.util.Collection<String>> cb =
+                onLightClientVerdict;
+        if (cb != null && (!newConfirmed.isEmpty() || !newDenied.isEmpty())) {
+            cb.accept(newConfirmed, newDenied);
+        }
+    }
 
     /**
      * Push the current store state into the shared {@link BeaconSyncState}.

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/libp2p/BeaconP2PService.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/libp2p/BeaconP2PService.java
@@ -96,6 +96,25 @@ public class BeaconP2PService implements AutoCloseable {
     /** Cached agent version (client ID) per peer ID. */
     private final Map<String, String> peerAgentVersions = new ConcurrentHashMap<>();
 
+    /** Cap for the two Identify caches above. Boot-time Identify touched ~64
+     *  peers so growth never mattered; the steady-state classification sweep
+     *  Identifies the whole pool over time on an always-on host, so the maps
+     *  need a bound. Eviction is arbitrary-batch (CHM iteration order): the
+     *  caches are best-effort — a re-Identify repopulates an evicted entry. */
+    private static final int IDENTIFY_CACHE_MAX = 2048;
+
+    private <V> void boundedPut(Map<String, V> cache, String key, V value) {
+        if (cache.size() >= IDENTIFY_CACHE_MAX && !cache.containsKey(key)) {
+            int evict = IDENTIFY_CACHE_MAX / 8;
+            var it = cache.keySet().iterator();
+            while (evict-- > 0 && it.hasNext()) {
+                it.next();
+                it.remove();
+            }
+        }
+        cache.put(key, value);
+    }
+
     /**
      * Peer's advertised {@code earliest_available_slot} from its Status (v2),
      * keyed by peer ID. Lets catch-up skip peers that can't serve an old period
@@ -277,10 +296,10 @@ public class BeaconP2PService implements AutoCloseable {
                 sp.getController().thenCompose(ctrl -> ctrl.id()).thenAccept(idMsg -> {
                     List<String> protos = idMsg.getProtocolsList().stream()
                             .map(Object::toString).toList();
-                    peerProtocols.put(pid, protos);
+                    boundedPut(peerProtocols, pid, protos);
                     String agent = idMsg.getAgentVersion();
                     if (agent != null && !agent.isEmpty()) {
-                        peerAgentVersions.put(pid, agent);
+                        boundedPut(peerAgentVersions, pid, agent);
                     }
                     long lcCount = protos.stream().filter(p -> p.contains("light_client")).count();
                     log.debug("[beacon-p2p] Identify auto-query for {}: agent={}, {} protocols ({} light_client)",
@@ -839,6 +858,21 @@ public class BeaconP2PService implements AutoCloseable {
             PeerId peerId = peerAddr.getPeerId();
             if (peerId == null) return CompletableFuture.failedFuture(new IllegalArgumentException("no peer id"));
 
+            // Honor the Goodbye cooldown exactly like doReqResp: re-dialing a peer
+            // that just told us to go away is the signal that gets us scored down.
+            // Boot-time Identify never hit this; the steady-state classification
+            // sweep re-dials pool peers continuously, so it must respect it.
+            Long cooldownUntil = goodbyeUntilMs.get(peerId.toString());
+            if (cooldownUntil != null) {
+                long remaining = cooldownUntil - System.currentTimeMillis();
+                if (remaining > 0) {
+                    return CompletableFuture.failedFuture(
+                            new RuntimeException("peer " + peerId + " in Goodbye cooldown for "
+                                    + remaining + "ms"));
+                }
+                goodbyeUntilMs.remove(peerId.toString());
+            }
+
             CompletableFuture<io.libp2p.core.Connection> connFuture = findOrConnect(h, peerId, peerAddr);
             return connFuture.thenCompose(conn -> {
                 StreamPromise<IdentifyController> streamPromise =
@@ -852,10 +886,10 @@ public class BeaconP2PService implements AutoCloseable {
                 try {
                     PeerId pid = new Multiaddr(peerMultiaddr).getPeerId();
                     if (pid != null) {
-                        peerProtocols.put(pid.toString(), protoStrings);
+                        boundedPut(peerProtocols, pid.toString(), protoStrings);
                         String agent = idMsg.getAgentVersion();
                         if (agent != null && !agent.isEmpty()) {
-                            peerAgentVersions.put(pid.toString(), agent);
+                            boundedPut(peerAgentVersions, pid.toString(), agent);
                         }
                     }
                 } catch (Exception ignored) {}

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeController.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeController.kt
@@ -205,7 +205,7 @@ data class NodeSnapshot(
     val clConnectedPeers: Int,      // connected CL libp2p peers (usually 0 — connections are short-lived)
     val clServedPeersLastMin: Int,  // distinct peers that served a light-client response in the last 60s
     val clCachedPeers: Int,         // CL peers in cl-peers[-net].cache (live file count)
-    val clCachedProven: Int,        // …of which proven catch-up servers (served-range token)
+    val clCachedProven: Int,        // …of which proven LC servers (served range/bootstrap or lc token)
     val clCachedNolc: Int,          // …of which known non-LC (skipped when dialing for updates)
     val elCachedPeers: Int,         // EL peers in peers[-net].cache (live file count)
     val elCachedSnapOk: Int,        // …of which snap-serving confirmed

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
@@ -612,7 +612,11 @@ private fun StatusView(s: NodeSnapshot) {
         StatusRow("EL peers", "ready ${s.readyPeers}, snap ${s.snapPeers}, serving ${s.snapServingPeers}")
         // Cache rows: "proven" (CL) / "snap-ok" (EL) predict how fast the NEXT
         // cold start finds servers — the cache learning is visible live.
-        StatusRow("CL cache", "${s.clCachedPeers} (proven ${s.clCachedProven}, nolc ${s.clCachedNolc})")
+        StatusRow(
+            "CL cache",
+            "${s.clCachedPeers} (proven ${s.clCachedProven}, nolc ${s.clCachedNolc}, " +
+                "untried ${(s.clCachedPeers - s.clCachedProven - s.clCachedNolc).coerceAtLeast(0)})",
+        )
         StatusRow("EL cache", "${s.elCachedPeers} (snap-ok ${s.elCachedSnapOk}, snap-bad ${s.elCachedSnapBad})")
         StatusRow("Discovered", s.discoveredPeers.toString())
         StatusRow("Discv5 peers", s.discv5Peers.toString())

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
@@ -615,7 +615,7 @@ private fun StatusView(s: NodeSnapshot) {
         StatusRow(
             "CL cache",
             "${s.clCachedPeers} (proven ${s.clCachedProven}, nolc ${s.clCachedNolc}, " +
-                "untried ${(s.clCachedPeers - s.clCachedProven - s.clCachedNolc).coerceAtLeast(0)})",
+                "untried ${s.clCachedPeers - s.clCachedProven - s.clCachedNolc})",
         )
         StatusRow("EL cache", "${s.elCachedPeers} (snap-ok ${s.elCachedSnapOk}, snap-bad ${s.elCachedSnapBad})")
         StatusRow("Discovered", s.discoveredPeers.toString())


### PR DESCRIPTION
## Why

The Status row's CL-cache arithmetic never added up (e.g. \`9566 (proven 7, nolc 317)\`): ~96% of the cache is peers discovery wrote after a mere fork-digest match — never dialed, never classified. Classification only happened in the single 64-peer Identify round at boot, and the finality fan-out (which dials untried candidates every round when the proven tier is thin) recorded nothing for them. Result: 7 proven servers out of thousands of candidates, and fan-outs wasting dials on blind probes.

## What

**1. Harvest what the fan-out already pays for** (\`BeaconLightClient\`): every finality-poll probe now teaches something, independent of the round outcome and of the (winner-gated) strike buffer — a decodable finality update (winner or loser) confirms the peer as an LC server (dial-priority only; trust still requires the verified apply); a \`NoSuchRemoteProtocolException\` (definitive mux rejection, verified against jvm-libp2p sources) marks nolc — deliberately NOT connection-closed/timeout failures, which is how genuine-but-at-capacity servers fail. Verdicts apply once per round on the poll thread; only state CHANGES reach the persistence callback.

**2. Background Identify sweep** (\`classifyUntriedPeers\`): every 12s cycle, Identify a rotating batch of 4 UNTRIED pool peers and apply verdicts through the boot round's batched persistence path (extracted as \`applyIdentifyVerdicts\`). Fire-and-forget on the catch-up executor; failed Identifies stay untried (unreachable ≠ not-an-LC-server). Respects the Goodbye cooldown (\`queryIdentify\` now checks it like \`doReqResp\`); the Identify caches get a 2048-entry bound now that they're continuously fed.

**3. Honest buckets**: \`CL cache N (proven X, nolc Y, untried Z)\` with X+Y+Z=N. Both stat parsers (Android + the desktop Kotlin twin, which feeds the same shared row) now use mutually exclusive buckets, and proven counts ANY positive LC signal — served catch-up range, Identify-confirmed \`lc\`, or served bootstrap \`b<period>\` (previously invisible/overlapping, which is exactly why the numbers didn't add up).

**Invariants kept**: \`recentServes\` (the servedPeersLastMinute health signal + recency ordering) is stamped only on verified serves — decode-only losers deliberately don't count, or a stale-committee stall would read as "16 peers serving". An Identify list lacking light_client never demotes a serve-proven peer (mirrors the cache's stickiness; the per-cycle sweep would otherwise wedge real servers out of the fan-out window). Cross-engine note: Rust's poll stays neutral on UnsupportedProtocol and persists nothing for decode-only responders — divergence documented, to align when Rust grows a sweep.

## Verified on-device (Pixel 7, mainnet)

- Fan-out harvest: proven 2 → 10, nolc 601 → 616 within ~8 min (untried draining; was frozen)
- Sweep build: untried 1826 → 1804 in 6.5 min (+16 nolc, +3 proven) — continuous drain, rate limited by dead cache entries timing out (correctly staying untried)
- Status row sums exactly; \`:consensus:build\`, \`:android-app:testDebugUnitTest\`, \`:app-desktop:build\`, \`:ui:build\` green

Two independent no-context review passes before opening (initial + delta on the sweep): 1 blocker (a unit test pinning the old bucket semantics — caught by the reviewer running testDebugUnitTest, which assembleDebug doesn't), 2 majors (missed desktop twin; a health-metric invariant violation), and the sweep minors (Goodbye-cooldown bypass, ungated verdict re-reporting, unbounded Identify caches) — all addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017MUyVxaEcPKwfgya4FZptF