### PR TITLE
Retire the Kotlin tuweni/netty forks; back to upstream (io.consensys.tuweni 2.7.2, io.netty 4.2.10)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
 
       # Robust Gradle dependency + plugin caching. Restores the base-branch cache
       # (read-only on PRs) so artifacts that already built on main — Besu, AGP,
-      # the JitPack netty/tuweni forks — come from cache instead of being re-fetched
+      # the JitPack Besu fork — come from cache instead of being re-fetched
       # from flaky external repos on every run.
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/devp2p-discovery.yml
+++ b/.github/workflows/devp2p-discovery.yml
@@ -29,20 +29,19 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: gradle-${{ hashFiles('**/*.gradle.kts', '**/gradle-wrapper.properties') }}
+          key: gradle-${{ hashFiles('**/*.gradle.kts', 'gradle/libs.versions.toml', '**/gradle-wrapper.properties') }}
           restore-keys: gradle-
 
       - name: Build
-        # --offline: jitpack 403 workaround (com.github.biafra23.tuweni-kotlin fork);
-        # build from the restored Gradle cache until the jitpack issue is resolved.
-        # (Gradle --offline only blocks dependency fetches, not the app's own networking.)
-        run: ./gradlew build -x test --no-daemon --offline
+        # (--offline was a jitpack-403 workaround for the retired tuweni-kotlin fork;
+        # deps now come from Maven Central, so fetch normally.)
+        run: ./gradlew build -x test --no-daemon
 
       - name: Run devp2p discovery (5 min timeout)
         id: discovery
         run: |
           # Capture output; allow the app to exit with non-zero (timeout case) without failing
-          ./gradlew :app:run --no-daemon --offline 2>&1 | tee discovery.log || true
+          ./gradlew :app:run --no-daemon 2>&1 | tee discovery.log || true
 
       - name: Report result
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ Key Gradle modules:
 
 ## Key Dependencies
 
-- **Tuweni 2.7.2** (ConsenSys) — RLP encoding, SECP256K1, byte utilities. Fetched from ConsenSys Maven repo.
+- **Tuweni 2.7.2** (upstream `io.consensys.tuweni`, Maven Central; original `org.apache.tuweni` packages) — RLP encoding, SECP256K1, byte utilities.
 - **Netty 4.2.x** — NIO-only (no epoll/kqueue). 4-thread `NioEventLoopGroup` for RLPx.
 - **BouncyCastle** — SECP256K1 crypto provider
 

--- a/README.md
+++ b/README.md
@@ -792,8 +792,8 @@ DNS resolution is best-effort: on timeout, missing TXT records, or signature mis
 
 ### Key dependencies
 
-- **Tuweni 2.7.2** (`tuweni-kotlin` fork, `2.7.2-jvm17.1`) -- RLP encoding, SECP256K1, byte utilities
-- **Netty 4.2.x (modified)** -- NIO transport. Uses a modified Netty archive based on 4.2 that has been rewritten in Kotlin. This is a proof-of-concept for migrating the Java codebase to Kotlin to enable use in a Compose Multiplatform project
+- **Tuweni 2.7.2** (upstream, `io.consensys.tuweni` on Maven Central) -- RLP encoding, SECP256K1, byte utilities
+- **Netty 4.2.x** (upstream) -- NIO transport. (The earlier Kotlin-transpiled tuweni/netty forks existed to explore a Kotlin-Multiplatform engine; multiplatform now comes from the Rust engine, so the forks were retired.)
 - **BouncyCastle** -- SECP256K1 crypto provider
 - **jvm-libp2p** -- beacon chain P2P networking (consensus module)
 - **dnsjava 3.6** -- TXT-record resolution for EIP-1459 ENR tree walks

--- a/android-app/build.gradle.kts
+++ b/android-app/build.gradle.kts
@@ -16,11 +16,6 @@ plugins {
 // JVM daemon stays on upstream Besu, where those APIs work.
 val besuForkVersion = "26.4.0-android.1"
 
-// The JitPack netty-kotlin fork republishes netty-common/buffer/etc. with the
-// same fully-qualified classes; the JVM tolerates the shadowing but the dexer
-// doesn't. vertx-core (transitive via tuweni-crypto) drags upstream netty in,
-// so strip it project-wide and rely on the fork.
-//
 // log4j-api is excluded because its `LogManager.getLogger()` no-args overload
 // uses StackWalker to name the logger after the caller class, and Android's
 // StackWalker returns null `getDeclaringClass()` for some frames — every
@@ -28,7 +23,6 @@ val besuForkVersion = "26.4.0-android.1"
 // blows up at <clinit>. Replaced with a tiny shim under
 // src/main/java/org/apache/logging/log4j that routes to slf4j.
 configurations.all {
-    exclude(group = "io.netty")
     exclude(group = "org.apache.logging.log4j")
     // Swap Besu's evm + algorithms to the Android-patched fork (biafra23/besu via
     // JitPack); everything else stays upstream. Eager `all` so AGP's classpaths
@@ -55,10 +49,6 @@ configurations.all {
     // fork's exact version) so nothing pulls io.tmio anymore — the exclude
     // stays as a cheap guard against a transitive reintroducing it.
     exclude(group = "io.tmio")
-    // tuweni's post-rename coordinates (io.consensys.tuweni, pulled by the
-    // Besu 26.4 fork's POM) collide with our Kotlin fork the same way io.tmio
-    // did — same classes, D8 rejects the duplicates. The fork supplies them.
-    exclude(group = "io.consensys.tuweni")
     // Requesting the STANDARD_JVM Guava variant (below) clashes with the
     // `android` variant that Besu pulls transitively — both provide the guava
     // capability. Resolve the conflict toward the JRE variant, which is the one
@@ -151,10 +141,13 @@ android {
                 "META-INF/LGPL2.1",
                 "META-INF/INDEX.LIST",
                 "META-INF/io.netty.versions.properties",
+                // Upstream netty jars each carry license texts under META-INF/license/;
+                // several ship identical filenames and the merger rejects duplicates.
+                "META-INF/license/**",
                 "META-INF/com.jaeckel.versions.properties",
             )
-            // The jitpack netty-kotlin fork ships the same native-image hint
-            // file as upstream netty-common; just take the first one.
+            // Multiple netty modules ship the same native-image hint file;
+            // metadata-only, take the first.
             pickFirsts += setOf(
                 "META-INF/native-image/io.netty/netty-common/native-image.properties",
                 // jvm-libp2p drags in four bouncycastle jars (bcprov, bcpkix,
@@ -249,7 +242,14 @@ dependencies {
     implementation(libs.netty.transport)
 
     // consensus stack — BeaconLightClient, libp2p, BLS, snappy.
-    implementation(libs.jvm.libp2p)
+    implementation(libs.jvm.libp2p) {
+        // Mirror :consensus (single-netty policy): keep libp2p's own netty set out —
+        // it drags netty-tcnative-boringssl (macOS/Windows natives, ~9.6 MB of dead
+        // APK weight), codec-http, and epoll classes we never load. The netty modules
+        // we DO use (transport/codec/handler 4.2.x + their transitives) arrive via
+        // :networking/:consensus, exactly like the daemon.
+        exclude(group = "io.netty")
+    }
     implementation(libs.milagro)
     implementation(libs.snappy)
 

--- a/app-desktop/build.gradle.kts
+++ b/app-desktop/build.gradle.kts
@@ -20,27 +20,14 @@ kotlin { jvmToolchain(21) }
 // that FQN: tuweni-rlp 2.7.2 (BytesRLPWriter.kt) needs the 2.7.2 Bytes' Kotlin `Companion`,
 // which the 2.4.2 class lacks → NoSuchFieldError at launch. The `gradle run` daemon happens
 // to load the 2.7.2 jar first; jpackage's flattened classpath lets the 2.4.2 one win. Strip
-// io.tmio so only the 2.7.2 fork remains (same packages; Besu already runs against 2.7.2 on
+// io.tmio so only one tuweni 2.7.2 remains (same packages; Besu already runs against 2.7.2 on
 // the daemon, so 2.4.2 is unneeded) — mirrors the :android-app exclusion.
-//
-// io.netty: the same class of conflict. The JitPack netty-kotlin fork
-// (com.github.biafra23.netty-kotlin, 4.2.x) republishes io.netty.* classes; Besu / vertx /
-// jvm-libp2p drag in upstream io.netty 4.1.115. Both ship e.g. io.netty.channel
-// .SingleThreadEventLoop, and the fork's NioEventLoopGroup calls a 4.2.x constructor the
-// 4.1.115 class lacks → NoSuchMethodError, so the stack fails to start in the flattened
-// jpackage bundle. The :app daemon excludes io.netty group-wide and runs end-to-end on only
-// the fork (reaches SYNCED), so it's safe to do the same here.
+// (Historical: while the Kotlin tuweni/netty forks were in use, io.consensys.tuweni and
+// io.netty were also excluded here to prevent duplicate-class crashes in the flattened
+// jpackage bundle. Upstream is canonical again, so those excludes are gone — a single
+// source per class.)
 configurations.all {
     exclude(group = "io.tmio")
-    // Besu 26.4 pulls tuweni under its POST-RENAME coordinates
-    // (io.consensys.tuweni) — the same Bytes classes as our Kotlin fork but
-    // WITHOUT the Kotlin Companion. The gradle-run daemon happened to
-    // classload the fork first; jpackage's flattened classpath let the Java
-    // jar win and the PACKAGED app died at launch with
-    // NoSuchFieldError: Bytes.Companion (found by launching the app image).
-    // The fork supplies these classes; exclude the upstream twins.
-    exclude(group = "io.consensys.tuweni")
-    exclude(group = "io.netty")
 }
 
 dependencies {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,13 +1,3 @@
-// The daemon must run the SAME netty as the Android app: the JitPack
-// netty-kotlin fork, not upstream io.netty. jvm-libp2p (via :consensus) and
-// Besu's netty-bom (via :myotis-evm) would otherwise drag upstream io.netty
-// onto the runtime classpath. Strip it group-wide; the fork (republished under
-// the same io.netty.* package names) is supplied by :consensus and :networking
-// and satisfies every io.netty.* reference at runtime. Mirrors android-app.
-configurations.all {
-    exclude(group = "io.netty")
-}
-
 dependencies {
     implementation(project(":core"))
     implementation(project(":networking"))
@@ -27,9 +17,9 @@ dependencies {
     // the Java or Rust engine per -Dmyotis.engine.
     implementation(project(":myotis-engines"))
     // :app source references io.netty.channel.* (via :networking's RLPxConnector
-    // API). With io.netty excluded group-wide, the fork must be on :app's compile
-    // classpath explicitly (:networking declares it as implementation, so it
-    // isn't exposed transitively). Same fork artifacts as android-app/:consensus.
+    // API); :networking declares netty as implementation, so it isn't exposed
+    // transitively — declare it here for the compile classpath. Gradle's
+    // highest-version conflict resolution keeps the runtime on 4.2.x everywhere.
     implementation(libs.netty.transport)
     implementation(libs.netty.codec)
     implementation(libs.netty.handler)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,13 +16,8 @@ dependencies {
     // The engine selector: Main's composition root is Engines.engine(), routing to
     // the Java or Rust engine per -Dmyotis.engine.
     implementation(project(":myotis-engines"))
-    // :app source references io.netty.channel.* (via :networking's RLPxConnector
-    // API); :networking declares netty as implementation, so it isn't exposed
-    // transitively — declare it here for the compile classpath. Gradle's
-    // highest-version conflict resolution keeps the runtime on 4.2.x everywhere.
-    implementation(libs.netty.transport)
-    implementation(libs.netty.codec)
-    implementation(libs.netty.handler)
+    // io.netty.channel.* (RLPxConnector's API surface) arrives transitively:
+    // :networking declares netty-transport as `api`.
     implementation(libs.tuweni.bytes)
     implementation(libs.tuweni.rlp)
     implementation(libs.tuweni.crypto)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,6 +52,9 @@ subprojects {
         exclude(group = "io.netty", module = "netty-transport-native-epoll")
         exclude(group = "io.netty", module = "netty-transport-native-kqueue")
         exclude(group = "io.netty", module = "netty-transport-native-unix-common")
+        // jvm-libp2p constrains in the QUIC codec (+ big per-OS natives); we only use
+        // its TCP transport and ran without QUIC classes throughout the fork era.
+        exclude(group = "io.netty", module = "netty-codec-native-quic")
         exclude(group = "org.apache.logging.log4j", module = "log4j-slf4j2-impl")
         exclude(group = "org.apache.logging.log4j", module = "log4j-slf4j-impl")
         exclude(group = "org.apache.logging.log4j", module = "log4j-slf4j18-impl")
@@ -70,17 +73,9 @@ subprojects {
         }
     }
 
-    configurations.all {
-        // Besu 26.4 pulls tuweni under its post-rename coordinates
-        // (io.consensys.tuweni) — the same org.apache.tuweni classes as our
-        // Kotlin fork but WITHOUT the Kotlin Companion objects. Whichever jar
-        // classloads first wins: gradle-run happened to pick the fork, but
-        // jpackage's flattened classpath picked the upstream jar and the
-        // packaged desktop app died at launch (NoSuchFieldError:
-        // Bytes.Companion). The fork supplies these classes everywhere —
-        // exclude the upstream twins for every JVM module.
-        exclude(group = "io.consensys.tuweni")
-    }
+    // (Historical: while the tuweni-kotlin fork was in use, io.consensys.tuweni was
+    // excluded here project-wide to prevent duplicate org.apache.tuweni classes.
+    // Upstream io.consensys.tuweni is canonical again — single source per class.)
 
     tasks.test {
         useJUnitPlatform()

--- a/consensus/build.gradle.kts
+++ b/consensus/build.gradle.kts
@@ -11,13 +11,11 @@ dependencies {
     implementation(libs.snappy)
     implementation(libs.slf4j.api)
     implementation(libs.milagro)
-    // jvm-libp2p transitively pulls UPSTREAM io.netty (4.1.x). On Android we
-    // strip io.netty group-wide and let the JitPack netty-kotlin fork (same
-    // io.netty.* FQCNs, different coordinates) satisfy it. The JVM daemon must
-    // resolve to the EXACT SAME netty bytecode as Android, otherwise the two
-    // run different transport stacks and any libp2p reliability difference is
-    // un-diagnosable. Exclude upstream io.netty here and supply the fork
-    // explicitly (mirrors :networking's discovery exclude).
+    // Single-netty policy (one netty everywhere — Android, daemon, desktop — so
+    // any libp2p reliability difference stays diagnosable): exclude jvm-libp2p's
+    // own netty 4.2.10 set (which includes tcnative/codec-http modules we never
+    // load) and supply the catalog's netty explicitly; libp2p ran fine on this
+    // reduced 4.2 set throughout the netty-kotlin era.
     implementation(libs.jvm.libp2p) {
         exclude(group = "io.netty")
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,14 @@
 [versions]
-tuweni = "2.7.2-jvm17.1"
+# Upstream Tuweni (post-rename Maven coordinates io.consensys.tuweni, still the
+# org.apache.tuweni packages). Java-21 bytecode, plain POMs (no Gradle-metadata JVM
+# floor) — 17-target modules compile against it fine and Android dexes classfile 65
+# already (discv5). Replaces the tuweni-kotlin KMP fork: multiplatform now comes from
+# the Rust engine, not from Kotlin-transpiled Java deps.
+tuweni = "2.7.2"
 discovery = "26.4.0"
-#netty-kotlin = "c5a8303903"
-netty-kotlin = "main-SNAPSHOT"
-#netty = "4.2.7.Final"
+# Upstream Netty (NIO-only usage; Android-safe). Replaces the netty-kotlin
+# transpile PoC — same io.netty.* FQCNs, so this is a coordinate swap.
+netty = "4.2.10.Final"  # matches jvm-libp2p 1.3.2's netty constraint (one netty everywhere)
 bouncycastle = "1.78.1"
 junit = "5.10.0"
 slf4j = "2.0.12"
@@ -56,16 +61,16 @@ compose-multiplatform = { id = "org.jetbrains.compose",             version.ref 
 
 [libraries]
 minimal-json        = { module = "com.eclipsesource.minimal-json:minimal-json", version.ref = "minimal-json" }
-tuweni-bytes        = { module = "com.github.biafra23.tuweni-kotlin:tuweni-bytes",       version.ref = "tuweni" }
-tuweni-rlp          = { module = "com.github.biafra23.tuweni-kotlin:tuweni-rlp",         version.ref = "tuweni" }
-tuweni-crypto       = { module = "com.github.biafra23.tuweni-kotlin:tuweni-crypto",      version.ref = "tuweni" }
-tuweni-merkle-trie  = { module = "com.github.biafra23.tuweni-kotlin:tuweni-merkle-trie", version.ref = "tuweni" }
-tuweni-ssz          = { module = "com.github.biafra23.tuweni-kotlin:tuweni-ssz",         version.ref = "tuweni" }
-tuweni-units        = { module = "com.github.biafra23.tuweni-kotlin:tuweni-units",       version.ref = "tuweni" }
+tuweni-bytes        = { module = "io.consensys.tuweni:tuweni-bytes",       version.ref = "tuweni" }
+tuweni-rlp          = { module = "io.consensys.tuweni:tuweni-rlp",         version.ref = "tuweni" }
+tuweni-crypto       = { module = "io.consensys.tuweni:tuweni-crypto",      version.ref = "tuweni" }
+tuweni-merkle-trie  = { module = "io.consensys.tuweni:tuweni-merkle-trie", version.ref = "tuweni" }
+tuweni-ssz          = { module = "io.consensys.tuweni:tuweni-ssz",         version.ref = "tuweni" }
+tuweni-units        = { module = "io.consensys.tuweni:tuweni-units",       version.ref = "tuweni" }
 
-netty-transport     = { module = "com.github.biafra23.netty-kotlin:netty-transport",               version.ref = "netty-kotlin" }
-netty-codec         = { module = "com.github.biafra23.netty-kotlin:netty-codec",                   version.ref = "netty-kotlin" }
-netty-handler       = { module = "com.github.biafra23.netty-kotlin:netty-handler",                 version.ref = "netty-kotlin" }
+netty-transport     = { module = "io.netty:netty-transport", version.ref = "netty" }
+netty-codec         = { module = "io.netty:netty-codec",     version.ref = "netty" }
+netty-handler       = { module = "io.netty:netty-handler",   version.ref = "netty" }
 
 bouncycastle        = { module = "org.bouncycastle:bcprov-jdk18on",        version.ref = "bouncycastle" }
 

--- a/networking/build.gradle.kts
+++ b/networking/build.gradle.kts
@@ -1,3 +1,11 @@
+plugins {
+    // java-library (on top of the root's java): RLPxConnector's public surface
+    // returns io.netty.channel.ChannelFuture, so netty-transport is an API
+    // dependency — consumers (:app, :node-core) get it on their compile
+    // classpath transitively instead of redeclaring it.
+    `java-library`
+}
+
 java {
     // Bumped from 17 to 21 because io.consensys.protocols:discovery:26.4.0
     // (ConsenSys discv5) publishes Gradle module metadata declaring a JVM-21
@@ -19,7 +27,7 @@ dependencies {
     implementation(libs.tuweni.bytes)
     implementation(libs.tuweni.rlp)
     implementation(libs.tuweni.crypto)
-    implementation(libs.netty.transport)
+    api(libs.netty.transport) // leaked by RLPxConnector's API (ChannelFuture) — see plugins block
     implementation(libs.netty.codec)
     implementation(libs.netty.handler)
     implementation(libs.bouncycastle)

--- a/networking/build.gradle.kts
+++ b/networking/build.gradle.kts
@@ -27,27 +27,16 @@ dependencies {
     implementation(libs.slf4j.api)
     implementation(libs.dnsjava)
     // ConsenSys discv5 library — republished successor of tech.pegasys.discovery.
-    // Excludes upstream io.netty: the JitPack netty-kotlin fork republishes the
-    // same classes under different coordinates; D8 rejects the duplicates on
-    // Android. android-app already strips io.netty group-wide; mirror that here
-    // so the JVM daemon also resolves to the fork.
-    //
-    // Same story for io.consensys.tuweni: discovery transitively pulls upstream
-    // tuweni 2.7.0, but we resolve tuweni via the JitPack fork
-    // (com.github.biafra23.tuweni-kotlin, recompiled to Java 17 bytecode). The
-    // fork kept the original org.apache.tuweni.* package names, so both jars
-    // ship identical FQCNs under different coordinates — Gradle can't dedupe
-    // them and D8's checkDebugDuplicateClasses fails. The fork is a >=2.7.0
-    // recompile of the same classes, so it satisfies everything discovery needs.
-    //
     // log4j is NOT excluded: several of the library's internal classes
     // (IdentitySchemaV4Interpreter etc.) reference org.apache.logging.log4j.LogManager
     // in their <clinit>, so stripping it NoClassDefFoundErrors the whole library
     // at first use. Our own code stays on slf4j + logback; log4j-api just
     // satisfies the library's static init.
     implementation(libs.discovery) {
+        // Single-netty policy: discovery pulls 4.1.x; we standardize on 4.2.x
+        // (supplied above). Its tuweni deps now match ours (io.consensys.tuweni
+        // 2.7.2), so no tuweni exclude is needed anymore.
         exclude(group = "io.netty")
-        exclude(group = "io.consensys.tuweni")
     }
 
     testImplementation(platform(libs.junit.bom))

--- a/node-core/build.gradle.kts
+++ b/node-core/build.gradle.kts
@@ -39,12 +39,8 @@ dependencies {
     implementation(project(":jsonrpc-server"))
     implementation(project(":rpc-backend"))
 
-    // node-core source references io.netty.channel.* via :networking's RLPxConnector
-    // API; :networking declares netty as implementation (not exposed transitively),
-    // so declare it here for the compile classpath (same as :app).
-    implementation(libs.netty.transport)
-    implementation(libs.netty.codec)
-    implementation(libs.netty.handler)
+    // io.netty.channel.* (RLPxConnector's API surface) arrives transitively:
+    // :networking declares netty-transport as `api`.
 
     implementation(libs.tuweni.bytes)
     implementation(libs.tuweni.units)

--- a/node-core/build.gradle.kts
+++ b/node-core/build.gradle.kts
@@ -21,13 +21,6 @@ plugins {
     `java-library`
 }
 
-configurations.all {
-    // Mirror :app / :android-app: strip upstream io.netty so the JitPack
-    // netty-kotlin fork (republished under the same io.netty.* names, supplied by
-    // :networking/:consensus) is the single netty on the runtime classpath.
-    exclude(group = "io.netty")
-}
-
 java {
     sourceCompatibility = JavaVersion.VERSION_21
     targetCompatibility = JavaVersion.VERSION_21
@@ -47,8 +40,8 @@ dependencies {
     implementation(project(":rpc-backend"))
 
     // node-core source references io.netty.channel.* via :networking's RLPxConnector
-    // API; with io.netty excluded group-wide the fork must be on the compile
-    // classpath explicitly (same as :app).
+    // API; :networking declares netty as implementation (not exposed transitively),
+    // so declare it here for the compile classpath (same as :app).
     implementation(libs.netty.transport)
     implementation(libs.netty.codec)
     implementation(libs.netty.handler)


### PR DESCRIPTION
## Why

The `tuweni-kotlin` and `netty-kotlin` JitPack forks existed to explore a Kotlin-Multiplatform engine. Multiplatform (including iOS) now comes from the Rust engine, so the forks are pure maintenance burden. Back to upstream where it exists:

- **Tuweni** → `io.consensys.tuweni:2.7.2` (Maven Central; the post-rename coordinates still use the `org.apache.tuweni` packages, so zero import changes). Java-21 bytecode with plain POMs — 17-target modules compile against it under the 21 toolchain, and Android has been dexing classfile-65 (discv5) all along.
- **Netty** → `io.netty:4.2.10.Final` (matches jvm-libp2p 1.3.2's constraint). One netty version resolves everywhere — every 4.1 transitive request upgrades.

## What's unwound / kept / added

- **Unwound**: all fork-era duplicate-class guards — the group-wide `io.netty` / `io.consensys.tuweni` excludes in the root build, `:app`, `:node-core`, `:android-app`, `:app-desktop`, and the fork-specific comments. The historical `NoSuchFieldError: Bytes.Companion` crash class cannot recur: it was a mixed-classpath artifact (code compiled against the fork's Kotlin companion running against upstream jars); with one canonical source recompiled end-to-end, Kotlin call sites resolve to the upstream statics.
- **Kept**: the dep-scoped `io.netty` excludes on jvm-libp2p/discovery (single-netty policy — Android, daemon, and desktop all run the exact same reduced 4.2 set, proven throughout the fork era), the `io.tmio` guard, the log4j excludes, and the **Besu Android fork** (ART runtime patches, not a KMP artifact — stays as long as the Java EL runs on Android).
- **Added**: `netty-codec-native-quic` excluded at the root (libp2p constrains it in; we only use its TCP transport and ran without QUIC classes for the fork's entire lifetime) and `META-INF/license/**` in APK packaging (upstream netty jars ship duplicate license files the merger rejects).

## Review findings addressed (independent pre-PR review)

- `devp2p-discovery.yml` still ran with `--offline` — a JitPack-403 workaround for the retired fork that would have hard-failed the workflow on the first post-merge run (stale cache + unfetchable new deps). Removed; the cache key now also hashes `libs.versions.toml`.
- `:android-app`'s direct `jvm-libp2p` dependency lost its netty filtering when the group-wide exclude went away — the APK silently regained **~9.6 MB of macOS/Windows tcnative natives** plus codec-http/epoll classes. Now dep-scope excluded like `:consensus`; verified zero tcnative/quic entries in the rebuilt APK.
- Stale fork references in ci.yml comments and build-file comments corrected.

## Verification

- Full `./gradlew build` green — every module's tests, including the LC and el-eth conformance corpora (byte-level equivalence of the RLP/SSZ/crypto surfaces between fork and upstream).
- Resolved classpaths contain zero fork artifacts; single netty version everywhere.
- Live mainnet daemon: 29 READY peers across eth/66–69 within seconds, snap negotiated, CL libp2p up, beacon **SYNCED**, zero LinkageErrors.
- Desktop `packageDeb` + a headless launch of the freshly packaged app image (the flattened-classpath path where the historical crash was only ever visible): boots the node, zero linkage errors.
- Android `assembleDebug` packages; tcnative/quic absent.

## Notes

- The rust `myotis-net el::pool::warm_start_dials_cached_peers_and_survives_a_flush` test is **broken on main** (fails identically there) — unrelated to this PR and excluded from its verification. Worth a separate fix.
- On-device Android run recommended when convenient — upstream netty on ART is the one surface this machine can't exercise end-to-end (the fork era's netty was 4.2-based, so behavior should be identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)