### PR TITLE
Snap oracle: fail fast instead of re-asking a peer that already failed

### DIFF
--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/snap/EthHandlerSnapPeer.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/snap/EthHandlerSnapPeer.java
@@ -59,6 +59,16 @@ public final class EthHandlerSnapPeer implements SnapPeer {
     }
 
     @Override
+    public Object identity() {
+        return handler;
+    }
+
+    @Override
+    public String describe() {
+        return handler.getRemoteAddress();
+    }
+
+    @Override
     public void reportRootUnavailable() {
         if (onRootUnavailable != null) onRootUnavailable.run();
     }

--- a/app/src/main/java/com/jaeckel/ethp2p/app/snap/EthHandlerSnapPeer.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/snap/EthHandlerSnapPeer.java
@@ -55,6 +55,16 @@ public final class EthHandlerSnapPeer implements SnapPeer {
     }
 
     @Override
+    public Object identity() {
+        return handler;
+    }
+
+    @Override
+    public String describe() {
+        return handler.getRemoteAddress();
+    }
+
+    @Override
     public void reportRootUnavailable() {
         if (onRootUnavailable != null) onRootUnavailable.run();
     }

--- a/myotis-evm/src/main/java/io/myotis/evm/EvmExecutionError.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/EvmExecutionError.java
@@ -27,6 +27,11 @@ public sealed interface EvmExecutionError {
         }
         @Override public byte[] stateRoot() { return stateRoot.clone(); }
         @Override public byte[] slot() { return slot == null ? null : slot.clone(); }
+        // Records render byte[] by identity — useless in logs; see InvalidProof.
+        @Override public String toString() {
+            return "StateUnavailable[stateRoot=" + toHex(stateRoot)
+                    + ", address=" + address + ", slot=" + toHex(slot) + "]";
+        }
     }
 
     /** Bytecode fetch failed after retries. */
@@ -62,6 +67,12 @@ public sealed interface EvmExecutionError {
     record InvalidProof(byte[] stateRoot, Address address, String detail) implements EvmExecutionError {
         public InvalidProof { stateRoot = stateRoot.clone(); }
         @Override public byte[] stateRoot() { return stateRoot.clone(); }
+        // Records render byte[] by identity ("[B@6e8e2cf3") — useless in logs.
+        // Every diagnostic surface prints this record, so render the root as hex.
+        @Override public String toString() {
+            return "InvalidProof[stateRoot=" + toHex(stateRoot)
+                    + ", address=" + address + ", detail=" + detail + "]";
+        }
     }
 
     /** Content-aware hex formatter for error log lines. */

--- a/myotis-evm/src/main/java/io/myotis/evm/world/SnapBackedStateOracle.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/world/SnapBackedStateOracle.java
@@ -390,7 +390,7 @@ public final class SnapBackedStateOracle implements SnapStateOracle {
      *  rotation counter across concurrent operations, so a repeat does not by
      *  itself prove exhaustion — a couple of extra (cheap, I/O-free) consults
      *  skim past interleaving; a one-peer pool still fails in microseconds. */
-    private static final int FAIL_FAST_CONSULTS_PER_ATTEMPT = 4;
+    static final int FAIL_FAST_CONSULTS_PER_ATTEMPT = 4; // package-visible for tests
 
     private <T> void attempt(
             java.util.function.Function<SnapPeer, CompletableFuture<T>> op,

--- a/myotis-evm/src/main/java/io/myotis/evm/world/SnapBackedStateOracle.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/world/SnapBackedStateOracle.java
@@ -366,18 +366,38 @@ public final class SnapBackedStateOracle implements SnapStateOracle {
      * {@link #maxAttempts}. {@link EvmExecutionError.InvalidProof} and
      * generic IO failures both trigger retries with the next peer; the last
      * failure surfaces if every attempt fails.
+     *
+     * <p><b>Fail-fast:</b> a peer that already failed within THIS operation is
+     * never retried — its refusal is deterministic on the timescale of one
+     * read (an empty proof for a root it doesn't retain won't materialize ten
+     * seconds later, and a hung peer costs a full request timeout per retry).
+     * When the supplier has no peer we haven't already tried, the last failure
+     * surfaces immediately. On a healthy multi-peer pool this changes nothing
+     * (the routing supplier rotates anyway); on a one-peer pool it collapses
+     * the worst case from {@code maxAttempts × request-timeout} (~30s of
+     * zombie latency, longer than wallet client timeouts) to a single attempt.
      */
     private <T> CompletableFuture<T> tryWithRetries(java.util.function.Function<SnapPeer, CompletableFuture<T>> op) {
         CompletableFuture<T> result = new CompletableFuture<>();
-        attempt(op, 0, null, result);
+        // Keys are SnapPeer.identity() tokens, compared by reference.
+        attempt(op, 0, null, result,
+                java.util.Collections.newSetFromMap(new java.util.IdentityHashMap<>()));
         return result;
     }
+
+    /** How many supplier consults one attempt slot may spend skimming for an
+     *  UNTRIED peer before concluding there is none. Routing suppliers share a
+     *  rotation counter across concurrent operations, so a repeat does not by
+     *  itself prove exhaustion — a couple of extra (cheap, I/O-free) consults
+     *  skim past interleaving; a one-peer pool still fails in microseconds. */
+    private static final int FAIL_FAST_CONSULTS_PER_ATTEMPT = 4;
 
     private <T> void attempt(
             java.util.function.Function<SnapPeer, CompletableFuture<T>> op,
             int attemptIdx,
             Throwable lastError,
-            CompletableFuture<T> sink) {
+            CompletableFuture<T> sink,
+            java.util.Set<Object> triedPeers) {
         if (attemptIdx >= maxAttempts) {
             sink.completeExceptionally(lastError != null ? lastError
                     : new EvmExecutionException(new EvmExecutionError.InvalidProof(
@@ -385,8 +405,36 @@ public final class SnapBackedStateOracle implements SnapStateOracle {
                             "exhausted " + maxAttempts + " peer attempts")));
             return;
         }
-        SnapPeer peer = peerSupplier.get();
+        // Find a peer this operation hasn't tried yet. Dedup keys on
+        // SnapPeer.identity() — production suppliers wrap the long-lived
+        // connection in a fresh adapter per call, so the adapter's own
+        // object identity would never repeat and the dedup would be inert.
+        SnapPeer untried = null;
+        for (int consult = 0; consult < FAIL_FAST_CONSULTS_PER_ATTEMPT; consult++) {
+            SnapPeer candidate = peerSupplier.get();
+            if (candidate == null) {
+                sink.completeExceptionally(lastError != null ? lastError
+                        : new EvmExecutionException(new EvmExecutionError.StateUnavailable(
+                                new byte[32], Address.ZERO, null)));
+                return;
+            }
+            if (triedPeers.add(candidate.identity())) {
+                untried = candidate;
+                break;
+            }
+        }
+        final SnapPeer peer = untried;
         if (peer == null) {
+            // Every consult returned a peer this operation already tried — the
+            // pool has nothing new. Surface the last failure NOW instead of
+            // burning another identical attempt (fail-fast): a refusal is
+            // deterministic on the timescale of one read, and a hung peer
+            // costs a full request timeout per re-ask. lastError is always
+            // non-null here (attempt 0 can't collide with an empty tried-set),
+            // but keep the synthetic fallback rather than an NPE if that
+            // invariant ever shifts.
+            log.warn("[snap-oracle] no untried peer left after {} attempt(s) — failing fast: {}",
+                    attemptIdx, lastError == null ? "?" : String.valueOf(unwrap(lastError)));
             sink.completeExceptionally(lastError != null ? lastError
                     : new EvmExecutionException(new EvmExecutionError.StateUnavailable(
                             new byte[32], Address.ZERO, null)));
@@ -396,8 +444,9 @@ public final class SnapBackedStateOracle implements SnapStateOracle {
         try {
             future = op.apply(peer);
         } catch (Throwable t) {
-            log.warn("[snap-oracle] attempt {} threw synchronously: {}", attemptIdx, t.getMessage());
-            attempt(op, attemptIdx + 1, t, sink);
+            log.warn("[snap-oracle] attempt {} via {} threw synchronously: {}",
+                    attemptIdx, peer.describe(), t.getMessage());
+            attempt(op, attemptIdx + 1, t, sink, triedPeers);
             return;
         }
         future.whenComplete((value, error) -> {
@@ -425,8 +474,9 @@ public final class SnapBackedStateOracle implements SnapStateOracle {
             if (cantServe) {
                 try { peer.reportRootUnavailable(); } catch (RuntimeException ignore) {}
             }
-            log.warn("[snap-oracle] attempt {} failed: {}", attemptIdx, error.getMessage());
-            attempt(op, attemptIdx + 1, cause, sink);
+            log.warn("[snap-oracle] attempt {} via {} failed: {}",
+                    attemptIdx, peer.describe(), String.valueOf(cause));
+            attempt(op, attemptIdx + 1, cause, sink, triedPeers);
         });
     }
 

--- a/myotis-evm/src/main/java/io/myotis/evm/world/SnapPeer.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/world/SnapPeer.java
@@ -76,4 +76,25 @@ public interface SnapPeer {
      * serve a later head. Default no-op for fixture/test implementations.
      */
     default void reportRootUnavailable() {}
+
+    /**
+     * Short human-readable identity for logs ("ip:port" for network-backed
+     * implementations). Purely diagnostic — never used for routing decisions.
+     */
+    default String describe() {
+        String simple = getClass().getSimpleName();
+        return simple.isEmpty() ? getClass().getName() : simple;
+    }
+
+    /**
+     * Stable identity of the underlying peer, used to recognize "same peer
+     * again" across supplier calls within one oracle operation (the fail-fast
+     * dedup). Implementations that wrap a per-call adapter around a long-lived
+     * connection MUST return the underlying connection object — otherwise
+     * every supplier call looks like a fresh peer and the dedup never fires.
+     * Compared by object identity, never by equals.
+     */
+    default Object identity() {
+        return this;
+    }
 }

--- a/myotis-evm/src/test/java/io/myotis/evm/world/SnapBackedStateOracleTest.java
+++ b/myotis-evm/src/test/java/io/myotis/evm/world/SnapBackedStateOracleTest.java
@@ -128,10 +128,50 @@ class SnapBackedStateOracleTest {
         // the same peer (the 30s zombie-call fix). The supplier is consulted once
         // for the real attempt plus a short I/O-free skim (bounded per attempt
         // slot) that discovers there is nothing untried.
-        assertEquals(1 + 4, attempts.get());
+        assertEquals(1 + SnapBackedStateOracle.FAIL_FAST_CONSULTS_PER_ATTEMPT, attempts.get());
         // The one real attempt reports the peer so a routing supplier rotates
         // away from it for the rest of this head context.
         assertEquals(1, peer.rootUnavailableCalls.get());
+    }
+
+    @Test
+    void maxAttemptsStillCapsRotationAcrossDistinctPeers() {
+        // Three DISTINCT refusing peers with maxAttempts=2: the budget branch (not
+        // fail-fast) must end the operation — two real attempts, the third peer
+        // never asked, and the LAST real attempt's error surfaces.
+        Address addr = Address.fromHex("0xabcdef0102030405060708090a0b0c0d0e0f1011");
+        Bytes32 root = Bytes32.fromHexString(
+                "0x7777777777777777777777777777777777777777777777777777777777777777");
+        Bytes garbage = RLP.encodeList(w -> {
+            w.writeValue(Bytes.fromHexString("0x20"));
+            w.writeValue(Bytes.fromHexString("0xdead"));
+        });
+        List<FixturePeer> peers = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            FixturePeer fp = new FixturePeer();
+            fp.addTrieNodes(root, List.of(garbage));
+            peers.add(fp);
+        }
+        AtomicInteger consults = new AtomicInteger();
+        Supplier<SnapPeer> supplier = () -> peers.get(consults.getAndIncrement() % peers.size());
+
+        var oracle = new SnapBackedStateOracle(supplier, BytecodeCache.inMemory(), 2);
+        try {
+            oracle.fetchAccount(root.toArrayUnsafe(), addr).get();
+            fail("expected fetchAccount to fail");
+        } catch (Exception e) {
+            Throwable cause = e instanceof ExecutionException ? e.getCause() : e;
+            var eee = assertInstanceOf(EvmExecutionException.class, cause);
+            assertInstanceOf(EvmExecutionError.InvalidProof.class, eee.error(),
+                    "the exhaustion branch surfaces the last real attempt's error");
+        }
+        // Budget branch, not fail-fast: exactly maxAttempts consults (each found an
+        // untried peer on the first try), and the third peer was never asked.
+        assertEquals(2, consults.get());
+        assertEquals(1, peers.get(0).rootUnavailableCalls.get());
+        assertEquals(1, peers.get(1).rootUnavailableCalls.get());
+        assertEquals(0, peers.get(2).rootUnavailableCalls.get(),
+                "the peer beyond the budget must never be asked");
     }
 
     @Test
@@ -178,7 +218,7 @@ class SnapBackedStateOracleTest {
         // One real attempt + the bounded skim — NOT maxAttempts real attempts.
         // Without identity()-keyed dedup this would be 3 real attempts and the
         // report counter would read 3.
-        assertEquals(1 + 4, consults.get());
+        assertEquals(1 + SnapBackedStateOracle.FAIL_FAST_CONSULTS_PER_ATTEMPT, consults.get());
         assertEquals(1, underlying.rootUnavailableCalls.get());
     }
 
@@ -213,7 +253,7 @@ class SnapBackedStateOracleTest {
         }
         // a tried, b tried, then the bounded skim finds only repeats → fail fast
         // with most of the 5-attempt budget unused (2 real attempts, not 5).
-        assertEquals(2 + 4, consults.get(),
+        assertEquals(2 + SnapBackedStateOracle.FAIL_FAST_CONSULTS_PER_ATTEMPT, consults.get(),
                 "one consult per real attempt plus the bounded fail-fast skim");
         assertEquals(1, a.rootUnavailableCalls.get());
         assertEquals(1, b.rootUnavailableCalls.get());

--- a/myotis-evm/src/test/java/io/myotis/evm/world/SnapBackedStateOracleTest.java
+++ b/myotis-evm/src/test/java/io/myotis/evm/world/SnapBackedStateOracleTest.java
@@ -123,11 +123,100 @@ class SnapBackedStateOracleTest {
             var eee = assertInstanceOf(EvmExecutionException.class, cause);
             assertInstanceOf(EvmExecutionError.InvalidProof.class, eee.error());
         }
-        // Supplier was consulted once per attempt.
-        assertEquals(3, attempts.get());
-        // Each InvalidProof tells the peer it can't serve this root, so a routing
-        // supplier can rotate away from it (the fix for empty-proof churn).
-        assertEquals(3, peer.rootUnavailableCalls.get());
+        // Fail-fast: the refusal is deterministic, so the operation ends after ONE
+        // real attempt instead of burning the rest of the retry budget re-asking
+        // the same peer (the 30s zombie-call fix). The supplier is consulted once
+        // for the real attempt plus a short I/O-free skim (bounded per attempt
+        // slot) that discovers there is nothing untried.
+        assertEquals(1 + 4, attempts.get());
+        // The one real attempt reports the peer so a routing supplier rotates
+        // away from it for the rest of this head context.
+        assertEquals(1, peer.rootUnavailableCalls.get());
+    }
+
+    @Test
+    void failFastSeesThroughFreshAdapterWrappers() {
+        // Production suppliers (VerifiedRpcBackend) wrap the long-lived connection
+        // in a NEW adapter object on every supplier call. The dedup must key on
+        // SnapPeer.identity() — the underlying connection — or it never fires in
+        // production (each wrapper would look like a fresh peer).
+        Address addr = Address.fromHex("0xabcdef0102030405060708090a0b0c0d0e0f1011");
+        Bytes32 root = Bytes32.fromHexString(
+                "0x6666666666666666666666666666666666666666666666666666666666666666");
+        Bytes garbage = RLP.encodeList(w -> {
+            w.writeValue(Bytes.fromHexString("0x20"));
+            w.writeValue(Bytes.fromHexString("0xdead"));
+        });
+        FixturePeer underlying = new FixturePeer();
+        underlying.addTrieNodes(root, List.of(garbage));
+
+        record Wrapper(FixturePeer delegate) implements SnapPeer {
+            @Override public CompletableFuture<List<Bytes>> getTrieNodes(Bytes32 sr, List<PathSet> p) {
+                return delegate.getTrieNodes(sr, p);
+            }
+            @Override public CompletableFuture<List<Bytes>> getByteCodes(List<Bytes32> h) {
+                return delegate.getByteCodes(h);
+            }
+            @Override public void reportRootUnavailable() { delegate.reportRootUnavailable(); }
+            @Override public Object identity() { return delegate; }
+        }
+        AtomicInteger consults = new AtomicInteger();
+        Supplier<SnapPeer> freshWrapperPerCall = () -> {
+            consults.incrementAndGet();
+            return new Wrapper(underlying); // new object identity every call
+        };
+
+        var oracle = new SnapBackedStateOracle(freshWrapperPerCall, BytecodeCache.inMemory(), 3);
+        try {
+            oracle.fetchAccount(root.toArrayUnsafe(), addr).get();
+            fail("expected fetchAccount to fail");
+        } catch (Exception e) {
+            Throwable cause = e instanceof ExecutionException ? e.getCause() : e;
+            var eee = assertInstanceOf(EvmExecutionException.class, cause);
+            assertInstanceOf(EvmExecutionError.InvalidProof.class, eee.error());
+        }
+        // One real attempt + the bounded skim — NOT maxAttempts real attempts.
+        // Without identity()-keyed dedup this would be 3 real attempts and the
+        // report counter would read 3.
+        assertEquals(1 + 4, consults.get());
+        assertEquals(1, underlying.rootUnavailableCalls.get());
+    }
+
+    @Test
+    void failFastEndsAfterBothDistinctPeersRefuse() {
+        // Two refusing peers, supplier alternating between them, budget of 5: the
+        // operation must try each exactly once, then fail fast when the supplier
+        // has nothing it hasn't already tried — never re-asking either peer.
+        Address addr = Address.fromHex("0xabcdef0102030405060708090a0b0c0d0e0f1011");
+        Bytes32 root = Bytes32.fromHexString(
+                "0x5555555555555555555555555555555555555555555555555555555555555555");
+        Bytes garbage = RLP.encodeList(w -> {
+            w.writeValue(Bytes.fromHexString("0x20"));
+            w.writeValue(Bytes.fromHexString("0xdead"));
+        });
+        FixturePeer a = new FixturePeer();
+        FixturePeer b = new FixturePeer();
+        a.addTrieNodes(root, List.of(garbage));
+        b.addTrieNodes(root, List.of(garbage));
+        AtomicInteger consults = new AtomicInteger();
+        Supplier<SnapPeer> alternating = () -> consults.getAndIncrement() % 2 == 0 ? a : b;
+
+        var oracle = new SnapBackedStateOracle(alternating, BytecodeCache.inMemory(), 5);
+        try {
+            oracle.fetchAccount(root.toArrayUnsafe(), addr).get();
+            fail("expected fetchAccount to fail");
+        } catch (Exception e) {
+            Throwable cause = e instanceof ExecutionException ? e.getCause() : e;
+            var eee = assertInstanceOf(EvmExecutionException.class, cause);
+            assertInstanceOf(EvmExecutionError.InvalidProof.class, eee.error(),
+                    "the surfaced failure is the last real attempt's, not a synthetic one");
+        }
+        // a tried, b tried, then the bounded skim finds only repeats → fail fast
+        // with most of the 5-attempt budget unused (2 real attempts, not 5).
+        assertEquals(2 + 4, consults.get(),
+                "one consult per real attempt plus the bounded fail-fast skim");
+        assertEquals(1, a.rootUnavailableCalls.get());
+        assertEquals(1, b.rootUnavailableCalls.get());
     }
 
     @Test
@@ -177,7 +266,10 @@ class SnapBackedStateOracleTest {
             Thread.currentThread().interrupt();
             fail("interrupted");
         }
-        assertEquals(3, reported.get(), "each timeout must report the peer root-unavailable");
+        // One report, not maxAttempts: after the first timeout the fail-fast path
+        // refuses to re-ask the only peer (each extra ask would cost a full request
+        // timeout for a peer already flagged useless for this head).
+        assertEquals(1, reported.get(), "the timeout must report the peer root-unavailable");
     }
 
     @Test
@@ -207,7 +299,7 @@ class SnapBackedStateOracleTest {
             Thread.currentThread().interrupt();
             fail("interrupted");
         }
-        assertEquals(2, reported.get());
+        assertEquals(1, reported.get(), "one report — fail-fast skips the identical re-ask");
     }
 
     @Test
@@ -247,7 +339,7 @@ class SnapBackedStateOracleTest {
             Thread.currentThread().interrupt();
             fail("interrupted");
         }
-        assertEquals(2, reported.get(),
+        assertEquals(1, reported.get(),
                 "a multiply-wrapped timeout must still be unwrapped and denied");
     }
 
@@ -413,21 +505,27 @@ class SnapBackedStateOracleTest {
                 Bytes32.wrap(Hash.keccak256(Bytes.EMPTY).toArrayUnsafe()));
         var accountTrie = TrieFixture.singleLeaf(keccak(addr.toByteArray()), accountValue);
 
+        // Two DISTINCT peers (fail-fast never re-asks a peer that failed within one
+        // operation, so the rotation must be real): the first serves only the account
+        // proof, the second only the storage proof.
         AtomicInteger attempt = new AtomicInteger();
-        SnapPeer rotating = new SnapPeer() {
+        record HalfPeer(java.util.function.Supplier<List<Bytes>> proof, AtomicInteger counter)
+                implements SnapPeer {
             @Override public CompletableFuture<List<Bytes>> getTrieNodes(Bytes32 sr, List<PathSet> p) {
-                // 1st: account proof only (slot fails → chunk retries).
-                // 2nd+: storage proof only (account must come from the warm cache).
-                int n = attempt.incrementAndGet();
-                return CompletableFuture.completedFuture(n == 1 ? accountTrie.proof : storageTrie.proof);
+                counter.incrementAndGet();
+                return CompletableFuture.completedFuture(proof.get());
             }
             @Override public CompletableFuture<List<Bytes>> getByteCodes(List<Bytes32> h) {
                 return CompletableFuture.completedFuture(List.of());
             }
-            @Override public void reportRootUnavailable() { }
-        };
+        }
+        SnapPeer accountOnly = new HalfPeer(() -> accountTrie.proof, attempt);
+        SnapPeer storageOnly = new HalfPeer(() -> storageTrie.proof, attempt);
+        AtomicInteger consults = new AtomicInteger();
+        Supplier<SnapPeer> rotation = () ->
+                consults.getAndIncrement() == 0 ? accountOnly : storageOnly;
         var oracle = new SnapBackedStateOracle(
-                () -> rotating, BytecodeCache.inMemory(), 8, StateProofCache.inMemory(1024));
+                rotation, BytecodeCache.inMemory(), 8, StateProofCache.inMemory(1024));
         byte[] root = accountTrie.root.toArrayUnsafe();
 
         Map<Address, Set<BigInteger>> req = new HashMap<>();

--- a/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
+++ b/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
@@ -1767,8 +1767,9 @@ public final class VerifiedRpcBackend implements io.myotis.api.VerifiedReads,
                                 return new EthHandlerSnapPeer(
                                         chosen,
                                         () -> { rootDenied.add(chosen); rootServed.remove(chosen);
-                                                recordSnapQuality(chosen, false); },
-                                        () -> { rootServed.add(chosen); recordSnapQuality(chosen, true); },
+                                                recordSnapQualityAsync(chosen, false); },
+                                        () -> { rootServed.add(chosen);
+                                                recordSnapQualityAsync(chosen, true); },
                                         snapLaneGate);
                             }
                             // Discovery phase (none proven yet): probed peer first (known to
@@ -1779,8 +1780,9 @@ public final class VerifiedRpcBackend implements io.myotis.api.VerifiedReads,
                                 return new EthHandlerSnapPeer(
                                         pp,
                                         () -> { rootDenied.add(pp); rootServed.remove(pp);
-                                                recordSnapQuality(pp, false); },
-                                        () -> { rootServed.add(pp); recordSnapQuality(pp, true); },
+                                                recordSnapQualityAsync(pp, false); },
+                                        () -> { rootServed.add(pp);
+                                                recordSnapQualityAsync(pp, true); },
                                         snapLaneGate);
                             }
                             // activeSnapHandlers() already returns only ready, snap-negotiated,
@@ -1795,8 +1797,9 @@ public final class VerifiedRpcBackend implements io.myotis.api.VerifiedReads,
                             return new EthHandlerSnapPeer(
                                     chosen,
                                     () -> { rootDenied.add(chosen); rootServed.remove(chosen);
-                                            recordSnapQuality(chosen, false); },
-                                    () -> { rootServed.add(chosen); recordSnapQuality(chosen, true); });
+                                            recordSnapQualityAsync(chosen, false); },
+                                    () -> { rootServed.add(chosen);
+                                            recordSnapQualityAsync(chosen, true); });
                         },
                         bytecodeCache,
                         SNAP_ORACLE_MAX_ATTEMPTS,
@@ -3841,6 +3844,14 @@ public final class VerifiedRpcBackend implements io.myotis.api.VerifiedReads,
      * on a usable proof, {@code false} on a root-unavailable (empty/invalid proof,
      * timeout, IO). No-op if the handler's remote address can't be parsed.
      */
+    /** Offloaded quality recording for the snap-peer routing callbacks: those run
+     *  SYNCHRONOUSLY on the reporting thread (the adapter needs the routing sets
+     *  updated before the oracle's fail-fast skim re-consults the supplier), so
+     *  the potentially blocking sink call moves off-thread here instead. */
+    private void recordSnapQualityAsync(EthHandler peer, boolean served) {
+        java.util.concurrent.CompletableFuture.runAsync(() -> recordSnapQuality(peer, served));
+    }
+
     private void recordSnapQuality(EthHandler peer, boolean served) {
         if (peer == null) return;
         InetSocketAddress addr = remoteAddressOf(peer);

--- a/rpc-backend/src/main/java/io/myotis/rpc/snap/EthHandlerSnapPeer.java
+++ b/rpc-backend/src/main/java/io/myotis/rpc/snap/EthHandlerSnapPeer.java
@@ -70,6 +70,16 @@ public final class EthHandlerSnapPeer implements SnapPeer {
     }
 
     @Override
+    public Object identity() {
+        return handler;
+    }
+
+    @Override
+    public String describe() {
+        return handler.getRemoteAddress();
+    }
+
+    @Override
     public void reportRootUnavailable() {
         // The oracle reports this from a future-completion handler that runs on the
         // Netty event loop; a host's deny callback may block (lock contention, sync

--- a/rpc-backend/src/main/java/io/myotis/rpc/snap/EthHandlerSnapPeer.java
+++ b/rpc-backend/src/main/java/io/myotis/rpc/snap/EthHandlerSnapPeer.java
@@ -54,7 +54,9 @@ public final class EthHandlerSnapPeer implements SnapPeer {
 
     /**
      * @param onRootUnavailable run when the oracle reports this peer can't serve the
-     *  current state root (deprioritize it for this head).
+     *  current state root (deprioritize it for this head). Runs SYNCHRONOUSLY on
+     *  the reporting thread (often the Netty event loop): keep it to lock-free
+     *  routing mutations and offload anything that can block.
      * @param onRootServed run when this peer returns a usable (non-empty) proof, so
      *  the EL peer cache can record it as a proven snap-serving peer to dial first
      *  on a restart. The two callbacks are mutually exclusive per fetch: a non-empty
@@ -81,14 +83,16 @@ public final class EthHandlerSnapPeer implements SnapPeer {
 
     @Override
     public void reportRootUnavailable() {
-        // The oracle reports this from a future-completion handler that runs on the
-        // Netty event loop; a host's deny callback may block (lock contention, sync
-        // persistence), so offload like onRootServed — a shared adapter must not let
-        // a host callback stall network processing.
+        // SYNCHRONOUS on purpose: the oracle's fail-fast skim consults the peer
+        // supplier immediately after this returns, and the supplier's routing
+        // state (rootDenied/rootServed in VerifiedRpcBackend) must already
+        // reflect the deny — an async offload here loses that race and the
+        // skim sees the pre-failure world, failing operations fast while
+        // untried peers exist. The callback contract is therefore: routing
+        // mutations only (lock-free sets); any potentially blocking work
+        // (quality sinks, persistence) must be offloaded BY THE CALLBACK.
         if (onRootUnavailable != null) {
-            CompletableFuture.runAsync(() -> {
-                try { onRootUnavailable.run(); } catch (RuntimeException ignore) {}
-            });
+            try { onRootUnavailable.run(); } catch (RuntimeException ignore) {}
         }
     }
 
@@ -143,14 +147,13 @@ public final class EthHandlerSnapPeer implements SnapPeer {
                 // A non-empty proof means this peer actually retains the trie for
                 // this root — the durable "snap-serving" signal the EL cache wants.
                 // Empty proofs fall through to the oracle's no-state path, which
-                // calls reportRootUnavailable instead. Offloaded: this completion
-                // chain runs on the Netty event loop, and a host's quality sink may
-                // block (lock contention, sync persistence) — a shared adapter must
-                // not let a host callback stall network processing.
+                // calls reportRootUnavailable instead. Synchronous, mirroring
+                // reportRootUnavailable: the supplier's rootServed preference
+                // should see the serve before the next consult, and the callback
+                // contract requires callbacks to offload their own blocking work
+                // (see reportRootUnavailable).
                 if (!all.isEmpty() && onRootServed != null) {
-                    CompletableFuture.runAsync(() -> {
-                        try { onRootServed.run(); } catch (RuntimeException ignore) {}
-                    });
+                    try { onRootServed.run(); } catch (RuntimeException ignore) {}
                 }
                 return all;
             });


### PR DESCRIPTION
## Problem

Field data (sepolia desktop, 2026-08-06): with a snap pool of **one** peer answering `empty proof for non-empty root`, the oracle's retry ladder re-asked the same refusing peer at ~10s request-timeout intervals. Kohaku's `eth_call`/`eth_getTransactionCount` took **30–44s** before failing — far past wallet client timeouts, so even eventual successes read as failures wallet-side:

```
attempt 0 failed: TimeoutException     (07:38:13)
attempt 1 failed: TimeoutException     (07:38:23)
attempt 2 failed: TimeoutException     (07:38:33)
attempt 3 failed: InvalidProof[… empty proof for non-empty root]
```

## Changes

- **Fail-fast dedup in `tryWithRetries`**: each operation tracks the peers it has tried, keyed by the new `SnapPeer.identity()` — the *underlying `EthHandler`* in the three `EthHandlerSnapPeer` mirrors. (Keying on the `SnapPeer` object itself would be inert in production: `VerifiedRpcBackend`'s supplier wraps the connection in a fresh adapter per call — caught by the internal review, pinned by a dedicated test.) Each attempt slot skims a bounded number of I/O-free supplier consults for an untried peer; when only already-tried peers come back, the last real failure surfaces immediately. A one-peer pool collapses from `maxAttempts × 10s` to a single attempt; healthy pools are unaffected (the skim rides past rotation interleaving from concurrent operations — also an internal-review catch).
- **Diagnosability**: `SnapPeer.describe()` (remote `ip:port`) in every oracle log line; unwrapped causes instead of wrapper messages; hex state roots in `InvalidProof`/`StateUnavailable` `toString()` — no more `stateRoot=[B@6e8e2cf3`.
- **Tests**: existing retry tests updated to the new contract (one root-unavailable report per peer per operation; the batch-retry test now rotates two genuinely distinct peers, matching its own comment); new tests pin multi-peer fail-fast and the production-shaped fresh-adapter-per-call supplier.

## Semantics note

A `TimeoutException` re-ask of the same peer is also skipped (not just deterministic refusals): a 10s request-timeout "blip" is not meaningfully transient, and the timed-out peer was already being denied for the head context anyway. The internal review examined and endorsed this trade-off.

Internal no-context review ran before this PR; its HIGH (wrapper-identity inertness), MEDIUM (stray jniLibs in the commit), and LOW findings (double `0x` prefix, premature-abort risk under shared rotation, lost `maxAttempts` coverage, nits) are all addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPnTFwmAVMypWYtoioAXQT