### PR TITLE
Release prep: bump versions to 0.1.4

### DIFF
--- a/.github/workflows/desktop-dmg.yml
+++ b/.github/workflows/desktop-dmg.yml
@@ -133,7 +133,8 @@ jobs:
           echo "::error::DMG build failed after 3 attempts"
           exit 1
 
-      # Compose names both arches' output the same (Myotis-1.0.0.dmg); rename so the
+      # Compose names both arches' output the same (Myotis-<packageVersion>.dmg, derived
+      # from the project version in app-desktop/build.gradle.kts); rename so the
       # downloaded file itself states the architecture, not just the artifact wrapper.
       - name: Tag .dmg with architecture
         run: |

--- a/.github/workflows/desktop-dmg.yml
+++ b/.github/workflows/desktop-dmg.yml
@@ -136,11 +136,21 @@ jobs:
       # Compose names both arches' output the same (Myotis-<packageVersion>.dmg, derived
       # from the project version in app-desktop/build.gradle.kts); rename so the
       # downloaded file itself states the architecture, not just the artifact wrapper.
+      # Assert exactly one — zero or multiple should fail here, not silently ship
+      # an arbitrary pick (parity with the deb workflow). This matters more now
+      # that the filename tracks the project version: while it was frozen at
+      # Myotis-1.0.0.dmg a leftover build was overwritten in place, but two
+      # differently-versioned dmgs can now coexist and `head -n1` would take the
+      # lexicographically first — i.e. the OLDER one. The arch-verify step below
+      # wouldn't catch that: a stale bundle of the right arch passes.
       - name: Tag .dmg with architecture
         run: |
-          set -e
-          dmg=$(ls app-desktop/build/compose/binaries/main/dmg/*.dmg | head -n1)
-          mv "$dmg" "app-desktop/build/compose/binaries/main/dmg/Myotis-${{ matrix.arch }}.dmg"
+          set -eu
+          shopt -s nullglob
+          dmgs=(app-desktop/build/compose/binaries/main/dmg/*.dmg)
+          [ "${#dmgs[@]}" -eq 1 ] \
+            || { echo "::error::expected exactly 1 dmg, found ${#dmgs[@]}: ${dmgs[*]}"; exit 1; }
+          mv "${dmgs[0]}" "app-desktop/build/compose/binaries/main/dmg/Myotis-${{ matrix.arch }}.dmg"
 
       # Guard against a SILENTLY wrong-arch build. The job otherwise goes green on
       # "BUILD SUCCESSFUL" alone; any future regression (runner-image change, Gradle re-enabling

--- a/android-app/build.gradle.kts
+++ b/android-app/build.gradle.kts
@@ -89,8 +89,8 @@ android {
         applicationId = "com.jaeckel.ethp2p.android"
         minSdk = 29
         targetSdk = 34
-        versionCode = 4
-        versionName = "0.1.3"
+        versionCode = 5
+        versionName = "0.1.4"
         buildConfigField("String", "RPC_UPSTREAM", "\"$rpcUpstream\"")
     }
 

--- a/android-app/build.gradle.kts
+++ b/android-app/build.gradle.kts
@@ -81,6 +81,11 @@ val rpcUpstream: String = run {
     props.getProperty("rpc.upstream", "")
 }
 
+// Derived from the project version so a release sweep can't leave the app
+// reporting a stale version in Settings → Apps, the same way :app-desktop
+// derives its installer versions. 0.1.4-SNAPSHOT -> 0.1.4.
+val releaseVersion = project.version.toString().substringBefore('-')
+
 android {
     namespace = "com.jaeckel.ethp2p.android"
     compileSdk = 35
@@ -89,8 +94,11 @@ android {
         applicationId = "com.jaeckel.ethp2p.android"
         minSdk = 29
         targetSdk = 34
+        // Stays a manual literal: a monotonic install counter with no relation
+        // to semver, so there is nothing to derive it from. Bump it on every
+        // release or the new APK won't install over the previous one.
         versionCode = 5
-        versionName = "0.1.4"
+        versionName = releaseVersion
         buildConfigField("String", "RPC_UPSTREAM", "\"$rpcUpstream\"")
     }
 

--- a/app-desktop/build.gradle.kts
+++ b/app-desktop/build.gradle.kts
@@ -216,7 +216,7 @@ compose.desktop {
             linux {
                 // Unlike the dmg (jpackage requires major > 0 on macOS), deb versions may
                 // start at 0 — so Linux carries the app's honest version.
-                packageVersion = "0.1.3"
+                packageVersion = "0.1.4"
                 debMaintainer = "dirk@jaeckel.com"
             }
         }

--- a/app-desktop/build.gradle.kts
+++ b/app-desktop/build.gradle.kts
@@ -20,22 +20,26 @@ kotlin { jvmToolchain(21) }
 val releaseVersion = project.version.toString().substringBefore('-')  // 0.1.4-SNAPSHOT -> 0.1.4
 
 // jpackage REJECTS a major of 0 on macOS (--app-version must start above 0), so
-// the .dmg cannot carry the honest 0.x version. Force MAJOR to 1 and keep the
-// project's MINOR.PATCH (0.1.4 -> 1.1.4): that stays strictly increasing across
-// releases, which is what macOS needs to see a new bundle as an upgrade.
+// the .dmg cannot carry the honest 0.x version. The rule is therefore: macOS
+// MAJOR is always the project MAJOR plus one (0.1.4 -> 1.1.4, 1.0.0 -> 2.0.0).
 //
-// Deliberately NOT "1.0.<patch>", which reads closer to the real version but is
-// not monotonic — the next minor bump (0.2.0) would emit 1.0.0, LOWER than
-// 0.1.4's 1.0.4, and macOS treats a lower bundle version as a downgrade.
-//
-// Revisit at the real 1.0.0: the honest 1.0.0 is lower than the 1.x this rule
-// emits for late 0.x (0.9.0 -> 1.9.0), so the macOS version has to jump ahead
-// (e.g. 2.0.0) to keep moving forward.
+// Adding a constant to the major is order-preserving, so the emitted version is
+// strictly increasing for every version bump, forever — which is what macOS
+// needs to treat a new bundle as an upgrade rather than a downgrade. Two wrong
+// rules it deliberately avoids:
+//   - "1.0.<patch>" reads closest to the real version but breaks on a minor
+//     bump: 0.2.0 would emit 1.0.0, LOWER than 0.1.4's 1.0.4.
+//   - "1.<minor>.<patch>" for 0.x only (what this started as) is fine within
+//     0.x but falls off a cliff at the real 1.0.0, which emits 1.0.0 — lower
+//     than every 1.x already shipped for late 0.x (0.9.0 -> 1.9.0). Silent
+//     downgrade, and it only surfaces years later.
+// The +1 rule has no cliff and needs no revisiting at 1.0, so nothing here
+// depends on someone re-reading this comment before the transition.
 val macOsPackageVersion: String = releaseVersion.split('.').let { parts ->
-    require(parts.size == 3) {
-        "Unexpected project version '${project.version}': expected MAJOR.MINOR.PATCH"
+    require(parts.size == 3 && parts.all { it.toIntOrNull() != null }) {
+        "Unexpected project version '${project.version}': expected numeric MAJOR.MINOR.PATCH"
     }
-    if (parts[0] == "0") "1.${parts[1]}.${parts[2]}" else releaseVersion
+    "${parts[0].toInt() + 1}.${parts[1]}.${parts[2]}"
 }
 
 // Historical (Besu ≤24.12; 26.4 targets tuweni 2.7.2 so io.tmio is gone from the
@@ -225,7 +229,7 @@ compose.desktop {
             targetFormats(TargetFormat.Dmg, TargetFormat.Deb)
             packageName = "Myotis"
             // Applies to the dmg (and a future msi); the deb overrides it below.
-            // See macOsPackageVersion at the top of this file for the 0.x mapping.
+            // See macOsPackageVersion at the top of this file for the +1-major rule.
             packageVersion = macOsPackageVersion
             // jpackage builds the deb's Maintainer field as "<vendor> <debMaintainer>",
             // so the human name lives here and debMaintainer stays a bare email.

--- a/app-desktop/build.gradle.kts
+++ b/app-desktop/build.gradle.kts
@@ -13,6 +13,31 @@ plugins {
 
 kotlin { jvmToolchain(21) }
 
+// Installer versions, DERIVED from the project version so a release sweep can't
+// leave an installer stamped with the previous release (v0.1.0–v0.1.3 all shipped
+// a dmg hardcoded to "1.0.0", so every macOS bundle reported the same frozen
+// version in About / Get Info regardless of the release it came from).
+val releaseVersion = project.version.toString().substringBefore('-')  // 0.1.4-SNAPSHOT -> 0.1.4
+
+// jpackage REJECTS a major of 0 on macOS (--app-version must start above 0), so
+// the .dmg cannot carry the honest 0.x version. Force MAJOR to 1 and keep the
+// project's MINOR.PATCH (0.1.4 -> 1.1.4): that stays strictly increasing across
+// releases, which is what macOS needs to see a new bundle as an upgrade.
+//
+// Deliberately NOT "1.0.<patch>", which reads closer to the real version but is
+// not monotonic — the next minor bump (0.2.0) would emit 1.0.0, LOWER than
+// 0.1.4's 1.0.4, and macOS treats a lower bundle version as a downgrade.
+//
+// Revisit at the real 1.0.0: the honest 1.0.0 is lower than the 1.x this rule
+// emits for late 0.x (0.9.0 -> 1.9.0), so the macOS version has to jump ahead
+// (e.g. 2.0.0) to keep moving forward.
+val macOsPackageVersion: String = releaseVersion.split('.').let { parts ->
+    require(parts.size == 3) {
+        "Unexpected project version '${project.version}': expected MAJOR.MINOR.PATCH"
+    }
+    if (parts[0] == "0") "1.${parts[1]}.${parts[2]}" else releaseVersion
+}
+
 // Historical (Besu ≤24.12; 26.4 targets tuweni 2.7.2 so io.tmio is gone from the
 // graph — the exclude stays as a cheap guard):
 // Besu (via :myotis-evm) dragged in the pre-rename tuweni coordinates io.tmio:tuweni-* 2.4.2,
@@ -199,7 +224,9 @@ compose.desktop {
             // Windows host exists.
             targetFormats(TargetFormat.Dmg, TargetFormat.Deb)
             packageName = "Myotis"
-            packageVersion = "1.0.0"  // jpackage/dmg requires MAJOR > 0
+            // Applies to the dmg (and a future msi); the deb overrides it below.
+            // See macOsPackageVersion at the top of this file for the 0.x mapping.
+            packageVersion = macOsPackageVersion
             // jpackage builds the deb's Maintainer field as "<vendor> <debMaintainer>",
             // so the human name lives here and debMaintainer stays a bare email.
             vendor = "Dirk Jäckel"
@@ -216,7 +243,7 @@ compose.desktop {
             linux {
                 // Unlike the dmg (jpackage requires major > 0 on macOS), deb versions may
                 // start at 0 — so Linux carries the app's honest version.
-                packageVersion = "0.1.4"
+                packageVersion = releaseVersion
                 debMaintainer = "dirk@jaeckel.com"
             }
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ plugins {
 
 allprojects {
     group = "com.jaeckel.ethp2p"
-    version = "0.1.3-SNAPSHOT"
+    version = "0.1.4-SNAPSHOT"
 }
 
 subprojects {

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/messages/HelloMessage.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/messages/HelloMessage.java
@@ -39,7 +39,7 @@ public final class HelloMessage {
             // Keep in sync with the Rust engine's Hello client id
             // (rust/myotis-net/src/el/rlpx/transport.rs) — dedicated
             // myotis-serving nodes admit peers by matching "myotis" here.
-            writer.writeString("myotis/0.1.3");
+            writer.writeString("myotis/0.1.4");
             writer.writeList(capWriter -> {
                 // Capabilities must be ascending (name, then version). eth/66 is the
                 // floor: it has request-IDs (which our GetBlockHeaders/snap requests

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4084,7 +4084,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-bls"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "blst",
  "jni",
@@ -4092,7 +4092,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-consensus"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "myotis-bls",
  "sha2",
@@ -4100,7 +4100,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-core"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "k256",
  "sha3 0.10.9",
@@ -4108,7 +4108,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-engine"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "myotis-consensus",
  "myotis-core",
@@ -4124,7 +4124,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-evm"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "myotis-core",
  "revm",
@@ -4132,7 +4132,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-net"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "aes",
  "arti-client",
@@ -4160,7 +4160,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-node"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "myotis-engine",
  "napi",

--- a/rust/myotis-bls/Cargo.lock
+++ b/rust/myotis-bls/Cargo.lock
@@ -134,7 +134,7 @@ checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "myotis-bls"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "blst",
  "jni",

--- a/rust/myotis-bls/Cargo.toml
+++ b/rust/myotis-bls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "myotis-bls"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "Native BLS12-381 fast-aggregate-verify (blst) behind a JNI shim for Myotis"
 license = "MIT OR Apache-2.0"

--- a/rust/myotis-consensus/Cargo.toml
+++ b/rust/myotis-consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "myotis-consensus"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "Myotis sync-committee light client (pure Rust; grows through the Rust-engine PRs)"
 license = "MIT OR Apache-2.0"

--- a/rust/myotis-core/Cargo.toml
+++ b/rust/myotis-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "myotis-core"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "Myotis execution-layer primitives: keccak-256, RLP, secp256k1 identity, BlockHeader, ENR (sans-I/O; grows through the EL-phase PRs)"
 license = "MIT OR Apache-2.0"

--- a/rust/myotis-engine/Cargo.toml
+++ b/rust/myotis-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "myotis-engine"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "Rust implementation of the io.myotis.api engine contract (JNI cdylib)"
 license = "MIT OR Apache-2.0"

--- a/rust/myotis-evm/Cargo.toml
+++ b/rust/myotis-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "myotis-evm"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "Myotis EVM: view-call / gas-estimation over SNAP-proof-verified state (revm behind a SnapStateOracle trait; sans-I/O). Grows through the EL-phase Milestone-C PRs (docs/reimplementation/07)."
 license = "MIT OR Apache-2.0"

--- a/rust/myotis-net/Cargo.toml
+++ b/rust/myotis-net/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "myotis-net"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "Myotis consensus-layer networking: discv5 discovery + libp2p eth2 req/resp + the light-client sync loop (ALL I/O lives here; myotis-consensus stays sans-I/O)"
 license = "MIT OR Apache-2.0"

--- a/rust/myotis-net/src/el/rlpx/transport.rs
+++ b/rust/myotis-net/src/el/rlpx/transport.rs
@@ -320,7 +320,7 @@ pub fn encode_hello(node_pubkey: &[u8; 64], listen_port: u16) -> Vec<u8> {
     };
     rlp::encode(&Item::List(vec![
         Item::Bytes(rlp::u64_to_minimal_be(5)), // protocol version
-        Item::Bytes(b"myotis/0.1.3".to_vec()),
+        Item::Bytes(b"myotis/0.1.4".to_vec()),
         Item::List(vec![
             cap("eth", 66),
             cap("eth", 67),
@@ -392,7 +392,7 @@ mod tests {
         let body = encode_hello(&pubkey, 30303);
         let hello = decode_hello(&body).unwrap();
         assert_eq!(hello.protocol_version, 5);
-        assert_eq!(hello.client_id, "myotis/0.1.3");
+        assert_eq!(hello.client_id, "myotis/0.1.4");
         assert_eq!(hello.listen_port, 30303);
         assert_eq!(hello.node_id, pubkey.to_vec());
         assert_eq!(hello.capabilities.len(), 5);

--- a/rust/myotis-net/src/reqresp.rs
+++ b/rust/myotis-net/src/reqresp.rs
@@ -270,7 +270,7 @@ impl Behaviour {
             ),
             identify: identify::Behaviour::new(
                 identify::Config::new("eth2/1.0.0".into(), local_public_key)
-                    .with_agent_version("myotis/0.1.3-rs".into()),
+                    .with_agent_version("myotis/0.1.4-rs".into()),
             ),
             status_v2: rr(protocols::STATUS_V2, ProtocolSupport::Full, RESP_TIMEOUT),
             status_v1: rr(protocols::STATUS_V1, ProtocolSupport::Full, RESP_TIMEOUT),

--- a/rust/myotis-node/Cargo.toml
+++ b/rust/myotis-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "myotis-node"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "Node.js (napi-rs) binding over the myotis-engine C ABI — for Electron/Node hosts"
 license = "MIT OR Apache-2.0"

--- a/rust/tor-poc/Cargo.lock
+++ b/rust/tor-poc/Cargo.lock
@@ -3848,14 +3848,14 @@ dependencies = [
 
 [[package]]
 name = "myotis-bls"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "blst",
 ]
 
 [[package]]
 name = "myotis-consensus"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "myotis-bls",
  "sha2",
@@ -3863,7 +3863,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-core"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "k256",
  "sha3 0.10.9",
@@ -3871,7 +3871,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-evm"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "myotis-core",
  "revm",
@@ -3879,7 +3879,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-net"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "aes",
  "async-trait",


### PR DESCRIPTION
Version sweep for the next GitHub pre-release. Tagging `v0.1.4` after this merges is what actually publishes it — the five `v*`-triggered workflows (`ci`, `android-apk`, `desktop-dmg`, `desktop-linux-deb`, `node-binding`) build the assets and create the pre-release.

## The sweep (`chore: bump versions to 0.1.4`)

Same shape as the v0.1.3 prep (#284) — the changed-file set is byte-for-byte identical to `e14aad4f` + `61180a84`:

- root Gradle `version`, Android `versionCode` 4→5 + `versionName`, desktop `packageVersion`
- the devp2p Hello client id, Java and Rust sides in sync (`HelloMessage.java` / `transport.rs`) plus the test that pins it
- the libp2p `-rs` agent version
- all seven workspace crate versions + all three lockfiles

The excluded-from-the-workspace lockfiles (`myotis-bls`, `tor-poc`) are synced in the same commit this time rather than as a follow-up — both would otherwise be rewritten by the next standalone build and dirty the tree.

## Installer versions are now derived (`build(desktop): …`)

Pre-existing bug caught in review: only the `.deb` carried the real version. The `.dmg` was hardcoded `packageVersion = "1.0.0"`, so **v0.1.0 through v0.1.3 all shipped a macOS bundle reporting the same frozen 1.0.0** in About / Get Info.

Both are derived from the project version now, so a future sweep can't leave one behind:

| installer | v0.1.4 value | rule |
|---|---|---|
| `.deb` | `0.1.4` | project version verbatim |
| `.dmg` | `1.1.4` | MAJOR forced to 1 (jpackage rejects major 0 on macOS), MINOR.PATCH kept |

Not `1.0.<patch>`: it reads closer to the real version but isn't monotonic — the next minor bump (0.2.0) would emit 1.0.0, *lower* than 0.1.4's 1.0.4, which macOS treats as a downgrade. `1.1.4 > 1.0.0`, so existing macOS installs see an upgrade. The mapping needs revisiting at the real 1.0.0; that's flagged in the comment.

## Verification

- all three lockfiles resolve under `cargo metadata --locked`
- `cargo test -p myotis-net --lib el::rlpx::transport` passes (the hello round-trip pins the client id)
- `:networking:compileJava` clean
- derived installer versions confirmed by printing them at configuration time: `deb=0.1.4 dmg=1.1.4`
- two independent no-context reviews (sweep completeness/over-reach; derivation correctness). The second checked the derived strings against Compose's own `MacVersionChecker`/`DebVersionChecker` — `0.1.4` is rejected for macOS, `1.1.4` accepted, confirming the major-0 constraint the comment claims. Its one finding (a stale `Myotis-1.0.0.dmg` literal in a workflow comment) is fixed in the third commit.

## Known-remaining, deliberately not in this PR

- `android-app` `versionName`/`versionCode` are still manual literals in the sweep — could be derived the same way.
- `rust/include/myotis_engine.h` tells C consumers to gate on ABI **19** while `ABI_VERSION` is **22**. Real header/source drift, unrelated to versioning.
- `docs/privacy-and-tor.md:271` and `docs/dedicated-sepolia-node.md:422` still quote `myotis/0.1.2` in illustrative text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)