### PR TITLE
docs: readiness & verified-head-age guide + README Rust-engine refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,14 @@ A built-in **JSON-RPC server** exposes a verified subset of the Ethereum API ove
 
 Built in Java 21 on the [tuweni](https://github.com/apache/incubator-tuweni) libraries (RLP, SECP256K1, byte utilities; via a Kotlin-rewrite fork), with in-house SSZ and Merkle-Patricia verification, a pure-Java BLS verifier, and an embedded Hyperledger Besu EVM. JVM 17 bytecode where the Android consumer needs it; long-term direction is Kotlin + Compose Multiplatform.
 
+There are now **two interchangeable engines** behind the same zero-dependency API (`:myotis-api`): the original **Java engine** and a **Rust engine** (`rust/` Cargo workspace — discv4/discv5, RLPx, eth/66-69, snap/1, beacon light client, revm-based EVM, ENS + CCIP-Read, multichain). Hosts pick one per network via the `:myotis-engines` selector (`myotis.engine=java|rust|auto`, default `java`; `-Pengine=…` on run tasks, a Settings toggle in the apps). Behavioral parity is pinned by shared conformance vectors and golden tests on both sides — see [Engines](#engines-java-and-rust).
+
 ## Documentation
 
 - [Architecture](docs/architecture-doc.md) — Describes the target design for how the library will obtain and cryptographically verify all Ethereum data without relying on JSON-RPC providers; not all parts are implemented yet.
 - [Benefits](docs/benefits-doc.md) — Explains why a trustless wallet matters and what risks centralized RPC providers pose to users.
 - [Implementation Status](docs/implementation-status.md) — Current implementation progress and what remains to be done.
+- [Readiness & Verified Head Age](docs/readiness-and-verified-head-age.md) — When the node counts as synced and ready to answer queries, and what the "verified head age" on the Status screen means.
 - [Re-Implementation Specification](docs/reimplementation/README.md) — A language-agnostic spec for rebuilding Myotis (everything except the Android-specific host) as a cross-platform engine in Go or Rust, consumable from Desktop, Android, and iOS apps.
 
 ## Wallet API — verified JSON-RPC over HTTP
@@ -109,7 +112,7 @@ Build a native installer for the host OS with jpackage. **jpackage is host-OS-bo
 ./gradlew :app-desktop:runDistributable
 ```
 
-The bundle embeds a full Java 21 runtime (the `:networking`/`:myotis-evm` backend ships Java-21 classes and reaches JDK modules reflectively, so the whole module graph is included). Packaged builds currently ship the Java engine; the Rust engine is loaded only on the `run`/`syncSmoke` dev tasks until the packaging PR bundles the native lib. Logs roll under `~/.myotis/logs`; the app's log level comes from the `myotis.log.level` JVM system property (default `INFO`). Note that a `-D` flag on a `./gradlew :app-desktop:run` command line reaches the Gradle JVM, not the app — for a packaged app, edit the `java-options` in the bundle's generated `Myotis.cfg`.
+The bundle embeds a full Java 21 runtime (the `:networking`/`:myotis-evm` backend ships Java-21 classes and reaches JDK modules reflectively, so the whole module graph is included). Packaged builds (dmg/deb/`runDistributable`) **bundle the Rust engine** as an app resource — packaging fails loudly if cargo isn't available, so an installed app can always switch engines. Logs roll under `~/.myotis/logs`; the app's log level comes from the `myotis.log.level` JVM system property (default `INFO`). Note that a `-D` flag on a `./gradlew :app-desktop:run` command line reaches the Gradle JVM, not the app — for a packaged app, edit the `java-options` in the bundle's generated `Myotis.cfg`.
 
 ### Desktop daemon
 
@@ -722,10 +725,33 @@ The light client syncs from the **beacon chain P2P network** (libp2p) -- fully d
 
 > **Debug only (not for production):** During development, the light client can also seed initial state from a local beacon node's HTTP API (e.g. Lighthouse on `http://localhost:5052`). This is a convenience fallback for debugging and will not be part of a future release. Helper scripts: `scripts/lighthouse.sh`, `scripts/lodestar.sh`.
 
+## Engines: Java and Rust
+
+Myotis is mid-migration from a single Java implementation to a **Rust engine** that reimplements the whole verification stack natively. Both engines live behind the same contract and are interchangeable per network at (re)start:
+
+- **The contract** is `:myotis-api` — zero-dependency Java-17 interfaces (`MyotisEngine`/`ChainHandle`, FFI-portable types only). Hosts (Android app, desktop app, daemon) consume *only* this API and never import engine internals.
+- **The Java engine** is the original implementation (`node-core` adapters over the `networking`/`consensus`/`myotis-evm` modules).
+- **The Rust engine** is the `rust/` Cargo workspace (`myotis-core`, `myotis-net`, `myotis-consensus`, `myotis-bls`, `myotis-evm`, `myotis-engine`): discv4 + discv5 discovery, RLPx/eth/snap, the beacon light client with BLS via blst, a revm-based EVM with the same snap-proof state oracle, ENS incl. CCIP-Read, and multichain (mainnet, Sepolia, Gnosis). It reaches the JVM through hand-written JNI; compound values cross as JSON, pinned by golden tests on both sides.
+- **Selection**: the `:myotis-engines` selector (`Engines.engine()`) routes each network to an engine via the `myotis.engine` property — `java` (default), `rust`, or `auto`. On run tasks use `-Pengine=rust`; in the apps it's a Settings toggle (applies on network restart). The Status screen shows which engine hosts each network — "Mainnet (r)" vs "(j)".
+- **Parity** is enforced by shared conformance vectors (BLS fixtures, a captured mainnet light-client corpus, the EL verification-ladder vectors) run against both implementations, plus a benchmark gate for the JNI path.
+
+Rust builds are **optional for the pure-Java dev loop**: without cargo the Gradle tasks self-skip and the committed Android jniLibs act as the fallback. Release artifacts don't rely on that fallback — CI builds the Rust engine from source for the APK (`cargoNdkAndroid`) and bundles it into the packaged desktop apps.
+
+```bash
+./gradlew cargoBuildHost    # cargo build --release (auto-runs before :app:run / :consensus:test)
+./gradlew cargoTest         # cargo test --workspace (part of `check`)
+./gradlew cargoNdkAndroid   # Android jniLibs (needs cargo-ndk + NDK)
+./gradlew :app:run -Pengine=rust          # daemon on the Rust engine
+./gradlew :app-desktop:run -Pengine=rust  # desktop GUI on the Rust engine
+```
+
 ## Architecture
 
-Eight Gradle modules:
+Key Gradle modules (plus the `rust/` Cargo workspace):
 
+- **myotis-api** -- the engine contract: zero-dependency interfaces every host consumes exclusively
+- **myotis-engines** -- the engine selector (`Engines.engine()`; `myotis.engine=java|rust|auto`) routing to the Java engine or the Rust one over JNI
+- **node-core** -- the Java engine's adapters (`JavaMyotisEngine`/`JavaChainHandle`) plus the verification ladder over the modules below
 - **core** -- cryptographic identity (`NodeKey`), data types (`BlockHeader`), ENR decoding
 - **networking** -- protocol layers, all Netty-based:
   - `discv4` -- UDP peer discovery (ping/pong/findnode/neighbors)
@@ -737,7 +763,10 @@ Eight Gradle modules:
 - **myotis-evm** -- Hyperledger Besu EVM running against a SNAP-backed `StateOracle`. Powers ENS resolution, `eth_call`, and local gas estimation (`DefaultEvmExecutor.estimateGas` — intrinsic + EVM-metered + 15% safety buffer). Includes `CcipReadEvmExecutor` for ERC-3668 off-chain lookups and `PrefetchingEvmExecutor` (multi-hop speculative prefetch) to amortize SNAP round-trips.
 - **myotis-ens** -- ENS resolver (`EnsResolver`, `ReverseLookup`) using the Universal Resolver via the local EVM. Forward and reverse resolution, ENSIP-10 wildcards, ERC-3668 off-chain records.
 - **jsonrpc-server** -- host-agnostic verified JSON-RPC router (Kotlin/Ktor). `RpcRouter` maps the Ethereum API onto a `MyotisRpcBackend` interface that the Android `NodeService` implements against its connector + beacon state. Strict permissionless mode by default; binds loopback only. (Consumed by `android-app`; the daemon uses its own CLI/IPC surface instead.)
+- **rpc-backend** -- the verified RPC backend (`VerifiedRpcBackend`): anchored-head building, serve-stale policy, and the readiness probe (`verifiedHeadAgeMs`) shared by the JSON-RPC server and the hosts
+- **ui** -- shared Compose Multiplatform `NodeScreen` (status, readiness strip, peers, logs, settings) used by both apps
 - **app** -- daemon/CLI entry point, Unix domain socket IPC server, peer caching
+- **app-desktop** -- the Compose desktop GUI over `:ui`, packaged with jpackage (dmg/deb), bundling the Rust engine
 - **android-app** -- the Android wallet node (`NodeService` foreground service). Runs the full devp2p + libp2p stack, the local EVM, and the JSON-RPC server on-device, with Android-native peer/snapshot caching and a Compose UI; persists the sync snapshot, the known-state-root window, and light-client-capable peers for fast warm restarts (~10 s vs. a cold checkpoint bootstrap).
 
 ### Protocol flow

--- a/docs/readiness-and-verified-head-age.md
+++ b/docs/readiness-and-verified-head-age.md
@@ -113,7 +113,7 @@ than failing while a refresh is in flight:
   (`eth_getTransactionCount`), since a stale nonce breaks transaction signing.
 - **≤ ~12.8 min** — header-only last resort (e.g. `eth_blockNumber`,
   `eth_getBlockByNumber`), and the cap for state reads only if strict state
-  freshness is explicitly disabled (`myotis.rpc.strictStateFreshness=false`;
+  freshness is explicitly disabled (`-Dmyotis.rpc.strictStateFreshness=false`;
   Android exposes this as a Settings toggle, off by default).
 
 Beyond the applicable cap the node **refuses** (JSON-RPC `-32000`, IPC

--- a/docs/readiness-and-verified-head-age.md
+++ b/docs/readiness-and-verified-head-age.md
@@ -1,0 +1,172 @@
+# Readiness: when is the node synced and ready for queries?
+
+This document explains when a Myotis node considers itself **synced**, when it is
+actually **ready to answer queries with verified data**, and what the
+**"verified head age"** shown on the Status screen means. It applies to all three
+hosts (Android app, desktop app, daemon) and both engines (Java and Rust), with
+engine differences called out where they exist.
+
+## TL;DR — how to tell it's ready
+
+- **In the apps**: the readiness strip under a network's status card is **green**
+  ("ready for simple reads") or **bright green** ("fully ready — deep peer pool").
+- **On the daemon**: `./gradlew :app:run -Pargs=beacon-status` returns
+  `"state":"SYNCED"`, and a query such as `get-account` returns
+  `"verifyMethod":"headerChain"` (or `"stateRootMatch"`) instead of a `failReason`.
+- **Over JSON-RPC** (Android's loopback `127.0.0.1:8545`): requests return data
+  instead of error `-32000` ("can't be answered verified right now — retryable").
+
+Being *synced* is necessary but not sufficient: a node can be beacon-SYNCED and
+still unable to serve reads (e.g. no snap-serving peers yet). Readiness is the
+conjunction of three gates, described next.
+
+## The three readiness gates
+
+A verified read (balance, nonce, code, storage, `eth_call`, …) can only be served
+when all three of these hold:
+
+1. **Beacon light client is SYNCED** — the node holds a current sync-committee
+   and a recent *finalized* execution state root attested by ≥ 2/3 of the sync
+   committee. This is the trust anchor: every answer is ultimately verified
+   against it. Without it, queries fail with `failReason: "beaconNotSynced"`.
+
+2. **At least one snap-serving EL peer is connected** — account/storage data is
+   fetched as snap/1 Merkle-Patricia proofs from execution-layer peers. The
+   `snapPeers` count in `status` output shows this; the UI shows it as the
+   EL peers line.
+
+3. **A verified head context has been built** — the node has recently anchored a
+   peer-reported head block to the beacon-finalized block via a contiguous,
+   parent-hash-verified header chain. "Verified head age" (below) measures how
+   fresh this gate is; `readyForReads` requires it to be finite.
+
+The engine-internal check is exactly gates 1 + 3
+(`ChainStack.readyForReads()`: state == `SYNCED` **and**
+`verifiedHeadAgeMs != Long.MAX_VALUE`); gate 2 is implied because a head context
+cannot be built or refreshed without snap peers.
+
+## Beacon sync states
+
+The state reported by `beacon-status`, `myotis_beaconStatus`, and the UI:
+
+| State | Meaning |
+|---|---|
+| `STARTING` | The network handle exists but hasn't started syncing yet. |
+| `SYNCING` | No trust anchor yet: bootstrapping from the checkpoint, no finalized execution state root landed. Verified queries fail (`beaconNotSynced`). |
+| `CATCHING_UP` | Trust anchor present but not yet dependable: the light client is replaying sync-committee periods or hasn't accumulated enough recent finalized roots. |
+| `SYNCED` | Verification-ready: the sync committee is current and the finalized head is recent. **Not latched** — a node can regress to `CATCHING_UP` (e.g. after sleeping across a committee-period boundary) and come back. |
+
+The two engines use slightly different criteria for `SYNCED` (same contract,
+different heuristics):
+
+- **Java engine** (`BeaconSyncState.getSyncState`): SYNCED requires a finalized
+  execution state root, **≥ 4 known state roots** in the attested window (i.e. at
+  least two successful finality polls), and the tracked sync-committee period to
+  match the wall-clock period.
+- **Rust engine** (`sync.rs::publish_status`): SYNCED requires the store's
+  committee period to match the wall-clock period **and** the finalized slot to
+  be within **5 epochs** of the wall-clock slot (finality itself trails ~2
+  epochs). The Rust engine also has an internal `BOOTSTRAPPING` state, reported
+  to hosts as `SYNCING`.
+
+## What "verified head age" means
+
+Shown on the Status screen as **"Verified head age: N ms"** (or `—` when there is
+none yet), and carried in the engine API as `StatusSnapshot.verifiedHeadAgeMs`.
+
+It answers: *how stale is the head context that verified reads are currently
+served against?* A small value means answers reflect the chain as of a few
+seconds ago; `Long.MAX_VALUE` (displayed `—`) means no verified head has been
+built yet, so no state read can be served.
+
+The measurement differs per engine:
+
+- **Java engine**: milliseconds since the anchored RPC head context was last
+  successfully **rebuilt**. A background warmer rebuilds it every ~5 s while
+  peers cooperate, so a healthy node hovers in the low seconds. The clock is
+  monotonic (`System.nanoTime` / `SystemClock.elapsedRealtime`), so device sleep
+  or clock changes don't corrupt it.
+- **Rust engine**: milliseconds since the optimistic head **block number last
+  advanced** — a new block roughly every 12 s (mainnet) resets it to 0. If the
+  engine is not currently serveable (not SYNCED, no head, or no snap peers) it
+  reports `Long.MAX_VALUE`, and the timer restarts from 0 when serving resumes.
+
+In both cases: **fresh = ready, stale = warming up or wedged**. The shared UI
+draws the line at **45 s** (`READY_HEAD_WARM_MS`): beyond that the strip turns
+amber ("warming up, not ready to transact") even though the beacon side is
+SYNCED, because reads would be served from an aging head or refused.
+
+Note that head age is *not* the age of the latest block — it's the age of the
+node's last successful verification of a head. The chain keeps moving regardless;
+this number tells you whether the node is keeping up with it.
+
+### How stale is too stale? (serve behavior as the head ages)
+
+The Java RPC backend reuses and, within limits, serves a last-good head rather
+than failing while a refresh is in flight:
+
+- **≤ 12 s** — a built head is reused as-is across a burst of requests.
+- **≤ 30 s** — the last-good head is served while a rebuild runs in the background.
+- **≤ 120 s** — hard cap for *state* reads (balances, code, storage, `eth_call`,
+  gas estimates) in the default **strict** mode, and always the cap for nonces
+  (`eth_getTransactionCount`), since a stale nonce breaks transaction signing.
+- **≤ ~12.8 min** — header-only last resort (e.g. `eth_blockNumber`,
+  `eth_getBlockByNumber`), and the cap for state reads only if strict state
+  freshness is explicitly disabled (`myotis.rpc.strictStateFreshness=false`;
+  Android exposes this as a Settings toggle, off by default).
+
+Beyond the applicable cap the node **refuses** (JSON-RPC `-32000`, IPC
+`failReason`) rather than serving an unverifiable or misleading answer.
+
+## Where to observe readiness, per host
+
+### Android + desktop apps (shared UI)
+
+Each network card has a readiness strip, evaluated top-down:
+
+| Strip | Meaning |
+|---|---|
+| grey | sleeping (idle-paused) — an incoming request wakes it |
+| red | not running, or beacon not SYNCED |
+| amber | SYNCED but verified head age > 45 s — warming up, not ready to transact |
+| green | ready for simple reads |
+| bright green (thicker) | fully ready — deep snap-peer pool (≥ 16 serving peers by default) |
+
+The Android foreground notification condenses the same tiers into words:
+`sleeping` → `syncing` → `warming up` (SYNCED but no verified head yet) →
+`ready`, per network (e.g. "mainnet ready · gnosis syncing"). The Status screen
+additionally shows the raw "Verified head age" row, and a banner warns when the
+beacon side is unsynced (any values shown then are peer-claimed, not verified).
+
+### Daemon (IPC / CLI)
+
+```bash
+./gradlew :app:run -Pargs=beacon-status   # "state": "SYNCING" | "CATCHING_UP" | "SYNCED"
+./gradlew :app:run -Pargs=status          # lifecycle, peer counts incl. snapPeers
+./gradlew :app:run -Pargs="get-account 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+```
+
+`beacon-status` shows the sync state plus progress (`currentPeriod` /
+`targetPeriod` while catching up; `finalizedSlot`, `executionBlockNumber`,
+`knownStateRoots` once synced). A query response's `verification` object gives
+the definitive answer: `verifyMethod` (`headerChain` or `stateRootMatch`) on
+success, an ordered `failReason` token (`beaconNotSynced`, `noPeerStateRoot`,
+`headerChainGapTooLarge`, …) otherwise.
+
+### JSON-RPC (wallet-facing)
+
+`myotis_status` and `myotis_beaconStatus` mirror the IPC fields. Verified
+`eth_*` methods return `-32000` while any readiness gate is unmet — wallets
+should treat it as retryable.
+
+## Code pointers
+
+- Java sync states + criteria: `consensus/.../BeaconSyncState.java`
+- Rust sync states + criteria: `rust/myotis-net/src/sync.rs` (`publish_status`)
+- Head age (Java): `rpc-backend/.../VerifiedRpcBackend.java`
+  (`verifiedHeadAgeMs`, staleness constants `RPC_*_MS`)
+- Head age (Rust mapping): `myotis-engines/.../RustChainHandle.java` (`status()`)
+- Readiness gate: `node-core/.../ChainStack.java` (`readyForReads`)
+- UI strip + 45 s threshold: `ui/.../NodeScreen.kt` (`ReadinessStrip`, `READY_HEAD_WARM_MS`)
+- Verification ladder (verifyMethod/failReason): `node-core/.../VerifiedAccountQuery.java`,
+  `rust/myotis-net/src/el/verify.rs`

--- a/docs/readiness-and-verified-head-age.md
+++ b/docs/readiness-and-verified-head-age.md
@@ -14,7 +14,8 @@ engine differences called out where they exist.
   `"state":"SYNCED"`, and a query such as `get-account` returns
   `"verifyMethod":"headerChain"` (or `"stateRootMatch"`) instead of a `failReason`.
 - **Over JSON-RPC** (Android's loopback `127.0.0.1:8545`): requests return data
-  instead of error `-32000` ("can't be answered verified right now — retryable").
+  instead of error `-32000` (method cannot be served verified right now —
+  retryable).
 
 Being *synced* is necessary but not sufficient: a node can be beacon-SYNCED and
 still unable to serve reads (e.g. no snap-serving peers yet). Readiness is the
@@ -40,8 +41,8 @@ when all three of these hold:
    parent-hash-verified header chain. "Verified head age" (below) measures how
    fresh this gate is; `readyForReads` requires it to be finite.
 
-The engine-internal check is exactly gates 1 + 3
-(`ChainStack.readyForReads()`: state == `SYNCED` **and**
+The engine-internal check is gates 1 + 3, plus the stack actually running
+(`ChainStack.readyForReads()`: stack `RUNNING`, state == `SYNCED`, **and**
 `verifiedHeadAgeMs != Long.MAX_VALUE`); gate 2 is implied because a head context
 cannot be built or refreshed without snap peers.
 


### PR DESCRIPTION
## What

**New [docs/readiness-and-verified-head-age.md](https://github.com/biafra23/myotis/blob/docs/readiness-and-head-age/docs/readiness-and-verified-head-age.md)** — explains, for all three hosts and both engines:
- when the node counts as **synced** (beacon sync states and the per-engine `SYNCED` criteria: Java's known-roots window vs Rust's 5-epoch slot slack),
- when it is actually **ready to receive queries** (the three readiness gates: beacon SYNCED, snap peers, a built verified head),
- what **"verified head age"** means (per-engine measurement, the 45 s warm threshold, the serve-stale ladder: 12 s / 30 s / 120 s / ~12.8 min caps),
- where to observe readiness in each host (UI strip, Android notification words, IPC/CLI, JSON-RPC).

Linked from the README's Documentation section.

**README Rust-engine refresh** (also requested):
- intro paragraph introducing the two interchangeable engines,
- new "Engines: Java and Rust" section (API contract, selector + `myotis.engine`/`-Pengine`, Rust workspace scope, parity via conformance vectors, cargo tasks),
- corrected the stale claim that packaged desktop builds ship only the Java engine (they bundle the Rust engine fail-loud since #212),
- Architecture module list updated with the missing engine/host modules (`myotis-api`, `myotis-engines`, `node-core`, `rpc-backend`, `ui`, `app-desktop`) and no longer claims "Eight Gradle modules".

## Review

An independent no-context review verified the doc's claims against the source (all constants, state-machine criteria, and README claims checked out); its two nits (readyForReads also requires RUNNING; -32000 message gloss) are addressed in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CeXnyL7k1Dp68PcRwcade