### PR TITLE
Peers: treat TooManyPeers (0x04) as its own class — alive, just full

### DIFF
--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/EthHandler.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/EthHandler.java
@@ -87,6 +87,10 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
     private volatile org.apache.tuweni.bytes.Bytes32 peerBestBlockHash; // full hash for queries
     private volatile String ourBestHash;  // what we claimed in Status
     private volatile boolean incompatibleNetwork; // confirmed wrong chain
+    /** Peer sent Disconnect(0x04 TooManyPeers): a healthy node on our network
+     *  with no free slots — worth patient retries, NOT a dead/bad peer. */
+    private volatile boolean peerBusy;
+    private static final int DISC_TOO_MANY_PEERS = 0x04;
     private volatile boolean snapNegotiated = false;
     private volatile String clientId;
     /** How long an empty snap response benches a peer from the serving pool. NOT permanent:
@@ -402,6 +406,7 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
             sendStatus(ctx);
         } else if (msg.code() == P2P_DISCONNECT) {
             int reason = decodeDisconnectReason(msg.payload());
+            if (reason == DISC_TOO_MANY_PEERS) peerBusy = true;
             log.info("[eth] Peer {} disconnected during Hello (reason={}/{})",
                 remoteAddress, reason, disconnectReasonName(reason));
             ctx.close();
@@ -476,6 +481,7 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
             sendPong(ctx);
         } else if (msg.code() == P2P_DISCONNECT) {
             int reason = decodeDisconnectReason(msg.payload());
+            if (reason == DISC_TOO_MANY_PEERS) peerBusy = true;
             log.info("[eth] Peer {} ({}) disconnected during Status exchange (reason={}/{}, eth/{})",
                 remoteAddress, clientId != null ? clientId : "unknown",
                 reason, disconnectReasonName(reason), negotiatedEthVersion);
@@ -708,6 +714,7 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
             case P2P_PING -> sendPong(ctx);
             case P2P_DISCONNECT -> {
                 int reason = decodeDisconnectReason(msg.payload());
+                if (reason == DISC_TOO_MANY_PEERS) peerBusy = true;
                 log.info("[eth] Peer {} ({}) disconnected in READY (reason={}/{})",
                     remoteAddress, clientId != null ? clientId : "unknown",
                     reason, disconnectReasonName(reason));
@@ -1570,6 +1577,11 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
     /** Returns true if this peer was confirmed on an incompatible network. */
     public boolean isIncompatibleNetwork() {
         return incompatibleNetwork;
+    }
+
+    /** Returns true if this peer rejected/dropped us with TooManyPeers (0x04). */
+    public boolean isPeerBusy() {
+        return peerBusy;
     }
 
     /** Returns true if this handler has completed the eth handshake. */

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/rlpx/RLPxConnector.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/rlpx/RLPxConnector.java
@@ -55,9 +55,14 @@ public final class RLPxConnector implements AutoCloseable {
         void onPeerReady(InetSocketAddress address, String publicKeyHex, boolean snapSupported);
     }
 
-    /** Callback when a peer connection closes, with incompatibility info and node identity. */
+    /** Callback when a peer connection closes, with incompatibility info and node identity.
+     *  {@code busy} = the peer sent Disconnect(0x04 TooManyPeers) at any phase: an
+     *  ALIVE node with no free slots — callers should back off patiently instead of
+     *  treating it like a generic transient failure. (0x04 says nothing about the
+     *  peer's chain — full wrong-chain nodes send it too, so busy alone must never
+     *  promote a peer to any verified/known-good tier.) */
     public interface PeerCloseCallback {
-        void onPeerClose(boolean incompatibleNetwork, String nodeIdHex);
+        void onPeerClose(boolean incompatibleNetwork, boolean busy, String nodeIdHex);
     }
 
     private final NodeKey localKey;
@@ -203,7 +208,8 @@ public final class RLPxConnector implements AutoCloseable {
                     ch.closeFuture().addListener(f -> {
                         activeHandlers.remove(ethHandler);
                         if (closeCallback != null) {
-                            closeCallback.onPeerClose(ethHandler.isIncompatibleNetwork(), pubKeyHex);
+                            closeCallback.onPeerClose(ethHandler.isIncompatibleNetwork(),
+                                ethHandler.isPeerBusy(), pubKeyHex);
                         }
                     });
                 }

--- a/node-core/src/main/java/io/myotis/node/ChainStack.java
+++ b/node-core/src/main/java/io/myotis/node/ChainStack.java
@@ -79,6 +79,17 @@ public final class ChainStack {
      *  the DNS dial budget, and shortens the DNS re-walk interval. The Rust
      *  engine's pool maintainer applies the same trigger (EL_HUNT_STALL). */
     static final long EL_HUNT_STALL_MS = 60_000L;
+
+    /** Backoff for peers that rejected us with TooManyPeers (0x04): alive, just
+     *  full. Longer than transient (halves the dial burn on saturated networks)
+     *  but short enough to keep farming freed slots. */
+    static final long BACKOFF_BUSY_MS = 60_000L;
+
+    /** Distinct peers that rejected us with TooManyPeers recently (rolling
+     *  window) — hunt diagnostics: distinguishes "the network is full" from
+     *  "the network is dead" when the serving pool is empty. */
+    private final Map<String, Long> busySeen = new ConcurrentHashMap<>();
+    private static final long BUSY_SEEN_WINDOW_MS = 10 * 60 * 1000L;
     /** DNS ENR re-walk interval while the EL hunt is engaged (vs 4 min normally). */
     private static final long DNS_REFRESH_HUNT_INTERVAL_MS = 60_000L;
 
@@ -686,10 +697,12 @@ public final class ChainStack {
             dialed++;
             final String key = peerKey;
             try {
-                connector.connect(pe.address(), pe.pubkey(), (incompatible, nodeIdHex) -> {
+                connector.connect(pe.address(), pe.pubkey(), (incompatible, busy, nodeIdHex) -> {
                             if (incompatible) blacklistedNodeIds.add(nodeIdHex);
+                            if (busy) noteBusy(key);
                             backoff.putIfAbsent(key, System.currentTimeMillis()
-                                    + (incompatible ? BACKOFF_INCOMPATIBLE_MS : BACKOFF_TRANSIENT_MS));
+                                    + (incompatible ? BACKOFF_INCOMPATIBLE_MS
+                                       : busy ? BACKOFF_BUSY_MS : BACKOFF_TRANSIENT_MS));
                             attempted.remove(key);
                         })
                         .addListener(future -> { if (!future.isSuccess()) attempted.remove(key); });
@@ -749,9 +762,11 @@ public final class ChainStack {
             try {
                 SECP256K1.PublicKey pubKey = SECP256K1.PublicKey.fromBytes(
                         Bytes.fromHexString(peer.publicKeyHex()));
-                connector.connect(peer.address(), pubKey, (incompatible, nodeIdHex) -> {
+                connector.connect(peer.address(), pubKey, (incompatible, busy, nodeIdHex) -> {
                             if (incompatible) blacklistedNodeIds.add(nodeIdHex);
-                            long backoffMs = incompatible ? BACKOFF_INCOMPATIBLE_MS : BACKOFF_TRANSIENT_MS;
+                            if (busy) noteBusy(peerKey);
+                            long backoffMs = incompatible ? BACKOFF_INCOMPATIBLE_MS
+                                    : busy ? BACKOFF_BUSY_MS : BACKOFF_TRANSIENT_MS;
                             backoff.putIfAbsent(peerKey, System.currentTimeMillis() + backoffMs);
                             attempted.remove(peerKey);
                         })
@@ -777,9 +792,11 @@ public final class ChainStack {
                 if (!attempted.add(peerKey)) continue;
                 directDialed++;
                 final String key = peerKey;
-                connector.connect(peerTcp, pub.get(), (incompatible, nodeIdHex) -> {
+                connector.connect(peerTcp, pub.get(), (incompatible, busy, nodeIdHex) -> {
                             if (incompatible) blacklistedNodeIds.add(nodeIdHex);
-                            long backoffMs = incompatible ? BACKOFF_INCOMPATIBLE_MS : BACKOFF_TRANSIENT_MS;
+                            if (busy) noteBusy(key);
+                            long backoffMs = incompatible ? BACKOFF_INCOMPATIBLE_MS
+                                    : busy ? BACKOFF_BUSY_MS : BACKOFF_TRANSIENT_MS;
                             backoff.putIfAbsent(key, System.currentTimeMillis() + backoffMs);
                             attempted.remove(key);
                         })
@@ -958,9 +975,11 @@ public final class ChainStack {
             Bytes nodeId = entry.nodeId();
             if (nodeId.size() != 64) { attempted.remove(peerKey); return; }
             SECP256K1.PublicKey peerPubkey = SECP256K1.PublicKey.fromBytes(nodeId);
-            connector.connect(peerTcp, peerPubkey, (incompatible, nodeIdHex) -> {
+            connector.connect(peerTcp, peerPubkey, (incompatible, busy, nodeIdHex) -> {
                         if (incompatible) blacklistedNodeIds.add(nodeIdHex);
-                        long backoffMs = incompatible ? BACKOFF_INCOMPATIBLE_MS : BACKOFF_TRANSIENT_MS;
+                        if (busy) noteBusy(peerKey);
+                        long backoffMs = incompatible ? BACKOFF_INCOMPATIBLE_MS
+                                    : busy ? BACKOFF_BUSY_MS : BACKOFF_TRANSIENT_MS;
                         backoff.putIfAbsent(peerKey, System.currentTimeMillis() + backoffMs);
                         attempted.remove(peerKey);
                     })
@@ -1043,7 +1062,9 @@ public final class ChainStack {
                 elHunting = true;
                 log.info("[{}][peers] EL hunt engaged — snap serving pool empty {}s "
                         + "(bypassing transient backoffs for confirmed snap servers, "
-                        + "boosted DNS budget)", network.name(), EL_HUNT_STALL_MS / 1000);
+                        + "boosted DNS budget; {} distinct busy peer(s) in the last {} min "
+                        + "— busy means full-not-dead)", network.name(), EL_HUNT_STALL_MS / 1000,
+                        busySeenCount(), BUSY_SEEN_WINDOW_MS / 60_000);
             }
             if (snapPeers >= targetSnapPeers) return;
             log.info("[{}][peers] {} snap peer(s) < target {}; re-dialing cached + DNS pool",
@@ -1211,9 +1232,11 @@ public final class ChainStack {
             }
             if (attempted.size() >= MAX_ATTEMPTED || !attempted.add(peerKey)) return false;
             final String key = peerKey;
-            conn.connect(peerTcp, pub.get(), (incompatible, idHex) -> {
+            conn.connect(peerTcp, pub.get(), (incompatible, busy, idHex) -> {
                 if (incompatible) blacklistedNodeIds.add(idHex);
-                long ms = incompatible ? BACKOFF_INCOMPATIBLE_MS : BACKOFF_TRANSIENT_MS;
+                if (busy) noteBusy(key);
+                long ms = incompatible ? BACKOFF_INCOMPATIBLE_MS
+                        : busy ? BACKOFF_BUSY_MS : BACKOFF_TRANSIENT_MS;
                 backoff.putIfAbsent(key, System.currentTimeMillis() + ms);
                 attempted.remove(key);
             }).addListener(future -> {
@@ -1242,9 +1265,11 @@ public final class ChainStack {
         if (attempted.size() >= MAX_ATTEMPTED || !attempted.add(peerKey)) return;
         try {
             SECP256K1.PublicKey pubKey = SECP256K1.PublicKey.fromBytes(Bytes.fromHexString(p.publicKeyHex()));
-            conn.connect(p.address(), pubKey, (incompatible, idHex) -> {
+            conn.connect(p.address(), pubKey, (incompatible, busy, idHex) -> {
                 if (incompatible) blacklistedNodeIds.add(idHex);
-                long ms = incompatible ? BACKOFF_INCOMPATIBLE_MS : BACKOFF_TRANSIENT_MS;
+                if (busy) noteBusy(peerKey);
+                long ms = incompatible ? BACKOFF_INCOMPATIBLE_MS
+                        : busy ? BACKOFF_BUSY_MS : BACKOFF_TRANSIENT_MS;
                 backoff.putIfAbsent(peerKey, System.currentTimeMillis() + ms);
                 attempted.remove(peerKey);
             }).addListener(future -> {
@@ -1260,6 +1285,22 @@ public final class ChainStack {
         } catch (Exception e) {
             attempted.remove(peerKey);
         }
+    }
+
+    /** Note a TooManyPeers rejection for hunt diagnostics (bounded, rolling). */
+    private void noteBusy(String peerKey) {
+        long now = System.currentTimeMillis();
+        busySeen.put(peerKey, now);
+        if (busySeen.size() > 256) {
+            busySeen.values().removeIf(t -> now - t > BUSY_SEEN_WINDOW_MS);
+        }
+    }
+
+    /** Distinct busy peers seen inside the rolling window (prunes as it counts). */
+    private int busySeenCount() {
+        long now = System.currentTimeMillis();
+        busySeen.values().removeIf(t -> now - t > BUSY_SEEN_WINDOW_MS);
+        return busySeen.size();
     }
 
     /** Report a TCP-level dial failure to the peer cache (streaks demote and

--- a/node-core/src/main/java/io/myotis/node/ChainStack.java
+++ b/node-core/src/main/java/io/myotis/node/ChainStack.java
@@ -464,6 +464,7 @@ public final class ChainStack {
         try { clPeerCache.close(); } catch (Throwable ignored) {}
         attempted.clear();
         backoff.clear();
+        busySeen.clear();
         blacklistedNodeIds.clear();
     }
 
@@ -1080,11 +1081,15 @@ public final class ChainStack {
                 try {
                     // Hunting: free a CONFIRMED snap server's TRANSIENT backoff so
                     // this pass dials it NOW. Confirmed = it served chain-verified
-                    // snap data. The backoff map holds transient (30s) and
-                    // incompatible (10min) entries under the same key, so only clear
-                    // entries within the transient window — a peer re-marked
+                    // snap data. The backoff map holds transient (30s), busy (60s),
+                    // and incompatible (10min) entries under the same key, so only
+                    // clear entries within the transient window — a peer re-marked
                     // incompatible after its confirm (post-fork lag) keeps its
                     // 10-min timer instead of being re-dialed every 10s tick.
+                    // A confirmed-but-BUSY server's 60s entry enters the clearable
+                    // window once ≤30s remain — intentional: in emergency mode an
+                    // eager re-dial of a known-good, merely-full server is exactly
+                    // the slot-farming we want.
                     if (hunting && p.snapQuality() == SnapQuality.CONFIRMED) {
                         String key = p.address().getHostString() + ":" + p.address().getPort();
                         backoff.computeIfPresent(key,
@@ -1293,6 +1298,17 @@ public final class ChainStack {
         busySeen.put(peerKey, now);
         if (busySeen.size() > 256) {
             busySeen.values().removeIf(t -> now - t > BUSY_SEEN_WINDOW_MS);
+            // Hard bound even when >256 are genuinely inside the window: drop
+            // oldest first — the counter is diagnostics, not bookkeeping.
+            while (busySeen.size() > 256) {
+                String oldest = null;
+                long oldestTs = Long.MAX_VALUE;
+                for (Map.Entry<String, Long> e : busySeen.entrySet()) {
+                    if (e.getValue() < oldestTs) { oldestTs = e.getValue(); oldest = e.getKey(); }
+                }
+                if (oldest == null) break;
+                busySeen.remove(oldest);
+            }
         }
     }
 

--- a/rust/myotis-net/src/el/eth/session.rs
+++ b/rust/myotis-net/src/el/eth/session.rs
@@ -506,7 +506,10 @@ fn response_request_id(payload: &[u8]) -> Option<u64> {
 }
 
 /// A p2p Disconnect body is `[reason]`; decode the reason code for logging.
-fn describe_disconnect(payload: &[u8]) -> String {
+/// `pub(crate)` so the pool's busy-classification test can pin the classifier
+/// against THIS producer — a format change here must break that test instead
+/// of silently degrading busy classification to transient.
+pub(crate) fn describe_disconnect(payload: &[u8]) -> String {
     let reason = rlp::decode(payload)
         .ok()
         .and_then(|it| match it {

--- a/rust/myotis-net/src/el/pool.rs
+++ b/rust/myotis-net/src/el/pool.rs
@@ -869,6 +869,20 @@ mod tests {
         assert!(!is_busy_disconnect("incompatible peer: networkId=137 genesis=..."));
         // A peer-controlled client id echoed mid-string can't fake the prefix.
         assert!(!is_busy_disconnect("expected Status, got code 0x04 from peer disconnected: reason=4x"));
+        // Producer-coupled: build the string through the REAL session
+        // formatter (RLP [0x04] = TooManyPeers) so a future format change in
+        // describe_disconnect breaks this test instead of silently degrading
+        // busy classification to transient.
+        let produced = format!(
+            "peer disconnected: {}",
+            crate::el::eth::session::describe_disconnect(&[0xc1, 0x04])
+        );
+        assert!(is_busy_disconnect(&produced), "producer drifted: {produced}");
+        let produced_other = format!(
+            "peer disconnected: {}",
+            crate::el::eth::session::describe_disconnect(&[0xc1, 0x03])
+        );
+        assert!(!is_busy_disconnect(&produced_other));
     }
 
     #[test]

--- a/rust/myotis-net/src/el/pool.rs
+++ b/rust/myotis-net/src/el/pool.rs
@@ -52,6 +52,13 @@ const BACKOFF_BUSY: Duration = Duration::from_secs(60);
 /// matching cannot be steered by peer-controlled content. 0x04 says nothing
 /// about the peer's CHAIN (full wrong-chain nodes send it too), so busy only
 /// selects a backoff class — never a verified/known-good promotion.
+///
+/// Known divergences from the Java twin (deliberate, scope): (1) Java also
+/// flags 0x04 on a READY peer's disconnect; here a serving peer's close
+/// reason isn't plumbed through `ManagedPeer`, so its address is simply
+/// freed by `prune_closed` with no backoff. (2) The Java hunt log reports a
+/// rolling distinct-busy-peer count; the Rust hunt log doesn't (the per-dial
+/// `busy` debug field is the Rust-side signal).
 fn is_busy_disconnect(e: &str) -> bool {
     e.starts_with("peer disconnected") && e.ends_with("reason=4")
 }

--- a/rust/myotis-net/src/el/pool.rs
+++ b/rust/myotis-net/src/el/pool.rs
@@ -41,6 +41,20 @@ const BACKOFF_INCOMPATIBLE: Duration = Duration::from_secs(10 * 60);
 /// Transient failures / not-snap peers: a short cool-off (Java's
 /// `BACKOFF_TRANSIENT_MS`).
 const BACKOFF_TRANSIENT: Duration = Duration::from_secs(30);
+/// TooManyPeers (Disconnect 0x04) rejections: the peer is ALIVE, just full —
+/// retry patiently enough to halve the dial burn, often enough to keep
+/// farming freed slots (Java's `BACKOFF_BUSY_MS`).
+const BACKOFF_BUSY: Duration = Duration::from_secs(60);
+
+/// True when a dial error is a TooManyPeers rejection. The session's
+/// disconnect errors are fixed-format ("peer disconnected[ during
+/// handshake]: reason=N" — see `describe_disconnect`), so prefix+suffix
+/// matching cannot be steered by peer-controlled content. 0x04 says nothing
+/// about the peer's CHAIN (full wrong-chain nodes send it too), so busy only
+/// selects a backoff class — never a verified/known-good promotion.
+fn is_busy_disconnect(e: &str) -> bool {
+    e.starts_with("peer disconnected") && e.ends_with("reason=4")
+}
 /// How often the maintainer checks the pool and tops it back up to target
 /// (Java's `maintainSnapPeers` fixed delay).
 const MAINTAINER_INTERVAL: Duration = Duration::from_secs(10);
@@ -193,10 +207,8 @@ impl PoolInner {
         peers.len()
     }
 
-    /// Record an address backoff. `long` selects the wrong-chain (10 min) vs the
-    /// transient (30 s) window.
-    async fn record_backoff(&self, addr: SocketAddr, long: bool, now: Instant) {
-        let window = if long { BACKOFF_INCOMPATIBLE } else { BACKOFF_TRANSIENT };
+    /// Record an address backoff for `window` (one of the BACKOFF_* consts).
+    async fn record_backoff(&self, addr: SocketAddr, window: Duration, now: Instant) {
         let mut backoff = self.backoff.lock().await;
         // Entries are normally dropped when their address resurfaces as a
         // candidate, but an address that never comes back would linger forever.
@@ -228,7 +240,7 @@ impl PoolInner {
                     cache.record_connect_failure(addr);
                     cache.flush();
                 }
-                self.record_backoff(addr, false, Instant::now()).await;
+                self.record_backoff(addr, BACKOFF_TRANSIENT, Instant::now()).await;
                 self.attempted.lock().await.remove(&addr);
                 return;
             }
@@ -281,7 +293,7 @@ impl PoolInner {
                     cache.record_connect_success(addr);
                     cache.flush();
                 }
-                self.record_backoff(addr, false, now).await;
+                self.record_backoff(addr, BACKOFF_TRANSIENT, now).await;
                 self.attempted.lock().await.remove(&addr);
             }
             Err(e) => {
@@ -296,11 +308,19 @@ impl PoolInner {
                 // steered by a hostile peer.
                 let incompatible =
                     e.starts_with("incompatible peer") || e.starts_with("peer Status decode");
-                tracing::debug!(%addr, incompatible, error = %e, "el dial: failed");
+                let busy = is_busy_disconnect(&e);
+                tracing::debug!(%addr, incompatible, busy, error = %e, "el dial: failed");
                 if incompatible {
                     self.blacklist.lock().await.insert(pubkey);
                 }
-                self.record_backoff(addr, incompatible, now).await;
+                let window = if incompatible {
+                    BACKOFF_INCOMPATIBLE
+                } else if busy {
+                    BACKOFF_BUSY
+                } else {
+                    BACKOFF_TRANSIENT
+                };
+                self.record_backoff(addr, window, now).await;
                 self.attempted.lock().await.remove(&addr);
             }
         }
@@ -830,6 +850,18 @@ mod tests {
 
         pool.stop().await;
         let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn busy_disconnect_classification_is_prefix_and_suffix_bound() {
+        assert!(is_busy_disconnect("peer disconnected: reason=4"));
+        assert!(is_busy_disconnect("peer disconnected during handshake: reason=4"));
+        // Other reasons and other error shapes are NOT busy.
+        assert!(!is_busy_disconnect("peer disconnected: reason=3"));
+        assert!(!is_busy_disconnect("peer disconnected: reason=42"));
+        assert!(!is_busy_disconnect("incompatible peer: networkId=137 genesis=..."));
+        // A peer-controlled client id echoed mid-string can't fake the prefix.
+        assert!(!is_busy_disconnect("expected Status, got code 0x04 from peer disconnected: reason=4x"));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

A saturated network looks identical to a dead one: a peer rejecting us with `Disconnect(0x04 TooManyPeers)` got the same 30s transient backoff as a timeout, so busy-but-healthy nodes were re-dialed every ~40s and were indistinguishable from corpses when diagnosing why the serving pool is small (on sepolia, most long-running nodes sit at their peer limit).

## Changes

- **Java**: `EthHandler` flags `0x04` at every phase (instead-of-Hello, during Status, in READY); `PeerCloseCallback` gains a `busy` param; `ChainStack` gives busy peers a 60s backoff (halves dial burn, still farms freed slots), tracks distinct busy peers in a 10-min rolling window (hard-bounded, cleared on stop), and reports the count when the EL hunt engages — "N busy peers" = the network is full, not dead.
- **Rust twin**: fixed-format disconnect errors classify as busy (prefix+suffix bound — not steerable by peer-controlled strings, unit-tested); same 60s backoff; `record_backoff` now takes the window directly.
- **Deliberately NOT cached as known-good**: `0x04` usually arrives before Status, so the peer's *chain* is unverified — a full wrong-chain node sends it too. Busy selects a backoff class only. Documented at both classification sites.
- Hunt interplay: while hunting, a confirmed-but-busy server's backoff becomes clearable in its last 30s — intentional emergency slot-farming (documented at the bypass).

## Notes for reviewers

Stacked on #276 (touches the same dial-outcome match arms) — will retarget to main when #276 merges. An internal no-context review ran first; its findings are addressed in the second commit. Documented divergences: Rust has no READY-phase busy backoff (close reasons aren't plumbed through `ManagedPeer`) and no hunt-log busy counter. Accepted test gaps: no live-Netty test drives a real 0x04 through `EthHandler`/the callback; the Rust string classifier and Java compile-level changes are covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPnTFwmAVMypWYtoioAXQT