### PR TITLE
docs: define the PR review-response workflow in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,34 @@ Key Gradle modules:
   `RustEngineNative`; same JSON shapes, pinned by the same golden tests) and
   never touches engine internals either.
 
+## Pull requests and code review
+
+- **ALWAYS respond to every review comment, individually, on its own thread.**
+  One comment, one reply. A single bulk PR-level summary is not a substitute —
+  it may be posted *in addition*, but a reviewer must be able to see the
+  disposition of each point where they raised it. Silently fixing a comment in
+  a follow-up commit does not count as responding, and neither does silently
+  ignoring one.
+- **Verify every claim against the source before replying.** Reviewers —
+  human, Copilot, or `claude[bot]` — are frequently right and occasionally
+  wrong. Treat a review comment as information to check, not an instruction to
+  obey. Quote the file and symbol you checked.
+- **State a plain verdict** in each reply, one of:
+  - *Accepted* — say what changed and name the commit.
+  - *Disputed* — say why, with the evidence that settles it. Disagreeing is
+    correct when the code supports it; do not change working code to satisfy a
+    review that is mistaken.
+  - *Deferred* — say who decides and what the options are. Use this for
+    anything that amends a project rule (this file included) or changes
+    architecture; those are the owner's call, not the PR author's.
+- **Do not mark a thread resolved on the author's own say-so.** Leave that to
+  the reviewer or the owner.
+- Reply with `gh api repos/<owner>/<repo>/pulls/<n>/comments/<comment_id>/replies`
+  so the response threads under the original comment, rather than
+  `gh pr comment`, which starts a detached top-level discussion.
+- **Drive CI to green.** Do not leave a PR on a red or pending check without
+  either pushing a fix or stating the blocker explicitly.
+
 ## Platform & language direction
 
 - **Android compatibility is a first-class concern.** This is ultimately a wallet

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,12 +134,23 @@ Key Gradle modules:
 
 ## Pull requests and code review
 
+These rules are for the **PR author** answering a review. The reviewer's own
+instructions live in `.github/claude-review-prompt.md` and
+`.github/workflows/claude-review.yml`; a reviewer agent reads this file too
+(its prompt opens "Read CLAUDE.md first"), so note that the mechanism below is
+not addressed to it — and it could not follow it anyway, since `gh api` is not
+on its allowlist.
+
 - **ALWAYS respond to every review comment, individually, on its own thread.**
   One comment, one reply. A single bulk PR-level summary is not a substitute —
   it may be posted *in addition*, but a reviewer must be able to see the
   disposition of each point where they raised it. Silently fixing a comment in
   a follow-up commit does not count as responding, and neither does silently
   ignoring one.
+- **Only *inline* review comments have a thread.** A submitted review's summary
+  body and a top-level PR comment have no reply endpoint at all. Answer those
+  in a single top-level reply that quotes each point it addresses — that is the
+  one legitimate use of `gh pr comment`.
 - **Verify every claim against the source before replying.** Reviewers —
   human, Copilot, or `claude[bot]` — are frequently right and occasionally
   wrong. Treat a review comment as information to check, not an instruction to
@@ -154,9 +165,16 @@ Key Gradle modules:
     architecture; those are the owner's call, not the PR author's.
 - **Do not mark a thread resolved on the author's own say-so.** Leave that to
   the reviewer or the owner.
-- Reply with `gh api repos/<owner>/<repo>/pulls/<n>/comments/<comment_id>/replies`
+- Reply with
+  `gh api repos/<owner>/<repo>/pulls/<n>/comments/<comment_id>/replies -f body='…'`
   so the response threads under the original comment, rather than
-  `gh pr comment`, which starts a detached top-level discussion.
+  `gh pr comment`, which starts a detached top-level discussion. **The `-f body`
+  is not optional**: `body` is required by the endpoint, and `gh api` switches
+  from `GET` to `POST` only when a parameter is present — without it the call is
+  a `GET` against a `POST`-only path. List the ids with
+  `gh api repos/<owner>/<repo>/pulls/<n>/comments --jq '.[].id'`. For bodies
+  containing backticks or quotes, prefer `--raw-field body="$(cat <<'EOF' … EOF)"`
+  over `-f`.
 - **Drive CI to green.** Do not leave a PR on a red or pending check without
   either pushing a fix or stating the blocker explicitly.
 


### PR DESCRIPTION
CLAUDE.md had **no section on pull requests or code review at all**, so how to handle review feedback was undocumented and had to be inferred. It's now been gotten wrong twice in practice — replies posted as one bulk PR-level comment instead of threaded under each review comment, leaving reviewers unable to see the disposition of the individual points they raised.

## What this adds

The rule that was missing: **always respond to every review comment, individually, on its own thread.** One comment, one reply. A bulk summary may be posted in addition, never instead. Silently fixing a point in a follow-up commit doesn't count as responding.

Plus the surrounding practice that makes those replies worth reading:

- **Verify every claim against the source before replying.** Reviewers — human, Copilot, or `claude[bot]` — are frequently right and occasionally wrong. A review comment is information to check, not an instruction to obey.
- **State a plain verdict**: *accepted* (name the commit), *disputed* (with the evidence — disagreeing is correct when the code supports it), or *deferred* (name who decides).
- **Route rule and architecture changes to the owner.** Anything amending a project rule, CLAUDE.md included, is the owner's call rather than something a PR author settles in passing.
- **Don't self-resolve threads**, and **drive CI to green** rather than leaving a PR red or pending without stating the blocker.

It also records the mechanism, because the obvious command is the wrong one: `gh pr comment` starts a detached top-level discussion, while `gh api .../comments/<id>/replies` threads under the original.

## Note

Separate from #325 on purpose — that PR is the LC server design, and a repo-wide convention change doesn't belong inside it. #325 is where the workflow gap surfaced; all 14 of its review comments have since been answered individually per the rule above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYVwpfHg77oibuD2733jPj