### PR TITLE
eth_getLogs head-follow appender: finalized blocks into the log index (slice 3)

### DIFF
--- a/rust/myotis-core/src/bloom.rs
+++ b/rust/myotis-core/src/bloom.rs
@@ -23,6 +23,23 @@ pub fn accrue(bloom: &mut LogsBloom, item: &[u8]) {
     }
 }
 
+/// Probe: could `item` have been accrued into `bloom`? The dual of
+/// [`accrue`], with bloom semantics — `false` is definitive ("this address/
+/// topic emitted nothing here", a safe skip), `true` is only "maybe" and
+/// must be confirmed against receiptsRoot-verified receipts. Used by the
+/// eth_getLogs indexer to skip blocks whose header bloom cannot contain any
+/// watched address (docs/eth-getlogs-design.md).
+pub fn may_contain(bloom: &LogsBloom, item: &[u8]) -> bool {
+    let h = keccak256(item);
+    for i in (0..6).step_by(2) {
+        let bit = ((usize::from(h[i]) << 8) | usize::from(h[i + 1])) & 0x7ff;
+        if bloom[255 - bit / 8] & (1 << (bit % 8)) == 0 {
+            return false;
+        }
+    }
+    true
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -50,5 +67,22 @@ mod tests {
         for (x, y) in after_a.iter().zip(bloom.iter()) {
             assert_eq!(x & y, *x);
         }
+    }
+}
+
+#[cfg(test)]
+mod may_contain_tests {
+    use super::*;
+
+    #[test]
+    fn accrued_items_probe_true_absent_items_probe_false() {
+        let mut bloom = EMPTY_BLOOM;
+        accrue(&mut bloom, b"present");
+        assert!(may_contain(&bloom, b"present"));
+        assert!(!may_contain(&bloom, b"absent-item"));
+        assert!(!may_contain(&EMPTY_BLOOM, b"present"));
+        // A saturated bloom answers maybe for everything — probe semantics.
+        let full = [0xffu8; 256];
+        assert!(may_contain(&full, b"anything"));
     }
 }

--- a/rust/myotis-engine/src/host.rs
+++ b/rust/myotis-engine/src/host.rs
@@ -386,6 +386,7 @@ pub fn pause(handle: i64) -> bool {
     engine.rt.block_on(async move {
         sync.stop().await;
         if let Some(reader) = reader {
+            reader.stop_log_index_appender().await;
             if let Ok(reader) = Arc::try_unwrap(reader) {
                 reader.stop().await;
             }
@@ -405,7 +406,10 @@ fn shutdown(engine: &EngineState, sync: SyncHandle, reader: Option<Arc<ElReader>
         if let Some(reader) = reader {
             // Only our just-started reader holds an Arc here, so unwrapping the
             // Arc to consume `stop(self)` succeeds; if it somehow doesn't, the
-            // reader's Drop still aborts its tasks.
+            // reader's Drop still aborts its tasks. The appender is stopped
+            // (abort + await) FIRST so its per-tick strong Arc can't defeat
+            // the unwrap.
+            reader.stop_log_index_appender().await;
             if let Ok(reader) = Arc::try_unwrap(reader) {
                 reader.stop().await;
             }
@@ -534,6 +538,7 @@ pub fn stop(handle: i64) {
         engine.rt.block_on(async move {
             sync.stop().await;
             if let Some(reader) = reader {
+                reader.stop_log_index_appender().await;
                 if let Ok(reader) = Arc::try_unwrap(reader) {
                     reader.stop().await;
                 }
@@ -1923,10 +1928,8 @@ pub fn set_log_index_config_json(handle: i64, config_json: &str) -> bool {
     };
     let installed = reader.set_log_index_config(myotis_net::el::logindex::LogIndexConfig { enabled, watch });
     if installed && enabled {
-        // Spawn (or keep) the head-follow appender inside the engine runtime.
-        let reader = reader.clone();
-        let _guard = engine.rt.enter();
-        reader.ensure_log_index_appender();
+        // Spawn (or keep) the head-follow appender on the engine runtime.
+        reader.ensure_log_index_appender(engine.rt.handle());
     }
     installed
 }

--- a/rust/myotis-engine/src/host.rs
+++ b/rust/myotis-engine/src/host.rs
@@ -1921,7 +1921,14 @@ pub fn set_log_index_config_json(handle: i64, config_json: &str) -> bool {
     let Ok((reader, _, _)) = snapshot_reader(engine, handle) else {
         return false;
     };
-    reader.set_log_index_config(myotis_net::el::logindex::LogIndexConfig { enabled, watch })
+    let installed = reader.set_log_index_config(myotis_net::el::logindex::LogIndexConfig { enabled, watch });
+    if installed && enabled {
+        // Spawn (or keep) the head-follow appender inside the engine runtime.
+        let reader = reader.clone();
+        let _guard = engine.rt.enter();
+        reader.ensure_log_index_appender();
+    }
+    installed
 }
 
 /// Index status for hosts/UI: enabled, log count, backfill cursor, and per

--- a/rust/myotis-net/src/el/logindex.rs
+++ b/rust/myotis-net/src/el/logindex.rs
@@ -395,6 +395,10 @@ impl LogIndex {
     /// The next block the head-follow appender should record: one past the
     /// highest covered block across entries, or None when nothing is indexed
     /// yet (the appender then starts fresh at the current head).
+    /// Invariant making `max` safe here: append_block extends every
+    /// at-or-past-from_block entry together and rewind_above pulls highs to
+    /// a common fork point, so all `Some` highs are equal at rest; an entry
+    /// below the max is either pre-from_block or `None` (backfill's job).
     pub fn append_edge(&self) -> Option<u64> {
         self.coverage
             .iter()

--- a/rust/myotis-net/src/el/logindex.rs
+++ b/rust/myotis-net/src/el/logindex.rs
@@ -392,6 +392,31 @@ impl LogIndex {
         self.logs.len()
     }
 
+    /// The next block the head-follow appender should record: one past the
+    /// highest covered block across entries, or None when nothing is indexed
+    /// yet (the appender then starts fresh at the current head).
+    pub fn append_edge(&self) -> Option<u64> {
+        self.coverage
+            .iter()
+            .filter_map(|c| c.span.map(|(_, high)| high))
+            .max()
+            .map(|h| h.saturating_add(1))
+    }
+
+    /// Bloom pre-filter for one block: could its header bloom contain a log
+    /// any watch entry would store? `false` is a definitive skip (blooms
+    /// have no false negatives); `true` still requires verified receipts.
+    /// Entries whose `from_block` is above `block_number` are ignored, and
+    /// a topic0-restricted entry requires address AND one of its topic0s.
+    pub fn bloom_may_match(&self, block_number: u64, bloom: &myotis_core::bloom::LogsBloom) -> bool {
+        self.config.watch.iter().any(|w| {
+            block_number >= w.from_block
+                && myotis_core::bloom::may_contain(bloom, &w.address)
+                && (w.topic0s.is_empty()
+                    || w.topic0s.iter().any(|t| myotis_core::bloom::may_contain(bloom, t)))
+        })
+    }
+
     /// Watch entries paired with their coverage — the status surface.
     pub fn coverage_entries(&self) -> Vec<(WatchEntry, Coverage)> {
         self.config.watch.iter().cloned().zip(self.coverage.iter().copied()).collect()
@@ -864,5 +889,29 @@ mod tests {
         assert_eq!(c1.fingerprint(), c2.fingerprint());
         let c3 = config(vec![a, WatchEntry { address: addr(2), from_block: 10, topic0s: vec![topic(3), topic(4)] }]);
         assert_ne!(c1.fingerprint(), c3.fingerprint());
+    }
+}
+
+#[cfg(test)]
+mod bloom_match_tests {
+    use super::*;
+    use myotis_core::bloom::{accrue, EMPTY_BLOOM};
+
+    #[test]
+    fn bloom_prefilter_respects_from_block_and_topics() {
+        fn addr(b: u8) -> [u8; 20] {
+            [b; 20]
+        }
+        let watch = WatchEntry { address: addr(1), from_block: 100, topic0s: vec![[7; 32]] };
+        let ix = LogIndex::new(LogIndexConfig { enabled: true, watch: vec![watch] }).unwrap();
+        let mut hit = EMPTY_BLOOM;
+        accrue(&mut hit, &addr(1));
+        accrue(&mut hit, &[7u8; 32]);
+        assert!(ix.bloom_may_match(100, &hit));
+        assert!(!ix.bloom_may_match(99, &hit)); // below from_block
+        let mut addr_only = EMPTY_BLOOM;
+        accrue(&mut addr_only, &addr(1));
+        assert!(!ix.bloom_may_match(100, &addr_only)); // topic0-restricted entry needs a topic hit
+        assert!(!ix.bloom_may_match(100, &EMPTY_BLOOM));
     }
 }

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -681,9 +681,25 @@ impl ElReader {
         self.anchored_head().ok().map(|(n, _)| n)
     }
 
+    /// Deterministically stop the appender: abort AND await the task, which
+    /// guarantees its per-tick strong Arc has been dropped — hosts call this
+    /// BEFORE Arc::try_unwrap so teardown never races a long catch-up tick.
+    pub async fn stop_log_index_appender(&self) {
+        let handle = match self.log_index_task.lock() {
+            Ok(mut t) => t.take(),
+            Err(_) => None,
+        };
+        if let Some(h) = handle {
+            h.abort();
+            let _ = h.await; // JoinError::Cancelled — the task's Arc is gone
+        }
+    }
+
     /// Spawn (or keep) the head-follow appender for this reader. Idempotent:
-    /// a live task is left alone. Caller must be inside a tokio runtime.
-    pub fn ensure_log_index_appender(self: &Arc<Self>) {
+    /// a live task is left alone. `rt` makes the runtime-context invariant
+    /// unforgeable (a bare tokio::spawn outside a runtime would abort the
+    /// whole host process under panic="abort").
+    pub fn ensure_log_index_appender(self: &Arc<Self>, rt: &tokio::runtime::Handle) {
         let Ok(mut slot) = self.log_index_task.lock() else {
             return;
         };
@@ -697,7 +713,7 @@ impl ElReader {
         // the task exits on its own once the reader is gone; the abort in
         // stop() is the fast path.
         let weak = Arc::downgrade(self);
-        *slot = Some(tokio::spawn(async move {
+        *slot = Some(rt.spawn(async move {
             // Slice-3 rule: append FINALIZED blocks only. Finalized never
             // reorgs, so coverage stays honest with zero rewind machinery;
             // optimistic-tail appending (with the design doc's rewind rule)
@@ -720,6 +736,16 @@ impl ElReader {
     /// One appender tick: record finalized blocks from the append edge up to
     /// the finalized head (bounded batch per tick).
     async fn log_index_append_tick(&self, since_persist: &mut u32, ticks: u64) {
+        // Checkpoint due from a PREVIOUS tick first: batches that end early
+        // (peer failure mid-catch-up) must not defer persistence forever.
+        if *since_persist >= 64 {
+            if let (Some(path), Ok(slot)) = (self.log_index_path.as_deref(), self.log_index.lock()) {
+                if let Some(ix) = slot.as_ref() {
+                    let _ = ix.persist(path);
+                }
+            }
+            *since_persist = 0;
+        }
         let enabled = self.with_log_index(|ix| ix.config().enabled).unwrap_or(false);
         if !enabled {
             return;

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -690,7 +690,13 @@ impl ElReader {
         if slot.as_ref().is_some_and(|h| !h.is_finished()) {
             return;
         }
-        let reader = Arc::clone(self);
+        // The task holds only a WEAK reference: a strong Arc here would keep
+        // the reader's strong count above 1 forever, making the host's
+        // Arc::try_unwrap → ElReader::stop teardown unreachable (leaked
+        // networking on stop/pause). Each tick upgrades for its duration and
+        // the task exits on its own once the reader is gone; the abort in
+        // stop() is the fast path.
+        let weak = Arc::downgrade(self);
         *slot = Some(tokio::spawn(async move {
             // Slice-3 rule: append FINALIZED blocks only. Finalized never
             // reorgs, so coverage stays honest with zero rewind machinery;
@@ -699,16 +705,21 @@ impl ElReader {
             let mut tick = tokio::time::interval(std::time::Duration::from_secs(6));
             tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
             let mut since_persist = 0u32;
+            let mut ticks = 0u64;
             loop {
                 tick.tick().await;
-                reader.log_index_append_tick(&mut since_persist).await;
+                let Some(reader) = weak.upgrade() else {
+                    return; // reader torn down; the appender dies with it
+                };
+                reader.log_index_append_tick(&mut since_persist, ticks).await;
+                ticks = ticks.wrapping_add(1);
             }
         }));
     }
 
     /// One appender tick: record finalized blocks from the append edge up to
     /// the finalized head (bounded batch per tick).
-    async fn log_index_append_tick(&self, since_persist: &mut u32) {
+    async fn log_index_append_tick(&self, since_persist: &mut u32, ticks: u64) {
         let enabled = self.with_log_index(|ix| ix.config().enabled).unwrap_or(false);
         if !enabled {
             return;
@@ -727,7 +738,11 @@ impl ElReader {
         // the optimistic head; stay well inside its lookback cap. A deeper
         // lag is the backfill walker's job — say so once per tick.
         if finalized.saturating_sub(start) > 128 {
-            tracing::warn!(start, finalized, "log index append edge too far behind; waiting for backfill");
+            // Rate-limited: this state persists until the backfill walker
+            // exists / catches up, and a warn every 6 s is just noise.
+            if ticks % 100 == 0 {
+                tracing::warn!(start, finalized, "log index append edge too far behind; waiting for backfill");
+            }
             return;
         }
         let last = finalized.min(start.saturating_add(15));
@@ -740,33 +755,31 @@ impl ElReader {
                     return;
                 }
             };
-            let logs: Vec<crate::el::logindex::StoredLog> = receipts
-                .iter()
-                .flat_map(|r| {
-                    r.receipt.logs.iter().enumerate().filter_map(move |(k, l)| {
-                        Some(crate::el::logindex::StoredLog {
-                            block_number: r.block_number,
-                            block_hash: r.block_hash,
-                            tx_hash: r.tx_hash,
-                            tx_index: u32::try_from(r.tx_index).ok()?,
-                            log_index: u32::try_from(r.log_index_base).ok()?.checked_add(u32::try_from(k).ok()?)?,
-                            address: l.address.as_slice().try_into().ok()?,
-                            topics: l.topics.iter().filter_map(|t| t.as_slice().try_into().ok()).collect(),
-                            data: l.data.clone(),
-                        })
-                    })
-                })
-                .collect();
-            let appended = self
-                .with_log_index(|_| ())
-                .is_some()
-                && match self.log_index.lock() {
-                    Ok(mut slot) => match slot.as_mut() {
-                        Some(ix) => ix.append_block(n, logs).is_ok(),
-                        None => false,
+            // Strict conversion: any malformed field (wrong-length address or
+            // topic, index overflow) aborts THIS block's append rather than
+            // silently storing an altered shape under advancing coverage — a
+            // dropped topic0 would shift the rest and change what
+            // filter/watch matching sees for verified data.
+            let Some(logs) = stored_logs_for_block(&receipts) else {
+                tracing::warn!(block = n, "log index append: malformed log field in verified receipts; will retry");
+                return;
+            };
+            let appended = match self.log_index.lock() {
+                Ok(mut slot) => match slot.as_mut() {
+                    Some(ix) => match ix.append_block(n, logs) {
+                        Ok(()) => true,
+                        Err(gap) => {
+                            // Transient (config replaced / rewind raced this
+                            // tick) → retrying next tick is right; if it ever
+                            // became persistent this warn is the telemetry.
+                            tracing::warn!(block = n, edge = gap.edge, "log index append rejected (coverage gap); retrying");
+                            false
+                        }
                     },
-                    Err(_) => false,
-                };
+                    None => false,
+                },
+                Err(_) => false,
+            };
             if !appended {
                 return;
             }
@@ -3291,4 +3304,30 @@ mod tests {
         let tips = vec![(7u128, 0u64), (3, 0)];
         assert_eq!(percentile_rewards(tips, &[50.0, 99.0]), vec![3, 3]);
     }
+}
+
+/// Convert one block's [`VerifiedReceipt`]s into stored logs — strictly:
+/// `None` on any field that does not have its canonical width, so a caller
+/// never records a block whose stored shape differs from what was verified.
+fn stored_logs_for_block(receipts: &[VerifiedReceipt]) -> Option<Vec<crate::el::logindex::StoredLog>> {
+    let mut out = Vec::new();
+    for r in receipts {
+        for (k, l) in r.receipt.logs.iter().enumerate() {
+            let mut topics = Vec::with_capacity(l.topics.len());
+            for t in &l.topics {
+                topics.push(t.as_slice().try_into().ok()?);
+            }
+            out.push(crate::el::logindex::StoredLog {
+                block_number: r.block_number,
+                block_hash: r.block_hash,
+                tx_hash: r.tx_hash,
+                tx_index: u32::try_from(r.tx_index).ok()?,
+                log_index: u32::try_from(r.log_index_base).ok()?.checked_add(u32::try_from(k).ok()?)?,
+                address: l.address.as_slice().try_into().ok()?,
+                topics,
+                data: l.data.clone(),
+            });
+        }
+    }
+    Some(out)
 }

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -513,6 +513,8 @@ pub struct ElReader {
     /// stop, never under a network await.
     log_index: std::sync::Mutex<Option<crate::el::logindex::LogIndex>>,
     log_index_path: Option<std::path::PathBuf>,
+    /// The head-follow appender task (spawned on enable, aborted on stop).
+    log_index_task: std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
 }
 
 /// The scan-cursor map plus its last TTL sweep — one lock covers both, so the
@@ -633,6 +635,7 @@ impl ElReader {
             sent_tx_watch,
             log_index: std::sync::Mutex::new(None),
             log_index_path: cfg.log_index_path,
+            log_index_task: std::sync::Mutex::new(None),
         })
     }
 
@@ -676,6 +679,108 @@ impl ElReader {
     /// resolution target for `latest`-style tags in eth_getLogs filters.
     pub fn head_block_number(&self) -> Option<u64> {
         self.anchored_head().ok().map(|(n, _)| n)
+    }
+
+    /// Spawn (or keep) the head-follow appender for this reader. Idempotent:
+    /// a live task is left alone. Caller must be inside a tokio runtime.
+    pub fn ensure_log_index_appender(self: &Arc<Self>) {
+        let Ok(mut slot) = self.log_index_task.lock() else {
+            return;
+        };
+        if slot.as_ref().is_some_and(|h| !h.is_finished()) {
+            return;
+        }
+        let reader = Arc::clone(self);
+        *slot = Some(tokio::spawn(async move {
+            // Slice-3 rule: append FINALIZED blocks only. Finalized never
+            // reorgs, so coverage stays honest with zero rewind machinery;
+            // optimistic-tail appending (with the design doc's rewind rule)
+            // and deep-gap bridging both belong to the backfill slice.
+            let mut tick = tokio::time::interval(std::time::Duration::from_secs(6));
+            tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            let mut since_persist = 0u32;
+            loop {
+                tick.tick().await;
+                reader.log_index_append_tick(&mut since_persist).await;
+            }
+        }));
+    }
+
+    /// One appender tick: record finalized blocks from the append edge up to
+    /// the finalized head (bounded batch per tick).
+    async fn log_index_append_tick(&self, since_persist: &mut u32) {
+        let enabled = self.with_log_index(|ix| ix.config().enabled).unwrap_or(false);
+        if !enabled {
+            return;
+        }
+        let finalized = self.finalized_block_number();
+        if finalized == 0 {
+            return;
+        }
+        let edge = self.with_log_index(|ix| ix.append_edge()).flatten();
+        let start = match edge {
+            None => finalized, // fresh index: start at the finalized head
+            Some(e) if e <= finalized => e,
+            Some(_) => return, // caught up
+        };
+        // The verified whole-block path anchors a window from the target to
+        // the optimistic head; stay well inside its lookback cap. A deeper
+        // lag is the backfill walker's job — say so once per tick.
+        if finalized.saturating_sub(start) > 128 {
+            tracing::warn!(start, finalized, "log index append edge too far behind; waiting for backfill");
+            return;
+        }
+        let last = finalized.min(start.saturating_add(15));
+        for n in start..=last {
+            let receipts = match self.get_block_receipts(Some(n)).await {
+                Ok(Some(r)) => r,
+                Ok(None) => return, // future/unknown under this anchor — retry next tick
+                Err(e) => {
+                    tracing::debug!(block = n, error = %e, "log index append: receipts unavailable");
+                    return;
+                }
+            };
+            let logs: Vec<crate::el::logindex::StoredLog> = receipts
+                .iter()
+                .flat_map(|r| {
+                    r.receipt.logs.iter().enumerate().filter_map(move |(k, l)| {
+                        Some(crate::el::logindex::StoredLog {
+                            block_number: r.block_number,
+                            block_hash: r.block_hash,
+                            tx_hash: r.tx_hash,
+                            tx_index: u32::try_from(r.tx_index).ok()?,
+                            log_index: u32::try_from(r.log_index_base).ok()?.checked_add(u32::try_from(k).ok()?)?,
+                            address: l.address.as_slice().try_into().ok()?,
+                            topics: l.topics.iter().filter_map(|t| t.as_slice().try_into().ok()).collect(),
+                            data: l.data.clone(),
+                        })
+                    })
+                })
+                .collect();
+            let appended = self
+                .with_log_index(|_| ())
+                .is_some()
+                && match self.log_index.lock() {
+                    Ok(mut slot) => match slot.as_mut() {
+                        Some(ix) => ix.append_block(n, logs).is_ok(),
+                        None => false,
+                    },
+                    Err(_) => false,
+                };
+            if !appended {
+                return;
+            }
+            *since_persist += 1;
+        }
+        // Checkpoint roughly every 64 appended blocks (best-effort).
+        if *since_persist >= 64 {
+            if let (Some(path), Ok(slot)) = (self.log_index_path.as_deref(), self.log_index.lock()) {
+                if let Some(ix) = slot.as_ref() {
+                    let _ = ix.persist(path);
+                }
+            }
+            *since_persist = 0;
+        }
     }
 
     /// Run `f` against the index if one is configured. The single accessor
@@ -2460,6 +2565,11 @@ impl ElReader {
 
     /// Stop discovery + the pool.
     pub async fn stop(self) {
+        if let Ok(mut t) = self.log_index_task.lock() {
+            if let Some(h) = t.take() {
+                h.abort();
+            }
+        }
         // Best-effort index checkpoint before teardown: a failed write only
         // costs a re-index of the uncheckpointed tail, never correctness.
         if let (Some(path), Ok(slot)) = (self.log_index_path.as_deref(), self.log_index.lock()) {


### PR DESCRIPTION
Slice 3 of eth_getLogs (follows #269/#270). With this, an opted-in node **actually starts answering** `eth_getLogs`: an ElReader-owned tokio task records finalized blocks — through the existing verified whole-block receipts path (anchored window, body+receipts vs both roots) — into the gap-rejecting index, up to 16 blocks per 6 s tick, checkpointing every ~64 blocks.

## Design points (deliberate, stated)
- **Finalized-only appending**: finalized blocks cannot reorg, so coverage stays honest with zero rewind machinery. Coverage trails head by the finality distance; queries into the optimistic tail err retryably. Optimistic-tail + rewind and deep-gap bridging belong to the backfill slice (an edge >128 behind parks with a rate-limited warn until the walker exists).
- **Restart dormancy**: nothing engine-side re-installs the config after a restart — the persisted index sits on disk until the host re-pushes `set_log_index_config` (slice 5 wires hosts to do that on boot). Disabling leaves the task as a cheap no-op ticker.
- **Lifecycle**: the task holds a **Weak** reader reference (a strong Arc would have made the host's `try_unwrap` → `stop()` teardown unreachable — caught in internal review) and exits when the reader goes; `stop()` aborts it fast-path and checkpoints the index.
- **Strict conversion**: any wrong-width address/topic or index overflow in verified receipts aborts that block's append with telemetry rather than storing an altered shape under advancing coverage.
- Also in: `bloom::may_contain` (the probe dual of `accrue`) + `LogIndex::bloom_may_match`/`append_edge` — groundwork the backfill walker consumes; not yet on a runtime path.

## Validation
`cargo test --workspace` green (new tests for the bloom probe and index primitives). No Kotlin changes. Independent no-context review done; its blocking finding (the Arc lifecycle leak) and all should-fixes are in the last commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JibVnmRGPUp1692WebwfEs