### PR TITLE
C ABI header: stop telling consumers to gate on ABI 19, and pin it mechanically

### DIFF
--- a/app-ios/src/iosMain/kotlin/io/myotis/ios/RustEngine.kt
+++ b/app-ios/src/iosMain/kotlin/io/myotis/ios/RustEngine.kt
@@ -1,5 +1,6 @@
 package io.myotis.ios
 
+import io.myotis.engine.capi.MYOTIS_ABI_VERSION
 import io.myotis.engine.capi.myotis_available_networks_json
 import io.myotis.engine.capi.myotis_canonical_network_name
 import io.myotis.engine.capi.myotis_create
@@ -47,9 +48,15 @@ import kotlinx.cinterop.toKString
 @OptIn(ExperimentalForeignApi::class)
 object RustEngine {
 
-    /** Must match `ABI_VERSION` in rust/myotis-engine/src/lib.rs — the same
-     *  handshake `RustEngineNative.EXPECTED_ABI_VERSION` performs over JNI. */
-    const val EXPECTED_ABI_VERSION = 22
+    /** The ABI this host was built against, taken from the C header itself
+     *  (`MYOTIS_ABI_VERSION` in rust/include/myotis_engine.h) rather than
+     *  copied — the header instructs consumers to gate on the macro, and a
+     *  capi.rs test pins it to `ABI_VERSION` in rust/myotis-engine/src/lib.rs.
+     *  So there is no number to keep in sync here; cinterop reads it from the
+     *  same header it generates these bindings from. The JVM twin
+     *  `RustEngineNative.EXPECTED_ABI_VERSION` still mirrors by hand (UniFFI,
+     *  no header in the loop). */
+    const val EXPECTED_ABI_VERSION = MYOTIS_ABI_VERSION
 
     private val abiVersion: Int by lazy { myotis_init() }
 

--- a/myotis-engines/src/test/java/io/myotis/engines/AbiVersionMirrorTest.java
+++ b/myotis-engines/src/test/java/io/myotis/engines/AbiVersionMirrorTest.java
@@ -1,0 +1,82 @@
+package io.myotis.engines;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * The ABI handshake constant is copied by hand into every host that gates on it, and a
+ * copy that falls behind is worse here than anywhere else: {@link RustEngineNative}
+ * turns a mismatch into {@code isAvailable() == false}, which {@code Engines} reads as
+ * "no Rust engine" and silently serves the Java one instead — {@code myotis.engine=rust}
+ * quietly not being honoured, behind a single {@code log.warn}.
+ *
+ * <p>UniFFI's per-function checksums do NOT cover this. They catch a library whose SHAPE
+ * disagrees with the bindings (a stale {@code .so}); they pass cleanly when the library
+ * is current and correct and only the hand-copied integer is behind — which is exactly
+ * the drift this pins.
+ *
+ * <p>Deliberately reads the Rust tree as TEXT, the same trick
+ * {@code NetworksJsonGoldenTest} uses for the catalog golden: no native library, no
+ * cargo, so this runs in the plain {@code ./gradlew build} CI job. That matters because
+ * the Rust-side twin of this check ({@code capi::tests::header_pins_the_current_abi_version})
+ * sits behind {@code cargoTest}'s {@code onlyIf { rustAvailable }} and can silently skip.
+ * Checking the header here too makes the whole chain — crate constant, C header, JVM
+ * mirror — verified unconditionally.
+ */
+class AbiVersionMirrorTest {
+
+    /** The source of truth. */
+    private static final Path CRATE_LIB = Path.of("..", "rust", "myotis-engine", "src", "lib.rs");
+
+    /** The C ABI contract consumed by :app-ios via cinterop. */
+    private static final Path C_HEADER = Path.of("..", "rust", "include", "myotis_engine.h");
+
+    private static final Pattern CRATE_CONST =
+            Pattern.compile("^pub const ABI_VERSION: i32 = (\\d+);", Pattern.MULTILINE);
+
+    /** Column 0 only, so a `#define` quoted inside a comment isn't mistaken for one. */
+    private static final Pattern HEADER_DEFINE =
+            Pattern.compile("^#define MYOTIS_ABI_VERSION[ \\t]+(\\d+)", Pattern.MULTILINE);
+
+    @Test
+    void javaMirrorMatchesTheCrateConstant() throws IOException {
+        assertEquals(soleMatch(CRATE_LIB, CRATE_CONST), RustEngineNative.EXPECTED_ABI_VERSION,
+                "RustEngineNative.EXPECTED_ABI_VERSION has drifted from ABI_VERSION in "
+                        + "rust/myotis-engine/src/lib.rs. Left stale, the Rust engine reports "
+                        + "unavailable and every host silently falls back to the Java engine.");
+    }
+
+    @Test
+    void cHeaderMatchesTheCrateConstant() throws IOException {
+        assertEquals(soleMatch(CRATE_LIB, CRATE_CONST), soleMatch(C_HEADER, HEADER_DEFINE),
+                "MYOTIS_ABI_VERSION in rust/include/myotis_engine.h has drifted from "
+                        + "ABI_VERSION in rust/myotis-engine/src/lib.rs. The header is the "
+                        + "contract for the plain-C ABI consumers, and :app-ios derives "
+                        + "RustEngine.EXPECTED_ABI_VERSION from it through cinterop.");
+    }
+
+    /**
+     * The single capture in {@code file}. Requiring exactly one match is part of the
+     * contract on both sides: a second, stale definition left behind (in a dead
+     * preprocessor branch, say) must fail loudly rather than shadow the live one.
+     */
+    private static int soleMatch(Path file, Pattern pattern) throws IOException {
+        Matcher m = pattern.matcher(Files.readString(file));
+        List<String> found = new ArrayList<>();
+        while (m.find()) {
+            found.add(m.group(1));
+        }
+        assertEquals(1, found.size(),
+                file + " must match " + pattern + " exactly once, found " + found);
+        return Integer.parseInt(found.get(0));
+    }
+}

--- a/rust/include/myotis_engine.h
+++ b/rust/include/myotis_engine.h
@@ -24,9 +24,15 @@
 extern "C" {
 #endif
 
+/* The ABI version this header describes. Mirrors ABI_VERSION in
+ * rust/myotis-engine/src/lib.rs and is pinned to it by a capi.rs unit test
+ * (header_pins_the_current_abi_version), so a bump that forgets this file
+ * fails `cargo test`. Gate on this macro — do not copy the number. */
+#define MYOTIS_ABI_VERSION 22
+
 /* Availability + ABI handshake. Installs the log ring subscriber (idempotent)
  * and returns the engine's ABI version; refuse to call anything else if it
- * differs from the version this header was written against (19). */
+ * differs from MYOTIS_ABI_VERSION. */
 int32_t myotis_init(void);
 
 /* Up to `max` buffered tracing lines, oldest first, newline-joined; ""

--- a/rust/myotis-engine/src/capi.rs
+++ b/rust/myotis-engine/src/capi.rs
@@ -477,6 +477,34 @@ mod tests {
         assert_eq!(myotis_init(), crate::ABI_VERSION);
     }
 
+    /// The hand-maintained C header is the contract for the plain-ABI consumers
+    /// (:app-ios via cinterop, the napi loader), and its version is what they
+    /// gate on — so it has to name the same number as the crate constant. The
+    /// `include_str!` makes the header a compile input of this test: bumping
+    /// `ABI_VERSION` without touching the header fails `cargo test` (wired into
+    /// the root Gradle `check`) instead of shipping a header that tells C
+    /// consumers to refuse a perfectly good engine.
+    #[test]
+    fn header_pins_the_current_abi_version() {
+        const HEADER: &str = include_str!("../../include/myotis_engine.h");
+        let declared: i32 = HEADER
+            .lines()
+            .find_map(|l| l.trim().strip_prefix("#define MYOTIS_ABI_VERSION "))
+            .expect("rust/include/myotis_engine.h must #define MYOTIS_ABI_VERSION")
+            .trim()
+            .parse()
+            .expect("MYOTIS_ABI_VERSION must be a plain integer literal");
+        assert_eq!(
+            declared,
+            crate::ABI_VERSION,
+            "rust/include/myotis_engine.h declares MYOTIS_ABI_VERSION {declared} but \
+             crate::ABI_VERSION is {}. Update the header, and check the host mirrors \
+             too: RustEngineNative.EXPECTED_ABI_VERSION (myotis-engines) and \
+             RustEngine.EXPECTED_ABI_VERSION (app-ios).",
+            crate::ABI_VERSION
+        );
+    }
+
     #[test]
     fn catalog_crosses_the_c_boundary_verbatim() {
         let json = unsafe { take(myotis_available_networks_json()) };

--- a/rust/myotis-engine/src/capi.rs
+++ b/rust/myotis-engine/src/capi.rs
@@ -495,9 +495,13 @@ mod tests {
         // exactly once is itself part of the contract, so a leftover copy in a
         // dead `#if 0` branch (or a per-platform variant) fails loudly instead
         // of shadowing the live one and passing against a stale value.
+        // Column 0 only (no `trim()`): the live definition starts its line, while a
+        // `#define` quoted inside a comment sits behind the block's ` * ` or is
+        // indented — so prose ABOUT a bump can't read as a stray second definition
+        // and turn the duplicate rule into a false positive.
         let defined: Vec<&str> = HEADER
             .lines()
-            .filter_map(|l| l.trim().strip_prefix("#define MYOTIS_ABI_VERSION"))
+            .filter_map(|l| l.strip_prefix("#define MYOTIS_ABI_VERSION"))
             .filter(|rest| rest.starts_with(char::is_whitespace))
             .filter_map(|rest| rest.split_whitespace().next())
             .collect();

--- a/rust/myotis-engine/src/capi.rs
+++ b/rust/myotis-engine/src/capi.rs
@@ -480,27 +480,44 @@ mod tests {
     /// The hand-maintained C header is the contract for the plain-ABI consumers
     /// (:app-ios via cinterop, the napi loader), and its version is what they
     /// gate on — so it has to name the same number as the crate constant. The
-    /// `include_str!` makes the header a compile input of this test: bumping
-    /// `ABI_VERSION` without touching the header fails `cargo test` (wired into
-    /// the root Gradle `check`) instead of shipping a header that tells C
-    /// consumers to refuse a perfectly good engine.
+    /// `include_str!` makes the header a compile input of this test, so a
+    /// header-only edit still reruns it: bumping `ABI_VERSION` without updating
+    /// the header fails `cargo test` instead of shipping a header that tells C
+    /// consumers to refuse a perfectly good engine. The root Gradle `check`
+    /// runs that suite whenever cargo is present — it self-skips on a
+    /// toolchain-less build, so this is the guard, not a hard gate.
     #[test]
     fn header_pins_the_current_abi_version() {
         const HEADER: &str = include_str!("../../include/myotis_engine.h");
-        let declared: i32 = HEADER
+        // Collect every definition rather than taking the first: being defined
+        // exactly once is itself part of the contract, so a leftover copy in a
+        // dead `#if 0` branch (or a per-platform variant) fails loudly instead
+        // of shadowing the live one and passing against a stale value.
+        let defined: Vec<&str> = HEADER
             .lines()
-            .find_map(|l| l.trim().strip_prefix("#define MYOTIS_ABI_VERSION "))
-            .expect("rust/include/myotis_engine.h must #define MYOTIS_ABI_VERSION")
-            .trim()
+            .filter_map(|l| l.trim().strip_prefix("#define MYOTIS_ABI_VERSION"))
+            .filter(|rest| rest.starts_with(char::is_whitespace))
+            .filter_map(|rest| rest.split_whitespace().next())
+            .collect();
+        assert_eq!(
+            defined.len(),
+            1,
+            "rust/include/myotis_engine.h must #define MYOTIS_ABI_VERSION exactly once, \
+             found {defined:?}"
+        );
+        // First token only, so the house style of annotating a bump inline
+        // (`#define MYOTIS_ABI_VERSION 23 /* + setFoo */`, the C twin of
+        // RustEngineNative.EXPECTED_ABI_VERSION's trailing comment) still parses.
+        let declared: i32 = defined[0]
             .parse()
-            .expect("MYOTIS_ABI_VERSION must be a plain integer literal");
+            .expect("MYOTIS_ABI_VERSION must be an integer literal");
         assert_eq!(
             declared,
             crate::ABI_VERSION,
             "rust/include/myotis_engine.h declares MYOTIS_ABI_VERSION {declared} but \
-             crate::ABI_VERSION is {}. Update the header, and check the host mirrors \
-             too: RustEngineNative.EXPECTED_ABI_VERSION (myotis-engines) and \
-             RustEngine.EXPECTED_ABI_VERSION (app-ios).",
+             crate::ABI_VERSION is {}. Update the header; :app-ios picks the new value \
+             up automatically, but RustEngineNative.EXPECTED_ABI_VERSION (myotis-engines) \
+             is still a hand-kept mirror.",
             crate::ABI_VERSION
         );
     }

--- a/rust/myotis-engine/src/capi.rs
+++ b/rust/myotis-engine/src/capi.rs
@@ -477,9 +477,11 @@ mod tests {
         assert_eq!(myotis_init(), crate::ABI_VERSION);
     }
 
-    /// The hand-maintained C header is the contract for the plain-ABI consumers
-    /// (:app-ios via cinterop, the napi loader), and its version is what they
-    /// gate on — so it has to name the same number as the crate constant. The
+    /// The hand-maintained C header is the contract for the plain-C ABI, and
+    /// :app-ios gates on its version: cinterop reads `MYOTIS_ABI_VERSION` out of
+    /// this file for `RustEngine.EXPECTED_ABI_VERSION`. (The napi binding links
+    /// the same surface but reaches the symbols from Rust, so it never parses the
+    /// header.) It therefore has to name the crate constant's number. The
     /// `include_str!` makes the header a compile input of this test, so a
     /// header-only edit still reruns it: bumping `ABI_VERSION` without updating
     /// the header fails `cargo test` instead of shipping a header that tells C


### PR DESCRIPTION
## The bug

`rust/include/myotis_engine.h` is the contract for the plain-C ABI consumers — `:app-ios` via cinterop, and the napi/Node binding path. Its handshake prose told them to refuse the engine unless `myotis_init()` returned **19**:

> refuse to call anything else if it differs from the version this header was written against (19).

But [`rust/myotis-engine/src/lib.rs:75`](../blob/main/rust/myotis-engine/src/lib.rs#L75) has been `pub const ABI_VERSION: i32 = 22` for three revisions — v20 (Tor toggle), v21 (getLogs index), v22 (`set_served_block_window`). A consumer following the header literally would refuse a perfectly good engine.

The header was the odd one out: `node-binding.yml` reads the crate constant directly and publishes "Engine ABI version: **22**" in release notes.

## Scope check: only the number had drifted, not the surface

Worth stating explicitly, because stamping `22` on a header whose *declarations* were also stale would be a worse lie than the stale prose. They weren't — every exported `#[no_mangle] myotis_*` symbol in `capi.rs` matches the header, **34 vs 34, zero diff in both directions**. The v20/v21/v22 functions are all correctly declared. Only the prose number was wrong.

## The fix

The header's own top comment already instructed readers to "bump `MYOTIS_ABI_VERSION`" — a macro that never existed. So the header now actually defines it, and the prose points at the macro instead of carrying a second copyable number:

```c
#define MYOTIS_ABI_VERSION 22
```

## Preventing recurrence

**1. A test pins the header to the crate constant.** `capi.rs` `include_str!`s the header and asserts the macro equals `crate::ABI_VERSION`. `include_str!` makes the header a *compile input* — confirmed in cargo's depinfo (`myotis-engine/src/../../include/myotis_engine.h`), so a header-only edit reruns the test. It requires the macro to be defined **exactly once**, so a leftover copy in a dead `#if 0` branch can't shadow the live one and pass against a stale value.

**2. The iOS mirror is deleted, not tested.** `RustEngine.EXPECTED_ABI_VERSION` now reads `MYOTIS_ABI_VERSION` through cinterop, from the same header cinterop generates the bindings from. There is no longer a number to keep in sync there. This also resolves a contradiction the first commit introduced: the header says "gate on this macro — do not copy the number" while the repo's only header consumer copied it.

**3. The JVM mirror is pinned by a cargo-free JUnit test.** `AbiVersionMirrorTest` reads `lib.rs` and the header as text — the same trick `NetworksJsonGoldenTest` uses for the catalog golden — and pins both `RustEngineNative.EXPECTED_ABI_VERSION` and the header's macro to the crate constant. No native library, no cargo, so it runs in the plain `./gradlew build` CI job.

That last point matters more than it first looks, and an earlier draft of this PR got it wrong. I had argued the JVM mirror was covered by UniFFI's per-function checksums. It isn't: those catch a library whose *shape* disagrees with the bindings (a stale `.so`), and they pass cleanly in exactly the case at hand — library current and correct, only the hand-copied integer behind. And the JVM failure mode is the *quietest* of the three: `RustEngineNative` turns a mismatch into `isAvailable() == false`, which `Engines` reads as "no Rust engine", so `myotis.engine=rust` is silently not honoured behind a single `log.warn`. iOS at least throws. So the mirror with the widest reach (daemon, desktop, Android) had the softest failure and no guard.

It also fixes an enforcement asymmetry: the Rust-side header test sits behind `cargoTest`'s `onlyIf { rustAvailable }` and can skip, whereas the JUnit test always runs. Checking the header from both sides makes the whole chain — crate constant → C header → JVM mirror — verified unconditionally.

### Mirror status after this change

| Mirror | Before | After |
|---|---|---|
| `lib.rs` `ABI_VERSION` | 22 | source of truth |
| `myotis_engine.h` | **19 (drifted)** | 22, pinned from both sides (Rust + JUnit) |
| `RustEngine.kt` (iOS) | 22, hand-copied | derived from header — mirror eliminated |
| `RustEngineNative.java` (JVM) | 22, unguarded | 22, pinned by `AbiVersionMirrorTest` |

## Verification

- `cargo test --workspace` — green.
- Guard bites, not just passes. Pinning the header back to 19 fails with `declares MYOTIS_ABI_VERSION 19 but crate::ABI_VERSION is 22`; deleting the macro fails with `must #define MYOTIS_ABI_VERSION`; a dead `#if 0` copy fails with `found ["22", "23"]`.
- Guard doesn't false-positive: an inline bump annotation (`#define MYOTIS_ABI_VERSION 22 /* + setServedBlockWindow */` — the C twin of the style already at `RustEngineNative.java:40`) still passes.
- `./gradlew :app-ios:cinteropMyotisEngineIosSimulatorArm64` — BUILD SUCCESSFUL; `MYOTIS_ABI_VERSION` lands in the klib metadata under `io.myotis.engine.capi`.
- `./gradlew :app-ios:compileKotlinIosSimulatorArm64` — BUILD SUCCESSFUL, confirming the macro is a compile-time constant usable in a `const val`.
- Header compiles standalone as C99 and C++17, including double-inclusion.
- `node-binding.yml`'s ABI extraction reads `lib.rs`, untouched here — release notes unaffected.

## Caveat on gating strength

`cargoTest` is `onlyIf { rustAvailable }`, so the root Gradle `check` runs this only where cargo is present. `ci.yml` relies on `ubuntu-latest` shipping Rust preinstalled rather than installing it. That's the repo's existing "cargo is strictly optional" design, not something this PR changes — but it means the guard is a strong guard, not an absolute gate. The test comment says so rather than overclaiming.

## Left out deliberately

- [`rust/myotis-node/smoke.mjs:25`](../blob/main/rust/myotis-node/smoke.mjs#L25) gates with `abi < 19` — a fourth mirror carrying the same stale `19`. It isn't broken (an intentional `>=` sanity floor; its comment notes prebuilt-addon hosts gate on the release-notes value instead), but it silently accepts anything ≥ 19. Tightening it changes deliberate behavior, so it's a separate call.
- `docs/react-native.md` cites `EXPECTED_ABI_VERSION = 14` and describes the surface as "hand-JNI", which the UniFFI migration replaced. Stale beyond just the number, and it sits under "What already exists" as a point-in-time plan — wants its own doc refresh, not a misleading one-digit patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
