### PR TITLE
storage proof cache: key slots by storageRoot for cross-block reuse

### DIFF
--- a/docs/reimplementation/06-rust-phase-notes.md
+++ b/docs/reimplementation/06-rust-phase-notes.md
@@ -103,6 +103,17 @@ a Pixel re-test of the fixed Java build.
   failure, so a half-created Rust chain would double-host.
 - `RustMyotisEngine`'s "Supported: mainnet, sepolia, gnosis" error text is a
   hand-copy of `NetworkConfig.byName`'s — keep in sync when networks change.
+- **Rust EL parity gap: storage-proof cache keying.** The Java engine's
+  `StateProofCache` keys verified storage slots by the account's
+  **storageRoot** (accounts stay keyed by world stateRoot), so slots of
+  unchanged contracts replay across head advances and a wallet's per-poll
+  Multicall3 sweep costs one account proof per contract per block instead of
+  re-proving every slot (the Kohaku eth_call-timeout fix, PR for
+  feat/storage-cache-by-storage-root). The Rust engine's twin cache
+  (`rust/myotis-evm/src/cache.rs`) still keys storage by
+  `(state_root, address, slot)` — mirror the storageRoot keying (and the
+  hot-call replay-warm in `VerifiedRpcBackend`, feat/hot-call-replay-warm)
+  when the Rust EL reaches per-poll eth_call serving.
 - **OPEN (user decision pending): extraData-offset leniency.** Both the Java
   and Rust `ExecutionPayloadHeader` decoders tolerate out-of-range extraData
   offsets (decode as empty) instead of rejecting — declined in #129 for Java

--- a/myotis-evm/src/main/java/io/myotis/evm/world/SnapBackedStateOracle.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/world/SnapBackedStateOracle.java
@@ -42,8 +42,11 @@ import java.util.function.Supplier;
  * </ol>
  *
  * <p>Bytecode is cached via the supplied {@link BytecodeCache}; the cache is
- * checked before issuing any request. State is not cached here — the
- * per-call cache lives in {@link SyncStateView}.
+ * checked before issuing any request. Verified account/storage state is cached
+ * in the node-level {@link StateProofCache} this oracle is constructed with —
+ * across calls, oracle instances, and (for storage slots, keyed by their
+ * account's storageRoot) across head advances. The per-call view cache lives
+ * in {@link SyncStateView}.
  *
  * <p>The peer abstraction lets tests substitute a fixture peer and lets the
  * wallet integration provide an {@code EthHandler}-backed implementation
@@ -185,6 +188,17 @@ public final class SnapBackedStateOracle implements SnapStateOracle {
         // an unchanged contract's slots carry over from the previous block); for
         // uncached accounts every slot rides along and verifyAndCacheChunk skips
         // the cache hits after the account proof reveals the storageRoot.
+        //
+        // FOLLOW-UP (deferred): a ride-along slot is real peer work — the peer
+        // assembles (and we download) a storage proof the verify step then discards
+        // as a cache hit. The dominant sweep flow dodges this because the
+        // PrefetchingEvmExecutor's sentinel waves discover an account one wave
+        // before its slots, so the account is cached at the root by the time slots
+        // batch. Flows where a new account and its slots land in the SAME wave
+        // (real-mode iterations, proxy -> impl reads) still pay it. If residual
+        // latency shows up on proxy-heavy calls, split the batch in two phases:
+        // account proofs for uncached accounts first, then only the still-missing
+        // slots — making "N account proofs per poll" hold in every flow.
         List<BatchItem> items = new ArrayList<>();
         for (Map.Entry<Address, ? extends Set<BigInteger>> entry : request.entrySet()) {
             Address address = entry.getKey();

--- a/myotis-evm/src/main/java/io/myotis/evm/world/SnapBackedStateOracle.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/world/SnapBackedStateOracle.java
@@ -65,9 +65,11 @@ public final class SnapBackedStateOracle implements SnapStateOracle {
     private final Supplier<SnapPeer> peerSupplier;
     private final BytecodeCache bytecodeCache;
     private final int maxAttempts;
-    /** Cross-call, node-level cache of verified account/storage state keyed by
-     *  stateRoot — survives head-context rebuilds so a wallet's repeated retries of
-     *  the same heavy call reuse fetched slots instead of re-proving them. */
+    /** Cross-call, node-level cache of verified state — accounts keyed by world
+     *  stateRoot, storage slots by their account's storageRoot (see
+     *  {@link StateProofCache}). Survives head-context rebuilds AND head advances:
+     *  a contract whose storage is unchanged re-proves only its account record per
+     *  block, its slots replay from cache. */
     private final StateProofCache stateCache;
 
     /**
@@ -116,36 +118,39 @@ public final class SnapBackedStateOracle implements SnapStateOracle {
 
     @Override
     public CompletableFuture<BigInteger> fetchStorage(byte[] stateRoot, Address address, BigInteger slot) {
-        byte[] addr = address.toByteArray();
-        // Cross-call cache hit: the verified value at this (stateRoot, addr, slot)
-        // is returned with zero round-trips. This is what lets a wallet's repeated
-        // retries of a 1000-slot balance sweep converge instead of re-proving every
-        // slot each time.
-        Optional<BigInteger> cached = stateCache.getStorage(stateRoot, addr, slot);
-        if (cached.isPresent()) return CompletableFuture.completedFuture(cached.get());
-
         Bytes32 root = Bytes32.wrap(stateRoot.clone());
-        Bytes addressBytes = Bytes.wrap(addr);
-        Bytes32 accountHash = Bytes32.wrap(Hash.keccak256(addressBytes).toArrayUnsafe());
+        Bytes32 accountHash = Bytes32.wrap(
+                Hash.keccak256(Bytes.wrap(address.toByteArray())).toArrayUnsafe());
         Bytes32 slotKey = paddedSlotKey(slot);
         Bytes32 slotHash = Bytes32.wrap(Hash.keccak256(slotKey).toArrayUnsafe());
 
         // Storage proofs anchor at the account's storageRoot, not the world
-        // stateRoot — so we need the account record first. The per-call
+        // stateRoot — so we need the account record first (a cache hit at this
+        // world root, or one proof per contract per block). The per-call
         // SyncStateView cache means this account fetch happens only once
         // even when the EVM does many SLOADs against the same contract.
         return fetchAccountWithRoot(stateRoot, address).thenCompose(awr -> {
             Bytes32 storageRoot = awr.storageRoot();
             if (MerklePatriciaProofVerifier.EMPTY_TRIE_ROOT.equals(storageRoot)) {
-                // Account has no storage at all; every slot is zero.
-                stateCache.putStorage(stateRoot, addr, slot, BigInteger.ZERO);
+                // Account has no storage at all; every slot is zero. Nothing to
+                // cache — the (cached) account record alone implies it.
                 return CompletableFuture.completedFuture(BigInteger.ZERO);
             }
+            // Cross-call, cross-BLOCK cache hit: the verified value at this
+            // (storageRoot, slot) is returned with zero further round-trips.
+            // Keyed by the storage trie root the proof anchors at, so as long
+            // as the contract's storage is unchanged, every head advance reuses
+            // the slots and only the account proof above cost a fetch — this is
+            // what lets a wallet's ~20s-cadence Multicall3 sweep converge
+            // instead of re-proving hundreds of slots every block.
+            byte[] storageRootBytes = storageRoot.toArrayUnsafe();
+            Optional<BigInteger> cached = stateCache.getStorage(storageRootBytes, slot);
+            if (cached.isPresent()) return CompletableFuture.completedFuture(cached.get());
             return tryWithRetries(peer -> peer
                     .getTrieNodes(root, List.of(SnapPeer.PathSet.storageSlot(accountHash, slotHash)))
                     .thenApply(nodes -> verifyAndDecodeStorage(storageRoot, slotHash, address, nodes)))
                     .thenApply(value -> {
-                        stateCache.putStorage(stateRoot, addr, slot, value);
+                        stateCache.putStorage(storageRootBytes, slot, value);
                         return value;
                     });
         });
@@ -171,21 +176,31 @@ public final class SnapBackedStateOracle implements SnapStateOracle {
         }
         Bytes32 root = Bytes32.wrap(stateRoot.clone());
         // Build per-account work, skipping anything already in the proof cache so a
-        // partially-warm sweep only fetches the misses.
+        // partially-warm sweep only fetches the misses. The storage cache is keyed
+        // by the account's storageRoot, so slots can only be pre-filtered for
+        // accounts whose record is already cached at this world root (which is how
+        // an unchanged contract's slots carry over from the previous block); for
+        // uncached accounts every slot rides along and verifyAndCacheChunk skips
+        // the cache hits after the account proof reveals the storageRoot.
         List<BatchItem> items = new ArrayList<>();
         for (Map.Entry<Address, ? extends Set<BigInteger>> entry : request.entrySet()) {
             Address address = entry.getKey();
             byte[] addr = address.toByteArray();
             Bytes32 accountHash = Bytes32.wrap(Hash.keccak256(Bytes.wrap(addr)).toArrayUnsafe());
-            boolean accountCached = stateCache.getAccount(stateRoot, addr).isPresent();
+            Optional<StateProofCache.AccountEntry> cachedAccount = stateCache.getAccount(stateRoot, addr);
+            byte[] knownStorageRoot = cachedAccount.map(StateProofCache.AccountEntry::storageRoot).orElse(null);
+            boolean emptyStorage = knownStorageRoot != null && MerklePatriciaProofVerifier
+                    .EMPTY_TRIE_ROOT.equals(Bytes32.wrap(knownStorageRoot));
             List<BigInteger> slots = new ArrayList<>();
             List<Bytes32> slotHashes = new ArrayList<>();
             for (BigInteger slot : entry.getValue()) {
-                if (stateCache.getStorage(stateRoot, addr, slot).isPresent()) continue;
+                if (emptyStorage) continue;   // every slot is a verified zero
+                if (knownStorageRoot != null
+                        && stateCache.getStorage(knownStorageRoot, slot).isPresent()) continue;
                 slots.add(slot);
                 slotHashes.add(Bytes32.wrap(Hash.keccak256(paddedSlotKey(slot)).toArrayUnsafe()));
             }
-            if (accountCached && slots.isEmpty()) continue;  // fully cached → nothing to do
+            if (cachedAccount.isPresent() && slots.isEmpty()) continue;  // fully cached → nothing to do
             items.add(new BatchItem(address, addr, accountHash, slots, slotHashes));
         }
         if (items.isEmpty()) return CompletableFuture.completedFuture(null);
@@ -240,13 +255,16 @@ public final class SnapBackedStateOracle implements SnapStateOracle {
                         new StateProofCache.AccountEntry(awr.account(), awr.storageRoot().toArrayUnsafe()));
             }
             Bytes32 storageRoot = awr.storageRoot();
-            boolean emptyStorage = MerklePatriciaProofVerifier.EMPTY_TRIE_ROOT.equals(storageRoot);
+            if (MerklePatriciaProofVerifier.EMPTY_TRIE_ROOT.equals(storageRoot)) {
+                continue;   // every slot is a verified zero; the account record implies it
+            }
+            byte[] storageRootBytes = storageRoot.toArrayUnsafe();
             for (int s = 0; s < it.slots().size(); s++) {
                 BigInteger slot = it.slots().get(s);
-                if (stateCache.getStorage(stateRoot, it.addr(), slot).isPresent()) continue;
-                BigInteger value = emptyStorage ? BigInteger.ZERO
-                        : verifyAndDecodeStorage(storageRoot, it.slotHashes().get(s), it.address(), nodes);
-                stateCache.putStorage(stateRoot, it.addr(), slot, value);
+                if (stateCache.getStorage(storageRootBytes, slot).isPresent()) continue;
+                BigInteger value = verifyAndDecodeStorage(
+                        storageRoot, it.slotHashes().get(s), it.address(), nodes);
+                stateCache.putStorage(storageRootBytes, slot, value);
             }
         }
     }

--- a/myotis-evm/src/main/java/io/myotis/evm/world/SnapBackedStateOracle.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/world/SnapBackedStateOracle.java
@@ -143,7 +143,10 @@ public final class SnapBackedStateOracle implements SnapStateOracle {
             // the slots and only the account proof above cost a fetch — this is
             // what lets a wallet's ~20s-cadence Multicall3 sweep converge
             // instead of re-proving hundreds of slots every block.
-            byte[] storageRootBytes = storageRoot.toArrayUnsafe();
+            // toArray (a copy), NOT toArrayUnsafe: StateProofCache is a public
+            // interface, and an implementation that mutated or retained the array
+            // must not be able to corrupt the Bytes32 verification anchor below.
+            byte[] storageRootBytes = storageRoot.toArray();
             Optional<BigInteger> cached = stateCache.getStorage(storageRootBytes, slot);
             if (cached.isPresent()) return CompletableFuture.completedFuture(cached.get());
             return tryWithRetries(peer -> peer
@@ -258,7 +261,7 @@ public final class SnapBackedStateOracle implements SnapStateOracle {
             if (MerklePatriciaProofVerifier.EMPTY_TRIE_ROOT.equals(storageRoot)) {
                 continue;   // every slot is a verified zero; the account record implies it
             }
-            byte[] storageRootBytes = storageRoot.toArrayUnsafe();
+            byte[] storageRootBytes = storageRoot.toArray();   // copy — see fetchStorage
             for (int s = 0; s < it.slots().size(); s++) {
                 BigInteger slot = it.slots().get(s);
                 if (stateCache.getStorage(storageRootBytes, slot).isPresent()) continue;

--- a/myotis-evm/src/main/java/io/myotis/evm/world/StateProofCache.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/world/StateProofCache.java
@@ -8,39 +8,53 @@ import java.util.Map;
 import java.util.Optional;
 
 /**
- * Cross-call cache of proof-<em>verified</em> state, keyed by world {@code stateRoot}.
+ * Cross-call cache of proof-<em>verified</em> state.
  *
- * <p><b>Why this exists.</b> A wallet confirm screen fires huge {@code eth_call}s —
- * a ~1000-token balance sweep (MetaMask's BalanceChecker) and Multicall3
- * simulations — and, when they exceed the per-call timeout, MetaMask <em>retries
- * the identical call</em> many times. {@link SnapBackedStateOracle}'s account
- * memo is per-instance (rebuilt with each head context) and storage slots were
- * not cached across calls at all, so every retry re-fetched hundreds of storage
- * proofs from scratch — a retry-storm that saturated the few snap peers, starved
- * cheap reads, and never converged. Caching the verified results at the node
- * level lets each retry reuse what the last one fetched, so the call converges in
- * a couple of attempts instead of looping forever.
+ * <p><b>Why this exists.</b> A wallet fires huge {@code eth_call}s —
+ * ~1000-token balance sweeps (MetaMask's BalanceChecker), 67KB Multicall3
+ * batches (Kohaku's per-poll state sync) — and re-issues them every poll
+ * cycle. {@link SnapBackedStateOracle}'s account memo is per-instance
+ * (rebuilt with each head context), so without a node-level cache every
+ * poll re-fetched hundreds of storage proofs from scratch — a storm that
+ * saturated the few snap peers, starved cheap reads, and never converged.
  *
- * <p><b>Why it's safe.</b> Entries are keyed by {@code stateRoot} and stored only
- * after the MPT proof has been verified against that root (see
- * {@code verifyAndDecode*} in {@link SnapBackedStateOracle}). State at a fixed
- * {@code stateRoot} is immutable, so a cached {@code (stateRoot, address, slot) ->
- * value} mapping is a cryptographic fact, not peer-trusted data — reusing it
- * across any call pinned to that root is sound. MetaMask number-pins its confirm
- * reads to a block, so the retries share a {@code stateRoot} and hit the cache.
+ * <p><b>Keying.</b> The two kinds are keyed by what their proofs anchor to:
+ * <ul>
+ *   <li><b>Accounts</b> are keyed by world {@code stateRoot}: the account
+ *       leaf is proven against the world trie, and a new block means a new
+ *       world root, so the (cheap, one-proof) account record must be
+ *       re-proven per block.
+ *   <li><b>Storage slots</b> are keyed by the account's {@code storageRoot}:
+ *       a slot proof anchors at the storage trie root, not the world root,
+ *       so a verified {@code (storageRoot, slot) -> value} mapping is a
+ *       cryptographic fact independent of which block it was fetched at.
+ *       Since most contracts' storage doesn't change every block, this lets
+ *       a per-poll sweep reuse all slots of every unchanged contract across
+ *       head advances — the per-block account proof (whose leaf carries the
+ *       storageRoot) is exactly the freshness check that makes reuse sound.
+ * </ul>
  *
- * <p>Bounded (LRU, per kind) so a long-lived node doesn't grow without limit as
- * the head advances and old roots fall out of use.
+ * <p><b>Why it's safe.</b> Entries are stored only after the MPT proof has
+ * been verified against the respective root (see {@code verifyAndDecode*} in
+ * {@link SnapBackedStateOracle}). State under a fixed root is immutable, so a
+ * cached mapping is a cryptographic fact, not peer-trusted data — reusing it
+ * for any call whose account resolves to that root is sound.
+ *
+ * <p>Bounded (LRU, per kind) so a long-lived node doesn't grow without limit
+ * as the head advances and old roots fall out of use.
  */
 public interface StateProofCache {
 
-    /** Verified value of {@code slot} for {@code address} at {@code stateRoot}, if cached. */
-    Optional<BigInteger> getStorage(byte[] stateRoot, byte[] address, BigInteger slot);
+    /** Verified value of {@code slot} in the storage trie rooted at
+     *  {@code storageRoot}, if cached. NOTE: keyed by the account's storage
+     *  trie root (from its proven account leaf), NOT the world stateRoot. */
+    Optional<BigInteger> getStorage(byte[] storageRoot, BigInteger slot);
 
-    /** Cache a verified storage value. */
-    void putStorage(byte[] stateRoot, byte[] address, BigInteger slot, BigInteger value);
+    /** Cache a verified storage value under its storage trie root. */
+    void putStorage(byte[] storageRoot, BigInteger slot, BigInteger value);
 
-    /** Verified account record (+ storage root) for {@code address} at {@code stateRoot}, if cached. */
+    /** Verified account record (+ storage root) for {@code address} at world
+     *  {@code stateRoot}, if cached. */
     Optional<AccountEntry> getAccount(byte[] stateRoot, byte[] address);
 
     /** Cache a verified account record. */
@@ -69,8 +83,8 @@ public interface StateProofCache {
 
     enum Noop implements StateProofCache {
         INSTANCE;
-        @Override public Optional<BigInteger> getStorage(byte[] r, byte[] a, BigInteger s) { return Optional.empty(); }
-        @Override public void putStorage(byte[] r, byte[] a, BigInteger s, BigInteger v) {}
+        @Override public Optional<BigInteger> getStorage(byte[] r, BigInteger s) { return Optional.empty(); }
+        @Override public void putStorage(byte[] r, BigInteger s, BigInteger v) {}
         @Override public Optional<AccountEntry> getAccount(byte[] r, byte[] a) { return Optional.empty(); }
         @Override public void putAccount(byte[] r, byte[] a, AccountEntry e) {}
     }
@@ -98,16 +112,16 @@ public interface StateProofCache {
             return hex(root) + ':' + hex(addr);
         }
 
-        private static String storageKey(byte[] root, byte[] addr, BigInteger slot) {
-            return hex(root) + ':' + hex(addr) + ':' + slot.toString(16);
+        private static String storageKey(byte[] storageRoot, BigInteger slot) {
+            return hex(storageRoot) + ':' + slot.toString(16);
         }
 
-        @Override public Optional<BigInteger> getStorage(byte[] root, byte[] addr, BigInteger slot) {
-            return Optional.ofNullable(storage.get(storageKey(root, addr, slot)));
+        @Override public Optional<BigInteger> getStorage(byte[] storageRoot, BigInteger slot) {
+            return Optional.ofNullable(storage.get(storageKey(storageRoot, slot)));
         }
 
-        @Override public void putStorage(byte[] root, byte[] addr, BigInteger slot, BigInteger value) {
-            storage.put(storageKey(root, addr, slot), value);   // BigInteger is immutable
+        @Override public void putStorage(byte[] storageRoot, BigInteger slot, BigInteger value) {
+            storage.put(storageKey(storageRoot, slot), value);   // BigInteger is immutable
         }
 
         @Override public Optional<AccountEntry> getAccount(byte[] root, byte[] addr) {

--- a/myotis-evm/src/test/java/io/myotis/evm/world/SnapBackedStateOracleTest.java
+++ b/myotis-evm/src/test/java/io/myotis/evm/world/SnapBackedStateOracleTest.java
@@ -486,6 +486,141 @@ class SnapBackedStateOracleTest {
     }
 
     @Test
+    void storageCacheReusedAcrossBlocksWhenStorageRootUnchanged() throws Exception {
+        // The cross-BLOCK reuse the storageRoot keying buys: a slot verified at world
+        // root A must be served from cache at world root B — zero storage round-trips —
+        // when the account's storageRoot is unchanged (the per-block account proof is
+        // the freshness check). This is what turns a wallet's per-poll 67KB Multicall3
+        // sweep from re-proving hundreds of slots every block into one account proof
+        // per contract per block.
+        Address addr = Address.fromHex("0xabcdef0102030405060708090a0b0c0d0e0f1011");
+        BigInteger slot = BigInteger.valueOf(7);
+        BigInteger value = new BigInteger("1234567890123456789");
+
+        Bytes32 slotHash = Bytes32.wrap(Hash.keccak256(paddedSlot(slot)).toArrayUnsafe());
+        Bytes valueRlp = RLP.encode(w -> w.writeBigInteger(value));
+        var storageTrie = TrieFixture.singleLeaf(slotHash, valueRlp);
+
+        // Two world roots ("block N" / "block N+1"): the account's nonce differs, its
+        // storageRoot is the SAME trie.
+        Bytes accountAtA = encodeAccount(1L, BigInteger.TEN, storageTrie.root,
+                Bytes32.wrap(Hash.keccak256(Bytes.EMPTY).toArrayUnsafe()));
+        Bytes accountAtB = encodeAccount(2L, BigInteger.TEN, storageTrie.root,
+                Bytes32.wrap(Hash.keccak256(Bytes.EMPTY).toArrayUnsafe()));
+        var worldA = TrieFixture.singleLeaf(keccak(addr.toByteArray()), accountAtA);
+        var worldB = TrieFixture.singleLeaf(keccak(addr.toByteArray()), accountAtB);
+
+        FixturePeer peer = new FixturePeer();
+        peer.addAccountProof(worldA.root, worldA.proof);
+        peer.addStorageProof(worldA.root, storageTrie.proof);
+        // Root B's peer serves ONLY the account proof — a storage request at B
+        // would come back empty and fail the verify, so a pass proves the slot
+        // was replayed from cache, not re-fetched.
+        peer.addAccountProof(worldB.root, worldB.proof);
+
+        StateProofCache shared = StateProofCache.inMemory(1024);
+        var oracleA = new SnapBackedStateOracle(() -> peer, BytecodeCache.inMemory(),
+                SnapBackedStateOracle.DEFAULT_MAX_ATTEMPTS, shared);
+        assertEquals(value, oracleA.fetchStorage(worldA.root.toArrayUnsafe(), addr, slot).get());
+
+        var oracleB = new SnapBackedStateOracle(() -> peer, BytecodeCache.inMemory(),
+                SnapBackedStateOracle.DEFAULT_MAX_ATTEMPTS, shared);
+        assertEquals(value, oracleB.fetchStorage(worldB.root.toArrayUnsafe(), addr, slot).get(),
+                "unchanged storageRoot at the new world root must replay the cached slot");
+    }
+
+    @Test
+    void storageCacheNotReusedWhenStorageRootChanges() throws Exception {
+        // Safety control for the reuse above: when the contract's storage DID change
+        // between blocks (different storageRoot in the new account leaf), the cached
+        // value from the old root must NOT be served — the slot re-proves against the
+        // new storage trie and returns the new value.
+        Address addr = Address.fromHex("0xabcdef0102030405060708090a0b0c0d0e0f1011");
+        BigInteger slot = BigInteger.valueOf(7);
+        BigInteger oldValue = new BigInteger("1234567890123456789");
+        BigInteger newValue = new BigInteger("987654321");
+
+        Bytes32 slotHash = Bytes32.wrap(Hash.keccak256(paddedSlot(slot)).toArrayUnsafe());
+        var oldStorage = TrieFixture.singleLeaf(slotHash, RLP.encode(w -> w.writeBigInteger(oldValue)));
+        var newStorage = TrieFixture.singleLeaf(slotHash, RLP.encode(w -> w.writeBigInteger(newValue)));
+
+        Bytes accountAtA = encodeAccount(1L, BigInteger.TEN, oldStorage.root,
+                Bytes32.wrap(Hash.keccak256(Bytes.EMPTY).toArrayUnsafe()));
+        Bytes accountAtB = encodeAccount(1L, BigInteger.TEN, newStorage.root,
+                Bytes32.wrap(Hash.keccak256(Bytes.EMPTY).toArrayUnsafe()));
+        var worldA = TrieFixture.singleLeaf(keccak(addr.toByteArray()), accountAtA);
+        var worldB = TrieFixture.singleLeaf(keccak(addr.toByteArray()), accountAtB);
+
+        FixturePeer peer = new FixturePeer();
+        peer.addAccountProof(worldA.root, worldA.proof);
+        peer.addStorageProof(worldA.root, oldStorage.proof);
+        peer.addAccountProof(worldB.root, worldB.proof);
+        peer.addStorageProof(worldB.root, newStorage.proof);
+
+        StateProofCache shared = StateProofCache.inMemory(1024);
+        var oracleA = new SnapBackedStateOracle(() -> peer, BytecodeCache.inMemory(),
+                SnapBackedStateOracle.DEFAULT_MAX_ATTEMPTS, shared);
+        assertEquals(oldValue, oracleA.fetchStorage(worldA.root.toArrayUnsafe(), addr, slot).get());
+
+        var oracleB = new SnapBackedStateOracle(() -> peer, BytecodeCache.inMemory(),
+                SnapBackedStateOracle.DEFAULT_MAX_ATTEMPTS, shared);
+        assertEquals(newValue, oracleB.fetchStorage(worldB.root.toArrayUnsafe(), addr, slot).get(),
+                "a changed storageRoot must re-prove the slot, never replay the stale value");
+    }
+
+    @Test
+    void fetchBatchPrefiltersSlotsCachedUnderKnownStorageRoot() throws Exception {
+        // fetchBatch at a NEW world root, where the account record is already cached
+        // at that root (as the head-build priming does) and the slots were verified at
+        // the PREVIOUS root under the same storageRoot: nothing is left to fetch, so
+        // the batch must issue ZERO GetTrieNodes requests.
+        Address addr = Address.fromHex("0xabcdef0102030405060708090a0b0c0d0e0f1011");
+        BigInteger slot = BigInteger.valueOf(7);
+        BigInteger value = new BigInteger("1234567890123456789");
+
+        Bytes32 slotHash = Bytes32.wrap(Hash.keccak256(paddedSlot(slot)).toArrayUnsafe());
+        var storageTrie = TrieFixture.singleLeaf(slotHash, RLP.encode(w -> w.writeBigInteger(value)));
+        Bytes accountAtA = encodeAccount(1L, BigInteger.TEN, storageTrie.root,
+                Bytes32.wrap(Hash.keccak256(Bytes.EMPTY).toArrayUnsafe()));
+        Bytes accountAtB = encodeAccount(2L, BigInteger.TEN, storageTrie.root,
+                Bytes32.wrap(Hash.keccak256(Bytes.EMPTY).toArrayUnsafe()));
+        var worldA = TrieFixture.singleLeaf(keccak(addr.toByteArray()), accountAtA);
+        var worldB = TrieFixture.singleLeaf(keccak(addr.toByteArray()), accountAtB);
+
+        FixturePeer warmPeer = new FixturePeer();
+        warmPeer.addAccountProof(worldA.root, worldA.proof);
+        warmPeer.addStorageProof(worldA.root, storageTrie.proof);
+        warmPeer.addAccountProof(worldB.root, worldB.proof);
+
+        StateProofCache shared = StateProofCache.inMemory(1024);
+        var oracle = new SnapBackedStateOracle(() -> warmPeer, BytecodeCache.inMemory(),
+                SnapBackedStateOracle.DEFAULT_MAX_ATTEMPTS, shared);
+        // Warm: slot at root A (banks it under storageRoot), account at root B.
+        assertEquals(value, oracle.fetchStorage(worldA.root.toArrayUnsafe(), addr, slot).get());
+        oracle.fetchAccount(worldB.root.toArrayUnsafe(), addr).get();
+
+        AtomicInteger calls = new AtomicInteger();
+        SnapPeer countingDead = new SnapPeer() {
+            @Override public CompletableFuture<List<Bytes>> getTrieNodes(Bytes32 r, List<PathSet> p) {
+                calls.incrementAndGet();
+                return CompletableFuture.failedFuture(new java.io.IOException("should not be called"));
+            }
+            @Override public CompletableFuture<List<Bytes>> getByteCodes(List<Bytes32> h) {
+                return CompletableFuture.failedFuture(new java.io.IOException("should not be called"));
+            }
+        };
+        var oracleB = new SnapBackedStateOracle(() -> countingDead, BytecodeCache.inMemory(),
+                SnapBackedStateOracle.DEFAULT_MAX_ATTEMPTS, shared);
+        Map<Address, Set<BigInteger>> req = new HashMap<>();
+        req.put(addr, Set.of(slot));
+        oracleB.fetchBatch(worldB.root.toArrayUnsafe(), req).get();
+        assertEquals(0, calls.get(),
+                "a fully carried-over account (cached record + slots under its storageRoot) "
+                        + "must add no batch work");
+        assertEquals(value, oracleB.fetchStorage(worldB.root.toArrayUnsafe(), addr, slot).get());
+    }
+
+    @Test
     void noopStateCacheStillRefetchesAcrossOracles() throws Exception {
         // Control for the test above: with the default noop cache, a fresh oracle has
         // no memory, so a dead peer DOES fail — confirming the pass above is the cache

--- a/myotis-evm/src/test/java/io/myotis/evm/world/SnapBackedStateOracleTest.java
+++ b/myotis-evm/src/test/java/io/myotis/evm/world/SnapBackedStateOracleTest.java
@@ -590,14 +590,21 @@ class SnapBackedStateOracleTest {
         FixturePeer warmPeer = new FixturePeer();
         warmPeer.addAccountProof(worldA.root, worldA.proof);
         warmPeer.addStorageProof(worldA.root, storageTrie.proof);
-        warmPeer.addAccountProof(worldB.root, worldB.proof);
 
         StateProofCache shared = StateProofCache.inMemory(1024);
         var oracle = new SnapBackedStateOracle(() -> warmPeer, BytecodeCache.inMemory(),
                 SnapBackedStateOracle.DEFAULT_MAX_ATTEMPTS, shared);
-        // Warm: slot at root A (banks it under storageRoot), account at root B.
+        // Warm: slot at root A (banks it under storageRoot). fetchStorage banks the
+        // slot before its future completes, so this is race-free.
         assertEquals(value, oracle.fetchStorage(worldA.root.toArrayUnsafe(), addr, slot).get());
-        oracle.fetchAccount(worldB.root.toArrayUnsafe(), addr).get();
+        // Bank the account at root B directly (what the head-build priming does).
+        // Going through fetchAccount here would be racy: its promotion to the shared
+        // cache runs async after the future completes.
+        shared.putAccount(worldB.root.toArrayUnsafe(), addr.toByteArray(),
+                new StateProofCache.AccountEntry(
+                        new AccountState(addr, 2L, BigInteger.TEN,
+                                Hash.keccak256(Bytes.EMPTY).toArrayUnsafe()),
+                        storageTrie.root.toArrayUnsafe()));
 
         AtomicInteger calls = new AtomicInteger();
         SnapPeer countingDead = new SnapPeer() {

--- a/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
+++ b/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
@@ -217,12 +217,15 @@ public final class VerifiedRpcBackend implements io.myotis.api.VerifiedReads,
     /** keccak256("") — an account with this codeHash is an EOA (no contract code). */
     private static final byte[] EMPTY_CODE_HASH = Hash.keccak256(Bytes.EMPTY).toArrayUnsafe();
 
-    // Cross-call cache of proof-verified account/storage state, keyed by stateRoot.
-    // Shared across every head-context oracle so a wallet's repeated retries of a
-    // heavy eth_call (MetaMask's ~1000-token BalanceChecker sweep / Multicall3
-    // simulation) reuse already-fetched slots instead of re-proving hundreds each
-    // time — turning a 30s-timeout retry-storm into a couple of converging attempts.
-    // Bounded LRU per kind; ~64k storage slots ≈ a few MB.
+    // Cross-call cache of proof-verified account/storage state — accounts keyed by
+    // world stateRoot, storage slots by their account's storageRoot (see
+    // StateProofCache). Shared across every head-context oracle so a wallet's
+    // repeated retries of a heavy eth_call (MetaMask's ~1000-token BalanceChecker
+    // sweep / Multicall3 simulation) reuse already-fetched slots instead of
+    // re-proving hundreds each time, and so slots of unchanged contracts carry
+    // over across head advances (only the per-block account proof is re-paid).
+    // Bounded LRU per kind; ~64k storage slots ≈ a few MB. Slot entries now
+    // outlive their roots, so the LRU bound (not root churn) is what ages them out.
     private static final int STATE_PROOF_CACHE_MAX = 65_536;
 
     /** How long a verified eth_call / estimateGas RESULT stays replayable (see
@@ -382,13 +385,18 @@ public final class VerifiedRpcBackend implements io.myotis.api.VerifiedReads,
      * Frozen anchored context per pinned block NUMBER. A wallet (MetaMask) pins a
      * confirm to one block and retries the same heavy calls against it for minutes.
      * Serving each retry against the <em>current</em> head — which the warmer rebuilds
-     * to a new stateRoot every ~12-15s — reset the stateRoot-keyed StateProofCache on
-     * every rebuild, so a 1000-slot BalanceChecker / Multicall3 simulation re-fetched
-     * from scratch each retry and never converged (the persistent confirm-screen hang,
-     * uptime-independent). Freezing the context — and thus its stateRoot — per pinned
-     * number makes all retries hit one stable root, so the cache accumulates and the
-     * call converges in a couple of tries. Bounded LRU (wallets pin a few recent
-     * blocks); each entry ages out at {@link #RPC_HEAD_SERVE_STALE_MAX_MS}.
+     * to a new stateRoot every ~12-15s — pointed every retry at a different root, so
+     * everything root-keyed (the account side of StateProofCache, callResultCache,
+     * the in-flight call dedup) reset each rebuild and a 1000-slot BalanceChecker /
+     * Multicall3 simulation re-fetched from scratch each retry and never converged
+     * (the persistent confirm-screen hang, uptime-independent). Freezing the context
+     * — and thus its stateRoot — per pinned number makes all retries hit one stable
+     * root, so those caches accumulate and the call converges in a couple of tries.
+     * (Storage slots are now keyed by their account's storageRoot and survive root
+     * changes on their own — see StateProofCache — but the pin still matters for the
+     * account records, the result replay, and execution dedup.) Bounded LRU (wallets
+     * pin a few recent blocks); each entry ages out at
+     * {@link #RPC_HEAD_SERVE_STALE_MAX_MS}.
      */
     private final Map<Long, HeadWithTimestamp> pinnedHeadByNumber =
             java.util.Collections.synchronizedMap(
@@ -1208,8 +1216,9 @@ public final class VerifiedRpcBackend implements io.myotis.api.VerifiedReads,
             }
         }
         // Pinned-number fast path: reuse the context already frozen to this number so
-        // its (fixed) stateRoot lets the StateProofCache accumulate across the wallet's
-        // minutes-long retries instead of resetting every time the head rebuilds.
+        // its (fixed) stateRoot lets the root-keyed caches (account proofs, call
+        // results, execution dedup) accumulate across the wallet's minutes-long
+        // retries instead of resetting every time the head rebuilds.
         if (requestedNum >= 0) {
             HeadWithTimestamp frozen = pinnedHeadByNumber.get(requestedNum);
             // State-read reuse bound: a frozen root older than a few slots is pruned by
@@ -1250,7 +1259,8 @@ public final class VerifiedRpcBackend implements io.myotis.api.VerifiedReads,
             // On a concurrent first-read race the putIfAbsent loser must serve the
             // WINNER's context, not its own — otherwise two contexts with different
             // stateRoots briefly serve the same pinned number, splitting the
-            // StateProofCache across roots for that block.
+            // root-keyed caches (account proofs, call results) across roots for
+            // that block.
             HeadWithTimestamp existing = pinnedHeadByNumber.putIfAbsent(requestedNum,
                     new HeadWithTimestamp(ctx, clock.elapsedMillis()));
             if (existing != null) {


### PR DESCRIPTION
## Problem

Kohaku (pointed at the Sepolia RPC service) fires a 67KB Multicall3 `aggregate3` sweep every ~20s, pinned to the latest block. Each poll paid ~90–120s of snap fetches (p50=90s, p90=114s uncached) against the 120s RPC deadline — ~1,450 `-32000` timeouts in one day, because the `StateProofCache` keyed storage slots by **world stateRoot**: every new block invalidated every cached slot, even though the touched contracts' storage rarely changes.

## Change

Key the **storage side** of the cache by the account's **storageRoot** (accounts stay keyed by world root):

- A slot proof anchors at the storage trie root, not the world root, so a verified `(storageRoot, slot) → value` mapping is a cryptographic fact independent of the block it was fetched at. The per-block account proof — whose verified leaf carries the storageRoot — is exactly the freshness check that makes reuse sound.
- `fetchStorage` now resolves the account record before consulting the slot cache (cache hit at the current root, or one proof per contract per block).
- `fetchBatch` pre-filters slots only for accounts already cached at the requested root; `verifyAndCacheChunk` skips cache hits live once the account proof reveals the storageRoot.
- Empty-storage accounts no longer cache per-slot zeros — the account record alone implies them.

Net effect: a poll over N unchanged contracts costs N batchable account proofs instead of re-proving hundreds of slots — the sweep drops from ~90–120s per poll to seconds.

## Trust

No relaxation. Every cached value is stored only after MPT verification against the root its proof anchors at; a changed storageRoot never replays stale values (pinned by test). Absence caching is backed by exclusion proofs as before.

## Internal review

Independent no-context review completed; addressed: race-free test warm-up (async account promotion), defensive copy of the storageRoot across the public cache interface, stale doc comments in `VerifiedRpcBackend`. The Rust engine's twin cache (`rust/myotis-evm/src/cache.rs`) still keys by state_root — tracked in `docs/reimplementation/06-rust-phase-notes.md` (this optimization is Java-engine only for now).

Companion PR (independent, same investigation): hot-call replay-warm in `rpc-backend`.

## Testing

- `./gradlew :myotis-evm:test` — 20 tests incl. 3 new: cross-block reuse on unchanged storageRoot, no reuse on changed storageRoot, zero-request `fetchBatch` for fully carried-over accounts.
- Full `compileJava compileTestJava` across modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XtMNVcqeJoWayJTZHWK66A