### PR TITLE
feeHistory follow-up: fee_json doc re-attached, strict gas accounting (#242 review)

### DIFF
--- a/rust/myotis-engine/src/eljson.rs
+++ b/rust/myotis-engine/src/eljson.rs
@@ -411,9 +411,6 @@ pub fn tx_json(t: &VerifiedTransaction) -> String {
     s
 }
 
-/// Serialize a verified fee suggestion. Both values are decimal-wei strings (the
-/// FFI-neutral form the Java `VerifiedReads.gasPrice()/maxPriorityFeePerGas()`
-/// return); the Java side re-encodes to 0x-QUANTITY at the JSON-RPC boundary.
 /// Serialize a verified `eth_feeHistory` result. Mirrors the Java
 /// `rpcFeeHistory` emission exactly in shape: `oldestBlock` + every base fee /
 /// reward tip as minimal-hex QUANTITYs, `gasUsedRatio` as raw JSON numbers,
@@ -467,6 +464,9 @@ pub fn fee_history_json(f: &FeeHistory) -> String {
     s
 }
 
+/// Serialize a verified fee suggestion. Both values are decimal-wei strings (the
+/// FFI-neutral form the Java `VerifiedReads.gasPrice()/maxPriorityFeePerGas()`
+/// return); the Java side re-encodes to 0x-QUANTITY at the JSON-RPC boundary.
 pub fn fee_json(f: &FeeEstimate) -> String {
     let mut obj = serde_json::Map::new();
     obj.insert("gasPriceWei".into(), f.gas_price_wei.to_string().into());

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -2036,6 +2036,18 @@ fn block_tx_tips(
     let body = bodies.into_iter().next().ok_or("peer returned no block body")?;
     verify_body_transactions(header, &body)?;
     if body.transactions.is_empty() {
+        // A root-verified EMPTY tx list ⇒ the anchored header must carry
+        // gasUsed 0 (same strictness as the non-empty path's final-sum check).
+        // Receipts are deliberately NOT consulted here — no weights to derive —
+        // matching the Java decodeBlockTips early return, and not making a
+        // quiet chain's feeHistory depend on how peers answer GetReceipts for
+        // zero-tx blocks.
+        if header.gas_used != 0 {
+            return Err(format!(
+                "block {} has no transactions but a non-zero header gasUsed {}",
+                header.number, header.gas_used
+            ));
+        }
         return Ok(Vec::new());
     }
     let receipts = receipt_blocks.into_iter().next().ok_or("peer returned no receipts")?;

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -2055,8 +2055,26 @@ fn block_tx_tips(
         let tip = tx::effective_tip(raw, base_fee)
             .ok_or_else(|| format!("block {} has an undecodable tx", header.number))?;
         let cum = crate::el::receipt::decode(receipt)?.cumulative_gas_used;
-        out.push((tip, cum.saturating_sub(prev_cum)));
+        // Strict, like the rest of this path: cumulative gas must be
+        // monotonic (a regression is impossible in a consensus-valid block —
+        // fail the block rather than silently zero a weight), …
+        if cum < prev_cum {
+            return Err(format!(
+                "block {} receipts have non-monotonic cumulative gas",
+                header.number
+            ));
+        }
+        out.push((tip, cum - prev_cum));
         prev_cum = cum;
+    }
+    // …and the last receipt's cumulative must equal the ANCHORED header's
+    // gasUsed (the header field is beacon-anchored; the receipts are
+    // root-verified — consensus ties the two together).
+    if prev_cum != header.gas_used {
+        return Err(format!(
+            "block {} receipts' final cumulative gas {} does not match the header gasUsed {}",
+            header.number, prev_cum, header.gas_used
+        ));
     }
     Ok(out)
 }


### PR DESCRIPTION
Cherry-pick of the #242 Copilot-review response that missed the merge window (the PR merged between my two review-fix pushes; `ab14d75` made it in, `0a6788b` — this commit — did not).

- **`fee_json` doc re-attached**: the `eth_feeHistory` serializer's insertion had landed between `fee_json`'s doc comment and its function, so `fee_history_json` carried both docs and `fee_json` none ([Copilot comment](https://github.com/biafra23/myotis/pull/242#discussion_r3586027837)).
- **Strict gas accounting in `block_tx_tips`** ([Copilot comment](https://github.com/biafra23/myotis/pull/242#discussion_r3586027876)): fail the block on non-monotonic cumulative receipt gas (instead of saturating a negative delta to 0 and silently skewing percentile weights), and require the last receipt's cumulative to equal the beacon-anchored header's `gasUsed` — both unreachable for consensus-valid data, but the path is strict by design and the final-sum check ties the root-verified receipts to the anchored header. The receipt-serve path's `saturating_sub` stays deliberately (Java `buildReceiptJson` wire parity).

No ABI/JSON-shape change; `cargo test -p myotis-net -p myotis-engine` green. Content was already reviewed on #242 (it *is* the review response), so no separate review round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)