### PR TITLE
Logs tab: reliable tail-follow with explicit intent state (+ desktop kotlinx-datetime runtime fix)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,7 +49,11 @@ kotlinx-serialization = "1.7.3"
 # 0.6.2 = the compatibility release for the kotlin.time.Instant the 2.1.20+ stdlib
 # introduced. The iOS (klib) compile still resolves the experimental stdlib Instant
 # in :ui's formatLogTime — see the local @OptIn there.
-kotlinx-datetime = "0.6.2"
+# 0.7.x: kotlinx.datetime.Instant became a typealias for kotlin.time.Instant (no binary class).
+# Compose material3-desktop already pulls 0.7.1 onto every desktop runtime classpath, so
+# compiling :ui against 0.6.x crashed the desktop Logs tab with NoClassDefFoundError at runtime
+# — keep this in sync with what the Compose BOM ships.
+kotlinx-datetime = "0.7.1"
 # Tiny (~30 KB), dependency-free, Android-safe JSON parser for :myotis-engines'
 # JNI JSON marshalling (hand-JNI decision, docs/reimplementation/05).
 minimal-json = "0.9.5"

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
@@ -49,12 +49,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
-import androidx.compose.ui.input.nestedscroll.NestedScrollSource
-import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.AnnotatedString
@@ -1088,31 +1085,56 @@ private fun LogsTab(logs: LogSource, filter: String, onFilterChange: (String) ->
     }
 
     val listState = rememberLazyListState()
-    // Tail-follow is explicit intent state, NOT derived from layout. Deriving "at bottom?" from
-    // visibleItemsInfo raced the 250ms poll: one batch of 2+ appended lines made the stale layout
-    // fail the check before the snap ran, silently breaking follow (how often depended on the
+    // Tail-follow is explicit intent state, NOT re-derived from layout on every append: the old
+    // "last visible >= shown.size - 2" check compared a stale layout against the fresh list, so
+    // any poll batch of more than 2 lines silently broke follow (how often depended on each
     // platform's log volume and frame timing). Entering the tab starts following — this
-    // composition is disposed on tab switch, so `remember` resets the flag to true on each visit.
+    // composition is disposed on tab switch, so `remember` resets the flag to true per visit.
     var follow by remember { mutableStateOf(true) }
-    // A user scroll toward older lines stops following. Programmatic scrollToItem bypasses
-    // nested scroll, so the auto-snap below can never cancel itself; the canScrollBackward
-    // guard ignores wheel/drag noise when everything already fits on screen.
-    val followBreaker = remember(listState) {
-        object : NestedScrollConnection {
-            override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
-                if (available.y > 0f && listState.canScrollBackward) follow = false
-                return Offset.Zero
-            }
-        }
+    // Guards the auto-snap below so its own scrollToItem can't read as a user scroll.
+    var autoSnapping by remember { mutableStateOf(false) }
+    // "At the tail" with ~1 item of tolerance (trackpad jitter, a stop a hair above the last
+    // line). Index and count come from the SAME layout pass, so a freshly-appended batch that
+    // hasn't been laid out yet can't skew the comparison the way the old shown.size check did.
+    fun nearTail(): Boolean {
+        val info = listState.layoutInfo
+        val last = info.visibleItemsInfo.lastOrNull() ?: return true
+        return last.index >= info.totalItemsCount - 2
     }
-    // Invariant: resting at the very bottom means following. Restores follow when the user
-    // scrolls (or flings) back down to the tail; including `follow` in the expression re-arms
-    // the check even when canScrollForward itself never toggles.
+    // Break: any scroll this composable didn't initiate that leaves the tail stops following.
+    // isScrollInProgress covers every input path uniformly — touch drag/fling, desktop mouse
+    // wheel and trackpad, and accessibility scroll actions (which bypass nested scroll and
+    // pointer input entirely, so a NestedScrollConnection would miss them).
     LaunchedEffect(listState) {
-        snapshotFlow { !listState.canScrollForward && !follow }.collect { if (it) follow = true }
+        snapshotFlow { listState.isScrollInProgress && !autoSnapping && !nearTail() }
+            .collect { if (it) follow = false }
     }
-    LaunchedEffect(shown, follow) {
-        if (follow && shown.isNotEmpty()) listState.scrollToItem(shown.size - 1)
+    // Resume: coming to rest at the tail re-arms following (drag, fling, or the button below).
+    // canScrollBackward keeps a list that merely FITS the viewport from re-arming — without it,
+    // scrolling up to read and then typing a filter that shrinks `shown` onto one screen would
+    // silently flip follow back on, and clearing the filter would yank away the reading
+    // position. Reading `follow` in the expression re-evaluates it when only the flag changed,
+    // so a break-then-return while the layout stays put can't leave follow stuck off.
+    LaunchedEffect(listState) {
+        snapshotFlow { !follow && listState.canScrollBackward && nearTail() }
+            .collect { if (it) follow = true }
+    }
+    // Snap while following, keyed on the tail line's identity — sequence, not size, because at
+    // ring capacity the size stays constant while lines shift. One long-lived collector instead
+    // of an effect restart per 250ms poll (snapshotFlow conflates, and emits nothing at all
+    // while follow is off or the tail is unchanged).
+    LaunchedEffect(listState) {
+        snapshotFlow { if (follow) shown.lastOrNull()?.sequence else null }
+            .collect {
+                if (it != null) {
+                    autoSnapping = true
+                    try {
+                        listState.scrollToItem(shown.size - 1)
+                    } finally {
+                        autoSnapping = false
+                    }
+                }
+            }
     }
 
     Column(Modifier.fillMaxSize()) {
@@ -1133,7 +1155,8 @@ private fun LogsTab(logs: LogSource, filter: String, onFilterChange: (String) ->
                 }
             }) { Text("Copy") }
             Spacer(Modifier.width(4.dp))
-            OutlinedButton(onClick = { logs.clear() }) { Text("Clear") }
+            // Clearing empties the ring — tail-follow the fresh lines that come after.
+            OutlinedButton(onClick = { logs.clear(); follow = true }) { Text("Clear") }
         }
         Spacer(Modifier.height(4.dp))
         // Capture level: lower it (e.g. DEBUG) to surface the chatty wire / peer-churn lines,
@@ -1154,12 +1177,12 @@ private fun LogsTab(logs: LogSource, filter: String, onFilterChange: (String) ->
         }
         Spacer(Modifier.height(8.dp))
         Box(Modifier.weight(1f).fillMaxWidth()) {
-            LazyColumn(state = listState, modifier = Modifier.fillMaxSize().nestedScroll(followBreaker)) {
+            LazyColumn(state = listState, modifier = Modifier.fillMaxSize().testTag("logList")) {
                 items(shown, key = { it.sequence }) { LogLineRow(it, tz) }
             }
             if (!follow && shown.isNotEmpty()) {
                 Button(
-                    // Setting follow restarts the auto-snap effect, which scrolls to the tail.
+                    // Setting follow makes the snap collector emit, which scrolls to the tail.
                     onClick = { follow = true },
                     modifier = Modifier.align(Alignment.BottomEnd).padding(8.dp),
                 ) { Text("↓ Latest") }

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
@@ -40,16 +40,20 @@ import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -65,7 +69,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 
@@ -1084,16 +1088,31 @@ private fun LogsTab(logs: LogSource, filter: String, onFilterChange: (String) ->
     }
 
     val listState = rememberLazyListState()
-    // Auto-follow: key on `shown` so the derived state re-reads the current list (not a stale
-    // capture); size-2 tolerates the one-frame lag before a freshly-appended item is laid out.
-    val atBottom by remember(shown) {
-        derivedStateOf {
-            val last = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
-            last >= shown.size - 2
+    // Tail-follow is explicit intent state, NOT derived from layout. Deriving "at bottom?" from
+    // visibleItemsInfo raced the 250ms poll: one batch of 2+ appended lines made the stale layout
+    // fail the check before the snap ran, silently breaking follow (how often depended on the
+    // platform's log volume and frame timing). Entering the tab starts following — this
+    // composition is disposed on tab switch, so `remember` resets the flag to true on each visit.
+    var follow by remember { mutableStateOf(true) }
+    // A user scroll toward older lines stops following. Programmatic scrollToItem bypasses
+    // nested scroll, so the auto-snap below can never cancel itself; the canScrollBackward
+    // guard ignores wheel/drag noise when everything already fits on screen.
+    val followBreaker = remember(listState) {
+        object : NestedScrollConnection {
+            override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+                if (available.y > 0f && listState.canScrollBackward) follow = false
+                return Offset.Zero
+            }
         }
     }
-    LaunchedEffect(shown.size) {
-        if (atBottom && shown.isNotEmpty()) listState.scrollToItem(shown.size - 1)
+    // Invariant: resting at the very bottom means following. Restores follow when the user
+    // scrolls (or flings) back down to the tail; including `follow` in the expression re-arms
+    // the check even when canScrollForward itself never toggles.
+    LaunchedEffect(listState) {
+        snapshotFlow { !listState.canScrollForward && !follow }.collect { if (it) follow = true }
+    }
+    LaunchedEffect(shown, follow) {
+        if (follow && shown.isNotEmpty()) listState.scrollToItem(shown.size - 1)
     }
 
     Column(Modifier.fillMaxSize()) {
@@ -1135,12 +1154,13 @@ private fun LogsTab(logs: LogSource, filter: String, onFilterChange: (String) ->
         }
         Spacer(Modifier.height(8.dp))
         Box(Modifier.weight(1f).fillMaxWidth()) {
-            LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
+            LazyColumn(state = listState, modifier = Modifier.fillMaxSize().nestedScroll(followBreaker)) {
                 items(shown, key = { it.sequence }) { LogLineRow(it, tz) }
             }
-            if (!atBottom && shown.isNotEmpty()) {
+            if (!follow && shown.isNotEmpty()) {
                 Button(
-                    onClick = { scope.launch { listState.scrollToItem(shown.size - 1) } },
+                    // Setting follow restarts the auto-snap effect, which scrolls to the tail.
+                    onClick = { follow = true },
                     modifier = Modifier.align(Alignment.BottomEnd).padding(8.dp),
                 ) { Text("↓ Latest") }
             }
@@ -1198,9 +1218,8 @@ private fun formatDuration(ms: Long): String {
 }
 
 /** HH:mm:ss.SSS in [tz] (matches the logback console/file pattern). */
-// The opt-in is for the iOS (klib) compile, where kotlinx-datetime 0.6.x resolves
-// Instant against the 2.2 stdlib's experimental kotlin.time.Instant; the JVM and
-// Android compiles resolve kotlinx-datetime's own stable Instant and ignore it.
+// kotlin.time.Instant (used by kotlinx-datetime 0.7.x on every target) is still
+// @ExperimentalTime in the 2.2 stdlib.
 @OptIn(kotlin.time.ExperimentalTime::class)
 private fun formatLogTime(ms: Long, tz: TimeZone): String {
     val dt = Instant.fromEpochMilliseconds(ms).toLocalDateTime(tz)

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
@@ -1129,7 +1129,9 @@ private fun LogsTab(logs: LogSource, filter: String, onFilterChange: (String) ->
                 if (it != null) {
                     autoSnapping = true
                     try {
-                        listState.scrollToItem(shown.size - 1)
+                        // Re-check: `shown` can go empty (Clear, filter) between the emission
+                        // and this collect step, and scrollToItem(-1) throws.
+                        if (shown.isNotEmpty()) listState.scrollToItem(shown.size - 1)
                     } finally {
                         autoSnapping = false
                     }

--- a/ui/src/desktopTest/kotlin/io/myotis/ui/LogsFilterPersistenceTest.kt
+++ b/ui/src/desktopTest/kotlin/io/myotis/ui/LogsFilterPersistenceTest.kt
@@ -7,8 +7,6 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOf
 import org.junit.Rule
 import org.junit.Test
 
@@ -63,7 +61,7 @@ class LogsFilterPersistenceTest {
     /** Run a few frames so clicks/typing recompose while the clock stays paused. */
     private fun pumpFrames() = repeat(3) { rule.mainClock.advanceTimeByFrame() }
 
-    // ---- minimal fakes for the NodeScreen seams (nothing backend-bound) ----
+    // FakeController/FakeSettings live in NodeScreenTestFakes.kt (shared fixtures).
 
     private class FakeLogs : LogSource {
         override fun version(): Long = 0L
@@ -73,49 +71,4 @@ class LogsFilterPersistenceTest {
         override fun setLevel(level: LogLevel) {}
     }
 
-    private class FakeController : NodeController {
-        override val running: Boolean = false
-        override fun snapshots(): Flow<Map<String, NodeSnapshot>> = flowOf(emptyMap())
-        override fun enableNetwork(name: String) {}
-        override fun disableNetwork(name: String) {}
-        override fun startNetwork(name: String) {}
-        override fun stopNetwork(name: String) {}
-        override fun rebootNetwork(name: String) {}
-        override fun shutdown() {}
-        override fun setTargetSnapPeers(target: Int) {}
-        override fun setServedBlockWindow(blocks: Int) {}
-        override fun applyBlsBackend() {}
-        override fun applyEngineChoice() {}
-        override fun clearCaches(network: String) {}
-        override fun resetSyncState(network: String) {}
-        override suspend fun requestAccount(network: String, address: String): AccountResult =
-            error("not used in this test")
-        override suspend fun resolveEns(network: String, name: String): EnsResult =
-            error("not used in this test")
-    }
-
-    private class FakeSettings : Settings {
-        override fun enabledNetworks(): List<String> = listOf("mainnet")
-        override fun primaryNetwork(): String = "mainnet"
-        override fun allNetworks(): List<String> = listOf("mainnet")
-        override fun isNetworkEnabled(name: String): Boolean = name == "mainnet"
-        override fun setNetworkEnabled(name: String, enabled: Boolean) {}
-        override fun rpcPortFor(network: String): Int = 8545
-        override fun setRpcPort(network: String, port: Int) {}
-        override fun snapTarget(): Int = 3
-        override fun setSnapTarget(v: Int) {}
-        override fun servedBlockWindow(): Int = 32
-        override fun setServedBlockWindow(v: Int) {}
-        override fun displayName(network: String): String = network
-        override fun defaultRpcPort(network: String): Int = 8545
-        override fun hasEns(network: String): Boolean = true
-        override fun deepPoolThreshold(): Int = 0
-        override fun setDeepPool(v: Int) {}
-        override fun strictStateFreshness(): Boolean = false
-        override fun setStrictStateFreshness(v: Boolean) {}
-        override fun nativeBlsEnabled(): Boolean = false
-        override fun setNativeBlsEnabled(v: Boolean) {}
-        override fun rustEngineEnabled(): Boolean = false
-        override fun setRustEngineEnabled(v: Boolean) {}
-    }
 }

--- a/ui/src/desktopTest/kotlin/io/myotis/ui/LogsTailFollowTest.kt
+++ b/ui/src/desktopTest/kotlin/io/myotis/ui/LogsTailFollowTest.kt
@@ -1,0 +1,174 @@
+package io.myotis.ui
+
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isSelectable
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipeDown
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Regression tests for the Logs tab's tail-follow behavior:
+ *
+ *  - While the user is at the tail, arbitrarily LARGE batches of appended lines must keep
+ *    following (the old layout-derived "am I at bottom?" check broke follow as soon as one
+ *    250ms poll delivered more than 2 lines, with platform-dependent timing).
+ *  - Only an actual user scroll toward older lines stops following and shows "↓ Latest".
+ *  - Pressing "↓ Latest" resumes following.
+ */
+class LogsTailFollowTest {
+
+    @get:Rule
+    val rule = createComposeRule()
+
+    private val logs = MutableLogs()
+
+    @Test
+    fun followSurvivesBatchedAppendsUntilUserScrollsBack() {
+        // Same clock regime as LogsFilterPersistenceTest: the tab polls in an infinite
+        // delay(250) loop, so pause the clock and advance it manually.
+        rule.mainClock.autoAdvance = false
+        rule.setContent {
+            NodeScreen(controller = FakeController(), settings = FakeSettings(), logs = logs)
+        }
+        pumpFrames()
+        tab("Logs").performClick()
+        pumpFrames()
+
+        // A large batch lands in ONE poll — far beyond the viewport. Follow must hold:
+        // the newest line is on screen and no "↓ Latest" button appears.
+        logs.append(120)
+        awaitLine("line 119")
+        rule.onNodeWithText("line 119", substring = true).assertIsDisplayed()
+        rule.onAllLatestButtons().assertCountEquals(0)
+
+        // A second big batch — still following.
+        logs.append(120)
+        awaitLine("line 239")
+        rule.onNodeWithText("line 239", substring = true).assertIsDisplayed()
+        rule.onAllLatestButtons().assertCountEquals(0)
+
+        // The user scrolls back (touch drag toward older lines): following stops,
+        // the button appears, and new appends no longer yank the list down.
+        rule.onNodeWithText("line 239", substring = true).performTouchInput { swipeDown() }
+        pumpFrames(20)  // let the fling settle
+        rule.onLatestButton().assertIsDisplayed()
+
+        logs.append(60)
+        rule.mainClock.advanceTimeBy(600)
+        Thread.sleep(50)  // off-main snapshot hop
+        pumpFrames()
+        rule.onLatestButton().assertIsDisplayed()
+        rule.onAllNodes(hasText("line 299", substring = true)).assertCountEquals(0)
+
+        // "↓ Latest" resumes following: newest line visible, button gone again.
+        rule.onLatestButton().performClick()
+        pumpFrames()
+        rule.onNodeWithText("line 299", substring = true).assertIsDisplayed()
+        rule.onAllLatestButtons().assertCountEquals(0)
+
+        // And follow keeps holding for the next batch.
+        logs.append(80)
+        awaitLine("line 379")
+        rule.onNodeWithText("line 379", substring = true).assertIsDisplayed()
+        rule.onAllLatestButtons().assertCountEquals(0)
+    }
+
+    private fun androidx.compose.ui.test.junit4.ComposeContentTestRule.onAllLatestButtons() =
+        onAllNodes(hasText("↓ Latest"))
+    private fun androidx.compose.ui.test.junit4.ComposeContentTestRule.onLatestButton() =
+        onNodeWithText("↓ Latest")
+
+    /** The tab bar's tabs are the only selectable nodes on the screen. */
+    private fun tab(label: String) = rule.onNode(isSelectable() and hasText(label))
+
+    private fun pumpFrames(n: Int = 3) = repeat(n) { rule.mainClock.advanceTimeByFrame() }
+
+    /**
+     * Drive the poll loop until [text] is composed. The 250ms poll delay is on the virtual
+     * clock, but the snapshot itself hops to Dispatchers.Default (a real thread), so pair
+     * each virtual advance with a short real-time sleep.
+     */
+    private fun awaitLine(text: String) {
+        repeat(100) {
+            rule.mainClock.advanceTimeBy(300)
+            Thread.sleep(20)
+            pumpFrames()
+            if (rule.onAllNodes(hasText(text, substring = true)).fetchSemanticsNodes().isNotEmpty()) return
+        }
+        error("timed out waiting for log line containing \"$text\"")
+    }
+
+    // ---- fakes ----
+
+    /** Appendable in-memory LogSource; snapshot() is called from Dispatchers.Default. */
+    private class MutableLogs : LogSource {
+        private val lines = mutableListOf<LogLine>()
+        private var v = 0L
+        @Synchronized override fun version(): Long = v
+        @Synchronized override fun snapshot(): List<LogLine> = lines.toList()
+        @Synchronized override fun clear() { lines.clear(); v++ }
+        override fun level(): LogLevel = LogLevel.DEBUG
+        override fun setLevel(level: LogLevel) {}
+        @Synchronized fun append(n: Int) {
+            repeat(n) {
+                val seq = lines.size.toLong()
+                lines += LogLine(seq, 1_700_000_000_000 + seq, 'I', "test", "line $seq")
+            }
+            v++
+        }
+    }
+
+    private class FakeController : NodeController {
+        override val running: Boolean = false
+        override fun snapshots(): Flow<Map<String, NodeSnapshot>> = flowOf(emptyMap())
+        override fun enableNetwork(name: String) {}
+        override fun disableNetwork(name: String) {}
+        override fun startNetwork(name: String) {}
+        override fun stopNetwork(name: String) {}
+        override fun rebootNetwork(name: String) {}
+        override fun shutdown() {}
+        override fun setTargetSnapPeers(target: Int) {}
+        override fun setServedBlockWindow(blocks: Int) {}
+        override fun applyBlsBackend() {}
+        override fun applyEngineChoice() {}
+        override fun clearCaches(network: String) {}
+        override fun resetSyncState(network: String) {}
+        override suspend fun requestAccount(network: String, address: String): AccountResult =
+            error("not used in this test")
+        override suspend fun resolveEns(network: String, name: String): EnsResult =
+            error("not used in this test")
+    }
+
+    private class FakeSettings : Settings {
+        override fun enabledNetworks(): List<String> = listOf("mainnet")
+        override fun primaryNetwork(): String = "mainnet"
+        override fun allNetworks(): List<String> = listOf("mainnet")
+        override fun isNetworkEnabled(name: String): Boolean = name == "mainnet"
+        override fun setNetworkEnabled(name: String, enabled: Boolean) {}
+        override fun rpcPortFor(network: String): Int = 8545
+        override fun setRpcPort(network: String, port: Int) {}
+        override fun snapTarget(): Int = 3
+        override fun setSnapTarget(v: Int) {}
+        override fun servedBlockWindow(): Int = 32
+        override fun setServedBlockWindow(v: Int) {}
+        override fun displayName(network: String): String = network
+        override fun defaultRpcPort(network: String): Int = 8545
+        override fun hasEns(network: String): Boolean = true
+        override fun deepPoolThreshold(): Int = 0
+        override fun setDeepPool(v: Int) {}
+        override fun strictStateFreshness(): Boolean = false
+        override fun setStrictStateFreshness(v: Boolean) {}
+        override fun nativeBlsEnabled(): Boolean = false
+        override fun setNativeBlsEnabled(v: Boolean) {}
+        override fun rustEngineEnabled(): Boolean = false
+        override fun setRustEngineEnabled(v: Boolean) {}
+    }
+}

--- a/ui/src/desktopTest/kotlin/io/myotis/ui/LogsTailFollowTest.kt
+++ b/ui/src/desktopTest/kotlin/io/myotis/ui/LogsTailFollowTest.kt
@@ -5,12 +5,13 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isSelectable
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performMouseInput
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipeDown
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOf
+import androidx.compose.ui.test.swipeUp
 import org.junit.Rule
 import org.junit.Test
 
@@ -20,8 +21,10 @@ import org.junit.Test
  *  - While the user is at the tail, arbitrarily LARGE batches of appended lines must keep
  *    following (the old layout-derived "am I at bottom?" check broke follow as soon as one
  *    250ms poll delivered more than 2 lines, with platform-dependent timing).
- *  - Only an actual user scroll toward older lines stops following and shows "↓ Latest".
- *  - Pressing "↓ Latest" resumes following.
+ *  - Only an actual user scroll toward older lines stops following and shows "↓ Latest" —
+ *    covered for both touch drags and mouse-wheel scrolls (desktop's primary input, which
+ *    takes a different dispatch path than drags).
+ *  - Scrolling back down to the tail, or pressing "↓ Latest", resumes following.
  */
 class LogsTailFollowTest {
 
@@ -32,81 +35,120 @@ class LogsTailFollowTest {
 
     @Test
     fun followSurvivesBatchedAppendsUntilUserScrollsBack() {
-        // Same clock regime as LogsFilterPersistenceTest: the tab polls in an infinite
-        // delay(250) loop, so pause the clock and advance it manually.
+        openLogsTab()
+
+        // A large batch lands in ONE poll — far beyond the viewport. Follow must hold:
+        // the newest line is on screen and no "↓ Latest" button appears.
+        logs.append(120)
+        awaitText("line 119")
+        rule.onNodeWithText("line 119", substring = true).assertIsDisplayed()
+        latestButtons().assertCountEquals(0)
+
+        // A second big batch — still following.
+        logs.append(120)
+        awaitText("line 239")
+        rule.onNodeWithText("line 239", substring = true).assertIsDisplayed()
+        latestButtons().assertCountEquals(0)
+
+        // The user scrolls back (touch drag toward older lines): following stops and
+        // the button appears.
+        logList().performTouchInput { swipeDown() }
+        pumpFrames(20)  // let the fling settle
+        latestButton().assertIsDisplayed()
+
+        // New appends no longer yank the list down. The counter proves the batch actually
+        // reached the composition (otherwise the "tail not shown" check would pass vacuously
+        // just because the poll hadn't landed yet).
+        logs.append(60)
+        awaitText("300 / 300 lines")
+        latestButton().assertIsDisplayed()
+        rule.onAllNodes(hasText("line 299", substring = true)).assertCountEquals(0)
+
+        // "↓ Latest" resumes following: newest line visible, button gone again.
+        latestButton().performClick()
+        pumpFrames()
+        rule.onNodeWithText("line 299", substring = true).assertIsDisplayed()
+        latestButtons().assertCountEquals(0)
+
+        // And follow keeps holding for the next batch.
+        logs.append(80)
+        awaitText("line 379")
+        rule.onNodeWithText("line 379", substring = true).assertIsDisplayed()
+        latestButtons().assertCountEquals(0)
+
+        // Scrolling back down to the tail (no button press) also resumes following.
+        logList().performTouchInput { swipeDown() }
+        pumpFrames(20)
+        latestButton().assertIsDisplayed()
+        var attempts = 0
+        while (latestButtons().fetchSemanticsNodes().isNotEmpty() && attempts++ < 8) {
+            logList().performTouchInput { swipeUp() }
+            pumpFrames(20)
+        }
+        latestButtons().assertCountEquals(0)
+        logs.append(20)
+        awaitText("line 399")
+        rule.onNodeWithText("line 399", substring = true).assertIsDisplayed()
+        latestButtons().assertCountEquals(0)
+    }
+
+    @Test
+    fun mouseWheelScrollBackBreaksFollow() {
+        openLogsTab()
+        logs.append(120)
+        awaitText("line 119")
+        latestButtons().assertCountEquals(0)
+
+        // Wheel toward older lines. Desktop wheel scrolling dispatches differently from touch
+        // drags (this is the input path real desktop users take), so pin it separately.
+        logList().performMouseInput {
+            moveTo(center)
+            repeat(3) { scroll(-3f) }
+        }
+        pumpFrames(20)
+        latestButton().assertIsDisplayed()
+
+        latestButton().performClick()
+        pumpFrames()
+        latestButtons().assertCountEquals(0)
+        rule.onNodeWithText("line 119", substring = true).assertIsDisplayed()
+    }
+
+    // ---- harness ----
+
+    /** Same clock regime as LogsFilterPersistenceTest: the tab polls in an infinite
+     *  delay(250) loop, so pause the clock and advance it manually. */
+    private fun openLogsTab() {
         rule.mainClock.autoAdvance = false
         rule.setContent {
             NodeScreen(controller = FakeController(), settings = FakeSettings(), logs = logs)
         }
         pumpFrames()
-        tab("Logs").performClick()
+        rule.onNode(isSelectable() and hasText("Logs")).performClick()
         pumpFrames()
-
-        // A large batch lands in ONE poll — far beyond the viewport. Follow must hold:
-        // the newest line is on screen and no "↓ Latest" button appears.
-        logs.append(120)
-        awaitLine("line 119")
-        rule.onNodeWithText("line 119", substring = true).assertIsDisplayed()
-        rule.onAllLatestButtons().assertCountEquals(0)
-
-        // A second big batch — still following.
-        logs.append(120)
-        awaitLine("line 239")
-        rule.onNodeWithText("line 239", substring = true).assertIsDisplayed()
-        rule.onAllLatestButtons().assertCountEquals(0)
-
-        // The user scrolls back (touch drag toward older lines): following stops,
-        // the button appears, and new appends no longer yank the list down.
-        rule.onNodeWithText("line 239", substring = true).performTouchInput { swipeDown() }
-        pumpFrames(20)  // let the fling settle
-        rule.onLatestButton().assertIsDisplayed()
-
-        logs.append(60)
-        rule.mainClock.advanceTimeBy(600)
-        Thread.sleep(50)  // off-main snapshot hop
-        pumpFrames()
-        rule.onLatestButton().assertIsDisplayed()
-        rule.onAllNodes(hasText("line 299", substring = true)).assertCountEquals(0)
-
-        // "↓ Latest" resumes following: newest line visible, button gone again.
-        rule.onLatestButton().performClick()
-        pumpFrames()
-        rule.onNodeWithText("line 299", substring = true).assertIsDisplayed()
-        rule.onAllLatestButtons().assertCountEquals(0)
-
-        // And follow keeps holding for the next batch.
-        logs.append(80)
-        awaitLine("line 379")
-        rule.onNodeWithText("line 379", substring = true).assertIsDisplayed()
-        rule.onAllLatestButtons().assertCountEquals(0)
     }
 
-    private fun androidx.compose.ui.test.junit4.ComposeContentTestRule.onAllLatestButtons() =
-        onAllNodes(hasText("↓ Latest"))
-    private fun androidx.compose.ui.test.junit4.ComposeContentTestRule.onLatestButton() =
-        onNodeWithText("↓ Latest")
-
-    /** The tab bar's tabs are the only selectable nodes on the screen. */
-    private fun tab(label: String) = rule.onNode(isSelectable() and hasText(label))
+    private fun latestButtons() = rule.onAllNodes(hasText("↓ Latest"))
+    private fun latestButton() = rule.onNodeWithText("↓ Latest")
+    private fun logList() = rule.onNodeWithTag("logList")
 
     private fun pumpFrames(n: Int = 3) = repeat(n) { rule.mainClock.advanceTimeByFrame() }
 
     /**
      * Drive the poll loop until [text] is composed. The 250ms poll delay is on the virtual
      * clock, but the snapshot itself hops to Dispatchers.Default (a real thread), so pair
-     * each virtual advance with a short real-time sleep.
+     * each virtual advance with a short real-time sleep; the loop retries until the hop
+     * lands, so a slow CI thread costs iterations, not correctness.
      */
-    private fun awaitLine(text: String) {
-        repeat(100) {
+    private fun awaitText(text: String) {
+        repeat(200) {
             rule.mainClock.advanceTimeBy(300)
             Thread.sleep(20)
             pumpFrames()
             if (rule.onAllNodes(hasText(text, substring = true)).fetchSemanticsNodes().isNotEmpty()) return
         }
-        error("timed out waiting for log line containing \"$text\"")
+        error("timed out waiting for \"$text\"")
     }
-
-    // ---- fakes ----
 
     /** Appendable in-memory LogSource; snapshot() is called from Dispatchers.Default. */
     private class MutableLogs : LogSource {
@@ -124,51 +166,5 @@ class LogsTailFollowTest {
             }
             v++
         }
-    }
-
-    private class FakeController : NodeController {
-        override val running: Boolean = false
-        override fun snapshots(): Flow<Map<String, NodeSnapshot>> = flowOf(emptyMap())
-        override fun enableNetwork(name: String) {}
-        override fun disableNetwork(name: String) {}
-        override fun startNetwork(name: String) {}
-        override fun stopNetwork(name: String) {}
-        override fun rebootNetwork(name: String) {}
-        override fun shutdown() {}
-        override fun setTargetSnapPeers(target: Int) {}
-        override fun setServedBlockWindow(blocks: Int) {}
-        override fun applyBlsBackend() {}
-        override fun applyEngineChoice() {}
-        override fun clearCaches(network: String) {}
-        override fun resetSyncState(network: String) {}
-        override suspend fun requestAccount(network: String, address: String): AccountResult =
-            error("not used in this test")
-        override suspend fun resolveEns(network: String, name: String): EnsResult =
-            error("not used in this test")
-    }
-
-    private class FakeSettings : Settings {
-        override fun enabledNetworks(): List<String> = listOf("mainnet")
-        override fun primaryNetwork(): String = "mainnet"
-        override fun allNetworks(): List<String> = listOf("mainnet")
-        override fun isNetworkEnabled(name: String): Boolean = name == "mainnet"
-        override fun setNetworkEnabled(name: String, enabled: Boolean) {}
-        override fun rpcPortFor(network: String): Int = 8545
-        override fun setRpcPort(network: String, port: Int) {}
-        override fun snapTarget(): Int = 3
-        override fun setSnapTarget(v: Int) {}
-        override fun servedBlockWindow(): Int = 32
-        override fun setServedBlockWindow(v: Int) {}
-        override fun displayName(network: String): String = network
-        override fun defaultRpcPort(network: String): Int = 8545
-        override fun hasEns(network: String): Boolean = true
-        override fun deepPoolThreshold(): Int = 0
-        override fun setDeepPool(v: Int) {}
-        override fun strictStateFreshness(): Boolean = false
-        override fun setStrictStateFreshness(v: Boolean) {}
-        override fun nativeBlsEnabled(): Boolean = false
-        override fun setNativeBlsEnabled(v: Boolean) {}
-        override fun rustEngineEnabled(): Boolean = false
-        override fun setRustEngineEnabled(v: Boolean) {}
     }
 }

--- a/ui/src/desktopTest/kotlin/io/myotis/ui/NodeScreenTestFakes.kt
+++ b/ui/src/desktopTest/kotlin/io/myotis/ui/NodeScreenTestFakes.kt
@@ -1,0 +1,55 @@
+package io.myotis.ui
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+
+/**
+ * Shared no-op fakes for the [NodeScreen] seams, used by the desktop UI tests
+ * (LogsFilterPersistenceTest, LogsTailFollowTest). Kept in one place so a
+ * NodeController/Settings interface change breaks exactly one fixture.
+ */
+internal class FakeController : NodeController {
+    override val running: Boolean = false
+    override fun snapshots(): Flow<Map<String, NodeSnapshot>> = flowOf(emptyMap())
+    override fun enableNetwork(name: String) {}
+    override fun disableNetwork(name: String) {}
+    override fun startNetwork(name: String) {}
+    override fun stopNetwork(name: String) {}
+    override fun rebootNetwork(name: String) {}
+    override fun shutdown() {}
+    override fun setTargetSnapPeers(target: Int) {}
+    override fun setServedBlockWindow(blocks: Int) {}
+    override fun applyBlsBackend() {}
+    override fun applyEngineChoice() {}
+    override fun clearCaches(network: String) {}
+    override fun resetSyncState(network: String) {}
+    override suspend fun requestAccount(network: String, address: String): AccountResult =
+        error("not used in UI tests")
+    override suspend fun resolveEns(network: String, name: String): EnsResult =
+        error("not used in UI tests")
+}
+
+internal class FakeSettings : Settings {
+    override fun enabledNetworks(): List<String> = listOf("mainnet")
+    override fun primaryNetwork(): String = "mainnet"
+    override fun allNetworks(): List<String> = listOf("mainnet")
+    override fun isNetworkEnabled(name: String): Boolean = name == "mainnet"
+    override fun setNetworkEnabled(name: String, enabled: Boolean) {}
+    override fun rpcPortFor(network: String): Int = 8545
+    override fun setRpcPort(network: String, port: Int) {}
+    override fun snapTarget(): Int = 3
+    override fun setSnapTarget(v: Int) {}
+    override fun servedBlockWindow(): Int = 32
+    override fun setServedBlockWindow(v: Int) {}
+    override fun displayName(network: String): String = network
+    override fun defaultRpcPort(network: String): Int = 8545
+    override fun hasEns(network: String): Boolean = true
+    override fun deepPoolThreshold(): Int = 0
+    override fun setDeepPool(v: Int) {}
+    override fun strictStateFreshness(): Boolean = false
+    override fun setStrictStateFreshness(v: Boolean) {}
+    override fun nativeBlsEnabled(): Boolean = false
+    override fun setNativeBlsEnabled(v: Boolean) {}
+    override fun rustEngineEnabled(): Boolean = false
+    override fun setRustEngineEnabled(v: Boolean) {}
+}


### PR DESCRIPTION
## Problem

The Logs tab's "↓ Latest" auto-follow was re-derived every frame from LazyList layout (`last visible index >= shown.size - 2`). That check races the 250 ms poll: a single batch of more than 2 appended lines compares a stale layout against the fresh list and silently breaks follow — how often depended on each platform's log volume and frame timing, which is why the behavior differed across Android/Desktop/iOS.

## Fix

Tail-follow is now **explicit intent state**, not a per-frame layout inference:

- **Entering the Logs tab starts following** (the tab's composition is disposed on switch, so the flag resets per visit).
- **Only a real scroll away from the tail stops it**: any scroll in progress that the composable didn't itself initiate (`autoSnapping` guard) while more than ~1 item from the end. `isScrollInProgress` covers every input path uniformly — touch drag/fling, desktop mouse wheel/trackpad, and accessibility scroll actions (which bypass nested scroll entirely).
- **Returning to the tail (or pressing "↓ Latest") resumes it**, with ~1 item of tolerance; a list that merely *fits* the viewport can't silently re-arm (so a narrow filter no longer steals a scrolled-up reading position). Clear explicitly restores following.
- The snap runs from one long-lived collector keyed on the tail line's *sequence* (not size — at ring capacity the size is constant while lines shift), so nothing restarts per poll and appends can never cancel follow by construction.

## Latent desktop crash fixed on the way

Writing the regression test surfaced that `:ui` compiled against kotlinx-datetime **0.6.2** while every desktop runtime classpath resolves **0.7.1** (pulled by compose material3-desktop), where the `kotlinx.datetime.Instant` binary class no longer exists — rendering any log row on desktop JVM threw `NoClassDefFoundError`. The catalog now pins 0.7.1 and `formatLogTime` uses `kotlin.time.Instant` (what iOS already compiled against). Verified: kotlinx-datetime is used only by `:ui`, and 0.7.1 resolves uniformly on Android, desktop, and iOS.

## Tests

New `LogsTailFollowTest` (desktop, headless):
- large batched appends keep following (fails against the old heuristic — verified by temporarily restoring it),
- touch-swipe back stops following and shows the button, and new appends provably arrive (line-counter await) without yanking,
- "↓ Latest" resumes; scrolling back down to the tail also resumes,
- a dedicated **mouse-wheel** case pins desktop's real input path.

Shared `FakeController`/`FakeSettings` extracted to `NodeScreenTestFakes.kt` (used by this and `LogsFilterPersistenceTest`).

An independent no-context review (8 finder angles + adversarial verification) ran before this PR; all confirmed findings are addressed in the second commit. `./gradlew :ui:build`, `:app-desktop:build`, `:android-app:compileDebugKotlin`, and `:app-ios:compileKotlinIosSimulatorArm64` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)