### PR TITLE
land #249 (compat batch) — stranded by stack merge order

### DIFF
--- a/app-ios/src/iosMain/kotlin/io/myotis/ios/IosRpcStatusSource.kt
+++ b/app-ios/src/iosMain/kotlin/io/myotis/ios/IosRpcStatusSource.kt
@@ -38,7 +38,12 @@ class IosRpcStatusSource(
             put("state", if (running) "RUNNING" else if (paused) "PAUSED" else "STOPPED")
             put("uptimeSeconds", uptimeSeconds)
             put("discoveredPeers", o.engineLong("discoveredPeers"))
-            put("connectedPeers", o.engineLong("peerCount"))
+            // OMITTED (not zero) when the engine status is unreadable/not running:
+            // net_peerCount answers from this field, and a fabricated 0 would tell
+            // a health probe "node isolated" when the truth is "can't read status"
+            // (→ the router's strict -32000 instead). The zeros below are fine —
+            // nothing answers a JSON-RPC method from them.
+            if (o.containsKey("peerCount")) put("connectedPeers", o.engineLong("peerCount"))
             put("readyPeers", snapPeers)
             put("snapPeers", snapPeers)
             put("backedOffPeers", o.engineLong("backedOffPeers"))

--- a/docs/reimplementation/07-el-implementation-plan.md
+++ b/docs/reimplementation/07-el-implementation-plan.md
@@ -369,6 +369,20 @@ Spec: README §5.3, doc 04 §2. Highlights per PR-sized chunk:
      hashes form already fetched. An undecodable tx fails the whole block
      (found-but-unrenderable must never serve a partial list); the Java stale
      re-serve (`lastGoodLatestBlock`) stays hashes-only.
+   - **Landed (compat batch, router-only — both engines for free):**
+     `eth_accounts` (exactly `[]` — the node holds no keys), `net_listening`
+     (true — the discovery UDP listener), `net_peerCount` (from the
+     `myotis_status` snapshot's `connectedPeers`), `web3_sha3` (pure-Kotlin
+     Keccak-256 in commonMain, vector-pinned + Tuweni-cross-checked),
+     `eth_getBlockTransactionCountByNumber/ByHash` and
+     `eth_getUncleCountByBlockNumber/ByHash` (array sizes read out of the
+     verified block serve), `eth_getTransactionByBlockNumberAndIndex/
+     ByBlockHashAndIndex` (`transactions[i]` of a fullTransactions serve), and
+     `eth_getUncleByBlockNumberAndIndex/ByBlockHashAndIndex` (post-merge window
+     → always eth-null once the block resolves). Deliberately NOT included:
+     `eth_blobBaseFee` — the blob base-fee update fraction is fork-dependent
+     (and BPO forks reschedule it), so a router-side constant would silently go
+     stale; it needs an engine-side answer if it's ever wanted.
 3. **`sendRawTransaction` + pending overlay.** Gossip raw bytes to all READY peers, return
    `keccak256(rawTx)`, cache own-tx bytes (shows pending until mined), rebroadcast until the
    gossip echo (the EL-A5 hash-observation hook); pending-nonce overlay — only-raises,

--- a/jsonrpc-server/build.gradle.kts
+++ b/jsonrpc-server/build.gradle.kts
@@ -57,6 +57,13 @@ kotlin {
         jvmTest.dependencies {
             implementation(project.dependencies.platform(libs.junit.bom))
             implementation(libs.junit.jupiter)
+            // Cross-check the commonMain Keccak-256 against Tuweni's (KeccakTest) —
+            // test-only; the seam itself must stay dependency-free for iOS.
+            // Tuweni's keccak256 resolves via JCA, so BouncyCastle registers as
+            // the provider in the test.
+            implementation(libs.tuweni.bytes)
+            implementation(libs.tuweni.crypto)
+            implementation(libs.bouncycastle)
             // logback on the test COMPILE classpath (not just runtime): RpcAccessLogTest attaches a
             // ListAppender to the io.myotis.jsonrpc.access logger to assert the access-log lines.
             implementation(libs.logback.classic)

--- a/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/Keccak256.kt
+++ b/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/Keccak256.kt
@@ -1,0 +1,110 @@
+package io.myotis.jsonrpc
+
+/**
+ * Keccak-256 — the pre-NIST-padding variant Ethereum uses — in pure Kotlin so
+ * commonMain can serve `web3_sha3` without a per-platform crypto dependency
+ * (the JVM ships no Keccak, and pulling BouncyCastle/Tuweni into the seam
+ * would break the iOS target). Sponge with rate 1088 bits (136-byte blocks),
+ * capacity 512, multi-rate padding `0x01 … 0x80`, 24-round Keccak-f[1600].
+ *
+ * This is a hashing convenience for a COMPAT method, not a trust surface:
+ * nothing verified depends on it. Pinned by the official Keccak test vectors
+ * and, on the JVM, cross-checked against Tuweni's implementation over random
+ * inputs (KeccakTest).
+ */
+internal object Keccak256 {
+
+    private const val RATE = 136 // bytes; 1088-bit rate for the 256-bit digest
+
+    /** Keccak-f round constants (ι step), one per round. */
+    private val RC = ulongArrayOf(
+        0x0000000000000001uL, 0x0000000000008082uL, 0x800000000000808AuL, 0x8000000080008000uL,
+        0x000000000000808BuL, 0x0000000080000001uL, 0x8000000080008081uL, 0x8000000000008009uL,
+        0x000000000000008AuL, 0x0000000000000088uL, 0x0000000080008009uL, 0x000000008000000AuL,
+        0x000000008000808BuL, 0x800000000000008BuL, 0x8000000000008089uL, 0x8000000000008003uL,
+        0x8000000000008002uL, 0x8000000000000080uL, 0x000000000000800AuL, 0x800000008000000AuL,
+        0x8000000080008081uL, 0x8000000000008080uL, 0x0000000080000001uL, 0x8000000080008008uL,
+    )
+
+    /** Rotation offsets (ρ step), lane order `x + 5y`. */
+    private val ROT = intArrayOf(
+        0, 1, 62, 28, 27,
+        36, 44, 6, 55, 20,
+        3, 10, 43, 25, 39,
+        41, 45, 15, 21, 8,
+        18, 2, 61, 56, 14,
+    )
+
+    fun digest(input: ByteArray): ByteArray {
+        val state = ULongArray(25)
+        var offset = 0
+        while (input.size - offset >= RATE) {
+            absorb(state, input, offset)
+            keccakF(state)
+            offset += RATE
+        }
+        // Final block: the remaining < RATE bytes plus multi-rate padding. The
+        // 0x01 and 0x80 land on the same byte for a remainder of RATE-1 (the
+        // `or` below), per the spec's single-byte-pad case.
+        val block = ByteArray(RATE)
+        input.copyInto(block, 0, offset, input.size)
+        block[input.size - offset] = 0x01
+        block[RATE - 1] = (block[RATE - 1].toInt() or 0x80).toByte()
+        absorb(state, block, 0)
+        keccakF(state)
+        // Squeeze: the first 4 lanes, little-endian, are the 32-byte digest.
+        val out = ByteArray(32)
+        for (i in 0 until 4) {
+            val lane = state[i]
+            for (j in 0 until 8) {
+                out[i * 8 + j] = ((lane shr (8 * j)) and 0xFFu).toByte()
+            }
+        }
+        return out
+    }
+
+    /** XOR one RATE-sized block into the state, lanes little-endian. */
+    private fun absorb(state: ULongArray, data: ByteArray, offset: Int) {
+        for (i in 0 until RATE / 8) {
+            var lane = 0uL
+            for (j in 7 downTo 0) {
+                lane = (lane shl 8) or data[offset + i * 8 + j].toUByte().toULong()
+            }
+            state[i] = state[i] xor lane
+        }
+    }
+
+    private fun keccakF(a: ULongArray) {
+        val c = ULongArray(5)
+        val b = ULongArray(25)
+        for (round in 0 until 24) {
+            // θ
+            for (x in 0 until 5) {
+                c[x] = a[x] xor a[x + 5] xor a[x + 10] xor a[x + 15] xor a[x + 20]
+            }
+            for (x in 0 until 5) {
+                val d = c[(x + 4) % 5] xor c[(x + 1) % 5].rotl(1)
+                for (y in 0 until 5) {
+                    a[x + 5 * y] = a[x + 5 * y] xor d
+                }
+            }
+            // ρ + π
+            for (x in 0 until 5) {
+                for (y in 0 until 5) {
+                    b[y + 5 * ((2 * x + 3 * y) % 5)] = a[x + 5 * y].rotl(ROT[x + 5 * y])
+                }
+            }
+            // χ
+            for (x in 0 until 5) {
+                for (y in 0 until 5) {
+                    a[x + 5 * y] = b[x + 5 * y] xor (b[(x + 1) % 5 + 5 * y].inv() and b[(x + 2) % 5 + 5 * y])
+                }
+            }
+            // ι
+            a[0] = a[0] xor RC[round]
+        }
+    }
+
+    private fun ULong.rotl(n: Int): ULong =
+        if (n == 0) this else (this shl n) or (this shr (64 - n))
+}

--- a/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/Keccak256.kt
+++ b/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/Keccak256.kt
@@ -63,13 +63,19 @@ internal object Keccak256 {
         return out
     }
 
-    /** XOR one RATE-sized block into the state, lanes little-endian. */
+    /** XOR one RATE-sized block into the state, lanes little-endian
+     *  (unrolled — no per-byte loop bookkeeping on the 17 lanes per block). */
     private fun absorb(state: ULongArray, data: ByteArray, offset: Int) {
         for (i in 0 until RATE / 8) {
-            var lane = 0uL
-            for (j in 7 downTo 0) {
-                lane = (lane shl 8) or data[offset + i * 8 + j].toUByte().toULong()
-            }
+            val base = offset + i * 8
+            val lane = data[base].toUByte().toULong() or
+                (data[base + 1].toUByte().toULong() shl 8) or
+                (data[base + 2].toUByte().toULong() shl 16) or
+                (data[base + 3].toUByte().toULong() shl 24) or
+                (data[base + 4].toUByte().toULong() shl 32) or
+                (data[base + 5].toUByte().toULong() shl 40) or
+                (data[base + 6].toUByte().toULong() shl 48) or
+                (data[base + 7].toUByte().toULong() shl 56)
             state[i] = state[i] xor lane
         }
     }

--- a/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/RpcRouter.kt
+++ b/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/RpcRouter.kt
@@ -47,6 +47,11 @@ class RpcRouter(
             "eth_gasPrice", "eth_maxPriorityFeePerGas", "eth_feeHistory", "eth_estimateGas",
             "eth_getTransactionByHash", "eth_getBlockByHash", "eth_getBlockReceipts",
             "web3_clientVersion", "eth_syncing",
+            "eth_accounts", "net_listening", "net_peerCount", "web3_sha3",
+            "eth_getBlockTransactionCountByNumber", "eth_getBlockTransactionCountByHash",
+            "eth_getTransactionByBlockNumberAndIndex", "eth_getTransactionByBlockHashAndIndex",
+            "eth_getUncleCountByBlockNumber", "eth_getUncleCountByBlockHash",
+            "eth_getUncleByBlockNumberAndIndex", "eth_getUncleByBlockHashAndIndex",
         )
     }
 
@@ -335,6 +340,81 @@ class RpcRouter(
                 val blockJson = withContext(rpcIoDispatcher) { b.getBlockByHash(blockHash, fullTx) } ?: return null
                 resultEnvelope(id, json.parseToJsonElement(blockJson))
             }
+            // ---- compat batch: answers derived from reads already served above ----
+            // The node holds no keys and signs nothing: the accounts list is
+            // exactly empty — a verified-grade constant, not a stub.
+            "eth_accounts" -> resultEnvelope(id, JsonArray(emptyList()))
+            // Dialer-only on TCP, but the discovery UDP listener is live whenever
+            // the node runs — "actively listening for network connections" in the
+            // sense health probes mean it. Config-derived like eth_chainId.
+            "net_listening" -> resultEnvelope(id, JsonPrimitive(true))
+            "net_peerCount" -> {
+                // Served from the same status snapshot myotis_status exposes; no
+                // status source wired (or a shape-drifted snapshot) → strict error,
+                // never a fabricated zero.
+                val sr = statusReads ?: return null
+                val peers = withContext(rpcIoDispatcher) {
+                    (sr.statusJson(sr.uptimeSeconds())["connectedPeers"] as? JsonPrimitive)
+                        ?.contentOrNull?.toLongOrNull()
+                } ?: return null
+                resultEnvelope(id, JsonPrimitive(hexQuantity(peers)))
+            }
+            // Pure local compute (keccak-256 of the DATA param) — no chain state.
+            "web3_sha3" -> {
+                val data = (root.params()?.getOrNull(0) as? JsonPrimitive)?.asHexBytes() ?: return null
+                resultEnvelope(id, JsonPrimitive(hexData(Keccak256.digest(data))))
+            }
+            // Counts/lookups below reuse the verified block serve and read the
+            // answer out of its JSON — the tri-state (object | "null" | Kotlin
+            // null) carries through unchanged.
+            "eth_getBlockTransactionCountByNumber" -> {
+                val block = root.params().blockTag(0)
+                val blockJson = withContext(rpcIoDispatcher) { b.getBlockByNumber(block, false) } ?: return null
+                blockArraySizeResult(id, blockJson, "transactions")
+            }
+            "eth_getBlockTransactionCountByHash" -> {
+                val blockHash = (root.params()?.getOrNull(0))?.asHexBytes()?.takeIf { it.size == 32 } ?: return null
+                val blockJson = withContext(rpcIoDispatcher) { b.getBlockByHash(blockHash, false) } ?: return null
+                blockArraySizeResult(id, blockJson, "transactions")
+            }
+            "eth_getTransactionByBlockNumberAndIndex" -> {
+                val p = root.params()
+                val block = p.blockTag(0)
+                val index = p?.getOrNull(1)?.asQuantityIndex() ?: return null
+                val blockJson = withContext(rpcIoDispatcher) { b.getBlockByNumber(block, true) } ?: return null
+                txAtIndexResult(id, blockJson, index)
+            }
+            "eth_getTransactionByBlockHashAndIndex" -> {
+                val p = root.params()
+                val blockHash = (p?.getOrNull(0))?.asHexBytes()?.takeIf { it.size == 32 } ?: return null
+                val index = p?.getOrNull(1)?.asQuantityIndex() ?: return null
+                val blockJson = withContext(rpcIoDispatcher) { b.getBlockByHash(blockHash, true) } ?: return null
+                txAtIndexResult(id, blockJson, index)
+            }
+            "eth_getUncleCountByBlockNumber" -> {
+                val block = root.params().blockTag(0)
+                val blockJson = withContext(rpcIoDispatcher) { b.getBlockByNumber(block, false) } ?: return null
+                blockArraySizeResult(id, blockJson, "uncles")
+            }
+            "eth_getUncleCountByBlockHash" -> {
+                val blockHash = (root.params()?.getOrNull(0))?.asHexBytes()?.takeIf { it.size == 32 } ?: return null
+                val blockJson = withContext(rpcIoDispatcher) { b.getBlockByHash(blockHash, false) } ?: return null
+                blockArraySizeResult(id, blockJson, "uncles")
+            }
+            "eth_getUncleByBlockNumberAndIndex" -> {
+                val p = root.params()
+                val block = p.blockTag(0)
+                val index = p?.getOrNull(1)?.asQuantityIndex() ?: return null
+                val blockJson = withContext(rpcIoDispatcher) { b.getBlockByNumber(block, false) } ?: return null
+                uncleAtIndexResult(id, blockJson, index)
+            }
+            "eth_getUncleByBlockHashAndIndex" -> {
+                val p = root.params()
+                val blockHash = (p?.getOrNull(0))?.asHexBytes()?.takeIf { it.size == 32 } ?: return null
+                val index = p?.getOrNull(1)?.asQuantityIndex() ?: return null
+                val blockJson = withContext(rpcIoDispatcher) { b.getBlockByHash(blockHash, false) } ?: return null
+                uncleAtIndexResult(id, blockJson, index)
+            }
             "eth_getBlockReceipts" -> {
                 val p = root.params()
                 // One selector param: tag | 0x-hex number | 0x-32-byte hash (absent →
@@ -448,6 +528,52 @@ class RpcRouter(
         } catch (e: IllegalArgumentException) {
             null
         }
+    }
+
+    /** Parse a JSON-RPC QUANTITY index param (0x-hex string) as a non-negative
+     *  Int; null for malformed / non-string / absurd width (an index beyond
+     *  Int range can never address a block's tx/uncle list). */
+    private fun JsonElement.asQuantityIndex(): Int? {
+        val s = (this as? JsonPrimitive)?.takeIf { it.isString }?.contentOrNull ?: return null
+        if (!(s.startsWith("0x") || s.startsWith("0X")) || s.length <= 2 || s.length > 10) return null
+        val h = s.substring(2)
+        if (!h.all { it in '0'..'9' || it in 'a'..'f' || it in 'A'..'F' }) return null
+        val v = h.toLong(16)
+        return if (v <= Int.MAX_VALUE) v.toInt() else null
+    }
+
+    /** eth_getBlockTransactionCountBy* / eth_getUncleCountBy*: the size of the
+     *  served block's [key] array as a QUANTITY. "null" (unknown block) passes
+     *  through as a null result; a block object WITHOUT the array is shape
+     *  drift → Kotlin null → strict error, never a fabricated zero. */
+    private fun blockArraySizeResult(id: JsonElement, blockJson: String, key: String): String? {
+        val el = json.parseToJsonElement(blockJson)
+        if (el is JsonNull) return resultEnvelope(id, JsonNull)
+        val arr = (el as? JsonObject)?.get(key) as? JsonArray ?: return null
+        return resultEnvelope(id, JsonPrimitive(hexQuantity(arr.size.toLong())))
+    }
+
+    /** eth_getTransactionByBlock*AndIndex: `transactions[index]` of a fullTx
+     *  block serve. Unknown block or an index past the end → eth's null. */
+    private fun txAtIndexResult(id: JsonElement, blockJson: String, index: Int): String? {
+        val el = json.parseToJsonElement(blockJson)
+        if (el is JsonNull) return resultEnvelope(id, JsonNull)
+        val txs = (el as? JsonObject)?.get("transactions") as? JsonArray ?: return null
+        val tx = txs.getOrNull(index) ?: return resultEnvelope(id, JsonNull)
+        return resultEnvelope(id, tx)
+    }
+
+    /** eth_getUncleByBlock*AndIndex: the verified window is post-merge, so a
+     *  served block's uncle list is empty and any index is past the end →
+     *  eth's null. A NON-empty list (unreachable today — pre-merge blocks
+     *  aren't served) would be found-but-unrenderable (the block JSON carries
+     *  only uncle hashes, not the uncle header this method returns) → Kotlin
+     *  null → strict error, never null-as-if-absent. */
+    private fun uncleAtIndexResult(id: JsonElement, blockJson: String, index: Int): String? {
+        val el = json.parseToJsonElement(blockJson)
+        if (el is JsonNull) return resultEnvelope(id, JsonNull)
+        val uncles = (el as? JsonObject)?.get("uncles") as? JsonArray ?: return null
+        return if (index < uncles.size) null else resultEnvelope(id, JsonNull)
     }
 
     /** Decode a `0x…` hex JSON string to bytes; null if not a hex string. */

--- a/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/RpcRouter.kt
+++ b/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/RpcRouter.kt
@@ -350,12 +350,15 @@ class RpcRouter(
             "net_listening" -> resultEnvelope(id, JsonPrimitive(true))
             "net_peerCount" -> {
                 // Served from the same status snapshot myotis_status exposes; no
-                // status source wired (or a shape-drifted snapshot) → strict error,
-                // never a fabricated zero.
+                // status source wired, a throwing read (it can cross an FFI, like
+                // the myotis_status handler guards for), or a snapshot without the
+                // field → strict error, never a fabricated zero.
                 val sr = statusReads ?: return null
                 val peers = withContext(rpcIoDispatcher) {
-                    (sr.statusJson(sr.uptimeSeconds())["connectedPeers"] as? JsonPrimitive)
-                        ?.contentOrNull?.toLongOrNull()
+                    runCatching {
+                        (sr.statusJson(sr.uptimeSeconds())["connectedPeers"] as? JsonPrimitive)
+                            ?.contentOrNull?.toLongOrNull()
+                    }.getOrNull()
                 } ?: return null
                 resultEnvelope(id, JsonPrimitive(hexQuantity(peers)))
             }
@@ -368,7 +371,7 @@ class RpcRouter(
             // answer out of its JSON — the tri-state (object | "null" | Kotlin
             // null) carries through unchanged.
             "eth_getBlockTransactionCountByNumber" -> {
-                val block = root.params().blockTag(0)
+                val block = root.params().specShapedBlockTag(0) ?: return null
                 val blockJson = withContext(rpcIoDispatcher) { b.getBlockByNumber(block, false) } ?: return null
                 blockArraySizeResult(id, blockJson, "transactions")
             }
@@ -379,7 +382,7 @@ class RpcRouter(
             }
             "eth_getTransactionByBlockNumberAndIndex" -> {
                 val p = root.params()
-                val block = p.blockTag(0)
+                val block = p.specShapedBlockTag(0) ?: return null
                 val index = p?.getOrNull(1)?.asQuantityIndex() ?: return null
                 val blockJson = withContext(rpcIoDispatcher) { b.getBlockByNumber(block, true) } ?: return null
                 txAtIndexResult(id, blockJson, index)
@@ -392,7 +395,7 @@ class RpcRouter(
                 txAtIndexResult(id, blockJson, index)
             }
             "eth_getUncleCountByBlockNumber" -> {
-                val block = root.params().blockTag(0)
+                val block = root.params().specShapedBlockTag(0) ?: return null
                 val blockJson = withContext(rpcIoDispatcher) { b.getBlockByNumber(block, false) } ?: return null
                 blockArraySizeResult(id, blockJson, "uncles")
             }
@@ -403,7 +406,7 @@ class RpcRouter(
             }
             "eth_getUncleByBlockNumberAndIndex" -> {
                 val p = root.params()
-                val block = p.blockTag(0)
+                val block = p.specShapedBlockTag(0) ?: return null
                 val index = p?.getOrNull(1)?.asQuantityIndex() ?: return null
                 val blockJson = withContext(rpcIoDispatcher) { b.getBlockByNumber(block, false) } ?: return null
                 uncleAtIndexResult(id, blockJson, index)
@@ -433,13 +436,7 @@ class RpcRouter(
                         ?.takeIf { it.isString }?.contentOrNull?.trim()?.ifEmpty { "latest" }
                         ?: return null
                 }
-                // ASCII hex only — Char.isDigit() also accepts Unicode digits, which
-                // the engines' ASCII-only parsers would then reject inconsistently.
-                val specShaped = selector in setOf("latest", "pending", "safe", "finalized", "earliest")
-                    || (selector.length > 2 && selector.length <= 66
-                        && (selector.startsWith("0x") || selector.startsWith("0X"))
-                        && selector.drop(2).all { it in '0'..'9' || it in 'a'..'f' || it in 'A'..'F' })
-                if (!specShaped) return null
+                if (!specShapedSelector(selector)) return null
                 // Array string when served; "null" for a verified unknown/future
                 // block; Kotlin null (can't verify) → strict error.
                 val receiptsJson =
@@ -512,6 +509,24 @@ class RpcRouter(
     private fun JsonArray?.blockTag(index: Int): String =
         (this?.getOrNull(index) as? JsonPrimitive)?.contentOrNull ?: "latest"
 
+    /** Spec-shaped block selector gate: a tag, or 0x-hex ASCII (≤ 66 chars —
+     *  covers numbers and 32-byte hashes). Applied to every selector-taking
+     *  method ADDED since the engines split, because their bare-numeric
+     *  conventions differ (the Java engine reads bare as decimal — and octal
+     *  under a leading zero — the Rust parser as hex): only spec shapes pass,
+     *  so the same request can never resolve to different blocks depending on
+     *  which engine is behind the router. Trimmed like both backends trim. */
+    private fun specShapedSelector(s: String): Boolean =
+        s in setOf("latest", "pending", "safe", "finalized", "earliest")
+            || (s.length > 2 && s.length <= 66
+                && (s.startsWith("0x") || s.startsWith("0X"))
+                && s.drop(2).all { it in '0'..'9' || it in 'a'..'f' || it in 'A'..'F' })
+
+    /** [blockTag] + [specShapedSelector] for the compat batch's by-number
+     *  methods: the trimmed spec-shaped selector, or null (→ proxy/strict). */
+    private fun JsonArray?.specShapedBlockTag(index: Int): String? =
+        blockTag(index).trim().ifEmpty { "latest" }.takeIf { specShapedSelector(it) }
+
     /** Decode a storage position (QUANTITY or 32-byte DATA) to a left-padded
      *  32-byte big-endian key; null if not a hex string or wider than 32 bytes. */
     private fun JsonElement.asWord32(): ByteArray? {
@@ -531,15 +546,19 @@ class RpcRouter(
     }
 
     /** Parse a JSON-RPC QUANTITY index param (0x-hex string) as a non-negative
-     *  Int; null for malformed / non-string / absurd width (an index beyond
-     *  Int range can never address a block's tx/uncle list). */
+     *  Int; null only for MALFORMED input (non-string, no 0x, non-hex). A
+     *  well-formed value too large for any real tx/uncle list (or with
+     *  leading zeros pushing past Int) clamps to Int.MAX_VALUE — "past the
+     *  end", which the callers answer with eth's null result, not an error. */
     private fun JsonElement.asQuantityIndex(): Int? {
         val s = (this as? JsonPrimitive)?.takeIf { it.isString }?.contentOrNull ?: return null
-        if (!(s.startsWith("0x") || s.startsWith("0X")) || s.length <= 2 || s.length > 10) return null
+        if (!(s.startsWith("0x") || s.startsWith("0X")) || s.length <= 2 || s.length > 66) return null
         val h = s.substring(2)
         if (!h.all { it in '0'..'9' || it in 'a'..'f' || it in 'A'..'F' }) return null
-        val v = h.toLong(16)
-        return if (v <= Int.MAX_VALUE) v.toInt() else null
+        val minimal = h.trimStart('0').ifEmpty { "0" }
+        if (minimal.length > 8) return Int.MAX_VALUE // can't address any real list
+        val v = minimal.toLong(16)
+        return if (v <= Int.MAX_VALUE) v.toInt() else Int.MAX_VALUE
     }
 
     /** eth_getBlockTransactionCountBy* / eth_getUncleCountBy*: the size of the

--- a/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/RpcRouter.kt
+++ b/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/RpcRouter.kt
@@ -355,10 +355,14 @@ class RpcRouter(
                 // field → strict error, never a fabricated zero.
                 val sr = statusReads ?: return null
                 val peers = withContext(rpcIoDispatcher) {
-                    runCatching {
+                    try {
                         (sr.statusJson(sr.uptimeSeconds())["connectedPeers"] as? JsonPrimitive)
                             ?.contentOrNull?.toLongOrNull()
-                    }.getOrNull()
+                    } catch (e: kotlinx.coroutines.CancellationException) {
+                        throw e // never swallow cancellation (the myotis_status rule)
+                    } catch (e: Exception) {
+                        null
+                    }
                 } ?: return null
                 resultEnvelope(id, JsonPrimitive(hexQuantity(peers)))
             }

--- a/jsonrpc-server/src/jvmTest/kotlin/io/myotis/jsonrpc/KeccakTest.kt
+++ b/jsonrpc-server/src/jvmTest/kotlin/io/myotis/jsonrpc/KeccakTest.kt
@@ -1,0 +1,47 @@
+package io.myotis.jsonrpc
+
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import kotlin.random.Random
+
+class KeccakTest {
+
+    private fun hex(b: ByteArray) = b.joinToString("") { "%02x".format(it) }
+
+    /** The Keccak team's published 256-bit vectors (pre-NIST padding — what
+     *  Ethereum uses; the SHA3-256 digests of the same inputs differ). */
+    @Test
+    fun officialVectors() {
+        assertEquals(
+            "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+            hex(Keccak256.digest(ByteArray(0))),
+        )
+        assertEquals(
+            "4e03657aea45a94fc7d47ba826c8d667c0d1e6e33a64a036ec44f58fa12d6c45",
+            hex(Keccak256.digest("abc".encodeToByteArray())),
+        )
+        assertEquals(
+            "4d741b6f1eb29cb2a9b9911c82f56fa8d73b04959d3d9d222895df6c0b28aa15",
+            hex(Keccak256.digest("The quick brown fox jumps over the lazy dog".encodeToByteArray())),
+        )
+    }
+
+    /** Cross-check against Tuweni over sizes that exercise every padding case:
+     *  empty, sub-block, the exact rate (136), rate±1 (the one-byte-pad merge),
+     *  and multi-block. Deterministic seed so a failure reproduces. */
+    @Test
+    fun matchesTuweniAcrossBlockBoundaries() {
+        // Tuweni resolves KECCAK-256 through JCA — register the provider.
+        java.security.Security.addProvider(org.bouncycastle.jce.provider.BouncyCastleProvider())
+        val rnd = Random(42)
+        for (size in intArrayOf(0, 1, 31, 32, 135, 136, 137, 271, 272, 273, 1000)) {
+            val input = ByteArray(size).also { rnd.nextBytes(it) }
+            assertArrayEquals(
+                org.apache.tuweni.crypto.Hash.keccak256(org.apache.tuweni.bytes.Bytes.wrap(input)).toArrayUnsafe(),
+                Keccak256.digest(input),
+                "size $size",
+            )
+        }
+    }
+}

--- a/jsonrpc-server/src/jvmTest/kotlin/io/myotis/jsonrpc/RpcRouterTest.kt
+++ b/jsonrpc-server/src/jvmTest/kotlin/io/myotis/jsonrpc/RpcRouterTest.kt
@@ -2,7 +2,11 @@ package io.myotis.jsonrpc
 
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.put
 import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -560,6 +564,123 @@ class RpcRouterTest {
             assertEquals("0x0", result["currentBlock"]?.jsonPrimitive?.content, resp)
             assertEquals("0x0", result["highestBlock"]?.jsonPrimitive?.content, resp)
         }
+    }
+
+    // ---- compat batch ----
+
+    @Test fun accounts_isExactlyEmpty() {
+        val resp = route(FakeBackend(), """{"jsonrpc":"2.0","id":1,"method":"eth_accounts","params":[]}""")
+        assertEquals(0, json.parseToJsonElement(resp).jsonObject["result"]!!.jsonArray.size, resp)
+    }
+
+    @Test fun netListening_isTrue() {
+        val resp = route(FakeBackend(), """{"jsonrpc":"2.0","id":1,"method":"net_listening","params":[]}""")
+        assertEquals(true, json.parseToJsonElement(resp).jsonObject["result"]?.jsonPrimitive?.booleanOrNull, resp)
+    }
+
+    @Test fun netPeerCount_fromStatusSnapshot() {
+        val sr = object : RpcStatusSource {
+            override fun uptimeSeconds() = 5L
+            override fun statusJson(uptimeSeconds: Long) =
+                buildJsonObject { put("connectedPeers", JsonPrimitive(7)) }
+            override fun beaconStatusJson(uptimeSeconds: Long) = buildJsonObject {}
+        }
+        val resp = runBlocking {
+            RpcRouter(null, MethodLogger(), VerifiedReadsBackend(FakeBackend()), sr)
+                .handle("""{"jsonrpc":"2.0","id":1,"method":"net_peerCount","params":[]}""")
+        }
+        assertEquals("0x7", result(resp))
+    }
+
+    @Test fun netPeerCount_withoutStatusSource_isStrictError() {
+        // No status source → -32000 ("can't answer right now"), never a fabricated 0x0.
+        val resp = route(FakeBackend(), """{"jsonrpc":"2.0","id":1,"method":"net_peerCount","params":[]}""")
+        assertEquals(-32000, errorCode(resp))
+    }
+
+    @Test fun web3Sha3_keccaksTheDataParam() {
+        // keccak256(0x68656c6c6f20776f726c64 = "hello world") — a public vector.
+        val resp = route(FakeBackend(),
+            """{"jsonrpc":"2.0","id":1,"method":"web3_sha3","params":["0x68656c6c6f20776f726c64"]}""")
+        assertEquals("0x47173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad", result(resp))
+    }
+
+    @Test fun blockTransactionCount_countsTxArray_hashesForm() {
+        val b = FakeBackend().apply {
+            blockJson = """{"number":"0x10","transactions":["0xaa","0xbb","0xcc"],"uncles":[]}"""
+        }
+        val resp = route(b,
+            """{"jsonrpc":"2.0","id":1,"method":"eth_getBlockTransactionCountByNumber","params":["0x10"]}""")
+        assertEquals("0x3", result(resp))
+        assertEquals(false, b.lastFullTx)   // counting needs only the hashes form
+        assertEquals("0x10", b.lastBlockTag)
+    }
+
+    @Test fun blockTransactionCount_unknownBlock_isNullResult() {
+        val b = FakeBackend().apply { blockJson = "null" }
+        val resp = route(b,
+            """{"jsonrpc":"2.0","id":1,"method":"eth_getBlockTransactionCountByNumber","params":["0x10"]}""")
+        assertEquals(true, json.parseToJsonElement(resp).jsonObject["result"] is JsonNull, resp)
+    }
+
+    @Test fun txByBlockNumberAndIndex_picksTheEmbeddedObject() {
+        val b = FakeBackend().apply {
+            blockJson = """{"number":"0x10","transactions":[{"hash":"0xaa"},{"hash":"0xbb"}],"uncles":[]}"""
+        }
+        val resp = route(b,
+            """{"jsonrpc":"2.0","id":1,"method":"eth_getTransactionByBlockNumberAndIndex","params":["0x10","0x1"]}""")
+        val tx = json.parseToJsonElement(resp).jsonObject["result"]!!.jsonObject
+        assertEquals("0xbb", tx["hash"]?.jsonPrimitive?.content, resp)
+        assertEquals(true, b.lastFullTx)    // the lookup needs full tx objects
+    }
+
+    @Test fun txByBlockNumberAndIndex_pastEnd_isNullResult() {
+        val b = FakeBackend().apply {
+            blockJson = """{"number":"0x10","transactions":[{"hash":"0xaa"}],"uncles":[]}"""
+        }
+        val resp = route(b,
+            """{"jsonrpc":"2.0","id":1,"method":"eth_getTransactionByBlockNumberAndIndex","params":["0x10","0x5"]}""")
+        assertEquals(true, json.parseToJsonElement(resp).jsonObject["result"] is JsonNull, resp)
+    }
+
+    @Test fun txByBlockHashAndIndex_threadsTheHash() {
+        val b = FakeBackend().apply {
+            blockByHashJson = """{"number":"0x10","transactions":[{"hash":"0xaa"}],"uncles":[]}"""
+        }
+        val hash = "0x" + "ab".repeat(32)
+        val resp = route(b,
+            """{"jsonrpc":"2.0","id":1,"method":"eth_getTransactionByBlockHashAndIndex","params":["$hash","0x0"]}""")
+        val tx = json.parseToJsonElement(resp).jsonObject["result"]!!.jsonObject
+        assertEquals("0xaa", tx["hash"]?.jsonPrimitive?.content, resp)
+        assertEquals(hash, b.lastBlockHash!!.toHex())
+    }
+
+    @Test fun uncleCount_isZeroForServedBlocks() {
+        val b = FakeBackend().apply {
+            blockJson = """{"number":"0x10","transactions":[],"uncles":[]}"""
+        }
+        val resp = route(b,
+            """{"jsonrpc":"2.0","id":1,"method":"eth_getUncleCountByBlockNumber","params":["0x10"]}""")
+        assertEquals("0x0", result(resp))
+    }
+
+    @Test fun uncleByIndex_isNullResult_neverAnObject() {
+        val b = FakeBackend().apply {
+            blockJson = """{"number":"0x10","transactions":[],"uncles":[]}"""
+        }
+        val resp = route(b,
+            """{"jsonrpc":"2.0","id":1,"method":"eth_getUncleByBlockNumberAndIndex","params":["0x10","0x0"]}""")
+        assertEquals(true, json.parseToJsonElement(resp).jsonObject["result"] is JsonNull, resp)
+    }
+
+    @Test fun compatMethods_malformedIndex_isStrictError() {
+        // A JSON-number index (not the spec's 0x-hex string) must not be coerced.
+        val b = FakeBackend().apply {
+            blockJson = """{"number":"0x10","transactions":[{"hash":"0xaa"}],"uncles":[]}"""
+        }
+        val resp = route(b,
+            """{"jsonrpc":"2.0","id":1,"method":"eth_getTransactionByBlockNumberAndIndex","params":["0x10",1]}""")
+        assertEquals(-32000, errorCode(resp))
     }
 
     private fun ByteArray.toHex() = joinToString(prefix = "0x", separator = "") { "%02x".format(it.toInt() and 0xff) }

--- a/jsonrpc-server/src/jvmTest/kotlin/io/myotis/jsonrpc/RpcRouterTest.kt
+++ b/jsonrpc-server/src/jvmTest/kotlin/io/myotis/jsonrpc/RpcRouterTest.kt
@@ -673,6 +673,40 @@ class RpcRouterTest {
         assertEquals(true, json.parseToJsonElement(resp).jsonObject["result"] is JsonNull, resp)
     }
 
+    @Test fun compatByNumber_bareNumericSelector_isStrictError() {
+        // A JSON-number (or bare-string) selector must not reach the backend: the
+        // engines' bare-numeric conventions differ (Java decimal vs Rust hex), so
+        // only spec-shaped selectors pass — same gate as eth_getBlockReceipts.
+        val b = FakeBackend().apply {
+            blockJson = """{"number":"0x10","transactions":[],"uncles":[]}"""
+        }
+        for (params in listOf("""[291]""", """["291"]""")) {
+            val resp = route(b,
+                """{"jsonrpc":"2.0","id":1,"method":"eth_getBlockTransactionCountByNumber","params":$params}""")
+            assertEquals(-32000, errorCode(resp))
+            assertNull(b.lastBlockTag) // never reached the backend
+        }
+    }
+
+    @Test fun txByIndex_hugeButWellFormedIndex_isNullResult() {
+        // A well-formed QUANTITY beyond any real list (incl. leading-zero forms)
+        // is "past the end" → eth's null result, not a retryable-looking error.
+        val b = FakeBackend().apply {
+            blockJson = """{"number":"0x10","transactions":[{"hash":"0xaa"}],"uncles":[]}"""
+        }
+        for (idx in listOf("0x100000000", "0x0000000001")) {
+            val resp = route(b,
+                """{"jsonrpc":"2.0","id":1,"method":"eth_getTransactionByBlockNumberAndIndex","params":["0x10","$idx"]}""")
+            val result = json.parseToJsonElement(resp).jsonObject["result"]
+            if (idx == "0x0000000001") {
+                // leading zeros are still index 1 → past this 1-tx list's end → null
+                assertEquals(true, result is JsonNull, resp)
+            } else {
+                assertEquals(true, result is JsonNull, resp)
+            }
+        }
+    }
+
     @Test fun compatMethods_malformedIndex_isStrictError() {
         // A JSON-number index (not the spec's 0x-hex string) must not be coerced.
         val b = FakeBackend().apply {


### PR DESCRIPTION
## Why this PR exists

Same merge-order stranding as #250: #249 merged into its stacked base branch (`claude/rpc-full-transactions`) rather than main, so the compat batch (12 JSON-RPC methods + the pure-Kotlin Keccak-256) is not in main. This PR is that branch's tip vs main — **exactly the diff already reviewed in #249**, review fixes included. No new code.

Heads-up for the remaining stack: stacked PRs don't auto-retarget unless the base branch is deleted on merge. Merging bottom-up and deleting each branch (or letting me retarget the child PR to main after each merge) avoids this. The in-flight sent-tx-watch branch is based on already-landed content, so it won't hit this again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)