### PR TITLE
Settings knob for the eth/69 served-block window (follow-up to #221)

### DIFF
--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -105,6 +105,7 @@ public final class NodeService extends Service {
     private static final String K_NETWORK = "network";
     private static final String K_RPC_PORT = "rpcPort";
     private static final String K_SNAP_TARGET = "snapTarget";
+    private static final String K_SERVED_WINDOW = "servedBlockWindow";
     private static final String K_DEEP_POOL = "deepPoolThreshold";
     private static final String K_STRICT_FRESHNESS = "strictStateFreshness";
     private static final String K_NATIVE_BLS = "nativeBls";
@@ -252,6 +253,17 @@ public final class NodeService extends Service {
     public static void setSnapTargetPref(android.content.Context c, int v) {
         prefs(c).edit().putInt(K_SNAP_TARGET, clampInt(v, 1, 128, DEFAULT_SNAP_TARGET)).apply();
     }
+    /** eth/69 served-block window (1-4096, default 32) — recent headers retained and
+     *  advertised as servable to peers. NB clampInt resets OUT-OF-RANGE input to the
+     *  DEFAULT (32) — matching snapTarget's semantics — whereas desktop/ChainStack
+     *  coerce to the nearer bound; within this host, persisted and live values always
+     *  agree because both paths clamp identically. */
+    public static int servedBlockWindow(android.content.Context c) {
+        return clampInt(prefs(c).getInt(K_SERVED_WINDOW, 32), 1, 4096, 32);
+    }
+    public static void setServedBlockWindowPref(android.content.Context c, int v) {
+        prefs(c).edit().putInt(K_SERVED_WINDOW, clampInt(v, 1, 4096, 32)).apply();
+    }
     /** UI readiness "deep pool" threshold (1–128, default 16). */
     public static int deepPoolThreshold(android.content.Context c) {
         return clampInt(prefs(c).getInt(K_DEEP_POOL, DEFAULT_DEEP_POOL), 1, 128, DEFAULT_DEEP_POOL);
@@ -351,6 +363,13 @@ public final class NodeService extends Service {
         this.targetSnapPeers = c;
         setSnapTargetPref(this, c);
         for (ChainHandle h : handles.values()) h.setTargetSnapPeers(c);
+    }
+
+    /** Live-update the eth/69 served-block window (no restart) on every live stack and persist it. */
+    public void setServedBlockWindow(int v) {
+        int c = clampInt(v, 1, 4096, 32);
+        setServedBlockWindowPref(this, c);
+        for (ChainHandle h : handles.values()) h.setServedBlockWindow(c);
     }
 
     /** Currently live networks (a chip per entry), in display order. */
@@ -1471,6 +1490,10 @@ public final class NodeService extends Service {
 
                 ChainHandle handle = ENGINE.create(config, ports);
                 created = handle;
+                // Apply the Settings served-block window before start(): the stack anchors
+                // its ServedHeaderWindow when the connector is built, so the very first
+                // eth/69 Status already advertises the configured size.
+                handle.setServedBlockWindow(servedBlockWindow(this));
                 handles.put(n, handle);
                 if (!handle.start()) {
                     LogBuffer.e(TAG, "[" + n + "] node stack failed to start");

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/cmp/AndroidNodeBridge.kt
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/cmp/AndroidNodeBridge.kt
@@ -88,6 +88,7 @@ class AndroidNodeController(
     override fun rebootNetwork(name: String) { serviceProvider()?.rebootNetwork(name) }
     override fun shutdown() { serviceProvider()?.shutdown() }
     override fun setTargetSnapPeers(target: Int) { serviceProvider()?.setTargetSnapPeers(target) }
+    override fun setServedBlockWindow(blocks: Int) { serviceProvider()?.setServedBlockWindow(blocks) }
     override fun applyBlsBackend() { NodeService.applyBlsBackend(appContext) }
     override fun applyEngineChoice() { NodeService.applyEngineChoice(appContext) }
     override fun clearCaches(network: String) { serviceProvider()?.clearCaches(network) }
@@ -188,6 +189,8 @@ class AndroidSettings(private val ctx: Context) : Settings {
     override fun setRpcPort(network: String, port: Int) = NodeService.setRpcPort(ctx, network, port)
     override fun snapTarget(): Int = NodeService.snapTarget(ctx)
     override fun setSnapTarget(v: Int) = NodeService.setSnapTargetPref(ctx, v)
+    override fun servedBlockWindow(): Int = NodeService.servedBlockWindow(ctx)
+    override fun setServedBlockWindow(v: Int) = NodeService.setServedBlockWindowPref(ctx, v)
 
     override fun displayName(network: String): String = NodeService.displayName(network)
     override fun defaultRpcPort(network: String): Int = NodeService.defaultRpcPort(network)

--- a/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
@@ -117,6 +117,10 @@ class DesktopNodeController(
                     null, null,              // engine default logger/clock
                 )
                 val handle = engine.create(config, ports)
+                // Apply the Settings served-block window before start(): the stack anchors
+                // its ServedHeaderWindow when the connector is built, so the very first
+                // eth/69 Status already advertises the configured size.
+                handle.setServedBlockWindow(settings.servedBlockWindow())
                 // start() is fault-isolated: false (resources closed) on failure rather than a
                 // throw. Either way, drop the network so a later enable can retry — leaving a
                 // dead entry would report "running" forever and block retries.
@@ -169,6 +173,10 @@ class DesktopNodeController(
 
     override fun setTargetSnapPeers(target: Int) {
         engine.hostedNetworks().forEach { engine.get(it)?.setTargetSnapPeers(target) }
+    }
+
+    override fun setServedBlockWindow(blocks: Int) {
+        engine.hostedNetworks().forEach { engine.get(it)?.setServedBlockWindow(blocks) }
     }
 
     override fun applyBlsBackend() {
@@ -363,6 +371,7 @@ class DesktopSettings(
     private val enabled = linkedSetOf("mainnet")
     private val ports = HashMap<String, Int>()
     private var snap = 32
+    private var servedWindow = 32
     private var deep = 16
     private var strict = true
     // Desktop has no bundled native blst yet (Milagro-only), so the honest default is off; the
@@ -402,6 +411,9 @@ class DesktopSettings(
     // Clamp like Android's NodeService (1..128) so the live value and the reloaded
     // value can't differ (load() applies the same clamp).
     override fun setSnapTarget(v: Int) = mutate { snap = v.coerceIn(1, 128) }
+    override fun servedBlockWindow(): Int = synchronized(this) { servedWindow }
+    // Clamp like ChainStack.setServedBlockWindow (1..4096) so live and reloaded values agree.
+    override fun setServedBlockWindow(v: Int) = mutate { servedWindow = v.coerceIn(1, 4096) }
 
     override fun displayName(network: String): String = info(network)?.displayName() ?: network
     override fun defaultRpcPort(network: String): Int = info(network)?.defaultRpcPort() ?: 8545
@@ -435,6 +447,7 @@ class DesktopSettings(
                 ?.let { ports[n.name()] = it }
         }
         p.getProperty(K_SNAP)?.toIntOrNull()?.let { snap = it.coerceIn(1, 128) }
+        p.getProperty(K_SERVED_WINDOW)?.toIntOrNull()?.let { servedWindow = it.coerceIn(1, 4096) }
         p.getProperty(K_DEEP)?.toIntOrNull()?.let { deep = it.coerceIn(1, 128) }
         p.getProperty(K_STRICT)?.toBooleanStrictOrNull()?.let { strict = it }
         p.getProperty(K_NATIVE_BLS)?.toBooleanStrictOrNull()?.let { nativeBls = it }
@@ -472,6 +485,7 @@ class DesktopSettings(
         p.setProperty(K_ENABLED, enabled.joinToString(","))
         ports.forEach { (net, port) -> p.setProperty("$K_RPC_PORT_PREFIX$net", port.toString()) }
         p.setProperty(K_SNAP, snap.toString())
+        p.setProperty(K_SERVED_WINDOW, servedWindow.toString())
         p.setProperty(K_DEEP, deep.toString())
         p.setProperty(K_STRICT, strict.toString())
         p.setProperty(K_NATIVE_BLS, nativeBls.toString())
@@ -506,6 +520,7 @@ class DesktopSettings(
         const val K_ENABLED = "networks.enabled"
         const val K_RPC_PORT_PREFIX = "rpcPort."
         const val K_SNAP = "snapTarget"
+        const val K_SERVED_WINDOW = "servedBlockWindow"
         const val K_DEEP = "deepPool"
         const val K_STRICT = "strictStateFreshness"
         const val K_NATIVE_BLS = "nativeBls"

--- a/app-desktop/src/test/kotlin/io/myotis/desktop/DesktopSettingsPersistenceTest.kt
+++ b/app-desktop/src/test/kotlin/io/myotis/desktop/DesktopSettingsPersistenceTest.kt
@@ -29,6 +29,7 @@ class DesktopSettingsPersistenceTest {
         first.setNetworkEnabled("mainnet", false)
         first.setRpcPort("gnosis", 9999)
         first.setSnapTarget(48)
+        first.setServedBlockWindow(64)
         first.setDeepPool(8)
         first.setStrictStateFreshness(false)
         first.setNativeBlsEnabled(true)
@@ -40,6 +41,7 @@ class DesktopSettingsPersistenceTest {
         assertFalse(second.isNetworkEnabled("mainnet"))
         assertEquals(9999, second.rpcPortFor("gnosis"))
         assertEquals(48, second.snapTarget())
+        assertEquals(64, second.servedBlockWindow())
         assertEquals(8, second.deepPoolThreshold())
         assertFalse(second.strictStateFreshness())
         assertTrue(second.nativeBlsEnabled())
@@ -60,6 +62,7 @@ class DesktopSettingsPersistenceTest {
         assertFalse(s.rustEngineEnabled())
         assertTrue(s.strictStateFreshness())
         assertEquals(32, s.snapTarget())
+        assertEquals(32, s.servedBlockWindow())
         assertEquals(16, s.deepPoolThreshold())
     }
 
@@ -73,6 +76,7 @@ class DesktopSettingsPersistenceTest {
             rpcPort.gnosis=99
             rpcPort.mainnet=not-a-number
             snapTarget=100000
+            servedBlockWindow=-7
             deepPool=zero
             rustEngine=yes-please
             strictStateFreshness=false
@@ -86,6 +90,7 @@ class DesktopSettingsPersistenceTest {
         assertEquals(8545, s.rpcPortFor("mainnet"))
         // Ints clamped, bad bools fall back to their defaults, good ones apply.
         assertEquals(128, s.snapTarget())
+        assertEquals(1, s.servedBlockWindow())
         assertEquals(16, s.deepPoolThreshold())
         assertFalse(s.rustEngineEnabled())
         assertFalse(s.strictStateFreshness())

--- a/myotis-api/src/main/java/io/myotis/api/ChainHandle.java
+++ b/myotis-api/src/main/java/io/myotis/api/ChainHandle.java
@@ -73,6 +73,16 @@ public interface ChainHandle {
     void setTargetSnapPeers(int target);
 
     /**
+     * Live-update the eth/69 served-block window (no restart): how many recent block
+     * headers this node retains and advertises as servable to peers via the EIP-7642
+     * Status range / BlockRangeUpdate. Clamped by the engine at both ends
+     * (currently [1, 4096]: 0 would disable serving; an unbounded window is an
+     * archive-node promise a light client cannot keep).
+     * Engines without an EL treat this as a no-op.
+     */
+    void setServedBlockWindow(int blocks);
+
+    /**
      * Clear the live dial bookkeeping — backoff entries and this session's
      * blacklist — so discovery re-dials from a fresh slate. On-disk peer-cache
      * FILES are host-owned; deleting those is the host's job.

--- a/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
@@ -455,6 +455,12 @@ final class RustChainHandle implements ChainHandle, NodeStatusReads {
     }
 
     @Override
+    public void setServedBlockWindow(int blocks) {
+        log.debug("[engines] setServedBlockWindow({}) is a no-op on the R1 Rust engine (CL-only: no eth layer)",
+                blocks);
+    }
+
+    @Override
     public void clearPeerState() {
         log.debug("[engines] clearPeerState is a no-op on the R1 Rust engine (CL-only)");
     }

--- a/networking/src/test/java/com/jaeckel/ethp2p/networking/eth/ServedHeaderWindowTest.java
+++ b/networking/src/test/java/com/jaeckel/ethp2p/networking/eth/ServedHeaderWindowTest.java
@@ -84,6 +84,27 @@ class ServedHeaderWindowTest {
     }
 
     @Test
+    void liveShrinkEvictsAndLiveGrowRefills() {
+        // The Settings knob calls setMaxWindow on a live window: shrinking must evict the
+        // tail immediately (the advertised range must never exceed the new cap), growing
+        // widens the cap and the window refills as new headers arrive.
+        ServedHeaderWindow w = new ServedHeaderWindow(10, hash(0), rlp(0));
+        for (long n = 100; n <= 109; n++) w.put(n, hash(n), rlp(n));
+
+        w.setMaxWindow(3);
+        ServedHeaderWindow.Range shrunk = w.advertise(109, hash(109));
+        assertEquals(107, shrunk.earliest());
+        assertEquals(109, shrunk.latest());
+        assertNull(w.getByNumber(106), "shrink evicts below the new cap");
+
+        w.setMaxWindow(5);
+        for (long n = 110; n <= 111; n++) w.put(n, hash(n), rlp(n));
+        ServedHeaderWindow.Range grown = w.advertise(111, hash(111));
+        assertEquals(107, grown.earliest(), "grow keeps survivors and refills forward");
+        assertEquals(111, grown.latest());
+    }
+
+    @Test
     void servesHeldHeadersByNumberAndHashAndAlwaysGenesis() {
         ServedHeaderWindow w = new ServedHeaderWindow(32, hash(0), rlp(0));
         w.put(105, hash(105), rlp(105));

--- a/node-core/src/main/java/io/myotis/node/ChainStack.java
+++ b/node-core/src/main/java/io/myotis/node/ChainStack.java
@@ -170,6 +170,21 @@ public final class ChainStack {
         this.targetSnapPeers = target;
     }
 
+    /** eth/69 served-block window size; applied to the connector's shared
+     *  ServedHeaderWindow when it is built and live via {@link #setServedBlockWindow}. */
+    private volatile int servedBlockWindow =
+            com.jaeckel.ethp2p.networking.eth.EthHandler.DEFAULT_SERVED_BLOCK_WINDOW;
+
+    /** Live-update the eth/69 served-block window (no restart). Clamped to [1, 4096]:
+     *  0/negative would kill header serving entirely, and an unbounded window is an
+     *  archive-node promise a light client can't keep (also a memory knob, ~500 B/header). */
+    public void setServedBlockWindow(int blocks) {
+        int clamped = Math.max(1, Math.min(blocks, 4096));
+        this.servedBlockWindow = clamped;
+        RLPxConnector conn = connector;
+        if (conn != null) conn.servedWindow().setMaxWindow(clamped);
+    }
+
     // -------------------------------------------------------------------------
     // Lifecycle
     // -------------------------------------------------------------------------
@@ -209,6 +224,11 @@ public final class ChainStack {
 
             // 2. RLPx connector + immediate cached / DNS-direct dials.
             this.connector = buildConnector();
+            // Re-apply after publish: a Save racing this build can read connector==null in
+            // setServedBlockWindow (skipping the live apply) after buildConnector already read
+            // the old field value — without this, the new size would sit unapplied until the
+            // next Save. Idempotent when there was no race.
+            this.connector.servedWindow().setMaxWindow(Math.max(1, Math.min(servedBlockWindow, 4096)));
             dialInitialPeers(dnsElEnrs);
 
             // 3. discv4.
@@ -281,6 +301,11 @@ public final class ChainStack {
         log.info("[{}] resuming from pause ({})", network.name(), reason);
         try {
             this.connector = buildConnector();
+            // Re-apply after publish: a Save racing this build can read connector==null in
+            // setServedBlockWindow (skipping the live apply) after buildConnector already read
+            // the old field value — without this, the new size would sit unapplied until the
+            // next Save. Idempotent when there was no race.
+            this.connector.servedWindow().setMaxWindow(Math.max(1, Math.min(servedBlockWindow, 4096)));
             dialInitialPeers(dnsElPool);
             startDiscV4(dnsElPool);          // essential — throws on bind failure
             startDiscV5();                   // non-essential, warn-and-continue
@@ -601,11 +626,15 @@ public final class ChainStack {
     }
 
     private RLPxConnector buildConnector() {
-        return new RLPxConnector(nodeKey, ports.elPort(), network, headers -> {
+        RLPxConnector conn = new RLPxConnector(nodeKey, ports.elPort(), network, headers -> {
             if (!headers.isEmpty()) {
                 log.debug("[{}] {} block header(s) received", network.name(), headers.size());
             }
         }, (address, publicKeyHex, snap) -> peerCache.add(address, publicKeyHex, snap));
+        // Apply a window size set before start(): setServedBlockWindow may have run while
+        // connector was still null (hosts read Settings before booting the stack).
+        conn.servedWindow().setMaxWindow(servedBlockWindow);
+        return conn;
     }
 
     private void dialCachedPeers() {

--- a/node-core/src/main/java/io/myotis/node/api/JavaChainHandle.java
+++ b/node-core/src/main/java/io/myotis/node/api/JavaChainHandle.java
@@ -96,6 +96,8 @@ public final class JavaChainHandle implements ChainHandle, NodeStatusReads {
 
     @Override public void setTargetSnapPeers(int target) { stack.setTargetSnapPeers(target); }
 
+    @Override public void setServedBlockWindow(int blocks) { stack.setServedBlockWindow(blocks); }
+
     @Override
     public void clearPeerState() {
         stack.backoff().clear();

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeController.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeController.kt
@@ -46,6 +46,9 @@ interface NodeController {
     /** Live-update the snap-peer target on all running stacks. */
     fun setTargetSnapPeers(target: Int)
 
+    /** Live-update the eth/69 served-block window on all running stacks. */
+    fun setServedBlockWindow(blocks: Int)
+
     /**
      * Re-apply the BLS backend to the process-global selector after [Settings.setNativeBlsEnabled]
      * flips the preference (Android: native blst ⇄ pure-Java Milagro). Takes effect immediately —
@@ -134,6 +137,10 @@ interface Settings {
     fun setRpcPort(network: String, port: Int)
     fun snapTarget(): Int
     fun setSnapTarget(v: Int)
+    /** eth/69 served-block window: how many recent headers the node retains and
+     *  advertises as servable to peers (EIP-7642 Status range). */
+    fun servedBlockWindow(): Int
+    fun setServedBlockWindow(v: Int)
 
     // --- network metadata (so commonMain need not reference the Java NetworkConfig) ---
     /** Human-facing name for the Settings row, e.g. "Gnosis Chain". */

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
@@ -264,6 +264,7 @@ private fun SettingsTab(
         }
     }
     var snapTarget by remember { mutableStateOf(settings.snapTarget().toString()) }
+    var servedWindow by remember { mutableStateOf(settings.servedBlockWindow().toString()) }
     var deepPool by remember { mutableStateOf(settings.deepPoolThreshold().toString()) }
     var idlePause by remember { mutableStateOf(settings.idlePauseMinutes().toString()) }
     var stayAwakeCharging by remember { mutableStateOf(settings.stayAwakeWhileCharging()) }
@@ -318,6 +319,14 @@ private fun SettingsTab(
             value = snapTarget,
             onValueChange = { snapTarget = it.filter(Char::isDigit).take(3) },
             label = { Text("Snap-peer target (default 32)") },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+            modifier = Modifier.fillMaxWidth(),
+        )
+        OutlinedTextField(
+            value = servedWindow,
+            onValueChange = { servedWindow = it.filter(Char::isDigit).take(4) },
+            label = { Text("Served-block window (eth/69, default 32)") },
             singleLine = true,
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
             modifier = Modifier.fillMaxWidth(),
@@ -414,16 +423,19 @@ private fun SettingsTab(
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
         Text(
-            "An RPC-port change reboots that chain; snap-peer target applies live to every " +
-                "running chain, and the readiness threshold persists for the next check.",
+            "An RPC-port change reboots that chain; the snap-peer target and served-block " +
+                "window apply live to every running chain, and the readiness threshold persists " +
+                "for the next check.",
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
         Button(
             onClick = {
                 val snap = snapTarget.toIntOrNull() ?: 32
+                val window = servedWindow.toIntOrNull() ?: 32
                 val deep = deepPool.toIntOrNull() ?: 16
                 settings.setSnapTarget(snap)          // persist
+                settings.setServedBlockWindow(window) // persist
                 settings.setDeepPool(deep)            // persist (read at readiness-check time)
                 // Idle sleep: persisted only on hosts that run the controller; the tick reads it
                 // live. Blank/invalid input keeps the CURRENT value rather than silently enabling
@@ -432,6 +444,7 @@ private fun SettingsTab(
                     settings.setIdlePauseMinutes(idlePause.toIntOrNull() ?: settings.idlePauseMinutes())
                 }
                 controller.setTargetSnapPeers(snap)   // live-apply to running stacks
+                controller.setServedBlockWindow(window) // live-apply to running stacks
                 networks.forEach { id ->
                     // Compare the EFFECTIVE (post-clamp) persisted port before vs after, not the
                     // raw typed value: setRpcPort clamps out-of-range input to the network default,

--- a/ui/src/desktopTest/kotlin/io/myotis/ui/LogsFilterPersistenceTest.kt
+++ b/ui/src/desktopTest/kotlin/io/myotis/ui/LogsFilterPersistenceTest.kt
@@ -83,6 +83,7 @@ class LogsFilterPersistenceTest {
         override fun rebootNetwork(name: String) {}
         override fun shutdown() {}
         override fun setTargetSnapPeers(target: Int) {}
+        override fun setServedBlockWindow(blocks: Int) {}
         override fun applyBlsBackend() {}
         override fun applyEngineChoice() {}
         override fun clearCaches(network: String) {}
@@ -103,6 +104,8 @@ class LogsFilterPersistenceTest {
         override fun setRpcPort(network: String, port: Int) {}
         override fun snapTarget(): Int = 3
         override fun setSnapTarget(v: Int) {}
+        override fun servedBlockWindow(): Int = 32
+        override fun setServedBlockWindow(v: Int) {}
         override fun displayName(network: String): String = network
         override fun defaultRpcPort(network: String): Int = 8545
         override fun hasEns(network: String): Boolean = true


### PR DESCRIPTION
## What

The follow-up promised in #221: the served-block window size (how many recent headers we retain and advertise as servable to peers via the EIP-7642 Status range / `BlockRangeUpdate`) is now configurable in the Settings tab on both Android and desktop, mirroring the snap-peer-target pattern end to end.

- **API**: `ChainHandle.setServedBlockWindow(int)` — live, no restart; clamped by the engine to `[1, 4096]` (0 would disable serving; an unbounded window is an archive-node promise a light client can't keep). No-op on the CL-only Rust engine.
- **Engine**: `JavaChainHandle` → `ChainStack` (volatile field) → the connector's shared `ServedHeaderWindow.setMaxWindow` (shrink evicts immediately, so the advertised range can never exceed the new cap). The stack stores a pre-start value and applies it when the connector is built — hosts set it between `create()` and `start()`, so the **first** eth/69 Status already advertises the configured size.
- **UI**: "Served-block window (eth/69, default 32)" field in the shared Compose Settings tab, persisted per host (SharedPreferences / `settings.properties`) and live-applied to every running chain on Save.

## Review findings addressed (independent pre-PR review + verification pass)

- Lost-update race: a Save racing `start()`/`resume()`'s connector build could leave the new size unapplied until the next Save — closed with an idempotent post-publish re-apply at both connector-assignment sites (Dekker-style pairing on the two volatiles; verified ordering-safe, it runs before any peer dialing).
- Clamp-semantics documentation: Android's `clampInt` resets out-of-range input to the default (32), matching its `snapTarget` precedent, while desktop/`ChainStack` coerce to the nearer bound — the javadoc now says so explicitly instead of claiming the clamps are identical. Within each host, persisted and live values always agree.
- `ChainHandle` javadoc documents both clamp ends.

## Tests

`ServedHeaderWindowTest.liveShrinkEvictsAndLiveGrowRefills` (live shrink evicts, grow refills); desktop settings persistence round-trip incl. garbage-value clamping (`-7` → 1); ui test fakes extended. Full `:networking`, `:node-core`, `:app-desktop`, `:ui` test suites green; `:app` and `:android-app` compile.

## Notes

- The knob is visible on Rust-engine chains where it's a no-op — same behavior as the snap-target knob, and the API javadoc documents it.
- Daemon `-P` flag parity deliberately not included (the ask was the Settings tab); the daemon uses the default 32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)