### PR TITLE
build: keep cargo strictly optional for :app-ios (skip, don't fail)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 # iOS (macOS only; needs Xcode 26+ and the rustup targets on the toolchain the
 # workspace's rust-toolchain.toml selects — i.e.
-# `rustup target add --toolchain stable aarch64-apple-ios aarch64-apple-ios-sim`)
+# `rustup target add --toolchain stable aarch64-apple-ios aarch64-apple-ios-sim`).
+# Cargo stays optional here too: without the toolchain (and with no previously
+# built libmyotis_engine.a) :app-ios disables its framework tasks with a warning
+# instead of failing the build — the full toolchain is required only to actually
+# build the iOS app.
 ./gradlew cargoBuildIosSim                              # libmyotis_engine.a for the arm64 simulator
 ./gradlew cargoBuildIosDevice                           # libmyotis_engine.a for arm64 devices
 ./gradlew :app-ios:linkDebugFrameworkIosSimulatorArm64  # MyotisKit.framework (runs cargo first)

--- a/app-ios/build.gradle.kts
+++ b/app-ios/build.gradle.kts
@@ -70,3 +70,26 @@ mapOf(
         dependsOn(rootProject.tasks.named(cargoTask))
     }
 }
+
+// -----------------------------------------------------------------------------
+// Cargo stays STRICTLY OPTIONAL (the root build's contract): the cinterop fails
+// outright when libmyotis_engine.a is missing, so when any target's .a can
+// neither be built now (macOS + cargo + the rustup target — the cargo task's own
+// onlyIf) nor absorbed from an earlier build, this module disables its whole
+// task chain instead. `./gradlew build` then passes on a cargo-less machine —
+// the root build prints one warning per skipped triple naming the missing
+// prerequisites. The verdict is computed once in the root build (single source,
+// beside the cargo probes it derives from). Building the actual iOS app DOES
+// require the full toolchain — against a disabled module the Gradle step
+// reports success with every task SKIPPED, and it is Xcode's subsequent link
+// that fails at the missing framework, with the same warnings explaining why.
+// -----------------------------------------------------------------------------
+if (!(rootProject.extra["myotis.iosFrameworkBuildable"] as Boolean)) {
+    tasks.configureEach {
+        // `clean` keeps working (nothing about a missing toolchain makes deleting
+        // build output wrong), and the help/diagnostic tasks (`tasks`,
+        // `dependencies`, …) stay usable for debugging this module; everything
+        // else is skipped.
+        if (name != "clean" && group != "help") enabled = false
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -341,6 +341,21 @@ fun registerCargoBuildIos(taskName: String, triple: String) =
 registerCargoBuildIos("cargoBuildIosDevice", "aarch64-apple-ios")
 registerCargoBuildIos("cargoBuildIosSim", "aarch64-apple-ios-sim")
 
+// Whether the :app-ios framework chain can run at all: EVERY triple's
+// libmyotis_engine.a can either be built now (the cargo task's own onlyIf) or
+// absorbed from an earlier build. When false, :app-ios disables its whole task
+// chain (see its build file — it reads this single-sourced verdict) instead of
+// failing at the cinterop, keeping "cargo strictly optional" true build-wide.
+// All-or-nothing across the triples: the shared-source metadata/commonizer
+// tasks span both targets, so a half-enabled module would just move the
+// missing-input failure.
+val iosTriples = listOf("aarch64-apple-ios", "aarch64-apple-ios-sim")
+val iosFrameworkBuildable = iosTriples.all { triple ->
+    (rustAvailable && isMacHost && triple in installedRustupTargets) ||
+        file("rust/target/$triple/release/libmyotis_engine.a").exists()
+}
+extra["myotis.iosFrameworkBuildable"] = iosFrameworkBuildable
+
 // Exactly ONE note when Rust work was requested but is being skipped — enough
 // to explain the SKIPPED tasks without spamming every unrelated invocation.
 // (taskGraph.whenReady isn't configuration-cache-safe; this build doesn't
@@ -366,15 +381,23 @@ gradle.taskGraph.whenReady {
         logger.lifecycle("[rust] wasm32 canary skipped — needs rustup target wasm32-unknown-unknown + clang")
     }
     // The iOS skips get a WARNING, not a note: unlike the other cargo tasks there
-    // is no committed fallback — the cinterop absorbs whatever (possibly stale)
-    // libmyotis_engine.a sits in rust/target, and only the runtime ABI handshake
-    // would catch the drift. A missing .a fails the cinterop outright.
+    // is no committed fallback. With a previously built libmyotis_engine.a in
+    // rust/target the cinterop absorbs it (possibly STALE — only the runtime ABI
+    // handshake would catch the drift); with no .a at all, :app-ios disables its
+    // whole framework chain (see app-ios/build.gradle.kts) so a cargo-less build
+    // still passes.
     listOf("cargoBuildIosDevice" to "aarch64-apple-ios", "cargoBuildIosSim" to "aarch64-apple-ios-sim")
         .forEach { (task, triple) ->
             if (allTasks.any { it.name == task } && (!isMacHost || rustSkipNote != null || triple !in installedRustupTargets)) {
+                val prereqs = "needs macOS + cargo + `rustup target add --toolchain stable $triple`"
                 logger.warn(
-                    "[rust] $task skipped (needs macOS + cargo + `rustup target add --toolchain stable $triple`) — " +
-                        "the iOS framework will embed the EXISTING rust/target/$triple/release/libmyotis_engine.a, which may be stale"
+                    if (iosFrameworkBuildable)
+                        "[rust] $task skipped ($prereqs) — the iOS framework will embed the EXISTING " +
+                            "rust/target/$triple/release/libmyotis_engine.a, which may be stale"
+                    else
+                        "[rust] $task skipped ($prereqs) — the :app-ios framework tasks are disabled " +
+                            "(not every triple has a previously built libmyotis_engine.a to embed); " +
+                            "the rest of the build is unaffected"
                 )
             }
         }


### PR DESCRIPTION
Since #235, a Mac without cargo (or the rustup iOS targets) failed `./gradlew build` outright: the `:app-ios` cinterop needs `libmyotis_engine.a`, and when the cargo task self-skips with no previously built `.a` to absorb, the missing input is a hard failure. That broke the root build's "cargo strictly optional / pure-Java build unaffected" contract that every other cargo task honors.

## What this does

- The root build computes one single-sourced verdict (`myotis.iosFrameworkBuildable`): every triple's `.a` can either be built now (exactly the cargo task's own `onlyIf`: macOS + cargo + rustup target) or absorbed from an earlier build.
- When false, `:app-ios` disables its whole task chain — `clean` and the help/diagnostic tasks stay usable — so `./gradlew build` passes with every `:app-ios` task SKIPPED. All-or-nothing across the triples: the shared-source metadata/commonizer tasks span both targets, so a half-enabled module would just move the missing-input failure.
- The existing per-triple warning now tells the truth for both cases: "will embed the EXISTING (possibly stale) .a" when the module still builds, vs "the :app-ios framework tasks are disabled" when it can't.
- CLAUDE.md documents the behavior; building the actual iOS app still requires the full toolchain (the Gradle step reports success with tasks SKIPPED; Xcode's link then fails at the missing framework, with the warnings explaining why).

## Verified

- **No cargo on PATH, no `.a`**: `./gradlew :app-ios:build` → `BUILD SUCCESSFUL`, all 113 `:app-ios` tasks SKIPPED, two warnings naming the missing prerequisites; `:app-ios:tasks` (help group) still works.
- **Full toolchain**: `./gradlew :app-ios:build` → `BUILD SUCCESSFUL` with the framework linked (no regression).
- Independent no-context review found no correctness issues; its two polish notes (keep help tasks enabled; the "fails fast" comment overstating the Xcode-side failure point) are applied. It also confirmed Linux CI behavior is unchanged (`:app-ios` was already inert off-mac) and that the disabled chain still pulls the root cargo tasks into the graph so the warning fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)