### PR TITLE
status: show the JSON-RPC listener (RPC row) on desktop and Android

### DIFF
--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -1142,7 +1142,9 @@ public final class NodeService extends Service {
             long peerBodyRequests,        // inbound GetBlockBodies from peers this run
             long peerBodyRequestsServed,  //   ...answered with >=1 body (always 0 today)
             boolean lcHunting,            // LC hunt engaged (starved of light-client servers)
-            boolean elHunting) {}         // EL hunt engaged (snap serving pool empty past stall)
+            boolean elHunting,            // EL hunt engaged (snap serving pool empty past stall)
+            int rpcPort,                  // configured JSON-RPC port (0 = none)
+            boolean rpcServing) {}        // listener bound and live on 127.0.0.1:rpcPort
 
     /** Result of a get-account query. Mirrors the JVM daemon's JSON response shape. */
     public record AccountQueryResult(
@@ -1854,7 +1856,7 @@ public final class NodeService extends Service {
                     s.lastResumeEpochMs(), s.lastWakeReason(),
                     s.peerHeaderRequests(), s.peerHeaderRequestsServed(),
                     s.peerBodyRequests(), s.peerBodyRequestsServed(),
-                    s.lcHunting(), s.elHunting());
+                    s.lcHunting(), s.elHunting(), s.rpcPort(), s.rpcServing());
         }
         return new Snapshot(true, lifecycle, chainStartMs,
                 s.discoveredPeers(), s.connectedPeers(), s.readyPeers(),
@@ -1870,7 +1872,7 @@ public final class NodeService extends Service {
                 s.lastResumeEpochMs(), s.lastWakeReason(),
                 s.peerHeaderRequests(), s.peerHeaderRequestsServed(),
                 s.peerBodyRequests(), s.peerBodyRequestsServed(),
-                s.lcHunting(), s.elHunting());
+                s.lcHunting(), s.elHunting(), s.rpcPort(), s.rpcServing());
     }
 
     // ---- Failure forensics (see ProcessHealthDiag) ----

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/cmp/AndroidNodeBridge.kt
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/cmp/AndroidNodeBridge.kt
@@ -225,6 +225,8 @@ private fun NodeService.Snapshot.toModel(): NodeSnapshot = NodeSnapshot(
     lastWakeReason = lastWakeReason(),
     lcHunting = lcHunting(),
     elHunting = elHunting(),
+    rpcPort = rpcPort(),
+    rpcServing = rpcServing(),
 )
 
 /** Android actual of [Settings] over the NodeService SharedPreferences statics. */

--- a/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
@@ -461,6 +461,8 @@ class DesktopNodeController(
             lastWakeReason = s.lastWakeReason(),
             lcHunting = s.lcHunting(),
             elHunting = s.elHunting(),
+            rpcPort = s.rpcPort(),
+            rpcServing = s.rpcServing(),
         )
     }
 }

--- a/jsonrpc-server/src/jvmTest/kotlin/io/myotis/jsonrpc/MyotisStatusRpcTest.kt
+++ b/jsonrpc-server/src/jvmTest/kotlin/io/myotis/jsonrpc/MyotisStatusRpcTest.kt
@@ -69,6 +69,8 @@ class MyotisStatusRpcTest {
         /* peerBodyRequestsServed */ 0L,
         /* lcHunting */ false,
         /* elHunting */ false,
+        /* rpcPort */ 8545,
+        /* rpcServing */ true,
     )
 
     private fun beaconStatus(

--- a/myotis-api/src/main/java/io/myotis/api/StatusSnapshot.java
+++ b/myotis-api/src/main/java/io/myotis/api/StatusSnapshot.java
@@ -52,6 +52,11 @@ import java.util.List;
  * @param elHunting             EL hunt engaged: the snap serving pool has been empty past
  *                              the stall window and the peer maintainer is in emergency
  *                              re-dial mode (backoff bypass for confirmed snap servers)
+ * @param rpcPort               the JSON-RPC port this network's engine-owned listener was
+ *                              CONFIGURED with; 0 = no listener configured (row hidden)
+ * @param rpcServing            true = bound and serving on {@code 127.0.0.1:rpcPort};
+ *                              false with a non-zero port = the bind failed or the
+ *                              listener died (hosts render this as an error)
  */
 public record StatusSnapshot(
         boolean running,
@@ -88,5 +93,7 @@ public record StatusSnapshot(
         long peerBodyRequests,
         long peerBodyRequestsServed,
         boolean lcHunting,
-        boolean elHunting) {
+        boolean elHunting,
+        int rpcPort,
+        boolean rpcServing) {
 }

--- a/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
@@ -541,10 +541,12 @@ final class RustChainHandle implements ChainHandle, NodeStatusReads {
                 s.lcHunting(),
                 s.elHunting(),
                 // Host-side listener truth (the JVM owns the server for Rust-hosted
-                // networks): the configured port — while the handle runs — and
-                // whether the server is live right now. A stopped handle reports 0
-                // so the status row hides instead of faking a red bind failure.
-                s.running() && rpcPort > 0 ? rpcPort : 0,
+                // networks): the configured port — while the handle runs OR is
+                // idle-paused (the listener deliberately survives pause: a request
+                // on 127.0.0.1:rpcPort is what WAKES the stack) — and whether the
+                // server is live right now. Only a STOPPED handle reports 0, hiding
+                // the row instead of faking a red bind failure.
+                (s.running() || s.paused()) && rpcPort > 0 ? rpcPort : 0,
                 rpcServing());
     }
 

--- a/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
@@ -319,6 +319,12 @@ final class RustChainHandle implements ChainHandle, NodeStatusReads {
      * bind failure is logged and the stack continues without JSON-RPC (mirrors the
      * Java engine): the IPC socket still serves the same verified primitives.
      */
+    /** Live listener state (bound AND no fatal supervisor failure) — ChainStack parity. */
+    private boolean rpcServing() {
+        io.myotis.jsonrpc.MyotisRpcServer s = rpcServer;
+        return s != null && s.isServing();
+    }
+
     private void startRpc() {
         if (rpcPort <= 0) return;        // RPC disabled (test seam / explicit opt-out)
         if (rpcServer != null) return;   // already started — avoid a re-bind / server leak
@@ -533,7 +539,11 @@ final class RustChainHandle implements ChainHandle, NodeStatusReads {
                 s.peerBodyRequests(),
                 s.peerBodyRequestsServed(),
                 s.lcHunting(),
-                s.elHunting());
+                s.elHunting(),
+                // Host-side listener truth (the JVM owns the server for Rust-hosted
+                // networks): the configured port, and whether it is live right now.
+                rpcPort > 0 ? rpcPort : 0,
+                rpcServing());
     }
 
     @Override

--- a/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
@@ -541,8 +541,10 @@ final class RustChainHandle implements ChainHandle, NodeStatusReads {
                 s.lcHunting(),
                 s.elHunting(),
                 // Host-side listener truth (the JVM owns the server for Rust-hosted
-                // networks): the configured port, and whether it is live right now.
-                rpcPort > 0 ? rpcPort : 0,
+                // networks): the configured port — while the handle runs — and
+                // whether the server is live right now. A stopped handle reports 0
+                // so the status row hides instead of faking a red bind failure.
+                s.running() && rpcPort > 0 ? rpcPort : 0,
                 rpcServing());
     }
 

--- a/myotis-engines/src/test/java/io/myotis/engines/RustStatusJsonTest.java
+++ b/myotis-engines/src/test/java/io/myotis/engines/RustStatusJsonTest.java
@@ -125,6 +125,23 @@ class RustStatusJsonTest {
         // Older natives omit the hunt keys → default to false, never throw.
         assertFalse(s.lcHunting());
         assertFalse(s.elHunting());
+        // No listener configured on the test seam → row-hidden sentinel values.
+        assertEquals(0, s.rpcPort());
+        assertFalse(s.rpcServing());
+    }
+
+    @Test
+    void configuredButUnservedRpcPortSurfacesAsNotServing() {
+        // A handle configured with a port whose server never started (bind
+        // failure shape): the RUNNING status must carry the port with
+        // rpcServing=false — the state the UI renders as the red
+        // "port N unavailable" row. A stopped handle must hide the row (port 0).
+        RustChainHandle h = new RustChainHandle(0L, "mainnet", 1L, 8545, false);
+        StatusSnapshot running = h.statusFromJsonOnThisHandle(CATCHING_UP_JSON);
+        assertEquals(8545, running.rpcPort());
+        assertFalse(running.rpcServing());
+        StatusSnapshot stopped = h.statusFromJsonOnThisHandle(NOT_STARTED_JSON);
+        assertEquals(0, stopped.rpcPort(), "stopped handle must hide the RPC row");
     }
 
     @Test

--- a/myotis-engines/src/test/java/io/myotis/engines/RustStatusJsonTest.java
+++ b/myotis-engines/src/test/java/io/myotis/engines/RustStatusJsonTest.java
@@ -142,6 +142,11 @@ class RustStatusJsonTest {
         assertFalse(running.rpcServing());
         StatusSnapshot stopped = h.statusFromJsonOnThisHandle(NOT_STARTED_JSON);
         assertEquals(0, stopped.rpcPort(), "stopped handle must hide the RPC row");
+        // PAUSED keeps the row: the listener survives idle sleep — a request on
+        // this very port is what wakes the stack, so hiding it would remove the
+        // one address the user needs while sleeping.
+        StatusSnapshot paused = h.statusFromJsonOnThisHandle(PAUSED_JSON);
+        assertEquals(8545, paused.rpcPort(), "paused handle must keep showing the RPC port");
     }
 
     @Test

--- a/node-core/src/main/java/io/myotis/node/ChainStack.java
+++ b/node-core/src/main/java/io/myotis/node/ChainStack.java
@@ -140,6 +140,9 @@ public final class ChainStack {
     private volatile BeaconLightClient beaconLightClient;
     private volatile io.myotis.rpc.VerifiedRpcBackend rpcBackend;
     private volatile io.myotis.jsonrpc.MyotisRpcServer rpcServer;
+    /** The port startRpc() was configured with (recorded even when the bind fails,
+     *  so the status row can show the failure); 0 until startRpc runs. */
+    private volatile int rpcListenPort;
 
     /** Status source for the JSON-RPC myotis_status / myotis_beaconStatus methods; the
      *  wrapping handle late-binds it (see {@link #setStatusReads}) before start(). */
@@ -517,6 +520,19 @@ public final class ChainStack {
     }
 
     /** EL hunt engaged: snap serving pool empty past the stall window. */
+    /** The JSON-RPC port the listener was configured with (0 = none configured yet). */
+    public int rpcListenPort() {
+        return rpcListenPort;
+    }
+
+    /** Live listener state: bound AND its supervisor hasn't recorded a fatal
+     *  failure. Consults the server (not just the start outcome) so an
+     *  asynchronously-died listener reads false, iOS-controller parity. */
+    public boolean rpcServing() {
+        io.myotis.jsonrpc.MyotisRpcServer s = rpcServer;
+        return s != null && s.isServing();
+    }
+
     public boolean elHunting() {
         return elHunting;
     }
@@ -874,6 +890,7 @@ public final class ChainStack {
 
     private void startRpc() {
         int rpcPort = ports.rpcPort();
+        rpcListenPort = rpcPort;
         try {
             // Deterministic up-front bind probe: Ktor's CIO engine surfaces bind
             // failures asynchronously, which a try/catch around start() can miss.

--- a/node-core/src/main/java/io/myotis/node/ChainStack.java
+++ b/node-core/src/main/java/io/myotis/node/ChainStack.java
@@ -341,13 +341,21 @@ public final class ChainStack {
             startDiscV5();                   // non-essential, warn-and-continue
             BeaconLightClient blc = beaconLightClient;
             if (blc != null) blc.resume();
-            if (rpcServer != null) {
+            io.myotis.jsonrpc.MyotisRpcServer liveServer = rpcServer;
+            if (liveServer != null && liveServer.isServing()) {
                 // The listener survived the pause; swap a fresh backend in behind
                 // the gate (the old one died with the previous connector).
                 io.myotis.rpc.VerifiedRpcBackend backend = buildAndStartBackend();
                 this.rpcBackend = backend;
             } else {
-                startRpc(); // first start's bind failed — retry best-effort
+                // Absent (first bind failed) OR dead (crashGuard latched a fatal
+                // failure — previously unrecoverable, the row stayed red forever):
+                // tear down any corpse and retry the full start best-effort.
+                if (liveServer != null) {
+                    try { liveServer.stop(); } catch (Throwable ignored) {}
+                    rpcServer = null;
+                }
+                startRpc();
             }
             if (maintainerEnabled) startPeerMaintainer();
             phase.set(RUNNING);
@@ -416,6 +424,10 @@ public final class ChainStack {
         ScheduledExecutorService pm = peerMaintainer;
         if (pm != null) { pm.shutdownNow(); peerMaintainer = null; }
         if (rpcServer != null) { try { rpcServer.stop(); } catch (Throwable ignored) {} }
+        // A stopped stack has no listener EXPECTATION either — zero the recorded
+        // port so the status row hides instead of misreporting a normal stop as
+        // a red bind failure.
+        rpcListenPort = 0;
         if (rpcBackend != null) { try { rpcBackend.close(); } catch (Throwable ignored) {} }
         if (beaconLightClient != null) { try { beaconLightClient.close(); } catch (Throwable ignored) {} }
         if (connector != null) { try { connector.close(); } catch (Throwable ignored) {} }
@@ -890,7 +902,6 @@ public final class ChainStack {
 
     private void startRpc() {
         int rpcPort = ports.rpcPort();
-        rpcListenPort = rpcPort;
         try {
             // Deterministic up-front bind probe: Ktor's CIO engine surfaces bind
             // failures asynchronously, which a try/catch around start() can miss.
@@ -908,6 +919,7 @@ public final class ChainStack {
                 server.start();
                 this.rpcServer = server;
                 this.rpcBackend = backend;
+                rpcListenPort = rpcPort; // publish AFTER the server: no red flash mid-boot
                 log.info("[{}] JSON-RPC listening on http://127.0.0.1:{} (verified, strict)",
                         network.name(), rpcPort);
             } catch (Throwable serverEx) {
@@ -915,9 +927,11 @@ public final class ChainStack {
                 throw serverEx;
             }
         } catch (java.io.IOException bindEx) {
+            rpcListenPort = rpcPort; // recorded so the status row shows the failure
             log.warn("[{}][rpc] port {} unavailable ({}); continuing without JSON-RPC",
                     network.name(), rpcPort, bindEx.getMessage());
         } catch (Throwable t) {
+            rpcListenPort = rpcPort;
             log.warn("[{}][rpc] failed to start JSON-RPC; continuing without it: {}",
                     network.name(), t.toString());
         }

--- a/node-core/src/main/java/io/myotis/node/api/JavaChainHandle.java
+++ b/node-core/src/main/java/io/myotis/node/api/JavaChainHandle.java
@@ -174,7 +174,9 @@ public final class JavaChainHandle implements ChainHandle, NodeStatusReads {
                 stack.serveStats().bodyRequests(),
                 stack.serveStats().bodyRequestsServed(),
                 stack.lcHunting(),
-                stack.elHunting());
+                stack.elHunting(),
+                stack.rpcListenPort(),
+                stack.rpcServing());
     }
 
     /** {@link NodeStatusReads}: node uptime for the JSON-RPC status result's {@code uptimeSeconds}. */


### PR DESCRIPTION
The Status "RPC" row (#24ca6f8) renders `127.0.0.1:<port>` — or a red **"port N unavailable"** — but only iOS fed it; desktop and Android hid it via the `rpcPort=0` default. Since the port is user-configurable in Settings and another app can legitimately hold it, that silent absence is exactly the wrong behavior — the bind failure must be visible.

## Approach

On desktop/Android the listener lives **inside the engine** (unlike iOS, whose controller owns its own server), so the truth flows engine → API: `StatusSnapshot` gains `rpcPort` (the configured port) and `rpcServing` (bound AND the server's supervisor hasn't latched a fatal failure — live `isServing()`, iOS parity).

- **ChainStack** (Java engine): records the configured port with intent — published *after* a successful bind (no transient red flash mid-boot) or in the failure catches (so the red row shows); zeroed on `shutdown()` so a normal stop doesn't masquerade as a bind failure. `resume()` now also **restarts a dead listener** (crashGuard-latched) instead of only an absent one — previously a latched failure kept RPC down with no recovery path (pre-existing; this row would have surfaced it as permanently red).
- **RustChainHandle**: host-side listener fields for Rust-hosted networks (the JVM owns that server); a stopped handle reports 0 → row hidden.
- Plumbed through `JavaChainHandle`, Android `NodeService.Snapshot`/`AndroidNodeBridge`, and `DesktopNode` into the shared UI. No UI changes needed — the row logic already existed.

## Tests

`RustStatusJsonTest` pins the bind-failure shape (port carried + `rpcServing=false` → the red row) and the stopped-handle hidden sentinel; the jvmTest fixture extended. Full node-core/engines/jsonrpc/ui/app-desktop suites and the Android compile are green.

An independent no-context review ran pre-PR; its findings (stopped-stack red row, boot flash, unrecoverable dead listener, missing pins) are addressed in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CeXnyL7k1Dp68PcRwcade