### PR TITLE
ci: review on Fable 5 with an Opus 5 fallback, at max effort

### DIFF
--- a/.github/claude-review-prompt.md
+++ b/.github/claude-review-prompt.md
@@ -1,0 +1,27 @@
+Review this pull request as an independent reviewer with no prior
+context. Read CLAUDE.md first and hold the diff against the repo's
+standing rules, especially:
+- Trust model: peer data is NEVER trusted — everything must be
+  cryptographically verified (sync-committee signatures + the
+  embedded accumulators are the only trust anchors). Flag any new
+  code path that returns unverified data without saying so.
+- Data sources: devp2p/libp2p only in production; HTTP to a local
+  client is debugging-only. No trusted-RPC fallbacks.
+- API boundary: hosts talk ONLY to :myotis-api — engine internals
+  (node-core/networking/consensus types) must not leak into host
+  runtime paths outside the documented exemptions in CLAUDE.md.
+- Android first: no JVM-only APIs desugaring can't cover, no
+  java.net.http, HTTP via Ktor; Java 17 target unless a module
+  documents why it needs 21.
+- FFI discipline: the Rust workspace builds panic = "abort" —
+  native-boundary paths must be panic-free by construction.
+
+Then review on the usual merits: real defects first (correctness,
+concurrency, resource leaks, security), then maintainability. Rank
+findings by severity and skip style nits a formatter would catch.
+
+The PR branch is checked out in the working directory. Use
+`gh pr comment` for the overall review summary and
+`mcp__github_inline_comment__create_inline_comment` (with
+`confirmed: true`) for line-specific findings. Only post GitHub
+comments — don't leave review text as plain messages.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -9,13 +9,33 @@
 #      API credits instead, swap the input below for
 #      anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}.
 #
+# Model strategy — Fable 5 first, Opus 5 when its limit is exhausted:
+#   Usage limits are PER MODEL, so an exhausted Fable 5 limit leaves Opus 5
+#   untouched. Fable 5 is the more capable reviewer, so it gets first refusal;
+#   Opus 5 covers the gap instead of the review silently not happening (which
+#   is what did happen on 2026-08-07: the job errored at turn 1 for
+#   total_cost_usd 0, having read nothing and posted nothing).
+#
+#   The retry is safe precisely because that failure mode is all-or-nothing —
+#   the limit is rejected before any inference, so no partial review has been
+#   posted and the second attempt cannot duplicate comments.
+#
+#   NOT --fallback-model: that flag only covers "overloaded or not available".
+#   Verified against a live exhausted limit — it falls back correctly from a
+#   retired model, but a usage-limit rejection does not trigger it.
+#
 # Scope decisions:
 #   - Reviews once per PR (opened / reopened / ready_for_review), NOT on every
 #     push (`synchronize`) — re-run the workflow from the Actions tab (or
-#     close/reopen the PR) for a fresh pass after big changes.
+#     close/reopen the PR) for a fresh pass after big changes. Note a re-run
+#     replays the ORIGINAL commit and workflow file, so it cannot pick up a
+#     workflow change; close/reopen is the way to get a fresh one.
 #   - Drafts are skipped until marked ready.
 #   - Fork PRs are skipped: `pull_request` runs from forks get no secrets, so
 #     the job could only fail there. Same-repo PRs are the review target.
+#   - A PR that edits THIS FILE cannot review itself: the action requires the
+#     workflow to match the default branch and skips (green, but a no-op).
+#     Changes here are only exercised once merged to main.
 name: claude-review
 
 on:
@@ -37,41 +57,43 @@ jobs:
         with:
           fetch-depth: 1
 
-      - uses: anthropics/claude-code-action@v1
+      # Both attempts below send the identical prompt, so it lives in one file
+      # and is assembled once here. GitHub Actions has no YAML anchors, and
+      # duplicating the prompt across two steps would drift.
+      - name: Assemble review prompt
+        id: prompt
+        run: |
+          {
+            echo 'text<<CLAUDE_PROMPT_EOF'
+            echo "REPO: ${{ github.repository }}"
+            echo "PR NUMBER: ${{ github.event.pull_request.number }}"
+            echo
+            cat .github/claude-review-prompt.md
+            echo 'CLAUDE_PROMPT_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      # First choice. continue-on-error so an exhausted Fable 5 limit falls
+      # through to Opus 5 below instead of failing the job.
+      - name: Review (Fable 5)
+        id: fable
+        continue-on-error: true
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          prompt: |
-            REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
+          prompt: ${{ steps.prompt.outputs.text }}
+          claude_args: |
+            --model claude-fable-5
+            --effort max
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
 
-            Review this pull request as an independent reviewer with no prior
-            context. Read CLAUDE.md first and hold the diff against the repo's
-            standing rules, especially:
-            - Trust model: peer data is NEVER trusted — everything must be
-              cryptographically verified (sync-committee signatures + the
-              embedded accumulators are the only trust anchors). Flag any new
-              code path that returns unverified data without saying so.
-            - Data sources: devp2p/libp2p only in production; HTTP to a local
-              client is debugging-only. No trusted-RPC fallbacks.
-            - API boundary: hosts talk ONLY to :myotis-api — engine internals
-              (node-core/networking/consensus types) must not leak into host
-              runtime paths outside the documented exemptions in CLAUDE.md.
-            - Android first: no JVM-only APIs desugaring can't cover, no
-              java.net.http, HTTP via Ktor; Java 17 target unless a module
-              documents why it needs 21.
-            - FFI discipline: the Rust workspace builds panic = "abort" —
-              native-boundary paths must be panic-free by construction.
-
-            Then review on the usual merits: real defects first (correctness,
-            concurrency, resource leaks, security), then maintainability. Rank
-            findings by severity and skip style nits a formatter would catch.
-
-            The PR branch is checked out in the working directory. Use
-            `gh pr comment` for the overall review summary and
-            `mcp__github_inline_comment__create_inline_comment` (with
-            `confirmed: true`) for line-specific findings. Only post GitHub
-            comments — don't leave review text as plain messages.
-
+      # `outcome` is the raw step result (conclusion is masked to success by
+      # continue-on-error), so this fires exactly when Fable 5 failed.
+      - name: Review (Opus 5 — Fable 5 limit exhausted)
+        if: steps.fable.outcome == 'failure'
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: ${{ steps.prompt.outputs.text }}
           claude_args: |
             --model claude-opus-5
             --effort max

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -74,4 +74,5 @@ jobs:
 
           claude_args: |
             --model claude-opus-5
+            --effort max
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -16,9 +16,15 @@
 #   is what did happen on 2026-08-07: the job errored at turn 1 for
 #   total_cost_usd 0, having read nothing and posted nothing).
 #
-#   The retry is safe precisely because that failure mode is all-or-nothing —
-#   the limit is rejected before any inference, so no partial review has been
-#   posted and the second attempt cannot duplicate comments.
+#   The retry does NOT assume the failure was a usage limit. A timeout, an API
+#   error, or an action failure can strike AFTER Claude has already posted a
+#   summary or inline findings (the action flushes buffered inline comments in
+#   an always() sub-step), and a second review on top of that would duplicate
+#   or contradict the first. So the fallback is gated on the property we
+#   actually care about — that the failed attempt posted nothing — measured by
+#   comparing the PR's comment count before and after. If the first attempt
+#   failed after posting, the fallback is suppressed and the job fails loudly
+#   instead of quietly stacking two reviews.
 #
 #   NOT --fallback-model: that flag only covers "overloaded or not available".
 #   Verified against a live exhausted limit — it falls back correctly from a
@@ -72,6 +78,22 @@ jobs:
             echo 'CLAUDE_PROMPT_EOF'
           } >> "$GITHUB_OUTPUT"
 
+      # Baseline for the "posted nothing" check below. `.comments` (issue
+      # comments) + `.review_comments` (inline) come straight off the PR object,
+      # so this is one call with no pagination to get wrong.
+      - name: Count review feedback before the first attempt
+        id: before
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Assign, don't inline into echo: a failed gh api inside an echo
+          # argument would still exit 0 and silently record an empty baseline.
+          n=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" \
+            --jq '.comments + .review_comments')
+          [[ "$n" =~ ^[0-9]+$ ]] || { echo "::error::Unexpected comment count: '$n'"; exit 1; }
+          echo "count=$n" >> "$GITHUB_OUTPUT"
+
       # First choice. continue-on-error so an exhausted Fable 5 limit falls
       # through to Opus 5 below instead of failing the job.
       - name: Review (Fable 5)
@@ -87,9 +109,33 @@ jobs:
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
 
       # `outcome` is the raw step result (conclusion is masked to success by
-      # continue-on-error), so this fires exactly when Fable 5 failed.
-      - name: Review (Opus 5 — Fable 5 limit exhausted)
+      # continue-on-error), so this fires exactly when Fable 5 failed. The
+      # action has already flushed any buffered inline comments by now, so an
+      # unchanged count means genuinely nothing was posted and a second attempt
+      # is safe. A human commenting during the review window also trips this —
+      # rare, and it fails safe (a loud skip, never a silent duplicate).
+      - name: Did the failed attempt post anything?
+        id: unposted
         if: steps.fable.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          before='${{ steps.before.outputs.count }}'
+          now=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" \
+            --jq '.comments + .review_comments')
+          [[ "$now" =~ ^[0-9]+$ && "$before" =~ ^[0-9]+$ ]] \
+            || { echo "::error::Non-numeric comment count (before='$before' now='$now')"; exit 1; }
+          echo "before=$before now=$now"
+          if [ "$now" -eq "$before" ]; then
+            echo "safe=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "safe=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Fable 5 failed after posting $((now - before)) comment(s) — suppressing the Opus 5 fallback so the PR does not get two overlapping reviews."
+          fi
+
+      - name: Review (Opus 5 — Fable 5 limit exhausted)
+        if: steps.fable.outcome == 'failure' && steps.unposted.outputs.safe == 'true'
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -98,3 +144,12 @@ jobs:
             --model claude-opus-5
             --effort max
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+
+      # Suppressing the fallback must not look like a clean review. Without
+      # this the job would go green (continue-on-error masks the Fable 5
+      # failure) having left only a partial review on the PR.
+      - name: Fail when the review was left incomplete
+        if: steps.fable.outcome == 'failure' && steps.unposted.outputs.safe != 'true'
+        run: |
+          echo "::error::The Fable 5 review failed partway through, after already posting to the PR. The Opus 5 fallback was suppressed to avoid a duplicate review, so this PR has only partial feedback — close/reopen it for a clean pass."
+          exit 1

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -73,5 +73,5 @@ jobs:
             comments — don't leave review text as plain messages.
 
           claude_args: |
-            --model claude-fable-5
+            --model claude-opus-5
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
Reviews now try **Fable 5** first and fall back to **Opus 5** when Fable 5's usage limit is exhausted, both at `--effort max`.

## Why

The `review` job started failing today on #303 — two attempts, identical signature: Claude Code initializes, then errors on turn 1 in under 1.2s, the second at **`total_cost_usd: 0`**. Nothing billed, so the request was rejected before any inference; it read nothing and posted nothing.

The cause is a **Fable-5-specific usage limit**, not general subscription exhaustion. The CLI says so directly:

> `You've reached your Fable 5 limit. Run /usage-credits to continue or switch models with /model.`

Limits are per model, so Opus 5's headroom was untouched the whole time. Rather than giving up Fable 5 (the more capable reviewer) or leaving reviews to break unpredictably, this runs Fable 5 first and lets Opus 5 cover the gap.

## Why not `--fallback-model`

The CLI has exactly this flag — `--fallback-model <model>`, "automatic fallback when the default model is overloaded or not available", re-trying the primary each turn. It looked like a one-flag answer. It isn't: **tested against the live exhausted limit and it does not trigger.**

```
$ claude -p "Reply with exactly: OK" --model claude-fable-5 --fallback-model claude-opus-5
You've reached your Fable 5 limit. Run /usage-credits to continue or switch models with /model.

$ claude -p "Reply with exactly: OK" --model claude-3-opus-20240229 --fallback-model claude-opus-5
OK          # control: falls back correctly from a retired model
```

So the flag works — a usage-limit rejection just isn't classified as "not available."

## Why the retry is safe

**Corrected after review.** The first version gated the fallback on `steps.fable.outcome == 'failure'` and justified it by the observed failure being all-or-nothing (rejected before any inference, nothing posted). That reasoning held for the *observed* failure but not for the *condition being tested*: a timeout, API error, or action failure can strike after Claude has already posted a summary or inline findings — the action flushes buffered inline comments in an `always()` sub-step — and Opus would then stack a second review on top of the first.

The gate now checks the property that actually matters instead of trying to classify the error: **the PR's comment count before vs. after the attempt**, falling back only when it is unchanged. `.comments + .review_comments` off the PR object is a single call with no pagination to get wrong (verified against the issue/review comment lists).

When the count *did* move, the fallback is suppressed **and the job fails loudly** — otherwise `continue-on-error` would mask the failure and a PR carrying half a review would show a green check.

| Fable 5 outcome | posted anything? | result |
|---|---|---|
| success | — | one review, job green |
| failure | no | Opus 5 runs, job green |
| failure | yes | fallback suppressed, job **fails** with a pointer to close/reopen |

A human commenting during the review window also trips the check — rare, and it fails safe (a loud skip, never a silent duplicate).

Both shell steps assign before echoing and assert the count is numeric: `echo "count=$(gh api ...)"` exits 0 even when the API call fails, which would have silently recorded an empty baseline.

## Prompt extraction

Both attempts need the same prompt and Actions has no YAML anchors, so the prompt moves to `.github/claude-review-prompt.md` and is assembled once into a step output. Verified locally that the assembled string is **byte-identical** to the previous inline prompt (`diff` clean), and that the body contains no heredoc-delimiter collision.

## `--effort max`

Top of the CLI's ladder (`low, medium, high, xhigh, max`). Review is the one job where more thinking per PR pays — a missed defect costs more than the tokens. Worth knowing the docs put **xhigh**, not max, as the coding/agentic sweet spot and note max can show diminishing returns and sometimes overthink; dropping to xhigh is a one-word change if reviews start over-reporting or running long.

## This PR cannot verify itself — and neither could a re-run

The review check here is **green because it skipped**, not because it reviewed:

> Skipping action due to workflow validation: The workflow file must exist and have identical content to the version on the repository's default branch.

`claude-code-action` refuses to run when the PR modifies its own workflow file, so any change to `claude-review.yml` is unverifiable until it lands on `main`. A re-run wouldn't help either — it replays the original commit and workflow file version.

Compensating checks, run locally: workflow YAML parses and the step wiring is correct (`continue-on-error` on step 1, `if: steps.fable.outcome == 'failure'` on step 2); the assembled prompt diffs clean against the original.

**Verification path:** merge, then close/reopen another open PR (e.g. #303). Its merge ref picks up `main`'s workflow, validation passes, and the review runs for real. Expect the Fable 5 step to fail and the Opus 5 step to produce the review while the limit is still out.

Split out from #303 (v0.1.4 release prep) deliberately: unrelated to that version sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

