### PR TITLE
Peers: retry busy peers on the transient cadence while hunting

### DIFF
--- a/node-core/src/main/java/io/myotis/node/ChainStack.java
+++ b/node-core/src/main/java/io/myotis/node/ChainStack.java
@@ -82,7 +82,8 @@ public final class ChainStack {
 
     /** Backoff for peers that rejected us with TooManyPeers (0x04): alive, just
      *  full. Longer than transient (halves the dial burn on saturated networks)
-     *  but short enough to keep farming freed slots. */
+     *  but short enough to keep farming freed slots. While the EL hunt is
+     *  engaged the transient window applies instead — see {@link #busyBackoffMs}. */
     static final long BACKOFF_BUSY_MS = 60_000L;
 
     /** Distinct peers that rejected us with TooManyPeers recently (rolling
@@ -1105,10 +1106,17 @@ public final class ChainStack {
                     // clear entries within the transient window — a peer re-marked
                     // incompatible after its confirm (post-fork lag) keeps its
                     // 10-min timer instead of being re-dialed every 10s tick.
-                    // A confirmed-but-BUSY server's 60s entry enters the clearable
-                    // window once ≤30s remain — intentional: in emergency mode an
-                    // eager re-dial of a known-good, merely-full server is exactly
-                    // the slot-farming we want.
+                    // Busy entries: outside the hunt they're 60s and enter the
+                    // clearable window once ≤30s remain; DURING the hunt they're
+                    // written at 30s (busyBackoffMs) and are therefore clearable
+                    // immediately — a CONFIRMED-but-busy server gets re-dialed
+                    // roughly every maintainer tick (~10s) while the pool is
+                    // empty. Intentional, eyes open: it's bounded to the few
+                    // confirmed servers, only runs in emergency mode, and each
+                    // extra attempt is a cheap fast-refusal (geth-class nodes
+                    // throttle repeat inbound within ~30s anyway) — maximal
+                    // slot-farming pressure exactly when a freed slot is the
+                    // only way back to verified reads.
                     if (hunting && p.snapQuality() == SnapQuality.CONFIRMED) {
                         String key = p.address().getHostString() + ":" + p.address().getPort();
                         backoff.computeIfPresent(key,

--- a/node-core/src/main/java/io/myotis/node/ChainStack.java
+++ b/node-core/src/main/java/io/myotis/node/ChainStack.java
@@ -703,7 +703,7 @@ public final class ChainStack {
                             if (busy) noteBusy(key);
                             backoff.putIfAbsent(key, System.currentTimeMillis()
                                     + (incompatible ? BACKOFF_INCOMPATIBLE_MS
-                                       : busy ? BACKOFF_BUSY_MS : BACKOFF_TRANSIENT_MS));
+                                       : busy ? busyBackoffMs() : BACKOFF_TRANSIENT_MS));
                             attempted.remove(key);
                         })
                         .addListener(future -> { if (!future.isSuccess()) attempted.remove(key); });
@@ -786,7 +786,7 @@ public final class ChainStack {
                             if (incompatible) blacklistedNodeIds.add(nodeIdHex);
                             if (busy) noteBusy(peerKey);
                             long backoffMs = incompatible ? BACKOFF_INCOMPATIBLE_MS
-                                    : busy ? BACKOFF_BUSY_MS : BACKOFF_TRANSIENT_MS;
+                                    : busy ? busyBackoffMs() : BACKOFF_TRANSIENT_MS;
                             backoff.putIfAbsent(peerKey, System.currentTimeMillis() + backoffMs);
                             attempted.remove(peerKey);
                         })
@@ -816,7 +816,7 @@ public final class ChainStack {
                             if (incompatible) blacklistedNodeIds.add(nodeIdHex);
                             if (busy) noteBusy(key);
                             long backoffMs = incompatible ? BACKOFF_INCOMPATIBLE_MS
-                                    : busy ? BACKOFF_BUSY_MS : BACKOFF_TRANSIENT_MS;
+                                    : busy ? busyBackoffMs() : BACKOFF_TRANSIENT_MS;
                             backoff.putIfAbsent(key, System.currentTimeMillis() + backoffMs);
                             attempted.remove(key);
                         })
@@ -999,7 +999,7 @@ public final class ChainStack {
                         if (incompatible) blacklistedNodeIds.add(nodeIdHex);
                         if (busy) noteBusy(peerKey);
                         long backoffMs = incompatible ? BACKOFF_INCOMPATIBLE_MS
-                                    : busy ? BACKOFF_BUSY_MS : BACKOFF_TRANSIENT_MS;
+                                    : busy ? busyBackoffMs() : BACKOFF_TRANSIENT_MS;
                         backoff.putIfAbsent(peerKey, System.currentTimeMillis() + backoffMs);
                         attempted.remove(peerKey);
                     })
@@ -1260,7 +1260,7 @@ public final class ChainStack {
                 if (incompatible) blacklistedNodeIds.add(idHex);
                 if (busy) noteBusy(key);
                 long ms = incompatible ? BACKOFF_INCOMPATIBLE_MS
-                        : busy ? BACKOFF_BUSY_MS : BACKOFF_TRANSIENT_MS;
+                        : busy ? busyBackoffMs() : BACKOFF_TRANSIENT_MS;
                 backoff.putIfAbsent(key, System.currentTimeMillis() + ms);
                 attempted.remove(key);
             }).addListener(future -> {
@@ -1293,7 +1293,7 @@ public final class ChainStack {
                 if (incompatible) blacklistedNodeIds.add(idHex);
                 if (busy) noteBusy(peerKey);
                 long ms = incompatible ? BACKOFF_INCOMPATIBLE_MS
-                        : busy ? BACKOFF_BUSY_MS : BACKOFF_TRANSIENT_MS;
+                        : busy ? busyBackoffMs() : BACKOFF_TRANSIENT_MS;
                 backoff.putIfAbsent(peerKey, System.currentTimeMillis() + ms);
                 attempted.remove(peerKey);
             }).addListener(future -> {
@@ -1309,6 +1309,14 @@ public final class ChainStack {
         } catch (Exception e) {
             attempted.remove(peerKey);
         }
+    }
+
+    /** Busy peers wait {@link #BACKOFF_BUSY_MS} normally — but while the EL
+     *  hunt is engaged they retry on the transient cadence instead: when the
+     *  serving pool is empty, proven-alive-but-full nodes are the only
+     *  realistic source of a freed slot, and slots are won by fast retries. */
+    private long busyBackoffMs() {
+        return elHunting ? BACKOFF_TRANSIENT_MS : BACKOFF_BUSY_MS;
     }
 
     /** Note a TooManyPeers rejection for hunt diagnostics (bounded, rolling). */

--- a/rust/myotis-net/src/el/pool.rs
+++ b/rust/myotis-net/src/el/pool.rs
@@ -43,7 +43,8 @@ const BACKOFF_INCOMPATIBLE: Duration = Duration::from_secs(10 * 60);
 const BACKOFF_TRANSIENT: Duration = Duration::from_secs(30);
 /// TooManyPeers (Disconnect 0x04) rejections: the peer is ALIVE, just full —
 /// retry patiently enough to halve the dial burn, often enough to keep
-/// farming freed slots (Java's `BACKOFF_BUSY_MS`).
+/// farming freed slots (Java's `BACKOFF_BUSY_MS`). While the EL hunt is
+/// engaged the transient window applies instead (see the dial Err arm).
 const BACKOFF_BUSY: Duration = Duration::from_secs(60);
 
 /// True when a dial error is a TooManyPeers rejection. The session's
@@ -339,7 +340,15 @@ impl PoolInner {
                 let window = if incompatible {
                     BACKOFF_INCOMPATIBLE
                 } else if busy {
-                    BACKOFF_BUSY
+                    // While the EL hunt is engaged, busy peers retry on the
+                    // transient cadence: with the serving pool empty they are
+                    // the only realistic source of a freed slot, and slots
+                    // are won by fast retries (Java busyBackoffMs twin).
+                    if self.hunting.load(Ordering::Relaxed) {
+                        BACKOFF_TRANSIENT
+                    } else {
+                        BACKOFF_BUSY
+                    }
                 } else {
                     BACKOFF_TRANSIENT
                 };

--- a/rust/myotis-net/src/el/pool.rs
+++ b/rust/myotis-net/src/el/pool.rs
@@ -641,9 +641,14 @@ async fn maintainer_loop(inner: Arc<PoolInner>, dial_slots: Arc<Semaphore>) {
             // so the dial loop below reaches them NOW instead of after the
             // standard cool-off. Confirmed = served us chain-verified snap
             // data. Entries whose remaining window exceeds the transient
-            // length are INCOMPATIBLE (10 min) — keep those: try_dial's
-            // blacklist check would block the dial anyway, but the timer
-            // must stay honest too. Non-confirmed peers keep their timers.
+            // length are INCOMPATIBLE (10 min) or a not-yet-elapsed 60s busy
+            // entry — keep those: the timer must stay honest (and for
+            // incompatible, try_dial's blacklist would block the dial anyway).
+            // Hunt-time BUSY entries are written at the transient window, so a
+            // confirmed-but-busy server is clearable immediately and re-dials
+            // roughly every maintainer tick while the pool is empty —
+            // intentional, bounded slot-farming (Java maintainSnapPeers twin
+            // documents the same trade-off). Non-confirmed peers keep timers.
             let now = Instant::now();
             let mut backoff = inner.backoff.lock().await;
             for c in cached.iter().filter(|c| c.quality == SnapQuality::Confirmed) {


### PR DESCRIPTION
## Problem

Fresh field data (sepolia desktop log, ~05:34 today): the busy counter pegged at **256 distinct TooManyPeers rejections in 10 minutes** while the serving pool sat at zero and every Kohaku `eth_call`/`estimateGas`/`getTransactionCount` failed on a stale head. On a network that saturated, the 60s busy backoff from #278 inverts its own goal: freed slots are won by fast retries, and busy peers are the only realistic slot source once the pool is empty.

## Change

While the EL hunt is engaged, busy peers retry on the 30s transient cadence; the 60s window still applies outside the hunt. Both engines (Java `busyBackoffMs()` on the volatile `elHunting`; Rust reads the `hunting` AtomicBool in the dial Err arm).

Documented side effect (kept deliberately): hunt-time 30s busy entries fall inside the maintainer's confirmed-peer bypass window, so a CONFIRMED-but-busy server re-dials roughly every maintainer tick (~10s) while the pool is empty — bounded to the few confirmed servers, emergency-only, and each extra attempt is a cheap fast-refusal against geth-class inbound throttling. Stale comments from #278 describing the 60s-only world are corrected on both sides.

## Notes

Internal no-context review ran first; findings were the bypass interaction above (documented) and comment/doc drift (fixed). Accepted gap: no unit test pins the hunt-time window selection on either side — the selection sites are private/inline and the flag plumbing is already covered by the hunt-trigger tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPnTFwmAVMypWYtoioAXQT