### PR TITLE
ci: fail the release when the pushed v* tag disagrees with the tree's version

### DIFF
--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -101,6 +101,15 @@ jobs:
           if-no-files-found: error
           retention-days: 30
 
+  # Refuse to publish when the pushed tag disagrees with the version in the tree
+  # — the asset name below comes from the tag, the versionName inside the apk
+  # comes from project.version. See release-version-guard.yml. Runs in parallel
+  # with the build, so a mismatch is reported early rather than after the build.
+  version-guard:
+    name: Release version guard
+    if: startsWith(github.ref, 'refs/tags/v')
+    uses: ./.github/workflows/release-version-guard.yml
+
   # Attach the built APK to the GitHub Release for the pushed tag. Runs ONLY on
   # `v*` tags (never on branch/PR builds), and reuses the build job's artifact
   # rather than rebuilding. The desktop-dmg workflow publishes to the SAME
@@ -108,7 +117,9 @@ jobs:
   # just uploads its asset — the create step below tolerates that race.
   release:
     name: Publish APK to release
-    needs: build
+    # version-guard carries the same `if` as this job, so it is never merely
+    # skipped underneath it — on a tag push both run, otherwise both are skipped.
+    needs: [build, version-guard]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -100,6 +100,12 @@ jobs:
           path: android-app/build/outputs/apk/debug/*.apk
           if-no-files-found: error
           retention-days: 30
+          # Artifacts are immutable per run; without this, "re-run all jobs" on a
+          # tag 409s in the build leg and the release job never runs. That is the
+          # button people reach for after the version guard fails, so the recovery
+          # path must not wedge the release. (node-binding.yml has carried this
+          # fix since it hit exactly that.)
+          overwrite: true
 
   # Refuse to publish when the pushed tag disagrees with the version in the tree
   # — the asset name below comes from the tag, the versionName inside the apk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,10 +53,21 @@ jobs:
           echo "::error::Gradle build failed after 3 attempts"
           exit 1
 
+  # Refuse to publish when the pushed tag disagrees with the version in the tree
+  # (see release-version-guard.yml). Not strictly needed for the jar names here,
+  # but the release this job creates/updates is the SAME one the apk/dmg/deb
+  # workflows publish tag-named assets to, so it fails alongside them.
+  version-guard:
+    name: Release version guard
+    if: startsWith(github.ref, 'refs/tags/v')
+    uses: ./.github/workflows/release-version-guard.yml
+
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: build
+    # version-guard carries the same `if` as this job, so it is never merely
+    # skipped underneath it — on a tag push both run, otherwise both are skipped.
+    needs: [build, version-guard]
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write

--- a/.github/workflows/desktop-dmg.yml
+++ b/.github/workflows/desktop-dmg.yml
@@ -206,8 +206,9 @@ jobs:
   # Refuse to publish when the pushed tag disagrees with the version in the tree
   # — the release is named after the tag, while the .dmg's packageVersion comes
   # from project.version (via the +1-major macOS rule). See
-  # release-version-guard.yml. Runs in parallel with the builds, so a mismatch
-  # surfaces in minutes instead of after both jpackage legs.
+  # release-version-guard.yml. Runs in parallel with the builds, so a mismatch is
+  # REPORTED within minutes rather than after both jpackage legs — Actions has no
+  # cross-job fail-fast, so the legs themselves still run to completion.
   version-guard:
     name: Release version guard
     if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/desktop-dmg.yml
+++ b/.github/workflows/desktop-dmg.yml
@@ -202,6 +202,12 @@ jobs:
           path: app-desktop/build/compose/binaries/main/dmg/*.dmg
           if-no-files-found: error
           retention-days: 30
+          # Artifacts are immutable per run; without this, "re-run all jobs" on a
+          # tag 409s in every build leg and the release job never runs. That is
+          # the button people reach for after the version guard fails, so the
+          # recovery path must not wedge the release — and here it would cost two
+          # 40-minute jpackage legs. (node-binding.yml already carries this fix.)
+          overwrite: true
 
   # Refuse to publish when the pushed tag disagrees with the version in the tree
   # — the release is named after the tag, while the .dmg's packageVersion comes

--- a/.github/workflows/desktop-dmg.yml
+++ b/.github/workflows/desktop-dmg.yml
@@ -203,6 +203,16 @@ jobs:
           if-no-files-found: error
           retention-days: 30
 
+  # Refuse to publish when the pushed tag disagrees with the version in the tree
+  # — the release is named after the tag, while the .dmg's packageVersion comes
+  # from project.version (via the +1-major macOS rule). See
+  # release-version-guard.yml. Runs in parallel with the builds, so a mismatch
+  # surfaces in minutes instead of after both jpackage legs.
+  version-guard:
+    name: Release version guard
+    if: startsWith(github.ref, 'refs/tags/v')
+    uses: ./.github/workflows/release-version-guard.yml
+
   # Attach both arch dmgs to the GitHub Release for the pushed tag. Runs ONLY on
   # `v*` tags, ONCE (not per-arch), after BOTH matrix build jobs finish, and
   # reuses their artifacts rather than rebuilding. The android-apk workflow
@@ -210,7 +220,9 @@ jobs:
   # creates it and the other just uploads — the create step tolerates that race.
   release:
     name: Publish dmgs to release
-    needs: build
+    # version-guard carries the same `if` as this job, so it is never merely
+    # skipped underneath it — on a tag push both run, otherwise both are skipped.
+    needs: [build, version-guard]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/desktop-linux-deb.yml
+++ b/.github/workflows/desktop-linux-deb.yml
@@ -21,9 +21,13 @@ on:
         type: string
 
 # Cancel a superseded run when new commits land on the same branch/PR (both
-# arch jobs are cancelled/restarted together).
+# arch jobs are cancelled/restarted together). The event name is part of the
+# group — like node-binding, and for the same reason: this workflow has a
+# workflow_dispatch trigger that SHARES REFS with push runs, so without it a
+# republish dispatched on a tag ref would cancel that tag's in-flight push run
+# and leave the release with no debs.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -170,8 +174,16 @@ jobs:
   #     built from the dispatched ref are uploaded to a different, existing tag,
   #     so ref-version and target-tag are EXPECTED to disagree. Judging the ref's
   #     own pair here would answer a question nobody asked. Deliberately skipped.
-  # On a push, `inputs` is null, so the second disjunct is false and the first
-  # decides — and `||` short-circuits, so it is never even reached.
+  # On a push there is no `inputs` context; dereferencing a nonexistent property
+  # yields the EMPTY STRING (documented), which loose-compares as 0 against a
+  # `v…` tag name's NaN, so the second disjunct is simply false and the first
+  # decides. (Don't lean on `||` short-circuiting — GitHub documents no
+  # evaluation order, and an undefined named-value would be a template error
+  # rather than something position could protect against.)
+  #
+  # Expression `==` is case-INSENSITIVE while git tags are not, so this gate
+  # alone would also accept release-tag `V0.1.5` on ref `v0.1.5` — guard green,
+  # upload to a different tag. The release job asserts that away in shell below.
   version-guard:
     name: Release version guard
     if: >-
@@ -188,13 +200,20 @@ jobs:
     # Unlike the sibling workflows, this job's condition is BROADER than
     # version-guard's (it also runs on workflow_dispatch), and a skipped `needs:`
     # would otherwise skip it too — killing the manual publish path. So spell the
-    # dependency results out: success-or-skipped guard proceeds, a FAILED guard
-    # still blocks the upload, and a failed/cancelled build still blocks it as
-    # the implicit success() used to.
+    # dependency results out. A FAILED guard always blocks the upload, and a
+    # failed/cancelled build still blocks it as the implicit success() used to.
+    #
+    # 'skipped' is accepted ONLY on workflow_dispatch. On a tag push the guard is
+    # required to have actually SUCCEEDED: this is the one workflow of the five
+    # whose release job doesn't share its `if` with the guard, so it is the only
+    # one where a future mis-gate could silently degrade to an unguarded publish.
+    # Narrowing 'skipped' to the event that legitimately skips makes that fail
+    # closed instead.
     if: >-
       !cancelled()
       && needs.build.result == 'success'
-      && (needs.version-guard.result == 'success' || needs.version-guard.result == 'skipped')
+      && (needs.version-guard.result == 'success'
+          || (needs.version-guard.result == 'skipped' && github.event_name == 'workflow_dispatch'))
       && (startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     permissions:
@@ -219,6 +238,7 @@ jobs:
           # like `x"; curl … | sh; #` would execute — and the shape check below
           # runs far too late to stop that, since bash has already parsed it.
           RELEASE_TAG_INPUT: ${{ inputs.release-tag }}
+          GUARD_RESULT: ${{ needs.version-guard.result }}
         run: |
           set -eu
           # Tag ref on push; explicit input on manual dispatch.
@@ -231,6 +251,18 @@ jobs:
           # to gh, so a stray value (e.g. leading '-') can't be parsed as a flag.
           printf '%s' "$tag" | grep -Eq '^v[A-Za-z0-9._-]+$' \
             || { echo "::error::'$tag' is not a valid release tag (expected v<version>)"; exit 1; }
+          # When the version guard RAN, it validated GITHUB_REF_NAME — so its
+          # green verdict only covers an upload to that same tag. Assert that
+          # identity here, in shell, where the comparison is case-SENSITIVE like
+          # git itself: the expression that gates the guard is not (GitHub
+          # ignores case in `==`), so release-tag 'V0.1.5' on ref 'v0.1.5' would
+          # otherwise run the guard against v0.1.5 and then publish to the
+          # distinct tag V0.1.5 — creating it — under a green check.
+          # Guard skipped (the backfill) => no verdict to over-claim, inert.
+          if [ "${GUARD_RESULT}" = "success" ] && [ "$tag" != "${GITHUB_REF_NAME}" ]; then
+            echo "::error::the version guard validated '${GITHUB_REF_NAME}' but this job would publish to '$tag'; refusing to trade on a verdict that does not cover this tag (differs only by case?)"
+            exit 1
+          fi
           # Fail loudly if either arch deb is missing rather than shipping a
           # half release (e.g. one matrix job was cancelled).
           for arch in x64 arm64; do

--- a/.github/workflows/desktop-linux-deb.yml
+++ b/.github/workflows/desktop-linux-deb.yml
@@ -152,13 +152,18 @@ jobs:
 
   # Refuse to publish when the pushed tag disagrees with the version in the tree
   # — the release is named after the tag, while the .deb's packageVersion comes
-  # from project.version. See release-version-guard.yml. Tag pushes ONLY: the
-  # workflow_dispatch path below deliberately uploads assets built from the
-  # dispatched branch tip to an already-existing tag, so its ref and its tag are
-  # expected to disagree and this check does not apply to it.
+  # from project.version. See release-version-guard.yml.
+  #
+  # Tag PUSHES only, hence the explicit event check (the sibling workflows can
+  # gate on the ref alone; this one can't). The workflow_dispatch path below
+  # deliberately uploads assets built from the dispatched ref to a SEPARATE,
+  # already-existing tag given as an input — the guard compares the ref's tag to
+  # the ref's version, which is not the pair that matters there, so it would
+  # either pass vacuously or fail a dispatch it has no business judging. That
+  # path stays deliberately unguarded; see the PR that added this file.
   version-guard:
     name: Release version guard
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     uses: ./.github/workflows/release-version-guard.yml
 
   # Attach both arch debs to the GitHub Release. Runs on `v*` tags (same

--- a/.github/workflows/desktop-linux-deb.yml
+++ b/.github/workflows/desktop-linux-deb.yml
@@ -150,13 +150,34 @@ jobs:
           if-no-files-found: error
           retention-days: 30
 
+  # Refuse to publish when the pushed tag disagrees with the version in the tree
+  # — the release is named after the tag, while the .deb's packageVersion comes
+  # from project.version. See release-version-guard.yml. Tag pushes ONLY: the
+  # workflow_dispatch path below deliberately uploads assets built from the
+  # dispatched branch tip to an already-existing tag, so its ref and its tag are
+  # expected to disagree and this check does not apply to it.
+  version-guard:
+    name: Release version guard
+    if: startsWith(github.ref, 'refs/tags/v')
+    uses: ./.github/workflows/release-version-guard.yml
+
   # Attach both arch debs to the GitHub Release. Runs on `v*` tags (same
   # race-tolerant create as the dmg/apk workflows) and on manual dispatch
   # (uploads to the given existing tag). Runs ONCE after both matrix jobs.
   release:
     name: Publish debs to release
-    needs: build
-    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+    needs: [build, version-guard]
+    # Unlike the sibling workflows, this job's condition is BROADER than
+    # version-guard's (it also runs on workflow_dispatch), and a skipped `needs:`
+    # would otherwise skip it too — killing the manual publish path. So spell the
+    # dependency results out: success-or-skipped guard proceeds, a FAILED guard
+    # still blocks the upload, and a failed/cancelled build still blocks it as
+    # the implicit success() used to.
+    if: >-
+      !cancelled()
+      && needs.build.result == 'success'
+      && (needs.version-guard.result == 'success' || needs.version-guard.result == 'skipped')
+      && (startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     permissions:
       # gh release create/upload needs write access to Releases (repo contents).

--- a/.github/workflows/desktop-linux-deb.yml
+++ b/.github/workflows/desktop-linux-deb.yml
@@ -149,21 +149,34 @@ jobs:
           path: app-desktop/build/compose/binaries/main/deb/*.deb
           if-no-files-found: error
           retention-days: 30
+          # Artifacts are immutable per run; without this, "re-run all jobs" on a
+          # tag 409s in every build leg and the release job never runs. That is
+          # the button people reach for after the version guard fails, so the
+          # recovery path must not wedge the release. (node-binding.yml has
+          # carried this fix since it hit exactly that.)
+          overwrite: true
 
   # Refuse to publish when the pushed tag disagrees with the version in the tree
   # — the release is named after the tag, while the .deb's packageVersion comes
   # from project.version. See release-version-guard.yml.
   #
-  # Tag PUSHES only, hence the explicit event check (the sibling workflows can
-  # gate on the ref alone; this one can't). The workflow_dispatch path below
-  # deliberately uploads assets built from the dispatched ref to a SEPARATE,
-  # already-existing tag given as an input — the guard compares the ref's tag to
-  # the ref's version, which is not the pair that matters there, so it would
-  # either pass vacuously or fail a dispatch it has no business judging. That
-  # path stays deliberately unguarded; see the PR that added this file.
+  # The condition is finer-grained than the sibling workflows' because this one
+  # has TWO dispatch shapes hiding behind one event, and the guard compares the
+  # ref's tag to the ref's version:
+  #   - push of a `v*` tag                     → the right pair. Guard.
+  #   - dispatch, release-tag == the ref's tag → the right pair (plain
+  #     republish, matching node-binding's ref-gated republish path). Guard.
+  #   - dispatch, release-tag != the ref       → the documented BACKFILL: assets
+  #     built from the dispatched ref are uploaded to a different, existing tag,
+  #     so ref-version and target-tag are EXPECTED to disagree. Judging the ref's
+  #     own pair here would answer a question nobody asked. Deliberately skipped.
+  # On a push, `inputs` is null, so the second disjunct is false and the first
+  # decides — and `||` short-circuits, so it is never even reached.
   version-guard:
     name: Release version guard
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    if: >-
+      startsWith(github.ref, 'refs/tags/v')
+      && (github.event_name == 'push' || inputs.release-tag == github.ref_name)
     uses: ./.github/workflows/release-version-guard.yml
 
   # Attach both arch debs to the GitHub Release. Runs on `v*` tags (same
@@ -201,11 +214,16 @@ jobs:
           # No checkout in this job — gh must be told the repo explicitly or it
           # dies with "fatal: not a git repository".
           GH_REPO: ${{ github.repository }}
+          # Through the ENVIRONMENT, never `${{ }}` inside the script: a `${{ }}`
+          # is pasted into the script text before bash parses it, so an input
+          # like `x"; curl … | sh; #` would execute — and the shape check below
+          # runs far too late to stop that, since bash has already parsed it.
+          RELEASE_TAG_INPUT: ${{ inputs.release-tag }}
         run: |
           set -eu
           # Tag ref on push; explicit input on manual dispatch.
           if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
-            tag="${{ inputs.release-tag }}"
+            tag="${RELEASE_TAG_INPUT}"
           else
             tag="${GITHUB_REF_NAME}"
           fi

--- a/.github/workflows/node-binding.yml
+++ b/.github/workflows/node-binding.yml
@@ -213,7 +213,8 @@ jobs:
   # Both smoke jobs are manual-only (workflow_dispatch): a 100-minute
   # live-network job is too heavy for every main push, its outcome depends on
   # whether Ethereum peers accept connections from Azure datacenter IPs, and
-  # releases must never gate on it (the release job needs only `build`).
+  # releases must never gate on it (the release job needs `build` and the
+  # version guard — never the smokes).
   smoke-linux:
     # Tag refs excluded: dispatching on a tag is the release-republish path
     # and must not launch the smokes alongside it.

--- a/.github/workflows/node-binding.yml
+++ b/.github/workflows/node-binding.yml
@@ -82,6 +82,14 @@ jobs:
           # on a tag 409s in every build leg and the release job never runs.
           overwrite: true
 
+  # Refuse to publish when the pushed tag disagrees with the version in the tree
+  # (see release-version-guard.yml). Gated on the REF like the release job below,
+  # so it covers the manual republish path (dispatch against a tag ref) too.
+  version-guard:
+    name: Release version guard
+    if: startsWith(github.ref, 'refs/tags/v')
+    uses: ./.github/workflows/release-version-guard.yml
+
   # Attach the five prebuilt addons plus a SHA-256 checksum file to the GitHub
   # Release for the pushed tag, and pin the engine ABI version in the release
   # notes so downstream loaders can gate on it. Runs ONLY on `v*` tags. The
@@ -90,7 +98,9 @@ jobs:
   # the create step below tolerates that race.
   release:
     name: Publish addons to release
-    needs: build
+    # version-guard carries the same `if` as this job, so it is never merely
+    # skipped underneath it — both run on a tag ref, both skip otherwise.
+    needs: [build, version-guard]
     # Deliberately gated on the REF, not the event: a workflow_dispatch
     # targeting a tag ref (gh workflow run node-binding.yml --ref vX.Y.Z) is
     # the manual republish path — the job is idempotent (--clobber uploads,

--- a/.github/workflows/release-version-guard.yml
+++ b/.github/workflows/release-version-guard.yml
@@ -27,16 +27,18 @@ jobs:
     name: Verify tag matches project version
     runs-on: ubuntu-latest
     # This job gates every release upload, so a wedged Gradle configuration must
-    # not hold the release hostage for the 6-hour default.
-    timeout-minutes: 20
+    # not hold the release hostage for the 6-hour default. Generous enough that
+    # three COLD attempts plus their two 25s sleeps still end in the explicit
+    # error below rather than a bare, unexplained timeout.
+    timeout-minutes: 30
     permissions:
       contents: read
 
     steps:
+      # No `submodules: recursive` (unlike the sibling build jobs): the repo has
+      # none, and this job only ever reads the build scripts.
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4

--- a/.github/workflows/release-version-guard.yml
+++ b/.github/workflows/release-version-guard.yml
@@ -1,0 +1,94 @@
+# Refuse to publish a release whose TAG disagrees with the version in the TREE.
+#
+# Release asset names come from the tag (Myotis-${GITHUB_REF_NAME}-android-debug.apk,
+# the release title), while what is *inside* those assets comes from the source:
+# :app-desktop and :android-app both derive their versions from project.version.
+# Nothing connected the two, so tagging v0.1.5 without first running the version
+# sweep went green and published a v0.1.5-named apk that reports versionName 0.1.4
+# in Settings -> Apps, next to a .deb stamped 0.1.4 and a .dmg stamped 1.1.4.
+#
+# Called as a job by every workflow that publishes tag-named release assets:
+# android-apk, ci, desktop-dmg, desktop-linux-deb, node-binding. Each one gates
+# the call on startsWith(github.ref, 'refs/tags/v') and makes its publishing job
+# needs: it, so a mismatch fails the run before anything is uploaded. Because it
+# is a separate job it runs in PARALLEL with the builds — the verdict lands in a
+# couple of minutes instead of after a 40-minute dmg build.
+#
+# GitHub has no cross-workflow job dependencies, so "one shared guard" means one
+# shared *definition*: this file is the single source of the check, instantiated
+# once per calling workflow.
+name: Release version guard
+
+on:
+  workflow_call:
+
+jobs:
+  verify:
+    name: Verify tag matches project version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Make gradlew executable
+        run: chmod +x gradlew
+
+      - name: Compare tag against project version
+        run: |
+          set -eu
+          # Defence in depth: the callers gate on refs/tags/v*, but a mis-wired
+          # caller must fail loudly here rather than compare a branch name to a
+          # version and report a confusing "mismatch".
+          case "${GITHUB_REF}" in
+            refs/tags/v*) ;;
+            *) echo "::error::release-version-guard ran on ${GITHUB_REF}; it is only meaningful on a refs/tags/v* push"; exit 1 ;;
+          esac
+
+          # Ask the BUILD for the version (never grep the build file) so this can
+          # never drift from the version the packaged apps actually report.
+          # Retry to ride out transient repo-resolution blips, like the sibling
+          # build steps: a flaky download must not read as a version mismatch.
+          # Gradle's stderr streams to the log, so a real failure is diagnosable.
+          out=""
+          for attempt in 1 2 3; do
+            if out=$(./gradlew -q :printReleaseVersion); then break; fi
+            [ "$attempt" -lt 3 ] || { echo "::error::could not read the project version from Gradle after 3 attempts"; exit 1; }
+            echo "::warning::reading the project version failed (attempt $attempt); retrying in 25s (transient dependency resolution?)"
+            sleep 25
+          done
+
+          # The task prints releaseVersion=<x.y.z>; match the marker instead of
+          # trusting the last line — even under -q a cold runner also puts the
+          # wrapper's distribution-download progress on stdout.
+          version=$(printf '%s\n' "$out" | sed -n 's/^releaseVersion=//p' | tail -n1)
+          printf '%s' "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' \
+            || { echo "::error::printReleaseVersion did not yield a MAJOR.MINOR.PATCH version (got '$version')"; exit 1; }
+
+          tag="${GITHUB_REF_NAME}"
+          echo "pushed tag:      $tag"
+          echo "project version: $version (expected tag: v$version)"
+          if [ "$tag" != "v$version" ]; then
+            echo "Release assets are named after the TAG, but the binaries inside report the"
+            echo "PROJECT VERSION. Publishing now would ship $tag assets that identify"
+            echo "themselves as $version (and an Android versionCode that may not have been"
+            echo "bumped, so the 'upgrade' would not install over the previous build)."
+            echo "Fix: run the version sweep on main (version in build.gradle.kts, plus"
+            echo "android-app's versionCode), merge it, then re-tag that commit."
+            echo "::error::tag/version mismatch: pushed tag $tag, but the tree builds $version (expected tag v$version)"
+            exit 1
+          fi
+          echo "OK: tag $tag matches project version $version"

--- a/.github/workflows/release-version-guard.yml
+++ b/.github/workflows/release-version-guard.yml
@@ -11,12 +11,27 @@
 # android-apk, ci, desktop-dmg, desktop-linux-deb, node-binding. Each one gates
 # the call on startsWith(github.ref, 'refs/tags/v') and makes its publishing job
 # needs: it, so a mismatch fails the run before anything is uploaded. Because it
-# is a separate job it runs in PARALLEL with the builds — the verdict lands in a
-# couple of minutes instead of after a 40-minute dmg build.
+# is a separate job it runs in PARALLEL with the builds, and the whole step is
+# ~30s, so the verdict lands long before a 40-minute dmg leg. (Those legs still
+# run to completion — Actions has no cross-job fail-fast.)
 #
 # GitHub has no cross-workflow job dependencies, so "one shared guard" means one
 # shared *definition*: this file is the single source of the check, instantiated
 # once per calling workflow.
+#
+# HOW TO EXERCISE IT without waiting for a release, and without publishing
+# anything: a tag push runs the workflow files FROM THE TAGGED COMMIT, so a
+# throwaway tag on any branch tests the real thing. Pick a version the tree
+# cannot match, so the expected outcome is a refusal:
+#
+#     git tag v9.9.9-guardtest && git push origin v9.9.9-guardtest
+#     # expect: this job fails in all five workflows, every publishing job is
+#     #         SKIPPED, and `gh release view v9.9.9-guardtest` finds nothing
+#     git push origin --delete v9.9.9-guardtest && git tag -d v9.9.9-guardtest
+#
+# The opposite direction (a CORRECT tag passes) cannot be rehearsed this way —
+# it publishes a real prerelease — so it is first exercised by an actual
+# release. That is why changes to this guard should land well before one.
 name: Release version guard
 
 on:

--- a/.github/workflows/release-version-guard.yml
+++ b/.github/workflows/release-version-guard.yml
@@ -26,6 +26,9 @@ jobs:
   verify:
     name: Verify tag matches project version
     runs-on: ubuntu-latest
+    # This job gates every release upload, so a wedged Gradle configuration must
+    # not hold the release hostage for the 6-hour default.
+    timeout-minutes: 20
     permissions:
       contents: read
 
@@ -62,33 +65,44 @@ jobs:
           # never drift from the version the packaged apps actually report.
           # Retry to ride out transient repo-resolution blips, like the sibling
           # build steps: a flaky download must not read as a version mismatch.
-          # Gradle's stderr streams to the log, so a real failure is diagnosable.
+          # Only stdout is captured — Gradle's own failure output goes to stderr
+          # and streams straight into this log, so a real breakage is readable.
           out=""
           for attempt in 1 2 3; do
             if out=$(./gradlew -q :printReleaseVersion); then break; fi
-            [ "$attempt" -lt 3 ] || { echo "::error::could not read the project version from Gradle after 3 attempts"; exit 1; }
-            echo "::warning::reading the project version failed (attempt $attempt); retrying in 25s (transient dependency resolution?)"
+            [ "$attempt" -lt 3 ] || { echo "::error::could not read the project version from Gradle after 3 attempts — see the Gradle output above (a renamed or removed :printReleaseVersion task fails exactly like this, and retrying will not fix it)"; exit 1; }
+            echo "::warning::reading the project version failed (attempt $attempt); retrying in 25s"
             sleep 25
           done
 
-          # The task prints releaseVersion=<x.y.z>; match the marker instead of
-          # trusting the last line — even under -q a cold runner also puts the
-          # wrapper's distribution-download progress on stdout.
-          version=$(printf '%s\n' "$out" | sed -n 's/^releaseVersion=//p' | tail -n1)
+          # The task prints releaseVersion=<x.y.z>. Match the marker anywhere in
+          # the output rather than trusting the last line: even under -q a cold
+          # runner puts the wrapper's distribution-download progress on stdout,
+          # and it is emitted without a trailing newline, so the marker is not
+          # guaranteed to start its own line. The strict shape check below is
+          # what actually decides whether we got a version.
+          version=$(printf '%s\n' "$out" | sed -n 's/.*releaseVersion=\([0-9][0-9.]*\).*/\1/p' | tail -n1)
           printf '%s' "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' \
             || { echo "::error::printReleaseVersion did not yield a MAJOR.MINOR.PATCH version (got '$version')"; exit 1; }
 
           tag="${GITHUB_REF_NAME}"
           echo "pushed tag:      $tag"
-          echo "project version: $version (expected tag: v$version)"
-          if [ "$tag" != "v$version" ]; then
-            echo "Release assets are named after the TAG, but the binaries inside report the"
-            echo "PROJECT VERSION. Publishing now would ship $tag assets that identify"
-            echo "themselves as $version (and an Android versionCode that may not have been"
-            echo "bumped, so the 'upgrade' would not install over the previous build)."
-            echo "Fix: run the version sweep on main (version in build.gradle.kts, plus"
-            echo "android-app's versionCode), merge it, then re-tag that commit."
-            echo "::error::tag/version mismatch: pushed tag $tag, but the tree builds $version (expected tag v$version)"
-            exit 1
-          fi
+          echo "project version: $version (accepted tags: v$version, or v$version-<suffix>)"
+          # `v*` is the trigger, so pre-release/hotfix shapes like v0.1.5-rc1 must
+          # stay publishable: require the tag's version CORE to match, and allow a
+          # -suffix after it. The '-' is mandatory in the second pattern, so
+          # v0.1.40 can never satisfy a 0.1.4 tree.
+          case "$tag" in
+            "v$version"|"v$version-"*) ;;
+            *)
+              echo "Release assets are named after the TAG, but the binaries inside report the"
+              echo "PROJECT VERSION — so publishing now would ship $tag assets that identify"
+              echo "themselves as $version."
+              echo "Fix: run the version sweep on main (the version in build.gradle.kts, and"
+              echo "bump android-app's versionCode — which this guard does NOT check), merge"
+              echo "it, then tag that commit."
+              echo "::error::tag/version mismatch: pushed tag $tag, but the tree builds $version (expected v$version or v$version-<suffix>)"
+              exit 1
+              ;;
+          esac
           echo "OK: tag $tag matches project version $version"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,26 @@ allprojects {
     version = "0.1.4-SNAPSHOT"
 }
 
+// The release version — project.version minus the -SNAPSHOT suffix — exactly as
+// :app-desktop and :android-app derive their installer / app versions from it.
+// Release CI reads it from HERE (via Gradle, so it can never drift from what the
+// build actually uses) and refuses to publish when the pushed `v*` tag disagrees:
+// otherwise tagging without running the version sweep goes green and ships assets
+// named after the tag while the binaries inside report the older version.
+// See .github/workflows/release-version-guard.yml.
+//
+// Marker-prefixed output: `./gradlew -q` still lets non-task text reach stdout
+// (wrapper distribution download progress on a cold runner, JVM/plugin warnings),
+// so the consumer greps for the marker instead of trusting the last line.
+tasks.register("printReleaseVersion") {
+    group = "help"
+    description = "Print the release version (project.version without -SNAPSHOT) as releaseVersion=<x.y.z>"
+    // Read at configuration time: the task action captures a plain String, so it
+    // stays configuration-cache compatible.
+    val releaseVersion = project.version.toString().substringBefore('-')
+    doLast { println("releaseVersion=$releaseVersion") }
+}
+
 subprojects {
     // These bring their own plugins (Android Gradle Plugin / Kotlin Multiplatform /
     // Compose), which are incompatible with the `java` plugin applied below:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,10 @@ allprojects {
 // build actually uses) and refuses to publish when the pushed `v*` tag disagrees:
 // otherwise tagging without running the version sweep goes green and ships assets
 // named after the tag while the binaries inside report the older version.
-// See .github/workflows/release-version-guard.yml.
+// See .github/workflows/release-version-guard.yml. This reads the ROOT project's
+// version, which is what the consumers see only because `allprojects` above sets
+// ONE version for the whole build — give a module its own version and it silently
+// stops being covered by the guard.
 //
 // Marker-prefixed output: `./gradlew -q` still lets non-task text reach stdout
 // (wrapper distribution download progress on a cold runner, JVM/plugin warnings),


### PR DESCRIPTION
## The gap

Release asset names come from the **tag**; what is *inside* them comes from the **source**. Nothing connected the two.

`.github/workflows/android-apk.yml` names the published apk after `GITHUB_REF_NAME`:

```bash
mv "${apks[0]}" "apk/Myotis-${GITHUB_REF_NAME}-android-debug.apk"
```

So tagging `v0.1.5` without first running the version sweep goes green and publishes `Myotis-v0.1.5-android-debug.apk` that reports `versionName 0.1.4` in Settings → Apps, next to a `.deb` stamped `0.1.4` and a `.dmg` stamped `1.1.4`. Found in review of #303.

## The guard

`.github/workflows/release-version-guard.yml` is a `workflow_call` reusable workflow — the single *definition* of the check. GitHub has no cross-workflow job dependencies, so "one shared guard job" means one shared definition instantiated once per calling workflow; that beats five copies of the script.

It reads the version **from Gradle**, never by grepping the build file, so it cannot drift from what the build actually uses. New root task:

```kotlin
tasks.register("printReleaseVersion") { … println("releaseVersion=$releaseVersion") }
```

`project.version` minus `-SNAPSHOT`, exactly as `:app-desktop` and `:android-app` already derive their versions. Then it requires the pushed tag to be `v<x.y.z>` (or `v<x.y.z>-<suffix>`, so `v0.1.5-rc1` stays publishable — `v*` is the trigger).

Wired into all five workflows that publish tag-named assets — `android-apk`, `ci`, `desktop-dmg`, `desktop-linux-deb`, `node-binding` — as a job gated on the tag ref, with each publishing job `needs:`-ing it. A mismatch fails the run before anything is uploaded. Being a separate job, the verdict is *reported* within a minute instead of after a 40-minute dmg leg (the build legs themselves still run — Actions has no cross-job fail-fast).

Four workflows carry the *same* `if` on the guard and on `release`, so the guard is never merely skipped underneath a running publish job. `desktop-linux-deb` is the exception, because one event hides two different situations:

| case | pair the guard would compare | verdict |
|---|---|---|
| push of a `v*` tag | ref's tag vs ref's version | right pair → guard |
| dispatch, `release-tag` == the ref's tag (plain republish) | ref's tag vs ref's version | right pair → guard |
| dispatch, `release-tag` != the ref (the documented **backfill**) | ref's version vs a *different* tag's assets | wrong question → skip |

Its `release` job therefore spells the dependency results out, accepting `skipped` **only** on `workflow_dispatch` — on a tag push the guard must have actually succeeded, so a future mis-gate fails closed rather than degrading to an unguarded publish. And because GitHub's expression `==` is case-insensitive while git tags are not, the job additionally asserts in shell that *if the guard ran, the tag being published to is the tag it validated*.

## Verified on a real tag

The premise that this couldn't be tested before merging turned out to be wrong in one direction: a tag push runs the workflow files **from the tagged commit**, so tagging this branch exercises the real thing. Pushed `v9.9.9-guardtest` at 97dbe284 (tree version `0.1.4`, so the guard must refuse it), then deleted the tag.

```
pushed tag:      v9.9.9-guardtest
project version: 0.1.4 (accepted tags: v0.1.4, or v0.1.4-<suffix>)
##[error]tag/version mismatch: pushed tag v9.9.9-guardtest, but the tree builds 0.1.4 (expected v0.1.4 or v0.1.4-<suffix>)
```

| workflow | guard | publishing job |
|---|---|---|
| Android APK | failure | `Publish APK to release` — **skipped** |
| CI & Release | failure | `Release` — **skipped** |
| Desktop DEB (Linux) | failure | `Publish debs to release` — **skipped** |
| Desktop DMG (macOS) | failure | `Publish dmgs to release` — **skipped** |
| node-binding | failure | `Publish addons to release` — **skipped** |

`gh release view v9.9.9-guardtest` → *release not found*; the release list is unchanged. **Nothing was published.** All five workflows fired, including `node-binding` despite its `paths:` filter — confirming that path filters aren't evaluated for tag pushes.

Also now measured rather than assumed: Gradle reads the version fine on a clean `ubuntu-latest` runner, and the whole guard step takes **~31 seconds**.

The direction still untested is "a *correct* tag passes", which can't be checked without publishing a real prerelease — so **please still land this well before cutting a release**.

## Local testing

The step body was also extracted from the YAML and run against the real Gradle build and stubbed `gradlew`s:

| case | outcome |
|---|---|
| tag `v0.1.4`, tree `0.1.4` | pass |
| tag `v0.1.4-rc1`, tree `0.1.4` | pass |
| tag `v0.1.5` / `v0.1.40` (prefix confusion), tree `0.1.4` | **block** |
| branch / PR ref (mis-wired caller) | **block** |
| marker glued to wrapper download progress | pass |
| no marker / empty / 2-part / 4-part version | **block** |
| Gradle fails all 3 attempts | **block** |

And for the deb release job's tag selection: case-differing republish (`v0.1.5-rc1` vs `v0.1.5-RC1`) → **blocked**; backfill with the guard skipped → publishes; injection attempt in `release-tag` → inert.

No fail-open case was found. `actionlint` (with shellcheck) reports nothing new across all nine workflows — its only finding is the pre-existing SC2086 at `desktop-dmg.yml:126`, identical on `main`.

## Review

**Round 1** — two independent no-context reviewers before the PR was opened (per CLAUDE.md), including a full event-path enumeration. Neither could construct a fail-open. Fixed in 08cfe0ed: the `desktop-linux-deb` gate contradicted its own comment; suffixed tags (`v0.1.5-rc1`) would have become unpublishable; the marker match was anchored to column 0 while the wrapper's progress output has no trailing newline; the failure message referenced `versionCode`, which the guard doesn't read.

**Round 2** — the `claude-review` job. Verdict "sound, ship it", three findings, answered inline; fixed in 343cff74: the plain republish was being skipped along with the backfill; `overwrite: true` added to the apk/dmg/deb uploads (artifacts are immutable per run, so "re-run all jobs" 409s — and this PR makes tag runs fail on purpose, so that recovery stopped being independent of it); `--configure-on-demand` measured and **declined** — identical answer and ~45% faster warm, but `-i` shows every plugin *artifact* is resolved by the root `plugins { … apply false }` block in both modes, so it buys wall-clock, not the flaky-repo network surface that motivated it. Also folded in the `${{ inputs.release-tag }}`-inside-`run:` injection fix.

**Round 3** — `claude-review` fires on `opened/reopened/ready_for_review`, not `synchronize`, so it never saw the round-2 delta. An independent pass over it found three more, fixed in 97dbe284: GitHub's `==` is **case-insensitive** while git tags are not, so a `v0.1.5-rc1`/`v0.1.5-RC1` dispatch would report "guarded" while publishing to a tag the guard never examined (now asserted away in shell, where comparison is case-sensitive); `skipped` narrowed to `workflow_dispatch`; and the concurrency group given the event name, mirroring `node-binding`, since round 2 made dispatch-on-a-tag-ref a first-class path that could otherwise cancel a tag's in-flight push run.

## Known residuals (deliberately out of scope)

1. **`versionCode` is still hand-maintained** (`android-app/build.gradle.kts:100`, `= 5`) and is *not* checked. Bump `version`, forget `versionCode`, tag → the guard passes and the apk still won't install over the previous build. The guard's failure text says explicitly that it doesn't check this. Queued as a follow-up.
2. **The `desktop-linux-deb` backfill remains unguarded** — by design: it uploads assets built from one ref to a *different* existing tag, so ref-version and target-tag are expected to disagree. Catching a mislabel there means comparing the built deb's control `Version` against `release-tag` — a different check that doesn't involve the ref at all.
3. `ci.yml` still publishes `-SNAPSHOT`-named jars under a `v*` tag.
4. `devp2p-discovery.yml` still uploads an artifact without `overwrite:` or a run-unique name — outside the release path, so left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
