### PR TITLE
Java EthHandler: guard the serve window + chainHead against peer response poisoning

### DIFF
--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/EthHandler.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/EthHandler.java
@@ -114,6 +114,39 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
     private final AtomicLong requestId = new AtomicLong(1);
     private final ConcurrentMap<Long, CompletableFuture<List<BlockHeadersMessage.VerifiedHeader>>>
             pendingRequests = new ConcurrentHashMap<>();
+    /**
+     * What each OUTBOUND GetBlockHeaders request asked for, keyed by reqId. The
+     * ETH_BLOCK_HEADERS handler admits into the serve caches / {@link #chainHead}
+     * ONLY the headers matching the request we sent — a dialed peer answering with
+     * fabricated far-future numbers (or headers we never asked for) could otherwise
+     * pin the served window's eviction floor and inflate the announced head. Twin of
+     * the Rust EL's remember_served guard (PR #229). Bounded (fire-and-forget probes
+     * whose responses never arrive would otherwise leak entries); an evicted spec
+     * just means a late response isn't admitted to the serve surface — fail-closed,
+     * which is safe (the response is still returned to the verifying caller).
+     */
+    private static final int MAX_PENDING_HEADER_REQS = 256;
+    private final Map<Long, HeaderReq> pendingHeaderReqs = Collections.synchronizedMap(
+            new LinkedHashMap<>(16, 0.75f, false) {  // insertion-order: evict the oldest outstanding request
+                @Override protected boolean removeEldestEntry(Map.Entry<Long, HeaderReq> e) {
+                    return size() > MAX_PENDING_HEADER_REQS;
+                }
+            });
+
+    /** The block range or hash an outbound GetBlockHeaders asked for. All of our
+     *  requests use skip=0/ascending, so a by-number request admits exactly
+     *  {@code [start, start+count)} and a by-hash request admits only that hash.
+     *  Package-private for {@code HeaderReqTest}. */
+    record HeaderReq(org.apache.tuweni.bytes.Bytes32 hash, long start, int count) {
+        static HeaderReq byNumber(long start, int count) { return new HeaderReq(null, start, count); }
+        static HeaderReq byHash(org.apache.tuweni.bytes.Bytes32 hash) { return new HeaderReq(hash, 0, 0); }
+        boolean admits(org.apache.tuweni.bytes.Bytes32 headerHash, long number) {
+            if (hash != null) return hash.equals(headerHash);
+            // number - start (never overflows given number >= start) < count, so a huge
+            // start + count can't wrap negative and admit everything.
+            return number >= start && number - start < count;
+        }
+    }
     private final ConcurrentMap<Long, CompletableFuture<List<BlockBodiesMessage.BlockBody>>>
             pendingBodyRequests = new ConcurrentHashMap<>();
     private final ConcurrentMap<Long, CompletableFuture<List<List<org.apache.tuweni.bytes.Bytes>>>>
@@ -285,6 +318,7 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
             pendingRequests.values().forEach(f -> f.completeExceptionally(cause));
             pendingRequests.clear();
         }
+        pendingHeaderReqs.clear();
         if (!pendingBodyRequests.isEmpty()) {
             pendingBodyRequests.values().forEach(f -> f.completeExceptionally(cause));
             pendingBodyRequests.clear();
@@ -538,7 +572,14 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
                         BlockHeadersMessage.decodeWithRequestId(msg.payload());
                     log.info("[eth] Received {} block headers (reqId={})",
                             decoded.headers().size(), decoded.requestId());
+                    // Window-poisoning guard: admit into the serve caches / chainHead ONLY
+                    // the headers matching what we actually requested (a response for an
+                    // unknown reqId admits nothing). The FULL response still flows to the
+                    // pending future / onHeaders below — verification checks hashes itself.
+                    HeaderReq req = pendingHeaderReqs.remove(decoded.requestId());
+                    boolean admittedAny = false;
                     for (BlockHeadersMessage.VerifiedHeader vh : decoded.headers()) {
+                        if (req == null || !req.admits(vh.hash(), vh.header().number)) continue;
                         byte[] raw = vh.rawRlp().toArrayUnsafe();
                         headerCache.put(vh.header().number, raw);
                         hashCache.put(vh.hash().toHexString(), raw);
@@ -547,6 +588,7 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
                         log.debug("[eth] Cached header for block #{} hash={}",
                                 vh.header().number, vh.hash().toShortHexString());
                         chainHead.update(vh.header().number, vh.hash());
+                        admittedAny = true;
                         if (vh.header().number > latestStateRootBlockNumber) {
                             latestStateRootBlockNumber = vh.header().number;
                             latestStateRoot = vh.header().stateRoot;
@@ -554,7 +596,7 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
                     }
                     // Our servable range may have grown — let the connector push a
                     // BlockRangeUpdate to eth/69 peers who were told a narrower range.
-                    if (!decoded.headers().isEmpty()) {
+                    if (admittedAny) {
                         Runnable w = onWindowUpdated;
                         if (w != null) w.run();
                     }
@@ -917,6 +959,7 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
     public void requestBlockHeadersByHash(ChannelHandlerContext ctx, org.apache.tuweni.bytes.Bytes32 hash) {
         long reqId = requestId.getAndIncrement();
         log.info("[eth] GetBlockHeaders by hash={} reqId={}", hash.toShortHexString(), reqId);
+        pendingHeaderReqs.put(reqId, HeaderReq.byHash(hash));
         byte[] payload = GetBlockHeadersMessage.encodeByHash(reqId, hash, 1, 0, false);
         rlpxHandler.sendMessage(ctx, ETH_GET_BLOCK_HEADERS, payload);
     }
@@ -924,6 +967,7 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
     public void requestBlockHeaders(ChannelHandlerContext ctx, long blockNumber, int count) {
         long reqId = requestId.getAndIncrement();
         log.debug("[eth] GetBlockHeaders block={} count={} reqId={}", blockNumber, count, reqId);
+        pendingHeaderReqs.put(reqId, HeaderReq.byNumber(blockNumber, count));
         byte[] payload = GetBlockHeadersMessage.encodeByNumber(reqId, blockNumber, count, 0, false);
         rlpxHandler.sendMessage(ctx, ETH_GET_BLOCK_HEADERS, payload);
     }
@@ -942,6 +986,7 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
         CompletableFuture<List<BlockHeadersMessage.VerifiedHeader>> future = new CompletableFuture<>();
         long reqId = requestId.getAndIncrement();
         pendingRequests.put(reqId, future);
+        pendingHeaderReqs.put(reqId, HeaderReq.byNumber(blockNumber, count));
         log.debug("[eth] GetBlockHeaders (async) block={} count={} reqId={}", blockNumber, count, reqId);
         byte[] payload = GetBlockHeadersMessage.encodeByNumber(reqId, blockNumber, count, 0, false);
         rlpxHandler.sendMessage(ctx, ETH_GET_BLOCK_HEADERS, payload);
@@ -977,6 +1022,7 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
         long reqId = requestId.getAndIncrement();
         CompletableFuture<List<BlockHeadersMessage.VerifiedHeader>> headerFut = new CompletableFuture<>();
         pendingRequests.put(reqId, headerFut);
+        pendingHeaderReqs.put(reqId, HeaderReq.byHash(hash));
         byte[] payload = GetBlockHeadersMessage.encodeByHash(reqId, hash, 1, 0, false);
         log.debug("[eth] GetBlockHeaders (fresh head, hash={}) reqId={}",
             hash.toShortHexString(), reqId);
@@ -1020,6 +1066,7 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
         long reqId = requestId.getAndIncrement();
         CompletableFuture<List<BlockHeadersMessage.VerifiedHeader>> headerFut = new CompletableFuture<>();
         pendingRequests.put(reqId, headerFut);
+        pendingHeaderReqs.put(reqId, HeaderReq.byNumber(fromNumber, window));
         byte[] payload = GetBlockHeadersMessage.encodeByNumber(reqId, fromNumber, window, 0, false);
         log.debug("[eth] GetBlockHeaders (live head probe from #{} window={}) reqId={}",
             fromNumber, window, reqId);
@@ -1173,6 +1220,7 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
             return CompletableFuture.failedFuture(
                 new IllegalStateException("No best block hash from peer"));
         }
+        pendingHeaderReqs.put(reqId, HeaderReq.byHash(hash));
         byte[] headerPayload = GetBlockHeadersMessage.encodeByHash(reqId, hash, 1, 0, false);
         log.info("[snap] Fetching fresh header (hash={}) from peer {} before snap query",
             hash.toShortHexString(), remoteAddress);
@@ -1285,6 +1333,7 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
             return CompletableFuture.failedFuture(
                 new IllegalStateException("No best block hash from peer"));
         }
+        pendingHeaderReqs.put(reqId, HeaderReq.byHash(hash));
         byte[] headerPayload = GetBlockHeadersMessage.encodeByHash(reqId, hash, 1, 0, false);
         log.info("[snap] Fetching fresh header for storage query from peer {}", remoteAddress);
         rlpxHandler.sendMessage(ctx, ETH_GET_BLOCK_HEADERS, headerPayload);

--- a/networking/src/test/java/com/jaeckel/ethp2p/networking/eth/HeaderReqTest.java
+++ b/networking/src/test/java/com/jaeckel/ethp2p/networking/eth/HeaderReqTest.java
@@ -1,0 +1,56 @@
+package com.jaeckel.ethp2p.networking.eth;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The window-poisoning admission filter: a peer answering OUR GetBlockHeaders can
+ * only feed the serve caches / chainHead with headers matching what we asked for.
+ * A fabricated far-future number (or a header we never requested) must be rejected,
+ * so it cannot pin the served-window eviction floor or inflate the announced head.
+ * Twin of the Rust EL's remember_served guard (PR #229).
+ */
+class HeaderReqTest {
+
+    private static Bytes32 hash(long n) {
+        return Bytes32.rightPad(Bytes.ofUnsignedLong(0xC0FFEE0000000000L | n));
+    }
+
+    @Test
+    void byNumberAdmitsOnlyTheRequestedContiguousRange() {
+        EthHandler.HeaderReq req = EthHandler.HeaderReq.byNumber(21_000_000L, 8);
+        assertTrue(req.admits(hash(21_000_000L), 21_000_000L), "start of range");
+        assertTrue(req.admits(hash(21_000_007L), 21_000_007L), "last of range");
+        assertFalse(req.admits(hash(20_999_999L), 20_999_999L), "just below range");
+        assertFalse(req.admits(hash(21_000_008L), 21_000_008L), "just above range");
+        // The poisoning payload: a fabricated far-future number a hostile peer
+        // would use to pin the eviction floor / inflate the head.
+        assertFalse(req.admits(hash(Long.MAX_VALUE), Long.MAX_VALUE), "far-future fabrication");
+    }
+
+    @Test
+    void byNumberCountOfOneAdmitsExactlyThatBlock() {
+        EthHandler.HeaderReq req = EthHandler.HeaderReq.byNumber(500L, 1);
+        assertTrue(req.admits(hash(500L), 500L));
+        assertFalse(req.admits(hash(501L), 501L));
+    }
+
+    @Test
+    void byNumberDoesNotOverflowNearMaxCount() {
+        // start + count must not wrap negative and admit everything.
+        EthHandler.HeaderReq req = EthHandler.HeaderReq.byNumber(Long.MAX_VALUE - 2, Integer.MAX_VALUE);
+        assertTrue(req.admits(hash(Long.MAX_VALUE - 2), Long.MAX_VALUE - 2));
+        assertFalse(req.admits(hash(0L), 0L), "low number must not be admitted via overflow");
+    }
+
+    @Test
+    void byHashAdmitsOnlyTheExactRequestedHash() {
+        EthHandler.HeaderReq req = EthHandler.HeaderReq.byHash(hash(42L));
+        assertTrue(req.admits(hash(42L), 999L), "matching hash, any number");
+        assertFalse(req.admits(hash(43L), 42L), "wrong hash, even with a plausible number");
+    }
+}


### PR DESCRIPTION
## The vulnerability

The Java twin of the Rust hole fixed in #229. `EthHandler`'s `ETH_BLOCK_HEADERS` handler fed `headerCache` / `hashCache` / `servedWindow` (the eth/69 serve surface) **and** `chainHead` (the announced head) from **every** header a dialed peer returned to our own `GetBlockHeaders` requests — without checking the returned headers matched what we asked for.

A hostile peer answering one of our verdict-walk or head-probe fetches with a fabricated far-future-number header could:
- **pin the served window's eviction floor** at ~`u64::MAX`, killing header serving until reconnect;
- **poison the advertised eth/69 range** at every subsequent handshake;
- **inflate `chainHead`** (a monotonic max-CAS), corrupting the announced head.

## The fix

Record each **outbound** `GetBlockHeaders` request's spec (by-number range or by-hash), keyed by reqId, in a bounded map. At receive, admit into the serve caches / `chainHead` **only** the headers matching the request we sent (a response for an unknown reqId admits nothing). The **full** decoded response still flows to the pending future and `onHeaders` — verification checks hashes itself, so this only tightens the side-channel serve/advertise surface, never the verification path.

`HeaderReq.admits` is overflow-safe (`number - start < count`, not `start + count`) and package-private for the test.

## Review findings addressed (independent pre-PR review)

- **MAJOR**: my first pass recorded only 5 of the 7 outbound header-request sites — the two snap fresh-header fetches (`requestAccountAsync`/`requestStorageAsync`, run on every `get-account`/`get-storage`) were missed, which would have silently stopped those responses from feeding the window/chainHead (a functional regression on exactly the surface the fix protects). Now all 7 sites record their spec; a follow-up verification pass confirmed each `encode*` has a matching `put` of the correct shape.
- **NIT**: the bounded map's access-order flag was inert (only put/remove used) — set to insertion-order, which is the intended evict-oldest policy.

## Tests

`HeaderReqTest` pins the security property: far-future fabrication rejected, exact `[start, start+count)` range boundaries, count-of-1 exactness, by-hash exact-match, and the overflow guard (which caught a real `start + count` wrap bug during development). Full `:networking` and `:node-core` suites green; `:app` compiles.

Closes the open Java-side follow-up from #229.

🤖 Generated with [Claude Code](https://claude.com/claude-code)