### PR TITLE
Uptime restarts from zero on each engine start (per-network, both hosts)

### DIFF
--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -1499,14 +1499,18 @@ public final class NodeService extends Service {
             LogBuffer.i(TAG, "[" + n + "] node stack started (RPC " + rpcPort + ")");
         } catch (Exception e) {
             LogBuffer.e(TAG, "[" + n + "] node boot failed", e);
-            forgetStack(n);
-            // Tear down only the instance THIS boot created, under the lock, and only
-            // while it is still the registered one — after we dropped the lock a racing
-            // enable may have registered a fresh healthy instance that must not be
-            // stopped by our failure cleanup.
-            if (created != null) {
-                synchronized (bootLock(n)) {
-                    if (ENGINE.get(n) == created) {
+            // Clean up ONLY this attempt's state, under the lock. The exception released
+            // the bootLock, so a racing enable may already have registered a fresh healthy
+            // instance — an unconditional forgetStack here would wipe that instance's
+            // handle + stamps (and before the lock was even taken, an early throw would
+            // wipe a previous healthy run's bookkeeping). Tear down iff the registered
+            // handle is still OURS, or nothing is registered (then only stale cache/count
+            // bookkeeping from this attempt can remain).
+            synchronized (bootLock(n)) {
+                ChainHandle current = handles.get(n);
+                if (created != null ? current == created : current == null) {
+                    forgetStack(n);
+                    if (created != null && ENGINE.get(n) == created) {
                         try { ENGINE.stop(n); } catch (Throwable ignored) {}
                     }
                 }

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -566,10 +566,6 @@ public final class NodeService extends Service {
         return BOOT_LOCKS.computeIfAbsent(canonicalNetwork(network), k -> new Object());
     }
 
-    // Service-global uptime stamp (the whole service, not a single chain). Owned by the
-    // next start; never cleared in doShutdown — see the PR #82 note there.
-    private volatile long startTimeMs;
-
     // ---------------------------------------------------------------------
     // Idle sleep controller: pause a stack's networking after idlePauseMinutes
     // of no RPC / UI activity. The engine self-wakes on an incoming JSON-RPC
@@ -1066,7 +1062,9 @@ public final class NodeService extends Service {
             String lifecycle,         // "RUNNING" | "PAUSED" | "STOPPED" — PAUSED is the
                                       // idle sleep state: networking off, RPC listening,
                                       // warm state retained, first request wakes it
-            long startTimeMs,
+            long startTimeMs,         // start stamp of THIS network's stack (per engine
+                                      // start; resets on every network/engine reboot),
+                                      // 0 when the stack isn't live — drives the UI uptime
             int discoveredPeers,
             int connectedPeers,
             int readyPeers,
@@ -1352,7 +1350,6 @@ public final class NodeService extends Service {
             LogBuffer.i(TAG, "start requested but node is already running");
             return START_NOT_STICKY;
         }
-        startTimeMs = System.currentTimeMillis();
         // Failure forensics: report how the PREVIOUS process died (OOM-kill vs crash
         // vs clean), then start the health heartbeat. This is what makes an on-device
         // sync failure diagnosable instead of a silent "it doesn't work".
@@ -1471,6 +1468,13 @@ public final class NodeService extends Service {
 
                 ChainHandle handle = ENGINE.create(config, ports);
                 created = handle;
+                // Drop the previous run's start stamps BEFORE publishing the handle: the
+                // UI poll renders a snapshot as soon as handles has an entry, and start()
+                // below blocks for seconds — a stale stamp would show the old run's
+                // uptime (plus downtime) until the fresh stamp lands. Removed-then-
+                // restamped, a mid-boot snapshot reads 0s instead.
+                stackStartMs.remove(n);
+                stackStartNano.remove(n);
                 handles.put(n, handle);
                 if (!handle.start()) {
                     LogBuffer.e(TAG, "[" + n + "] node stack failed to start");
@@ -1484,11 +1488,13 @@ public final class NodeService extends Service {
                     try { ENGINE.stop(n); } catch (Throwable ignored) {}
                     return;
                 }
+                // A freshly-booted stack gets a full idle window before the controller
+                // may pause it (its engine activity clock starts at 0). Stamped INSIDE the
+                // bootLock: written outside it, a racing stopNetwork's forgetStack could
+                // remove the stamp first and have this put leak it back for a dead network.
+                stackStartMs.put(n, System.currentTimeMillis());
+                stackStartNano.put(n, System.nanoTime());   // monotonic clock for the sync-run ceiling
             }
-            // A freshly-booted stack gets a full idle window before the controller
-            // may pause it (its engine activity clock starts at 0).
-            stackStartMs.put(n, System.currentTimeMillis());
-            stackStartNano.put(n, System.nanoTime());   // monotonic clock for the sync-run ceiling
             updateNotification();
             LogBuffer.i(TAG, "[" + n + "] node stack started (RPC " + rpcPort + ")");
         } catch (Exception e) {
@@ -1603,16 +1609,15 @@ public final class NodeService extends Service {
         cachedClCounts.clear();
         elCaches.clear();
         clCaches.clear();
-        // Safe to clear (unlike startTimeMs below): a Stop->Start just re-runs the SYNCED-once
-        // gate until the restarted stack re-observes SYNCED — fast off the warm store, no freeze.
+        // Safe to clear: a Stop->Start just re-runs the SYNCED-once gate until the restarted
+        // stack re-observes SYNCED — fast off the warm store, no freeze. stackStartMs is
+        // deliberately NOT cleared here (it's static, per-network, and owned by boots): a
+        // whole-service stop may leave stale entries, but they're invisible — handles was
+        // cleared above so no snapshot is rendered — and the next boot of each network
+        // removes its stamp before publishing the handle, then re-stamps after start()
+        // succeeds. Clearing here would race a quick Stop->Start's fresh boot (the old
+        // service-global startTimeMs had exactly that clobber bug).
         reachedSynced.clear();
-        // NB: do NOT clear startTimeMs here. doShutdown() runs on a worker thread and its
-        // teardown takes seconds; a quick Stop -> Start has onStartCommand() flip RUNNING back
-        // to true and stamp a fresh startTimeMs while we're still mid-teardown (buildAndStart's
-        // ChainStack.start blocks on the synchronized monitor we hold). Writing startTimeMs = 0L
-        // here would clobber that fresh stamp, and since the UI shows the uptime row whenever
-        // running==true, uptime would jump to now - 0 (~epoch millis) and freeze. startTimeMs is
-        // owned by the next start (onStartCommand stamps it); leaving the old value is harmless.
         LogBuffer.i(TAG, "node shutdown complete");
     }
 
@@ -1703,6 +1708,13 @@ public final class NodeService extends Service {
      *  the string this UI has always shown pre-beacon). */
     private Snapshot snapshotOf(String network, ChainHandle h) {
         boolean running = RUNNING.get();
+        // Uptime is per-ENGINE-START, not per-service-start: stackStartMs is removed when a
+        // fresh boot publishes its handle and re-stamped once its start() succeeds (and
+        // removed again on per-network teardown), so a network restart — including an
+        // engine-toggle reboot — restarts the UI's uptime counter from zero, reading 0s
+        // while the new stack is still starting. A service-global stamp would keep
+        // counting across chain restarts.
+        long chainStartMs = stackStartMs.getOrDefault(network, 0L);
         StatusSnapshot s = h.status();
         BeaconStatus bs = h.beaconStatus();
         // Live counts from the cache FILES (mtime-memoized): the files are the
@@ -1720,7 +1732,7 @@ public final class NodeService extends Service {
         if (!running || !s.running()) {
             // Covers both a stopped stack and a PAUSED one (running=false, warm state
             // retained) — the lifecycle string lets the UI tell them apart.
-            return new Snapshot(running, lifecycle, startTimeMs, 0, 0, 0, 0, /*snapServing*/0,
+            return new Snapshot(running, lifecycle, chainStartMs, 0, 0, 0, 0, /*snapServing*/0,
                     elCache.total(), elCache.snapOk(), elCache.snapBad(), s.attemptedDials(), s.backedOffPeers(),
                     s.blacklistedPeers(), s.discv5TableSize(), 0,
                     beaconState, bs.bootstrapped(), bs.connectedPeers(), (int) bs.lightClientPeers(),
@@ -1731,7 +1743,7 @@ public final class NodeService extends Service {
                     s.pauseCount(), s.totalPausedMs(), s.lastPauseEpochMs(),
                     s.lastResumeEpochMs(), s.lastWakeReason());
         }
-        return new Snapshot(true, lifecycle, startTimeMs,
+        return new Snapshot(true, lifecycle, chainStartMs,
                 s.discoveredPeers(), s.connectedPeers(), s.readyPeers(),
                 s.snapPeers(), s.snapServingPeers(),
                 elCache.total(), elCache.snapOk(), elCache.snapBad(), s.attemptedDials(), s.backedOffPeers(),

--- a/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
@@ -119,7 +119,16 @@ class DesktopNodeController(
                     JavaHttpCcipGateway(),
                     null, null,              // engine default logger/clock
                 )
-                val handle = engine.create(config, ports)
+                // create() is all-or-nothing (nothing registered on failure), so on a throw
+                // dropNetwork only forgets the cache instances retained above — leaving them
+                // would hand clearCaches a live-looking instance for a network that never
+                // booted. engine.stop() on an unregistered network is a no-op.
+                val handle = try {
+                    engine.create(config, ports)
+                } catch (t: Throwable) {
+                    dropNetwork(canonical)
+                    throw t
+                }
                 // start() is fault-isolated: false (resources closed) on failure rather than a
                 // throw. Either way, drop the network so a later enable can retry — leaving a
                 // dead entry would report "running" forever and block retries.

--- a/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
@@ -49,8 +49,11 @@ class DesktopNodeController(
 
     private val log = org.slf4j.LoggerFactory.getLogger(DesktopNodeController::class.java)
 
+    // Per-network engine-start stamp driving the UI uptime: stamped on each successful
+    // start (any engine, Java or Rust) and cleared on drop, so the uptime counter restarts
+    // from zero on every network/engine (re)boot — it is NOT the controller's (app's) lifetime.
     // nanoTime, not currentTimeMillis: wall-clock / NTP steps must not skew uptime.
-    private val startNs = System.nanoTime()
+    private val startNsByNetwork = ConcurrentHashMap<String, Long>()
     // Per-network boot locks keyed by CANONICAL name, mirroring Android's NodeService.bootLocks:
     // serialize enable/disable for one network without a global lock, so a slow boot of network
     // A never blocks shutdown or lifecycle ops on B. The engine's registry is thread-safe, so
@@ -127,6 +130,7 @@ class DesktopNodeController(
                     throw t
                 }
                 if (!ok) dropNetwork(canonical)
+                else startNsByNetwork[canonical] = System.nanoTime() // uptime anchors to THIS start
             }
         }, "desktop-boot-$canonical").apply { isDaemon = true }.start()
     }
@@ -136,6 +140,7 @@ class DesktopNodeController(
         engine.stop(canonical)
         peerCaches.remove(canonical)
         clPeerCaches.remove(canonical)
+        startNsByNetwork.remove(canonical) // next start re-anchors uptime
     }
 
     override fun disableNetwork(name: String) {
@@ -165,6 +170,7 @@ class DesktopNodeController(
         // the stopped-chain purge path rather than clear()ing a closed instance.
         peerCaches.clear()
         clPeerCaches.clear()
+        startNsByNetwork.clear() // symmetry with dropNetwork: no stamp outlives its stack
     }
 
     override fun setTargetSnapPeers(target: Int) {
@@ -254,7 +260,7 @@ class DesktopNodeController(
     override fun snapshots(): Flow<Map<String, NodeSnapshot>> = flow {
         while (true) {
             emit(engine.hostedNetworks().mapNotNull { name ->
-                engine.get(name)?.let { name to snapshotOf(it) }
+                engine.get(name)?.let { name to snapshotOf(name, it) }
             }.toMap())
             delay(2000)
         }
@@ -295,7 +301,7 @@ class DesktopNodeController(
         }, "myotis-rust-logs").apply { isDaemon = true }.start()
     }
 
-    private fun snapshotOf(handle: ChainHandle): NodeSnapshot {
+    private fun snapshotOf(network: String, handle: ChainHandle): NodeSnapshot {
         val s = handle.status()
         // Live counts parsed from the cache FILES (the cross-engine truth; the
         // Rust engine writes them directly). Memoized on (mtime, size).
@@ -333,7 +339,10 @@ class DesktopNodeController(
             syncCurrentPeriod = s.syncCurrentPeriod(),
             syncTargetPeriod = s.syncTargetPeriod(),
             verifiedHeadAgeMs = s.verifiedHeadAgeMs(),
-            uptimeSeconds = (System.nanoTime() - startNs) / 1_000_000_000L,
+            // hostedNetworks() keys are canonical (create() canonicalizes), matching the
+            // boot path's startNsByNetwork key — no re-canonicalization needed here.
+            uptimeSeconds = startNsByNetwork[network]
+                ?.let { (System.nanoTime() - it) / 1_000_000_000L } ?: 0L,
             readyPeerList = s.readyPeerList().map { PeerRow(it.remoteAddress(), it.snapSupported(), it.clientId()) },
             pauseCount = s.pauseCount(),
             totalPausedMs = s.totalPausedMs(),


### PR DESCRIPTION
## Problem

The UI's Uptime row was anchored to the **host's** lifetime — Android used the service-global `onStartCommand` stamp, desktop the controller's construction-time stamp. Restarting a network, or flipping the Java/Rust engine toggle (which reboots it), kept the old count running instead of restarting from zero.

## Fix

Anchor uptime to the **per-network engine start**, uniformly for both engines (the host stamps when *it* starts the chain, so Java and Rust behave identically):

- **Android**: `snapshotOf` derives uptime from `stackStartMs` — the existing per-network stamp written after each successful boot. Two ordering fixes came out of review (below): a fresh boot now *removes* the previous run's stamp before publishing its handle, and re-stamps *inside* the bootLock after `start()` succeeds. The now-unread service-global `startTimeMs` is deleted.
- **Desktop**: controller-global `startNs` becomes `startNsByNetwork`, stamped after a successful `handle.start()`, cleared in `dropNetwork` and `shutdown()`; `snapshotOf` takes the network name.

Semantics: a mid-boot snapshot reads `0s`; idle pauses do **not** reset the counter (a pause isn't a restart — the Sleep row reports paused time separately); an engine adopted still-running from a previous service instance keeps its original stamp (it never stopped). The JSON-RPC `uptimeSeconds` was already per-engine-start via `ChainStack`'s own clock and is unaffected.

## Review findings addressed (independent pre-PR review + verification pass)

- **MAJOR**: `buildAndStart` publishes the handle before `start()` (which blocks for seconds) while the UI polls every ~2s — with the static `stackStartMs` not cleared by `doShutdown`/`rebootNetwork`, a mid-boot snapshot displayed the *previous* run's uptime-plus-downtime. Fixed by removing the stale stamps before `handles.put` (order matters) and re-stamping after start succeeds; the two comments that claimed otherwise were corrected.
- **MINOR**: stamps were written outside the bootLock, racing a concurrent `stopNetwork`'s `forgetStack` (stamp leak for a dead network) — moved inside.
- **MINOR**: desktop `shutdown()` now clears `startNsByNetwork` (symmetry with `dropNetwork`).

One narrow pre-existing window the verification pass documented (not introduced here): a stack booting >30 s with no recent UI activity can be idle-paused right after its start, because the pause thread serializes on the bootLock rather than being excluded by lifecycle — fail-safe in the battery direction, left as-is.

## Verification

`:android-app:compileDebugJavaWithJavac`, `:app-desktop:compileKotlin` green. Behavior is host-glue over existing stamps (no engine/protocol change); the on-device check is: start a network, note Uptime, stop/start it or flip the engine toggle — the counter restarts from ~0 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)