### PR TITLE
fix: persist desktop settings across restarts (engine choice, networks, ports, knobs)

### DIFF
--- a/app-desktop/build.gradle.kts
+++ b/app-desktop/build.gradle.kts
@@ -69,6 +69,19 @@ dependencies {
     // implementation (not runtimeOnly): DesktopLogAppender compiles against logback's
     // AppenderBase/ILoggingEvent to tee logs into the in-app Logs tab's in-memory ring.
     implementation(libs.logback.classic)
+
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.junit.jupiter)
+    // The Compose plugin drags an older junit-platform-launcher onto the test runtime
+    // classpath; pin the bom-aligned one or the jupiter engine fails discovery
+    // ("OutputDirectoryProvider not available … unaligned versions").
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+// This module skips the root `java`-plugin conventions (Compose brings its own plugins),
+// so wire the JUnit platform here like :app does.
+tasks.withType<Test> {
+    useJUnitPlatform()
 }
 
 // Headless check that the Desktop controller drives node-core (no display needed).

--- a/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
@@ -371,6 +371,12 @@ class DesktopSettings(
     // The Rust engine is experimental — off by default everywhere.
     private var rustEngine = false
 
+    /** Serializes file writes, separate from the state lock (`this`) so settings
+     *  readers never wait on disk I/O. */
+    private val ioLock = Any()
+    private var stateSeq = 0L   // guarded by `this`
+    private var writtenSeq = 0L // guarded by [ioLock]
+
     init {
         load()
     }
@@ -381,36 +387,34 @@ class DesktopSettings(
     override fun primaryNetwork(): String = synchronized(this) { enabled.firstOrNull() ?: "mainnet" }
     override fun allNetworks(): List<String> = networks.map { it.name() }
     override fun isNetworkEnabled(name: String): Boolean = synchronized(this) { name in enabled }
-    override fun setNetworkEnabled(name: String, on: Boolean) = synchronized(this) {
+    override fun setNetworkEnabled(name: String, on: Boolean) = mutate {
         if (on) enabled.add(name) else enabled.remove(name)
-        persist()
     }
     override fun rpcPortFor(network: String): Int = synchronized(this) {
         ports[network] ?: defaultRpcPort(network)
     }
-    override fun setRpcPort(network: String, port: Int) = synchronized(this) {
+    override fun setRpcPort(network: String, port: Int) = mutate {
         // Clamp to the valid TCP range, falling back to the network default on out-of-range
         // input (parity with Android's NodeService.setRpcPort).
         ports[network] = if (port in 1024..65535) port else defaultRpcPort(network)
-        persist()
     }
     override fun snapTarget(): Int = synchronized(this) { snap }
     // Clamp like Android's NodeService (1..128) so the live value and the reloaded
     // value can't differ (load() applies the same clamp).
-    override fun setSnapTarget(v: Int) = synchronized(this) { snap = v.coerceIn(1, 128); persist() }
+    override fun setSnapTarget(v: Int) = mutate { snap = v.coerceIn(1, 128) }
 
     override fun displayName(network: String): String = info(network)?.displayName() ?: network
     override fun defaultRpcPort(network: String): Int = info(network)?.defaultRpcPort() ?: 8545
     override fun hasEns(network: String): Boolean = info(network)?.hasEns() ?: false
 
     override fun deepPoolThreshold(): Int = synchronized(this) { deep }
-    override fun setDeepPool(v: Int) = synchronized(this) { deep = v.coerceIn(1, 128); persist() }
+    override fun setDeepPool(v: Int) = mutate { deep = v.coerceIn(1, 128) }
     override fun strictStateFreshness(): Boolean = synchronized(this) { strict }
-    override fun setStrictStateFreshness(v: Boolean) = synchronized(this) { strict = v; persist() }
+    override fun setStrictStateFreshness(v: Boolean) = mutate { strict = v }
     override fun nativeBlsEnabled(): Boolean = synchronized(this) { nativeBls }
-    override fun setNativeBlsEnabled(v: Boolean) = synchronized(this) { nativeBls = v; persist() }
+    override fun setNativeBlsEnabled(v: Boolean) = mutate { nativeBls = v }
     override fun rustEngineEnabled(): Boolean = synchronized(this) { rustEngine }
-    override fun setRustEngineEnabled(v: Boolean) = synchronized(this) { rustEngine = v; persist() }
+    override fun setRustEngineEnabled(v: Boolean) = mutate { rustEngine = v }
 
     /** Best-effort load; a missing or unreadable file just keeps the defaults. */
     private fun load() {
@@ -437,30 +441,63 @@ class DesktopSettings(
         p.getProperty(K_RUST_ENGINE)?.toBooleanStrictOrNull()?.let { rustEngine = it }
     }
 
-    /** Best-effort rewrite; called under `this`. Writes temp + atomic move so a crash
-     *  mid-write can't leave a truncated file; failures are logged (a silently
-     *  unwritable settings file would look exactly like the bug this class fixes). */
-    private fun persist() {
-        val f = file ?: return
-        runCatching {
-            f.parent?.let(Files::createDirectories)
-            val p = java.util.Properties()
-            p.setProperty(K_ENABLED, enabled.joinToString(","))
-            ports.forEach { (net, port) -> p.setProperty("$K_RPC_PORT_PREFIX$net", port.toString()) }
-            p.setProperty(K_SNAP, snap.toString())
-            p.setProperty(K_DEEP, deep.toString())
-            p.setProperty(K_STRICT, strict.toString())
-            p.setProperty(K_NATIVE_BLS, nativeBls.toString())
-            p.setProperty(K_RUST_ENGINE, rustEngine.toString())
-            val tmp = f.resolveSibling("${f.fileName}.tmp")
-            Files.newOutputStream(tmp).use { p.store(it, "Myotis desktop settings") }
-            try {
-                Files.move(tmp, f, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE)
-            } catch (_: AtomicMoveNotSupportedException) {
-                Files.move(tmp, f, StandardCopyOption.REPLACE_EXISTING)
+    /**
+     * Apply [change] under the state lock, snapshot the state, then write the snapshot
+     * to disk OUTSIDE that lock — settings readers (UI thread included) never wait on
+     * disk I/O. The write stays synchronous on the calling thread (it's a ~200-byte
+     * file written only when the user flips a Settings control, and a synchronous
+     * write keeps restart-persistence deterministically testable); [ioLock] serializes
+     * concurrent writers and the sequence number drops a stale snapshot that lost the
+     * race to a newer one.
+     */
+    private fun mutate(change: () -> Unit) {
+        val f = file
+        if (f == null) {
+            synchronized(this) { change() }
+            return
+        }
+        val p: java.util.Properties
+        val seq: Long
+        synchronized(this) {
+            change()
+            p = snapshot()
+            seq = ++stateSeq
+        }
+        persist(f, p, seq)
+    }
+
+    /** Snapshot the state as Properties; must be called under the state lock. */
+    private fun snapshot(): java.util.Properties {
+        val p = java.util.Properties()
+        p.setProperty(K_ENABLED, enabled.joinToString(","))
+        ports.forEach { (net, port) -> p.setProperty("$K_RPC_PORT_PREFIX$net", port.toString()) }
+        p.setProperty(K_SNAP, snap.toString())
+        p.setProperty(K_DEEP, deep.toString())
+        p.setProperty(K_STRICT, strict.toString())
+        p.setProperty(K_NATIVE_BLS, nativeBls.toString())
+        p.setProperty(K_RUST_ENGINE, rustEngine.toString())
+        return p
+    }
+
+    /** Best-effort rewrite. Writes temp + atomic move so a crash mid-write can't leave
+     *  a truncated file; failures are logged (a silently unwritable settings file would
+     *  look exactly like the bug this class fixes). */
+    private fun persist(f: Path, p: java.util.Properties, seq: Long) {
+        synchronized(ioLock) {
+            if (seq <= writtenSeq) return // a newer snapshot already landed
+            writtenSeq = seq
+            runCatching {
+                f.parent?.let(Files::createDirectories)
+                val tmp = f.resolveSibling("${f.fileName}.tmp")
+                Files.newOutputStream(tmp).use { p.store(it, "Myotis desktop settings") }
+                try {
+                    Files.move(tmp, f, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE)
+                } catch (_: AtomicMoveNotSupportedException) {
+                    Files.move(tmp, f, StandardCopyOption.REPLACE_EXISTING)
+                }
+            }.onFailure {
+                log.warn("settings not persisted to {}: {}", f, it.toString())
             }
-        }.onFailure {
-            log.warn("settings not persisted to {}: {}", f, it.toString())
         }
     }
 

--- a/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.withContext
+import java.nio.file.Files
 import java.nio.file.Path
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.io.path.createDirectories
@@ -342,13 +343,20 @@ class DesktopNodeController(
 }
 
 /**
- * Minimal in-memory desktop settings (Step 1). File-backed persistence is a follow-up.
+ * Desktop settings, file-backed so every toggle survives an app restart (Android parity —
+ * there SharedPreferences does this for free). [file] is a java.util.Properties file under
+ * the app data dir (`~/.myotis/settings.properties`); null keeps the store in-memory
+ * (tests, syncSmoke). Loaded once at construction; every setter rewrites the file.
+ * Unknown keys and unparsable values fall back to the defaults, so a hand-edited or
+ * older-version file can't break boot.
+ *
  * Network metadata comes from the engine's [NetworkInfo] catalog — no engine-internal
  * config types. Read/written from both the UI thread and the boot threads, so every
  * access is guarded by `synchronized(this)` over the non-thread-safe backing collections.
  */
 class DesktopSettings(
     private val networks: List<NetworkInfo> = Engines.engine().availableNetworks(),
+    private val file: Path? = null,
 ) : Settings {
     private val enabled = linkedSetOf("mainnet")
     private val ports = HashMap<String, Int>()
@@ -358,8 +366,12 @@ class DesktopSettings(
     // Desktop has no bundled native blst yet (Milagro-only), so the honest default is off; the
     // toggle persists but DesktopNodeController.applyBlsBackend() is a no-op until the dylib ships.
     private var nativeBls = false
-    // The Rust engine is experimental (catalog-only today) — off by default everywhere.
+    // The Rust engine is experimental — off by default everywhere.
     private var rustEngine = false
+
+    init {
+        load()
+    }
 
     private fun info(network: String): NetworkInfo? = networks.firstOrNull { it.name() == network }
 
@@ -369,7 +381,7 @@ class DesktopSettings(
     override fun isNetworkEnabled(name: String): Boolean = synchronized(this) { name in enabled }
     override fun setNetworkEnabled(name: String, on: Boolean) = synchronized(this) {
         if (on) enabled.add(name) else enabled.remove(name)
-        Unit
+        persist()
     }
     override fun rpcPortFor(network: String): Int = synchronized(this) {
         ports[network] ?: defaultRpcPort(network)
@@ -378,23 +390,75 @@ class DesktopSettings(
         // Clamp to the valid TCP range, falling back to the network default on out-of-range
         // input (parity with Android's NodeService.setRpcPort).
         ports[network] = if (port in 1024..65535) port else defaultRpcPort(network)
-        Unit
+        persist()
     }
     override fun snapTarget(): Int = synchronized(this) { snap }
-    override fun setSnapTarget(v: Int) = synchronized(this) { snap = v }
+    override fun setSnapTarget(v: Int) = synchronized(this) { snap = v; persist() }
 
     override fun displayName(network: String): String = info(network)?.displayName() ?: network
     override fun defaultRpcPort(network: String): Int = info(network)?.defaultRpcPort() ?: 8545
     override fun hasEns(network: String): Boolean = info(network)?.hasEns() ?: false
 
     override fun deepPoolThreshold(): Int = synchronized(this) { deep }
-    override fun setDeepPool(v: Int) = synchronized(this) { deep = v }
+    override fun setDeepPool(v: Int) = synchronized(this) { deep = v; persist() }
     override fun strictStateFreshness(): Boolean = synchronized(this) { strict }
-    override fun setStrictStateFreshness(v: Boolean) = synchronized(this) { strict = v }
+    override fun setStrictStateFreshness(v: Boolean) = synchronized(this) { strict = v; persist() }
     override fun nativeBlsEnabled(): Boolean = synchronized(this) { nativeBls }
-    override fun setNativeBlsEnabled(v: Boolean) = synchronized(this) { nativeBls = v }
+    override fun setNativeBlsEnabled(v: Boolean) = synchronized(this) { nativeBls = v; persist() }
     override fun rustEngineEnabled(): Boolean = synchronized(this) { rustEngine }
-    override fun setRustEngineEnabled(v: Boolean) = synchronized(this) { rustEngine = v }
+    override fun setRustEngineEnabled(v: Boolean) = synchronized(this) { rustEngine = v; persist() }
+
+    /** Best-effort load; a missing or unreadable file just keeps the defaults. */
+    private fun load() {
+        val f = file ?: return
+        if (!Files.exists(f)) return
+        val p = java.util.Properties()
+        if (runCatching { Files.newInputStream(f).use(p::load) }.isFailure) return
+        p.getProperty(K_ENABLED)?.let { csv ->
+            // Key present = the user's explicit set (possibly empty). Unknown names are
+            // dropped so a stale/hand-edited entry can't feed startNetwork() a bad name.
+            enabled.clear()
+            csv.split(',').map(String::trim).filter { it.isNotEmpty() && info(it) != null }
+                .forEach(enabled::add)
+        }
+        networks.forEach { n ->
+            p.getProperty("$K_RPC_PORT_PREFIX${n.name()}")?.toIntOrNull()
+                ?.takeIf { it in 1024..65535 }
+                ?.let { ports[n.name()] = it }
+        }
+        p.getProperty(K_SNAP)?.toIntOrNull()?.let { snap = it.coerceIn(1, 128) }
+        p.getProperty(K_DEEP)?.toIntOrNull()?.let { deep = it.coerceIn(1, 128) }
+        p.getProperty(K_STRICT)?.toBooleanStrictOrNull()?.let { strict = it }
+        p.getProperty(K_NATIVE_BLS)?.toBooleanStrictOrNull()?.let { nativeBls = it }
+        p.getProperty(K_RUST_ENGINE)?.toBooleanStrictOrNull()?.let { rustEngine = it }
+    }
+
+    /** Best-effort rewrite (same idiom as [DesktopQueryHistory]); called under `this`. */
+    private fun persist() {
+        val f = file ?: return
+        runCatching {
+            f.parent?.let(Files::createDirectories)
+            val p = java.util.Properties()
+            p.setProperty(K_ENABLED, enabled.joinToString(","))
+            ports.forEach { (net, port) -> p.setProperty("$K_RPC_PORT_PREFIX$net", port.toString()) }
+            p.setProperty(K_SNAP, snap.toString())
+            p.setProperty(K_DEEP, deep.toString())
+            p.setProperty(K_STRICT, strict.toString())
+            p.setProperty(K_NATIVE_BLS, nativeBls.toString())
+            p.setProperty(K_RUST_ENGINE, rustEngine.toString())
+            Files.newOutputStream(f).use { p.store(it, "Myotis desktop settings") }
+        }
+    }
+
+    private companion object {
+        const val K_ENABLED = "networks.enabled"
+        const val K_RPC_PORT_PREFIX = "rpcPort."
+        const val K_SNAP = "snapTarget"
+        const val K_DEEP = "deepPool"
+        const val K_STRICT = "strictStateFreshness"
+        const val K_NATIVE_BLS = "nativeBls"
+        const val K_RUST_ENGINE = "rustEngine"
+    }
 }
 
 /** Desktop is treated as always-online (no Android ConnectivityManager). */

--- a/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
@@ -27,8 +27,10 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.withContext
+import java.nio.file.AtomicMoveNotSupportedException
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.StandardCopyOption
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.io.path.createDirectories
 
@@ -393,14 +395,16 @@ class DesktopSettings(
         persist()
     }
     override fun snapTarget(): Int = synchronized(this) { snap }
-    override fun setSnapTarget(v: Int) = synchronized(this) { snap = v; persist() }
+    // Clamp like Android's NodeService (1..128) so the live value and the reloaded
+    // value can't differ (load() applies the same clamp).
+    override fun setSnapTarget(v: Int) = synchronized(this) { snap = v.coerceIn(1, 128); persist() }
 
     override fun displayName(network: String): String = info(network)?.displayName() ?: network
     override fun defaultRpcPort(network: String): Int = info(network)?.defaultRpcPort() ?: 8545
     override fun hasEns(network: String): Boolean = info(network)?.hasEns() ?: false
 
     override fun deepPoolThreshold(): Int = synchronized(this) { deep }
-    override fun setDeepPool(v: Int) = synchronized(this) { deep = v; persist() }
+    override fun setDeepPool(v: Int) = synchronized(this) { deep = v.coerceIn(1, 128); persist() }
     override fun strictStateFreshness(): Boolean = synchronized(this) { strict }
     override fun setStrictStateFreshness(v: Boolean) = synchronized(this) { strict = v; persist() }
     override fun nativeBlsEnabled(): Boolean = synchronized(this) { nativeBls }
@@ -433,7 +437,9 @@ class DesktopSettings(
         p.getProperty(K_RUST_ENGINE)?.toBooleanStrictOrNull()?.let { rustEngine = it }
     }
 
-    /** Best-effort rewrite (same idiom as [DesktopQueryHistory]); called under `this`. */
+    /** Best-effort rewrite; called under `this`. Writes temp + atomic move so a crash
+     *  mid-write can't leave a truncated file; failures are logged (a silently
+     *  unwritable settings file would look exactly like the bug this class fixes). */
     private fun persist() {
         val f = file ?: return
         runCatching {
@@ -446,11 +452,20 @@ class DesktopSettings(
             p.setProperty(K_STRICT, strict.toString())
             p.setProperty(K_NATIVE_BLS, nativeBls.toString())
             p.setProperty(K_RUST_ENGINE, rustEngine.toString())
-            Files.newOutputStream(f).use { p.store(it, "Myotis desktop settings") }
+            val tmp = f.resolveSibling("${f.fileName}.tmp")
+            Files.newOutputStream(tmp).use { p.store(it, "Myotis desktop settings") }
+            try {
+                Files.move(tmp, f, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE)
+            } catch (_: AtomicMoveNotSupportedException) {
+                Files.move(tmp, f, StandardCopyOption.REPLACE_EXISTING)
+            }
+        }.onFailure {
+            log.warn("settings not persisted to {}: {}", f, it.toString())
         }
     }
 
     private companion object {
+        val log: org.slf4j.Logger = org.slf4j.LoggerFactory.getLogger(DesktopSettings::class.java)
         const val K_ENABLED = "networks.enabled"
         const val K_RPC_PORT_PREFIX = "rpcPort."
         const val K_SNAP = "snapTarget"

--- a/app-desktop/src/main/kotlin/io/myotis/desktop/Main.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/Main.kt
@@ -33,8 +33,12 @@ fun main() {
     }
     val dataDir = Path.of(System.getProperty("user.home"), ".myotis")
     // settings first: the controller reads it at boot (configured RPC port + snap target).
-    val settings = DesktopSettings()
+    val settings = DesktopSettings(file = dataDir.resolve("settings.properties"))
     val controller = DesktopNodeController(dataDir, settings)
+    // Apply the persisted engine choice BEFORE the first network start, so a saved
+    // Rust-engine preference survives a restart (Android parity: NodeService applies
+    // it at service start). Networks keep the engine that created them.
+    controller.applyEngineChoice()
     val history = DesktopQueryHistory(dataDir.resolve("query-history.tsv"))
     settings.enabledNetworks().forEach(controller::startNetwork)
 

--- a/app-desktop/src/main/kotlin/io/myotis/desktop/Main.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/Main.kt
@@ -37,8 +37,12 @@ fun main() {
     val controller = DesktopNodeController(dataDir, settings)
     // Apply the persisted engine choice BEFORE the first network start, so a saved
     // Rust-engine preference survives a restart (Android parity: NodeService applies
-    // it at service start). Networks keep the engine that created them.
-    controller.applyEngineChoice()
+    // it at service start). Networks keep the engine that created them. An explicit
+    // -Dmyotis.engine (the `-Pengine=…` dev knob) wins over the persisted toggle —
+    // Engines seeded its choice from it, so don't stomp it here.
+    if (System.getProperty(io.myotis.engines.Engines.PROP) == null) {
+        controller.applyEngineChoice()
+    }
     val history = DesktopQueryHistory(dataDir.resolve("query-history.tsv"))
     settings.enabledNetworks().forEach(controller::startNetwork)
 

--- a/app-desktop/src/test/kotlin/io/myotis/desktop/DesktopSettingsPersistenceTest.kt
+++ b/app-desktop/src/test/kotlin/io/myotis/desktop/DesktopSettingsPersistenceTest.kt
@@ -1,0 +1,101 @@
+package io.myotis.desktop
+
+import io.myotis.api.NetworkInfo
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * DesktopSettings must survive an app restart (a fresh instance over the same file) —
+ * the engine choice and enabled networks in particular, which used to be in-memory only.
+ */
+class DesktopSettingsPersistenceTest {
+
+    private val nets = listOf(
+        NetworkInfo("mainnet", "Ethereum Mainnet", 1, true, 30303, 9000, 8545, 1606824023, 12),
+        NetworkInfo("gnosis", "Gnosis Chain", 100, false, 30303, 9000, 8547, 1638993340, 5),
+    )
+
+    @Test
+    fun `every setting round-trips across a restart`(@TempDir dir: Path) {
+        val file = dir.resolve("settings.properties")
+        val first = DesktopSettings(nets, file)
+        first.setRustEngineEnabled(true)
+        first.setNetworkEnabled("gnosis", true)
+        first.setNetworkEnabled("mainnet", false)
+        first.setRpcPort("gnosis", 9999)
+        first.setSnapTarget(48)
+        first.setDeepPool(8)
+        first.setStrictStateFreshness(false)
+        first.setNativeBlsEnabled(true)
+
+        // Fresh instance over the same file = app restart.
+        val second = DesktopSettings(nets, file)
+        assertTrue(second.rustEngineEnabled(), "engine choice must be sticky")
+        assertEquals(listOf("gnosis"), second.enabledNetworks(), "network selection must be sticky")
+        assertFalse(second.isNetworkEnabled("mainnet"))
+        assertEquals(9999, second.rpcPortFor("gnosis"))
+        assertEquals(48, second.snapTarget())
+        assertEquals(8, second.deepPoolThreshold())
+        assertFalse(second.strictStateFreshness())
+        assertTrue(second.nativeBlsEnabled())
+    }
+
+    @Test
+    fun `all networks disabled persists as the empty set, not the default`(@TempDir dir: Path) {
+        val file = dir.resolve("settings.properties")
+        DesktopSettings(nets, file).setNetworkEnabled("mainnet", false)
+        val reloaded = DesktopSettings(nets, file)
+        assertEquals(emptyList<String>(), reloaded.enabledNetworks())
+    }
+
+    @Test
+    fun `missing file keeps the defaults`(@TempDir dir: Path) {
+        val s = DesktopSettings(nets, dir.resolve("does-not-exist.properties"))
+        assertEquals(listOf("mainnet"), s.enabledNetworks())
+        assertFalse(s.rustEngineEnabled())
+        assertTrue(s.strictStateFreshness())
+        assertEquals(32, s.snapTarget())
+        assertEquals(16, s.deepPoolThreshold())
+    }
+
+    @Test
+    fun `garbage values fall back to defaults instead of breaking boot`(@TempDir dir: Path) {
+        val file = dir.resolve("settings.properties")
+        Files.writeString(
+            file,
+            """
+            networks.enabled=gnosis,holesky, ,mainnet
+            rpcPort.gnosis=99
+            rpcPort.mainnet=not-a-number
+            snapTarget=100000
+            deepPool=zero
+            rustEngine=yes-please
+            strictStateFreshness=false
+            """.trimIndent(),
+        )
+        val s = DesktopSettings(nets, file)
+        // Unknown ("holesky") and blank names dropped; known ones kept.
+        assertEquals(listOf("gnosis", "mainnet"), s.enabledNetworks())
+        // Out-of-range / unparsable ports ignored → network default.
+        assertEquals(8547, s.rpcPortFor("gnosis"))
+        assertEquals(8545, s.rpcPortFor("mainnet"))
+        // Ints clamped, bad bools fall back to their defaults, good ones apply.
+        assertEquals(128, s.snapTarget())
+        assertEquals(16, s.deepPoolThreshold())
+        assertFalse(s.rustEngineEnabled())
+        assertFalse(s.strictStateFreshness())
+    }
+
+    @Test
+    fun `null file keeps the store in-memory`(@TempDir dir: Path) {
+        val s = DesktopSettings(nets, null)
+        s.setRustEngineEnabled(true)
+        assertTrue(s.rustEngineEnabled())
+        assertEquals(0, Files.list(dir).count(), "no file must be written")
+    }
+}

--- a/app-desktop/src/test/kotlin/io/myotis/desktop/DesktopSettingsPersistenceTest.kt
+++ b/app-desktop/src/test/kotlin/io/myotis/desktop/DesktopSettingsPersistenceTest.kt
@@ -96,6 +96,6 @@ class DesktopSettingsPersistenceTest {
         val s = DesktopSettings(nets, null)
         s.setRustEngineEnabled(true)
         assertTrue(s.rustEngineEnabled())
-        assertEquals(0, Files.list(dir).count(), "no file must be written")
+        assertEquals(0, Files.list(dir).use { it.count() }, "no file must be written")
     }
 }


### PR DESCRIPTION
## Problem

The engine selection and network enable/disable switches on the desktop app reset on every restart — as did every other Settings value. `DesktopSettings` was explicitly in-memory ("Step 1 … file-backed persistence is a follow-up"), and even with persistence, the boot path never re-applied the saved engine choice.

## Fix

- **`DesktopSettings` is now file-backed** (`~/.myotis/settings.properties`, plain `java.util.Properties`): loaded at construction, rewritten atomically (temp + `ATOMIC_MOVE`) on every setter, failures logged. Persists enabled networks (including an explicit empty set), per-network RPC ports, snap target, deep-pool threshold, strict state freshness, native BLS, and the Rust-engine toggle. Unknown network names and unparsable values fall back to defaults, so a stale or hand-edited file can't break boot.
- **`Main.kt` applies the persisted engine choice before the first network start** (Android parity — `NodeService` does this at service start). An explicit `-Dmyotis.engine` / `-Pengine` dev flag still wins: the boot-time apply is skipped when the property is set, since `Engines` already seeded from it.
- **Setter clamps** for snap target / deep pool (1..128, Android parity) so the live value can't differ from the reloaded one.
- `SyncSmoke` and tests keep the in-memory store (`file = null`).

## Tests

First unit tests for `:app-desktop` (JUnit wiring added; the Compose plugin drags a misaligned `junit-platform-launcher` onto the test runtime, pinned via the BOM): restart round-trip of every setting, explicit empty network set vs missing file, garbage-file fallbacks, in-memory mode. 5/5 pass.

An independent no-context review ran before this PR; its findings (the `-Pengine` override interaction, setter clamps, atomic/logged persist) are addressed in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CeXnyL7k1Dp68PcRwcade