### PR TITLE
Desktop: make Compose packaging track the Rust engine dylib as input

### DIFF
--- a/app-desktop/build.gradle.kts
+++ b/app-desktop/build.gradle.kts
@@ -158,8 +158,12 @@ tasks.configureEach {
         // explicit input makes any dylib change dirty the image and every
         // installer built from it. Fingerprinting happens at execution time,
         // after prepareRustAppResources (dependsOn above) has created the dir.
-        inputs.dir(layout.buildDirectory.dir("rustAppResources"))
-            .withPropertyName("rustEngineAppResources")
+        // The uber-jar packagers match the name predicate but bundle no app
+        // resources — skip them so a Rust-only change doesn't re-zip the jar.
+        if (!name.contains("UberJar")) {
+            inputs.dir(layout.buildDirectory.dir("rustAppResources"))
+                .withPropertyName("rustEngineAppResources")
+        }
     }
 }
 

--- a/app-desktop/build.gradle.kts
+++ b/app-desktop/build.gradle.kts
@@ -148,6 +148,18 @@ tasks.configureEach {
         || name.startsWith("runDistributable") || name.startsWith("runRelease")
     ) {
         dependsOn(prepareRustAppResources)
+        // Compose's jpackage tasks do NOT track the app-resources CONTENT as
+        // an input: after a Rust-only change, prepareRustAppResources and
+        // Compose's own prepareAppResources both re-run, yet
+        // createDistributable/packageDmg still report UP-TO-DATE and ship the
+        // previous image — i.e. a stale engine dylib with no error anywhere
+        // (reproduced 2026-08-06: staged+prepared dirs carried a new exported
+        // symbol, the packaged .app didn't). Declaring the staged dir as an
+        // explicit input makes any dylib change dirty the image and every
+        // installer built from it. Fingerprinting happens at execution time,
+        // after prepareRustAppResources (dependsOn above) has created the dir.
+        inputs.dir(layout.buildDirectory.dir("rustAppResources"))
+            .withPropertyName("rustEngineAppResources")
     }
 }
 

--- a/app-desktop/build.gradle.kts
+++ b/app-desktop/build.gradle.kts
@@ -2,6 +2,7 @@
 // and drives the Java backend (`node-core`) in-process via DesktopNodeController — the same
 // backend the daemon and Android use, so there's no duplication. (JVM target; not iOS.)
 
+import org.gradle.api.tasks.PathSensitivity
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 
 plugins {
@@ -109,12 +110,17 @@ val composeOsArchDir = run {
     "$osPart-$archPart"
 }
 
+// Single source of truth for the staged-resources root: the staging task's
+// output, Compose's appResourcesRootDir, and the packaging tasks' input all
+// derive from it (a drifting duplicate literal would silently untrack).
+val rustAppResourcesRoot = layout.buildDirectory.dir("rustAppResources")
+
 val prepareRustAppResources = tasks.register("prepareRustAppResources") {
     group = "build"
     description = "Stage the Rust engine host lib into Compose appResources for packaging"
     dependsOn(rootProject.tasks.named("cargoBuildHost"))
     val src = rootProject.file("$rustReleaseDir/$rustHostLibName")
-    val destDir = layout.buildDirectory.dir("rustAppResources/$composeOsArchDir")
+    val destDir = rustAppResourcesRoot.map { it.dir(composeOsArchDir) }
     inputs.files(src).optional() // optional so the ACTION runs even when absent
     outputs.dir(destDir)
     // A plain task, NOT Copy: a Copy with a missing source is skipped as
@@ -161,8 +167,9 @@ tasks.configureEach {
         // The uber-jar packagers match the name predicate but bundle no app
         // resources — skip them so a Rust-only change doesn't re-zip the jar.
         if (!name.contains("UberJar")) {
-            inputs.dir(layout.buildDirectory.dir("rustAppResources"))
+            inputs.dir(rustAppResourcesRoot)
                 .withPropertyName("rustEngineAppResources")
+                .withPathSensitivity(PathSensitivity.RELATIVE)
         }
     }
 }
@@ -185,7 +192,7 @@ compose.desktop {
         }.get().metadata.installationPath.asFile.absolutePath
         nativeDistributions {
             // The staged Rust engine lib (see prepareRustAppResources above).
-            appResourcesRootDir.set(layout.buildDirectory.dir("rustAppResources"))
+            appResourcesRootDir.set(rustAppResourcesRoot)
             // jpackage is host-OS-bound: the .dmg can only be produced on macOS, the .deb only
             // on Linux. CI builds each on its matching runner (desktop-dmg.yml /
             // desktop-linux-deb.yml); locally you get the format for your OS. Msi when a


### PR DESCRIPTION
## The bug (bit us today)

Compose's jpackage tasks don't fingerprint app-resources **content** — `AbstractJPackageTask.appResourcesDir` is `@Internal` (verified against the decompiled Compose 1.9.3 plugin during review). After a **Rust-only** change: cargo rebuilds, `prepareRustAppResources` re-stages, Compose's own `prepareAppResources` re-copies — and `createDistributable`/`packageDmg` still report UP-TO-DATE and ship the previous image. A stale engine dylib, no error anywhere. Today that meant the #289 backfill fix compiled and staged correctly while the repackaged DMG silently carried the old engine and the log-index walker stayed stalled until we caught it by comparing dylib hashes.

## Reproduction (deterministic)

Add an exported symbol to the engine (`#[no_mangle] pub extern "C" fn …`), run `createDistributable`: the staged dir and Compose's prepared dir both carry the new symbol; the packaged `.app` does not, with `--info` showing `Skipping task ':app-desktop:createDistributable' as it is up-to-date`.

## Fix

Declare the staged `rustAppResources` dir as an explicit `inputs.dir` on the packaging task family (same `configureEach` block that already wires `dependsOn(prepareRustAppResources)`), excluding the uber-jar packagers which bundle no app resources. Verified both directions:

- Rust-only relink → packaging re-runs, bundle content follows (symbol appears, and disappears again on revert)
- no-change build → fully up-to-date in ~1s (no false-dirtiness)

Review notes (independent no-context pass, findings addressed): the input on `package*` is required on Linux/Windows (their package tasks consume `appResourcesDir` directly, not via `createDistributable`), run-tasks are unaffected (never up-to-date anyway), the missing-dir edge is unreachable outside `-x` exclusions, and the wiring is configuration-cache-safe.

With this merged, the usual `git pull && gw :app-desktop:packageDmg && …remount` flow is trustworthy again for Rust-only changes (the mountpoint-pinning suggestion for `hdiutil attach -mountpoint /Volumes/Myotis` remains advisable separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPnTFwmAVMypWYtoioAXQT