### PR TITLE
docs: record why a JS-side engine was rejected in the React Native design

### DIFF
--- a/docs/react-native.md
+++ b/docs/react-native.md
@@ -104,6 +104,43 @@ and `:myotis-engines`' minimal-json layer (JSON decode, error mapping,
   C shim must stay unwrap-free by construction like `jni_shim`/`capi.rs`;
   a panic kills the RN app process.
 
+### Alternative considered: a JS-side engine
+
+Implementing the engine itself in JavaScript inside the RN app was
+evaluated and **rejected**. For the record, since the question recurs:
+
+- **There is no pure-JS variant.** RN's JS runtime (Hermes/JSC) has no
+  TCP/UDP API at all; the only route is native socket-shim modules
+  (`react-native-tcp-socket`, `react-native-udp`). So a "JS engine" still
+  keeps sockets native and instead pays per-packet bridge marshalling in
+  both directions — the bridge's worst-case workload, given how chatty
+  discovery and RLPx framing are.
+- **Crypto cost, with no escape hatch.** ECIES, AES-CTR framing, keccak,
+  secp256k1, and BLS fast-aggregate-verify in pure JS (noble/ethereumjs)
+  run 10–100× slower than blst/native — a sustained battery tax for
+  continuous sync. Hermes has no WebAssembly, so compiling the existing
+  Rust crates to WASM is not available in the default RN engine.
+- **The ecosystem targets Node, not RN.** `@ethereumjs/devp2p`,
+  js-libp2p, Lodestar, and `@ethereumjs/evm` are real building blocks,
+  but they sit on Node's `net`/`dgram`/worker APIs — ports, not
+  drop-ins.
+- **Lifecycle gets worse, not better.** The JS runtime only runs while
+  RN runs: iOS background JS is effectively nonexistent, Android
+  headless-JS is fragile. This doc already rejects headless-JS as the
+  wrong lifetime for sockets even as a *service host*; a JS engine would
+  make it the only mode.
+- **A third verification surface.** The trust model ("peer trusted is
+  never an option") would gain a third independent implementation after
+  Java and Rust — tripling where a verification bug can hide, without
+  the golden-test parity that pins the two existing engines to each
+  other.
+
+What deliberately *does* live on the JS side is everything above the
+`VerifiedReads` line: wallet/account state, transaction construction and
+ABI encoding, signing orchestration, ENS UX, polling orchestration, and
+all UI logic. That split is what the module shape below is designed
+around.
+
 ### RN module shape
 
 One package, `react-native-myotis/`, built as a **New Architecture Turbo


### PR DESCRIPTION
Follow-up to #236 (merged before this change landed): adds an "Alternative considered: a JS-side engine" subsection to `docs/react-native.md`, recording why implementing the myotis engine on the JavaScript side of a React Native app was evaluated and rejected:

- RN's JS runtime has no TCP/UDP API — a "JS engine" still keeps sockets in native shim modules and pays per-packet bridge marshalling both ways, the bridge's worst-case workload for chatty discovery/RLPx traffic.
- Pure-JS crypto (ECIES, AES-CTR, keccak, secp256k1, BLS) runs 10–100× slower than blst/native, and Hermes has no WebAssembly, so compiling the existing Rust crates to WASM is not an escape hatch.
- The JS ecosystem building blocks (`@ethereumjs/devp2p`, js-libp2p, Lodestar, `@ethereumjs/evm`) target Node's `net`/`dgram`, not React Native — ports, not drop-ins.
- The JS runtime lifecycle is worse than native for background sync (iOS background JS is effectively nonexistent; Android headless-JS is fragile).
- A third independent verification implementation (after Java and Rust) conflicts with the trust model, without the golden-test parity that pins the two existing engines to each other.

The section closes with what deliberately does live in JS: everything above the `VerifiedReads` line (wallet state, tx construction, ABI encoding, signing orchestration, ENS UX, polling orchestration, UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011hsKa1PzNhbmzX3RX53H97

---
_Generated by [Claude Code](https://claude.ai/code/session_011hsKa1PzNhbmzX3RX53H97)_