### PR TITLE
Status: compact rows for phone-width screens

### DIFF
--- a/ios-app/MyotisUITests/ScreenshotTest.swift
+++ b/ios-app/MyotisUITests/ScreenshotTest.swift
@@ -1,0 +1,23 @@
+import XCTest
+
+/// Not a test of anything — a CLI screenshot utility for the PHYSICAL device,
+/// where `simctl io screenshot` has no counterpart. Attaches to the running
+/// app (activate, not launch — don't disturb its state) and stores one
+/// screenshot in the result bundle; extract it with `xcrun xcresulttool`.
+final class ScreenshotTest: XCTestCase {
+
+    func testCaptureScreenshot() throws {
+        let app = XCUIApplication()
+        app.activate()
+        XCTAssertTrue(app.staticTexts["Myotis"].waitForExistence(timeout: 20))
+        let shot = XCTAttachment(screenshot: app.screenshot())
+        shot.name = "device-screenshot"
+        shot.lifetime = .keepAlways
+        add(shot)
+        // Belt for CLI extraction: also write the PNG into the runner's own
+        // Documents, retrievable with `devicectl device copy from` (result-
+        // bundle attachment export has proven flaky from the command line).
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+        try app.screenshot().pngRepresentation.write(to: tmp.appendingPathComponent("shot.png"))
+    }
+}

--- a/ios-app/MyotisUITests/ScreenshotTest.swift
+++ b/ios-app/MyotisUITests/ScreenshotTest.swift
@@ -14,9 +14,11 @@ final class ScreenshotTest: XCTestCase {
         shot.name = "device-screenshot"
         shot.lifetime = .keepAlways
         add(shot)
-        // Belt for CLI extraction: also write the PNG into the runner's own
-        // Documents, retrievable with `devicectl device copy from` (result-
-        // bundle attachment export has proven flaky from the command line).
+        // Belt for CLI extraction: also write the PNG into the runner's tmp
+        // dir, for `devicectl device copy from --domain-type appDataContainer`
+        // (result-bundle attachment export has proven flaky from the command
+        // line; note the runner may get an ephemeral container per run, so
+        // this too is best-effort).
         let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
         try app.screenshot().pngRepresentation.write(to: tmp.appendingPathComponent("shot.png"))
     }

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
@@ -672,19 +672,28 @@ private fun StatusView(s: NodeSnapshot, hostSleeps: Boolean) {
         StatusRow("Beacon", s.beaconState)
         StatusRow("EL block", s.executionBlockNumber.toString())
         StatusRow("CL peers", "served ${s.clServedPeersLastMin}/min, con ${s.clConnectedPeers}")
-        StatusRow("EL peers", "ready ${s.readyPeers}, snap ${s.snapPeers}, serving ${s.snapServingPeers}")
-        // Cache rows: "proven" (CL) / "snap" (EL) predict how fast the NEXT
-        // cold start finds servers — the cache learning is visible live.
+        // Same total-first shape as the cache rows (the pool holds only ready
+        // peers, so the total IS the ready count).
+        StatusRow("EL peers", "${s.readyPeers} · snap ${s.snapPeers} · serving ${s.snapServingPeers}")
+        // Cache rows: confirmed-server counts predict how fast the NEXT cold
+        // start finds servers — the cache learning is visible live. One icon
+        // vocabulary for both rows, sized for phone-width screens:
+        // ✓ confirmed server (CL: proven LC · EL: snap-ok), ✕ confirmed not
+        // (nolc / snap-bad), ? untried.
         StatusRow(
             "CL cache",
-            "${s.clCachedPeers} (lc ${s.clCachedProven}, nolc ${s.clCachedNolc}, " +
-                "untried ${s.clCachedPeers - s.clCachedProven - s.clCachedNolc})",
+            "${s.clCachedPeers} · ✓${s.clCachedProven} ✕${s.clCachedNolc} " +
+                "?${s.clCachedPeers - s.clCachedProven - s.clCachedNolc}",
         )
-        StatusRow("EL cache", "${s.elCachedPeers} (snap ${s.elCachedSnapOk}, nosnap ${s.elCachedSnapBad})")
+        StatusRow(
+            "EL cache",
+            "${s.elCachedPeers} · ✓${s.elCachedSnapOk} ✕${s.elCachedSnapBad} " +
+                "?${s.elCachedPeers - s.elCachedSnapOk - s.elCachedSnapBad}",
+        )
         // What peers ask US for: demand for our served headers/blocks, and how often we
         // could answer. Bodies-served stays 0 (light client; prompt empty replies).
-        StatusRow("Peer asks · headers", "${s.peerHeaderRequests} asked, ${s.peerHeaderRequestsServed} served")
-        StatusRow("Peer asks · blocks", "${s.peerBodyRequests} asked, ${s.peerBodyRequestsServed} served")
+        StatusRow("Hdr asks", "${s.peerHeaderRequests} · served ${s.peerHeaderRequestsServed}")
+        StatusRow("Blk asks", "${s.peerBodyRequests} · served ${s.peerBodyRequestsServed}")
         StatusRow("Discovered", s.discoveredPeers.toString())
         StatusRow("Discv5 peers", s.discv5Peers.toString())
         StatusRow("In backoff", s.backedOffPeers.toString())
@@ -692,7 +701,7 @@ private fun StatusView(s: NodeSnapshot, hostSleeps: Boolean) {
         StatusRow("Sync period", "${s.syncCurrentPeriod} / ${s.syncTargetPeriod}")
         // verifiedHeadAgeMs == Long.MAX_VALUE is the "no verified head yet" sentinel — show a
         // dash instead of the raw ~9.2e18 ms, which would read as a nonsensical age.
-        StatusRow("Verified head age", if (s.verifiedHeadAgeMs == Long.MAX_VALUE) "—" else "${s.verifiedHeadAgeMs} ms")
+        StatusRow("Head age", if (s.verifiedHeadAgeMs == Long.MAX_VALUE) "—" else "${s.verifiedHeadAgeMs} ms")
         StatusRow("Uptime", "${s.uptimeSeconds}s")
         // Pseudo-sleep observability: how much the node has idle-slept, and when/why it
         // last woke. Foreground (opening the app) is excluded from the "last woke" reason,
@@ -704,7 +713,7 @@ private fun StatusView(s: NodeSnapshot, hostSleeps: Boolean) {
         StatusRow(
             "Sleep",
             when {
-                !hostSleeps -> "always on — no idle-sleep controller on this host"
+                !hostSleeps -> "always on"
                 s.pauseCount == 0 -> "never slept"
                 else -> "${formatDuration(s.totalPausedMs)} over ${s.pauseCount} " +
                     "${if (s.pauseCount == 1) "pause" else "pauses"}"

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
@@ -680,15 +680,19 @@ private fun StatusView(s: NodeSnapshot, hostSleeps: Boolean) {
         // vocabulary for both rows, sized for phone-width screens:
         // ✓ confirmed server (CL: proven LC · EL: snap-ok), ✕ confirmed not
         // (nolc / snap-bad), ? untried.
+        // The derived untried bucket can't go negative from ONE CacheFileStats
+        // parse (buckets are mutually exclusive per line), but coerce anyway so
+        // a future host feeding these fields from another source can't render
+        // "?-3".
         StatusRow(
             "CL cache",
             "${s.clCachedPeers} · ✓${s.clCachedProven} ✕${s.clCachedNolc} " +
-                "?${s.clCachedPeers - s.clCachedProven - s.clCachedNolc}",
+                "?${(s.clCachedPeers - s.clCachedProven - s.clCachedNolc).coerceAtLeast(0)}",
         )
         StatusRow(
             "EL cache",
             "${s.elCachedPeers} · ✓${s.elCachedSnapOk} ✕${s.elCachedSnapBad} " +
-                "?${s.elCachedPeers - s.elCachedSnapOk - s.elCachedSnapBad}",
+                "?${(s.elCachedPeers - s.elCachedSnapOk - s.elCachedSnapBad).coerceAtLeast(0)}",
         )
         // What peers ask US for: demand for our served headers/blocks, and how often we
         // could answer. Bodies-served stays 0 (light client; prompt empty replies).


### PR DESCRIPTION
The Status tab wrapped four rows at 390 pt (iPhone 16e — see the before/after in the session): EL peers, both cache rows, and Sleep.

- **Cache rows share one icon vocabulary**: ✓ confirmed server (CL: proven LC · EL: snap-ok), ✕ confirmed not (nolc / snap-bad), **? untried — which the EL row previously didn't show at all** (the CL row's derived third bucket, now on both).
- **EL peers** gets the same total-first shape: `5 · snap 5 · serving 5` (the pool holds only ready peers, so the total is the ready count).
- `Peer asks · headers/blocks` → `Hdr asks` / `Blk asks` with `N · served M`.
- `Verified head age` → `Head age`; the Sleep row's no-controller explanation shortens to `always on`.

Every row is now single-line at 390 pt and the whole tab + Start/Stop fits one viewport. Also includes ScreenshotTest, a CLI screenshot utility for the physical device. :ui:desktopTest green; verified on an iPhone 16e simulator and installed on the physical 16e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NepE2WEPuc1ZGdmsZYf79