### PR TITLE
Log index: tolerate byte-budget truncation in backfill; log getLogs filters

### DIFF
--- a/rust/myotis-engine/src/host.rs
+++ b/rust/myotis-engine/src/host.rs
@@ -2168,6 +2168,20 @@ fn parse_get_logs_filter(
 /// (the router maps it to strict -32000) — never an empty array for an
 /// unindexed range.
 pub fn get_logs_json(handle: i64, filter_json: &str) -> String {
+    let out = get_logs_json_impl(handle, filter_json);
+    // Observability for wallet integration (requested during the Kohaku
+    // bring-up): refusals log the exact filter at info so hosts can see what
+    // the wallet asked for without a proxy; successes stay at debug.
+    if let Some(reason) = out.strip_prefix("{\"error\":") {
+        tracing::info!(filter = %filter_json, refusal = %reason.trim_end_matches('}'),
+            "eth_getLogs refused");
+    } else {
+        tracing::debug!(filter = %filter_json, "eth_getLogs served");
+    }
+    out
+}
+
+fn get_logs_json_impl(handle: i64, filter_json: &str) -> String {
     use myotis_net::el::logindex::QueryError;
     let Ok(v) = serde_json::from_str::<serde_json::Value>(filter_json) else {
         return eljson::error_json("malformed filter");

--- a/rust/myotis-engine/src/host.rs
+++ b/rust/myotis-engine/src/host.rs
@@ -2171,10 +2171,36 @@ pub fn get_logs_json(handle: i64, filter_json: &str) -> String {
     let out = get_logs_json_impl(handle, filter_json);
     // Observability for wallet integration (requested during the Kohaku
     // bring-up): refusals log the exact filter at info so hosts can see what
-    // the wallet asked for without a proxy; successes stay at debug.
+    // the wallet asked for without a proxy; successes stay at debug. A
+    // polling wallet repeats the identical refused filter every few seconds
+    // for the whole backfill, so identical refusals are debounced to one
+    // line per minute. (Filter content is addresses/topics/ranges — the
+    // watched contract set — no secrets, but it IS the wallet's query
+    // surface, hence info not warn.)
     if let Some(reason) = out.strip_prefix("{\"error\":") {
-        tracing::info!(filter = %filter_json, refusal = %reason.trim_end_matches('}'),
-            "eth_getLogs refused");
+        let reason = reason.strip_suffix('}').unwrap_or(reason);
+        use std::hash::{Hash, Hasher};
+        let mut h = std::collections::hash_map::DefaultHasher::new();
+        filter_json.hash(&mut h);
+        reason.hash(&mut h);
+        let key = h.finish();
+        static LAST_REFUSAL: std::sync::Mutex<Option<(u64, std::time::Instant)>> =
+            std::sync::Mutex::new(None);
+        let log_it = match LAST_REFUSAL.lock() {
+            Ok(mut slot) => match *slot {
+                Some((k, at)) if k == key && at.elapsed() < std::time::Duration::from_secs(60) => {
+                    false
+                }
+                _ => {
+                    *slot = Some((key, std::time::Instant::now()));
+                    true
+                }
+            },
+            Err(_) => true,
+        };
+        if log_it {
+            tracing::info!(filter = %filter_json, refusal = %reason, "eth_getLogs refused");
+        }
     } else {
         tracing::debug!(filter = %filter_json, "eth_getLogs served");
     }

--- a/rust/myotis-engine/src/host.rs
+++ b/rust/myotis-engine/src/host.rs
@@ -2178,24 +2178,41 @@ pub fn get_logs_json(handle: i64, filter_json: &str) -> String {
     // watched contract set — no secrets, but it IS the wallet's query
     // surface, hence info not warn.)
     if let Some(reason) = out.strip_prefix("{\"error\":") {
-        let reason = reason.strip_suffix('}').unwrap_or(reason);
+        // Strip the JSON wrapping (trailing brace and the value's quotes) so
+        // the log line reads as prose, not nested JSON.
+        let reason = reason
+            .strip_suffix('}')
+            .unwrap_or(reason)
+            .trim_matches('"');
         use std::hash::{Hash, Hasher};
         let mut h = std::collections::hash_map::DefaultHasher::new();
+        handle.hash(&mut h); // distinct networks debounce independently
         filter_json.hash(&mut h);
         reason.hash(&mut h);
         let key = h.finish();
-        static LAST_REFUSAL: std::sync::Mutex<Option<(u64, std::time::Instant)>> =
-            std::sync::Mutex::new(None);
-        let log_it = match LAST_REFUSAL.lock() {
-            Ok(mut slot) => match *slot {
-                Some((k, at)) if k == key && at.elapsed() < std::time::Duration::from_secs(60) => {
-                    false
+        // Per-key debounce map, NOT a single slot: wallets poll several
+        // distinct filters (one per watched contract), and alternating
+        // refusals would evict a single slot every call — logging everything
+        // during exactly the catch-up window the debounce targets. Bounded:
+        // swept of expired entries whenever it grows past a handful.
+        static RECENT_REFUSALS: std::sync::Mutex<
+            Option<std::collections::HashMap<u64, std::time::Instant>>,
+        > = std::sync::Mutex::new(None);
+        const DEBOUNCE: std::time::Duration = std::time::Duration::from_secs(60);
+        let log_it = match RECENT_REFUSALS.lock() {
+            Ok(mut slot) => {
+                let map = slot.get_or_insert_with(std::collections::HashMap::new);
+                if map.len() > 64 {
+                    map.retain(|_, at| at.elapsed() < DEBOUNCE);
                 }
-                _ => {
-                    *slot = Some((key, std::time::Instant::now()));
-                    true
+                match map.get(&key) {
+                    Some(at) if at.elapsed() < DEBOUNCE => false,
+                    _ => {
+                        map.insert(key, std::time::Instant::now());
+                        true
+                    }
                 }
-            },
+            }
             Err(_) => true,
         };
         if log_it {

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -1067,8 +1067,16 @@ impl ElReader {
             else {
                 // Nothing served at all — a single block's receipts always fit
                 // a response budget, so this peer genuinely can't (or won't)
-                // serve the range; let the caller rotate to the next peer.
-                return Err("peer served no bodies/receipts for candidate chunk".to_string());
+                // serve the range (pruned history, not a byte budget); let the
+                // caller rotate to the next peer. DELIBERATE on later chunks
+                // too: this discards the batch's earlier verified chunks, but
+                // an empty serve is a data-availability signal, and retrying
+                // the whole batch against a peer that HAS the range beats
+                // committing a shortened batch sourced from one that doesn't.
+                return Err(format!(
+                    "peer served no bodies/receipts for candidate chunk starting at block {}",
+                    chunk_numbers.first().copied().unwrap_or_default()
+                ));
             };
             for ((vh, body), receipts) in
                 chunk[..usable].iter().zip(&bodies[..usable]).zip(&receipt_blocks[..usable]) {

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -922,6 +922,11 @@ impl ElReader {
         let from = cur_n - count;
         let peers = self.pool.snap_peers().await;
         if peers.is_empty() {
+            // Visible (rate-limited): a silently empty pool looked identical
+            // to a hung walker during the 2026-08-06 stall investigation.
+            if ticks % 100 == 0 {
+                tracing::info!(cursor = cur_n, "log index backfill idle: no snap peers this tick");
+            }
             return;
         }
         for peer in &peers {
@@ -930,6 +935,14 @@ impl ElReader {
                 .await
             {
                 Ok(()) => {
+                    if ticks % 50 == 0 {
+                        let new_cursor = self.with_log_index(|ix| ix.cursor).flatten();
+                        tracing::info!(
+                            cursor = new_cursor.map(|(n, _)| n).unwrap_or(cur_n),
+                            target = target_low,
+                            "log index backfill progress"
+                        );
+                    }
                     // Checkpoint after every applied batch: the store is
                     // small at Sepolia scale and a crash then costs at most
                     // one batch (paged store before mainnet — design doc).
@@ -1022,16 +1035,32 @@ impl ElReader {
         // Chunked: one request for ~1023 candidate blocks would blow through
         // peer soft response limits (~2 MiB) and permanently stall a
         // candidate-dense range on the exact-length check below.
-        for chunk in candidates.chunks(64) {
+        // First candidate the peer did NOT serve this round (honest byte-budget
+        // truncation): the batch is applied only ABOVE it, so coverage never
+        // claims a block whose receipts we didn't verify, and the next tick's
+        // batch resumes right at it. Never a hard error — geth-class peers cap
+        // bodies/receipts responses by a soft byte budget, so on candidate-dense
+        // ranges a short response is the EXPECTED shape, and treating it as
+        // peer failure permanently stalled the walk (observed on sepolia at
+        // ~#11.43M: 64 requested → 41 bodies / 23 receipt sets served).
+        let mut stop_below: Option<u64> = None;
+        'chunks: for chunk in candidates.chunks(64) {
             let hashes: Vec<[u8; 32]> = chunk.iter().map(|h| h.hash).collect();
             let (bodies, receipt_blocks) =
                 futures::future::join(peer.get_block_bodies(&hashes), peer.get_receipts(&hashes)).await;
             let bodies = bodies?;
             let receipt_blocks = receipt_blocks?;
-            if bodies.len() != chunk.len() || receipt_blocks.len() != chunk.len() {
-                return Err("peer returned a short bodies/receipts response".to_string());
+            // Served items are an in-order prefix of the request (the per-block
+            // root verification below catches any peer that violates that).
+            let usable = bodies.len().min(receipt_blocks.len()).min(chunk.len());
+            if usable == 0 {
+                // Nothing served at all — a single block's receipts always fit
+                // a response budget, so this peer genuinely can't (or won't)
+                // serve the range; let the caller rotate to the next peer.
+                return Err("peer served no bodies/receipts for candidate chunk".to_string());
             }
-            for ((vh, body), receipts) in chunk.iter().zip(&bodies).zip(&receipt_blocks) {
+            for ((vh, body), receipts) in
+                chunk[..usable].iter().zip(&bodies[..usable]).zip(&receipt_blocks[..usable]) {
                 verify_body_transactions(&vh.header, body)?;
                 if receipts.len() != body.transactions.len() {
                     return Err(format!(
@@ -1055,9 +1084,21 @@ impl ElReader {
                     logs_by_block.insert(vh.header.number, watched);
                 }
             }
+            if usable < chunk.len() {
+                stop_below = Some(chunk[usable].header.number);
+                tracing::debug!(
+                    served = usable,
+                    requested = chunk.len(),
+                    resume_at = chunk[usable].header.number,
+                    "backfill chunk truncated by peer response budget; applying partial batch"
+                );
+                break 'chunks;
+            }
         }
         // Apply top-down (the response is already descending) so every block
-        // adjoins the low edge; the trust edge advances with each block.
+        // adjoins the low edge; the trust edge advances with each block. A
+        // truncated chunk caps the applied span ABOVE the first unprocessed
+        // candidate — partial progress, never a lying coverage claim.
         match self.log_index.lock() {
             Ok(mut slot) => {
                 let Some(ix) = slot.as_mut() else {
@@ -1076,6 +1117,9 @@ impl ElReader {
                 }
                 for vh in new_blocks {
                     let n = vh.header.number;
+                    if stop_below.is_some_and(|stop| n <= stop) {
+                        break; // unprocessed candidate — resume here next tick
+                    }
                     let logs = logs_by_block.remove(&n).unwrap_or_default();
                     ix.backfill_block(n, vh.hash, logs)
                         .map_err(|g| format!("backfill gap at {} (edge {})", g.block, g.edge))?;

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -792,13 +792,14 @@ impl ElReader {
             tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
             let mut since_persist = 0u32;
             let mut ticks = 0u64;
+            let mut backfill_ok = 0u64;
             loop {
                 tick.tick().await;
                 let Some(reader) = weak.upgrade() else {
                     return; // reader torn down; the appender dies with it
                 };
                 reader.log_index_append_tick(&mut since_persist, ticks).await;
-                reader.log_index_backfill_step(ticks).await;
+                reader.log_index_backfill_step(ticks, &mut backfill_ok).await;
                 ticks = ticks.wrapping_add(1);
             }
         }));
@@ -901,7 +902,7 @@ impl ElReader {
     /// (bloom hit) get body+receipts fetched and verified against both roots
     /// before any log is stored. Peer refusal is a stall, never corruption:
     /// coverage simply doesn't extend until some peer serves the range.
-    async fn log_index_backfill_step(&self, ticks: u64) {
+    async fn log_index_backfill_step(&self, ticks: u64, backfill_ok: &mut u64) {
         let Some((config, cursor)) = self.with_log_index(|ix| (ix.config().clone(), ix.cursor)) else {
             return;
         };
@@ -935,11 +936,17 @@ impl ElReader {
                 .await
             {
                 Ok(()) => {
-                    if ticks % 50 == 0 {
+                    // Count SUCCESSES, not ticks: with intermittent failures a
+                    // ticks-modulo log can systematically miss the successful
+                    // ticks and stay silent while progressing. First success
+                    // logs immediately, then every 50th (~5 min when healthy).
+                    *backfill_ok += 1;
+                    if *backfill_ok % 50 == 1 {
                         let new_cursor = self.with_log_index(|ix| ix.cursor).flatten();
                         tracing::info!(
                             cursor = new_cursor.map(|(n, _)| n).unwrap_or(cur_n),
                             target = target_low,
+                            batches_applied = *backfill_ok,
                             "log index backfill progress"
                         );
                     }
@@ -1035,6 +1042,8 @@ impl ElReader {
         // Chunked: one request for ~1023 candidate blocks would blow through
         // peer soft response limits (~2 MiB) and permanently stall a
         // candidate-dense range on the exact-length check below.
+        // (Truncation arithmetic lives in `truncation_plan`/`should_apply` —
+        // pure and unit-tested; see backfill_truncation_tests.)
         // First candidate the peer did NOT serve this round (honest byte-budget
         // truncation): the batch is applied only ABOVE it, so coverage never
         // claims a block whose receipts we didn't verify, and the next tick's
@@ -1052,13 +1061,15 @@ impl ElReader {
             let receipt_blocks = receipt_blocks?;
             // Served items are an in-order prefix of the request (the per-block
             // root verification below catches any peer that violates that).
-            let usable = bodies.len().min(receipt_blocks.len()).min(chunk.len());
-            if usable == 0 {
+            let chunk_numbers: Vec<u64> = chunk.iter().map(|h| h.header.number).collect();
+            let Some((usable, chunk_stop)) =
+                truncation_plan(&chunk_numbers, bodies.len(), receipt_blocks.len())
+            else {
                 // Nothing served at all — a single block's receipts always fit
                 // a response budget, so this peer genuinely can't (or won't)
                 // serve the range; let the caller rotate to the next peer.
                 return Err("peer served no bodies/receipts for candidate chunk".to_string());
-            }
+            };
             for ((vh, body), receipts) in
                 chunk[..usable].iter().zip(&bodies[..usable]).zip(&receipt_blocks[..usable]) {
                 verify_body_transactions(&vh.header, body)?;
@@ -1084,12 +1095,12 @@ impl ElReader {
                     logs_by_block.insert(vh.header.number, watched);
                 }
             }
-            if usable < chunk.len() {
-                stop_below = Some(chunk[usable].header.number);
+            if let Some(stop) = chunk_stop {
+                stop_below = Some(stop);
                 tracing::debug!(
                     served = usable,
                     requested = chunk.len(),
-                    resume_at = chunk[usable].header.number,
+                    resume_at = stop,
                     "backfill chunk truncated by peer response budget; applying partial batch"
                 );
                 break 'chunks;
@@ -1117,7 +1128,7 @@ impl ElReader {
                 }
                 for vh in new_blocks {
                     let n = vh.header.number;
-                    if stop_below.is_some_and(|stop| n <= stop) {
+                    if !should_apply(n, stop_below) {
                         break; // unprocessed candidate — resume here next tick
                     }
                     let logs = logs_by_block.remove(&n).unwrap_or_default();
@@ -3697,3 +3708,71 @@ fn stored_logs_for_block(receipts: &[VerifiedReceipt]) -> Option<Vec<crate::el::
     }
     Some(out)
 }
+
+/// Pure truncation arithmetic for one backfill candidate chunk: given the
+/// chunk's block numbers (descending) and how many bodies/receipts the peer
+/// actually served, return `(usable, stop_below)` — the verified-prefix
+/// length and, when the peer's byte budget truncated the response, the block
+/// number of the FIRST unserved candidate (the batch must apply only above
+/// it). `None` = the peer served nothing usable (caller rotates peers).
+fn truncation_plan(
+    chunk_numbers_desc: &[u64],
+    bodies_served: usize,
+    receipts_served: usize,
+) -> Option<(usize, Option<u64>)> {
+    let usable = bodies_served.min(receipts_served).min(chunk_numbers_desc.len());
+    if usable == 0 {
+        return None;
+    }
+    let stop = chunk_numbers_desc.get(usable).copied();
+    Some((usable, stop))
+}
+
+/// Whether block `n` may be applied given the truncation cut: everything at
+/// or below the first unprocessed candidate is excluded — coverage must never
+/// claim a block whose candidate receipts were not verified.
+fn should_apply(n: u64, stop_below: Option<u64>) -> bool {
+    !stop_below.is_some_and(|stop| n <= stop)
+}
+
+#[cfg(test)]
+mod backfill_truncation_tests {
+    use super::{should_apply, truncation_plan};
+
+    #[test]
+    fn full_serve_has_no_cut() {
+        assert_eq!(truncation_plan(&[90, 80, 70], 3, 3), Some((3, None)));
+        // Over-serve (peer sent more than asked) still caps at the chunk.
+        assert_eq!(truncation_plan(&[90, 80], 5, 9), Some((2, None)));
+    }
+
+    #[test]
+    fn short_serve_cuts_at_first_unserved_candidate() {
+        // 3 candidates, only 2 receipt sets served → cut at the 3rd (70).
+        assert_eq!(truncation_plan(&[90, 80, 70], 3, 2), Some((2, Some(70))));
+        // The boundary block itself must NOT be applied; blocks above must.
+        assert!(should_apply(71, Some(70)));
+        assert!(!should_apply(70, Some(70)));
+        assert!(!should_apply(69, Some(70)));
+        assert!(should_apply(70, None));
+    }
+
+    #[test]
+    fn empty_serve_is_peer_failure() {
+        assert_eq!(truncation_plan(&[90, 80], 0, 5), None);
+        assert_eq!(truncation_plan(&[90, 80], 5, 0), None);
+        assert_eq!(truncation_plan(&[], 5, 5), None);
+    }
+
+    #[test]
+    fn first_candidate_only_still_makes_progress() {
+        // Only the first candidate served: the cut is the SECOND candidate,
+        // so the batch still applies at least every block above it — the
+        // cursor strictly descends (no same-cursor livelock).
+        let plan = truncation_plan(&[100, 99, 98], 1, 1);
+        assert_eq!(plan, Some((1, Some(99))));
+        assert!(should_apply(100, Some(99)));
+        assert!(!should_apply(99, Some(99)));
+    }
+}
+

--- a/rust/myotis-net/tests/live_dedicated_node.rs
+++ b/rust/myotis-net/tests/live_dedicated_node.rs
@@ -121,7 +121,8 @@ async fn dedicated_node_serves_backfill_shapes() {
             i
         );
     }
-    eprintln!("[dedicated] prefix consistent — node serves the backfill shapes");
+    eprintln!("[dedicated] prefix count-consistent — node serves the backfill shapes \
+         (counts only; the walker itself verifies tx/receipt roots)");
     drop(peer);
 }
 

--- a/rust/myotis-net/tests/live_dedicated_node.rs
+++ b/rust/myotis-net/tests/live_dedicated_node.rs
@@ -1,0 +1,136 @@
+//! Live diagnostic against the dedicated sepolia node (docs/dedicated-sepolia-node.md):
+//! dial it directly and run the exact request shapes the log-index backfill
+//! walker uses — reverse header window from a recent block, then bodies +
+//! receipts for a chunk — printing where (if anywhere) the node stops serving.
+//!
+//! Run with:
+//! `cargo test -p myotis-net --test live_dedicated_node -- --ignored --nocapture`
+
+use std::sync::Arc;
+
+use myotis_core::nodekey::NodeKey;
+use myotis_net::el::eth::session::{EthConfig, EthSession};
+use myotis_net::el::peer::ManagedPeer;
+use myotis_net::el::rlpx::transport::RlpxConnection;
+
+const NODE_ADDR: &str = "87.154.209.161:30405";
+const NODE_PUBKEY_HEX: &str =
+    "cfd3572bd7691fe03baf52106b873e01d9b5dca1714a74b316cb94151127dfd2\
+     0adae3be559e3e6b44b78a5af1ed6f92ecc8676a2555fc7cdb2d29a0c37e1b2c";
+const SEPOLIA_GENESIS: &str = "25a5cc106eea7138acab33231d7160d69cb777ee0c2c553fcddf5138993e6dd9";
+// Post-BPO2 (Fusaka) fork id — keep in lockstep with NetworkConfig.java.
+const SEPOLIA_FORK_ID: [u8; 4] = [0x26, 0x89, 0x56, 0xb6];
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "live network: exercises the dedicated node with backfill-shaped requests"]
+async fn dedicated_node_serves_backfill_shapes() {
+    let key = Arc::new(
+        NodeKey::from_secret_bytes(&myotis_core::keccak::keccak256(b"live-dedicated")).unwrap(),
+    );
+    let genesis = hex32(SEPOLIA_GENESIS);
+    let cfg = Arc::new(EthConfig {
+        network_id: 11155111,
+        genesis_hash: genesis,
+        fork_id_hash: SEPOLIA_FORK_ID,
+        fork_next: 0,
+        head_hash: genesis,
+        head_number: 0,
+        listen_port: 30303,
+        genesis_header_rlp: None,
+    });
+
+    let addr: std::net::SocketAddr = NODE_ADDR.parse().unwrap();
+    let mut pubkey = [0u8; 64];
+    for (i, b) in pubkey.iter_mut().enumerate() {
+        *b = u8::from_str_radix(&NODE_PUBKEY_HEX[i * 2..i * 2 + 2], 16).unwrap();
+    }
+
+    let conn = RlpxConnection::dial(Arc::clone(&key), addr, pubkey)
+        .await
+        .expect("rlpx dial+handshake");
+    let session = EthSession::handshake(conn, &key.public_key_bytes(), &cfg, None)
+        .await
+        .expect("eth handshake (status/forkid gate)");
+    eprintln!(
+        "[dedicated] handshake OK: eth/{} snap={} client={}",
+        session.eth_version, session.snap, session.peer_hello.client_id
+    );
+    let best_hash = session.peer_status.best_hash;
+    let peer = ManagedPeer::spawn(session, addr);
+
+    // Step 0: resolve the peer's own head to a (number, hash) cursor.
+    let head = peer
+        .get_block_headers_by_hash(&best_hash, 1)
+        .await
+        .expect("head header by hash");
+    let head = head.first().expect("head header present");
+    let cur_n = head.header.number;
+    let cur_hash = head.hash;
+    eprintln!("[dedicated] head #{cur_n}");
+
+    // Step 1: the walker's reverse window — 1024 headers descending from the cursor.
+    let window = peer
+        .get_block_headers_by_number(cur_n, 1024, 0, true)
+        .await
+        .expect("reverse header window");
+    eprintln!("[dedicated] reverse window: {} headers", window.len());
+    assert!(!window.is_empty(), "node served no headers for the reverse window");
+    let top = window.first().unwrap();
+    assert_eq!(top.header.number, cur_n, "window must start at the cursor");
+    assert_eq!(top.hash, cur_hash, "cursor hash mismatch");
+    let mut verified = 0usize;
+    for pair in window.windows(2) {
+        let [upper, lower] = pair else { break };
+        if upper.header.parent_hash != lower.hash
+            || lower.header.number != upper.header.number.wrapping_sub(1)
+        {
+            break;
+        }
+        verified += 1;
+    }
+    eprintln!("[dedicated] parent-hash-chained prefix: {verified} blocks");
+    assert!(verified > 0, "response does not chain to the cursor");
+
+    // Step 2: bodies + receipts for a walker-sized chunk (64 blocks).
+    let chunk: Vec<[u8; 32]> = window[1..].iter().take(64).map(|h| h.hash).collect();
+    let (bodies, receipts) = futures::future::join(
+        peer.get_block_bodies(&chunk),
+        peer.get_receipts(&chunk),
+    )
+    .await;
+    let bodies = bodies.expect("bodies response");
+    let receipts = receipts.expect("receipts response");
+    // Byte-budget truncation is the EXPECTED honest shape (this is exactly
+    // what the walker must tolerate — see log_index_backfill_batch): assert a
+    // non-empty, internally-consistent prefix rather than exact lengths.
+    let usable = bodies.len().min(receipts.len()).min(chunk.len());
+    eprintln!(
+        "[dedicated] chunk of {}: {} bodies, {} receipt sets -> usable prefix {}",
+        chunk.len(),
+        bodies.len(),
+        receipts.len(),
+        usable
+    );
+    assert!(usable > 0, "node served no bodies/receipts at all");
+    for (i, (body, rs)) in bodies[..usable].iter().zip(&receipts[..usable]).enumerate() {
+        assert_eq!(
+            rs.len(),
+            body.transactions.len(),
+            "block {} ({}th in chunk): receipts/txs mismatch",
+            window[1 + i].header.number,
+            i
+        );
+    }
+    eprintln!("[dedicated] prefix consistent — node serves the backfill shapes");
+    drop(peer);
+}
+
+fn hex32(s: &str) -> [u8; 32] {
+    let v: Vec<u8> = (0..s.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&s[i..i + 2], 16).unwrap())
+        .collect();
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&v);
+    out
+}


### PR DESCRIPTION
## The stall, root-caused live

Enabling the sepolia log index today produced exactly 3 backfill batches (16:32–16:34) and then a frozen checkpoint. A live diagnostic against the dedicated node (committed as `live_dedicated_node.rs`, `#[ignore]`-gated) found the cause:

```
[dedicated] reverse window: 1024 headers, 1023 chained     ← headers: perfect
[dedicated] chunk of 64: 41 bodies, 23 receipt sets        ← honest byte-budget truncation
```

Geth caps bodies/receipts responses by a **soft byte budget**. The walker treated any short response as a hard peer failure — so on candidate-dense ranges every peer (including the dedicated node, which serves everything it's allowed to) failed the same batch forever.

## Changes

- **`log_index_backfill_batch` tolerates truncation**: the verified in-order prefix is processed and the applied batch is cut **above the first unserved candidate** — partial progress, coverage never claims an unverified block, next tick resumes at the cut. Empty responses remain a peer failure (single-block receipts always fit a budget), so genuinely refusing peers still rotate. The arithmetic lives in pure `truncation_plan`/`should_apply` with unit tests pinning the boundary exclusion and the strict-progress guarantee (no same-cursor livelock).
- **Observability the stall investigation lacked**: rate-limited INFO when the walker idles on an empty pool (previously a silent early-return, indistinguishable from a hang), and a success-counted backfill-progress INFO (first batch immediately, then every 50th).
- **`eth_getLogs` filter logging** (requested for the Kohaku bring-up): every refusal logs the exact filter JSON + reason at info (debounced — identical filter+reason at most once/minute, since a polling wallet repeats the refused query throughout catch-up); successes at debug. Filter content is addresses/topics/ranges — no secrets.
- **Live diagnostic** dials the pinned sepolia node with the exact walker request shapes; its truncation tolerance mirrors the walker's. (Node IP/pubkey already public in-repo via the #281 pins.)

Internal no-context review verified coverage correctness (descending-order cut excludes the boundary block; later-chunk cuts sound; zip-misalignment always fails root verification; progress strictly descends) and its findings — missing unit tests, ticks-modulo progress-log blind spot, refusal-log volume, brace-stripping bug — are addressed in the second commit.

After merge + desktop restart: the sepolia backfill should walk ~1023 blocks/6s on sparse ranges and smaller verified strides on dense ones, with progress visible in the log; ETA to the Kohaku preset floor remains roughly overnight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPnTFwmAVMypWYtoioAXQT