### PR TITLE
CI: fix the dmg PR gate (matrix context unavailable in job-level if)

### DIFF
--- a/.github/workflows/desktop-dmg.yml
+++ b/.github/workflows/desktop-dmg.yml
@@ -32,19 +32,18 @@ jobs:
     # cross-build on the always-available arm64 runner removes that dependency.
     # An arm64 .dmg will NOT launch on an Intel Mac (Rosetta only translates x86→arm), so download
     # the one matching your Mac.
-    # PRs build only the arm64 dmg (the arch developers actually run; proves
-    # jpackage end-to-end). The x64/Rosetta leg is a release/main artifact —
-    # on PRs it doubled the macOS runner load for a result that never changes
-    # a PR decision.
-    if: ${{ matrix.arch == 'arm64' || github.event_name != 'pull_request' }}
     strategy:
       fail-fast: false
+      # PRs build only the arm64 dmg (the arch developers actually run; proves
+      # jpackage end-to-end). The x64/Rosetta leg is a release/main artifact —
+      # on PRs it doubled the macOS runner load for a result that never
+      # changes a PR decision. Gated HERE via a conditional matrix, NOT a
+      # job-level `if`: the matrix context is unavailable in job-level if
+      # (it evaluates empty), which silently skipped BOTH legs on PRs.
       matrix:
-        include:
-          - arch: arm64
-            java-arch: aarch64
-          - arch: x64
-            java-arch: x64
+        include: ${{ github.event_name == 'pull_request'
+          && fromJSON('[{"arch":"arm64","java-arch":"aarch64"}]')
+          || fromJSON('[{"arch":"arm64","java-arch":"aarch64"},{"arch":"x64","java-arch":"x64"}]') }}
     runs-on: macos-14
     permissions:
       contents: read


### PR DESCRIPTION
Follow-up bug-fix to #292, surfaced by the missing-jobs question on #293: the x64-dmg gate used `if: ${{ matrix.arch == 'arm64' || github.event_name != 'pull_request' }}` at **job level** — but the `matrix` context doesn't exist in job-level `if` expressions. `matrix.arch` evaluated empty, the condition was false for **both** matrix legs on PRs, and the dmg job silently vanished from PR checks entirely (instead of running arm64-only as intended).

Fix: gate via a **conditional matrix** — on `pull_request` the matrix expands to just the arm64 leg, on push/tags to both. Same intended behavior, evaluated in `strategy.matrix` where the `github` context is legal, with `fromJSON` supplying the include arrays.

This PR's own check list is the validation: it should show exactly one dmg job (arm64) building.

(For the record: the fully-missing checks on #293 itself were today's Actions event-loss incident — that push predates the #292 merge by 3 minutes, so the old workflows should have fired and simply never did.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPnTFwmAVMypWYtoioAXQT