### PR TITLE
eth_call: support the contract-creation form (the other deployless mode)

### DIFF
--- a/app-ios/src/iosMain/kotlin/io/myotis/ios/IosRpcBackend.kt
+++ b/app-ios/src/iosMain/kotlin/io/myotis/ios/IosRpcBackend.kt
@@ -115,6 +115,8 @@ class IosRpcBackend(
 
     override fun supportsStateOverrides(): Boolean = true   // the revm executor applies them
 
+    override fun supportsContractCreation(): Boolean = true // TxKind::Create
+
     override fun callWithOverrides(
         from: ByteArray?,
         to: ByteArray?,

--- a/app-ios/src/iosMain/kotlin/io/myotis/ios/IosRpcBackend.kt
+++ b/app-ios/src/iosMain/kotlin/io/myotis/ios/IosRpcBackend.kt
@@ -94,15 +94,15 @@ class IosRpcBackend(
         return ByteArray(32).also { raw.copyInto(it, 32 - raw.size) }
     }
 
-    override fun call(from: ByteArray?, to: ByteArray, data: ByteArray, valueWei: String?, block: String): ByteArray? {
+    override fun call(from: ByteArray?, to: ByteArray?, data: ByteArray, valueWei: String?, block: String): ByteArray? {
         if (!isServableBlock(block)) return null
-        if (to.size != 20) return null
+        if (to != null && to.size != 20) return null   // null = contract creation
         if (from != null && from.size != 20) return null
         val handle = handleProvider() ?: return null
         val o = resultOrNull(RustEngine.ethCallJson(
             handle,
             from?.let(::hex) ?: "",  // empty = anonymous zero sender
-            hex(to),
+            to?.let(::hex) ?: "",   // empty = contract creation
             if (data.isEmpty()) "" else hex(data),
             valueWei ?: "",
             block,
@@ -117,20 +117,20 @@ class IosRpcBackend(
 
     override fun callWithOverrides(
         from: ByteArray?,
-        to: ByteArray,
+        to: ByteArray?,
         data: ByteArray,
         valueWei: String?,
         block: String,
         stateOverridesJson: String,
     ): ByteArray? {
         if (!isServableBlock(block)) return null
-        if (to.size != 20) return null
+        if (to != null && to.size != 20) return null   // null = contract creation
         if (from != null && from.size != 20) return null
         val handle = handleProvider() ?: return null
         val o = resultOrNull(RustEngine.ethCallOverridesJson(
             handle,
             from?.let(::hex) ?: "",  // empty = anonymous zero sender
-            hex(to),
+            to?.let(::hex) ?: "",   // empty = contract creation
             if (data.isEmpty()) "" else hex(data),
             valueWei ?: "",
             block,

--- a/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/RpcBackend.kt
+++ b/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/RpcBackend.kt
@@ -23,7 +23,9 @@ interface RpcBackend {
      *  the caller, because wallets probe this to decide whether the node is
      *  alive. Never null: an unreadable status reads as [RpcSyncState.SYNCING]. */
     fun syncState(): RpcSyncState
-    fun call(from: ByteArray?, to: ByteArray, data: ByteArray, valueWei: String?, block: String): ByteArray?
+    /** `to` is NULL for contract creation (`eth_call` with no `to`): the calldata
+     *  is init code and its return data is the answer. */
+    fun call(from: ByteArray?, to: ByteArray?, data: ByteArray, valueWei: String?, block: String): ByteArray?
 
     /**
      * Whether this backend can APPLY state overrides. Distinguishes "overrides
@@ -44,7 +46,7 @@ interface RpcBackend {
      */
     fun callWithOverrides(
         from: ByteArray?,
-        to: ByteArray,
+        to: ByteArray?,
         data: ByteArray,
         valueWei: String?,
         block: String,

--- a/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/RpcBackend.kt
+++ b/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/RpcBackend.kt
@@ -37,6 +37,14 @@ interface RpcBackend {
     fun supportsStateOverrides(): Boolean = false
 
     /**
+     * Whether this backend can serve CONTRACT CREATION (`eth_call` with a null
+     * `to`). Consulted BEFORE dispatch: an engine that can't would otherwise be
+     * woken and made to wait for a verified head only to refuse — and the
+     * refusal would read as retryable when it is permanent for that build.
+     */
+    fun supportsContractCreation(): Boolean = false
+
+    /**
      * [call] with the `eth_call` state-override object as JSON — caller-supplied
      * state layered over verified state for this call only.
      *

--- a/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/RpcRouter.kt
+++ b/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/RpcRouter.kt
@@ -384,7 +384,11 @@ class RpcRouter(
                 if (stateOverrideParam(root) is OverrideParam.Malformed) return null
                 val overrideJson = stateOverrideJson(root)
                 val callObj = p?.getOrNull(0) as? JsonObject ?: return null
-                val to = callObj["to"]?.asHexBytes() ?: return null   // contract creation (to=null) -> proxy
+                // `to` absent or null is CONTRACT CREATION — the calldata is init
+                // code and its return data is the answer (the deployless Deploy
+                // form). Present-but-malformed is still a refusal.
+                val toElement = callObj["to"]?.takeUnless { it is JsonNull }
+                val to = if (toElement != null) (toElement.asHexBytes() ?: return null) else null
                 // The caller (msg.sender). Absent/null -> anonymous (backend uses the
                 // zero-address default); present-but-malformed -> proxy. Threading this
                 // is what lets a wallet's confirm-screen simulation of a sender-gated

--- a/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/RpcRouter.kt
+++ b/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/RpcRouter.kt
@@ -178,6 +178,15 @@ class RpcRouter(
     private fun blockOverridePresent(root: JsonObject): Boolean =
         (root.params()?.getOrNull(3) as? JsonObject)?.isNotEmpty() == true
 
+    /** True when the request is a contract-creation `eth_call`: `to` absent or
+     *  explicitly null. A present-but-malformed `to` is NOT creation — running
+     *  init code the caller never asked to run would be worse than refusing. */
+    private fun isContractCreation(root: JsonObject): Boolean {
+        val callObj = root.params()?.getOrNull(0) as? JsonObject ?: return false
+        val to = callObj["to"]
+        return to == null || to is JsonNull
+    }
+
     /** The methods that take override parameters. `eth_call` state overrides
      *  are APPLIED when the backend supports them; `blockOverrides` and every
      *  `eth_estimateGas` override are refused. */
@@ -279,6 +288,18 @@ class RpcRouter(
                     logger.record(m, idStr, "ERROR", elapsedMs(t0), -32602)
                     return errorEnvelope(id, -32602, "invalid state override: ${bad.why}")
                 }
+            }
+            // Contract creation this build cannot serve is permanent, not retryable.
+            if (m == "eth_call" && isContractCreation(root) &&
+                backend?.supportsContractCreation() != true
+            ) {
+                logger.record(m, idStr, "ERROR", elapsedMs(t0), -32602)
+                return errorEnvelope(
+                    id,
+                    -32602,
+                    "method 'eth_call' without a 'to' (contract creation) is not supported by " +
+                        "this node's engine",
+                )
             }
             val overrideUnsupported = takesOverrides(m) && hasUnsupportedOverride(root) && (
                 blockOverridePresent(root) ||            // never applied
@@ -389,6 +410,12 @@ class RpcRouter(
                 // form). Present-but-malformed is still a refusal.
                 val toElement = callObj["to"]?.takeUnless { it is JsonNull }
                 val to = if (toElement != null) (toElement.asHexBytes() ?: return null) else null
+                // Ask BEFORE dispatching. On an engine that can't serve creation
+                // (the Java engine is still the default) the call would wake a
+                // paused stack, wait for a verified head, and refuse anyway —
+                // an expensive refusal where there used to be a free one, and
+                // reported as retryable though it is permanent for that build.
+                if (to == null && backend?.supportsContractCreation() != true) return null
                 // The caller (msg.sender). Absent/null -> anonymous (backend uses the
                 // zero-address default); present-but-malformed -> proxy. Threading this
                 // is what lets a wallet's confirm-screen simulation of a sender-gated

--- a/jsonrpc-server/src/jvmMain/kotlin/io/myotis/jsonrpc/ApiAdapters.kt
+++ b/jsonrpc-server/src/jvmMain/kotlin/io/myotis/jsonrpc/ApiAdapters.kt
@@ -38,14 +38,14 @@ class VerifiedReadsBackend(private val v: io.myotis.api.VerifiedReads) : RpcBack
         io.myotis.api.SyncState.CATCHING_UP -> RpcSyncState.CATCHING_UP
         io.myotis.api.SyncState.SYNCING -> RpcSyncState.SYNCING
     }
-    override fun call(from: ByteArray?, to: ByteArray, data: ByteArray, valueWei: String?, block: String): ByteArray? =
+    override fun call(from: ByteArray?, to: ByteArray?, data: ByteArray, valueWei: String?, block: String): ByteArray? =
         v.call(from, to, data, valueWei, block)
 
     override fun supportsStateOverrides(): Boolean = v.supportsStateOverrides()
 
     override fun callWithOverrides(
         from: ByteArray?,
-        to: ByteArray,
+        to: ByteArray?,
         data: ByteArray,
         valueWei: String?,
         block: String,

--- a/jsonrpc-server/src/jvmMain/kotlin/io/myotis/jsonrpc/ApiAdapters.kt
+++ b/jsonrpc-server/src/jvmMain/kotlin/io/myotis/jsonrpc/ApiAdapters.kt
@@ -43,6 +43,8 @@ class VerifiedReadsBackend(private val v: io.myotis.api.VerifiedReads) : RpcBack
 
     override fun supportsStateOverrides(): Boolean = v.supportsStateOverrides()
 
+    override fun supportsContractCreation(): Boolean = v.supportsContractCreation()
+
     override fun callWithOverrides(
         from: ByteArray?,
         to: ByteArray?,

--- a/jsonrpc-server/src/jvmTest/kotlin/io/myotis/jsonrpc/RpcAccessLogTest.kt
+++ b/jsonrpc-server/src/jvmTest/kotlin/io/myotis/jsonrpc/RpcAccessLogTest.kt
@@ -27,7 +27,7 @@ class RpcAccessLogTest {
         override fun chainId() = 1L
         override fun headBlockNumber() = 0x1L
         override fun syncState() = io.myotis.api.SyncState.SYNCED
-        override fun call(from: ByteArray?, to: ByteArray, data: ByteArray, valueWei: String?, block: String): ByteArray? = null
+        override fun call(from: ByteArray?, to: ByteArray?, data: ByteArray, valueWei: String?, block: String): ByteArray? = null
         override fun getBalance(address: ByteArray, block: String): String? = null
         override fun getTransactionCount(address: ByteArray, block: String): Long? = null
         override fun getCode(address: ByteArray, block: String): ByteArray? = null

--- a/jsonrpc-server/src/jvmTest/kotlin/io/myotis/jsonrpc/RpcRouterTest.kt
+++ b/jsonrpc-server/src/jvmTest/kotlin/io/myotis/jsonrpc/RpcRouterTest.kt
@@ -196,7 +196,7 @@ class RpcRouterTest {
         override fun syncState() = syncStateValue
         var lastOverrides: String? = null
 
-        override fun call(from: ByteArray?, to: ByteArray, data: ByteArray,
+        override fun call(from: ByteArray?, to: ByteArray?, data: ByteArray,
                           valueWei: String?, block: String): ByteArray? {
             lastFrom = from; lastTo = to; lastData = data
             lastValue = valueWei?.let { BigInteger(it) }; lastBlock = block
@@ -204,7 +204,7 @@ class RpcRouterTest {
         }
         override fun supportsStateOverrides(): Boolean = applyOverrides
 
-        override fun callWithOverrides(from: ByteArray?, to: ByteArray, data: ByteArray,
+        override fun callWithOverrides(from: ByteArray?, to: ByteArray?, data: ByteArray,
                                        valueWei: String?, block: String,
                                        stateOverridesJson: String): ByteArray? {
             if (!applyOverrides) return null   // the interface default: unsupported
@@ -454,11 +454,34 @@ class RpcRouterTest {
         assertEquals("latest", b.lastBlock)
     }
 
-    @Test fun ethCall_missingTo_fallsThrough() {                   // contract creation -> proxy/strict
+    @Test fun ethCall_missingTo_isServedAsContractCreation() {
+        // CHANGED deliberately: a `to`-less eth_call is contract creation — the
+        // calldata is init code and its return data is the answer. It used to
+        // fall through to proxy/strict, which left wallets using the deployless
+        // Deploy form (Ambire picks it whenever a network is flagged
+        // rpcNoStateOverride) unable to read account state at all.
         val b = FakeBackend(callResult = byteArrayOf(9))
         val resp = route(b, """{"jsonrpc":"2.0","id":1,"method":"eth_call","params":[{"data":"0x00"}]}""")
-        assertTrue(hasError(resp))                                 // strict (no proxy) -> error, not the fake result
-        assertNull(b.lastTo)                                       // backend never invoked
+        assertEquals("0x09", result(resp))
+        assertNull(b.lastTo)                                       // null `to` reached the backend as creation
+        assertEquals("0x00", b.lastData!!.toHex())
+    }
+
+    @Test fun ethCall_explicitNullTo_isAlsoCreation() {
+        val b = FakeBackend(callResult = byteArrayOf(9))
+        val resp = route(b,
+            """{"jsonrpc":"2.0","id":1,"method":"eth_call","params":[{"to":null,"data":"0x00"}]}""")
+        assertEquals("0x09", result(resp))
+    }
+
+    @Test fun ethCall_malformedTo_isStillRefused() {
+        // Present-but-bad is not creation: serving it as one would run init code
+        // the caller never asked to run.
+        val b = FakeBackend(callResult = byteArrayOf(9))
+        val resp = route(b,
+            """{"jsonrpc":"2.0","id":1,"method":"eth_call","params":[{"to":"0xZZ","data":"0x00"}]}""")
+        assertTrue(hasError(resp))
+        assertNull(b.lastData)
     }
 
     @Test fun ethCall_malformedData_fallsThrough() {            // present-but-bad calldata -> proxy, not empty

--- a/jsonrpc-server/src/jvmTest/kotlin/io/myotis/jsonrpc/RpcRouterTest.kt
+++ b/jsonrpc-server/src/jvmTest/kotlin/io/myotis/jsonrpc/RpcRouterTest.kt
@@ -175,6 +175,9 @@ class RpcRouterTest {
         /** When true this fake CAN apply overrides (the engine-backed case);
          *  when false it inherits the interface default (null = unsupported). */
         private val applyOverrides: Boolean = false,
+        /** Whether this fake serves contract creation (the Rust engine does;
+         *  the Java engine does not). */
+        private val serveCreation: Boolean = true,
         var balance: BigInteger? = null,
         var nonce: Long? = null,
         var head: Long? = 0x100,
@@ -203,6 +206,8 @@ class RpcRouterTest {
             return callResult
         }
         override fun supportsStateOverrides(): Boolean = applyOverrides
+
+        override fun supportsContractCreation(): Boolean = serveCreation
 
         override fun callWithOverrides(from: ByteArray?, to: ByteArray?, data: ByteArray,
                                        valueWei: String?, block: String,
@@ -465,6 +470,18 @@ class RpcRouterTest {
         assertEquals("0x09", result(resp))
         assertNull(b.lastTo)                                       // null `to` reached the backend as creation
         assertEquals("0x00", b.lastData!!.toHex())
+    }
+
+    @Test fun ethCall_creation_onABackendThatCannotServeIt_isRefusedWithoutDispatch() {
+        // The Java engine (still the default) cannot serve creation, and asking
+        // it anyway wakes a paused stack and waits for a verified head only to
+        // refuse — an expensive refusal where there used to be a free one, and
+        // reported as retryable though it is permanent for that build.
+        val b = FakeBackend(callResult = byteArrayOf(9), serveCreation = false)
+        val resp = route(b, """{"jsonrpc":"2.0","id":1,"method":"eth_call","params":[{"data":"0x00"}]}""")
+        assertTrue(hasError(resp))
+        assertEquals(-32602, errorCode(resp))   // permanent, not the retryable -32000
+        assertNull(b.lastData)                  // never dispatched
     }
 
     @Test fun ethCall_explicitNullTo_isAlsoCreation() {

--- a/myotis-api/src/main/java/io/myotis/api/VerifiedReads.java
+++ b/myotis-api/src/main/java/io/myotis/api/VerifiedReads.java
@@ -30,6 +30,12 @@ public interface VerifiedReads {
      * null (zero sender — reverts {@code msg.sender}-gated contracts, as geth
      * does); {@code valueWei} decimal or null for zero.
      *
+     * <p>{@code to} may be null: that is CONTRACT CREATION, where {@code data}
+     * is init code and the constructor's return data is the result (geth's
+     * behaviour for a {@code to}-less call). Engines that cannot serve it must
+     * report {@link #supportsContractCreation()} false rather than relying on a
+     * null-{@code to} guard, so hosts can refuse without dispatching.
+     *
      * @return ABI return bytes, or null when unanswerable verified
      */
     byte[] call(byte[] from, byte[] to, byte[] data, String valueWei, String block);
@@ -48,6 +54,22 @@ public interface VerifiedReads {
      *     {@link #callWithOverrides} cannot apply them
      */
     default boolean supportsStateOverrides() {
+        return false;
+    }
+
+    /**
+     * Whether this engine can serve CONTRACT CREATION calls — {@code eth_call}
+     * with a null {@code to}, where the calldata is init code and the
+     * constructor's return data is the answer.
+     *
+     * <p>Hosts must consult this BEFORE dispatching: an engine that cannot serve
+     * it would otherwise be woken, wait for a verified head, and refuse anyway,
+     * turning a free refusal into an expensive one — and returning a retryable
+     * error for something permanently unanswerable on that build.
+     *
+     * @return false by default
+     */
+    default boolean supportsContractCreation() {
         return false;
     }
 

--- a/myotis-engines/src/main/java/io/myotis/engines/RustVerifiedReads.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustVerifiedReads.java
@@ -179,12 +179,14 @@ final class RustVerifiedReads implements VerifiedReads {
             String block,
             String stateOverridesJson) {
         if (!isServableBlock(block)) return null;
-        if (to == null || to.length != 20) return null;
+        // A NULL `to` is contract creation (eth_call with no `to`), passed to
+        // the engine as an empty string — not an error.
+        if (to != null && to.length != 20) return null;
         if (from != null && from.length != 20) return null;
         try {
             return handle.ethCallVerifiedWithOverrides(
                     from == null ? "" : toHex(from),
-                    toHex(to),
+                    to == null ? "" : toHex(to),
                     data == null ? "" : toHex(data),
                     valueWei == null ? "" : valueWei,
                     block,
@@ -198,7 +200,7 @@ final class RustVerifiedReads implements VerifiedReads {
     @Override
     public byte[] call(byte[] from, byte[] to, byte[] data, String valueWei, String block) {
         if (!isServableBlock(block)) return null;
-        if (to == null || to.length != 20) return null;        // 'to' is required
+        if (to != null && to.length != 20) return null;        // null 'to' = creation
         if (from != null && from.length != 20) return null;    // if present, must be 20 bytes
         try {
             // 'from' empty → anonymous zero sender; the revm executor runs the call
@@ -206,7 +208,7 @@ final class RustVerifiedReads implements VerifiedReads {
             // unverifiable outcome, matching the reference engine).
             return handle.ethCallVerified(
                     from == null ? "" : toHex(from),
-                    toHex(to),
+                    to == null ? "" : toHex(to),
                     data == null ? "" : toHex(data),
                     valueWei == null ? "" : valueWei,
                     block);

--- a/myotis-engines/src/main/java/io/myotis/engines/RustVerifiedReads.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustVerifiedReads.java
@@ -166,6 +166,11 @@ final class RustVerifiedReads implements VerifiedReads {
     }
 
     @Override
+    public boolean supportsContractCreation() {
+        return true;   // revm runs the init code (TxKind::Create)
+    }
+
+    @Override
     public boolean supportsStateOverrides() {
         return true;   // the revm executor applies them (myotis_evm::overrides)
     }

--- a/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
+++ b/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
@@ -1989,8 +1989,17 @@ public final class VerifiedRpcBackend implements io.myotis.api.VerifiedReads,
                 && isHeadIntentTag(block)) {
             hotCalls.record(from, to, value, data, clock.elapsedMillis());
         }
+        // Cheap rejections FIRST: verifiedHeadFor can wake the stack and block
+        // on a head build, and this engine cannot serve a null `to` (contract
+        // creation) at all, so paying that cost to refuse is pure waste. Hosts
+        // are expected to consult VerifiedReads.supportsContractCreation() and
+        // not dispatch at all; this is the belt-and-braces half.
+        if (to == null || to.length != 20) {
+            log.info("[rpc] eth_call " + desc + " -> contract creation is not served by this engine");
+            return null;
+        }
         RpcCallContext h = verifiedHeadFor(block);
-        if (h == null || to == null || to.length != 20) {
+        if (h == null) {
             log.info("[rpc] eth_call " + desc + " -> no verified head for block tag");
             return null;
         }

--- a/rust/include/myotis_engine.h
+++ b/rust/include/myotis_engine.h
@@ -91,7 +91,9 @@ char *myotis_eth_call_json(int64_t handle, const char *from, const char *to,
                            const char *block);
 
 /* eth_call with a STATE OVERRIDE object as JSON (empty => none). The answer is
-   a simulation over verified state — the caller's hypothesis, not a chain fact. */
+   a simulation over verified state — the caller's hypothesis, not a chain fact.
+   An EMPTY `to` selects contract creation: the calldata is init code and the
+   constructor's return data is the result. */
 char *myotis_eth_call_overrides_json(int64_t handle, const char *from,
                                      const char *to, const char *data,
                                      const char *value, const char *block,

--- a/rust/myotis-engine/src/capi.rs
+++ b/rust/myotis-engine/src/capi.rs
@@ -264,7 +264,16 @@ pub unsafe extern "C" fn myotis_eth_call_overrides_json(
     state_overrides: *const c_char,
 ) -> *mut c_char {
     let from = read_string(from).unwrap_or_default();
-    let to = read_string(to).unwrap_or_default();
+    // NOT `unwrap_or_default()`: an EMPTY `to` now means contract creation, so
+    // collapsing an UNDECODABLE one (NULL pointer, bad UTF-8) onto the same
+    // value would silently change which question is answered — the shape
+    // CLAUDE.md's apply-or-refuse rule exists to prevent. Absent and
+    // undecodable must stay distinguishable.
+    let Some(to) = read_string(to) else {
+        return into_c(crate::eljson::error_json(
+            "invalid 'to' (undecodable string; pass an empty string for contract creation)",
+        ));
+    };
     let data = read_string(data).unwrap_or_default();
     let value = read_string(value).unwrap_or_default();
     let block = read_string(block).unwrap_or_default();

--- a/rust/myotis-engine/src/ffi.rs
+++ b/rust/myotis-engine/src/ffi.rs
@@ -154,7 +154,9 @@ pub fn get_storage_at_json(handle: i64, address: String, position: String) -> St
 }
 
 /// Verified `eth_call` over the revm executor. `from` empty ⇒ anonymous call;
-/// `value` is wei as a decimal string; `block` is the RPC block tag.
+/// `to` EMPTY ⇒ contract creation (the calldata is init code, its return data
+/// is the answer); `value` is wei as a decimal string; `block` is the RPC block
+/// tag.
 #[uniffi::export]
 pub fn eth_call_json(
     handle: i64,
@@ -168,7 +170,8 @@ pub fn eth_call_json(
 }
 
 /// [`eth_call_json`] with an `eth_call` STATE OVERRIDE object (the JSON-RPC
-/// third parameter) as a JSON string; empty ⇒ none. The overrides are the
+/// third parameter) as a JSON string; empty ⇒ none. An empty `to` selects
+/// contract creation here too. The overrides are the
 /// caller's hypothesis layered over verified state for this call only, so the
 /// answer is not a chain fact — hosts log it under a distinct label.
 #[uniffi::export]

--- a/rust/myotis-engine/src/host.rs
+++ b/rust/myotis-engine/src/host.rs
@@ -764,8 +764,18 @@ pub fn eth_call_overrides_json(
         Ok(o) => o,
         Err(msg) => return eljson::error_json(&msg),
     };
-    let Some(to) = parse_address(to_hex) else {
-        return eljson::error_json("invalid 'to' address (expected 20-byte hex)");
+    // EMPTY `to` ⇒ contract creation (`eth_call` with no `to`): the calldata is
+    // init code, it runs, and its return data is the answer. Wallets use this
+    // as the second deployless form; serving only the override form would leave
+    // any wallet that picks this one broken.
+    let creation = to_hex.trim().is_empty();
+    let to = if creation {
+        [0u8; 20]
+    } else {
+        match parse_address(to_hex) {
+            Some(a) => a,
+            None => return eljson::error_json("invalid 'to' address (expected 20-byte hex)"),
+        }
     };
     // 'from' is optional: empty → an anonymous zero-address sender.
     let from = if from_hex.trim().is_empty() {
@@ -803,7 +813,11 @@ pub fn eth_call_overrides_json(
     match engine
         .rt
         .block_on(async {
-            reader.eth_call_overridden(from, to, data, value, chain_id, overrides).await
+            if creation {
+                reader.eth_call_create(from, data, value, chain_id, overrides).await
+            } else {
+                reader.eth_call_overridden(from, to, data, value, chain_id, overrides).await
+            }
         })
     {
         Ok(outcome) => eljson::call_json(&outcome),

--- a/rust/myotis-engine/src/host.rs
+++ b/rust/myotis-engine/src/host.rs
@@ -731,7 +731,9 @@ pub fn get_storage_at_json(handle: i64, address_hex: &str, position_hex: &str) -
 }
 
 /// `nativeEthCallJson`: run a verified `eth_call` for a running handle. `from` is
-/// empty for an anonymous call; `to` is required; `data_hex` is the calldata;
+/// empty for an anonymous call; an EMPTY `to` means CONTRACT CREATION (the
+/// calldata is init code and the constructor's return data is the answer);
+/// `data_hex` is the calldata;
 /// `value_dec` is the wei value as a decimal string (FFI-neutral); `block` is the
 /// RPC block tag (the Java side has already gated it to the servable window, so
 /// the call runs against the verified head). Returns the call JSON
@@ -764,19 +766,12 @@ pub fn eth_call_overrides_json(
         Ok(o) => o,
         Err(msg) => return eljson::error_json(&msg),
     };
-    // EMPTY `to` ⇒ contract creation (`eth_call` with no `to`): the calldata is
-    // init code, it runs, and its return data is the answer. Wallets use this
-    // as the second deployless form; serving only the override form would leave
-    // any wallet that picks this one broken.
-    let creation = to_hex.trim().is_empty();
-    let to = if creation {
-        [0u8; 20]
-    } else {
-        match parse_address(to_hex) {
-            Some(a) => a,
-            None => return eljson::error_json("invalid 'to' address (expected 20-byte hex)"),
-        }
+    let target = match call_target(to_hex) {
+        Ok(t) => t,
+        Err(msg) => return eljson::error_json(msg),
     };
+    let creation = target.is_none();
+    let to = target.unwrap_or([0u8; 20]);
     // 'from' is optional: empty → an anonymous zero-address sender.
     let from = if from_hex.trim().is_empty() {
         None
@@ -822,6 +817,25 @@ pub fn eth_call_overrides_json(
     {
         Ok(outcome) => eljson::call_json(&outcome),
         Err(e) => eljson::error_json(&e),
+    }
+}
+
+/// Which call the `to` argument selects. This is where the FFI convention lives
+/// now that the signature is unchanged, so it is a pure function with tests:
+///
+/// - EMPTY ⇒ `Ok(None)` = CONTRACT CREATION (the calldata is init code and the
+///   constructor's return data is the answer, as geth answers a `to`-less call).
+/// - a 20-byte hex address ⇒ `Ok(Some(addr))` = an ordinary call.
+/// - anything else ⇒ `Err` — NOT creation. Running init code the caller never
+///   asked to run would be worse than refusing, and a malformed argument must
+///   never silently change which question is answered.
+fn call_target(to_hex: &str) -> Result<Option<[u8; 20]>, &'static str> {
+    if to_hex.trim().is_empty() {
+        return Ok(None);
+    }
+    match parse_address(to_hex) {
+        Some(a) => Ok(Some(a)),
+        None => Err("invalid 'to' address (expected 20-byte hex)"),
     }
 }
 
@@ -2549,6 +2563,34 @@ mod log_index_json_tests {
         let s2 = build_log_index_status(&ix, None, 0);
         assert!(s2.contains("\"blocksRemaining\":500"), "{s2}");
         assert!(!s2.contains("etaSeconds"), "{s2}");
+    }
+}
+
+#[cfg(test)]
+mod call_target_tests {
+    use super::call_target;
+
+    #[test]
+    fn empty_to_selects_contract_creation() {
+        // The load-bearing half of the design: the Java/iOS adapters map a null
+        // `to` to "" across the FFI, and THIS is what turns that into a create.
+        assert_eq!(call_target(""), Ok(None));
+        assert_eq!(call_target("   "), Ok(None));
+    }
+
+    #[test]
+    fn an_address_selects_an_ordinary_call() {
+        let a = call_target("0x00000000219ab540356cBB839Cbe05303d7705Fa").unwrap();
+        assert_eq!(a.map(|x| x[0]), Some(0x00));
+        assert_eq!(a.map(|x| x[19]), Some(0xFa));
+    }
+
+    #[test]
+    fn a_malformed_to_is_an_error_not_a_creation() {
+        // Serving this as a creation would run init code nobody asked to run.
+        assert!(call_target("0xZZ").is_err());
+        assert!(call_target("0x1234").is_err());          // too short
+        assert!(call_target("not-hex-at-all").is_err());
     }
 }
 

--- a/rust/myotis-evm/src/executor.rs
+++ b/rust/myotis-evm/src/executor.rs
@@ -140,8 +140,34 @@ impl EvmExecutor {
     ) -> Result<Vec<u8>, EvmError> {
         self.call_capped_with(
             Address::from(sender),
-            target,
+            Some(target),
             calldata,
+            value,
+            ctx,
+            PREFETCH_ITERATION_CAP,
+            overrides,
+        )
+    }
+
+    /// `eth_call` with NO `to` — contract creation. The init code runs and its
+    /// return data is the answer, exactly as geth answers a `to`-less call.
+    ///
+    /// This is the second way wallets run a helper contract they never deploy
+    /// (Ambire's deployless `Deploy` mode; the first is a state override). A
+    /// node that serves only one of the two forces the wallet's build-time
+    /// choice to match, which is not a choice we should be making for it.
+    pub fn create_view(
+        &self,
+        sender: [u8; 20],
+        init_code: &[u8],
+        value: U256,
+        ctx: &BlockContext,
+        overrides: StateOverrides,
+    ) -> Result<Vec<u8>, EvmError> {
+        self.call_capped_with(
+            Address::from(sender),
+            None,
+            init_code,
             value,
             ctx,
             PREFETCH_ITERATION_CAP,
@@ -169,7 +195,7 @@ impl EvmExecutor {
     fn execute(
         &self,
         caller: Address,
-        target: [u8; 20],
+        target: Option<[u8; 20]>,
         calldata: &[u8],
         value: U256,
         ctx: &BlockContext,
@@ -207,7 +233,7 @@ impl EvmExecutor {
         db: &OracleDatabase,
         spec: revm::primitives::hardfork::SpecId,
         caller: Address,
-        target: [u8; 20],
+        target: Option<[u8; 20]>,
         calldata: &[u8],
         value: U256,
         ctx: &BlockContext,
@@ -226,7 +252,15 @@ impl EvmExecutor {
 
         let tx = TxEnv::builder()
             .caller(caller)
-            .kind(TxKind::Call(Address::from(target)))
+            // `None` ⇒ CONTRACT CREATION: `eth_call` with no `to`, where the
+            // "constructor" runs and its RETURN DATA is the answer. Wallets use
+            // this to run a helper contract they never deploy (Ambire's
+            // deployless Deploy mode), which is the same job as a state
+            // override by another route.
+            .kind(match target {
+                Some(to) => TxKind::Call(Address::from(to)),
+                None => TxKind::Create,
+            })
             .value(value)
             .data(calldata.to_vec().into())
             .gas_limit(VIEW_CALL_GAS)
@@ -275,14 +309,14 @@ impl EvmExecutor {
         ctx: &BlockContext,
         cap: usize,
     ) -> Result<Vec<u8>, EvmError> {
-        self.call_capped_with(caller, target, calldata, value, ctx, cap, StateOverrides::new())
+        self.call_capped_with(caller, Some(target), calldata, value, ctx, cap, StateOverrides::new())
     }
 
     #[allow(clippy::too_many_arguments)]
     fn call_capped_with(
         &self,
         caller: Address,
-        target: [u8; 20],
+        target: Option<[u8; 20]>,
         calldata: &[u8],
         value: U256,
         ctx: &BlockContext,
@@ -295,8 +329,11 @@ impl EvmExecutor {
         // Prime the target's account + code synchronously (sentinel OFF, not
         // access-tracked — Java parity) so iteration 0 executes real top-level
         // code instead of a sentinel empty account.
-        if let Some(acc) = db.basic_ref(Address::from(target))? {
-            db.code_by_hash_ref(acc.code_hash)?;
+        // A create has no target account to prime; its code is the calldata.
+        if let Some(to) = target {
+            if let Some(acc) = db.basic_ref(Address::from(to))? {
+                db.code_by_hash_ref(acc.code_hash)?;
+            }
         }
         let _ = db.take_access_set(); // the prime is not part of any snapshot
 
@@ -410,7 +447,7 @@ impl EvmExecutor {
                 return Ok(PLAIN_TRANSFER_GAS);
             }
         }
-        match self.execute(caller, target, calldata, value, ctx)? {
+        match self.execute(caller, Some(target), calldata, value, ctx)? {
             ExecutionResult::Success { gas, .. } => {
                 // The gas-limit base must cover BOTH the gross execution draw
                 // (`total_gas_spent`, before the EIP-3529 refund — so the run never
@@ -551,6 +588,55 @@ mod tests {
         // call sees verified state again. This is the trust-critical property —
         // a hypothesis must not become a "fact" for later calls.
         assert_eq!(U256::from_be_slice(&ex.call_view(TARGET, &[], &c).unwrap()), U256::from(7));
+    }
+
+    /// THE OTHER deployless form (#314 follow-up): `eth_call` with NO `to`,
+    /// where init code runs and its RETURN DATA is the answer. Ambire picks this
+    /// mode whenever a network is flagged `rpcNoStateOverride`, so a node that
+    /// serves only the override form leaves those wallets broken.
+    #[test]
+    fn contract_creation_call_returns_the_constructor_output() {
+        use crate::overrides::StateOverrides;
+        // Init code that returns 42 as its "deployed code" — exactly the shape a
+        // deployless helper uses to hand back an ABI result.
+        // PUSH1 0x2a; PUSH1 0; MSTORE; PUSH1 32; PUSH1 0; RETURN
+        let init = vec![0x60, 0x2a, 0x60, 0x00, 0x52, 0x60, 0x20, 0x60, 0x00, 0xf3];
+        let ex = EvmExecutor::new(
+            Arc::new(FixtureSnapStateOracle::new()),
+            Arc::new(NoopStateProofCache),
+            Arc::new(NoopBytecodeCache),
+        );
+        let out = ex
+            .create_view([0u8; 20], &init, U256::ZERO, &ctx(LONDON_BLOCK, CANCUN_TIME), StateOverrides::new())
+            .expect("creation call runs");
+        assert_eq!(U256::from_be_slice(&out), U256::from(42));
+    }
+
+    #[test]
+    fn contract_creation_call_sees_overrides_too() {
+        // The two deployless modes are interchangeable to the caller, so the
+        // create form must honour overrides as well — e.g. init code that reads
+        // another account's storage.
+        use crate::overrides::{AccountOverride, StateOverrides};
+        const OTHER: [u8; 20] = [0x77; 20];
+        // PUSH20 OTHER; EXTCODESIZE; PUSH1 0; MSTORE; PUSH1 32; PUSH1 0; RETURN
+        let mut init = vec![0x73];
+        init.extend_from_slice(&OTHER);
+        init.extend_from_slice(&[0x3b, 0x60, 0x00, 0x52, 0x60, 0x20, 0x60, 0x00, 0xf3]);
+        let ex = EvmExecutor::new(
+            Arc::new(FixtureSnapStateOracle::new()),
+            Arc::new(NoopStateProofCache),
+            Arc::new(NoopBytecodeCache),
+        );
+        let c = ctx(LONDON_BLOCK, CANCUN_TIME);
+        // No override: the account has no code, so size 0.
+        let bare = ex.create_view([0u8; 20], &init, U256::ZERO, &c, StateOverrides::new()).unwrap();
+        assert_eq!(U256::from_be_slice(&bare), U256::ZERO);
+        // With one: the injected code's length.
+        let mut ov = StateOverrides::new();
+        ov.insert(OTHER, AccountOverride { code: Some(vec![0x00; 5]), ..Default::default() });
+        let with = ex.create_view([0u8; 20], &init, U256::ZERO, &c, ov).unwrap();
+        assert_eq!(U256::from_be_slice(&with), U256::from(5));
     }
 
     /// Build an executor whose fixture hosts `code` (and optional slot-0 value) at
@@ -825,7 +911,7 @@ mod tests {
             let spec = spec_for(c.chain_id, c.block_number, c.timestamp).unwrap();
             let db = exec.database_for(&c);
             match exec
-                .execute_with_db(&db, spec, Address::from([0u8; 20]), TARGET, &[], U256::ZERO, &c)
+                .execute_with_db(&db, spec, Address::from([0u8; 20]), Some(TARGET), &[], U256::ZERO, &c)
                 .unwrap()
             {
                 ExecutionResult::Success { output, .. } => output_bytes(output),

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -2686,6 +2686,30 @@ impl ElReader {
     /// call only (see `myotis_evm::overrides`). The answer is what the call
     /// WOULD return under the caller's hypothesis — verified state underneath,
     /// but not itself a chain fact, so hosts label it distinctly.
+    /// `eth_call` with NO `to` — contract creation. The init code runs and its
+    /// return data is the answer (the deployless `Deploy` form wallets use).
+    pub async fn eth_call_create(
+        &self,
+        from: Option<[u8; 20]>,
+        init_code: Vec<u8>,
+        value: U256,
+        chain_id: u64,
+        overrides: myotis_evm::overrides::StateOverrides,
+    ) -> Result<CallOutcome, String> {
+        let (ctx, executor) = self.evm_setup(chain_id, "eth_call (create)").await?;
+        let joined = tokio::task::spawn_blocking(move || {
+            let sender = from.unwrap_or([0u8; 20]);
+            executor.create_view(sender, &init_code, value, &ctx, overrides)
+        })
+        .await
+        .map_err(|e| format!("eth_call task join error: {e}"))?;
+        Ok(match joined {
+            Ok(bytes) => CallOutcome::Success(bytes),
+            Err(EvmError::Reverted { data }) => CallOutcome::Revert(data),
+            Err(other) => CallOutcome::Unavailable(other.to_string()),
+        })
+    }
+
     pub async fn eth_call_overridden(
         &self,
         from: Option<[u8; 20]>,

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -2682,10 +2682,6 @@ impl ElReader {
         self.eth_call_overridden(from, to, data, value, chain_id, Default::default()).await
     }
 
-    /// [`Self::eth_call`] with caller-supplied state overrides applied for this
-    /// call only (see `myotis_evm::overrides`). The answer is what the call
-    /// WOULD return under the caller's hypothesis — verified state underneath,
-    /// but not itself a chain fact, so hosts label it distinctly.
     /// `eth_call` with NO `to` — contract creation. The init code runs and its
     /// return data is the answer (the deployless `Deploy` form wallets use).
     pub async fn eth_call_create(
@@ -2710,6 +2706,10 @@ impl ElReader {
         })
     }
 
+    /// [`Self::eth_call`] with caller-supplied state overrides applied for this
+    /// call only (see `myotis_evm::overrides`). The answer is what the call
+    /// WOULD return under the caller's hypothesis — verified state underneath,
+    /// but not itself a chain fact, so hosts label it distinctly.
     pub async fn eth_call_overridden(
         &self,
         from: Option<[u8; 20]>,


### PR DESCRIPTION
## Why

`eth_call` with no `to` runs the calldata as **init code** and returns what the constructor returns. It is the second way a wallet runs a helper contract it never deploys — Ambire calls it the deployless `Deploy` mode, and it picks it whenever a network is flagged `rpcNoStateOverride`.

Kohaku's build sets that flag unconditionally:

```
src/ambire-common/src/utils/networks.ts:187
  const rpcNoStateOverride = true // @TODO Revert when overrides are supported in Helios
```

So having shipped state overrides in #315/#318, this node still could not answer a single one of that wallet's account-state reads: **143 instant refusals in a 40-minute window** on sepolia, reproduced with one curl:

```
$ curl -s localhost:8547 -d '{"method":"eth_call","params":[{"data":"0x6080604052"},"latest"],...}'
{"error":{"code":-32000,"message":"method 'eth_call' cannot be served verified right now (no peer / not synced)"}}
```

Serving only one of the two deployless forms lets a wallet's build-time constant decide whether this node works — not a choice we should be making for it.

## What

revm handles creation natively, so the change is narrow: the executor's target becomes `Option<[u8;20]>` and `None` selects `TxKind::Create`. `output.into_data()` already covers both call and create output. The account-prime step is skipped for a create (there is no target account — its code *is* the calldata). Overrides apply to the create form too, since the two modes are interchangeable from the caller's side.

Through the stack `to` becomes nullable, mirroring `estimateGas` which was already `ByteArray?`. Across the FFI an empty `to` string means creation, so **the engine signature is unchanged**. A present-but-malformed `to` is still refused — serving that as a creation would run init code the caller never asked to run.

## A seam worth knowing about

`FakeBackend` and `IosRpcBackend` implement a **Java** interface, so `to` arrives as a platform type: a non-null Kotlin declaration compiles cleanly and then throws at runtime. The router tests caught it as an NPE rather than a type error. Anything else implementing `VerifiedReads` from Kotlin has the same trap.

## Tests

- Creation returns the constructor's output (init code returning 42).
- Creation honours state overrides — proving the two deployless forms are equivalent here, so a wallet's choice of mode no longer changes what it can read.
- A `to`-less request and an explicit `"to": null` are both served; a malformed `to` is still refused.
- `ethCall_missingTo_fallsThrough` asserted the OLD refusal; it now pins the new behaviour. That is a deliberate contract change and the test was the thing that flagged it.

Suites: myotis-evm 98, myotis-net 205, jsonrpc-server green.

## Follow-up not in scope

`eth_estimateGas` still refuses a `to`-less request (its backend signature has no override or block argument either — see #316).

Refs #314, #316.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPnTFwmAVMypWYtoioAXQT
