### PR TITLE
log index: pipeline candidate-chunk fetches within a backfill batch

### DIFF
--- a/rust/myotis-net/src/el/peer.rs
+++ b/rust/myotis-net/src/el/peer.rs
@@ -53,9 +53,37 @@ struct Pending {
 
 type PendingMap = Arc<Mutex<HashMap<u64, Pending>>>;
 
+/// The egress writer plus a torn-write marker. A frame write whose future is
+/// DROPPED mid-await (request futures are cancelled routinely — e.g. the
+/// backfill pipeline dropping its in-flight stream on truncation) may have put
+/// a partial frame on the wire with the egress MAC already advanced; nothing
+/// runs afterwards to notice. `torn` is set before every send and cleared only
+/// when the send completes, so the next lock holder observes the tear and
+/// refuses the corrupt stream instead of writing MAC-garbage after it.
+struct GuardedWriter {
+    inner: RlpxWriter,
+    torn: bool,
+}
+
+type SharedWriter = Arc<Mutex<GuardedWriter>>;
+
+/// Send one frame under the writer lock, cancel-safely: a previous send that
+/// was cancelled mid-frame leaves `torn` set, which this surfaces as a write
+/// error — every call site already treats that as fatal (`fail_all` + close).
+async fn send_frame(writer: &SharedWriter, code: u64, body: &[u8]) -> Result<(), String> {
+    let mut w = writer.lock().await;
+    if w.torn {
+        return Err("egress stream torn by a cancelled frame write".to_string());
+    }
+    w.torn = true;
+    let result = w.inner.send(code, body).await;
+    w.torn = false;
+    result
+}
+
 /// A negotiated eth/snap peer, driven by a background read loop.
 pub struct ManagedPeer {
-    writer: Arc<Mutex<RlpxWriter>>,
+    writer: SharedWriter,
     pending: PendingMap,
     next_id: AtomicU64,
     /// Set once the read loop terminates (disconnect / read error); requests
@@ -125,7 +153,7 @@ impl ManagedPeer {
     ) -> ManagedPeer {
         let (reader, writer, peer_pubkey) = conn.split();
         let snap_codes = snap.then(|| snap::SnapCodes::for_eth_version(eth_version));
-        let writer = Arc::new(Mutex::new(writer));
+        let writer = Arc::new(Mutex::new(GuardedWriter { inner: writer, torn: false }));
         let pending: PendingMap = Arc::new(Mutex::new(HashMap::new()));
         let closed = Arc::new(AtomicBool::new(false));
 
@@ -201,7 +229,11 @@ impl ManagedPeer {
         // stream in an indeterminate state (a partial frame may be on the wire),
         // so fail EVERY in-flight request — not just this one, which would leave
         // the others hanging until their own timeouts on a dead connection.
-        if let Err(e) = self.writer.lock().await.send(send_code, &body).await {
+        // (If THIS future is cancelled inside the send, the torn marker in
+        // `send_frame` makes the next writer fail here instead; the pending
+        // entry inserted above is then drained by that `fail_all`, or by the
+        // discarded late response — either way it stays bounded.)
+        if let Err(e) = send_frame(&self.writer, send_code, &body).await {
             fail_all(&self.pending, &self.closed, format!("peer write failure: {e}")).await;
             return Err(e);
         }
@@ -229,7 +261,7 @@ impl ManagedPeer {
         // frame-write timeout leaves the egress stream mid-frame with the MAC
         // advanced (see write_frame), so the writer must not be reused — close
         // the peer like every other send path does.
-        if let Err(e) = self.writer.lock().await.send(messages::BLOCK_RANGE_UPDATE, &body).await {
+        if let Err(e) = send_frame(&self.writer, messages::BLOCK_RANGE_UPDATE, &body).await {
             fail_all(&self.pending, &self.closed, format!("peer write failure: {e}")).await;
         }
     }
@@ -241,7 +273,7 @@ impl ManagedPeer {
     /// [`Self::request`].
     pub async fn send_transaction(&self, raw_tx: &[u8]) -> Result<(), String> {
         let body = messages::encode_transactions(raw_tx);
-        if let Err(e) = self.writer.lock().await.send(messages::TRANSACTIONS, &body).await {
+        if let Err(e) = send_frame(&self.writer, messages::TRANSACTIONS, &body).await {
             fail_all(&self.pending, &self.closed, format!("peer write failure: {e}")).await;
             return Err(e);
         }
@@ -553,7 +585,7 @@ impl Drop for ManagedPeer {
 /// error or a peer Disconnect, failing every in-flight request on the way out.
 async fn read_loop(
     mut reader: RlpxReader,
-    writer: Arc<Mutex<RlpxWriter>>,
+    writer: SharedWriter,
     pending: PendingMap,
     closed: Arc<AtomicBool>,
     snap_codes: Option<snap::SnapCodes>,
@@ -605,7 +637,7 @@ async fn read_loop(
             // Pong body is an empty RLP list. A write failure (e.g. a half-closed
             // connection where reads still succeed) means the peer is dead — fail
             // in-flight requests and stop, rather than spin on a zombie.
-            if let Err(e) = writer.lock().await.send(P2P_PONG, &[0xc0]).await {
+            if let Err(e) = send_frame(&writer, P2P_PONG, &[0xc0]).await {
                 fail_all(&pending, &closed, format!("peer write failure on Pong: {e}")).await;
                 break;
             }
@@ -628,7 +660,7 @@ async fn read_loop(
             if code == messages::GET_BLOCK_HEADERS {
                 ctx.stats.header_asked();
                 if let Some(resp) = serve_headers(ctx, &frame.payload) {
-                    if let Err(e) = writer.lock().await.send(messages::BLOCK_HEADERS, &resp).await {
+                    if let Err(e) = send_frame(&writer, messages::BLOCK_HEADERS, &resp).await {
                         fail_all(&pending, &closed, format!("peer write failure on served headers: {e}"))
                             .await;
                         break;
@@ -644,7 +676,7 @@ async fn read_loop(
 
         // An inbound Get* request we answer with an empty response.
         if let Some((resp_code, empty)) = empty_answer(code, &snap_codes, &frame.payload) {
-            if let Err(e) = writer.lock().await.send(resp_code, &empty).await {
+            if let Err(e) = send_frame(&writer, resp_code, &empty).await {
                 fail_all(&pending, &closed, format!("peer write failure on empty response: {e}"))
                     .await;
                 break;

--- a/rust/myotis-net/src/el/peer.rs
+++ b/rust/myotis-net/src/el/peer.rs
@@ -85,6 +85,35 @@ async fn send_frame(writer: &SharedWriter, code: u64, body: &[u8]) -> Result<(),
     result
 }
 
+/// Removes a request's pending-map entry if the owning [`ManagedPeer::request`]
+/// future is DROPPED mid-flight (routine under the backfill pipeline, which
+/// cancels in-flight fetches on truncation). Without this, a cancelled request
+/// whose peer never answers would leave its entry until disconnect. Disarmed on
+/// every completed path — there the entry is already removed (response
+/// delivery, explicit timeout removal, or `fail_all`'s drain). The pending
+/// mutex is async, so cleanup happens via a spawned task; at runtime shutdown
+/// (no handle) the whole map is being dropped anyway.
+struct PendingGuard {
+    pending: PendingMap,
+    id: u64,
+    armed: bool,
+}
+
+impl Drop for PendingGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            let pending = Arc::clone(&self.pending);
+            let id = self.id;
+            handle.spawn(async move {
+                pending.lock().await.remove(&id);
+            });
+        }
+    }
+}
+
 /// A negotiated eth/snap peer, driven by a background read loop.
 pub struct ManagedPeer {
     writer: SharedWriter,
@@ -228,6 +257,8 @@ impl ManagedPeer {
             }
             map.insert(id, Pending { want_code, tx });
         }
+        let mut guard =
+            PendingGuard { pending: Arc::clone(&self.pending), id, armed: true };
 
         // Send under the writer lock; a write failure leaves the egress frame
         // stream in an indeterminate state (a partial frame may be on the wire),
@@ -239,10 +270,11 @@ impl ManagedPeer {
         // discarded late response — either way it stays bounded.)
         if let Err(e) = send_frame(&self.writer, send_code, &body).await {
             fail_all(&self.pending, &self.closed, format!("peer write failure: {e}")).await;
+            guard.armed = false; // fail_all drained the map
             return Err(e);
         }
 
-        match tokio::time::timeout(REQUEST_TIMEOUT, rx).await {
+        let out = match tokio::time::timeout(REQUEST_TIMEOUT, rx).await {
             Ok(Ok(result)) => result,
             // The read loop dropped the sender (disconnect drained the map).
             Ok(Err(_)) => Err("peer connection closed".to_string()),
@@ -250,7 +282,9 @@ impl ManagedPeer {
                 self.pending.lock().await.remove(&id);
                 Err(format!("timed out awaiting code 0x{want_code:02x}"))
             }
-        }
+        };
+        guard.armed = false;
+        out
     }
 
     /// Push an eth/69 BlockRangeUpdate advertising our current servable range.

--- a/rust/myotis-net/src/el/peer.rs
+++ b/rust/myotis-net/src/el/peer.rs
@@ -77,7 +77,11 @@ async fn send_frame(writer: &SharedWriter, code: u64, body: &[u8]) -> Result<(),
     }
     w.torn = true;
     let result = w.inner.send(code, body).await;
-    w.torn = false;
+    // A completed-Err send (write error / frame-write timeout) leaves the
+    // stream just as mid-frame-corrupt as a cancelled one — keep the marker
+    // set so a request already queued on the writer lock (racing `fail_all`'s
+    // closed-store) can't write onto the corrupt stream.
+    w.torn = result.is_err();
     result
 }
 

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -1205,8 +1205,22 @@ impl ElReader {
                 .chunks(CHUNK_LEN)
                 .nth(chunk_idx)
                 .ok_or("chunk index out of range")?;
-            let bodies = bodies?;
-            let receipt_blocks = receipt_blocks?;
+            let (bodies, receipt_blocks) = match (bodies, receipt_blocks) {
+                (Ok(b), Ok(r)) => (b, r),
+                (b, r) => {
+                    // A failed chunk fetch may be a pipelining artifact: at
+                    // depth 4 a tail request's 15s timer runs while the peer
+                    // serves the full-budget responses queued ahead of it, so
+                    // a slow link can time out where the sequential shape
+                    // worked — and unlike truncation, an error would otherwise
+                    // leave the depth at 4 and repeat the failure on the next
+                    // peer. Degrade like a truncated batch; a clean batch
+                    // restores full depth.
+                    self.log_index_pipeline_full
+                        .store(false, std::sync::atomic::Ordering::Relaxed);
+                    return Err(b.err().or(r.err()).unwrap_or_else(|| "chunk fetch failed".into()));
+                }
+            };
             // Served items are an in-order prefix of the request (the per-block
             // root verification below catches any peer that violates that).
             let chunk_numbers: Vec<u64> = chunk.iter().map(|h| h.header.number).collect();

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -1261,9 +1261,10 @@ impl ElReader {
                 break 'chunks;
             }
         }
-        if stop_below.is_none() {
+        if stop_below.is_none() && !candidates.is_empty() {
             // Whole candidate set served untruncated — this range rewards
-            // pipelining; restore full depth for the next batch.
+            // pipelining; restore full depth for the next batch. (A bloom-empty
+            // batch is no evidence either way and leaves the depth alone.)
             self.log_index_pipeline_full
                 .store(true, std::sync::atomic::Ordering::Relaxed);
         }

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -565,6 +565,10 @@ pub struct ElReader {
     /// Last backfill checkpoint write — throttles the full-index persist
     /// (see the step's PERSIST_MIN_INTERVAL).
     log_index_last_persist: std::sync::Mutex<Option<std::time::Instant>>,
+    /// Adaptive chunk-pipeline depth signal: true after an untruncated batch
+    /// (pipelining pays), false after a budget-truncated one (prefetch would
+    /// waste the serving link). See log_index_backfill_batch.
+    log_index_pipeline_full: std::sync::atomic::AtomicBool,
     /// Rolling backfill throughput — see [`Self::log_index_rate_bps`]. The
     /// sample anchor is (instant, cursor) at the last PROGRESS observation, so
     /// the rate is measured against WALL CLOCK between progress points (idle
@@ -715,6 +719,7 @@ impl ElReader {
             log_index: std::sync::Mutex::new(None),
             log_index_rate: std::sync::Mutex::new(None),
             log_index_last_persist: std::sync::Mutex::new(None),
+            log_index_pipeline_full: std::sync::atomic::AtomicBool::new(true),
             log_index_path: cfg.log_index_path,
             log_index_task: std::sync::Mutex::new(None),
         })
@@ -1144,11 +1149,59 @@ impl ElReader {
         // ranges a short response is the EXPECTED shape, and treating it as
         // peer failure permanently stalled the walk (observed on sepolia at
         // ~#11.43M: 64 requested → 41 bodies / 23 receipt sets served).
+        // PIPELINED chunk fetches (#297 option 1): keep several chunk
+        // requests in flight on the multiplexed connection while results are
+        // consumed strictly IN ORDER — verification is per-block, but the
+        // truncation cut and coverage adjacency depend on request order, so
+        // ordering lives in the consumer (`buffered`, not `buffer_unordered`).
+        // On truncation/failure the stream is dropped, cancelling in-flight
+        // fetches (their late responses are discarded by the peer read loop;
+        // worst case a few response budgets of wasted bandwidth past the cut).
+        const CHUNK_PIPELINE: usize = 4;
+        const CHUNK_LEN: usize = 64;
+        // ADAPTIVE depth: pipelining only pays where chunks come back FULL
+        // (sequential RTTs dominate); in budget-truncated ranges the batch
+        // ends at the first chunk and any prefetched chunks are pure wasted
+        // bandwidth on the already-saturated serving link — so after a
+        // truncated batch the next one degrades to depth 1 (identical to the
+        // pre-pipeline behavior), and a clean batch restores full depth.
+        let depth = if self
+            .log_index_pipeline_full
+            .load(std::sync::atomic::Ordering::Relaxed)
+        {
+            CHUNK_PIPELINE
+        } else {
+            1
+        };
         let mut stop_below: Option<u64> = None;
-        'chunks: for chunk in candidates.chunks(64) {
-            let hashes: Vec<[u8; 32]> = chunk.iter().map(|h| h.hash).collect();
-            let (bodies, receipt_blocks) =
-                futures::future::join(peer.get_block_bodies(&hashes), peer.get_receipts(&hashes)).await;
+        // Owned per-chunk hash lists move into the fetch futures (borrowing
+        // the header slices across the stream trips Send inference in the
+        // spawned appender task); the consumer re-derives each chunk slice by
+        // index for verification.
+        let chunk_hashes: Vec<Vec<[u8; 32]>> = candidates
+            .chunks(CHUNK_LEN)
+            .map(|c| c.iter().map(|h| h.hash).collect())
+            .collect();
+        let mut fetches = futures::StreamExt::buffered(
+            futures::stream::iter(chunk_hashes.into_iter().enumerate().map(|(i, hashes)| {
+                async move {
+                    let (bodies, receipts) = futures::future::join(
+                        peer.get_block_bodies(&hashes),
+                        peer.get_receipts(&hashes),
+                    )
+                    .await;
+                    (i, bodies, receipts)
+                }
+            })),
+            depth,
+        );
+        'chunks: while let Some((chunk_idx, bodies, receipt_blocks)) =
+            futures::StreamExt::next(&mut fetches).await
+        {
+            let chunk = candidates
+                .chunks(CHUNK_LEN)
+                .nth(chunk_idx)
+                .ok_or("chunk index out of range")?;
             let bodies = bodies?;
             let receipt_blocks = receipt_blocks?;
             // Served items are an in-order prefix of the request (the per-block
@@ -1196,6 +1249,8 @@ impl ElReader {
                 }
             }
             if let Some(stop) = chunk_stop {
+                self.log_index_pipeline_full
+                    .store(false, std::sync::atomic::Ordering::Relaxed);
                 stop_below = Some(stop);
                 tracing::debug!(
                     served = usable,
@@ -1205,6 +1260,12 @@ impl ElReader {
                 );
                 break 'chunks;
             }
+        }
+        if stop_below.is_none() {
+            // Whole candidate set served untruncated — this range rewards
+            // pipelining; restore full depth for the next batch.
+            self.log_index_pipeline_full
+                .store(true, std::sync::atomic::Ordering::Relaxed);
         }
         // Apply top-down (the response is already descending) so every block
         // adjoins the low edge; the trust edge advances with each block. A

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -1156,7 +1156,10 @@ impl ElReader {
         // ordering lives in the consumer (`buffered`, not `buffer_unordered`).
         // On truncation/failure the stream is dropped, cancelling in-flight
         // fetches (their late responses are discarded by the peer read loop;
-        // worst case a few response budgets of wasted bandwidth past the cut).
+        // worst case a few response budgets of wasted bandwidth past the cut —
+        // or, if a cancellation lands mid-frame-write, the connection itself:
+        // the writer's torn marker then fails the peer at its next send
+        // rather than let it write MAC-garbage; see peer.rs `GuardedWriter`).
         const CHUNK_PIPELINE: usize = 4;
         const CHUNK_LEN: usize = 64;
         // ADAPTIVE depth: pipelining only pays where chunks come back FULL

--- a/rust/myotis-net/tests/live_pipeline_bench.rs
+++ b/rust/myotis-net/tests/live_pipeline_bench.rs
@@ -1,0 +1,214 @@
+//! Live A/B benchmark for the backfill chunk pipeline (#298): fetch the SAME
+//! bodies+receipts chunks from the dedicated sepolia node sequentially (the
+//! pre-pipeline shape, depth 1) and pipelined (`buffered(4)`, the PR shape),
+//! and print wall times per pass. Two regions:
+//!
+//! - a full-serve region (small early blocks — chunks come back complete;
+//!   this is where the pipeline should collapse the sequential RTT chain),
+//! - the bloom-saturated spam region near the current walk cursor (first
+//!   chunk truncates; the walker's adaptive depth stays at 1 there BY DESIGN,
+//!   so the pipelined pass here only quantifies what adaptivity avoids
+//!   wasting).
+//!
+//! MEASUREMENT ONLY: headers are fetched by number and nothing is verified —
+//! no trust claims are made; the real walker verifies every root.
+//!
+//! Run with:
+//! `cargo test -p myotis-net --test live_pipeline_bench -- --ignored --nocapture`
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use myotis_core::nodekey::NodeKey;
+use myotis_net::el::eth::session::{EthConfig, EthSession};
+use myotis_net::el::peer::ManagedPeer;
+use myotis_net::el::rlpx::transport::RlpxConnection;
+
+const NODE_ADDR: &str = "87.154.209.161:30405";
+const NODE_PUBKEY_HEX: &str =
+    "cfd3572bd7691fe03baf52106b873e01d9b5dca1714a74b316cb94151127dfd2\
+     0adae3be559e3e6b44b78a5af1ed6f92ecc8676a2555fc7cdb2d29a0c37e1b2c";
+const SEPOLIA_GENESIS: &str = "25a5cc106eea7138acab33231d7160d69cb777ee0c2c553fcddf5138993e6dd9";
+const SEPOLIA_FORK_ID: [u8; 4] = [0x26, 0x89, 0x56, 0xb6];
+
+/// Matches the walker (`reader.rs`).
+const CHUNK_LEN: usize = 64;
+const DEPTH: usize = 4;
+/// Chunks per pass: 8 × 64 = 512 blocks, i.e. a half-batch of walker work.
+const CHUNKS: usize = 8;
+/// Alternating rounds per region, to control for drift/warm-up bias.
+const ROUNDS: usize = 2;
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "live network: benchmarks chunk fetch pipelining against the dedicated node"]
+async fn pipeline_vs_sequential_chunk_fetches() {
+    let peer = dial().await;
+
+    // Probe first: how much does the node actually serve per chunk across the
+    // walk corpus? (bodies vs receipts separately — the budget binds on one.)
+    for top in [5_700_000u64, 7_000_000, 8_500_000, 10_000_000, 11_170_000] {
+        probe_chunk(&peer, top).await;
+    }
+
+    // Region A: early small blocks — full-serve regime (the walk floor is
+    // 5,594,611; this sits just above it, in range the walker will reach).
+    bench_region(&peer, "full-serve @6.0M", 6_000_000).await;
+    // Region B: the bloom-saturated spam era near the current walk cursor —
+    // truncating regime.
+    bench_region(&peer, "truncating @11.17M", 11_170_000).await;
+
+    drop(peer);
+}
+
+/// One 64-hash chunk at `top_block`, reporting bodies and receipts serve
+/// counts separately — shows which side of the byte budget binds.
+async fn probe_chunk(peer: &ManagedPeer, top_block: u64) {
+    let window = peer
+        .get_block_headers_by_number(top_block, CHUNK_LEN as u64, 0, true)
+        .await
+        .expect("probe header window");
+    let hashes: Vec<[u8; 32]> = window.iter().take(CHUNK_LEN).map(|h| h.hash).collect();
+    let started = Instant::now();
+    let (bodies, receipts) = futures::future::join(
+        peer.get_block_bodies(&hashes),
+        peer.get_receipts(&hashes),
+    )
+    .await;
+    eprintln!(
+        "[probe @{top_block}] chunk of {}: {} bodies, {} receipt sets in {} ms",
+        hashes.len(),
+        bodies.map(|b| b.len()).unwrap_or(0),
+        receipts.map(|r| r.len()).unwrap_or(0),
+        started.elapsed().as_millis()
+    );
+}
+
+async fn bench_region(peer: &ManagedPeer, label: &str, top_block: u64) {
+    // Headers by number, descending — bench-only, unverified.
+    let window = peer
+        .get_block_headers_by_number(top_block, (CHUNKS * CHUNK_LEN) as u64, 0, true)
+        .await
+        .expect("header window");
+    assert!(
+        window.len() >= CHUNKS * CHUNK_LEN,
+        "[{label}] node served only {} headers",
+        window.len()
+    );
+    let chunks: Vec<Vec<[u8; 32]>> = window[..CHUNKS * CHUNK_LEN]
+        .chunks(CHUNK_LEN)
+        .map(|c| c.iter().map(|h| h.hash).collect())
+        .collect();
+
+    // Warm-up: one chunk, discarded (TCP window growth, peer-side cache).
+    let _ = futures::future::join(
+        peer.get_block_bodies(&chunks[0]),
+        peer.get_receipts(&chunks[0]),
+    )
+    .await;
+
+    for round in 0..ROUNDS {
+        // Alternate order across rounds so neither shape always runs first.
+        if round % 2 == 0 {
+            run_sequential(peer, label, &chunks).await;
+            run_pipelined(peer, label, &chunks).await;
+        } else {
+            run_pipelined(peer, label, &chunks).await;
+            run_sequential(peer, label, &chunks).await;
+        }
+    }
+}
+
+async fn run_sequential(peer: &ManagedPeer, label: &str, chunks: &[Vec<[u8; 32]>]) {
+    let started = Instant::now();
+    let mut served = 0usize;
+    let mut truncated = false;
+    for hashes in chunks {
+        let (bodies, receipts) = futures::future::join(
+            peer.get_block_bodies(hashes),
+            peer.get_receipts(hashes),
+        )
+        .await;
+        let (bodies, receipts) = (bodies.expect("bodies"), receipts.expect("receipts"));
+        let usable = bodies.len().min(receipts.len()).min(hashes.len());
+        served += usable;
+        if usable < hashes.len() {
+            truncated = true;
+            break; // the walker stops the batch at the first short chunk
+        }
+    }
+    report(label, "sequential", served, truncated, started.elapsed());
+}
+
+async fn run_pipelined(peer: &ManagedPeer, label: &str, chunks: &[Vec<[u8; 32]>]) {
+    let started = Instant::now();
+    let mut served = 0usize;
+    let mut truncated = false;
+    let mut fetches = futures::StreamExt::buffered(
+        futures::stream::iter(chunks.iter().map(|hashes| async move {
+            futures::future::join(peer.get_block_bodies(hashes), peer.get_receipts(hashes)).await
+        })),
+        DEPTH,
+    );
+    while let Some((bodies, receipts)) = futures::StreamExt::next(&mut fetches).await {
+        let (bodies, receipts) = (bodies.expect("bodies"), receipts.expect("receipts"));
+        let usable = bodies.len().min(receipts.len()).min(CHUNK_LEN);
+        served += usable;
+        if usable < CHUNK_LEN {
+            truncated = true;
+            break; // drops in-flight fetches, like the walker
+        }
+    }
+    report(label, &format!("pipelined(x{DEPTH})"), served, truncated, started.elapsed());
+}
+
+fn report(label: &str, shape: &str, served: usize, truncated: bool, elapsed: std::time::Duration) {
+    let secs = elapsed.as_secs_f64();
+    eprintln!(
+        "[{label}] {shape:<14} {served:>3} blocks in {:>7.0} ms  ({:>5.1} blk/s chunk-phase{})",
+        secs * 1000.0,
+        served as f64 / secs,
+        if truncated { ", TRUNCATED" } else { "" }
+    );
+}
+
+async fn dial() -> ManagedPeer {
+    let key = Arc::new(
+        NodeKey::from_secret_bytes(&myotis_core::keccak::keccak256(b"live-pipeline-bench"))
+            .unwrap(),
+    );
+    let genesis = hex32(SEPOLIA_GENESIS);
+    let cfg = Arc::new(EthConfig {
+        network_id: 11155111,
+        genesis_hash: genesis,
+        fork_id_hash: SEPOLIA_FORK_ID,
+        fork_next: 0,
+        head_hash: genesis,
+        head_number: 0,
+        listen_port: 30303,
+        genesis_header_rlp: None,
+    });
+    let addr: std::net::SocketAddr = NODE_ADDR.parse().unwrap();
+    let mut pubkey = [0u8; 64];
+    for (i, b) in pubkey.iter_mut().enumerate() {
+        *b = u8::from_str_radix(&NODE_PUBKEY_HEX[i * 2..i * 2 + 2], 16).unwrap();
+    }
+    let conn = RlpxConnection::dial(Arc::clone(&key), addr, pubkey)
+        .await
+        .expect("rlpx dial+handshake");
+    let session = EthSession::handshake(conn, &key.public_key_bytes(), &cfg, None)
+        .await
+        .expect("eth handshake");
+    eprintln!(
+        "[bench] handshake OK: eth/{} snap={} client={}",
+        session.eth_version, session.snap, session.peer_hello.client_id
+    );
+    ManagedPeer::spawn(session, addr)
+}
+
+fn hex32(s: &str) -> [u8; 32] {
+    let mut out = [0u8; 32];
+    for (i, b) in out.iter_mut().enumerate() {
+        *b = u8::from_str_radix(&s[i * 2..i * 2 + 2], 16).unwrap();
+    }
+    out
+}


### PR DESCRIPTION
## Summary

Option 1 from #297: the backfill batch previously fetched its bodies/receipts chunks strictly sequentially, so in ranges where chunks come back full, batch time was a sum of round-trips to a single peer. Chunk fetches now ride the multiplexed connection with up to 4 in flight (`futures::StreamExt::buffered` — **ordered** consumption, because the truncation cut and coverage adjacency depend on request order; verification stays in the consumer).

- **Adaptive depth**: in byte-budget-truncated ranges (the sepolia spam era) a batch ends at its first chunk, and prefetched chunks would be pure wasted bandwidth on the already-saturated serving link. A truncated batch degrades the *next* batch to depth 1 (identical to pre-pipeline behavior); an untruncated batch restores depth 4. Bloom-empty batches leave the depth untouched (no evidence either way).
- **Cancel-safety (from pre-PR review)**: dropping the buffered stream — now routine on truncation and on any mid-batch error — can cancel a request future suspended inside the frame write, leaving a partial frame on the wire with the egress MAC advanced, with no error path running afterwards. All six egress send sites now go through one torn-aware helper (`GuardedWriter`/`send_frame`): a cancelled write leaves a marker set, and the next writer surfaces it as a fatal write error (`fail_all` + close) instead of writing MAC-garbage on a corrupt stream.

## Verification

- `cargo test --workspace` green (191 myotis-net lib tests among them).
- Live `#[ignore]` diagnostic against the dedicated sepolia node: handshake, reverse window walk, and a truncated chunk prefix all behave as before (dense truncating ranges keep today's exact profile by design).

## Notes

- Ordered-consumption invariant rests on `buffered`'s documented semantics; a refactor to `buffer_unordered` would corrupt coverage adjacency — called out in a comment at the pipeline site. No mock-peer harness exists yet to pin it in a unit test; noted as a gap.
- Cross-peer flag coarseness (a truncation on peer A starts the next batch at depth 1 even on peer B) is deliberate: cost is one sequential-profile batch, self-correcting.

Refs #297.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPnTFwmAVMypWYtoioAXQT