### PR TITLE
ci: publish node-binding prebuilts as GitHub Release assets (checksums + ABI pin)

### DIFF
--- a/.github/workflows/node-binding.yml
+++ b/.github/workflows/node-binding.yml
@@ -1,16 +1,26 @@
 # Prebuilds for the myotis-node napi-rs binding (Electron/Node hosts).
 # Artifacts: myotis-node.<platform>-<arch>.node per matrix leg, attached to
-# the workflow run; wire into the release workflow once the binding stabilizes.
-#
-# NOTE: authored as part of the Node-binding spike; the windows leg doubles as
-# the first Windows compile check for the whole Rust workspace.
+# the workflow run — and, on `v*` tags, published as GitHub Release assets
+# together with a myotis-node.SHA256SUMS checksum file and the engine ABI
+# version pinned in the release notes (downstream loaders download pinned
+# version + checksum and gate on the ABI).
 name: node-binding
 
 on:
+  # Scope push to main + release tags, matching the other asset workflows
+  # (android-apk/desktop-dmg/desktop-linux-deb): prebuilds stay green on main,
+  # `v*` tags publish the release assets. Deliberately no paths filter — tag
+  # pushes interact badly with paths filters (a tag push may carry no diff, so
+  # the release run could be skipped entirely).
   push:
-    branches: [feat/node-binding]
-    paths: ['rust/**', '.github/workflows/node-binding.yml']
+    branches: [ "main" ]
+    tags: [ "v*" ]
   workflow_dispatch:
+
+# Cancel a superseded run when new commits land on the same branch/PR.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -62,12 +72,125 @@ jobs:
           path: ${{ matrix.artifact }}
           if-no-files-found: error
 
+  # Attach the five prebuilt addons plus a SHA-256 checksum file to the GitHub
+  # Release for the pushed tag, and pin the engine ABI version in the release
+  # notes so downstream loaders can gate on it. Runs ONLY on `v*` tags. The
+  # android/desktop workflows publish to the SAME release for the same tag;
+  # whichever job runs first creates it and the others just add their assets —
+  # the create step below tolerates that race.
+  release:
+    name: Publish addons to release
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      # gh release create/upload/edit needs write access to Releases.
+      contents: write
+    steps:
+      # Checked out (unlike the android release job) because the ABI version
+      # is read from its source of truth in myotis-engine; this also gives gh
+      # its repo context.
+      - uses: actions/checkout@v4
+      - name: Download addon artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: 'myotis-node.*.node'
+          merge-multiple: true
+          path: addons
+      - name: Write myotis-node.SHA256SUMS
+        run: |
+          set -eu
+          cd addons
+          # Glob into an array and assert exactly five addons — a missing (or
+          # stray extra) build leg should fail here, not silently ship an
+          # incomplete release.
+          shopt -s nullglob
+          addons=(myotis-node.*.node)
+          [ "${#addons[@]}" -eq 5 ] \
+            || { echo "::error::expected exactly 5 addons, found ${#addons[@]}: ${addons[*]}"; exit 1; }
+          sha256sum "${addons[@]}" > myotis-node.SHA256SUMS
+          cat myotis-node.SHA256SUMS
+      - name: Publish to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -eu
+          tag="${GITHUB_REF_NAME}"
+          # Engine ABI version from its source of truth (the crate constant,
+          # currently 19) — loaders must refuse an addon whose init() returns
+          # anything else, so the notes state it explicitly.
+          abi=$(sed -n 's/^pub const ABI_VERSION: i32 = \([0-9][0-9]*\);.*$/\1/p' \
+            rust/myotis-engine/src/lib.rs)
+          [ -n "$abi" ] || { echo "::error::could not extract ABI_VERSION"; exit 1; }
+          # The addon section for the notes. Quoted heredoc keeps the markdown
+          # literal; the __ABI__ placeholder dodges backtick substitution.
+          section=$(mktemp)
+          cat > "$section" <<'SECTION'
+          **Node.js addon (`myotis-node.<platform>-<arch>.node`)** — prebuilt napi-rs
+          binding for Electron/Node hosts (linux-x64-gnu, linux-arm64-gnu, darwin-x64,
+          darwin-arm64, win32-x64-msvc). Verify downloads against
+          `myotis-node.SHA256SUMS`. Engine ABI version: **__ABI__** — loaders must
+          gate on `init()` returning exactly __ABI__.
+          SECTION
+          sed -i "s/__ABI__/$abi/g" "$section"
+          # Master notes for the case where THIS job creates the release (same
+          # text the android/desktop workflows carry), plus the addon section.
+          notes=$(mktemp)
+          cat > "$notes" <<'NOTES'
+          Pre-release build of the Myotis wallet apps.
+
+          **Android (`*-android-debug.apk`)** — unsigned *debug* build. Install via
+          "Install unknown apps". Not a signed release build.
+
+          **Desktop macOS (`Myotis-<arch>.dmg`)** — unsigned; download the dmg matching
+          your Mac (arm64 for Apple Silicon, x64 for Intel). First launch:
+          right-click → Open to get past Gatekeeper (not notarized yet).
+
+          **Desktop Linux (`Myotis-<arch>.deb`)** — install with
+          `sudo apt install ./Myotis-<arch>.deb` (x64 for Intel/AMD, arm64 for
+          Raspberry Pi 5 / ARM machines).
+          NOTES
+          printf '\n' >> "$notes"
+          cat "$section" >> "$notes"
+          # Create the release if it doesn't exist yet. Another workflow may
+          # win this race for the same tag: if `create` fails, re-check with
+          # `view` — success there means the other job already created it
+          # (fine), while a genuine failure still surfaces because `view` also
+          # fails.
+          if ! gh release view "$tag" >/dev/null 2>&1; then
+            gh release create "$tag" \
+              --prerelease \
+              --title "Myotis $tag" \
+              --notes-file "$notes" \
+              --target "${GITHUB_SHA}" \
+            || gh release view "$tag" >/dev/null 2>&1
+          fi
+          # Whether we created the release or another workflow did: make sure
+          # the notes carry the addon/ABI section exactly once (idempotent
+          # across re-runs, appends when the android/desktop notes won the
+          # create race).
+          body=$(mktemp)
+          gh release view "$tag" --json body --jq .body > "$body"
+          if ! grep -q 'Node.js addon' "$body"; then
+            printf '\n' >> "$body"
+            cat "$section" >> "$body"
+            gh release edit "$tag" --notes-file "$body"
+          fi
+          gh release upload "$tag" \
+            addons/myotis-node.*.node addons/myotis-node.SHA256SUMS --clobber
+
   # Control experiment for the Windows smoke: same mainnet smoke on a Linux
   # runner. First Windows attempt discovered 160 peers over UDP but held ZERO
   # TCP/libp2p connections in 55 min — this job disambiguates "Windows socket
   # problem in the engine" from "Ethereum peers deprioritize/ban datacenter
   # (Azure) IPs": if Linux-on-Azure also gets no peers, it's the environment.
+  #
+  # Both smoke jobs are manual-only (workflow_dispatch): a 100-minute
+  # live-network job is too heavy for every main push, its outcome depends on
+  # whether Ethereum peers accept connections from Azure datacenter IPs, and
+  # releases must never gate on it (the release job needs only `build`).
   smoke-linux:
+    if: github.event_name == 'workflow_dispatch'
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 100
@@ -82,21 +205,21 @@ jobs:
           path: myotis-data
           key: myotis-smoke-data-linux-${{ github.run_id }}
           restore-keys: myotis-smoke-data-linux-
-      - name: Ensure data dir exists
-        run: mkdir -p "${{ github.workspace }}/myotis-data"
       - name: Smoke — sync mainnet + verified reads
         working-directory: rust/myotis-node
         env:
           MYOTIS_SMOKE_TIMEOUT_MIN: '55'
         run: node smoke.mjs "${{ github.workspace }}/myotis-data" "${{ github.workspace }}/myotis-node.linux-x64-gnu.node"
 
-  # Full runtime validation on Windows: unit-test the workspace, then run the
-  # real smoke — sync mainnet over devp2p/libp2p from the runner, reach
-  # SYNCED, and serve verified reads (ENS, contenthash, account proof)
-  # through the .node addon. The sync snapshot is cached across runs, so the
-  # first run pays the cold checkpoint catch-up (~30-40 min) and later runs
-  # warm-restart in seconds.
+  # Full runtime validation on Windows: unit-test the workspace (green since
+  # the .gitattributes LF pin for the golden vectors), then run the real smoke
+  # — sync mainnet over devp2p/libp2p from the runner, reach SYNCED, and serve
+  # verified reads (ENS, contenthash, account proof) through the .node addon.
+  # The sync snapshot is cached across runs, so the first successful run pays
+  # the cold checkpoint catch-up (~30-40 min) and later runs warm-restart in
+  # seconds. Manual-only — see the smoke-linux comment.
   smoke-windows:
+    if: github.event_name == 'workflow_dispatch'
     needs: build
     runs-on: windows-latest
     timeout-minutes: 100
@@ -106,7 +229,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: rust
-      - name: Unit tests (whole workspace, first run on Windows)
+      - name: Unit tests (whole workspace)
         working-directory: rust
         run: cargo test --workspace
       - uses: actions/download-artifact@v4
@@ -118,11 +241,6 @@ jobs:
           path: myotis-data
           key: myotis-smoke-data-win-${{ github.run_id }}
           restore-keys: myotis-smoke-data-win-
-      - name: Ensure data dir exists
-        # The engine does not create data_dir itself yet (fix pending in a
-        # separate PR); without this, sync works but persistence — and this
-        # job's snapshot cache — silently no-ops.
-        run: New-Item -ItemType Directory -Force -Path "${{ github.workspace }}\myotis-data" | Out-Null
       - name: Smoke — sync mainnet + verified reads
         working-directory: rust/myotis-node
         env:

--- a/.github/workflows/node-binding.yml
+++ b/.github/workflows/node-binding.yml
@@ -9,17 +9,22 @@ name: node-binding
 on:
   # Scope push to main + release tags, matching the other asset workflows
   # (android-apk/desktop-dmg/desktop-linux-deb): prebuilds stay green on main,
-  # `v*` tags publish the release assets. Deliberately no paths filter — tag
-  # pushes interact badly with paths filters (a tag push may carry no diff, so
-  # the release run could be skipped entirely).
+  # `v*` tags publish the release assets. The paths filter only trims branch
+  # pushes — GitHub does not evaluate paths filters for tag pushes, so `v*`
+  # release runs always fire regardless of what the tagged commit touched.
   push:
     branches: [ "main" ]
     tags: [ "v*" ]
+    paths: ['rust/**', '.github/workflows/node-binding.yml']
   workflow_dispatch:
 
-# Cancel a superseded run when new commits land on the same branch/PR.
+# Cancel a superseded run when new commits land on the same branch/PR. The
+# event name is part of the group so a push to main can never cancel an
+# in-flight dispatched smoke run (or a dispatch cancel a tag's release run) —
+# unlike the sibling workflows, this one has a workflow_dispatch trigger
+# sharing refs with push runs.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -71,6 +76,9 @@ jobs:
           name: ${{ matrix.artifact }}
           path: ${{ matrix.artifact }}
           if-no-files-found: error
+          # Artifacts are immutable per run; without this, "re-run all jobs"
+          # on a tag 409s in every build leg and the release job never runs.
+          overwrite: true
 
   # Attach the five prebuilt addons plus a SHA-256 checksum file to the GitHub
   # Release for the pushed tag, and pin the engine ABI version in the release
@@ -116,9 +124,9 @@ jobs:
         run: |
           set -eu
           tag="${GITHUB_REF_NAME}"
-          # Engine ABI version from its source of truth (the crate constant,
-          # currently 19) — loaders must refuse an addon whose init() returns
-          # anything else, so the notes state it explicitly.
+          # Engine ABI version from its source of truth (the crate constant) —
+          # loaders must refuse an addon whose init() returns anything else,
+          # so the notes state it explicitly.
           abi=$(sed -n 's/^pub const ABI_VERSION: i32 = \([0-9][0-9]*\);.*$/\1/p' \
             rust/myotis-engine/src/lib.rs)
           [ -n "$abi" ] || { echo "::error::could not extract ABI_VERSION"; exit 1; }

--- a/.github/workflows/node-binding.yml
+++ b/.github/workflows/node-binding.yml
@@ -57,6 +57,8 @@ jobs:
             artifact: myotis-node.win32-x64-msvc.node
             built: rust/target/x86_64-pc-windows-msvc/release/myotis_node.dll
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -89,6 +91,11 @@ jobs:
   release:
     name: Publish addons to release
     needs: build
+    # Deliberately gated on the REF, not the event: a workflow_dispatch
+    # targeting a tag ref (gh workflow run node-binding.yml --ref vX.Y.Z) is
+    # the manual republish path — the job is idempotent (--clobber uploads,
+    # marker-guarded notes append), and the smoke jobs below exclude tag refs
+    # so a republish never drags the 100-minute smokes along.
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
@@ -198,8 +205,12 @@ jobs:
   # whether Ethereum peers accept connections from Azure datacenter IPs, and
   # releases must never gate on it (the release job needs only `build`).
   smoke-linux:
-    if: github.event_name == 'workflow_dispatch'
+    # Tag refs excluded: dispatching on a tag is the release-republish path
+    # and must not launch the smokes alongside it.
+    if: github.event_name == 'workflow_dispatch' && !startsWith(github.ref, 'refs/tags/')
     needs: build
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 100
     steps:
@@ -227,8 +238,11 @@ jobs:
   # the cold checkpoint catch-up (~30-40 min) and later runs warm-restart in
   # seconds. Manual-only — see the smoke-linux comment.
   smoke-windows:
-    if: github.event_name == 'workflow_dispatch'
+    # Tag refs excluded — see smoke-linux.
+    if: github.event_name == 'workflow_dispatch' && !startsWith(github.ref, 'refs/tags/')
     needs: build
+    permissions:
+      contents: read
     runs-on: windows-latest
     timeout-minutes: 100
     steps:

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -17,8 +17,9 @@ merge blockers; each should either be fixed or consciously dropped.
     the picture entirely.
 
 - [x] **`node-binding.yml` goes dead on merge.** Done: push trigger retargeted
-  to `main` + `v*` tags (no paths filter — tag pushes and paths filters
-  interact badly), and a release job now publishes the five addons plus
+  to `main` + `v*` tags, keeping the `rust/**` paths filter for branch pushes
+  (GitHub doesn't evaluate paths filters on tag pushes, so release runs
+  always fire), and a release job now publishes the five addons plus
   `myotis-node.SHA256SUMS` to the tag's GitHub Release with the engine ABI
   version pinned in the notes.
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -16,11 +16,11 @@ merge blockers; each should either be fixed or consciously dropped.
     complete via a napi threadsafe function, taking the libuv pool out of
     the picture entirely.
 
-- [ ] **`node-binding.yml` goes dead on merge.** The workflow triggers on
-  `push: branches: [feat/node-binding]` — after the PR merges only
-  `workflow_dispatch` remains. If the prebuilds should keep running, retarget
-  the trigger to `main` with the same `rust/**` paths filter (or add a
-  `pull_request` trigger).
+- [x] **`node-binding.yml` goes dead on merge.** Done: push trigger retargeted
+  to `main` + `v*` tags (no paths filter — tag pushes and paths filters
+  interact badly), and a release job now publishes the five addons plus
+  `myotis-node.SHA256SUMS` to the tag's GitHub Release with the engine ABI
+  version pinned in the notes.
 
 - [ ] **`panic = "abort"` now aborts a browser.** Workspace-wide release
   profile choice (`rust/Cargo.toml`), same exposure as the JNI seam — but the
@@ -29,12 +29,14 @@ merge blockers; each should either be fixed or consciously dropped.
   "panic-free by construction" discipline in `host.rs` is carrying more
   weight now.
 
-- [ ] **`smoke-windows` is network-flaky by construction.** Live devp2p/libp2p
-  sync from a GitHub runner; `actions/cache` saves only on job success, so
-  until one run reaches SYNCED within the 55-min budget every run repeats the
-  ~30–40 min cold catch-up — and the 100-min job timeout also covers the
-  first-ever `cargo test --workspace` on Windows plus the build. Keep it a
-  non-required canary and expect to tune the budgets.
+- [x] **`smoke-windows` is network-flaky by construction.** Resolved as
+  predicted: `cargo test --workspace` is green on Windows (after the
+  `.gitattributes` LF pin for the golden vectors), but the smoke discovers
+  peers over UDP yet holds no TCP/libp2p connections — possibly Windows,
+  possibly Ethereum peers deprioritizing Azure datacenter IPs (a Linux
+  control job disambiguates; real-Windows-box validation pending downstream).
+  Both smoke jobs are now manual-only (`workflow_dispatch`) and releases
+  never gate on them.
 
 - [ ] **Pin the flat-vs-nested verification-field divergence.** The Rust
   engine's account JSON carries `beaconChainVerified`/`blsVerified`/
@@ -45,25 +47,18 @@ merge blockers; each should either be fixed or consciously dropped.
 
 ## Interplay #261 ↔ #262
 
-- [ ] **Sweep the stale "data_dir must exist" notes** once PR #262 (engine
-  creates `data_dir` in `host::create`) lands. Three spots in #261 document
-  the old behavior: the README "data_dir must exist" note, the usage
-  comment (`// dir must exist`), and the workflow's "Ensure data dir exists"
-  step. Whichever PR merges second sweeps them; if #262 goes first, #261 can
-  drop the workflow workaround step entirely.
+- [x] **Sweep the stale "data_dir must exist" notes** once PR #262 (engine
+  creates `data_dir` in `host::create`) lands. Done: the README usage comment
+  and the workflow's "Ensure data dir exists" steps are gone (the README
+  Notes bullet had already been dropped at merge time).
 
 ## From PR #262 — data_dir creation
 
 Asked of the author in review; tracked here in case they don't land there.
 
-- [ ] **Stale `create()` doc contract.** The doc comment on
-  `rust/myotis-engine/src/host.rs` `create()` lists `CREATE_FAILED` causes as
-  "unknown name / unavailable runtime" — an uncreatable dataDir is now a
-  third cause and belongs in the list.
+- [x] **Stale `create()` doc contract.** Landed with #262: the doc comment now
+  lists "an unknown name, an unavailable runtime, or an uncreatable dataDir".
 
-- [ ] **Misleading Java-side error message.** `RustMyotisEngine.java` maps
-  every `id < 0` to "the Rust engine could not initialize the runtime for
-  <network>", which points debugging in the wrong direction when the actual
-  cause is an uncreatable dataDir (the Rust warn log is then the only clue).
-  Broaden the message ("… or create the dataDir for …") or introduce a
-  distinct sentinel.
+- [x] **Misleading Java-side error message.** Landed with #262:
+  `RustMyotisEngine.java` now throws "could not initialize the runtime or
+  create the dataDir for <network>".

--- a/rust/myotis-node/README.md
+++ b/rust/myotis-node/README.md
@@ -24,7 +24,7 @@ cp ../target/release/libmyotis_node.so myotis-node.node   # .dylib on macOS, .dl
 const myotis = require('./myotis-node.node');
 
 myotis.init();                                   // must return 19 (ABI handshake)
-const h = myotis.create('mainnet', '/path/to/data-dir');  // dir must exist
+const h = myotis.create('mainnet', '/path/to/data-dir');  // dir is created if missing
 myotis.start(h);
 
 // Lifecycle + status are cheap and synchronous:

--- a/rust/myotis-node/README.md
+++ b/rust/myotis-node/README.md
@@ -23,7 +23,9 @@ cp ../target/release/libmyotis_node.so myotis-node.node   # .dylib on macOS, .dl
 ```js
 const myotis = require('./myotis-node.node');
 
-myotis.init();                                   // must return 19 (ABI handshake)
+myotis.init();   // ABI handshake — returns the engine ABI version; gate on
+                 // the value pinned in the notes of the release you built or
+                 // downloaded against
 const h = myotis.create('mainnet', '/path/to/data-dir');  // dir is created if missing
 myotis.start(h);
 

--- a/rust/myotis-node/smoke.mjs
+++ b/rust/myotis-node/smoke.mjs
@@ -17,9 +17,13 @@ const t0 = Date.now();
 const elapsed = () => ((Date.now() - t0) / 1000).toFixed(1) + 's';
 const log = (...a) => console.log(`[${elapsed()}]`, ...a);
 
+// The addon is built from this same tree, so init() always returns the
+// current crate ABI_VERSION — assert it's sane and log it. Hosts loading
+// PREBUILT addons instead gate on the exact value pinned in the release
+// notes of the release they downloaded from.
 const abi = m.init();
-if (abi !== 19) {
-  console.error(`ABI mismatch: engine ${abi}, binding written against 19`);
+if (!Number.isInteger(abi) || abi < 19) {
+  console.error(`unexpected engine ABI: ${abi}`);
   process.exit(1);
 }
 log('abi ok:', abi);

--- a/rust/myotis-node/src/lib.rs
+++ b/rust/myotis-node/src/lib.rs
@@ -29,9 +29,10 @@ use napi::bindgen_prelude::AsyncTask;
 use napi::{Env, Result, Task};
 use napi_derive::napi;
 
-// The C ABI of myotis-engine (capi.rs / rust/include/myotis_engine.h, written
-// against ABI version 19), called by Rust path — linking the rlib does not
-// reliably resolve `extern "C"` imports of its no_mangle symbols.
+// The C ABI of myotis-engine (capi.rs / rust/include/myotis_engine.h; the
+// addon is built from the same tree, so init() reports the tree's current
+// ABI_VERSION), called by Rust path — linking the rlib does not reliably
+// resolve `extern "C"` imports of its no_mangle symbols.
 use myotis_engine::capi::{
     myotis_available_networks_json, myotis_canonical_network_name, myotis_create,
     myotis_drain_logs, myotis_ens_record_json, myotis_estimate_gas_json, myotis_eth_call_json,


### PR DESCRIPTION
Wires the node-binding prebuilds into the release flow, as discussed for the Electron/desktop consumers: every `v*` release now carries the five addons under their exact matrix names, a checksum file, and the engine ABI version pinned in the notes.

## What's in here

**Release publishing (`.github/workflows/node-binding.yml`):**
- Push trigger retargeted from the merged-away `feat/node-binding` branch to `main` + `v*` tags, keeping the `rust/**` paths filter for branch pushes (GitHub doesn't evaluate paths filters on tag pushes, so release runs always fire).
- New `release` job on `v*` tags, mirroring the android-apk release job: downloads the five matrix artifacts, asserts **exactly five** (an incomplete matrix fails instead of shipping a partial release), writes `myotis-node.SHA256SUMS` (standard `sha256sum` format), uploads all six files with `--clobber`, and pins the engine ABI version in the release notes — read dynamically from `ABI_VERSION` in `myotis-engine` (now **21**, not the 19 the binding shipped against). Tolerates the existing create race with the android/desktop release jobs and appends the addon section idempotently when another workflow's notes won.
- Concurrency group includes the event name so a push to main can never cancel an in-flight dispatched smoke run, nor a dispatch cancel a tag's release run mid-publish.
- `overwrite: true` on the artifact upload so "re-run all jobs" on a tag doesn't 409 and skip the release.

**Smoke jobs:** now manual-only (`workflow_dispatch`) — a 100-minute live-network job is too heavy for every main push, its outcome depends on whether Ethereum peers accept Azure datacenter IPs (Linux control job vs. Windows still under investigation), and releases must never gate on it. Also unpinned the hard-coded ABI 19 in `smoke.mjs` — the engine is at 21, so both smoke jobs died at startup before touching the network; the smoke now asserts sanity and logs the version, while prebuilt-addon hosts gate on the release-notes value.

**Sweeps:** the stale `data_dir` workarounds are gone (engine creates it since #262): both "Ensure data dir exists" steps and the README `// dir must exist` comment. `docs/TODO.md` ticks the resolved items (trigger, smoke-windows, data_dir sweep, and the two #262 follow-ups that landed upstream).

## Validation

- YAML parse + `bash -n` on the extracted release scripts; heredoc terminators verified flush after block-scalar indent stripping.
- ABI extraction dry-run against `lib.rs` prints 21; checksum + notes-append logic dry-run locally.
- Internally reviewed (adversarial pass over Actions semantics, shell, and factual claims); all four findings addressed in the second commit.
- The real end-to-end test is the next `v*` tag — the release job is deliberately not required for merge.

**Note for downstream (Freedom Browser):** the loader was written against ABI 19; current main is 21. Gate on the value in the release notes rather than a hard-coded 19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nnbMgMjoFgDhENhf7HnXZ