### PR TITLE
chore: bump versions to 0.1.5 for the next pre-release

### DIFF
--- a/android-app/build.gradle.kts
+++ b/android-app/build.gradle.kts
@@ -97,7 +97,7 @@ android {
         // Stays a manual literal: a monotonic install counter with no relation
         // to semver, so there is nothing to derive it from. Bump it on every
         // release or the new APK won't install over the previous one.
-        versionCode = 5
+        versionCode = 6
         versionName = releaseVersion
         buildConfigField("String", "RPC_UPSTREAM", "\"$rpcUpstream\"")
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ plugins {
 
 allprojects {
     group = "com.jaeckel.ethp2p"
-    version = "0.1.4-SNAPSHOT"
+    version = "0.1.5-SNAPSHOT"
 }
 
 subprojects {

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/messages/HelloMessage.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/messages/HelloMessage.java
@@ -39,7 +39,7 @@ public final class HelloMessage {
             // Keep in sync with the Rust engine's Hello client id
             // (rust/myotis-net/src/el/rlpx/transport.rs) — dedicated
             // myotis-serving nodes admit peers by matching "myotis" here.
-            writer.writeString("myotis/0.1.4");
+            writer.writeString("myotis/0.1.5");
             writer.writeList(capWriter -> {
                 // Capabilities must be ascending (name, then version). eth/66 is the
                 // floor: it has request-IDs (which our GetBlockHeaders/snap requests

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4084,7 +4084,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-bls"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "blst",
  "jni",
@@ -4092,7 +4092,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-consensus"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "myotis-bls",
  "sha2",
@@ -4100,7 +4100,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-core"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "k256",
  "sha3 0.10.9",
@@ -4108,7 +4108,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-engine"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "myotis-consensus",
  "myotis-core",
@@ -4124,7 +4124,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-evm"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "myotis-core",
  "revm",
@@ -4132,7 +4132,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-net"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "aes",
  "arti-client",
@@ -4160,7 +4160,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-node"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "myotis-engine",
  "napi",

--- a/rust/myotis-bls/Cargo.lock
+++ b/rust/myotis-bls/Cargo.lock
@@ -134,7 +134,7 @@ checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "myotis-bls"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "blst",
  "jni",

--- a/rust/myotis-bls/Cargo.toml
+++ b/rust/myotis-bls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "myotis-bls"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 description = "Native BLS12-381 fast-aggregate-verify (blst) behind a JNI shim for Myotis"
 license = "MIT OR Apache-2.0"

--- a/rust/myotis-consensus/Cargo.toml
+++ b/rust/myotis-consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "myotis-consensus"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 description = "Myotis sync-committee light client (pure Rust; grows through the Rust-engine PRs)"
 license = "MIT OR Apache-2.0"

--- a/rust/myotis-core/Cargo.toml
+++ b/rust/myotis-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "myotis-core"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 description = "Myotis execution-layer primitives: keccak-256, RLP, secp256k1 identity, BlockHeader, ENR (sans-I/O; grows through the EL-phase PRs)"
 license = "MIT OR Apache-2.0"

--- a/rust/myotis-engine/Cargo.toml
+++ b/rust/myotis-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "myotis-engine"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 description = "Rust implementation of the io.myotis.api engine contract (JNI cdylib)"
 license = "MIT OR Apache-2.0"

--- a/rust/myotis-evm/Cargo.toml
+++ b/rust/myotis-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "myotis-evm"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 description = "Myotis EVM: view-call / gas-estimation over SNAP-proof-verified state (revm behind a SnapStateOracle trait; sans-I/O). Grows through the EL-phase Milestone-C PRs (docs/reimplementation/07)."
 license = "MIT OR Apache-2.0"

--- a/rust/myotis-net/Cargo.toml
+++ b/rust/myotis-net/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "myotis-net"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 description = "Myotis consensus-layer networking: discv5 discovery + libp2p eth2 req/resp + the light-client sync loop (ALL I/O lives here; myotis-consensus stays sans-I/O)"
 license = "MIT OR Apache-2.0"

--- a/rust/myotis-net/src/el/rlpx/transport.rs
+++ b/rust/myotis-net/src/el/rlpx/transport.rs
@@ -320,7 +320,7 @@ pub fn encode_hello(node_pubkey: &[u8; 64], listen_port: u16) -> Vec<u8> {
     };
     rlp::encode(&Item::List(vec![
         Item::Bytes(rlp::u64_to_minimal_be(5)), // protocol version
-        Item::Bytes(b"myotis/0.1.4".to_vec()),
+        Item::Bytes(b"myotis/0.1.5".to_vec()),
         Item::List(vec![
             cap("eth", 66),
             cap("eth", 67),
@@ -392,7 +392,7 @@ mod tests {
         let body = encode_hello(&pubkey, 30303);
         let hello = decode_hello(&body).unwrap();
         assert_eq!(hello.protocol_version, 5);
-        assert_eq!(hello.client_id, "myotis/0.1.4");
+        assert_eq!(hello.client_id, "myotis/0.1.5");
         assert_eq!(hello.listen_port, 30303);
         assert_eq!(hello.node_id, pubkey.to_vec());
         assert_eq!(hello.capabilities.len(), 5);

--- a/rust/myotis-net/src/reqresp.rs
+++ b/rust/myotis-net/src/reqresp.rs
@@ -270,7 +270,7 @@ impl Behaviour {
             ),
             identify: identify::Behaviour::new(
                 identify::Config::new("eth2/1.0.0".into(), local_public_key)
-                    .with_agent_version("myotis/0.1.4-rs".into()),
+                    .with_agent_version("myotis/0.1.5-rs".into()),
             ),
             status_v2: rr(protocols::STATUS_V2, ProtocolSupport::Full, RESP_TIMEOUT),
             status_v1: rr(protocols::STATUS_V1, ProtocolSupport::Full, RESP_TIMEOUT),

--- a/rust/myotis-node/Cargo.toml
+++ b/rust/myotis-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "myotis-node"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 description = "Node.js (napi-rs) binding over the myotis-engine C ABI — for Electron/Node hosts"
 license = "MIT OR Apache-2.0"

--- a/rust/tor-poc/Cargo.lock
+++ b/rust/tor-poc/Cargo.lock
@@ -3848,14 +3848,14 @@ dependencies = [
 
 [[package]]
 name = "myotis-bls"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "blst",
 ]
 
 [[package]]
 name = "myotis-consensus"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "myotis-bls",
  "sha2",
@@ -3863,7 +3863,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-core"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "k256",
  "sha3 0.10.9",
@@ -3871,7 +3871,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-evm"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "myotis-core",
  "revm",
@@ -3879,7 +3879,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-net"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "aes",
  "async-trait",


### PR DESCRIPTION
Version-bump sweep for the **v0.1.5** pre-release, cutting the #291 Gnosis catch-up fix (#322).

### What changed
Same sweep as the v0.1.4 prep (#303):
- Root Gradle version → `0.1.5-SNAPSHOT` (Android `versionName` and desktop `packageVersion` derive from it)
- Android `versionCode` `5 → 6`
- devp2p Hello client id → `myotis/0.1.5` (Java `HelloMessage` + Rust `transport.rs`, kept in sync) and the libp2p agent version → `myotis/0.1.5-rs`
- All seven workspace crate versions → `0.1.5`
- The three lockfiles (main workspace, plus the workspace-excluded `myotis-bls` and `tor-poc`)

### ABI
Unchanged at **22**. v0.1.5 is internal CL peer-pool logic (reversible `nolc`, un-evictable pinned peers — #322) with no FFI or status-JSON shape change, so downstream loaders that gate on the ABI need no update.

### Verification
- All three lockfiles resolve under `cargo metadata --locked`.
- `myotis-net` rlpx hello round-trip test passes (it pins the client id string).
- The Java one-line client-id change compiles under CI's Build and Test.

### Release step
Once merged, pushing the `v0.1.5` tag to the merge commit fires the artifact workflows (`node-binding`, `desktop-dmg`, `android-apk`, `desktop-linux-deb`); `node-binding` publishes the GitHub Release with the addon assets, `SHA256SUMS`, and the pinned ABI (22).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CMWiMxPwkdD3FAZcSe1QKV)_