### PR TITLE
eth_getLogs surface: engine FFI (ABI v21) + router route with coverage-honest errors

### DIFF
--- a/app-ios/src/iosMain/kotlin/io/myotis/ios/RustEngine.kt
+++ b/app-ios/src/iosMain/kotlin/io/myotis/ios/RustEngine.kt
@@ -47,7 +47,7 @@ object RustEngine {
 
     /** Must match `ABI_VERSION` in rust/myotis-engine/src/lib.rs — the same
      *  handshake `RustEngineNative.EXPECTED_ABI_VERSION` performs over JNI. */
-    const val EXPECTED_ABI_VERSION = 20
+    const val EXPECTED_ABI_VERSION = 21
 
     private val abiVersion: Int by lazy { myotis_init() }
 

--- a/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/RpcBackend.kt
+++ b/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/RpcBackend.kt
@@ -34,6 +34,13 @@ interface RpcBackend {
     /** Tri-state like the other JSON methods, but the found form is an ARRAY
      *  string (the block's whole receipt list), not an object. */
     fun getBlockReceipts(blockSelector: String): String?
+
+    /** Verified eth_getLogs over the opt-in watch-list index: the log-array
+     *  JSON, an {"error": ...} object (coverage/config detail the router
+     *  surfaces at -32000), or null (backend has no index at all). Default
+     *  null so hosts without the index (Java engine, older iOS) stay source-
+     *  compatible and answer with the strict retryable error. */
+    fun getLogs(filterJson: String): String? = null
     fun getBlockByNumber(block: String, fullTransactions: Boolean): String?
     fun getBlockByHash(blockHash32: ByteArray, fullTransactions: Boolean): String?
     fun gasPrice(): String?

--- a/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/RpcRouter.kt
+++ b/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/RpcRouter.kt
@@ -45,7 +45,7 @@ class RpcRouter(
             "eth_getTransactionCount", "eth_getCode", "eth_getStorageAt",
             "eth_sendRawTransaction", "eth_getTransactionReceipt", "eth_getBlockByNumber",
             "eth_gasPrice", "eth_maxPriorityFeePerGas", "eth_feeHistory", "eth_estimateGas",
-            "eth_getTransactionByHash", "eth_getBlockByHash", "eth_getBlockReceipts",
+            "eth_getTransactionByHash", "eth_getBlockByHash", "eth_getBlockReceipts", "eth_getLogs",
             "web3_clientVersion", "eth_syncing",
             "eth_accounts", "net_listening", "net_peerCount", "web3_sha3",
             "eth_getBlockTransactionCountByNumber", "eth_getBlockTransactionCountByHash",
@@ -446,6 +446,24 @@ class RpcRouter(
                 val receiptsJson =
                     withContext(rpcIoDispatcher) { b.getBlockReceipts(selector) } ?: return null
                 resultEnvelope(id, json.parseToJsonElement(receiptsJson))
+            }
+            "eth_getLogs" -> {
+                // One filter-object param. The engine owns filter semantics
+                // (tags, address forms, positional topics) AND the coverage
+                // honesty rule — a range the index hasn't covered comes back
+                // as {"error": ...}, which we surface verbatim at -32000 so
+                // wallets see WHY (e.g. how far the backfill has come)
+                // instead of a bare cannot-serve.
+                val filter = root.params()?.getOrNull(0) as? JsonObject ?: return null
+                val resultJson = withContext(rpcIoDispatcher) { b.getLogs(filter.toString()) } ?: return null
+                val parsed = json.parseToJsonElement(resultJson)
+                val errorMessage = (parsed as? JsonObject)?.get("error")
+                    ?.let { (it as? JsonPrimitive)?.contentOrNull ?: it.toString() }
+                if (errorMessage != null) {
+                    errorEnvelope(id, -32000, errorMessage)
+                } else {
+                    resultEnvelope(id, parsed)
+                }
             }
             "eth_gasPrice" -> {
                 val price = withContext(rpcIoDispatcher) { b.gasPrice() } ?: return null

--- a/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/RpcRouter.kt
+++ b/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/RpcRouter.kt
@@ -454,7 +454,11 @@ class RpcRouter(
                 // as {"error": ...}, which we surface verbatim at -32000 so
                 // wallets see WHY (e.g. how far the backfill has come)
                 // instead of a bare cannot-serve.
-                val filter = root.params()?.getOrNull(0) as? JsonObject ?: return null
+                // A missing/non-object param is PERMANENTLY malformed — answer
+                // -32602 instead of the retryable -32000 a null would produce
+                // (wallets would retry a request that can never succeed).
+                val filter = root.params()?.getOrNull(0) as? JsonObject
+                    ?: return errorEnvelope(id, -32602, "eth_getLogs expects one filter object param")
                 val resultJson = withContext(rpcIoDispatcher) { b.getLogs(filter.toString()) } ?: return null
                 val parsed = json.parseToJsonElement(resultJson)
                 val errorMessage = (parsed as? JsonObject)?.get("error")

--- a/jsonrpc-server/src/jvmMain/kotlin/io/myotis/jsonrpc/ApiAdapters.kt
+++ b/jsonrpc-server/src/jvmMain/kotlin/io/myotis/jsonrpc/ApiAdapters.kt
@@ -49,6 +49,8 @@ class VerifiedReadsBackend(private val v: io.myotis.api.VerifiedReads) : RpcBack
     override fun getTransactionReceipt(txHash: ByteArray): String? = v.getTransactionReceipt(txHash)
     override fun getTransactionByHash(txHash: ByteArray): String? = v.getTransactionByHash(txHash)
     override fun getBlockReceipts(blockSelector: String): String? = v.getBlockReceipts(blockSelector)
+
+    override fun getLogs(filterJson: String): String? = v.getLogs(filterJson)
     override fun getBlockByNumber(block: String, fullTransactions: Boolean): String? =
         v.getBlockByNumber(block, fullTransactions)
     override fun getBlockByHash(blockHash32: ByteArray, fullTransactions: Boolean): String? =

--- a/jsonrpc-server/src/jvmTest/kotlin/io/myotis/jsonrpc/RpcAccessLogTest.kt
+++ b/jsonrpc-server/src/jvmTest/kotlin/io/myotis/jsonrpc/RpcAccessLogTest.kt
@@ -71,8 +71,8 @@ class RpcAccessLogTest {
     }
 
     @Test fun unsupportedMethod_logsErrorWithCode_atInfo() {
-        route("""{"jsonrpc":"2.0","id":2,"method":"eth_getLogs","params":[{}]}""")
-        val l = lines().single { it.contains("method=eth_getLogs") }
+        route("""{"jsonrpc":"2.0","id":2,"method":"eth_newFilter","params":[{}]}""")
+        val l = lines().single { it.contains("method=eth_newFilter") }
         assertTrue(l.contains("outcome=ERROR(-32601)"), l)
         // The whole access stream stays INFO — an error must NOT be emitted at WARN,
         // or raising the Logs-tab level would hide it along with the rest.
@@ -89,10 +89,10 @@ class RpcAccessLogTest {
         route(
             """[
                 {"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]},
-                {"jsonrpc":"2.0","id":2,"method":"eth_getLogs","params":[{}]}
+                {"jsonrpc":"2.0","id":2,"method":"eth_newFilter","params":[{}]}
             ]""",
         )
         assertTrue(lines().any { it.contains("method=eth_chainId") && it.contains("id=1") }, lines().toString())
-        assertTrue(lines().any { it.contains("method=eth_getLogs") && it.contains("id=2") }, lines().toString())
+        assertTrue(lines().any { it.contains("method=eth_newFilter") && it.contains("id=2") }, lines().toString())
     }
 }

--- a/jsonrpc-server/src/jvmTest/kotlin/io/myotis/jsonrpc/RpcRouterTest.kt
+++ b/jsonrpc-server/src/jvmTest/kotlin/io/myotis/jsonrpc/RpcRouterTest.kt
@@ -334,11 +334,11 @@ class RpcRouterTest {
         assertTrue(resp.contains("\"logIndex\":\"0x0\""))
     }
 
-    @Test fun getLogs_missingFilterObject_isStrictError() {
+    @Test fun getLogs_missingFilterObject_isInvalidParams() {
         val resp = route(FakeBackend(),
             """{"jsonrpc":"2.0","id":1,"method":"eth_getLogs","params":[]}""")
         assertTrue(hasError(resp))
-        assertEquals(-32000, errorCode(resp))
+        assertEquals(-32602, errorCode(resp))                    // permanent, not retryable
     }
 
     @Test fun strict_implementedButUnavailable_errorsServerError() {

--- a/jsonrpc-server/src/jvmTest/kotlin/io/myotis/jsonrpc/RpcRouterTest.kt
+++ b/jsonrpc-server/src/jvmTest/kotlin/io/myotis/jsonrpc/RpcRouterTest.kt
@@ -1,5 +1,6 @@
 package io.myotis.jsonrpc
 
+import io.myotis.api.VerifiedReads
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonNull
@@ -296,9 +297,48 @@ class RpcRouterTest {
 
     @Test fun strict_unimplementedMethod_errorsMethodNotSupported() {
         val resp = route(FakeBackend(),                          // no proxy → strict
-            """{"jsonrpc":"2.0","id":1,"method":"eth_getLogs","params":[{}]}""")
+            """{"jsonrpc":"2.0","id":1,"method":"eth_newFilter","params":[{}]}""")
         assertTrue(hasError(resp))
         assertEquals(-32601, errorCode(resp))                    // not served by this permissionless node
+    }
+
+    // ---- eth_getLogs (opt-in watch-list index) ---------------------------------------
+
+    @Test fun getLogs_backendWithoutIndex_errorsRetryable() {
+        val resp = route(FakeBackend(),                          // default getLogs = null
+            """{"jsonrpc":"2.0","id":1,"method":"eth_getLogs","params":[{"address":"0x${"11".repeat(20)}"}]}""")
+        assertTrue(hasError(resp))
+        assertEquals(-32000, errorCode(resp))                    // verified method, can't serve now
+    }
+
+    @Test fun getLogs_engineErrorEnvelope_surfacesMessageAt32000() {
+        val backend = object : VerifiedReads by FakeBackend() {
+            override fun getLogs(filterJson: String?): String =
+                """{"error":"requested range is not indexed yet (covered: 100-200); retry as the index catches up"}"""
+        }
+        val resp = route(backend,
+            """{"jsonrpc":"2.0","id":1,"method":"eth_getLogs","params":[{"address":"0x${"11".repeat(20)}"}]}""")
+        assertTrue(hasError(resp))
+        assertEquals(-32000, errorCode(resp))
+        assertTrue(resp.contains("covered: 100-200"))
+    }
+
+    @Test fun getLogs_arrayPassthrough_isResult() {
+        val logs = """[{"address":"0x${"11".repeat(20)}","topics":[],"data":"0x","blockNumber":"0x64","blockHash":"0x${"22".repeat(32)}","transactionHash":"0x${"33".repeat(32)}","transactionIndex":"0x0","logIndex":"0x0","removed":false}]"""
+        val backend = object : VerifiedReads by FakeBackend() {
+            override fun getLogs(filterJson: String?): String = logs
+        }
+        val resp = route(backend,
+            """{"jsonrpc":"2.0","id":1,"method":"eth_getLogs","params":[{"address":"0x${"11".repeat(20)}"}]}""")
+        assertTrue(!hasError(resp))
+        assertTrue(resp.contains("\"logIndex\":\"0x0\""))
+    }
+
+    @Test fun getLogs_missingFilterObject_isStrictError() {
+        val resp = route(FakeBackend(),
+            """{"jsonrpc":"2.0","id":1,"method":"eth_getLogs","params":[]}""")
+        assertTrue(hasError(resp))
+        assertEquals(-32000, errorCode(resp))
     }
 
     @Test fun strict_implementedButUnavailable_errorsServerError() {
@@ -521,7 +561,7 @@ class RpcRouterTest {
         val b = FakeBackend(head = 0x123)
         val resp = route(b, """[
             {"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]},
-            {"jsonrpc":"2.0","id":2,"method":"eth_getLogs","params":[{}]}
+            {"jsonrpc":"2.0","id":2,"method":"eth_newFilter","params":[{}]}
         ]""")
         val arr = json.parseToJsonElement(resp).jsonArray
         assertEquals(2, arr.size)

--- a/myotis-api/src/main/java/io/myotis/api/VerifiedReads.java
+++ b/myotis-api/src/main/java/io/myotis/api/VerifiedReads.java
@@ -75,6 +75,17 @@ public interface VerifiedReads {
      */
     String getBlockReceipts(String blockSelector);
 
+    /**
+     * Verified {@code eth_getLogs} over the engine's opt-in watch-list log
+     * index: the log-array JSON, an {@code {"error": ...}} object carrying
+     * coverage/config detail, or {@code null} when the engine has no index
+     * (the default — the Java engine does not implement the index yet and
+     * answers with the strict retryable error).
+     */
+    default String getLogs(String filterJson) {
+        return null;
+    }
+
     /** Legacy gas price in decimal wei (base fee + tip heuristics), or null. */
     String gasPrice();
 

--- a/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
@@ -932,6 +932,30 @@ final class RustChainHandle implements ChainHandle, NodeStatusReads {
     }
 
     /**
+     * eth_getLogs over the opt-in watch-list index. Returns the native payload
+     * VERBATIM — the log ARRAY on success, or the {@code {"error": ...}}
+     * envelope (coverage / config detail) for the router to surface at -32000.
+     * Only the lifecycle gate throws (not running / paused).
+     */
+    String getLogsJson(String filterJson) {
+        return gated(() -> RustEngineNative.nativeGetLogsJson(handle, filterJson));
+    }
+
+    /** Install the log-index config; false = invalid config or gate down. */
+    boolean setLogIndexConfig(String configJson) {
+        try {
+            return gated(() -> RustEngineNative.nativeSetLogIndexConfig(handle, configJson));
+        } catch (RuntimeException e) {
+            return false;
+        }
+    }
+
+    /** Log-index status JSON ({"error":...} when the gate is down). */
+    String logIndexStatusJson() {
+        return gated(() -> RustEngineNative.nativeLogIndexStatusJson(handle));
+    }
+
+    /**
      * Verified eth_getBlockReceipts: the receipts ARRAY JSON, the literal
      * {@code "null"} (verified unknown/future block or a never-verified hash),
      * or throws {@link EngineException} when it can't verify. {@code selector}

--- a/myotis-engines/src/main/java/io/myotis/engines/RustEngineNative.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustEngineNative.java
@@ -298,6 +298,21 @@ final class RustEngineNative {
         return Myotis_engineKt.getBlockReceiptsJson(handle, nz(selector));
     }
 
+    /** {@code eth_getLogs} over the watch-list index (array / {"error":...}). */
+    static String nativeGetLogsJson(long handle, String filterJson) {
+        return Myotis_engineKt.getLogsJson(handle, nz(filterJson));
+    }
+
+    /** Install the log-index watch-list config; false = invalid/unavailable. */
+    static boolean nativeSetLogIndexConfig(long handle, String configJson) {
+        return Myotis_engineKt.setLogIndexConfig(handle, nz(configJson));
+    }
+
+    /** Log-index status JSON (enabled, counts, coverage per entry). */
+    static String nativeLogIndexStatusJson(long handle) {
+        return Myotis_engineKt.logIndexStatusJson(handle);
+    }
+
     /** Verified {@code eth_feeHistory} (feeHistory JSON / error). */
     static String nativeFeeHistoryJson(
             long handle, long blockCount, String newestBlockTag, String percentilesJson) {

--- a/myotis-engines/src/main/java/io/myotis/engines/RustEngineNative.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustEngineNative.java
@@ -37,7 +37,7 @@ final class RustEngineNative {
     private static final Logger log = LoggerFactory.getLogger(RustEngineNative.class);
 
     /** Must match {@code ABI_VERSION} in rust/myotis-engine/src/lib.rs. */
-    static final int EXPECTED_ABI_VERSION = 20; // 20: + set_tor_enabled/tor_status (Tor)
+    static final int EXPECTED_ABI_VERSION = 21; // 21: + eth_getLogs watch-list index trio
 
     private static final boolean AVAILABLE = load();
 

--- a/myotis-engines/src/main/java/io/myotis/engines/RustVerifiedReads.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustVerifiedReads.java
@@ -260,6 +260,19 @@ final class RustVerifiedReads implements VerifiedReads {
     }
 
     @Override
+    public String getLogs(String filterJson) {
+        try {
+            // Array or {"error": ...} — passed through verbatim; the router
+            // turns the error envelope into a -32000 with the engine's
+            // message (coverage progress, unwatched address, ...).
+            return handle.getLogsJson(filterJson);
+        } catch (RuntimeException e) {
+            log.debug("[engines] getLogs unavailable: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    @Override
     public String getBlockReceipts(String blockSelector) {
         try {
             String sel = (blockSelector == null || blockSelector.isBlank())

--- a/myotis-engines/src/main/kotlin/uniffi/myotis_engine/myotis_engine.kt
+++ b/myotis-engines/src/main/kotlin/uniffi/myotis_engine/myotis_engine.kt
@@ -700,6 +700,8 @@ internal object IntegrityCheckingUniffiLib {
     ): Int
     external fun uniffi_myotis_engine_checksum_func_get_code_json(
     ): Int
+    external fun uniffi_myotis_engine_checksum_func_get_logs_json(
+    ): Int
     external fun uniffi_myotis_engine_checksum_func_get_storage_at_json(
     ): Int
     external fun uniffi_myotis_engine_checksum_func_get_storage_proof_json(
@@ -707,6 +709,8 @@ internal object IntegrityCheckingUniffiLib {
     external fun uniffi_myotis_engine_checksum_func_get_transaction_by_hash_json(
     ): Int
     external fun uniffi_myotis_engine_checksum_func_get_transaction_receipt_json(
+    ): Int
+    external fun uniffi_myotis_engine_checksum_func_log_index_status_json(
     ): Int
     external fun uniffi_myotis_engine_checksum_func_pause_handle(
     ): Int
@@ -719,6 +723,8 @@ internal object IntegrityCheckingUniffiLib {
     external fun uniffi_myotis_engine_checksum_func_resume_handle(
     ): Int
     external fun uniffi_myotis_engine_checksum_func_send_raw_transaction_json(
+    ): Int
+    external fun uniffi_myotis_engine_checksum_func_set_log_index_config(
     ): Int
     external fun uniffi_myotis_engine_checksum_func_set_tor_enabled(
     ): Int
@@ -771,6 +777,8 @@ internal object UniffiLib {
     ): RustBuffer.ByValue
     external fun uniffi_myotis_engine_fn_func_get_code_json(`handle`: Long,`address`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
+    external fun uniffi_myotis_engine_fn_func_get_logs_json(`handle`: Long,`filterJson`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+    ): RustBuffer.ByValue
     external fun uniffi_myotis_engine_fn_func_get_storage_at_json(`handle`: Long,`address`: RustBuffer.ByValue,`position`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
     external fun uniffi_myotis_engine_fn_func_get_storage_proof_json(`handle`: Long,`address`: RustBuffer.ByValue,`slot`: Long,`holder`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
@@ -778,6 +786,8 @@ internal object UniffiLib {
     external fun uniffi_myotis_engine_fn_func_get_transaction_by_hash_json(`handle`: Long,`txHashHex`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
     external fun uniffi_myotis_engine_fn_func_get_transaction_receipt_json(`handle`: Long,`txHashHex`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+    ): RustBuffer.ByValue
+    external fun uniffi_myotis_engine_fn_func_log_index_status_json(`handle`: Long,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
     external fun uniffi_myotis_engine_fn_func_pause_handle(`handle`: Long,uniffi_out_err: UniffiRustCallStatus, 
     ): Byte
@@ -791,6 +801,8 @@ internal object UniffiLib {
     ): Byte
     external fun uniffi_myotis_engine_fn_func_send_raw_transaction_json(`handle`: Long,`rawTxHex`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
+    external fun uniffi_myotis_engine_fn_func_set_log_index_config(`handle`: Long,`configJson`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+    ): Byte
     external fun uniffi_myotis_engine_fn_func_set_tor_enabled(`on`: Byte,uniffi_out_err: UniffiRustCallStatus, 
     ): Byte
     external fun uniffi_myotis_engine_fn_func_start_handle(`handle`: Long,uniffi_out_err: UniffiRustCallStatus, 
@@ -962,6 +974,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_myotis_engine_checksum_func_get_code_json() != 40825) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_myotis_engine_checksum_func_get_logs_json() != 29899) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_myotis_engine_checksum_func_get_storage_at_json() != 24299) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
@@ -972,6 +987,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_myotis_engine_checksum_func_get_transaction_receipt_json() != 56168) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_myotis_engine_checksum_func_log_index_status_json() != 7764) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_myotis_engine_checksum_func_pause_handle() != 51434) {
@@ -990,6 +1008,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_myotis_engine_checksum_func_send_raw_transaction_json() != 26871) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_myotis_engine_checksum_func_set_log_index_config() != 49994) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_myotis_engine_checksum_func_set_tor_enabled() != 16704) {
@@ -1482,6 +1503,23 @@ public object FfiConverterOptionalString: FfiConverterRustBuffer<kotlin.String?>
     
 
         /**
+         * eth_getLogs over the opt-in watch-list index: the log array on success,
+         * `{"error": ...}` otherwise — including for any range outside indexed
+         * coverage (never an empty array for unindexed blocks).
+         */ fun `getLogsJson`(`handle`: kotlin.Long, `filterJson`: kotlin.String): kotlin.String {
+            return FfiConverterString.lift(
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_myotis_engine_fn_func_get_logs_json(
+    
+        
+        FfiConverterLong.lower(`handle`),
+        FfiConverterString.lower(`filterJson`),_status)
+}
+    )
+    }
+    
+
+        /**
          * Verified RAW-32-byte-position storage query (`eth_getStorageAt`).
          */ fun `getStorageAtJson`(`handle`: kotlin.Long, `address`: kotlin.String, `position`: kotlin.String): kotlin.String {
             return FfiConverterString.lift(
@@ -1542,6 +1580,21 @@ public object FfiConverterOptionalString: FfiConverterRustBuffer<kotlin.String?>
         
         FfiConverterLong.lower(`handle`),
         FfiConverterString.lower(`txHashHex`),_status)
+}
+    )
+    }
+    
+
+        /**
+         * Log-index status JSON: enabled flag, log count, backfill cursor, and per
+         * watch entry its covered span.
+         */ fun `logIndexStatusJson`(`handle`: kotlin.Long): kotlin.String {
+            return FfiConverterString.lift(
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_myotis_engine_fn_func_log_index_status_json(
+    
+        
+        FfiConverterLong.lower(`handle`),_status)
 }
     )
     }
@@ -1633,6 +1686,22 @@ public object FfiConverterOptionalString: FfiConverterRustBuffer<kotlin.String?>
         
         FfiConverterLong.lower(`handle`),
         FfiConverterString.lower(`rawTxHex`),_status)
+}
+    )
+    }
+    
+
+        /**
+         * Install the log-index watch-list config (JSON; see host docs). False on
+         * malformed config, duplicate addresses, or an unavailable reader.
+         */ fun `setLogIndexConfig`(`handle`: kotlin.Long, `configJson`: kotlin.String): kotlin.Boolean {
+            return FfiConverterBoolean.lift(
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_myotis_engine_fn_func_set_log_index_config(
+    
+        
+        FfiConverterLong.lower(`handle`),
+        FfiConverterString.lower(`configJson`),_status)
 }
     )
     }

--- a/rust/include/myotis_engine.h
+++ b/rust/include/myotis_engine.h
@@ -131,6 +131,13 @@ char *myotis_send_raw_transaction_json(int64_t handle, const char *raw_tx_hex);
 /* Release any char* returned by the functions above. NULL is a no-op. */
 void myotis_string_free(char *s);
 
+/* v20: the opt-in eth_getLogs watch-list index (docs/eth-getlogs-design.md).
+ * get_logs answers only inside indexed coverage; anything else is an
+ * {"error": ...} JSON — never an empty array for unindexed ranges. */
+char *myotis_get_logs_json(int64_t handle, const char *filter_json);
+bool myotis_set_log_index_config(int64_t handle, const char *config_json);
+char *myotis_log_index_status_json(int64_t handle);
+
 #ifdef __cplusplus
 }
 #endif

--- a/rust/include/myotis_engine.h
+++ b/rust/include/myotis_engine.h
@@ -131,7 +131,7 @@ char *myotis_send_raw_transaction_json(int64_t handle, const char *raw_tx_hex);
 /* Release any char* returned by the functions above. NULL is a no-op. */
 void myotis_string_free(char *s);
 
-/* v20: the opt-in eth_getLogs watch-list index (docs/eth-getlogs-design.md).
+/* v21: the opt-in eth_getLogs watch-list index (docs/eth-getlogs-design.md).
  * get_logs answers only inside indexed coverage; anything else is an
  * {"error": ...} JSON — never an empty array for unindexed ranges. */
 char *myotis_get_logs_json(int64_t handle, const char *filter_json);

--- a/rust/myotis-engine/src/capi.rs
+++ b/rust/myotis-engine/src/capi.rs
@@ -495,3 +495,35 @@ mod tests {
         unsafe { myotis_string_free(std::ptr::null_mut()) };
     }
 }
+
+/// eth_getLogs over the watch-list index (see ffi::get_logs_json).
+/// Returned string must be freed with `myotis_string_free`.
+#[no_mangle]
+pub unsafe extern "C" fn myotis_get_logs_json(
+    handle: i64,
+    filter_json: *const std::os::raw::c_char,
+) -> *mut std::os::raw::c_char {
+    match read_string(filter_json) {
+        Some(f) => into_c(crate::host::get_logs_json(handle, &f)),
+        None => std::ptr::null_mut(),
+    }
+}
+
+/// Install the log-index watch-list config (see ffi::set_log_index_config).
+#[no_mangle]
+pub unsafe extern "C" fn myotis_set_log_index_config(
+    handle: i64,
+    config_json: *const std::os::raw::c_char,
+) -> bool {
+    match read_string(config_json) {
+        Some(c) => crate::host::set_log_index_config_json(handle, &c),
+        None => false,
+    }
+}
+
+/// Log-index status JSON (see ffi::log_index_status_json).
+/// Returned string must be freed with `myotis_string_free`.
+#[no_mangle]
+pub unsafe extern "C" fn myotis_log_index_status_json(handle: i64) -> *mut std::os::raw::c_char {
+    into_c(crate::host::log_index_status_json(handle))
+}

--- a/rust/myotis-engine/src/eljson.rs
+++ b/rust/myotis-engine/src/eljson.rs
@@ -1526,3 +1526,36 @@ pub fn get_logs_json(logs: &[myotis_net::el::logindex::StoredLog]) -> String {
     s.push(']');
     s
 }
+
+#[cfg(test)]
+mod get_logs_json_tests {
+    use myotis_net::el::logindex::StoredLog;
+
+    /// Golden pin: the per-log shape is byte-identical to the log objects
+    /// receipt_json emits (same field order, same hex forms, removed:false).
+    #[test]
+    fn get_logs_json_shape_is_pinned() {
+        let log = StoredLog {
+            block_number: 0x64,
+            block_hash: [0x22; 32],
+            tx_hash: [0x33; 32],
+            tx_index: 1,
+            log_index: 5,
+            address: [0x11; 20],
+            topics: vec![[0xaa; 32], [0xbb; 32]],
+            data: vec![0xde, 0xad],
+        };
+        let expected = format!(
+            "[{{\"address\":\"0x{}\",\"topics\":[\"0x{}\",\"0x{}\"],\"data\":\"0xdead\",\
+\"blockNumber\":\"0x64\",\"blockHash\":\"0x{}\",\"transactionHash\":\"0x{}\",\
+\"transactionIndex\":\"0x1\",\"logIndex\":\"0x5\",\"removed\":false}}]",
+            "11".repeat(20),
+            "aa".repeat(32),
+            "bb".repeat(32),
+            "22".repeat(32),
+            "33".repeat(32),
+        );
+        assert_eq!(super::get_logs_json(&[log]), expected);
+        assert_eq!(super::get_logs_json(&[]), "[]");
+    }
+}

--- a/rust/myotis-engine/src/eljson.rs
+++ b/rust/myotis-engine/src/eljson.rs
@@ -1486,3 +1486,43 @@ mod tests {
         assert_eq!(be_to_decimal(&big), "18446744073709551616");
     }
 }
+
+/// eth_getLogs result: a JSON array whose per-log shape matches the log
+/// objects `receipt_json` emits (address/topics/data/blockNumber/blockHash/
+/// transactionHash/transactionIndex/logIndex/removed) — one shape for logs
+/// everywhere, golden-pinned.
+pub fn get_logs_json(logs: &[myotis_net::el::logindex::StoredLog]) -> String {
+    let mut s = String::with_capacity(2 + logs.len() * 256);
+    s.push('[');
+    for (k, log) in logs.iter().enumerate() {
+        if k > 0 {
+            s.push(',');
+        }
+        s.push_str("{\"address\":\"");
+        s.push_str(&hex0x_var(&log.address));
+        s.push_str("\",\"topics\":[");
+        for (t, topic) in log.topics.iter().enumerate() {
+            if t > 0 {
+                s.push(',');
+            }
+            s.push('"');
+            s.push_str(&hex0x(topic));
+            s.push('"');
+        }
+        s.push_str("],\"data\":\"");
+        s.push_str(&hex0x_var(&log.data));
+        s.push_str("\",\"blockNumber\":\"");
+        s.push_str(&hex_quantity(log.block_number));
+        s.push_str("\",\"blockHash\":\"");
+        s.push_str(&hex0x(&log.block_hash));
+        s.push_str("\",\"transactionHash\":\"");
+        s.push_str(&hex0x(&log.tx_hash));
+        s.push_str("\",\"transactionIndex\":\"");
+        s.push_str(&hex_quantity(u64::from(log.tx_index)));
+        s.push_str("\",\"logIndex\":\"");
+        s.push_str(&hex_quantity(u64::from(log.log_index)));
+        s.push_str("\",\"removed\":false}");
+    }
+    s.push(']');
+    s
+}

--- a/rust/myotis-engine/src/ffi.rs
+++ b/rust/myotis-engine/src/ffi.rs
@@ -246,3 +246,25 @@ pub fn fee_history_json(
 ) -> String {
     crate::host::fee_history_json(handle, block_count, &newest_block_tag, &percentiles_json)
 }
+
+/// eth_getLogs over the opt-in watch-list index: the log array on success,
+/// `{"error": ...}` otherwise — including for any range outside indexed
+/// coverage (never an empty array for unindexed blocks).
+#[uniffi::export]
+pub fn get_logs_json(handle: i64, filter_json: String) -> String {
+    crate::host::get_logs_json(handle, &filter_json)
+}
+
+/// Install the log-index watch-list config (JSON; see host docs). False on
+/// malformed config, duplicate addresses, or an unavailable reader.
+#[uniffi::export]
+pub fn set_log_index_config(handle: i64, config_json: String) -> bool {
+    crate::host::set_log_index_config_json(handle, &config_json)
+}
+
+/// Log-index status JSON: enabled flag, log count, backfill cursor, and per
+/// watch entry its covered span.
+#[uniffi::export]
+pub fn log_index_status_json(handle: i64) -> String {
+    crate::host::log_index_status_json(handle)
+}

--- a/rust/myotis-engine/src/host.rs
+++ b/rust/myotis-engine/src/host.rs
@@ -1901,6 +1901,9 @@ pub fn set_log_index_config_json(handle: i64, config_json: &str) -> bool {
                 return false;
             };
             let mut topic0s = Vec::new();
+            if e.get("topic0s").is_some_and(|t| !t.is_array() && !t.is_null()) {
+                return false;
+            }
             if let Some(ts) = e.get("topic0s").and_then(|t| t.as_array()) {
                 for t in ts {
                     let Some(w32) = t.as_str().and_then(parse_word32) else {
@@ -1972,6 +1975,11 @@ fn parse_get_logs_filter(
     head: u64,
     finalized: u64,
 ) -> Result<myotis_net::el::logindex::LogFilter, String> {
+    if v.get("blockHash").is_some_and(|b| !b.is_null()) {
+        // EIP-234: silently resolving the tags instead would answer with the
+        // HEAD block's logs for a question about a specific other block.
+        return Err("blockHash filters are not supported by this scoped index".to_string());
+    }
     fn tag(v: Option<&serde_json::Value>, head: u64, finalized: u64) -> Result<u64, String> {
         match v {
             None | Some(serde_json::Value::Null) => Ok(head),
@@ -2091,6 +2099,15 @@ mod get_logs_filter_tests {
         for bad in ["\"0x\"", "\"0x+5\"", "\"nope\"", "5", "{}"] {
             assert!(f(&format!("{{{addr},\"fromBlock\":{bad}}}")).is_err(), "{bad}");
         }
+    }
+
+    #[test]
+    fn block_hash_filters_are_rejected() {
+        let addr = format!("\"address\":\"0x{}\"", "11".repeat(20));
+        let bh = format!("\"blockHash\":\"0x{}\"", "cc".repeat(32));
+        assert!(f(&format!("{{{addr},{bh}}}")).unwrap_err().contains("blockHash"));
+        // Explicit null blockHash is treated as absent, per JSON-RPC habits.
+        assert!(f(&format!("{{{addr},\"blockHash\":null}}")).is_ok());
     }
 
     #[test]

--- a/rust/myotis-engine/src/host.rs
+++ b/rust/myotis-engine/src/host.rs
@@ -1874,3 +1874,191 @@ mod tests {
         assert!(v["error"].as_str().unwrap().contains("invalid holder"));
     }
 }
+
+// ---------------------------------------------------------------------------
+// eth_getLogs (docs/eth-getlogs-design.md): watch-list config install, index
+// status, and the coverage-honest query. All JSON in / JSON out, panic-free.
+// ---------------------------------------------------------------------------
+
+/// Install the watch-list config: `{"enabled":bool,"watch":[{"address":"0x..",
+/// "fromBlock":n,"topic0s":["0x..",..]?}]}`. False on malformed input,
+/// duplicate addresses, or an unavailable reader.
+pub fn set_log_index_config_json(handle: i64, config_json: &str) -> bool {
+    let Ok(v) = serde_json::from_str::<serde_json::Value>(config_json) else {
+        return false;
+    };
+    let enabled = v.get("enabled").and_then(|e| e.as_bool()).unwrap_or(false);
+    let mut watch = Vec::new();
+    if let Some(entries) = v.get("watch").and_then(|w| w.as_array()) {
+        for e in entries {
+            let Some(address) = e.get("address").and_then(|a| a.as_str()).and_then(parse_address) else {
+                return false;
+            };
+            let Some(from_block) = e.get("fromBlock").and_then(|b| b.as_u64()) else {
+                return false;
+            };
+            let mut topic0s = Vec::new();
+            if let Some(ts) = e.get("topic0s").and_then(|t| t.as_array()) {
+                for t in ts {
+                    let Some(w32) = t.as_str().and_then(parse_word32) else {
+                        return false;
+                    };
+                    topic0s.push(w32);
+                }
+            }
+            watch.push(myotis_net::el::logindex::WatchEntry { address, from_block, topic0s });
+        }
+    }
+    let Some(engine) = engine() else {
+        return false;
+    };
+    let Ok((reader, _, _)) = snapshot_reader(engine, handle) else {
+        return false;
+    };
+    reader.set_log_index_config(myotis_net::el::logindex::LogIndexConfig { enabled, watch })
+}
+
+/// Index status for hosts/UI: enabled, log count, backfill cursor, and per
+/// watch entry the covered span (absent while nothing is indexed).
+pub fn log_index_status_json(handle: i64) -> String {
+    let Some(engine) = engine() else {
+        return eljson::error_json("engine unavailable");
+    };
+    let Ok((reader, _, _)) = snapshot_reader(engine, handle) else {
+        return eljson::error_json("node is not running");
+    };
+    let status = reader.with_log_index(|ix| {
+        let mut s = String::from("{\"enabled\":");
+        s.push_str(if ix.config().enabled { "true" } else { "false" });
+        s.push_str(",\"logCount\":");
+        s.push_str(&ix.log_count().to_string());
+        if let Some((n, _)) = ix.cursor {
+            s.push_str(",\"backfillCursor\":");
+            s.push_str(&n.to_string());
+        }
+        s.push_str(",\"entries\":[");
+        for (k, (w, c)) in ix.coverage_entries().iter().enumerate() {
+            if k > 0 {
+                s.push(',');
+            }
+            s.push_str("{\"address\":\"0x");
+            for b in &w.address {
+                let _ = std::fmt::Write::write_fmt(&mut s, format_args!("{b:02x}"));
+            }
+            s.push_str("\",\"fromBlock\":");
+            s.push_str(&w.from_block.to_string());
+            if let Some((low, high)) = c.span {
+                s.push_str(",\"coveredLow\":");
+                s.push_str(&low.to_string());
+                s.push_str(",\"coveredHigh\":");
+                s.push_str(&high.to_string());
+            }
+            s.push('}');
+        }
+        s.push_str("]}");
+        s
+    });
+    status.unwrap_or_else(|| "{\"enabled\":false,\"logCount\":0,\"entries\":[]}".to_string())
+}
+
+/// Resolve an eth_getLogs block tag: hex quantity, or latest/pending/safe →
+/// anchored head, finalized → finalized block. None = unresolvable now.
+fn resolve_block_tag(reader: &myotis_net::el::reader::ElReader, tag: Option<&serde_json::Value>, default_head: u64) -> Option<u64> {
+    match tag.and_then(|t| t.as_str()) {
+        None => Some(default_head),
+        Some("latest") | Some("pending") | Some("safe") => Some(default_head),
+        Some("finalized") => Some(reader.finalized_block_number()),
+        Some(hex) => {
+            let stripped = hex.strip_prefix("0x")?;
+            u64::from_str_radix(stripped, 16).ok()
+        }
+    }
+}
+
+/// The eth_getLogs query. Returns the log array ONLY when the requested
+/// range is inside indexed coverage; every other case is `{"error": ...}`
+/// (the router maps it to strict -32000) — never an empty array for an
+/// unindexed range.
+pub fn get_logs_json(handle: i64, filter_json: &str) -> String {
+    use myotis_net::el::logindex::{LogFilter, QueryError};
+    let Ok(v) = serde_json::from_str::<serde_json::Value>(filter_json) else {
+        return eljson::error_json("malformed filter");
+    };
+    let Some(engine) = engine() else {
+        return eljson::error_json("engine unavailable");
+    };
+    let Ok((reader, _, _)) = snapshot_reader(engine, handle) else {
+        return eljson::error_json("node is not running");
+    };
+    let Some(head) = reader.head_block_number() else {
+        return eljson::error_json("no verified head yet");
+    };
+    let (Some(from_block), Some(to_block)) = (
+        resolve_block_tag(&reader, v.get("fromBlock"), head),
+        resolve_block_tag(&reader, v.get("toBlock"), head),
+    ) else {
+        return eljson::error_json("unresolvable block tag");
+    };
+    // address: single string or array; both are required to be present —
+    // a scoped index cannot serve address-less queries.
+    let mut addresses = Vec::new();
+    match v.get("address") {
+        Some(serde_json::Value::String(a)) => match parse_address(a) {
+            Some(a) => addresses.push(a),
+            None => return eljson::error_json("malformed address"),
+        },
+        Some(serde_json::Value::Array(items)) => {
+            for a in items {
+                match a.as_str().and_then(parse_address) {
+                    Some(a) => addresses.push(a),
+                    None => return eljson::error_json("malformed address"),
+                }
+            }
+        }
+        _ => return eljson::error_json("eth_getLogs without an address is not served by this scoped index"),
+    }
+    // topics: positional array of null | "0x.." | ["0x..",..].
+    let mut topics: Vec<Vec<[u8; 32]>> = Vec::new();
+    if let Some(ts) = v.get("topics").and_then(|t| t.as_array()) {
+        for t in ts {
+            match t {
+                serde_json::Value::Null => topics.push(Vec::new()),
+                serde_json::Value::String(one) => match parse_word32(one) {
+                    Some(w) => topics.push(vec![w]),
+                    None => return eljson::error_json("malformed topic"),
+                },
+                serde_json::Value::Array(alts) => {
+                    let mut ors = Vec::new();
+                    for a in alts {
+                        match a.as_str().and_then(parse_word32) {
+                            Some(w) => ors.push(w),
+                            None => return eljson::error_json("malformed topic"),
+                        }
+                    }
+                    topics.push(ors);
+                }
+                _ => return eljson::error_json("malformed topics"),
+            }
+        }
+    }
+    let filter = LogFilter { from_block, to_block, addresses, topics };
+    let result = reader.with_log_index(|ix| ix.query(&filter));
+    match result {
+        None => eljson::error_json("log index is not configured on this network"),
+        Some(Ok(logs)) => eljson::get_logs_json(&logs),
+        Some(Err(QueryError::Disabled)) => eljson::error_json("log index is disabled on this network"),
+        Some(Err(QueryError::UnwatchedAddress(_))) => {
+            eljson::error_json("address is not on this node's log watch-list")
+        }
+        Some(Err(QueryError::UnindexedTopic(_))) => {
+            eljson::error_json("topic is outside this node's indexed signatures for that address")
+        }
+        Some(Err(QueryError::OutOfCoverage { covered, .. })) => match covered.span {
+            Some((low, high)) => eljson::error_json(&format!(
+                "requested range is not indexed yet (covered: {low}-{high}); retry as the index catches up"
+            )),
+            None => eljson::error_json("log index has not indexed any blocks yet; retry"),
+        },
+        Some(Err(QueryError::Unanswerable)) => eljson::error_json("unanswerable filter (from > to)"),
+    }
+}

--- a/rust/myotis-engine/src/host.rs
+++ b/rust/myotis-engine/src/host.rs
@@ -1889,6 +1889,9 @@ pub fn set_log_index_config_json(handle: i64, config_json: &str) -> bool {
     };
     let enabled = v.get("enabled").and_then(|e| e.as_bool()).unwrap_or(false);
     let mut watch = Vec::new();
+    if v.get("watch").is_some_and(|w| !w.is_array() && !w.is_null()) {
+        return false;
+    }
     if let Some(entries) = v.get("watch").and_then(|w| w.as_array()) {
         for e in entries {
             let Some(address) = e.get("address").and_then(|a| a.as_str()).and_then(parse_address) else {
@@ -1961,18 +1964,68 @@ pub fn log_index_status_json(handle: i64) -> String {
     status.unwrap_or_else(|| "{\"enabled\":false,\"logCount\":0,\"entries\":[]}".to_string())
 }
 
-/// Resolve an eth_getLogs block tag: hex quantity, or latest/pending/safe →
-/// anchored head, finalized → finalized block. None = unresolvable now.
-fn resolve_block_tag(reader: &myotis_net::el::reader::ElReader, tag: Option<&serde_json::Value>, default_head: u64) -> Option<u64> {
-    match tag.and_then(|t| t.as_str()) {
-        None => Some(default_head),
-        Some("latest") | Some("pending") | Some("safe") => Some(default_head),
-        Some("finalized") => Some(reader.finalized_block_number()),
-        Some(hex) => {
-            let stripped = hex.strip_prefix("0x")?;
-            u64::from_str_radix(stripped, 16).ok()
+/// Parse an eth_getLogs filter into a typed [`LogFilter`], resolving tags
+/// against the supplied head/finalized numbers. Pure (testable): every
+/// malformed shape is a specific error string; nothing is silently ignored.
+fn parse_get_logs_filter(
+    v: &serde_json::Value,
+    head: u64,
+    finalized: u64,
+) -> Result<myotis_net::el::logindex::LogFilter, String> {
+    fn tag(v: Option<&serde_json::Value>, head: u64, finalized: u64) -> Result<u64, String> {
+        match v {
+            None | Some(serde_json::Value::Null) => Ok(head),
+            Some(serde_json::Value::String(s)) => match s.as_str() {
+                "latest" | "pending" | "safe" => Ok(head),
+                "finalized" => Ok(finalized),
+                "earliest" => Ok(0),
+                hex => hex
+                    .strip_prefix("0x")
+                    .filter(|d| !d.is_empty() && d.bytes().all(|b| b.is_ascii_hexdigit()))
+                    .and_then(|d| u64::from_str_radix(d, 16).ok())
+                    .ok_or_else(|| "unresolvable block tag".to_string()),
+            },
+            Some(_) => Err("block tag must be a string".to_string()),
         }
     }
+    let from_block = tag(v.get("fromBlock"), head, finalized)?;
+    let to_block = tag(v.get("toBlock"), head, finalized)?;
+    let mut addresses = Vec::new();
+    match v.get("address") {
+        Some(serde_json::Value::String(a)) => {
+            addresses.push(parse_address(a).ok_or("malformed address")?);
+        }
+        Some(serde_json::Value::Array(items)) if !items.is_empty() => {
+            for a in items {
+                addresses.push(a.as_str().and_then(parse_address).ok_or("malformed address")?);
+            }
+        }
+        _ => return Err("eth_getLogs without an address is not served by this scoped index".to_string()),
+    }
+    let mut topics: Vec<Vec<[u8; 32]>> = Vec::new();
+    match v.get("topics") {
+        None | Some(serde_json::Value::Null) => {}
+        Some(serde_json::Value::Array(ts)) => {
+            for t in ts {
+                match t {
+                    serde_json::Value::Null => topics.push(Vec::new()),
+                    serde_json::Value::String(one) => {
+                        topics.push(vec![parse_word32(one).ok_or("malformed topic")?]);
+                    }
+                    serde_json::Value::Array(alts) => {
+                        let mut ors = Vec::new();
+                        for a in alts {
+                            ors.push(a.as_str().and_then(parse_word32).ok_or("malformed topic")?);
+                        }
+                        topics.push(ors);
+                    }
+                    _ => return Err("malformed topics".to_string()),
+                }
+            }
+        }
+        Some(_) => return Err("malformed topics".to_string()),
+    }
+    Ok(myotis_net::el::logindex::LogFilter { from_block, to_block, addresses, topics })
 }
 
 /// The eth_getLogs query. Returns the log array ONLY when the requested
@@ -1980,7 +2033,7 @@ fn resolve_block_tag(reader: &myotis_net::el::reader::ElReader, tag: Option<&ser
 /// (the router maps it to strict -32000) — never an empty array for an
 /// unindexed range.
 pub fn get_logs_json(handle: i64, filter_json: &str) -> String {
-    use myotis_net::el::logindex::{LogFilter, QueryError};
+    use myotis_net::el::logindex::QueryError;
     let Ok(v) = serde_json::from_str::<serde_json::Value>(filter_json) else {
         return eljson::error_json("malformed filter");
     };
@@ -1993,55 +2046,10 @@ pub fn get_logs_json(handle: i64, filter_json: &str) -> String {
     let Some(head) = reader.head_block_number() else {
         return eljson::error_json("no verified head yet");
     };
-    let (Some(from_block), Some(to_block)) = (
-        resolve_block_tag(&reader, v.get("fromBlock"), head),
-        resolve_block_tag(&reader, v.get("toBlock"), head),
-    ) else {
-        return eljson::error_json("unresolvable block tag");
+    let filter = match parse_get_logs_filter(&v, head, reader.finalized_block_number()) {
+        Ok(f) => f,
+        Err(msg) => return eljson::error_json(&msg),
     };
-    // address: single string or array; both are required to be present —
-    // a scoped index cannot serve address-less queries.
-    let mut addresses = Vec::new();
-    match v.get("address") {
-        Some(serde_json::Value::String(a)) => match parse_address(a) {
-            Some(a) => addresses.push(a),
-            None => return eljson::error_json("malformed address"),
-        },
-        Some(serde_json::Value::Array(items)) => {
-            for a in items {
-                match a.as_str().and_then(parse_address) {
-                    Some(a) => addresses.push(a),
-                    None => return eljson::error_json("malformed address"),
-                }
-            }
-        }
-        _ => return eljson::error_json("eth_getLogs without an address is not served by this scoped index"),
-    }
-    // topics: positional array of null | "0x.." | ["0x..",..].
-    let mut topics: Vec<Vec<[u8; 32]>> = Vec::new();
-    if let Some(ts) = v.get("topics").and_then(|t| t.as_array()) {
-        for t in ts {
-            match t {
-                serde_json::Value::Null => topics.push(Vec::new()),
-                serde_json::Value::String(one) => match parse_word32(one) {
-                    Some(w) => topics.push(vec![w]),
-                    None => return eljson::error_json("malformed topic"),
-                },
-                serde_json::Value::Array(alts) => {
-                    let mut ors = Vec::new();
-                    for a in alts {
-                        match a.as_str().and_then(parse_word32) {
-                            Some(w) => ors.push(w),
-                            None => return eljson::error_json("malformed topic"),
-                        }
-                    }
-                    topics.push(ors);
-                }
-                _ => return eljson::error_json("malformed topics"),
-            }
-        }
-    }
-    let filter = LogFilter { from_block, to_block, addresses, topics };
     let result = reader.with_log_index(|ix| ix.query(&filter));
     match result {
         None => eljson::error_json("log index is not configured on this network"),
@@ -2059,6 +2067,49 @@ pub fn get_logs_json(handle: i64, filter_json: &str) -> String {
             )),
             None => eljson::error_json("log index has not indexed any blocks yet; retry"),
         },
-        Some(Err(QueryError::Unanswerable)) => eljson::error_json("unanswerable filter (from > to)"),
+        Some(Err(QueryError::Unanswerable)) => eljson::error_json("unanswerable filter (fromBlock > toBlock)"),
+    }
+}
+
+#[cfg(test)]
+mod get_logs_filter_tests {
+    use super::parse_get_logs_filter;
+
+    fn f(json: &str) -> Result<myotis_net::el::logindex::LogFilter, String> {
+        parse_get_logs_filter(&serde_json::from_str(json).unwrap(), 1000, 900)
+    }
+
+    #[test]
+    fn tags_resolve_and_malformed_tags_error() {
+        let addr = format!("\"address\":\"0x{}\"", "11".repeat(20));
+        let ok = f(&format!("{{{addr}}}")).unwrap();
+        assert_eq!((ok.from_block, ok.to_block), (1000, 1000)); // absent → head
+        let ok = f(&format!("{{{addr},\"fromBlock\":\"earliest\",\"toBlock\":\"finalized\"}}")).unwrap();
+        assert_eq!((ok.from_block, ok.to_block), (0, 900));
+        let ok = f(&format!("{{{addr},\"fromBlock\":\"0x64\"}}")).unwrap();
+        assert_eq!(ok.from_block, 100);
+        for bad in ["\"0x\"", "\"0x+5\"", "\"nope\"", "5", "{}"] {
+            assert!(f(&format!("{{{addr},\"fromBlock\":{bad}}}")).is_err(), "{bad}");
+        }
+    }
+
+    #[test]
+    fn address_forms_and_empty_array_error() {
+        assert!(f("{}").is_err());
+        assert!(f("{\"address\":[]}").unwrap_err().contains("without an address"));
+        assert!(f(&format!("{{\"address\":[\"0x{}\",\"0x{}\"]}}", "11".repeat(20), "22".repeat(20))).unwrap().addresses.len() == 2);
+        assert!(f("{\"address\":\"0xzz\"}").is_err());
+    }
+
+    #[test]
+    fn topics_forms_and_malformed_topics_error() {
+        let addr = format!("\"address\":\"0x{}\"", "11".repeat(20));
+        let t = format!("0x{}", "aa".repeat(32));
+        let ok = f(&format!("{{{addr},\"topics\":[null,\"{t}\",[\"{t}\"]]}}")).unwrap();
+        assert_eq!(ok.topics.len(), 3);
+        assert!(ok.topics.first().is_some_and(|w| w.is_empty()));
+        // A non-array topics value must ERROR, not silently widen the query.
+        assert!(f(&format!("{{{addr},\"topics\":\"{t}\"}}")).unwrap_err().contains("malformed topics"));
+        assert!(f(&format!("{{{addr},\"topics\":[5]}}")).is_err());
     }
 }

--- a/rust/myotis-engine/src/lib.rs
+++ b/rust/myotis-engine/src/lib.rs
@@ -57,15 +57,17 @@ uniffi::setup_scaffolding!();
 /// v18: nativeGetBlockByNumberJson + nativeGetBlockByHashJson gained a
 ///      `boolean fullTransactions` parameter (fullTransactions=true blocks now
 ///      served natively: decoded tx objects instead of hashes).
-/// v19: added nativePendingNonceOverlay (the sent-tx slice: pending-tag nonce
-///      overlay); nativeGetTransactionByHashJson may now return the PENDING
-///      shape (block trio explicitly null) for the wallet's own broadcasts —
-///      a payload extension, no signature change there.
 /// v20: added the Tor toggle surface (set_tor_enabled/tor_status, UniFFI +
 ///      the iOS C ABI; docs/privacy-and-tor.md). The functions exist in every
 ///      build; a dylib compiled without `--features tor` reports "not supported"
 ///      (false / 0) rather than being absent.
-pub const ABI_VERSION: i32 = 20;
+/// v21: added get_logs_json / set_log_index_config / log_index_status_json
+///      (the opt-in eth_getLogs watch-list index, docs/eth-getlogs-design.md).
+/// v19: added nativePendingNonceOverlay (the sent-tx slice: pending-tag nonce
+///      overlay); nativeGetTransactionByHashJson may now return the PENDING
+///      shape (block trio explicitly null) for the wallet's own broadcasts —
+///      a payload extension, no signature change there.
+pub const ABI_VERSION: i32 = 21;
 
 // Keep the workspace edge alive so `cargo build -p myotis-engine` type-checks the
 // consensus crate too.

--- a/rust/myotis-engine/src/lib.rs
+++ b/rust/myotis-engine/src/lib.rs
@@ -57,16 +57,16 @@ uniffi::setup_scaffolding!();
 /// v18: nativeGetBlockByNumberJson + nativeGetBlockByHashJson gained a
 ///      `boolean fullTransactions` parameter (fullTransactions=true blocks now
 ///      served natively: decoded tx objects instead of hashes).
+/// v19: added nativePendingNonceOverlay (the sent-tx slice: pending-tag nonce
+///      overlay); nativeGetTransactionByHashJson may now return the PENDING
+///      shape (block trio explicitly null) for the wallet's own broadcasts —
+///      a payload extension, no signature change there.
 /// v20: added the Tor toggle surface (set_tor_enabled/tor_status, UniFFI +
 ///      the iOS C ABI; docs/privacy-and-tor.md). The functions exist in every
 ///      build; a dylib compiled without `--features tor` reports "not supported"
 ///      (false / 0) rather than being absent.
 /// v21: added get_logs_json / set_log_index_config / log_index_status_json
 ///      (the opt-in eth_getLogs watch-list index, docs/eth-getlogs-design.md).
-/// v19: added nativePendingNonceOverlay (the sent-tx slice: pending-tag nonce
-///      overlay); nativeGetTransactionByHashJson may now return the PENDING
-///      shape (block trio explicitly null) for the wallet's own broadcasts —
-///      a payload extension, no signature change there.
 pub const ABI_VERSION: i32 = 21;
 
 // Keep the workspace edge alive so `cargo build -p myotis-engine` type-checks the

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -672,6 +672,12 @@ impl ElReader {
         true
     }
 
+    /// The beacon-anchored head block number, if the anchor is ready — the
+    /// resolution target for `latest`-style tags in eth_getLogs filters.
+    pub fn head_block_number(&self) -> Option<u64> {
+        self.anchored_head().ok().map(|(n, _)| n)
+    }
+
     /// Run `f` against the index if one is configured. The single accessor
     /// for queries and status — callers never touch the lock directly.
     pub fn with_log_index<T>(&self, f: impl FnOnce(&crate::el::logindex::LogIndex) -> T) -> Option<T> {


### PR DESCRIPTION
Slice 2b of eth_getLogs (docs/eth-getlogs-design.md; follows #269's index core). The method now exists end-to-end — engine to router — answering only from indexed coverage; it stays dormant until a host installs a watch-list config (slice 5).

## Engine (Rust)
- `get_logs_json`: pure, unit-tested filter parser (hex/`latest`/`finalized`/`earliest` tags resolved against the beacon-anchored head; address string-or-array; positional topics with null wildcards and OR-lists; every malformed shape is a specific error — notably a non-array `topics` errors instead of silently widening the query). Answers through the coverage-honest index: unanswerable cases return `{"error":...}` with actionable detail (e.g. `covered: X–Y; retry`), never an empty array for unindexed ranges.
- `set_log_index_config` + `log_index_status_json` (the opt-in config channel and UI progress surface).
- Exported over UniFFI (bindings regenerated) and mirrored on the iOS C ABI; **ABI v21** — v20 was taken by the Tor toggle (#268) mid-flight, so this rebased on top; both host constants + header + changelog aligned. (The first commit's title says v20 from before that rebase; the code is v21 throughout.)
- eljson golden test pins the log-array shape byte-for-byte to `receipt_json`'s log objects.

## Router (Kotlin/Java)
- `eth_getLogs` joins `VERIFIED_METHODS`; the router passes the filter object through and surfaces the engine's error envelope verbatim at `-32000` (wallets see *why* — coverage progress, unwatched address) instead of a generic cannot-serve.
- `VerifiedReads.getLogs` is default-null (Java engine stays source-compatible, answers the strict retryable error), Rust-backed via the existing `gated()` convention.
- Router tests pin: no-index backend → -32000, error-envelope surfacing with message, array pass-through, missing filter object. Tests that used `eth_getLogs` as the canonical *unsupported* sample now use `eth_newFilter`.

## Validation
`cargo test --workspace`, `:myotis-engines` goldens (rebuilt dylib through the new bindings), `:jsonrpc-server` suites — all green. Independent no-context review done; its blocking finding (missing Rust-side tests) and all should-fixes are in the last commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JibVnmRGPUp1692WebwfEs