### PR TITLE
CI: stop building Linux debs and the x64 dmg on PR pushes

### DIFF
--- a/.github/workflows/desktop-dmg.yml
+++ b/.github/workflows/desktop-dmg.yml
@@ -32,6 +32,11 @@ jobs:
     # cross-build on the always-available arm64 runner removes that dependency.
     # An arm64 .dmg will NOT launch on an Intel Mac (Rosetta only translates x86→arm), so download
     # the one matching your Mac.
+    # PRs build only the arm64 dmg (the arch developers actually run; proves
+    # jpackage end-to-end). The x64/Rosetta leg is a release/main artifact —
+    # on PRs it doubled the macOS runner load for a result that never changes
+    # a PR decision.
+    if: ${{ matrix.arch == 'arm64' || github.event_name != 'pull_request' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/desktop-linux-deb.yml
+++ b/.github/workflows/desktop-linux-deb.yml
@@ -1,15 +1,14 @@
 name: Desktop DEB (Linux)
 
 on:
-  # Scope push to main + release tags so a branch push that also has an open PR
-  # doesn't build twice (the PR is covered by pull_request below). Tags still
-  # build the release .deb.
+  # Deliberately NO pull_request trigger: Linux installers are release/main
+  # artifacts, not per-push PR feedback. Building them on every PR push queued
+  # 4+ installer jobs ahead of the fast, decision-relevant checks (review,
+  # Build and Test) and starved them on busy days — the .deb result never
+  # changes a PR decision anyway (Build and Test compiles the same code).
   push:
     branches: [ "main" ]
     tags: [ "v*" ]
-  # pull_request stays unscoped (any base branch) — the double-run is already
-  # killed by narrowing push above, and this keeps CI on PRs that don't target main.
-  pull_request:
   # Manual publish path: attach debs built from the CURRENT ref to an existing
   # release (added so Linux builds could join v0.1.0, which was tagged before
   # this workflow existed, without moving the tag). Note the assets then come


### PR DESCRIPTION
Per-push installer builds were starving the decision-relevant checks. Every PR push queued **11 jobs**; on a flaky Actions day (like today's `Service Unavailable` incident) the claude-review run got superseded mid-flight or never scheduled, while four installer jobs built artifacts nobody consumes from PRs.

**After this change, PR pushes run**: Build and Test, Android APK, replay harness, claude-review, and the **arm64 dmg** (the architecture developers actually run — kept as the end-to-end jpackage proof).
**Moved to push-to-main + release tags** (unchanged there): both Linux debs and the x64/Rosetta dmg. The `workflow_dispatch` manual-publish path is untouched.

The x64 dmg gating uses a matrix-aware job `if` rather than a trigger change so the tag/main behavior of the workflow stays identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPnTFwmAVMypWYtoioAXQT