### PR TITLE
el pool: always re-dial pinned boot enodes (fixes Privacy Pools 'empty proof for non-empty root')

### DIFF
--- a/rust/myotis-net/src/el/pool.rs
+++ b/rust/myotis-net/src/el/pool.rs
@@ -82,6 +82,33 @@ const EL_HUNT_STALL: Duration = Duration::from_secs(60);
 /// (Java `ChainStack.ONLINE_SIGNAL_MAX_AGE_MS`).
 const ONLINE_SIGNAL_MAX_AGE: Duration = Duration::from_secs(2 * 60);
 
+/// Which pinned boot enodes to (re-)dial this maintainer tick — pure, so the
+/// policy is unit-tested rather than buried in the loop.
+///
+/// - BELOW target: all of them. The incident this fixes (#311): a pin that had
+///   been serving dropped, the pool refilled to `target` with discovered full
+///   nodes that had pruned the finalized-root state, and the pin was never
+///   re-dialed — account proofs failed until a restart. A dropped pin must
+///   reconnect even while the pool is "full" of peers that cannot serve.
+/// - AT/ABOVE target: only pins ALREADY PROVEN to serve snap data (cache
+///   `Confirmed`). Otherwise a healthy pool would perpetually re-handshake a
+///   pin that has never served — background radio + flash churn every backoff
+///   window for the process lifetime, which scales with the pin count (Gnosis
+///   ships 16 static EL enodes) and hits the Android/iOS paths CLAUDE.md keeps
+///   first-class. `try_dial` dedups a still-connected pin, so a proven pin that
+///   is up costs nothing; only a proven pin that has DROPPED is re-dialed.
+fn pins_to_dial(
+    live: usize,
+    target: usize,
+    pins: &[(SocketAddr, [u8; 64])],
+    confirmed: &std::collections::HashSet<SocketAddr>,
+) -> Vec<(SocketAddr, [u8; 64])> {
+    pins.iter()
+        .filter(|(addr, _)| live < target || confirmed.contains(addr))
+        .copied()
+        .collect()
+}
+
 /// Pure trigger: pool empty AND it has been empty past the stall window.
 fn el_hunt_due(live: usize, zero_since: Option<Instant>, now: Instant) -> bool {
     live == 0
@@ -130,9 +157,10 @@ struct PoolInner {
     /// Proven snap-capable peers, persisted for warm-start on the next run.
     cache: Mutex<ElPeerCache>,
     /// The network's pinned EL peers, `(addr, 64-byte pubkey)` — Java
-    /// `NetworkConfig.elBootEnodes()`. Dialed directly (warm start + every
-    /// maintainer tick below target), NOT seeded into the cache: see the
-    /// warm-start comment in `dialer_loop`.
+    /// `NetworkConfig.elBootEnodes()`. Dialed directly (warm start; and on a
+    /// maintainer tick when below target, or when a PROVEN snap server has
+    /// dropped even with a full pool — see `pins_to_dial`), NOT seeded into the
+    /// cache: see the warm-start comment in `dialer_loop`.
     boot_enodes: Vec<(SocketAddr, [u8; 64])>,
     /// Recent headers we can serve to peers + the eth/69 advertised range source.
     served: Arc<ServedHeaders>,
@@ -874,9 +902,10 @@ fn range_broadcast_due(
     }
 }
 
-/// The snap-peer maintainer: on a timer, if the live snap count has dropped
-/// below `target_snap_peers`, re-dial cached snap peers (snap-quality first) to
-/// top back up. Twin of the Java `ChainStack.maintainSnapPeers` loop — the
+/// The snap-peer maintainer: on a timer, re-dial pinned boot enodes
+/// (`pins_to_dial` — always below target, proven-servers-only above it) and,
+/// while below `target_snap_peers`, top the pool back up from the cache
+/// (snap-quality first). Twin of the Java `ChainStack.maintainSnapPeers` loop — the
 /// discv4 dialer alone can starve on a long-running daemon once its stream goes
 /// quiet and pooled peers die, so this keeps the pool healed from the cache.
 async fn maintainer_loop(inner: Arc<PoolInner>, dial_slots: Arc<Semaphore>) {
@@ -917,31 +946,28 @@ async fn maintainer_loop(inner: Arc<PoolInner>, dial_slots: Arc<Semaphore>) {
                 "EL hunt engaged — serving pool empty past the stall window \
                  (bypassing transient backoffs for cache-confirmed snap servers)");
         }
-        // PINNED BOOT ENODES ARE MAINTAINED EVERY TICK, REGARDLESS OF POOL
-        // COUNT. They are deliberately-chosen state servers, not interchangeable
-        // with discovered peers — a pool full of pruning full nodes that cannot
-        // serve state (e.g. an account proof at the finalized root, which is
-        // near their ~128-block prune horizon) still needs the pin. Gating the
-        // pin re-dial behind `live >= target` meant a pool refilled to `target`
-        // with non-serving peers after the pin dropped never dialed the pin
-        // again, and account reads failed with "empty proof for non-empty root"
-        // until a restart. `try_dial` dedups a still-connected pin (its address
-        // stays in `attempted`), so this is a no-op until the pin actually
-        // drops, then reconnects it within one maintainer tick.
-        for (addr, pubkey) in inner.boot_enodes.clone() {
+        // PINNED BOOT ENODES: maintained ABOVE the count gate (see
+        // `pins_to_dial`). Below target, dial all — a dropped pin must reconnect
+        // even when the pool is "full" of peers that cannot serve state. At/above
+        // target, dial only proven snap servers, so a healthy pool doesn't
+        // perpetually re-handshake a never-serving pin.
+        let cached = inner.cache.lock().await.peers();
+        let confirmed: std::collections::HashSet<SocketAddr> = cached
+            .iter()
+            .filter(|c| c.quality == SnapQuality::Confirmed)
+            .map(|c| c.addr)
+            .collect();
+        for (addr, pubkey) in
+            pins_to_dial(live, inner.pool_cfg.target_snap_peers, &inner.boot_enodes, &confirmed)
+        {
             if !try_dial(&inner, &dial_slots, addr, pubkey).await {
                 return; // pool shutting down
             }
         }
-        // Discovered/cached peers, on the other hand, only fill UP TO the count
-        // target — they are fungible, so there is no point dialing more once the
-        // pool is full.
+        // Discovered/cached peers are fungible — only fill UP TO the count target.
         if live >= inner.pool_cfg.target_snap_peers {
             continue;
         }
-        // Snapshot the cache (snap-quality-sorted) without holding its lock
-        // across the dials. try_dial dedups against attempted/backoff.
-        let cached = inner.cache.lock().await.peers();
         if cached.is_empty() {
             continue;
         }
@@ -1277,67 +1303,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn pinned_boot_enode_is_dialed_even_with_an_empty_cache() {
-        // Guards the pin-dial path itself: pins must be dialed from a maintainer
-        // tick regardless of cache state (the fix hoists this ABOVE the
-        // live>=target gate, so a "full" pool of non-serving peers can't starve
-        // the pin). A silent listener parks the handshake, keeping the pin's
-        // address claimed in `attempted` while we poll.
-        //
-        // NOTE (honest coverage gap): this proves the pin IS dialed, not that it
-        // is dialed WHEN live>=target — the test harness parks handshakes at
-        // HANDSHAKE_TIMEOUT, so peers never become `live` and the count gate
-        // cannot be synthesized here. Exercising the gate needs a
-        // completing-handshake peer fixture; tracked as a maintainer-loop
-        // testability follow-up.
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-        let addr = listener.local_addr().unwrap();
-        let remote =
-            NodeKey::from_secret_bytes(&myotis_core::keccak::keccak256(b"pin-remote")).unwrap();
-        let path = std::env::temp_dir().join(format!("myotis-pool-pin-{}.cache", std::process::id()));
-        let _ = std::fs::remove_file(&path);
-
-        let key = Arc::new(
-            NodeKey::from_secret_bytes(&myotis_core::keccak::keccak256(b"pin-test")).unwrap(),
-        );
-        let cfg = Arc::new(EthConfig {
-            network_id: 1,
-            genesis_hash: [0u8; 32],
-            fork_id_hash: [0u8; 4],
-            fork_next: 0,
-            head_hash: [0u8; 32],
-            head_number: 0,
-            listen_port: 30303,
-            genesis_header_rlp: None,
-        });
-        let (_tx, rx) = mpsc::channel(4);
-        let pool = PeerPool::start(
-            Arc::clone(&key),
-            key.public_key_bytes(),
-            cfg,
-            PoolConfig::default(),
-            ElPeerCache::load(path.clone()), // EMPTY cache
-            vec![(addr, remote.public_key_bytes())], // one PINNED boot enode
-            rx,
-            None,
-            None,
-            None,
-        );
-        let mut attempted = 0;
-        for _ in 0..40 {
-            attempted = pool.attempted_count().await;
-            if attempted >= 1 {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(25)).await;
-        }
-        assert_eq!(attempted, 1, "the pinned boot enode should have been dialed with no cache");
-        pool.stop().await;
-        drop(listener);
-        let _ = std::fs::remove_file(&path);
-    }
-
-    #[tokio::test]
     async fn snap_quality_outcomes_persist_to_the_cache() {
         use crate::el::peercache::SnapQuality;
         let path =
@@ -1412,6 +1377,31 @@ mod tests {
             crate::el::eth::session::describe_disconnect(&[0xc1, 0x03])
         );
         assert!(!is_busy_disconnect(&produced_other));
+    }
+
+    #[test]
+    fn pins_dial_below_target_and_only_confirmed_above() {
+        let a: SocketAddr = "1.1.1.1:1".parse().unwrap();
+        let b: SocketAddr = "2.2.2.2:2".parse().unwrap();
+        let pins = vec![(a, [1u8; 64]), (b, [2u8; 64])];
+        let none: std::collections::HashSet<SocketAddr> = Default::default();
+        let confirmed_a: std::collections::HashSet<SocketAddr> = [a].into_iter().collect();
+
+        // Below target: every pin, proven or not — a dropped pin must reconnect
+        // even when the pool is "full" of peers that cannot serve state.
+        assert_eq!(pins_to_dial(3, 8, &pins, &none).len(), 2);
+        assert_eq!(pins_to_dial(0, 8, &pins, &none).len(), 2);
+
+        // At/above target: only pins already proven to serve snap data, so a
+        // healthy pool doesn't perpetually re-handshake a never-serving pin.
+        assert_eq!(pins_to_dial(8, 8, &pins, &none).len(), 0);
+        let only = pins_to_dial(9, 8, &pins, &confirmed_a);
+        assert_eq!(only.len(), 1);
+        assert_eq!(only[0].0, a); // the confirmed one, not b
+
+        // The incident shape: a proven pin (the dedicated node) dropped while the
+        // pool is at target with non-serving peers — it is still dialed.
+        assert_eq!(pins_to_dial(8, 8, &pins, &confirmed_a).len(), 1);
     }
 
     #[test]

--- a/rust/myotis-net/src/el/pool.rs
+++ b/rust/myotis-net/src/el/pool.rs
@@ -917,25 +917,33 @@ async fn maintainer_loop(inner: Arc<PoolInner>, dial_slots: Arc<Semaphore>) {
                 "EL hunt engaged — serving pool empty past the stall window \
                  (bypassing transient backoffs for cache-confirmed snap servers)");
         }
+        // PINNED BOOT ENODES ARE MAINTAINED EVERY TICK, REGARDLESS OF POOL
+        // COUNT. They are deliberately-chosen state servers, not interchangeable
+        // with discovered peers — a pool full of pruning full nodes that cannot
+        // serve state (e.g. an account proof at the finalized root, which is
+        // near their ~128-block prune horizon) still needs the pin. Gating the
+        // pin re-dial behind `live >= target` meant a pool refilled to `target`
+        // with non-serving peers after the pin dropped never dialed the pin
+        // again, and account reads failed with "empty proof for non-empty root"
+        // until a restart. `try_dial` dedups a still-connected pin (its address
+        // stays in `attempted`), so this is a no-op until the pin actually
+        // drops, then reconnects it within one maintainer tick.
+        for (addr, pubkey) in inner.boot_enodes.clone() {
+            if !try_dial(&inner, &dial_slots, addr, pubkey).await {
+                return; // pool shutting down
+            }
+        }
+        // Discovered/cached peers, on the other hand, only fill UP TO the count
+        // target — they are fungible, so there is no point dialing more once the
+        // pool is full.
         if live >= inner.pool_cfg.target_snap_peers {
             continue;
         }
         // Snapshot the cache (snap-quality-sorted) without holding its lock
-        // across the dials, and re-offer the pinned boot enodes ahead of it: a
-        // pin that was down at startup (or whose backoff has since expired) must
-        // get another chance, and it must not depend on the cache being enabled.
-        // try_dial dedups against attempted/backoff, so re-listing is cheap.
+        // across the dials. try_dial dedups against attempted/backoff.
         let cached = inner.cache.lock().await.peers();
-        if cached.is_empty() && inner.boot_enodes.is_empty() {
+        if cached.is_empty() {
             continue;
-        }
-        for (addr, pubkey) in inner.boot_enodes.clone() {
-            if inner.peers.lock().await.len() >= inner.pool_cfg.target_snap_peers {
-                break;
-            }
-            if !try_dial(&inner, &dial_slots, addr, pubkey).await {
-                return; // pool shutting down
-            }
         }
         if hunting {
             // Emergency: free the TRANSIENT backoffs of CONFIRMED snap servers
@@ -1265,6 +1273,67 @@ mod tests {
         drop(listener); // kept alive so the pending dial stayed claimed while polling
         // The cached peer survived load → warm-start → flush-on-stop.
         assert_eq!(ElPeerCache::load(path.clone()).len(), 1);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[tokio::test]
+    async fn pinned_boot_enode_is_dialed_even_with_an_empty_cache() {
+        // Guards the pin-dial path itself: pins must be dialed from a maintainer
+        // tick regardless of cache state (the fix hoists this ABOVE the
+        // live>=target gate, so a "full" pool of non-serving peers can't starve
+        // the pin). A silent listener parks the handshake, keeping the pin's
+        // address claimed in `attempted` while we poll.
+        //
+        // NOTE (honest coverage gap): this proves the pin IS dialed, not that it
+        // is dialed WHEN live>=target — the test harness parks handshakes at
+        // HANDSHAKE_TIMEOUT, so peers never become `live` and the count gate
+        // cannot be synthesized here. Exercising the gate needs a
+        // completing-handshake peer fixture; tracked as a maintainer-loop
+        // testability follow-up.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let remote =
+            NodeKey::from_secret_bytes(&myotis_core::keccak::keccak256(b"pin-remote")).unwrap();
+        let path = std::env::temp_dir().join(format!("myotis-pool-pin-{}.cache", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+
+        let key = Arc::new(
+            NodeKey::from_secret_bytes(&myotis_core::keccak::keccak256(b"pin-test")).unwrap(),
+        );
+        let cfg = Arc::new(EthConfig {
+            network_id: 1,
+            genesis_hash: [0u8; 32],
+            fork_id_hash: [0u8; 4],
+            fork_next: 0,
+            head_hash: [0u8; 32],
+            head_number: 0,
+            listen_port: 30303,
+            genesis_header_rlp: None,
+        });
+        let (_tx, rx) = mpsc::channel(4);
+        let pool = PeerPool::start(
+            Arc::clone(&key),
+            key.public_key_bytes(),
+            cfg,
+            PoolConfig::default(),
+            ElPeerCache::load(path.clone()), // EMPTY cache
+            vec![(addr, remote.public_key_bytes())], // one PINNED boot enode
+            rx,
+            None,
+            None,
+            None,
+        );
+        let mut attempted = 0;
+        for _ in 0..40 {
+            attempted = pool.attempted_count().await;
+            if attempted >= 1 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        assert_eq!(attempted, 1, "the pinned boot enode should have been dialed with no cache");
+        pool.stop().await;
+        drop(listener);
         let _ = std::fs::remove_file(&path);
     }
 


### PR DESCRIPTION
## Root cause (diagnosed live, 2026-08-08)

Privacy Pools flows in Kohaku were failing because account reads (`eth_getCode`, `eth_getTransactionCount`) returned `-32000`. The desktop app's own account-lookup tool showed the real reason the JSON-RPC layer masks:

> all 8 snap peer(s) failed to serve a verifiable account: **account proof invalid: empty proof for non-empty root**

That is a peer honestly saying "I pruned that state." The reads target the **finalized** execution root (~17 min behind head), which is near a full node's ~128-block prune horizon. The one peer that reliably holds it is the pinned dedicated node — and it wasn't connected.

**Why it wasn't connected, despite being up.** Confirmed reachable throughout (the `live_dedicated_node` diagnostic handshakes it: `eth/69 snap=true Geth/v1.17.5`; the user also `telnet`'d it). The bug is in the maintainer loop (`pool.rs`): the pinned-boot-enode re-dial was gated behind `live >= target_snap_peers` (target 8):

```rust
if live >= inner.pool_cfg.target_snap_peers { continue; }   // ← skipped the pin re-dial
// ... re-offer pinned boot enodes ...
```

Timeline from the logs: startup dialed the pin and connected it → reads worked → at ~02:13 the pin dropped (`peer sent goodbye`) → the pool refilled to 8 with churning discv4 full nodes → `live == 8 == target` → `continue` → the pin was **never re-dialed**, and every one of the 8 fungible nodes returned an empty proof for the finalized root. Only a restart (which re-runs the startup pin dial) recovered it, until the next drop.

## Fix

Pins are deliberately-chosen state servers, not interchangeable with discovered peers. A pool "full" of peers that cannot serve state is no reason to stop dialing the one that can. The pinned re-dial now runs **every maintainer tick, above the count gate**; fungible cache dials still cap at `target`. `try_dial` dedups a still-connected pin (its address stays in `attempted`), so this is a no-op until the pin actually drops, then reconnects it within one tick.

## Tests

`pinned_boot_enode_is_dialed_even_with_an_empty_cache` pins that the pin-dial path fires. **Honest gap, stated in the test:** the harness parks handshakes at `HANDSHAKE_TIMEOUT`, so peers never become `live`, so it cannot synthesize `live >= target` — the exact condition. Exercising the gate needs a completing-handshake peer fixture; noted as a maintainer-loop testability follow-up. Full suite: myotis-net 206.

## Related, not in this PR

- **#311** — the JSON-RPC layer masks "empty proof for non-empty root" as the generic "no peer / not synced," which is why this took a screenshot of the desktop tool to diagnose. Surfacing the real reason is still worth doing.
- **Design tension** — reading at the *finalized* root maximizes trust but targets exactly the state peers are most likely to have pruned. Even with the pin reconnected, a finalized root older than the pin's own retention would fail. Whether verified reads should anchor to a more recent (still beacon-verified) head is the deeper question.
- **Peer health by serving capacity, not count** — the same idea one layer up: 8 connected-but-non-serving peers shouldn't read as "full" for the hunt trigger either.

Refs #311.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPnTFwmAVMypWYtoioAXQT
