### PR TITLE
Discovery: FINDNODE toward proven peers' UDP endpoints

### DIFF
--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/discv4/DiscV4Service.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/discv4/DiscV4Service.java
@@ -111,19 +111,25 @@ public final class DiscV4Service implements AutoCloseable {
      */
     public void probeEndpoint(InetSocketAddress udpAddr) {
         if (channel == null || !channel.isActive()) return;
-        long now = System.currentTimeMillis();
         String key = udpAddr.getHostString() + ":" + udpAddr.getPort();
-        // Bounded, coarse dedup: drop everything when oversized (probes are a
-        // nudge, not bookkeeping — losing history just allows a re-probe).
-        if (probedEndpoints.size() > PROBE_MAP_MAX) probedEndpoints.clear();
-        Long last = probedEndpoints.putIfAbsent(key, now);
-        if (last != null) {
-            if (now - last < PROBE_MIN_INTERVAL_MS) return;
-            probedEndpoints.put(key, now);
-        }
+        if (!shouldProbe(key, System.currentTimeMillis())) return;
         log.debug("[discv4] probing proven peer endpoint {}", udpAddr);
         sendPing((InetSocketAddress) channel.localAddress(), udpAddr);
         findNode(udpAddr, nodeKey.publicKeyBytes());
+    }
+
+    /** Dedup/rate-limit decision for {@link #probeEndpoint} (package-private for
+     *  tests). Bounded, coarse: the map is dropped wholesale when oversized —
+     *  probes are a nudge, not bookkeeping, so losing history just allows an
+     *  early re-probe. Races between concurrent READY events are benign for the
+     *  same reason (worst case one duplicate ping+FindNode). */
+    boolean shouldProbe(String key, long now) {
+        if (probedEndpoints.size() > PROBE_MAP_MAX) probedEndpoints.clear();
+        Long last = probedEndpoints.putIfAbsent(key, now);
+        if (last == null) return true;
+        if (now - last < PROBE_MIN_INTERVAL_MS) return false;
+        probedEndpoints.put(key, now);
+        return true;
     }
 
     public KademliaTable table() {

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/discv4/DiscV4Service.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/discv4/DiscV4Service.java
@@ -39,6 +39,11 @@ public final class DiscV4Service implements AutoCloseable {
     private ScheduledExecutorService scheduler;
     private final Consumer<KademliaTable.Entry> onPeerDiscovered;
 
+    /** Endpoint ("ip:port") → last probe millis (see {@link #probeEndpoint}). */
+    private final ConcurrentHashMap<String, Long> probedEndpoints = new ConcurrentHashMap<>();
+    private static final long PROBE_MIN_INTERVAL_MS = 60 * 60 * 1000L; // 1h per endpoint
+    private static final int PROBE_MAP_MAX = 1024;
+
     public DiscV4Service(NodeKey nodeKey, List<InetSocketAddress> bootnodes,
                          Consumer<KademliaTable.Entry> onPeerDiscovered) {
         this.nodeKey = nodeKey;
@@ -91,6 +96,34 @@ public final class DiscV4Service implements AutoCloseable {
     public void findNode(InetSocketAddress target, Bytes nodeId) {
         Bytes packet = Packet.encodeFindNode(nodeKey, nodeId);
         sendRaw(packet, target);
+    }
+
+    /**
+     * Bond with a specific UDP endpoint so its neighbourhood enters the walk —
+     * used for peers PROVEN over TCP (reached eth READY) whose UDP side the
+     * table may never have seen (e.g. DNS-ENR-pool peers): the periodic refresh
+     * only FindNodes peers already in the table, so without this nudge a proven
+     * peer's neighbours are never asked for. The ping establishes the bond and
+     * (on pong) lands the peer in the table, where {@link #refreshTable} then
+     * samples it; the immediate FindNode is a best-effort head start (peers may
+     * ignore it until the bond completes — the refresh loop retries later).
+     * Per-address rate limit so repeated READY events don't re-probe.
+     */
+    public void probeEndpoint(InetSocketAddress udpAddr) {
+        if (channel == null || !channel.isActive()) return;
+        long now = System.currentTimeMillis();
+        String key = udpAddr.getHostString() + ":" + udpAddr.getPort();
+        // Bounded, coarse dedup: drop everything when oversized (probes are a
+        // nudge, not bookkeeping — losing history just allows a re-probe).
+        if (probedEndpoints.size() > PROBE_MAP_MAX) probedEndpoints.clear();
+        Long last = probedEndpoints.putIfAbsent(key, now);
+        if (last != null) {
+            if (now - last < PROBE_MIN_INTERVAL_MS) return;
+            probedEndpoints.put(key, now);
+        }
+        log.debug("[discv4] probing proven peer endpoint {}", udpAddr);
+        sendPing((InetSocketAddress) channel.localAddress(), udpAddr);
+        findNode(udpAddr, nodeKey.publicKeyBytes());
     }
 
     public KademliaTable table() {

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/discv4/DiscV4Service.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/discv4/DiscV4Service.java
@@ -41,7 +41,13 @@ public final class DiscV4Service implements AutoCloseable {
 
     /** Endpoint ("ip:port") → last probe millis (see {@link #probeEndpoint}). */
     private final ConcurrentHashMap<String, Long> probedEndpoints = new ConcurrentHashMap<>();
+    /** Re-probe window for endpoints whose bond SUCCEEDED (they're in the table,
+     *  the refresh walk samples them — the probe is just a periodic top-up). */
     private static final long PROBE_MIN_INTERVAL_MS = 60 * 60 * 1000L; // 1h per endpoint
+    /** Re-probe window for endpoints that never bonded: a single lost UDP
+     *  datagram must not black out a proven peer's neighbourhood for an hour —
+     *  the peer isn't in the table, so nothing else will ever re-ping it. */
+    private static final long PROBE_RETRY_UNBONDED_MS = 10 * 60 * 1000L; // 10 min
     private static final int PROBE_MAP_MAX = 1024;
 
     public DiscV4Service(NodeKey nodeKey, List<InetSocketAddress> bootnodes,
@@ -112,22 +118,32 @@ public final class DiscV4Service implements AutoCloseable {
     public void probeEndpoint(InetSocketAddress udpAddr) {
         if (channel == null || !channel.isActive()) return;
         String key = udpAddr.getHostString() + ":" + udpAddr.getPort();
-        if (!shouldProbe(key, System.currentTimeMillis())) return;
+        // Bond state picks the retry window: table membership means the pong
+        // verified (the handler adds peers to the table only on that path).
+        boolean bonded = false;
+        for (KademliaTable.Entry e : table.allPeers()) {
+            if (e.udpAddr().equals(udpAddr)) { bonded = true; break; }
+        }
+        if (!shouldProbe(key, System.currentTimeMillis(), bonded)) return;
         log.debug("[discv4] probing proven peer endpoint {}", udpAddr);
         sendPing((InetSocketAddress) channel.localAddress(), udpAddr);
         findNode(udpAddr, nodeKey.publicKeyBytes());
     }
 
     /** Dedup/rate-limit decision for {@link #probeEndpoint} (package-private for
-     *  tests). Bounded, coarse: the map is dropped wholesale when oversized —
-     *  probes are a nudge, not bookkeeping, so losing history just allows an
-     *  early re-probe. Races between concurrent READY events are benign for the
+     *  tests). {@code bonded} selects the window: 1h for endpoints already in
+     *  the table, 10min for endpoints whose earlier probe never produced a
+     *  verified pong (lost datagram / UDP filtered — retry sooner). Bounded,
+     *  coarse: the map is dropped wholesale when oversized — probes are a
+     *  nudge, not bookkeeping, so losing history just allows an early
+     *  re-probe. Races between concurrent READY events are benign for the
      *  same reason (worst case one duplicate ping+FindNode). */
-    boolean shouldProbe(String key, long now) {
+    boolean shouldProbe(String key, long now, boolean bonded) {
         if (probedEndpoints.size() > PROBE_MAP_MAX) probedEndpoints.clear();
+        long window = bonded ? PROBE_MIN_INTERVAL_MS : PROBE_RETRY_UNBONDED_MS;
         Long last = probedEndpoints.putIfAbsent(key, now);
         if (last == null) return true;
-        if (now - last < PROBE_MIN_INTERVAL_MS) return false;
+        if (now - last < window) return false;
         probedEndpoints.put(key, now);
         return true;
     }

--- a/networking/src/test/java/com/jaeckel/ethp2p/networking/discv4/DiscV4ServiceProbeTest.java
+++ b/networking/src/test/java/com/jaeckel/ethp2p/networking/discv4/DiscV4ServiceProbeTest.java
@@ -1,0 +1,42 @@
+package com.jaeckel.ethp2p.networking.discv4;
+
+import com.jaeckel.ethp2p.core.crypto.NodeKey;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** The probe dedup/rate-limit decision (no socket needed — {@code shouldProbe}
+ *  is pure bookkeeping; the send path is exercised by live runs). */
+class DiscV4ServiceProbeTest {
+
+    private static DiscV4Service service() {
+        return new DiscV4Service(NodeKey.generate(), List.of(), entry -> { });
+    }
+
+    @Test
+    void firstProbePassesRepeatWithinWindowIsDeduped() {
+        DiscV4Service s = service();
+        long t0 = 1_000_000L;
+        assertTrue(s.shouldProbe("1.2.3.4:30303", t0), "first probe must pass");
+        assertFalse(s.shouldProbe("1.2.3.4:30303", t0 + 1), "immediate repeat deduped");
+        assertFalse(s.shouldProbe("1.2.3.4:30303", t0 + 59 * 60 * 1000L), "still inside 1h window");
+        assertTrue(s.shouldProbe("1.2.3.4:30303", t0 + 61 * 60 * 1000L), "window expired → re-probe");
+        assertTrue(s.shouldProbe("5.6.7.8:30303", t0), "different endpoint independent");
+    }
+
+    @Test
+    void oversizedMapIsDroppedAllowingEarlyReprobe() {
+        DiscV4Service s = service();
+        long t0 = 1_000_000L;
+        assertTrue(s.shouldProbe("target:1", t0));
+        for (int i = 0; i < 1025; i++) {
+            s.shouldProbe("filler:" + i, t0);
+        }
+        // The clear-on-overflow lost the history — an early re-probe is the
+        // documented worst case, not an error.
+        assertTrue(s.shouldProbe("target:1", t0 + 1));
+    }
+}

--- a/networking/src/test/java/com/jaeckel/ethp2p/networking/discv4/DiscV4ServiceProbeTest.java
+++ b/networking/src/test/java/com/jaeckel/ethp2p/networking/discv4/DiscV4ServiceProbeTest.java
@@ -17,26 +17,39 @@ class DiscV4ServiceProbeTest {
     }
 
     @Test
-    void firstProbePassesRepeatWithinWindowIsDeduped() {
+    void bondedEndpointsRetryHourly() {
         DiscV4Service s = service();
         long t0 = 1_000_000L;
-        assertTrue(s.shouldProbe("1.2.3.4:30303", t0), "first probe must pass");
-        assertFalse(s.shouldProbe("1.2.3.4:30303", t0 + 1), "immediate repeat deduped");
-        assertFalse(s.shouldProbe("1.2.3.4:30303", t0 + 59 * 60 * 1000L), "still inside 1h window");
-        assertTrue(s.shouldProbe("1.2.3.4:30303", t0 + 61 * 60 * 1000L), "window expired → re-probe");
-        assertTrue(s.shouldProbe("5.6.7.8:30303", t0), "different endpoint independent");
+        assertTrue(s.shouldProbe("1.2.3.4:30303", t0, true), "first probe must pass");
+        assertFalse(s.shouldProbe("1.2.3.4:30303", t0 + 1, true), "immediate repeat deduped");
+        assertFalse(s.shouldProbe("1.2.3.4:30303", t0 + 59 * 60 * 1000L, true), "inside 1h window");
+        assertTrue(s.shouldProbe("1.2.3.4:30303", t0 + 61 * 60 * 1000L, true), "window expired");
+        assertTrue(s.shouldProbe("5.6.7.8:30303", t0, true), "different endpoint independent");
+    }
+
+    @Test
+    void unbondedEndpointsRetrySooner() {
+        DiscV4Service s = service();
+        long t0 = 1_000_000L;
+        // A probe whose ping was lost (never bonded) must not black out the
+        // neighbourhood for an hour — the 10-min unbonded window applies.
+        assertTrue(s.shouldProbe("9.9.9.9:30303", t0, false));
+        assertFalse(s.shouldProbe("9.9.9.9:30303", t0 + 9 * 60 * 1000L, false), "inside 10min");
+        assertTrue(s.shouldProbe("9.9.9.9:30303", t0 + 11 * 60 * 1000L, false), "unbonded retry");
+        // Once bonded, the hourly window governs again.
+        assertFalse(s.shouldProbe("9.9.9.9:30303", t0 + 22 * 60 * 1000L, true), "bonded → 1h window");
     }
 
     @Test
     void oversizedMapIsDroppedAllowingEarlyReprobe() {
         DiscV4Service s = service();
         long t0 = 1_000_000L;
-        assertTrue(s.shouldProbe("target:1", t0));
+        assertTrue(s.shouldProbe("target:1", t0, true));
         for (int i = 0; i < 1025; i++) {
-            s.shouldProbe("filler:" + i, t0);
+            s.shouldProbe("filler:" + i, t0, true);
         }
         // The clear-on-overflow lost the history — an early re-probe is the
         // documented worst case, not an error.
-        assertTrue(s.shouldProbe("target:1", t0 + 1));
+        assertTrue(s.shouldProbe("target:1", t0 + 1, true));
     }
 }

--- a/node-core/src/main/java/io/myotis/node/ChainStack.java
+++ b/node-core/src/main/java/io/myotis/node/ChainStack.java
@@ -715,7 +715,22 @@ public final class ChainStack {
             if (!headers.isEmpty()) {
                 log.debug("[{}] {} block header(s) received", network.name(), headers.size());
             }
-        }, (address, publicKeyHex, snap) -> peerCache.add(address, publicKeyHex, snap), serveStats);
+        }, (address, publicKeyHex, snap) -> {
+            peerCache.add(address, publicKeyHex, snap);
+            // Nudge discovery toward this PROVEN peer's neighbourhood: peers
+            // reached via the DNS pool or cache may never enter the discv4
+            // table on their own, so the random walk would never ask them for
+            // neighbours. UDP port is a guess (= TCP port, the devp2p default);
+            // a wrong guess just means no pong, which is harmless.
+            DiscV4Service d4 = discV4;
+            if (d4 != null) {
+                try {
+                    d4.probeEndpoint(new InetSocketAddress(address.getHostString(), address.getPort()));
+                } catch (Throwable ignored) {
+                    // discovery nudge must never break the READY path
+                }
+            }
+        }, serveStats);
         // Apply a window size set before start(): setServedBlockWindow may have run while
         // connector was still null (hosts read Settings before booting the stack).
         conn.servedWindow().setMaxWindow(servedBlockWindow);

--- a/node-core/src/main/java/io/myotis/node/ChainStack.java
+++ b/node-core/src/main/java/io/myotis/node/ChainStack.java
@@ -725,7 +725,11 @@ public final class ChainStack {
             DiscV4Service d4 = discV4;
             if (d4 != null) {
                 try {
-                    d4.probeEndpoint(new InetSocketAddress(address.getHostString(), address.getPort()));
+                    // Pass the dial address through as-is (same host:port) —
+                    // constructing a fresh InetSocketAddress from a host string
+                    // could do a blocking DNS lookup on this Netty event-loop
+                    // thread if a dial source ever supplies hostnames.
+                    d4.probeEndpoint(address);
                 } catch (Throwable ignored) {
                     // discovery nudge must never break the READY path
                 }

--- a/rust/myotis-net/src/el/discv4.rs
+++ b/rust/myotis-net/src/el/discv4.rs
@@ -700,15 +700,34 @@ impl ServiceLoop {
     /// `refresh` uses (Java `DiscV4Service.probeEndpoint` twin). Deduped per
     /// endpoint (1 h) and bounded.
     async fn probe(&mut self, addr: SocketAddr) {
+        // Bonded endpoints (in the table — pong verified) re-probe hourly; an
+        // endpoint whose earlier probe never bonded retries sooner, so one
+        // lost datagram can't black out a proven peer's neighbourhood for an
+        // hour (Java `shouldProbe` twin).
         const PROBE_MIN_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60 * 60);
+        const PROBE_RETRY_UNBONDED: std::time::Duration = std::time::Duration::from_secs(10 * 60);
         const PROBE_MAP_MAX: usize = 1024;
         let now = tokio::time::Instant::now();
         // Coarse bound: losing history just allows a re-probe.
         if self.probed.len() > PROBE_MAP_MAX {
             self.probed.clear();
         }
+        let bonded = self
+            .table
+            .lock()
+            .map(|t| {
+                t.all_peers().iter().any(|e| {
+                    e.udp_port == addr.port()
+                        && match addr.ip() {
+                            IpAddr::V4(v4) => e.ip == v4.octets(),
+                            IpAddr::V6(v6) => e.ip == v6.octets(),
+                        }
+                })
+            })
+            .unwrap_or(false);
+        let window = if bonded { PROBE_MIN_INTERVAL } else { PROBE_RETRY_UNBONDED };
         if let Some(last) = self.probed.get(&addr) {
-            if now.duration_since(*last) < PROBE_MIN_INTERVAL {
+            if now.duration_since(*last) < window {
                 return;
             }
         }

--- a/rust/myotis-net/src/el/discv4.rs
+++ b/rust/myotis-net/src/el/discv4.rs
@@ -385,6 +385,8 @@ pub struct Discv4Service {
     table: Arc<Mutex<KademliaTable>>,
     local_port: u16,
     stop_tx: tokio::sync::watch::Sender<bool>,
+    /// Probe requests into the service loop (see [`Discv4Service::probe_sender`]).
+    probe_tx: tokio::sync::mpsc::Sender<SocketAddr>,
     /// `Option` so `stop(self)` can take the handle while `Drop` (the
     /// forgot-to-stop path) leaves it `None`.
     task: Option<tokio::task::JoinHandle<()>>,
@@ -406,6 +408,7 @@ impl Discv4Service {
             .port();
         let table = Arc::new(Mutex::new(KademliaTable::new(key.node_id())));
         let (stop_tx, stop_rx) = tokio::sync::watch::channel(false);
+        let (probe_tx, probe_rx) = tokio::sync::mpsc::channel(64);
         let loop_state = ServiceLoop {
             key,
             socket,
@@ -416,14 +419,27 @@ impl Discv4Service {
             events,
             pending_pings: HashMap::new(),
             limiter: PingRateLimiter::default(),
+            probe_rx,
+            probed: HashMap::new(),
         };
         let task = tokio::spawn(loop_state.run(stop_rx));
         Ok(Discv4Service {
             table,
             local_port,
             stop_tx,
+            probe_tx,
             task: Some(task),
         })
+    }
+
+    /// A clonable sender for probe requests: bond with a specific UDP endpoint
+    /// (the UDP-port guess for a peer PROVEN over TCP) so its neighbourhood
+    /// enters the walk — the refresh loop only FindNodes peers already in the
+    /// table, so a cache-/DNS-sourced peer's neighbours are otherwise never
+    /// asked for. Sends are best-effort (`try_send`; a full queue drops the
+    /// probe — it's a nudge, not bookkeeping).
+    pub fn probe_sender(&self) -> tokio::sync::mpsc::Sender<SocketAddr> {
+        self.probe_tx.clone()
     }
 
     pub fn table_size(&self) -> usize {
@@ -522,6 +538,10 @@ struct ServiceLoop {
     /// ping target → expected echo hash (the bond in flight).
     pending_pings: HashMap<SocketAddr, [u8; 32]>,
     limiter: PingRateLimiter,
+    /// Probe requests from the pool (proven-peer UDP endpoints to bond with).
+    probe_rx: tokio::sync::mpsc::Receiver<SocketAddr>,
+    /// Endpoint → last probe instant (1 h per-endpoint dedup, bounded).
+    probed: HashMap<SocketAddr, tokio::time::Instant>,
 }
 
 impl ServiceLoop {
@@ -546,6 +566,9 @@ impl ServiceLoop {
                     return;
                 }
                 _ = refresh.tick() => self.refresh().await,
+                // `Some(addr) =` disables this branch once all senders drop
+                // (recv() → None fails the pattern) — no busy-loop at shutdown.
+                Some(addr) = self.probe_rx.recv() => self.probe(addr).await,
                 recv = self.socket.recv_from(&mut buf) => {
                     let (n, sender) = match recv {
                         Ok(v) => v,
@@ -669,6 +692,31 @@ impl ServiceLoop {
             }
             Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {}
         }
+    }
+
+    /// Bond with a proven peer's UDP endpoint (see [`Discv4Service::probe_sender`]):
+    /// ping (the pong lands it in the table, where `refresh` samples it) plus a
+    /// best-effort FindNode-self head start — the same ping-then-FindNode shape
+    /// `refresh` uses (Java `DiscV4Service.probeEndpoint` twin). Deduped per
+    /// endpoint (1 h) and bounded.
+    async fn probe(&mut self, addr: SocketAddr) {
+        const PROBE_MIN_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60 * 60);
+        const PROBE_MAP_MAX: usize = 1024;
+        let now = tokio::time::Instant::now();
+        // Coarse bound: losing history just allows a re-probe.
+        if self.probed.len() > PROBE_MAP_MAX {
+            self.probed.clear();
+        }
+        if let Some(last) = self.probed.get(&addr) {
+            if now.duration_since(*last) < PROBE_MIN_INTERVAL {
+                return;
+            }
+        }
+        self.probed.insert(addr, now);
+        tracing::debug!(%addr, "probing proven peer endpoint");
+        self.send_ping(addr).await;
+        let self_target = self.key.public_key_bytes().to_vec();
+        self.send_find_node(addr, &self_target).await;
     }
 
     /// 15 s refresh: empty table → re-ping bootnodes; else FindNode-self to

--- a/rust/myotis-net/src/el/pool.rs
+++ b/rust/myotis-net/src/el/pool.rs
@@ -181,6 +181,17 @@ impl PoolInner {
         .await;
 
         let now = Instant::now();
+        // Any COMPATIBLE completed session (snap or not) proves the peer is on
+        // our network — nudge discovery toward its neighbourhood (UDP port
+        // guessed = TCP port, the devp2p default; a wrong guess just means no
+        // pong). The service dedups per endpoint. Same semantics as the Java
+        // twin, which probes on every eth-READY peer: a fork-verified plain-eth
+        // peer's neighbours may well serve snap.
+        if result.is_ok() {
+            if let Some(probe) = &self.probe {
+                let _ = probe.try_send(addr);
+            }
+        }
         match result {
             Ok(session) if session.snap => {
                 // INFO: the operator-visible signal that the EL found a usable
@@ -200,12 +211,6 @@ impl PoolInner {
                 // Keep `addr` in `attempted` while connected — dropped by
                 // prune_closed when the peer later closes.
                 self.peers.lock().await.push(PooledPeer { addr, peer });
-                // Nudge discovery toward this proven peer's neighbourhood (UDP
-                // port guessed = TCP port, the devp2p default; a wrong guess
-                // just means no pong). The service dedups per endpoint.
-                if let Some(probe) = &self.probe {
-                    let _ = probe.try_send(addr);
-                }
                 // Persist this proven snap-capable peer for warm-start next run.
                 // `add` only marks the cache dirty for a genuinely new peer, so
                 // `flush` no-ops on a re-connect.

--- a/rust/myotis-net/src/el/pool.rs
+++ b/rust/myotis-net/src/el/pool.rs
@@ -112,6 +112,11 @@ struct PoolInner {
     /// gossip sightings of our own broadcasts register (None for pools whose
     /// host never sends).
     tx_watch: Option<crate::el::sent_tx::SharedSentTxWatch>,
+    /// Probe requests toward discovery: when a snap peer connects, its address
+    /// is nudged into the discv4 walk so its neighbourhood gets explored (a
+    /// cache-/warm-start peer may never enter the table on its own). Best-effort
+    /// `try_send`; `None` for pools without discovery (tests).
+    probe: Option<mpsc::Sender<SocketAddr>>,
 }
 
 impl PoolInner {
@@ -195,6 +200,12 @@ impl PoolInner {
                 // Keep `addr` in `attempted` while connected — dropped by
                 // prune_closed when the peer later closes.
                 self.peers.lock().await.push(PooledPeer { addr, peer });
+                // Nudge discovery toward this proven peer's neighbourhood (UDP
+                // port guessed = TCP port, the devp2p default; a wrong guess
+                // just means no pong). The service dedups per endpoint.
+                if let Some(probe) = &self.probe {
+                    let _ = probe.try_send(addr);
+                }
                 // Persist this proven snap-capable peer for warm-start next run.
                 // `add` only marks the cache dirty for a genuinely new peer, so
                 // `flush` no-ops on a re-connect.
@@ -247,6 +258,7 @@ impl PeerPool {
         cache: ElPeerCache,
         rx: mpsc::Receiver<TableEntry>,
         tx_watch: Option<crate::el::sent_tx::SharedSentTxWatch>,
+        probe: Option<mpsc::Sender<SocketAddr>>,
     ) -> PeerPool {
         let inner = Arc::new(PoolInner {
             key,
@@ -262,6 +274,7 @@ impl PeerPool {
             serve_stats: Arc::new(ServeStats::default()),
             hunting: AtomicBool::new(false),
             tx_watch,
+            probe,
         });
         // Both the discv4 dialer and the maintainer dial through one shared
         // concurrency budget.
@@ -627,6 +640,7 @@ mod tests {
             ElPeerCache::disabled(),
             rx,
             None,
+            None,
         );
         assert_eq!(pool.snap_peer_count().await, 0);
         assert!(pool.snap_peer().await.is_none());
@@ -677,6 +691,7 @@ mod tests {
             PoolConfig::default(),
             ElPeerCache::load(path.clone()),
             rx,
+            None,
             None,
         );
         // The warm-start branch dials the cached peer, claiming its address.
@@ -732,6 +747,7 @@ mod tests {
             PoolConfig::default(),
             ElPeerCache::load(path.clone()),
             rx,
+            None,
             None,
         );
 

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -613,6 +613,7 @@ impl ElReader {
             cache,
             rx,
             Some(Arc::clone(&sent_tx_watch)),
+            Some(discovery.probe_sender()),
         );
         Ok(ElReader {
             discovery,

--- a/rust/myotis-net/tests/live_pool.rs
+++ b/rust/myotis-net/tests/live_pool.rs
@@ -73,6 +73,7 @@ async fn pool_dials_from_discovery_and_serves_a_verified_account() {
         myotis_net::el::peercache::ElPeerCache::disabled(),
         rx,
         None,
+        None,
     );
 
     let mut probe = [0u8; 20];


### PR DESCRIPTION
## Problem

The discv4 random walk only FindNodes peers already in the Kademlia table. A peer we reached over TCP via the DNS ENR pool or the warm-start cache — proven good by a completed, fork-verified eth handshake — may never enter the table, so its neighbourhood is never explored. On sparse networks (sepolia has ~50 known snap servers total) every unexplored neighbourhood matters.

## Changes

- **Java**: `DiscV4Service.probeEndpoint(addr)` — ping (bond; the pong lands the peer in the table where `refreshTable` samples it) plus a best-effort FindNode-self head start, the same ping-then-FindNode shape the refresh walk already uses. Called from `ChainStack`'s onPeerReady callback for every eth-READY peer. Per-endpoint 1-hour dedup, bounded map (clear-on-overflow: worst case is an early re-probe). UDP port is guessed = TCP port (the devp2p default); a wrong guess just means no pong.
- **Rust twin**: `Discv4Service` gains a probe mpsc channel into its service loop (same dedup); `PeerPool` takes an optional probe sender (wired in `ElReader::start`) and nudges it on any compatible completed session — same semantics as Java.
- Unit tests pin the dedup decision (`DiscV4ServiceProbeTest`, and the Rust plumbing compiles into the existing pool/discv4 test surface).

## Notes for reviewers

An internal no-context review ran first; its findings are addressed in the second commit (missed `PeerPool::start` call site in the ignored live test, twin drift on which peers get probed, a latent blocking-DNS construction, dedup testability). Known pre-existing quirks it flagged but that are unchanged by this PR: a probe ping racing a refresh ping to the same address overwrites the expected pong hash for one round (self-heals next refresh), and `pendingPings` has no TTL — both predate this change and are bounded in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPnTFwmAVMypWYtoioAXQT