### PR TITLE
Hide the Index tab unless the Kohaku log index is enabled in Settings

### DIFF
--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
@@ -110,10 +110,25 @@ fun NodeScreen(
     val snapshots by snapshotsFlow.collectAsState(initial = emptyMap())
     val onlineFlow = remember(netStatus) { netStatus.online() }
     val online by onlineFlow.collectAsState(initial = true)
-    var tab by remember { mutableStateOf(0) }
-    // Logs-tab text filter, hoisted HERE deliberately: the `when (tab)` below disposes a
+    // The Index tab only exists while the Kohaku log index reads as enabled in Settings —
+    // which is what its switch displays: the persisted per-network flags AND the Rust
+    // engine (without it the switch shows off/disabled and no engine serves the index).
+    // Both are plain settings reads, so the toggles that change them bump logIndexRev.
+    var logIndexRev by remember { mutableStateOf(0) }
+    val showIndexTab = remember(logIndexRev) {
+        settings.rustEngineEnabled() && KohakuPreset.byNetwork.keys.any { settings.logIndexEnabled(it) }
+    }
+    val tabs = remember(showIndexTab) {
+        if (showIndexTab) listOf("Status", "Query", "Logs", "Index", "Settings")
+        else listOf("Status", "Query", "Logs", "Settings")
+    }
+    // Selection is the tab's LABEL, not its position — positions shift when Index
+    // appears/disappears. A selection whose tab just vanished falls back to Status.
+    var tabLabel by remember { mutableStateOf("Status") }
+    val tab = tabs.indexOf(tabLabel).coerceAtLeast(0)
+    // Logs-tab text filter, hoisted HERE deliberately: the `when` below disposes a
     // tab's composition on switch, so any `remember` inside LogsTab dies with it. Living
-    // beside `tab` gives the filter the same lifetime as the tab selection itself (the
+    // beside `tabLabel` gives the filter the same lifetime as the tab selection itself (the
     // level filter needs no hoisting — it write-throughs to logs.setLevel and is re-read).
     var logFilter by remember { mutableStateOf("") }
 
@@ -159,20 +174,20 @@ fun NodeScreen(
                 Spacer(Modifier.height(12.dp))
 
                 TabRow(selectedTabIndex = tab) {
-                    Tab(selected = tab == 0, onClick = { tab = 0 }, text = { Text("Status") })
-                    Tab(selected = tab == 1, onClick = { tab = 1 }, text = { Text("Query") })
-                    Tab(selected = tab == 2, onClick = { tab = 2 }, text = { Text("Logs") })
-                    Tab(selected = tab == 3, onClick = { tab = 3 }, text = { Text("Index") })
-                    Tab(selected = tab == 4, onClick = { tab = 4 }, text = { Text("Settings") })
+                    tabs.forEachIndexed { i, label ->
+                        Tab(selected = tab == i, onClick = { tabLabel = label }, text = { Text(label) })
+                    }
                 }
                 Spacer(Modifier.height(16.dp))
 
-                when (tab) {
-                    0 -> StatusTab(controller, settings, current, network, online, onOpenNetworkSettings)
-                    1 -> QueryTab(controller, settings, current, network, history)
-                    2 -> LogsTab(logs, logFilter, onFilterChange = { logFilter = it })
-                    3 -> IndexTab(controller, settings, current, network)
-                    4 -> SettingsTab(controller, settings, snapshots, onEnabledChanged = { enabledRev++ })
+                when (tabs[tab]) {
+                    "Status" -> StatusTab(controller, settings, current, network, online, onOpenNetworkSettings)
+                    "Query" -> QueryTab(controller, settings, current, network, history)
+                    "Logs" -> LogsTab(logs, logFilter, onFilterChange = { logFilter = it })
+                    "Index" -> IndexTab(controller, settings, current, network,
+                        onLogIndexChanged = { logIndexRev++ })
+                    "Settings" -> SettingsTab(controller, settings, snapshots,
+                        onEnabledChanged = { enabledRev++ }, onLogIndexChanged = { logIndexRev++ })
                 }
             }
         }
@@ -270,6 +285,10 @@ private fun SettingsTab(
     // Notifies the screen that the persisted enabled set changed, so the network
     // chips (derived from settings, not snapshot state) re-derive immediately.
     onEnabledChanged: () -> Unit = {},
+    // Notifies the screen that the Kohaku log-index effective state changed (the
+    // per-network flags or the Rust engine it depends on), so the Index tab's
+    // visibility re-derives immediately.
+    onLogIndexChanged: () -> Unit = {},
 ) {
     val networks = remember { settings.allNetworks() }
     // Per-network enabled toggle + RPC-port text, seeded from persisted settings. Toggling a
@@ -432,7 +451,10 @@ private fun SettingsTab(
         SwitchRow(
             label = "Rust engine (experimental)",
             checked = rustEngine,
-            onChange = { on -> rustEngine = on; settings.setRustEngineEnabled(on); controller.applyEngineChoice() },
+            onChange = { on ->
+                rustEngine = on; settings.setRustEngineEnabled(on); controller.applyEngineChoice()
+                onLogIndexChanged()
+            },
         )
         Text(
             "Off (default): the proven Java engine runs every network. On: prefer the " +
@@ -458,6 +480,7 @@ private fun SettingsTab(
                     settings.setLogIndexEnabled(net, on)
                     controller.applyLogIndex(net)
                 }
+                onLogIndexChanged()
             },
         )
         // Tor routing — Rust-engine-only (Arti is embedded there), so the row is disabled
@@ -1622,6 +1645,9 @@ private fun IndexTab(
     settings: Settings,
     snapshot: NodeSnapshot?,
     network: String,
+    // Turning collection off for the last enabled network hides this tab (the screen
+    // falls back to Status), so the screen needs to hear about flag changes.
+    onLogIndexChanged: () -> Unit = {},
 ) {
     val preset = KohakuPreset.byNetwork[network]
     Column(
@@ -1641,6 +1667,7 @@ private fun IndexTab(
                 collecting = on
                 settings.setLogIndexEnabled(network, on)
                 controller.applyLogIndex(network)
+                onLogIndexChanged()
             },
         )
         Text(

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
@@ -126,6 +126,11 @@ fun NodeScreen(
     // appears/disappears. A selection whose tab just vanished falls back to Status.
     var tabLabel by remember { mutableStateOf("Status") }
     val tab = tabs.indexOf(tabLabel).coerceAtLeast(0)
+    // The fallback also RESETS the stale label: without this, a selection stuck on a
+    // vanished tab would silently jump back to it if a future change ever flipped the
+    // visibility inputs without a tab click in between (today every re-show path goes
+    // through a click on another tab, but nothing should rest on that).
+    LaunchedEffect(tabs) { if (tabLabel !in tabs) tabLabel = "Status" }
     // Logs-tab text filter, hoisted HERE deliberately: the `when` below disposes a
     // tab's composition on switch, so any `remember` inside LogsTab dies with it. Living
     // beside `tabLabel` gives the filter the same lifetime as the tab selection itself (the

--- a/ui/src/desktopTest/kotlin/io/myotis/ui/IndexTabVisibilityTest.kt
+++ b/ui/src/desktopTest/kotlin/io/myotis/ui/IndexTabVisibilityTest.kt
@@ -1,0 +1,111 @@
+package io.myotis.ui
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isSelectable
+import androidx.compose.ui.test.isToggleable
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Pins the Index tab's visibility rule: the tab exists only while the Kohaku log
+ * index reads as enabled in Settings — the persisted per-network flags AND the
+ * Rust engine (without it the Settings switch shows off/disabled and no engine
+ * serves the index) — and reacts live to the toggles that change either.
+ */
+class IndexTabVisibilityTest {
+
+    @get:Rule
+    val rule = createComposeRule()
+
+    /** [FakeSettings] with the two knobs the visibility rule reads made real. */
+    private class IndexSettings(
+        private var rust: Boolean,
+        kohakuOn: Set<String> = emptySet(),
+    ) : Settings by FakeSettings() {
+        private val logIndex = kohakuOn.associateWith { true }.toMutableMap()
+        override fun rustEngineEnabled(): Boolean = rust
+        override fun setRustEngineEnabled(v: Boolean) { rust = v }
+        override fun logIndexEnabled(network: String): Boolean = logIndex[network] == true
+        override fun setLogIndexEnabled(network: String, on: Boolean) { logIndex[network] = on }
+    }
+
+    @Test
+    fun indexTabHiddenByDefault() {
+        show(IndexSettings(rust = false))
+        tab("Settings").assertIsDisplayed()
+        tab("Index").assertDoesNotExist()
+    }
+
+    @Test
+    fun indexTabHiddenWhenKohakuFlagsSetButRustEngineOff() {
+        // Persisted flags survive a Rust-engine opt-out; the Settings switch then
+        // reads off/disabled, so the tab must read the same.
+        show(IndexSettings(rust = false, kohakuOn = KohakuPreset.byNetwork.keys))
+        tab("Index").assertDoesNotExist()
+    }
+
+    @Test
+    fun indexTabVisibleWhenKohakuEnabledInSettings() {
+        show(IndexSettings(rust = true, kohakuOn = setOf("mainnet")))
+        tab("Index").assertIsDisplayed()
+    }
+
+    @Test
+    fun togglingKohakuOnInSettingsRevealsTheIndexTab() {
+        show(IndexSettings(rust = true))
+        tab("Index").assertDoesNotExist()
+
+        tab("Settings").performClick()
+        toggle("Log index — Kohaku contracts (experimental)")
+        tab("Index").assertIsDisplayed()
+    }
+
+    @Test
+    fun turningOffTheLastCollectingNetworkHidesTheTabAndFallsBackToStatus() {
+        show(IndexSettings(rust = true, kohakuOn = setOf("mainnet")))
+        tab("Index").performClick()
+
+        toggle("Collect Kohaku contract logs on mainnet")
+        tab("Index").assertDoesNotExist()
+        // The vanished selection falls back to the Status tab's content.
+        rule.onNode(isSelectable() and hasText("Status")).assertIsDisplayed()
+    }
+
+    private fun show(settings: Settings) {
+        rule.setContent {
+            NodeScreen(controller = FakeController(), settings = settings, logs = FakeLogs())
+        }
+    }
+
+    /** The tab bar's tabs are the only selectable nodes on the screen. */
+    private fun tab(label: String) = rule.onNode(isSelectable() and hasText(label))
+
+    /**
+     * Click the SwitchRow switch sitting beside [label] (scrolling it into view
+     * first). Every switch in a tab is a semantics SIBLING of every label (the
+     * Rows aren't semantic boundaries), so the pairing goes by vertical overlap.
+     */
+    private fun toggle(label: String) {
+        val labelBounds =
+            rule.onNodeWithText(label).performScrollTo().fetchSemanticsNode().boundsInRoot
+        val switches = rule.onAllNodes(isToggleable())
+        val beside = switches.fetchSemanticsNodes().indexOfFirst {
+            it.boundsInRoot.top < labelBounds.bottom && it.boundsInRoot.bottom > labelBounds.top
+        }
+        check(beside >= 0) { "no switch beside '$label'" }
+        switches[beside].performClick()
+    }
+
+    private class FakeLogs : LogSource {
+        override fun version(): Long = 0L
+        override fun snapshot(): List<LogLine> = emptyList()
+        override fun clear() {}
+        override fun level(): LogLevel = LogLevel.DEBUG
+        override fun setLevel(level: LogLevel) {}
+    }
+}

--- a/ui/src/desktopTest/kotlin/io/myotis/ui/IndexTabVisibilityTest.kt
+++ b/ui/src/desktopTest/kotlin/io/myotis/ui/IndexTabVisibilityTest.kt
@@ -1,6 +1,7 @@
 package io.myotis.ui
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isSelectable
 import androidx.compose.ui.test.isToggleable
@@ -72,8 +73,18 @@ class IndexTabVisibilityTest {
 
         toggle("Collect Kohaku contract logs on mainnet")
         tab("Index").assertDoesNotExist()
-        // The vanished selection falls back to the Status tab's content.
-        rule.onNode(isSelectable() and hasText("Status")).assertIsDisplayed()
+        // The vanished selection falls back to the Status tab (selected, not merely present).
+        tab("Status").assertIsSelected()
+    }
+
+    @Test
+    fun togglingRustEngineOffInSettingsHidesTheIndexTabImmediately() {
+        show(IndexSettings(rust = true, kohakuOn = setOf("mainnet")))
+        tab("Index").assertIsDisplayed()
+
+        tab("Settings").performClick()
+        toggle("Rust engine (experimental)")
+        tab("Index").assertDoesNotExist()
     }
 
     private fun show(settings: Settings) {


### PR DESCRIPTION
## Problem

The shared `NodeScreen` (rendered by the Android, desktop, and iOS hosts alike) hardcoded all five tabs, so the **Index** tab was always visible — even for users who never opted into the experimental Kohaku log index.

## Change

All in `ui/src/commonMain`, so one fix covers every host:

- **Dynamic tab row.** The Index tab exists only while the Kohaku log index reads as enabled in Settings: at least one network's persisted `logIndexEnabled` flag is on **and** the Rust engine is enabled — mirroring exactly what the Settings switch displays (it shows off/disabled without the Rust engine, which is the only engine that serves the index).
- **Selection tracked by label, not position**, since positions shift when the Index tab appears/disappears. A selection whose tab vanishes falls back to Status.
- **Live reactivity.** The Settings toggles that affect visibility (Kohaku log index, Rust engine) and the Index tab's own per-network collect switch notify the screen via a revision bump, so the tab row re-derives immediately — including hiding the tab on the spot when collection is turned off for the last enabled network from inside the Index tab itself.

## Tests

New `IndexTabVisibilityTest` (desktop Compose UI tests) pins: hidden by default; hidden when the flags are set but the Rust engine is off; visible when enabled; appears live when Kohaku is toggled on in Settings; disappears with fallback to Status (asserted selected) when the last network's collection is turned off; and disappears live when the Rust engine is toggled off.

An internal review pass found no correctness defects; its two test-strength suggestions are addressed in the second commit. `./gradlew :ui:desktopTest` passes (16 tests) and `:app-desktop` compiles. The Android target couldn't be compiled in this environment (no Android SDK), but the change is entirely in shared `commonMain` code with an unchanged `NodeScreen` signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159hzUUT34RzQJB6oKZ8uoi

---
_Generated by [Claude Code](https://claude.ai/code/session_0159hzUUT34RzQJB6oKZ8uoi)_