### PR TITLE
eth_getLogs backfill walker: verified descending walk to the watch-list anchors (slice 4)

### DIFF
--- a/docs/eth-getlogs-design.md
+++ b/docs/eth-getlogs-design.md
@@ -116,6 +116,15 @@ genuinely cannot serve a range, coverage simply never reaches it and getLogs
 for that range keeps erroring — honest by construction. (This is exactly the
 case where a bundled seed becomes the necessary optimization.)
 
+**Tracked follow-up (upward bridging):** after node downtime longer than the
+appender's window guard (~128 blocks), the coverage gap sits ABOVE the walk
+cursor and neither component closes it — the appender waits, the walker only
+descends. Bridge design: anchor a fresh chained window at the new finalized
+head, walk down to the old high edge, then resume appending — absorbable by
+the single-span coverage model without a second cursor as long as the bridge
+completes before the high edge advances. Until it lands, the append-side warn
+says plainly that coverage above the edge stays frozen.
+
 ### 4. Serving (`getLogs`)
 
 Filter support: `fromBlock`/`toBlock` (hex or `latest`/`finalized`),

--- a/rust/myotis-net/src/el/logindex.rs
+++ b/rust/myotis-net/src/el/logindex.rs
@@ -257,7 +257,12 @@ impl LogIndex {
     /// makes "no events in this range" a servable answer. All-or-nothing: a
     /// gap against ANY affected entry rejects the whole call and stores
     /// nothing — the caller must process the missing blocks first.
-    pub fn append_block(&mut self, block_number: u64, logs: Vec<StoredLog>) -> Result<(), CoverageGap> {
+    pub fn append_block(
+        &mut self,
+        block_number: u64,
+        block_hash: [u8; 32],
+        logs: Vec<StoredLog>,
+    ) -> Result<(), CoverageGap> {
         for (w, c) in self.config.watch.iter().zip(self.coverage.iter()) {
             if block_number >= w.from_block {
                 if let Some((low, high)) = c.span {
@@ -283,6 +288,11 @@ impl LogIndex {
                 // Pre-checked above; a gap here is unreachable.
                 let _ = c.extend_up(block_number);
             }
+        }
+        // Seed the backfill trust edge at the first-ever appended block: the
+        // walker chains DOWNWARD from here (backfill_block then advances it).
+        if self.cursor.is_none() {
+            self.cursor = Some((block_number, block_hash));
         }
         Ok(())
     }
@@ -667,8 +677,8 @@ mod tests {
     #[test]
     fn query_outside_coverage_errors_never_empty() {
         let mut ix = LogIndex::new(config_ok(vec![watch_all(addr(1), 100)])).unwrap();
-        ix.append_block(200, vec![]).unwrap();
-        ix.append_block(201, vec![log(201, 0, addr(1), vec![topic(9)])]).unwrap();
+        ix.append_block(200, [0xbb; 32], vec![]).unwrap();
+        ix.append_block(201, [0xbb; 32], vec![log(201, 0, addr(1), vec![topic(9)])]).unwrap();
         // Covered range answers (including the empty block).
         assert_eq!(ix.query(&filter(200, 200, addr(1))).unwrap(), vec![]);
         assert_eq!(ix.query(&filter(200, 201, addr(1))).unwrap().len(), 1);
@@ -685,7 +695,7 @@ mod tests {
     #[test]
     fn range_below_from_block_needs_no_coverage() {
         let mut ix = LogIndex::new(config_ok(vec![watch_all(addr(1), 500)])).unwrap();
-        ix.append_block(500, vec![]).unwrap();
+        ix.append_block(500, [0xbb; 32], vec![]).unwrap();
         // 100..=500 is fine: below from_block the contract can't have logs.
         assert_eq!(ix.query(&filter(100, 500, addr(1))).unwrap(), vec![]);
         // Entirely below from_block: nothing to cover, empty is honest.
@@ -695,7 +705,7 @@ mod tests {
     #[test]
     fn unwatched_address_and_disabled_error() {
         let mut ix = LogIndex::new(config_ok(vec![watch_all(addr(1), 0)])).unwrap();
-        ix.append_block(10, vec![]).unwrap();
+        ix.append_block(10, [0xbb; 32], vec![]).unwrap();
         assert_eq!(ix.query(&filter(0, 10, addr(2))), Err(QueryError::UnwatchedAddress(addr(2))));
         let off = LogIndex::new(LogIndexConfig { enabled: false, watch: vec![watch_all(addr(1), 0)] }).unwrap();
         assert_eq!(off.query(&filter(0, 0, addr(1))), Err(QueryError::Disabled));
@@ -706,7 +716,7 @@ mod tests {
     fn topic_restricted_watch_rejects_wildcard_queries() {
         let w = WatchEntry { address: addr(1), from_block: 0, topic0s: vec![topic(7)] };
         let mut ix = LogIndex::new(config_ok(vec![w])).unwrap();
-        ix.append_block(5, vec![log(5, 0, addr(1), vec![topic(7)])]).unwrap();
+        ix.append_block(5, [0xbb; 32], vec![log(5, 0, addr(1), vec![topic(7)])]).unwrap();
         // Wildcard topic0 would deserve unindexed signatures → error.
         assert_eq!(ix.query(&filter(5, 5, addr(1))), Err(QueryError::UnindexedTopic(addr(1))));
         // Pinned to the indexed signature → answers.
@@ -721,7 +731,7 @@ mod tests {
     #[test]
     fn positional_topic_matching() {
         let mut ix = LogIndex::new(config_ok(vec![watch_all(addr(1), 0)])).unwrap();
-        ix.append_block(1, vec![log(1, 0, addr(1), vec![topic(7), topic(8)])]).unwrap();
+        ix.append_block(1, [0xbb; 32], vec![log(1, 0, addr(1), vec![topic(7), topic(8)])]).unwrap();
         let mut f = filter(1, 1, addr(1));
         f.topics = vec![vec![], vec![topic(8), topic(9)]]; // wildcard t0, OR at t1
         assert_eq!(ix.query(&f).unwrap().len(), 1);
@@ -734,7 +744,7 @@ mod tests {
     #[test]
     fn backfill_extends_down_and_tracks_cursor() {
         let mut ix = LogIndex::new(config_ok(vec![watch_all(addr(1), 100)])).unwrap();
-        ix.append_block(300, vec![]).unwrap();
+        ix.append_block(300, [0xbb; 32], vec![]).unwrap();
         ix.backfill_block(299, [9; 32], vec![log(299, 2, addr(1), vec![])]).unwrap();
         ix.backfill_block(298, [8; 32], vec![]).unwrap();
         assert_eq!(ix.coverage_of(&addr(1)).unwrap().span, Some((298, 300)));
@@ -746,7 +756,7 @@ mod tests {
     fn rewind_above_drops_logs_and_pulls_coverage_back() {
         let mut ix = LogIndex::new(config_ok(vec![watch_all(addr(1), 0)])).unwrap();
         for b in 10..=14 {
-            ix.append_block(b, vec![log(b, 0, addr(1), vec![])]).unwrap();
+            ix.append_block(b, [0xbb; 32], vec![log(b, 0, addr(1), vec![])]).unwrap();
         }
         ix.rewind_above(12);
         assert_eq!(ix.coverage_of(&addr(1)).unwrap().span, Some((10, 12)));
@@ -759,7 +769,7 @@ mod tests {
     fn unwatched_logs_are_not_stored() {
         let mut ix = LogIndex::new(config_ok(vec![watch_all(addr(1), 100)])).unwrap();
         // Wrong address, and right address but below from_block: both dropped.
-        ix.append_block(200, vec![log(200, 0, addr(2), vec![])]).unwrap();
+        ix.append_block(200, [0xbb; 32], vec![log(200, 0, addr(2), vec![])]).unwrap();
         ix.backfill_block(99, [1; 32], vec![log(99, 0, addr(1), vec![])]).unwrap();
         assert_eq!(ix.log_count(), 0);
     }
@@ -771,7 +781,7 @@ mod tests {
         let path = dir.join("logindex-test.db");
         let cfg = config(vec![watch_all(addr(1), 100), WatchEntry { address: addr(2), from_block: 0, topic0s: vec![topic(7)] }]);
         let mut ix = LogIndex::new(cfg.clone()).unwrap();
-        ix.append_block(200, vec![log(200, 3, addr(1), vec![topic(7), topic(8)])]).unwrap();
+        ix.append_block(200, [0xbb; 32], vec![log(200, 3, addr(1), vec![topic(7), topic(8)])]).unwrap();
         ix.backfill_block(199, [7; 32], vec![]).unwrap();
         ix.persist(&path).unwrap();
 
@@ -793,13 +803,13 @@ mod tests {
     #[test]
     fn gaps_are_rejected_not_bridged() {
         let mut ix = LogIndex::new(config_ok(vec![watch_all(addr(1), 0)])).unwrap();
-        ix.append_block(200, vec![]).unwrap();
+        ix.append_block(200, [0xbb; 32], vec![]).unwrap();
         // Skipping 201 must fail and store nothing.
-        assert_eq!(ix.append_block(205, vec![log(205, 0, addr(1), vec![])]), Err(CoverageGap { edge: 200, block: 205 }));
+        assert_eq!(ix.append_block(205, [0xbb; 32], vec![log(205, 0, addr(1), vec![])]), Err(CoverageGap { edge: 200, block: 205 }));
         assert_eq!(ix.log_count(), 0);
         assert_eq!(ix.coverage_of(&addr(1)).unwrap().span, Some((200, 200)));
         // Contiguous append still works; downward gap equally rejected.
-        ix.append_block(201, vec![]).unwrap();
+        ix.append_block(201, [0xbb; 32], vec![]).unwrap();
         assert_eq!(ix.backfill_block(150, [1; 32], vec![]), Err(CoverageGap { edge: 200, block: 150 }));
         ix.backfill_block(199, [2; 32], vec![]).unwrap();
         assert_eq!(ix.coverage_of(&addr(1)).unwrap().span, Some((199, 201)));
@@ -811,7 +821,7 @@ mod tests {
     fn deserialize_survives_arbitrary_corruption() {
         let cfg = config(vec![watch_all(addr(1), 0)]);
         let mut ix = LogIndex::new(cfg.clone()).unwrap();
-        ix.append_block(7, vec![log(7, 0, addr(1), vec![topic(1), topic(2)])]).unwrap();
+        ix.append_block(7, [0xbb; 32], vec![log(7, 0, addr(1), vec![topic(1), topic(2)])]).unwrap();
         let good = ix.serialize();
         assert!(LogIndex::deserialize(&cfg, &good).is_some());
         // Every single-byte mutation must yield Some-or-None, never panic,
@@ -841,14 +851,14 @@ mod tests {
     #[test]
     fn rewind_below_backfill_edge_drops_cursor() {
         let mut ix = LogIndex::new(config_ok(vec![watch_all(addr(1), 0)])).unwrap();
-        ix.append_block(200, vec![]).unwrap();
+        ix.append_block(200, [0xbb; 32], vec![]).unwrap();
         ix.backfill_block(199, [9; 32], vec![]).unwrap();
         // Fork below the walk's edge: the cursor hash may be orphaned.
         ix.rewind_above(150);
         assert_eq!(ix.cursor, None);
         // Fork above the edge leaves the cursor intact.
         let mut ix2 = LogIndex::new(config_ok(vec![watch_all(addr(1), 0)])).unwrap();
-        ix2.append_block(200, vec![]).unwrap();
+        ix2.append_block(200, [0xbb; 32], vec![]).unwrap();
         ix2.backfill_block(199, [9; 32], vec![]).unwrap();
         ix2.rewind_above(199);
         assert_eq!(ix2.cursor, Some((199, [9; 32])));
@@ -857,13 +867,13 @@ mod tests {
     #[test]
     fn append_below_low_and_backfill_above_high_are_rejected() {
         let mut ix = LogIndex::new(config_ok(vec![watch_all(addr(1), 0)])).unwrap();
-        ix.append_block(200, vec![]).unwrap();
+        ix.append_block(200, [0xbb; 32], vec![]).unwrap();
         ix.backfill_block(199, [1; 32], vec![]).unwrap();
-        assert!(ix.append_block(150, vec![log(150, 0, addr(1), vec![])]).is_err());
+        assert!(ix.append_block(150, [0xbb; 32], vec![log(150, 0, addr(1), vec![])]).is_err());
         assert_eq!(ix.log_count(), 0); // nothing stored outside coverage
         assert!(ix.backfill_block(300, [2; 32], vec![]).is_err());
         // Re-processing inside the span stays allowed on both paths.
-        ix.append_block(200, vec![]).unwrap();
+        ix.append_block(200, [0xbb; 32], vec![]).unwrap();
         ix.backfill_block(199, [1; 32], vec![]).unwrap();
     }
 
@@ -871,7 +881,7 @@ mod tests {
     fn payload_bitflip_is_detected() {
         let cfg = config(vec![watch_all(addr(1), 0)]);
         let mut ix = LogIndex::new(cfg.clone()).unwrap();
-        ix.append_block(7, vec![log(7, 0, addr(1), vec![topic(1)])]).unwrap();
+        ix.append_block(7, [0xbb; 32], vec![log(7, 0, addr(1), vec![topic(1)])]).unwrap();
         let good = ix.serialize();
         // Flip one bit inside every payload byte (past the 24-byte header):
         // the checksum must reject each one.
@@ -880,6 +890,19 @@ mod tests {
             bad[i] ^= 0x01;
             assert!(LogIndex::deserialize(&cfg, &bad).is_none(), "bitflip at {i} accepted");
         }
+    }
+
+    #[test]
+    fn first_append_seeds_the_backfill_cursor() {
+        let mut ix = LogIndex::new(config_ok(vec![watch_all(addr(1), 0)])).unwrap();
+        assert_eq!(ix.cursor, None);
+        ix.append_block(500, [5; 32], vec![]).unwrap();
+        assert_eq!(ix.cursor, Some((500, [5; 32])));
+        // Later appends leave the walk edge alone; backfill moves it down.
+        ix.append_block(501, [6; 32], vec![]).unwrap();
+        assert_eq!(ix.cursor, Some((500, [5; 32])));
+        ix.backfill_block(499, [4; 32], vec![]).unwrap();
+        assert_eq!(ix.cursor, Some((499, [4; 32])));
     }
 
     #[test]

--- a/rust/myotis-net/src/el/logindex.rs
+++ b/rust/myotis-net/src/el/logindex.rs
@@ -37,6 +37,19 @@ pub struct LogIndexConfig {
 }
 
 impl LogIndexConfig {
+    /// Would any watch entry store this log? (Address match at/past the
+    /// entry's from_block, honoring topic0 restrictions.) Exposed so batch
+    /// fetchers can pre-filter against a captured config snapshot instead of
+    /// buffering every log of every candidate block.
+    pub fn watches(&self, log: &StoredLog) -> bool {
+        self.watch.iter().any(|w| {
+            w.address == log.address
+                && log.block_number >= w.from_block
+                && (w.topic0s.is_empty()
+                    || log.topics.first().is_some_and(|t| w.topic0s.contains(t)))
+        })
+    }
+
     /// Order-insensitive fingerprint of the watch-list. A changed fingerprint
     /// on load invalidates the persisted index (derived data — re-index
     /// rather than risk serving under a stale subscription set).
@@ -244,12 +257,7 @@ impl LogIndex {
     }
 
     fn watched(&self, log: &StoredLog) -> bool {
-        self.config.watch.iter().any(|w| {
-            w.address == log.address
-                && log.block_number >= w.from_block
-                && (w.topic0s.is_empty()
-                    || log.topics.first().is_some_and(|t| w.topic0s.contains(t)))
-        })
+        self.config.watches(log)
     }
 
     /// Record a fully processed block adjoining the high edge (the head-follow

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -832,11 +832,12 @@ impl ElReader {
     /// before any log is stored. Peer refusal is a stall, never corruption:
     /// coverage simply doesn't extend until some peer serves the range.
     async fn log_index_backfill_step(&self, ticks: u64) {
-        let Some((enabled, target_low, cursor)) = self.with_log_index(|ix| {
+        let Some((enabled, target_low, cursor, fingerprint)) = self.with_log_index(|ix| {
             (
                 ix.config().enabled,
                 ix.config().watch.iter().map(|w| w.from_block).min(),
                 ix.cursor,
+                ix.config().fingerprint(),
             )
         }) else {
             return;
@@ -847,7 +848,10 @@ impl ElReader {
         if !enabled || cur_n <= target_low {
             return;
         }
-        const BATCH: u64 = 1024;
+        // count+1 headers are requested (the top one is the cursor block), and
+        // honest peers cap header serves at 1024 (our own served.rs agrees) —
+        // so the batch is 1023 new blocks, keeping the request exactly at cap.
+        const BATCH: u64 = 1023;
         let count = (cur_n - target_low).min(BATCH);
         let from = cur_n - count;
         let peers = self.pool.snap_peers().await;
@@ -855,7 +859,10 @@ impl ElReader {
             return;
         }
         for peer in &peers {
-            match self.log_index_backfill_batch(peer, from, count, cur_n, cur_hash).await {
+            match self
+                .log_index_backfill_batch(peer, from, count, cur_n, cur_hash, fingerprint)
+                .await
+            {
                 Ok(()) => {
                     // Checkpoint after every applied batch: the store is
                     // small at Sepolia scale and a crash then costs at most
@@ -892,6 +899,7 @@ impl ElReader {
         count: u64,
         cur_n: u64,
         cur_hash: [u8; 32],
+        fingerprint: u64,
     ) -> Result<(), String> {
         let window = peer.get_block_headers_by_number(from, count + 1, 0, false).await?;
         if window.len() as u64 != count + 1 {
@@ -905,14 +913,19 @@ impl ElReader {
             return Err("peer returned the wrong starting block number".to_string());
         }
         for pair in window.windows(2) {
-            let (lower, upper) = (&pair[0], &pair[1]);
+            let [lower, upper] = pair else {
+                return Err("header window pairing failed".to_string());
+            };
             if upper.header.parent_hash != lower.hash {
                 return Err("peer header window breaks the parent-hash chain".to_string());
             }
         }
         // Bloom-filter candidates among the NEW blocks (everything below the
         // cursor). A miss is a definitive skip; a hit needs verified receipts.
-        let candidates: Vec<&crate::el::eth::messages::VerifiedHeader> = window[..window.len() - 1]
+        let Some((_, new_headers)) = window.split_last() else {
+            return Err("empty header window".to_string());
+        };
+        let candidates: Vec<&crate::el::eth::messages::VerifiedHeader> = new_headers
             .iter()
             .filter(|h| {
                 let Ok(bloom): Result<&[u8; 256], _> = h.header.logs_bloom.as_slice().try_into() else {
@@ -923,16 +936,19 @@ impl ElReader {
             .collect();
         let mut logs_by_block: std::collections::HashMap<u64, Vec<crate::el::logindex::StoredLog>> =
             std::collections::HashMap::new();
-        if !candidates.is_empty() {
-            let hashes: Vec<[u8; 32]> = candidates.iter().map(|h| h.hash).collect();
+        // Chunked: one request for ~1023 candidate blocks would blow through
+        // peer soft response limits (~2 MiB) and permanently stall a
+        // candidate-dense range on the exact-length check below.
+        for chunk in candidates.chunks(64) {
+            let hashes: Vec<[u8; 32]> = chunk.iter().map(|h| h.hash).collect();
             let (bodies, receipt_blocks) =
                 futures::future::join(peer.get_block_bodies(&hashes), peer.get_receipts(&hashes)).await;
             let bodies = bodies?;
             let receipt_blocks = receipt_blocks?;
-            if bodies.len() != candidates.len() || receipt_blocks.len() != candidates.len() {
+            if bodies.len() != chunk.len() || receipt_blocks.len() != chunk.len() {
                 return Err("peer returned a short bodies/receipts response".to_string());
             }
-            for ((vh, body), receipts) in candidates.iter().zip(&bodies).zip(&receipt_blocks) {
+            for ((vh, body), receipts) in chunk.iter().zip(&bodies).zip(&receipt_blocks) {
                 verify_body_transactions(&vh.header, body)?;
                 if receipts.len() != body.transactions.len() {
                     return Err(format!(
@@ -956,7 +972,21 @@ impl ElReader {
                 let Some(ix) = slot.as_mut() else {
                     return Err("log index uninstalled mid-batch".to_string());
                 };
-                for vh in window[..window.len() - 1].iter().rev() {
+                // The batch ran across several awaits; a concurrent
+                // set_log_index_config may have replaced the index (fresh
+                // cursor None, empty spans that would accept ANY block). Our
+                // candidates were bloom-selected against the OLD watch-list —
+                // applying them to a new one would claim coverage for blocks
+                // whose new-address logs were "definitively" skipped. Bail
+                // unless both the trust edge and the config are the ones this
+                // batch was computed against.
+                if ix.cursor != Some((cur_n, cur_hash)) || ix.config().fingerprint() != fingerprint {
+                    return Err("index changed mid-batch; recomputing next tick".to_string());
+                }
+                let Some((_, new_blocks)) = window.split_last() else {
+                    return Err("empty header window".to_string());
+                };
+                for vh in new_blocks.iter().rev() {
                     let n = vh.header.number;
                     let logs = logs_by_block.remove(&n).unwrap_or_default();
                     ix.backfill_block(n, vh.hash, logs)

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -768,7 +768,7 @@ impl ElReader {
             // Rate-limited: this state persists until the backfill walker
             // exists / catches up, and a warn every 6 s is just noise.
             if ticks % 100 == 0 {
-                tracing::warn!(start, finalized, "log index append edge too far behind; waiting for backfill");
+                tracing::warn!(start, finalized, "log index append edge too far behind (node downtime?); upward bridging is a tracked follow-up — coverage above the edge stays frozen until then");
             }
             return;
         }
@@ -832,22 +832,18 @@ impl ElReader {
     /// before any log is stored. Peer refusal is a stall, never corruption:
     /// coverage simply doesn't extend until some peer serves the range.
     async fn log_index_backfill_step(&self, ticks: u64) {
-        let Some((enabled, target_low, cursor, fingerprint)) = self.with_log_index(|ix| {
-            (
-                ix.config().enabled,
-                ix.config().watch.iter().map(|w| w.from_block).min(),
-                ix.cursor,
-                ix.config().fingerprint(),
-            )
-        }) else {
+        let Some((config, cursor)) = self.with_log_index(|ix| (ix.config().clone(), ix.cursor)) else {
             return;
         };
-        let (Some(target_low), Some((cur_n, cur_hash))) = (target_low, cursor) else {
+        let (Some(target_low), Some((cur_n, cur_hash))) =
+            (config.watch.iter().map(|w| w.from_block).min(), cursor)
+        else {
             return; // no watch entries, or the appender hasn't seeded the edge yet
         };
-        if !enabled || cur_n <= target_low {
+        if !config.enabled || cur_n <= target_low {
             return;
         }
+        let fingerprint = config.fingerprint();
         // count+1 headers are requested (the top one is the cursor block), and
         // honest peers cap header serves at 1024 (our own served.rs agrees) —
         // so the batch is 1023 new blocks, keeping the request exactly at cap.
@@ -860,7 +856,7 @@ impl ElReader {
         }
         for peer in &peers {
             match self
-                .log_index_backfill_batch(peer, from, count, cur_n, cur_hash, fingerprint)
+                .log_index_backfill_batch(peer, count, cur_n, cur_hash, &config, fingerprint)
                 .await
             {
                 Ok(()) => {
@@ -892,40 +888,57 @@ impl ElReader {
     /// headers [from, cur_n] ascending (count+1, so the top one IS the cursor
     /// block), full parent-hash chain check, bloom-filtered candidate
     /// body+receipts fetch verified against both roots, then apply top-down.
+    /// Fetch and apply one descending backfill batch from one peer. The
+    /// request is `reverse=true` starting AT the trusted cursor block, so the
+    /// trust root is the FIRST header of the response — a short serve (peers
+    /// may cap below the 1024 ceiling, or truncate on byte budget) still
+    /// yields a verifiable parent-hash-chained prefix and partial progress,
+    /// instead of failing an exact-length check forever. (`remember_served`
+    /// only tracks ascending shapes, so reverse fetches skip that side
+    /// channel — harmless.) Candidates are bloom-filtered and their logs
+    /// pre-filtered against the captured config, so transient memory is
+    /// proportional to logs that will actually be stored.
     async fn log_index_backfill_batch(
         &self,
         peer: &ManagedPeer,
-        from: u64,
         count: u64,
         cur_n: u64,
         cur_hash: [u8; 32],
+        config: &crate::el::logindex::LogIndexConfig,
         fingerprint: u64,
     ) -> Result<(), String> {
-        let window = peer.get_block_headers_by_number(from, count + 1, 0, false).await?;
-        if window.len() as u64 != count + 1 {
-            return Err(format!("peer returned {} headers, expected {}", window.len(), count + 1));
-        }
-        let top = window.last().ok_or("empty header window")?;
+        let window = peer.get_block_headers_by_number(cur_n, count + 1, 0, true).await?;
+        let Some((top, rest)) = window.split_first() else {
+            return Err("peer returned no headers".to_string());
+        };
         if top.header.number != cur_n || top.hash != cur_hash {
-            return Err("peer window does not end at the trusted cursor block".to_string());
+            return Err("peer window does not start at the trusted cursor block".to_string());
         }
-        if window.first().is_some_and(|h| h.header.number != from) {
-            return Err("peer returned the wrong starting block number".to_string());
+        if rest.is_empty() {
+            return Err("peer served only the cursor block".to_string());
         }
+        // Descending parent-hash chain: each header's parent is the next one.
+        // Only the verified prefix is used, so a mid-response break just
+        // shortens the batch instead of failing it.
+        let mut verified = 0usize;
         for pair in window.windows(2) {
-            let [lower, upper] = pair else {
+            let [upper, lower] = pair else {
                 return Err("header window pairing failed".to_string());
             };
-            if upper.header.parent_hash != lower.hash {
-                return Err("peer header window breaks the parent-hash chain".to_string());
+            if upper.header.parent_hash != lower.hash
+                || lower.header.number != upper.header.number.wrapping_sub(1)
+            {
+                break;
             }
+            verified += 1;
         }
-        // Bloom-filter candidates among the NEW blocks (everything below the
-        // cursor). A miss is a definitive skip; a hit needs verified receipts.
-        let Some((_, new_headers)) = window.split_last() else {
-            return Err("empty header window".to_string());
-        };
-        let candidates: Vec<&crate::el::eth::messages::VerifiedHeader> = new_headers
+        if verified == 0 {
+            return Err("peer response does not chain to the cursor block".to_string());
+        }
+        let new_blocks = rest.get(..verified).ok_or("verified prefix out of range")?;
+        // Bloom-filter candidates among the NEW blocks. A miss is a
+        // definitive skip; a hit needs verified receipts.
+        let candidates: Vec<&crate::el::eth::messages::VerifiedHeader> = new_blocks
             .iter()
             .filter(|h| {
                 let Ok(bloom): Result<&[u8; 256], _> = h.header.logs_bloom.as_slice().try_into() else {
@@ -959,14 +972,22 @@ impl ElReader {
                     ));
                 }
                 verify_block_receipts(&vh.header, receipts)?;
-                let verified = build_block_receipts(&vh.header, vh.hash, body, receipts)?;
-                let stored = stored_logs_for_block(&verified)
+                let built = build_block_receipts(&vh.header, vh.hash, body, receipts)?;
+                let stored = stored_logs_for_block(&built)
                     .ok_or("malformed log field in verified receipts")?;
-                logs_by_block.insert(vh.header.number, stored);
+                // Pre-filter: buffer only logs the captured watch-list will
+                // store (the fingerprint recheck below discards the batch if
+                // the config changed, so filtering against the snapshot is
+                // safe) — transient memory stays proportional to stored logs.
+                let watched: Vec<crate::el::logindex::StoredLog> =
+                    stored.into_iter().filter(|l| config.watches(l)).collect();
+                if !watched.is_empty() {
+                    logs_by_block.insert(vh.header.number, watched);
+                }
             }
         }
-        // Apply top-down so every block adjoins the low edge; the trust edge
-        // (cursor) advances with each applied block.
+        // Apply top-down (the response is already descending) so every block
+        // adjoins the low edge; the trust edge advances with each block.
         match self.log_index.lock() {
             Ok(mut slot) => {
                 let Some(ix) = slot.as_mut() else {
@@ -983,10 +1004,7 @@ impl ElReader {
                 if ix.cursor != Some((cur_n, cur_hash)) || ix.config().fingerprint() != fingerprint {
                     return Err("index changed mid-batch; recomputing next tick".to_string());
                 }
-                let Some((_, new_blocks)) = window.split_last() else {
-                    return Err("empty header window".to_string());
-                };
-                for vh in new_blocks.iter().rev() {
+                for vh in new_blocks {
                     let n = vh.header.number;
                     let logs = logs_by_block.remove(&n).unwrap_or_default();
                     ix.backfill_block(n, vh.hash, logs)

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -728,6 +728,7 @@ impl ElReader {
                     return; // reader torn down; the appender dies with it
                 };
                 reader.log_index_append_tick(&mut since_persist, ticks).await;
+                reader.log_index_backfill_step(ticks).await;
                 ticks = ticks.wrapping_add(1);
             }
         }));
@@ -773,7 +774,7 @@ impl ElReader {
         }
         let last = finalized.min(start.saturating_add(15));
         for n in start..=last {
-            let receipts = match self.get_block_receipts(Some(n)).await {
+            let (block_hash, receipts) = match self.block_receipts_at(Some(n)).await {
                 Ok(Some(r)) => r,
                 Ok(None) => return, // future/unknown under this anchor — retry next tick
                 Err(e) => {
@@ -792,7 +793,7 @@ impl ElReader {
             };
             let appended = match self.log_index.lock() {
                 Ok(mut slot) => match slot.as_mut() {
-                    Some(ix) => match ix.append_block(n, logs) {
+                    Some(ix) => match ix.append_block(n, block_hash, logs) {
                         Ok(()) => true,
                         Err(gap) => {
                             // Transient (config replaced / rewind raced this
@@ -819,6 +820,151 @@ impl ElReader {
                 }
             }
             *since_persist = 0;
+        }
+    }
+
+    /// One backfill step: walk the verified header chain DOWNWARD from the
+    /// index's trust cursor toward the lowest watched from_block, one batch
+    /// per tick (docs/eth-getlogs-design.md §backfill). Every header is
+    /// trusted only through parent-hash linkage into the cursor (whose own
+    /// trust chains back to a beacon-anchored append); candidate blocks
+    /// (bloom hit) get body+receipts fetched and verified against both roots
+    /// before any log is stored. Peer refusal is a stall, never corruption:
+    /// coverage simply doesn't extend until some peer serves the range.
+    async fn log_index_backfill_step(&self, ticks: u64) {
+        let Some((enabled, target_low, cursor)) = self.with_log_index(|ix| {
+            (
+                ix.config().enabled,
+                ix.config().watch.iter().map(|w| w.from_block).min(),
+                ix.cursor,
+            )
+        }) else {
+            return;
+        };
+        let (Some(target_low), Some((cur_n, cur_hash))) = (target_low, cursor) else {
+            return; // no watch entries, or the appender hasn't seeded the edge yet
+        };
+        if !enabled || cur_n <= target_low {
+            return;
+        }
+        const BATCH: u64 = 1024;
+        let count = (cur_n - target_low).min(BATCH);
+        let from = cur_n - count;
+        let peers = self.pool.snap_peers().await;
+        if peers.is_empty() {
+            return;
+        }
+        for peer in &peers {
+            match self.log_index_backfill_batch(peer, from, count, cur_n, cur_hash).await {
+                Ok(()) => {
+                    // Checkpoint after every applied batch: the store is
+                    // small at Sepolia scale and a crash then costs at most
+                    // one batch (paged store before mainnet — design doc).
+                    if let (Some(path), Ok(slot)) = (self.log_index_path.as_deref(), self.log_index.lock()) {
+                        if let Some(ix) = slot.as_ref() {
+                            let _ = ix.persist(path);
+                        }
+                    }
+                    return;
+                }
+                Err(e) => {
+                    tracing::debug!(from, count, error = %e, "log index backfill batch failed; trying next peer");
+                }
+            }
+        }
+        if ticks % 100 == 0 {
+            tracing::warn!(
+                cursor = cur_n,
+                target = target_low,
+                "log index backfill: no peer served the range this round (history depth?); will keep retrying"
+            );
+        }
+    }
+
+    /// Fetch and apply one descending backfill batch from one peer:
+    /// headers [from, cur_n] ascending (count+1, so the top one IS the cursor
+    /// block), full parent-hash chain check, bloom-filtered candidate
+    /// body+receipts fetch verified against both roots, then apply top-down.
+    async fn log_index_backfill_batch(
+        &self,
+        peer: &ManagedPeer,
+        from: u64,
+        count: u64,
+        cur_n: u64,
+        cur_hash: [u8; 32],
+    ) -> Result<(), String> {
+        let window = peer.get_block_headers_by_number(from, count + 1, 0, false).await?;
+        if window.len() as u64 != count + 1 {
+            return Err(format!("peer returned {} headers, expected {}", window.len(), count + 1));
+        }
+        let top = window.last().ok_or("empty header window")?;
+        if top.header.number != cur_n || top.hash != cur_hash {
+            return Err("peer window does not end at the trusted cursor block".to_string());
+        }
+        if window.first().is_some_and(|h| h.header.number != from) {
+            return Err("peer returned the wrong starting block number".to_string());
+        }
+        for pair in window.windows(2) {
+            let (lower, upper) = (&pair[0], &pair[1]);
+            if upper.header.parent_hash != lower.hash {
+                return Err("peer header window breaks the parent-hash chain".to_string());
+            }
+        }
+        // Bloom-filter candidates among the NEW blocks (everything below the
+        // cursor). A miss is a definitive skip; a hit needs verified receipts.
+        let candidates: Vec<&crate::el::eth::messages::VerifiedHeader> = window[..window.len() - 1]
+            .iter()
+            .filter(|h| {
+                let Ok(bloom): Result<&[u8; 256], _> = h.header.logs_bloom.as_slice().try_into() else {
+                    return true; // odd bloom width: treat as maybe, verify via receipts
+                };
+                self.with_log_index(|ix| ix.bloom_may_match(h.header.number, bloom)).unwrap_or(false)
+            })
+            .collect();
+        let mut logs_by_block: std::collections::HashMap<u64, Vec<crate::el::logindex::StoredLog>> =
+            std::collections::HashMap::new();
+        if !candidates.is_empty() {
+            let hashes: Vec<[u8; 32]> = candidates.iter().map(|h| h.hash).collect();
+            let (bodies, receipt_blocks) =
+                futures::future::join(peer.get_block_bodies(&hashes), peer.get_receipts(&hashes)).await;
+            let bodies = bodies?;
+            let receipt_blocks = receipt_blocks?;
+            if bodies.len() != candidates.len() || receipt_blocks.len() != candidates.len() {
+                return Err("peer returned a short bodies/receipts response".to_string());
+            }
+            for ((vh, body), receipts) in candidates.iter().zip(&bodies).zip(&receipt_blocks) {
+                verify_body_transactions(&vh.header, body)?;
+                if receipts.len() != body.transactions.len() {
+                    return Err(format!(
+                        "block {}: {} receipts for {} transactions",
+                        vh.header.number,
+                        receipts.len(),
+                        body.transactions.len()
+                    ));
+                }
+                verify_block_receipts(&vh.header, receipts)?;
+                let verified = build_block_receipts(&vh.header, vh.hash, body, receipts)?;
+                let stored = stored_logs_for_block(&verified)
+                    .ok_or("malformed log field in verified receipts")?;
+                logs_by_block.insert(vh.header.number, stored);
+            }
+        }
+        // Apply top-down so every block adjoins the low edge; the trust edge
+        // (cursor) advances with each applied block.
+        match self.log_index.lock() {
+            Ok(mut slot) => {
+                let Some(ix) = slot.as_mut() else {
+                    return Err("log index uninstalled mid-batch".to_string());
+                };
+                for vh in window[..window.len() - 1].iter().rev() {
+                    let n = vh.header.number;
+                    let logs = logs_by_block.remove(&n).unwrap_or_default();
+                    ix.backfill_block(n, vh.hash, logs)
+                        .map_err(|g| format!("backfill gap at {} (edge {})", g.block, g.edge))?;
+                }
+                Ok(())
+            }
+            Err(_) => Err("log index lock poisoned".to_string()),
         }
     }
 


### PR DESCRIPTION
Slice 4 of eth_getLogs (follows #269/#270/#271). The walker closes the historical half: coverage now extends **downward** from the appender's first anchored block toward the lowest watched `fromBlock` — for the kohaku Sepolia preset, back to block 5,594,611.

## How it stays verified
- One batch per 6 s tick: 1023 new headers + the trusted cursor block, requested **exactly at the 1024 serve cap**; the top header must BE the cursor block (number and hash — hashes recomputed locally from raw RLP), then a full parent-hash chain check. Every header below is authentic by chain induction back to a beacon-anchored block (`append_block` seeds the cursor with the hash of the first anchored append).
- Bloom prefilter on authentic headers (miss = definitive skip); candidates get body+receipts fetched in **64-block chunks** (peer soft-limit safe) and verified against both roots before any log is stored.
- Applied top-down under one lock so every block adjoins the coverage low edge; the apply **re-checks the cursor and config fingerprint under the lock** — a config swap racing the batch's awaits can't fabricate coverage from stale bloom selection (internal-review catch, along with the 1025-header stall the previous batch size would have caused against every honest peer).
- Peer refusal (history depth) is a stall with rate-limited telemetry, never corruption; checkpoint after every applied batch; failed batches recompute from the persisted cursor.

## Throughput / scope
~170 blocks/s at one batch per tick → the Sepolia kohaku range backfills in under a day of node uptime. Mainnet remains gated on the design doc's paged-store constraint. `rewind_above` still has no production caller (appender is finalized-only); the walker tolerates it by construction (cursor drop → walk pauses until re-seeded).

## Validation
`cargo test --workspace` green (18 logindex tests incl. cursor seeding). Independent no-context review done; both blocking findings (1025-header stall, mid-batch config race) and the chunking should-fix are in the last commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JibVnmRGPUp1692WebwfEs