### PR TITLE
chore: bump versions to 0.1.3 for the next pre-release

### DIFF
--- a/android-app/build.gradle.kts
+++ b/android-app/build.gradle.kts
@@ -89,8 +89,8 @@ android {
         applicationId = "com.jaeckel.ethp2p.android"
         minSdk = 29
         targetSdk = 34
-        versionCode = 3
-        versionName = "0.1.2"
+        versionCode = 4
+        versionName = "0.1.3"
         buildConfigField("String", "RPC_UPSTREAM", "\"$rpcUpstream\"")
     }
 

--- a/app-desktop/build.gradle.kts
+++ b/app-desktop/build.gradle.kts
@@ -193,7 +193,7 @@ compose.desktop {
             linux {
                 // Unlike the dmg (jpackage requires major > 0 on macOS), deb versions may
                 // start at 0 — so Linux carries the app's honest version.
-                packageVersion = "0.1.2"
+                packageVersion = "0.1.3"
                 debMaintainer = "dirk@jaeckel.com"
             }
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ plugins {
 
 allprojects {
     group = "com.jaeckel.ethp2p"
-    version = "0.1.2-SNAPSHOT"
+    version = "0.1.3-SNAPSHOT"
 }
 
 subprojects {

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/messages/HelloMessage.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/messages/HelloMessage.java
@@ -39,7 +39,7 @@ public final class HelloMessage {
             // Keep in sync with the Rust engine's Hello client id
             // (rust/myotis-net/src/el/rlpx/transport.rs) — dedicated
             // myotis-serving nodes admit peers by matching "myotis" here.
-            writer.writeString("myotis/0.1.2");
+            writer.writeString("myotis/0.1.3");
             writer.writeList(capWriter -> {
                 // Capabilities must be ascending (name, then version). eth/66 is the
                 // floor: it has request-IDs (which our GetBlockHeaders/snap requests

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4084,7 +4084,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-bls"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "blst",
  "jni",
@@ -4092,7 +4092,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-consensus"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "myotis-bls",
  "sha2",
@@ -4100,7 +4100,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-core"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "k256",
  "sha3 0.10.9",
@@ -4108,7 +4108,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-engine"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "myotis-consensus",
  "myotis-core",
@@ -4124,7 +4124,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-evm"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "myotis-core",
  "revm",
@@ -4132,7 +4132,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-net"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "aes",
  "arti-client",
@@ -4160,7 +4160,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-node"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "myotis-engine",
  "napi",

--- a/rust/myotis-bls/Cargo.lock
+++ b/rust/myotis-bls/Cargo.lock
@@ -134,7 +134,7 @@ checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "myotis-bls"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "blst",
  "jni",

--- a/rust/myotis-bls/Cargo.toml
+++ b/rust/myotis-bls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "myotis-bls"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "Native BLS12-381 fast-aggregate-verify (blst) behind a JNI shim for Myotis"
 license = "MIT OR Apache-2.0"

--- a/rust/myotis-consensus/Cargo.toml
+++ b/rust/myotis-consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "myotis-consensus"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "Myotis sync-committee light client (pure Rust; grows through the Rust-engine PRs)"
 license = "MIT OR Apache-2.0"

--- a/rust/myotis-core/Cargo.toml
+++ b/rust/myotis-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "myotis-core"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "Myotis execution-layer primitives: keccak-256, RLP, secp256k1 identity, BlockHeader, ENR (sans-I/O; grows through the EL-phase PRs)"
 license = "MIT OR Apache-2.0"

--- a/rust/myotis-engine/Cargo.toml
+++ b/rust/myotis-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "myotis-engine"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "Rust implementation of the io.myotis.api engine contract (JNI cdylib)"
 license = "MIT OR Apache-2.0"

--- a/rust/myotis-evm/Cargo.toml
+++ b/rust/myotis-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "myotis-evm"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "Myotis EVM: view-call / gas-estimation over SNAP-proof-verified state (revm behind a SnapStateOracle trait; sans-I/O). Grows through the EL-phase Milestone-C PRs (docs/reimplementation/07)."
 license = "MIT OR Apache-2.0"

--- a/rust/myotis-net/Cargo.toml
+++ b/rust/myotis-net/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "myotis-net"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "Myotis consensus-layer networking: discv5 discovery + libp2p eth2 req/resp + the light-client sync loop (ALL I/O lives here; myotis-consensus stays sans-I/O)"
 license = "MIT OR Apache-2.0"

--- a/rust/myotis-net/src/el/rlpx/transport.rs
+++ b/rust/myotis-net/src/el/rlpx/transport.rs
@@ -320,7 +320,7 @@ pub fn encode_hello(node_pubkey: &[u8; 64], listen_port: u16) -> Vec<u8> {
     };
     rlp::encode(&Item::List(vec![
         Item::Bytes(rlp::u64_to_minimal_be(5)), // protocol version
-        Item::Bytes(b"myotis/0.1.2".to_vec()),
+        Item::Bytes(b"myotis/0.1.3".to_vec()),
         Item::List(vec![
             cap("eth", 66),
             cap("eth", 67),
@@ -392,7 +392,7 @@ mod tests {
         let body = encode_hello(&pubkey, 30303);
         let hello = decode_hello(&body).unwrap();
         assert_eq!(hello.protocol_version, 5);
-        assert_eq!(hello.client_id, "myotis/0.1.2");
+        assert_eq!(hello.client_id, "myotis/0.1.3");
         assert_eq!(hello.listen_port, 30303);
         assert_eq!(hello.node_id, pubkey.to_vec());
         assert_eq!(hello.capabilities.len(), 5);

--- a/rust/myotis-net/src/reqresp.rs
+++ b/rust/myotis-net/src/reqresp.rs
@@ -270,7 +270,7 @@ impl Behaviour {
             ),
             identify: identify::Behaviour::new(
                 identify::Config::new("eth2/1.0.0".into(), local_public_key)
-                    .with_agent_version("myotis/0.1.2-rs".into()),
+                    .with_agent_version("myotis/0.1.3-rs".into()),
             ),
             status_v2: rr(protocols::STATUS_V2, ProtocolSupport::Full, RESP_TIMEOUT),
             status_v1: rr(protocols::STATUS_V1, ProtocolSupport::Full, RESP_TIMEOUT),

--- a/rust/myotis-node/Cargo.toml
+++ b/rust/myotis-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "myotis-node"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "Node.js (napi-rs) binding over the myotis-engine C ABI — for Electron/Node hosts"
 license = "MIT OR Apache-2.0"

--- a/rust/tor-poc/Cargo.lock
+++ b/rust/tor-poc/Cargo.lock
@@ -3848,14 +3848,14 @@ dependencies = [
 
 [[package]]
 name = "myotis-bls"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "blst",
 ]
 
 [[package]]
 name = "myotis-consensus"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "myotis-bls",
  "sha2",
@@ -3863,7 +3863,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-core"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "k256",
  "sha3 0.10.9",
@@ -3871,7 +3871,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-evm"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "myotis-core",
  "revm",
@@ -3879,7 +3879,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-net"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "aes",
  "async-trait",


### PR DESCRIPTION
Release prep for the **v0.1.3** pre-release, same sweep as the v0.1.2 prep (#223):

- Root Gradle `version` → `0.1.3-SNAPSHOT`
- Android `versionCode` 3 → 4, `versionName` → `0.1.3`
- Desktop `packageVersion` → `0.1.3`
- devp2p Hello client id → `myotis/0.1.3` on both sides (Java `HelloMessage` + Rust `transport.rs`, which are documented to stay in sync), libp2p agent → `myotis/0.1.3-rs`
- All seven workspace crates → `0.1.3`, `rust/Cargo.lock` regenerated, the vestigial `rust/myotis-bls/Cargo.lock` synced

**Deliberately not re-committed:** the Android jniLibs. Since #211 the APK release workflow builds them from source (and fails loudly if it can't), so the committed copies are only the no-cargo local fallback — their embedded `myotis/0.1.2` client id never reaches a release artifact.

Validation: `cargo test -p myotis-net` (covers the client-id assertion and the EL conformance vectors) and `./gradlew :networking:test` both green locally.

Once this is merged I'll tag the merge commit `v0.1.3`, which fires all four release workflows (APK, dmgs, debs, and — for the first time end-to-end — the node-binding addons + `SHA256SUMS` + ABI pin from #282).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nnbMgMjoFgDhENhf7HnXZ

---
_Generated by [Claude Code](https://claude.ai/code/session_012nnbMgMjoFgDhENhf7HnXZ)_