### PR TITLE
rpc: replay-warm the wallet's recurring eth_call shapes on each new head

### DIFF
--- a/rpc-backend/src/main/java/io/myotis/rpc/HotCallTracker.java
+++ b/rpc-backend/src/main/java/io/myotis/rpc/HotCallTracker.java
@@ -114,6 +114,9 @@ final class HotCallTracker {
      *  (nothing real is that big; the cap bounds tracker memory). */
     synchronized void record(byte[] from, byte[] to, BigInteger value, byte[] data, long nowMs) {
         if (to == null || to.length != 20) return;
+        // A malformed from would make Address.of throw during EVERY replay of this
+        // shape — reject it here so a bad shape can never enter the tracker.
+        if (from != null && from.length != 20) return;
         if (data != null && data.length > maxCalldataBytes) return;
         String key = shapeKey(from, to, value, data);
         Entry e = shapes.get(key);
@@ -172,6 +175,12 @@ final class HotCallTracker {
         if (e == null) return;   // aged out of the LRU while warming
         e.warmInFlight = false;
         if (!success) e.lastWarmFailedMs = nowMs;
+    }
+
+    /** Drop every tracked shape (purge-cache): the recorded calldata profile is
+     *  cleared and warming only resumes once the wallet re-qualifies its shapes. */
+    synchronized void clear() {
+        shapes.clear();
     }
 
     /** Number of tracked shapes (test hook). */

--- a/rpc-backend/src/main/java/io/myotis/rpc/HotCallTracker.java
+++ b/rpc-backend/src/main/java/io/myotis/rpc/HotCallTracker.java
@@ -1,0 +1,181 @@
+package io.myotis.rpc;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.crypto.Hash;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Tracks the wallet's recurring {@code eth_call} shapes so the head warmer can
+ * re-execute them against each freshly-built head (the "replay warm").
+ *
+ * <p><b>Why.</b> A wallet syncs by firing the <em>identical</em> heavy call —
+ * observed live: Kohaku's 67KB Multicall3 {@code aggregate3} sweep, MetaMask's
+ * ~32KB BalanceChecker — every poll cycle, pinned to the latest block it just
+ * fetched from us. Executed on demand, each poll pays the full EVM + snap-fetch
+ * cost inside the wallet's timeout and usually dies at the deadline. But the
+ * node knows the shape in advance and knows the block the wallet will pin next
+ * (it hands out the head via {@code eth_blockNumber}) — so it can run the call
+ * once per new head in the background and serve the wallet's poll from the
+ * result cache in microseconds.
+ *
+ * <p>A shape is (from, to, value, calldata) — everything of the call except the
+ * block tag. A shape becomes warm-worthy after {@code minHits} sightings within
+ * {@code hotTtlMs} (a one-off call is never warmed). Warming is trust-neutral:
+ * the replay runs the exact same verified execution path a wallet-triggered
+ * call would, just earlier.
+ *
+ * <p>Per-shape warm bookkeeping lives here too: at most one warm per shape in
+ * flight ({@link #beginWarmables} marks, {@link #endWarm} clears, a stuck warm
+ * expires after {@code warmTimeoutMs}), and a shape whose last warm FAILED is
+ * backed off for {@code failureBackoffMs} so a persistently-failing call can't
+ * turn the warmer into a background retry storm.
+ *
+ * <p>Bounded LRU ({@code maxTracked} shapes; each holds a copy of its calldata,
+ * so with the {@code maxCalldataBytes} per-shape cap the whole tracker is a few
+ * MB at worst). All methods are synchronized — call rates are a handful per
+ * second at most.
+ */
+final class HotCallTracker {
+
+    static {
+        // shapeKey keccaks the calldata via Tuweni, which needs the BC provider.
+        io.myotis.evm.CryptoProviders.ensureRegistered();
+    }
+
+    /** One recorded call shape. Arrays are defensive copies; {@code from} and
+     *  {@code value} may be null (same meaning as in the RPC layer); {@code data}
+     *  is never null (empty for a no-calldata call). */
+    record HotCall(byte[] from, byte[] to, BigInteger value, byte[] data) {
+        HotCall(byte[] from, byte[] to, BigInteger value, byte[] data) {
+            this.from = from == null ? null : from.clone();
+            this.to = to.clone();
+            this.value = value;
+            this.data = data == null ? new byte[0] : data.clone();
+        }
+        @Override public byte[] from() { return from == null ? null : from.clone(); }
+        @Override public byte[] to() { return to.clone(); }
+        @Override public byte[] data() { return data.clone(); }
+    }
+
+    private static final class Entry {
+        final HotCall call;
+        int hits;
+        long lastSeenMs;
+        boolean warmInFlight;
+        long warmStartedMs;
+        long lastWarmFailedMs = Long.MIN_VALUE;
+
+        Entry(HotCall call) {
+            this.call = call;
+        }
+    }
+
+    private final int maxTracked;
+    private final int minHits;
+    private final long hotTtlMs;
+    private final int maxCalldataBytes;
+    private final long warmTimeoutMs;
+    private final long failureBackoffMs;
+
+    /** Access-ordered LRU of shapes, keyed by the shape's identity string. */
+    private final Map<String, Entry> shapes;
+
+    HotCallTracker(int maxTracked, int minHits, long hotTtlMs,
+                   int maxCalldataBytes, long warmTimeoutMs, long failureBackoffMs) {
+        this.maxTracked = maxTracked;
+        this.minHits = minHits;
+        this.hotTtlMs = hotTtlMs;
+        this.maxCalldataBytes = maxCalldataBytes;
+        this.warmTimeoutMs = warmTimeoutMs;
+        this.failureBackoffMs = failureBackoffMs;
+        this.shapes = new LinkedHashMap<>(16, 0.75f, true) {
+            @Override protected boolean removeEldestEntry(Map.Entry<String, Entry> eldest) {
+                return size() > HotCallTracker.this.maxTracked;
+            }
+        };
+    }
+
+    /** Shape identity: everything of the call except the block tag — mirrors the
+     *  root-less tail of the backend's flight key so one hashing scheme keys both. */
+    static String shapeKey(byte[] from, byte[] to, BigInteger value, byte[] data) {
+        return (from == null ? "0x0" : Bytes.wrap(from).toHexString())
+                + ":" + Bytes.wrap(to).toHexString()
+                + ":" + (value == null ? "0" : value.toString())
+                + ":" + (data == null || data.length == 0
+                        ? "0x" : Hash.keccak256(Bytes.wrap(data)).toHexString());
+    }
+
+    /** Record one sighting of a call shape. Oversized calldata is not tracked
+     *  (nothing real is that big; the cap bounds tracker memory). */
+    synchronized void record(byte[] from, byte[] to, BigInteger value, byte[] data, long nowMs) {
+        if (to == null || to.length != 20) return;
+        if (data != null && data.length > maxCalldataBytes) return;
+        String key = shapeKey(from, to, value, data);
+        Entry e = shapes.get(key);
+        if (e == null || nowMs - e.lastSeenMs > hotTtlMs) {
+            // New shape, or one gone cold: (re)start counting — stale hits must not
+            // qualify a shape that only just resumed.
+            Entry fresh = new Entry(new HotCall(from, to, value, data));
+            if (e != null) {   // keep warm bookkeeping across the reset
+                fresh.warmInFlight = e.warmInFlight;
+                fresh.warmStartedMs = e.warmStartedMs;
+                fresh.lastWarmFailedMs = e.lastWarmFailedMs;
+            }
+            e = fresh;
+            shapes.put(key, e);
+        }
+        e.hits++;
+        e.lastSeenMs = nowMs;
+    }
+
+    /**
+     * The shapes worth warming right now, most-recently-seen first, at most
+     * {@code max}: seen at least {@code minHits} times, last seen within
+     * {@code hotTtlMs}, no warm currently in flight (an in-flight warm older than
+     * {@code warmTimeoutMs} counts as dead), and not inside the failure backoff.
+     * Each returned shape is MARKED warm-in-flight — the caller must pair every
+     * one with an {@link #endWarm} call when its warm completes or fails to submit.
+     */
+    synchronized List<HotCall> beginWarmables(long nowMs, int max) {
+        List<Entry> candidates = new ArrayList<>();
+        for (Entry e : shapes.values()) {
+            if (e.hits < minHits) continue;
+            if (nowMs - e.lastSeenMs > hotTtlMs) continue;
+            if (e.warmInFlight && nowMs - e.warmStartedMs <= warmTimeoutMs) continue;
+            // Sentinel-guarded: nowMs - MIN_VALUE overflows negative, which would
+            // read as "inside the backoff" forever.
+            if (e.lastWarmFailedMs != Long.MIN_VALUE
+                    && nowMs - e.lastWarmFailedMs < failureBackoffMs) continue;
+            candidates.add(e);
+        }
+        candidates.sort((a, b) -> Long.compare(b.lastSeenMs, a.lastSeenMs));
+        List<HotCall> out = new ArrayList<>();
+        for (Entry e : candidates) {
+            if (out.size() >= max) break;
+            e.warmInFlight = true;
+            e.warmStartedMs = nowMs;
+            out.add(e.call);
+        }
+        return out;
+    }
+
+    /** Close out a warm begun by {@link #beginWarmables}. A failed warm starts the
+     *  per-shape backoff so the next head builds don't immediately re-run a call
+     *  that just demonstrated it can't complete. */
+    synchronized void endWarm(HotCall call, boolean success, long nowMs) {
+        Entry e = shapes.get(shapeKey(call.from, call.to, call.value, call.data));
+        if (e == null) return;   // aged out of the LRU while warming
+        e.warmInFlight = false;
+        if (!success) e.lastWarmFailedMs = nowMs;
+    }
+
+    /** Number of tracked shapes (test hook). */
+    synchronized int size() {
+        return shapes.size();
+    }
+}

--- a/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
+++ b/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
@@ -239,6 +239,31 @@ public final class VerifiedRpcBackend implements io.myotis.api.VerifiedReads,
      *  in flight at once. Each value is a small return blob, so this is low-MB. */
     private static final int CALL_RESULT_CACHE_MAX = 512;
 
+    // Replay-warm of the wallet's recurring eth_call shapes (see HotCallTracker and
+    // replayHotCalls): after each head build, the shapes the wallet keeps sending are
+    // re-executed in the background so its next poll — pinned to the block number WE
+    // handed out — replays from callResultCache instead of paying the full EVM +
+    // snap-fetch cost inside its own deadline (observed live: Kohaku's 67KB Multicall3
+    // sweep at p50≈90s / p90≈114s against the 120s timeout, failing nearly every poll).
+    /** Distinct call shapes remembered (LRU). A wallet cycles through a handful. */
+    private static final int HOT_CALL_MAX_TRACKED = 16;
+    /** Sightings before a shape is warmed — a one-off call is never replayed. */
+    private static final int HOT_CALL_MIN_HITS = 2;
+    /** A shape not seen for this long stops being warmed (wallet moved on / closed). */
+    private static final long HOT_CALL_TTL_MS = 10 * 60_000;
+    /** Warms kicked off per head build. Bounds background EVM/snap load; the heavy
+     *  hitters are what matter and there are only a few of them. */
+    private static final int HOT_CALL_MAX_WARMED_PER_HEAD = 4;
+    /** Per-shape calldata cap for tracking (the observed sweeps are 32-67KB). */
+    private static final int HOT_CALL_MAX_CALLDATA = 256 * 1024;
+    /** An in-flight warm older than this counts as dead (its queue slot was likely
+     *  dropped), so the shape becomes warmable again. Above the RPC call timeout so
+     *  a legitimately-slow warm is never doubled up on. */
+    private static final long HOT_CALL_WARM_TIMEOUT_MS = RPC_CALL_TIMEOUT_SEC * 1000 + 30_000;
+    /** After a FAILED warm, leave the shape alone this long — a call that just
+     *  demonstrated it can't complete must not turn the warmer into a retry storm. */
+    private static final long HOT_CALL_FAILURE_BACKOFF_MS = 30_000;
+
     // EVM pool. Was a single thread ("EVM is CPU-bound, oracle pinned to one
     // peer") — but the oracle rotates across peers now, and an EVM task spends
     // most of its wall-clock BLOCKED on snap fetch waves, not executing. A wallet
@@ -426,6 +451,15 @@ public final class VerifiedRpcBackend implements io.myotis.api.VerifiedReads,
     private final VerifiedResultCache<byte[]> callResultCache =
             new VerifiedResultCache<>(CALL_RESULT_CACHE_MAX, CALL_RESULT_CACHE_TTL_MS);
 
+    /** The wallet's recurring eth_call shapes, replayed against each fresh head so
+     *  its polls hit {@link #callResultCache} — see the HOT_CALL_* constants and
+     *  {@link #replayHotCalls}. */
+    private final HotCallTracker hotCalls = new HotCallTracker(
+            HOT_CALL_MAX_TRACKED, HOT_CALL_MIN_HITS, HOT_CALL_TTL_MS,
+            HOT_CALL_MAX_CALLDATA, HOT_CALL_WARM_TIMEOUT_MS, HOT_CALL_FAILURE_BACKOFF_MS);
+    /** {@link #REPLAY_WARM_PROP}, read once at construction. */
+    private final boolean replayWarmEnabled;
+
     /** Replayable eth_estimateGas results, keyed by {@code stateRoot:from:to:keccak(data):value}.
      *  Same rationale as {@link #callResultCache}: an estimate is deterministic given the
      *  anchored state, and estimateGas is a gating call on the confirm screen, so a retry
@@ -558,6 +592,11 @@ public final class VerifiedRpcBackend implements io.myotis.api.VerifiedReads,
      *  before building its stacks). See OPTIMISATIONS_AND_LIMITATIONS.md §2.14. */
     public static final String STRICT_STATE_FRESHNESS_PROP = "myotis.rpc.strictStateFreshness";
 
+    /** System property controlling the hot-call replay-warm (see {@link #replayHotCalls}).
+     *  Default ON; set {@code -Dmyotis.rpc.replayWarm=false} to disable the background
+     *  re-execution of recurring wallet calls after each head build. */
+    public static final String REPLAY_WARM_PROP = "myotis.rpc.replayWarm";
+
     /** Max age a stale-but-anchored head may have and still be served for a STATE-execution
      *  read (eth_call / getBalance / getCode / getStorageAt / estimateGas). STRICT BY DEFAULT
      *  (the tight 2-min {@link #RPC_STATE_HEAD_MAX_STALE_MS} bound) so a read fast-fails when
@@ -601,6 +640,11 @@ public final class VerifiedRpcBackend implements io.myotis.api.VerifiedReads,
                 strictFreshness ? RPC_STATE_HEAD_MAX_STALE_MS : RPC_HEAD_SERVE_STALE_MAX_MS;
         this.log.info("[rpc] state-read head staleness cap = " + (stateHeadStaleCapMs / 1000)
                 + "s (" + (strictFreshness ? "strict" : "relaxed") + ")");
+        this.replayWarmEnabled = Boolean.parseBoolean(
+                System.getProperty(REPLAY_WARM_PROP, "true"));
+        if (!replayWarmEnabled) {
+            this.log.info("[rpc] hot-call replay-warm disabled (" + REPLAY_WARM_PROP + "=false)");
+        }
         final RpcClock clk = this.clock;
         final RpcLogger lg = this.log;
         this.evmPool = task -> {
@@ -1403,6 +1447,9 @@ public final class VerifiedRpcBackend implements io.myotis.api.VerifiedReads,
                         // confirm-critical contracts at this root so a wallet's first
                         // confirm-screen calls start from warm state — see the method doc.
                         primeConfirmContracts(ctx);
+                        // ...then replay the wallet's recurring calls against this head
+                        // (async, heavy lane) so its next poll hits the result cache.
+                        replayHotCalls(ctx);
                     } catch (Throwable t) {
                         f.completeExceptionally(t);
                         synchronized (rpcCallCtxLock) {
@@ -1904,6 +1951,12 @@ public final class VerifiedRpcBackend implements io.myotis.api.VerifiedReads,
                         ? Bytes.wrap(data, 0, 4).toHexString() : "0x")
                 + " dataLen=" + (data == null ? 0 : data.length)
                 + " block=" + block;
+        // Track the shape for the replay-warm BEFORE head resolution: the calls most
+        // worth warming are exactly the ones currently failing ("no verified head",
+        // deadline timeouts) — they must still count as sightings.
+        if (replayWarmEnabled && to != null && to.length == 20) {
+            hotCalls.record(from, to, value, data, clock.elapsedMillis());
+        }
         RpcCallContext h = verifiedHeadFor(block);
         if (h == null || to == null || to.length != 20) {
             log.info("[rpc] eth_call " + desc + " -> no verified head for block tag");
@@ -1925,11 +1978,7 @@ public final class VerifiedRpcBackend implements io.myotis.api.VerifiedReads,
         // Key by (stateRoot, from, to, value, calldata): the sender and value are now
         // part of the input — a transfer simulated by vitalik vs by the zero address
         // computes a DIFFERENT verified result, so they must not share an execution.
-        String flightKey = Bytes.wrap(h.blockCtx().stateRoot()).toHexString()
-                + ":" + (from == null ? "0x0" : Bytes.wrap(from).toHexString())
-                + ":" + Bytes.wrap(to).toHexString()
-                + ":" + (value == null ? "0" : value.toString())
-                + ":" + (data == null ? "0x" : Hash.keccak256(Bytes.wrap(data)).toHexString());
+        String flightKey = callFlightKey(h, from, to, value, data);
         // Warm-result replay: a prior execution for this exact (root, target, calldata)
         // already produced a verified answer — possibly one whose original waiter timed
         // out but whose background leader finished and populated the cache. Replay it; the
@@ -2018,6 +2067,95 @@ public final class VerifiedRpcBackend implements io.myotis.api.VerifiedReads,
      *  distinct concurrent calls a wallet makes (~tens). */
     private final Map<String, CompletableFuture<byte[]>> inflightCalls =
             new java.util.concurrent.ConcurrentHashMap<>();
+
+    /** The eth_call dedup/replay key: (stateRoot, from, to, value, keccak(calldata)).
+     *  Shared by the wallet path ({@code rpcCall}) and the replay-warm
+     *  ({@link #replayHotCalls}) so a warmed result is found by the wallet's
+     *  identical call. Null and empty calldata key identically — they are the same
+     *  execution (callView substitutes an empty array for null). */
+    private String callFlightKey(RpcCallContext h, byte[] from, byte[] to,
+                                 java.math.BigInteger value, byte[] data) {
+        return Bytes.wrap(h.blockCtx().stateRoot()).toHexString()
+                + ":" + (from == null ? "0x0" : Bytes.wrap(from).toHexString())
+                + ":" + Bytes.wrap(to).toHexString()
+                + ":" + (value == null ? "0" : value.toString())
+                + ":" + (data == null || data.length == 0
+                        ? "0x" : Hash.keccak256(Bytes.wrap(data)).toHexString());
+    }
+
+    /**
+     * Replay the wallet's recurring eth_call shapes against a freshly-built head, so
+     * its next poll — pinned to the block number we hand out via eth_blockNumber —
+     * replays from {@link #callResultCache} in microseconds instead of executing
+     * inside its own deadline. Kicked off from the head-build thread right after
+     * {@link #primeConfirmContracts}; the executions themselves run on the heavy EVM
+     * lane (never the reserved interactive lane) and are registered in
+     * {@link #inflightCalls}, so a wallet call arriving mid-warm dedupes onto the
+     * warm execution instead of doubling the snap load. Trust-neutral: this is the
+     * exact verified execution path a wallet-triggered call takes, just earlier.
+     * Best-effort: failures only start the per-shape backoff (see HotCallTracker).
+     */
+    private void replayHotCalls(RpcCallContext ctx) {
+        if (!replayWarmEnabled) return;
+        List<HotCallTracker.HotCall> shapes =
+                hotCalls.beginWarmables(clock.elapsedMillis(), HOT_CALL_MAX_WARMED_PER_HEAD);
+        for (HotCallTracker.HotCall c : shapes) {
+            boolean submitted = false;
+            try {
+                byte[] from = c.from();
+                byte[] to = c.to();
+                byte[] data = c.data();
+                String flightKey = callFlightKey(ctx, from, to, c.value(), data);
+                if (callResultCache.get(flightKey, clock.elapsedMillis()) != null) {
+                    continue;   // already warm at this root
+                }
+                CompletableFuture<byte[]> mine = new CompletableFuture<>();
+                if (inflightCalls.putIfAbsent(flightKey, mine) != null) {
+                    continue;   // a wallet call is already executing this very shape+root
+                }
+                String desc = "to=" + Bytes.wrap(to).toHexString()
+                        + " sel=" + (data.length >= 4 ? Bytes.wrap(data, 0, 4).toHexString() : "0x")
+                        + " dataLen=" + data.length + " block #" + ctx.blockNumber();
+                long t0 = clock.elapsedMillis();
+                final HotCallTracker.HotCall shape = c;
+                ctx.offchainExecutor()
+                        .callView(from == null ? null : io.myotis.evm.Address.of(from),
+                                io.myotis.evm.Address.of(to), data, c.value(), ctx.blockCtx())
+                        // The warm has no waiter to give up on it, so bound it explicitly —
+                        // otherwise a dropped queue slot would leave the inflightCalls entry
+                        // and the per-shape warm flag stuck forever.
+                        .orTimeout(HOT_CALL_WARM_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                        .whenComplete((out, ex) -> {
+                            try {
+                                if (ex != null) {
+                                    mine.completeExceptionally(ex);
+                                    log.info("[rpc] warm eth_call " + desc + " -> error after "
+                                            + (clock.elapsedMillis() - t0) + "ms: "
+                                            + describeEvmError(ex));
+                                } else {
+                                    // Same clone rationale as the rpcCall leader: never cache
+                                    // an array a waiter also received.
+                                    callResultCache.put(flightKey,
+                                            out != null ? out.clone() : null, clock.elapsedMillis());
+                                    mine.complete(out);
+                                    log.info("[rpc] warm eth_call " + desc + " ok in "
+                                            + (clock.elapsedMillis() - t0) + "ms");
+                                }
+                            } finally {
+                                inflightCalls.remove(flightKey, mine);
+                                hotCalls.endWarm(shape, ex == null, clock.elapsedMillis());
+                            }
+                        });
+                submitted = true;
+            } catch (Throwable t) {
+                log.info("[rpc] warm eth_call submit failed: " + unwrap(t));
+            } finally {
+                // Shapes that never started an execution (cache hit / already in flight /
+                // sync throw) must release their warm mark so the next head retries them.
+                if (!submitted) hotCalls.endWarm(c, true, clock.elapsedMillis());
+            }
+        }
+    }
 
     /** Verified account record at the shared anchored head, or null (→ error). The
      *  oracle hash-verifies the account against the anchored stateRoot (storageRoot

--- a/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
+++ b/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
@@ -2126,6 +2126,7 @@ public final class VerifiedRpcBackend implements io.myotis.api.VerifiedReads,
                 hotCalls.beginWarmables(clock.elapsedMillis(), slots);
         for (HotCallTracker.HotCall c : shapes) {
             boolean submitted = false;
+            boolean failedSync = false;
             String flightKey = null;
             CompletableFuture<byte[]> mine = null;
             try {
@@ -2151,10 +2152,15 @@ public final class VerifiedRpcBackend implements io.myotis.api.VerifiedReads,
                         .callView(from == null ? null : io.myotis.evm.Address.of(from),
                                 io.myotis.evm.Address.of(to), data, c.value(), ctx.blockCtx());
                 warmsInFlight.incrementAndGet();
-                // A warm that finishes LATE (past the bookkeeping timeout below) still
-                // banks its verified result — same rationale as the wallet leader whose
-                // waiter timed out: the execution was paid for, the next poll should
-                // find it. Populated from the RAW future so the timeout can't drop it.
+                // The ONE authoritative cache put, on the RAW future so it also covers
+                // a warm that finishes LATE (past the bookkeeping timeout below) —
+                // same rationale as the wallet leader whose waiter timed out: the
+                // execution was paid for, the next poll should find it. Ordering
+                // caveat vs the bookkeeping chain: CompletableFuture dependents run
+                // LIFO, so the inflight entry can be removed just before this put
+                // lands — the worst case is one redundant execution by a call that
+                // slips into that gap (it re-derives the same verified result), never
+                // a stale or missing answer. Clone: never hand waiters the cached array.
                 exec.thenAccept(out -> callResultCache.put(key,
                         out != null ? out.clone() : null, clock.elapsedMillis()));
                 // The warm has no waiter to give up on it, so bound the BOOKKEEPING
@@ -2169,9 +2175,7 @@ public final class VerifiedRpcBackend implements io.myotis.api.VerifiedReads,
                                             + (clock.elapsedMillis() - t0) + "ms: "
                                             + describeEvmError(ex));
                                 } else {
-                                    // Clone: never hand waiters the cached array.
-                                    callResultCache.put(key,
-                                            out != null ? out.clone() : null, clock.elapsedMillis());
+                                    // Cache put lives on the raw exec future above.
                                     flight.complete(out);
                                     log.info("[rpc] warm eth_call " + desc + " ok in "
                                             + (clock.elapsedMillis() - t0) + "ms");
@@ -2192,11 +2196,18 @@ public final class VerifiedRpcBackend implements io.myotis.api.VerifiedReads,
                     inflightCalls.remove(flightKey, mine);
                     mine.completeExceptionally(t);
                 }
+                // A sync submit throw (most likely RejectedExecutionException from a
+                // saturated/shutting-down pool) tends to persist — give it the SAME
+                // failure backoff as an async failure, or the shape would be
+                // re-submitted and re-logged on every ~12s head build.
+                failedSync = true;
+                hotCalls.endWarm(c, false, clock.elapsedMillis());
                 log.info("[rpc] warm eth_call submit failed: " + unwrap(t));
             } finally {
-                // Shapes that never started an execution (cache hit / already in flight /
-                // sync throw) must release their warm mark so the next head retries them.
-                if (!submitted) hotCalls.endWarm(c, true, clock.elapsedMillis());
+                // Shapes that never started an execution (cache hit / already in
+                // flight) must release their warm mark so the next head retries
+                // them; the sync-throw case released above WITH backoff.
+                if (!submitted && !failedSync) hotCalls.endWarm(c, true, clock.elapsedMillis());
             }
         }
     }

--- a/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
+++ b/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
@@ -760,6 +760,7 @@ public final class VerifiedRpcBackend implements io.myotis.api.VerifiedReads,
         pinnedHeadByNumber.clear();
         callResultCache.clear();
         estimateCache.clear();
+        hotCalls.clear();   // drop the recorded calldata profile along with the results
         lastGoodLatestBlock = null;
         lastGoodFeeHistory = null;
     }
@@ -1449,7 +1450,13 @@ public final class VerifiedRpcBackend implements io.myotis.api.VerifiedReads,
                         primeConfirmContracts(ctx);
                         // ...then replay the wallet's recurring calls against this head
                         // (async, heavy lane) so its next poll hits the result cache.
-                        replayHotCalls(ctx);
+                        // Guarded: an escaping throw here would land in the build's
+                        // catch and null out rpcCallCtx even though the head is good.
+                        try {
+                            replayHotCalls(ctx);
+                        } catch (Throwable t) {
+                            log.info("[rpc] hot-call replay skipped: " + unwrap(t));
+                        }
                     } catch (Throwable t) {
                         f.completeExceptionally(t);
                         synchronized (rpcCallCtxLock) {
@@ -1951,10 +1958,22 @@ public final class VerifiedRpcBackend implements io.myotis.api.VerifiedReads,
                         ? Bytes.wrap(data, 0, 4).toHexString() : "0x")
                 + " dataLen=" + (data == null ? 0 : data.length)
                 + " block=" + block;
-        // Track the shape for the replay-warm BEFORE head resolution: the calls most
-        // worth warming are exactly the ones currently failing ("no verified head",
-        // deadline timeouts) — they must still count as sightings.
-        if (replayWarmEnabled && to != null && to.length == 20) {
+        // Track the shape for the replay-warm BEFORE head resolution AND before the
+        // single-flight dedup: the calls most worth warming are exactly the ones
+        // currently failing ("no verified head", deadline timeouts), which never
+        // reach a completed execution — they must still count as sightings. (A
+        // consequence, accepted: a wallet firing N concurrent copies of one call
+        // records N sightings in one cycle — a call duplicated that hard is worth
+        // warming anyway.) Only HEAVY shapes are tracked: small calls execute in
+        // ms on the reserved interactive lane, and warming one would let a wallet
+        // call dedupe onto a heavy-lane warm — queued behind sweep warms — where
+        // untracked it would have been leader on the small lane. Only head-intent
+        // block tags: a shape pinned to a genuinely historical block would warm
+        // against every fresh head yet never be asked at that head's root.
+        if (replayWarmEnabled && to != null && to.length == 20
+                && (from == null || from.length == 20)
+                && data != null && data.length > EVM_SMALL_CALLDATA_MAX
+                && isHeadIntentTag(block)) {
             hotCalls.record(from, to, value, data, clock.elapsedMillis());
         }
         RpcCallContext h = verifiedHeadFor(block);
@@ -2097,19 +2116,27 @@ public final class VerifiedRpcBackend implements io.myotis.api.VerifiedReads,
      */
     private void replayHotCalls(RpcCallContext ctx) {
         if (!replayWarmEnabled) return;
+        // Global in-flight cap, not just the per-head budget: heads rebuild every
+        // ~12s but a warm may run up to HOT_CALL_WARM_TIMEOUT_MS, so without this
+        // successive heads could stack up to maxTracked warms on the 2-thread heavy
+        // lane and starve non-hot wallet calls into queue-age skips.
+        int slots = HOT_CALL_MAX_WARMED_PER_HEAD - warmsInFlight.get();
+        if (slots <= 0) return;
         List<HotCallTracker.HotCall> shapes =
-                hotCalls.beginWarmables(clock.elapsedMillis(), HOT_CALL_MAX_WARMED_PER_HEAD);
+                hotCalls.beginWarmables(clock.elapsedMillis(), slots);
         for (HotCallTracker.HotCall c : shapes) {
             boolean submitted = false;
+            String flightKey = null;
+            CompletableFuture<byte[]> mine = null;
             try {
                 byte[] from = c.from();
                 byte[] to = c.to();
                 byte[] data = c.data();
-                String flightKey = callFlightKey(ctx, from, to, c.value(), data);
+                flightKey = callFlightKey(ctx, from, to, c.value(), data);
                 if (callResultCache.get(flightKey, clock.elapsedMillis()) != null) {
                     continue;   // already warm at this root
                 }
-                CompletableFuture<byte[]> mine = new CompletableFuture<>();
+                mine = new CompletableFuture<>();
                 if (inflightCalls.putIfAbsent(flightKey, mine) != null) {
                     continue;   // a wallet call is already executing this very shape+root
                 }
@@ -2118,42 +2145,80 @@ public final class VerifiedRpcBackend implements io.myotis.api.VerifiedReads,
                         + " dataLen=" + data.length + " block #" + ctx.blockNumber();
                 long t0 = clock.elapsedMillis();
                 final HotCallTracker.HotCall shape = c;
-                ctx.offchainExecutor()
+                final String key = flightKey;
+                final CompletableFuture<byte[]> flight = mine;
+                CompletableFuture<byte[]> exec = ctx.offchainExecutor()
                         .callView(from == null ? null : io.myotis.evm.Address.of(from),
-                                io.myotis.evm.Address.of(to), data, c.value(), ctx.blockCtx())
-                        // The warm has no waiter to give up on it, so bound it explicitly —
-                        // otherwise a dropped queue slot would leave the inflightCalls entry
-                        // and the per-shape warm flag stuck forever.
-                        .orTimeout(HOT_CALL_WARM_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                                io.myotis.evm.Address.of(to), data, c.value(), ctx.blockCtx());
+                warmsInFlight.incrementAndGet();
+                // A warm that finishes LATE (past the bookkeeping timeout below) still
+                // banks its verified result — same rationale as the wallet leader whose
+                // waiter timed out: the execution was paid for, the next poll should
+                // find it. Populated from the RAW future so the timeout can't drop it.
+                exec.thenAccept(out -> callResultCache.put(key,
+                        out != null ? out.clone() : null, clock.elapsedMillis()));
+                // The warm has no waiter to give up on it, so bound the BOOKKEEPING
+                // explicitly — otherwise a dropped queue slot would leave the
+                // inflightCalls entry and the per-shape warm flag stuck forever.
+                exec.orTimeout(HOT_CALL_WARM_TIMEOUT_MS, TimeUnit.MILLISECONDS)
                         .whenComplete((out, ex) -> {
                             try {
                                 if (ex != null) {
-                                    mine.completeExceptionally(ex);
+                                    flight.completeExceptionally(ex);
                                     log.info("[rpc] warm eth_call " + desc + " -> error after "
                                             + (clock.elapsedMillis() - t0) + "ms: "
                                             + describeEvmError(ex));
                                 } else {
-                                    // Same clone rationale as the rpcCall leader: never cache
-                                    // an array a waiter also received.
-                                    callResultCache.put(flightKey,
+                                    // Clone: never hand waiters the cached array.
+                                    callResultCache.put(key,
                                             out != null ? out.clone() : null, clock.elapsedMillis());
-                                    mine.complete(out);
+                                    flight.complete(out);
                                     log.info("[rpc] warm eth_call " + desc + " ok in "
                                             + (clock.elapsedMillis() - t0) + "ms");
                                 }
                             } finally {
-                                inflightCalls.remove(flightKey, mine);
+                                warmsInFlight.decrementAndGet();
+                                inflightCalls.remove(key, flight);
                                 hotCalls.endWarm(shape, ex == null, clock.elapsedMillis());
                             }
                         });
                 submitted = true;
             } catch (Throwable t) {
+                // Mirror the wallet-leader's sync-throw guard: if callView (or Address
+                // decoding, or the pool submit) threw AFTER this warm registered in
+                // inflightCalls, the never-completing future would stay registered and
+                // poison every later identical call into a guaranteed timeout.
+                if (mine != null && flightKey != null) {
+                    inflightCalls.remove(flightKey, mine);
+                    mine.completeExceptionally(t);
+                }
                 log.info("[rpc] warm eth_call submit failed: " + unwrap(t));
             } finally {
                 // Shapes that never started an execution (cache hit / already in flight /
                 // sync throw) must release their warm mark so the next head retries them.
                 if (!submitted) hotCalls.endWarm(c, true, clock.elapsedMillis());
             }
+        }
+    }
+
+    /** Warm executions currently in flight across ALL heads (see replayHotCalls). */
+    private final java.util.concurrent.atomic.AtomicInteger warmsInFlight =
+            new java.util.concurrent.atomic.AtomicInteger();
+
+    /** True when a call's block tag means "the head as the wallet sees it" — a
+     *  latest-ish tag, or a number pin at/near the optimistic head (wallets pin the
+     *  number they just fetched from us). Only these shapes are worth replay-warming:
+     *  a genuinely historical pin would re-execute against every fresh head yet never
+     *  be asked at that head's root. Lenient when the optimistic head is unknown. */
+    private boolean isHeadIntentTag(String block) {
+        if (isLatestTag(block) || "safe".equals(block) || "finalized".equals(block)) return true;
+        try {
+            long n = Long.decode(block);
+            BeaconSyncState bss = beaconSyncState;
+            long optimistic = bss != null ? bss.getOptimisticBlockNumber() : 0;
+            return optimistic <= 0 || n >= optimistic - RPC_BLOCK_NUM_LAG_TOLERANCE;
+        } catch (Exception e) {
+            return false;
         }
     }
 

--- a/rpc-backend/src/test/java/io/myotis/rpc/HotCallTrackerTest.java
+++ b/rpc-backend/src/test/java/io/myotis/rpc/HotCallTrackerTest.java
@@ -133,16 +133,54 @@ class HotCallTrackerTest {
         List<HotCallTracker.HotCall> hot = t.beginWarmables(3_000, 1);
         assertEquals(1, hot.size(), "budget of 1 must yield exactly one shape");
         assertArrayEquals(TO_B, hot.get(0).to(), "the most recently seen shape wins");
+        // Only the RETURNED shape may be marked in-flight: the shape that lost on
+        // budget must still be warmable — an implementation that marks every
+        // candidate would silently starve everything beyond the budget.
+        List<HotCallTracker.HotCall> next = t.beginWarmables(3_001, 10);
+        assertEquals(1, next.size(), "the budget loser must still be warmable");
+        assertArrayEquals(TO_A, next.get(0).to());
     }
 
     @Test
     void lruEvictsOldestShapeBeyondCapacity() {
         var t = tracker();   // capacity 4
+        byte[][] tos = new byte[5][];
         for (int i = 0; i < 5; i++) {
-            byte[] to = addr(0x10 + i);
-            t.record(FROM, to, null, DATA, 1_000 + i);
+            tos[i] = addr(0x10 + i);
+            t.record(FROM, tos[i], null, DATA, 1_000 + i);
         }
         assertEquals(4, t.size(), "capacity must hold");
+        // Pin WHICH shape was evicted — the oldest (tos[0]), not the newest: a
+        // second sighting of a survivor reaches minHits=2 and becomes warmable,
+        // while the evicted shape restarts at one sighting and stays cold.
+        t.record(FROM, tos[1], null, DATA, 2_000);   // survivor: 2nd sighting
+        t.record(FROM, tos[0], null, DATA, 2_001);   // evicted: back at 1st sighting
+        List<HotCallTracker.HotCall> hot = t.beginWarmables(2_002, 10);
+        assertEquals(1, hot.size(), "only the survivor may have accumulated hits");
+        assertArrayEquals(tos[1], hot.get(0).to());
+    }
+
+    @Test
+    void malformedFromIsNotTracked() {
+        // A wrong-length from would make Address.of throw during every replay of the
+        // shape — it must never enter the tracker.
+        var t = tracker();
+        byte[] badFrom = new byte[]{1, 2, 3};
+        t.record(badFrom, TO_A, null, DATA, 1_000);
+        t.record(badFrom, TO_A, null, DATA, 2_000);
+        assertTrue(t.beginWarmables(2_001, 10).isEmpty());
+        assertEquals(0, t.size());
+    }
+
+    @Test
+    void clearDropsAllShapes() {
+        var t = tracker();
+        t.record(FROM, TO_A, null, DATA, 1_000);
+        t.record(FROM, TO_A, null, DATA, 2_000);
+        t.clear();
+        assertEquals(0, t.size());
+        assertTrue(t.beginWarmables(2_001, 10).isEmpty(),
+                "purge must also reset warm-worthiness, not just memory");
     }
 
     @Test

--- a/rpc-backend/src/test/java/io/myotis/rpc/HotCallTrackerTest.java
+++ b/rpc-backend/src/test/java/io/myotis/rpc/HotCallTrackerTest.java
@@ -1,0 +1,196 @@
+package io.myotis.rpc;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HotCallTrackerTest {
+
+    private static final byte[] TO_A = addr(0xAA);
+    private static final byte[] TO_B = addr(0xBB);
+    private static final byte[] FROM = addr(0x01);
+    private static final byte[] DATA = new byte[]{1, 2, 3, 4, 5};
+
+    private static byte[] addr(int fill) {
+        byte[] a = new byte[20];
+        java.util.Arrays.fill(a, (byte) fill);
+        return a;
+    }
+
+    private static HotCallTracker tracker() {
+        // maxTracked=4, minHits=2, ttl=10s, maxCalldata=1KB, warmTimeout=5s, backoff=3s
+        return new HotCallTracker(4, 2, 10_000, 1024, 5_000, 3_000);
+    }
+
+    @Test
+    void singleSightingIsNeverWarmable() {
+        var t = tracker();
+        t.record(FROM, TO_A, null, DATA, 1_000);
+        assertTrue(t.beginWarmables(1_001, 10).isEmpty(),
+                "a one-off call must not be replayed");
+    }
+
+    @Test
+    void secondSightingMakesShapeWarmable() {
+        var t = tracker();
+        t.record(FROM, TO_A, null, DATA, 1_000);
+        t.record(FROM, TO_A, null, DATA, 2_000);
+        List<HotCallTracker.HotCall> hot = t.beginWarmables(2_001, 10);
+        assertEquals(1, hot.size());
+        assertArrayEquals(TO_A, hot.get(0).to());
+        assertArrayEquals(DATA, hot.get(0).data());
+        assertArrayEquals(FROM, hot.get(0).from());
+        assertNull(hot.get(0).value());
+    }
+
+    @Test
+    void distinctShapesTrackIndependently() {
+        var t = tracker();
+        t.record(FROM, TO_A, null, DATA, 1_000);
+        t.record(FROM, TO_B, null, DATA, 1_100);   // different target = different shape
+        t.record(FROM, TO_A, BigInteger.ONE, DATA, 1_200);   // different value = different shape
+        t.record(FROM, TO_A, null, new byte[]{9}, 1_300);    // different calldata = different shape
+        assertTrue(t.beginWarmables(1_400, 10).isEmpty(),
+                "four distinct single-sighting shapes — none warmable");
+        assertEquals(4, t.size());
+    }
+
+    @Test
+    void staleShapeIsNotWarmable() {
+        var t = tracker();
+        t.record(FROM, TO_A, null, DATA, 1_000);
+        t.record(FROM, TO_A, null, DATA, 2_000);
+        assertTrue(t.beginWarmables(13_000, 10).isEmpty(),
+                "not seen within the TTL -> wallet moved on, stop warming");
+    }
+
+    @Test
+    void hitsResetAfterShapeGoesCold() {
+        // Two sightings separated by more than the TTL must NOT qualify the shape:
+        // the counter restarts when a cold shape resumes.
+        var t = tracker();
+        t.record(FROM, TO_A, null, DATA, 1_000);
+        t.record(FROM, TO_A, null, DATA, 20_000);   // > ttl after the first
+        assertTrue(t.beginWarmables(20_001, 10).isEmpty());
+        t.record(FROM, TO_A, null, DATA, 21_000);   // second fresh sighting
+        assertEquals(1, t.beginWarmables(21_001, 10).size());
+    }
+
+    @Test
+    void warmInFlightBlocksReWarmUntilEnded() {
+        var t = tracker();
+        t.record(FROM, TO_A, null, DATA, 1_000);
+        t.record(FROM, TO_A, null, DATA, 2_000);
+        List<HotCallTracker.HotCall> first = t.beginWarmables(2_001, 10);
+        assertEquals(1, first.size());
+        assertTrue(t.beginWarmables(2_002, 10).isEmpty(),
+                "the same shape must not be double-warmed while one is in flight");
+        t.endWarm(first.get(0), true, 3_000);
+        assertEquals(1, t.beginWarmables(3_001, 10).size(),
+                "after endWarm the next head build may warm it again");
+    }
+
+    @Test
+    void deadWarmExpiresAndShapeBecomesWarmableAgain() {
+        var t = tracker();
+        t.record(FROM, TO_A, null, DATA, 1_000);
+        t.record(FROM, TO_A, null, DATA, 2_000);
+        assertEquals(1, t.beginWarmables(2_001, 10).size());
+        // No endWarm (the warm's queue slot was dropped). Past warmTimeout the mark
+        // is considered dead; the shape needs to still be fresh, so re-record.
+        t.record(FROM, TO_A, null, DATA, 8_000);
+        assertEquals(1, t.beginWarmables(8_001, 10).size(),
+                "a warm mark older than warmTimeout must not block warming forever");
+    }
+
+    @Test
+    void failedWarmBacksOff() {
+        var t = tracker();
+        t.record(FROM, TO_A, null, DATA, 1_000);
+        t.record(FROM, TO_A, null, DATA, 2_000);
+        List<HotCallTracker.HotCall> first = t.beginWarmables(2_001, 10);
+        t.endWarm(first.get(0), false, 2_500);
+        t.record(FROM, TO_A, null, DATA, 3_000);
+        assertTrue(t.beginWarmables(3_001, 10).isEmpty(),
+                "inside the failure backoff the shape must be left alone");
+        assertEquals(1, t.beginWarmables(6_000, 10).size(),
+                "after the backoff the shape is retried");
+    }
+
+    @Test
+    void mostRecentlySeenShapesWinTheWarmBudget() {
+        var t = tracker();
+        t.record(FROM, TO_A, null, DATA, 1_000);
+        t.record(FROM, TO_A, null, DATA, 2_000);
+        t.record(FROM, TO_B, null, DATA, 1_500);
+        t.record(FROM, TO_B, null, DATA, 2_500);   // B seen more recently
+        List<HotCallTracker.HotCall> hot = t.beginWarmables(3_000, 1);
+        assertEquals(1, hot.size(), "budget of 1 must yield exactly one shape");
+        assertArrayEquals(TO_B, hot.get(0).to(), "the most recently seen shape wins");
+    }
+
+    @Test
+    void lruEvictsOldestShapeBeyondCapacity() {
+        var t = tracker();   // capacity 4
+        for (int i = 0; i < 5; i++) {
+            byte[] to = addr(0x10 + i);
+            t.record(FROM, to, null, DATA, 1_000 + i);
+        }
+        assertEquals(4, t.size(), "capacity must hold");
+    }
+
+    @Test
+    void oversizedCalldataIsNotTracked() {
+        var t = tracker();   // 1KB cap
+        byte[] big = new byte[2048];
+        t.record(FROM, TO_A, null, big, 1_000);
+        t.record(FROM, TO_A, null, big, 2_000);
+        assertTrue(t.beginWarmables(2_001, 10).isEmpty());
+        assertEquals(0, t.size());
+    }
+
+    @Test
+    void endWarmForEvictedShapeIsHarmless() {
+        var t = tracker();
+        t.record(FROM, TO_A, null, DATA, 1_000);
+        t.record(FROM, TO_A, null, DATA, 2_000);
+        List<HotCallTracker.HotCall> hot = t.beginWarmables(2_001, 10);
+        for (int i = 0; i < 5; i++) {   // push the shape out of the LRU
+            t.record(FROM, addr(0x30 + i), null, DATA, 3_000 + i);
+        }
+        t.endWarm(hot.get(0), true, 4_000);   // must not throw
+    }
+
+    @Test
+    void nullFromAndValueAreValidShapeComponents() {
+        var t = tracker();
+        t.record(null, TO_A, null, null, 1_000);
+        t.record(null, TO_A, null, null, 2_000);
+        List<HotCallTracker.HotCall> hot = t.beginWarmables(2_001, 10);
+        assertEquals(1, hot.size());
+        assertNull(hot.get(0).from());
+        assertNull(hot.get(0).value());
+        assertEquals(0, hot.get(0).data().length, "null calldata normalizes to empty");
+    }
+
+    @Test
+    void recordedArraysAreDefensiveCopies() {
+        var t = tracker();
+        byte[] mutableTo = TO_A.clone();
+        byte[] mutableData = DATA.clone();
+        t.record(FROM, mutableTo, null, mutableData, 1_000);
+        mutableTo[0] = 0;
+        mutableData[0] = 0;
+        t.record(FROM, TO_A, null, DATA, 2_000);   // original bytes: same shape
+        List<HotCallTracker.HotCall> hot = t.beginWarmables(2_001, 10);
+        assertEquals(1, hot.size(), "caller mutation must not have corrupted the stored shape");
+        assertArrayEquals(TO_A, hot.get(0).to());
+        assertArrayEquals(DATA, hot.get(0).data());
+    }
+}


### PR DESCRIPTION
## Problem

Kohaku fires the identical 67KB Multicall3 `aggregate3` sweep every ~20s, pinned to the block number it just fetched via `eth_blockNumber`. Executed on demand, each poll pays the full EVM + snap-fetch cost inside the wallet's deadline: p50=90s / p90=114s against the 120s `RPC_CALL_TIMEOUT`, ~1,450 `-32000` timeouts in one day, with abandoned executions piling onto the `rpc-evm-heavy` queue (tasks observed queued 240s+, then skipped).

## Change

The node knows both the recurring call shape and the block the wallet will pin next — so run the call once per fresh head in the background and serve the poll from `callResultCache` in microseconds:

- **`HotCallTracker`** (new, 16 unit tests): remembers recurring heavy `(from, to, value, calldata)` shapes. Bounded LRU (16 shapes), min 2 sightings, 10-min TTL, per-shape at-most-one warm in flight with dead-warm expiry, 30s failure backoff. Only heavy shapes (>4KB calldata — small calls run in ms on the reserved interactive lane and must stay there) and only head-intent block tags are tracked.
- **`replayHotCalls()`**: runs after `primeConfirmContracts()` on each head build. Executions go to the heavy EVM lane, register in `inflightCalls` (a wallet call arriving mid-warm dedupes onto the warm), and populate `callResultCache` on completion — including late completions past the bookkeeping timeout, which still bank their verified result. Global in-flight cap of 4 warms across heads.
- The eth_call flight key moved into `callFlightKey()`, shared by both paths (null and empty calldata now key identically — same execution either way).
- Kill switch: `-Dmyotis.rpc.replayWarm=false`.

**Trust-neutral:** the replay is the exact verified execution path a wallet-triggered call takes — same `callView` against a beacon-anchored head context — just earlier. The result cache is populated only from verified executions.

## Internal review

Independent no-context review completed; both majors fixed and re-verified by a second independent pass: (1) the warm path now mirrors the wallet-leader's sync-throw guard (deregister + fail the in-flight future, so a throw can't poison later identical calls; malformed `from` also rejected at record time), (2) small shapes are never tracked, so interactive calls keep their reserved lane. Minors addressed: global warm cap, late-result banking, head-intent tag gate, `close()` clears the tracked profile, guarded call site on the head-build thread, and the test gaps.

Companion PR (independent, same investigation): #273 — storageRoot-keyed storage proof cache, which makes each warm cheap (account proofs only for unchanged contracts). Both are Java-engine only; the Rust engine parity gap is tracked in `docs/reimplementation/06-rust-phase-notes.md` (in #273).

## Testing

- `./gradlew :rpc-backend:test` — 41 tests green (16 new in `HotCallTrackerTest`).
- Full `compileJava compileTestJava` across modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XtMNVcqeJoWayJTZHWK66A