### PR TITLE
ui: fix common-metadata compile broken on main (missing kotlin.jvm imports)

### DIFF
--- a/ui/src/commonMain/kotlin/io/myotis/ui/KohakuPreset.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/KohakuPreset.kt
@@ -1,5 +1,8 @@
 package io.myotis.ui
 
+import kotlin.jvm.JvmOverloads
+import kotlin.jvm.JvmStatic
+
 /**
  * The shipped watch-list preset behind the "Log index (Kohaku contracts)"
  * toggle: the privacy contracts the Kohaku wallet libraries cold-sync from


### PR DESCRIPTION
## Summary

Main's `Build and Test` board is red: `:ui:compileCommonMainKotlinMetadata` fails with `Unresolved reference 'JvmStatic'/'JvmOverloads'` in `KohakuPreset.kt` (introduced by #293). The annotations resolve via default imports on JVM compilations but need explicit `kotlin.jvm.*` imports in common-metadata compilation — both are optional-expectation annotations, legal in common code. Two-line import fix.

Why it slipped: #293 merged during the 2026-08-06 GitHub Actions outage with no CI run, and local desktop builds never touch the metadata target. Surfaced by the re-fired checks on #298 (whose merge ref includes main).

## Verification

- `./gradlew :ui:compileCommonMainKotlinMetadata` fails on main, passes with this change.
- Annotation semantics on JVM/Android targets are unchanged by import style; full board runs here.
- `grep` shows no other commonMain file uses `@Jvm*` without the import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPnTFwmAVMypWYtoioAXQT