### PR TITLE
ci: rust-cache + realistic timeout for the devp2p discovery workflow

### DIFF
--- a/.github/workflows/devp2p-discovery.yml
+++ b/.github/workflows/devp2p-discovery.yml
@@ -26,6 +26,14 @@ jobs:
           distribution: temurin
           java-version: "21"
 
+      - name: Set up Rust
+        # Pin to real stable like the sibling Rust workflows — the runner
+        # image's preinstalled rustc lags on its own schedule, keys the cache
+        # to a different compiler, and if it ever fell below the Gradle
+        # probe's floor, cargoBuildHost would silently self-skip and this
+        # workflow would quietly stop exercising the Rust build.
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Cache Rust build
         # The :app build compiles the Rust workspace (cargoBuildHost auto-runs
         # before :app:run); without this cache a cold run eats the whole job

--- a/.github/workflows/devp2p-discovery.yml
+++ b/.github/workflows/devp2p-discovery.yml
@@ -11,7 +11,10 @@ jobs:
   discover:
     name: Peer Discovery (UDP allowed)
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Cold-cache days (post-outage evictions) compile the whole Rust workspace
+    # (~12 min) before Gradle even reaches the 5-min discovery run — 15 min
+    # guaranteed a timeout there. Warm runs stay well under the old budget.
+    timeout-minutes: 30
 
     steps:
       - name: Checkout
@@ -22,6 +25,14 @@ jobs:
         with:
           distribution: temurin
           java-version: "21"
+
+      - name: Cache Rust build
+        # The :app build compiles the Rust workspace (cargoBuildHost auto-runs
+        # before :app:run); without this cache a cold run eats the whole job
+        # budget in cargo. Same action/config as the other Rust workflows.
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust
 
       - name: Cache Gradle
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary

The devp2p Discovery run on main after the #299 merge failed by hitting the job's 15-minute `timeout-minutes` cap — the job log shows the runner terminating orphan `cargo`/`rustc` processes at the kill point. Cause: this workflow predates the Rust workspace (`cargoBuildHost` auto-runs before `:app:run`) and was the only Rust-compiling workflow without `Swatinem/rust-cache@v2`, so a cold-cache day (the Actions outage evicted caches) compiles the whole workspace (~12 min) before the 5-minute discovery run even starts.

- Add the same `Swatinem/rust-cache@v2` (`workspaces: rust`) config the android-apk / node-binding / linux-deb workflows already use.
- Raise `timeout-minutes` 15 → 30 so cache-miss days finish instead of dying at 99% (warm runs stay well under the old budget).

Not related to the earlier scheduled-run failure at 06:23 — that was the `KohakuPreset.kt` metadata-compile breakage, fixed by #299.

## Verification

- Workflow YAML parses (actionlint-clean structure, mirrors android-apk.yml's cache stanza verbatim).
- The workflow also triggers on push to main, so the merge itself is the live re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPnTFwmAVMypWYtoioAXQT