### PR TITLE
roost: compute fork digests from the chain's fork and blob schedule

### DIFF
--- a/docs/lc-server-design.md
+++ b/docs/lc-server-design.md
@@ -360,7 +360,7 @@ because `extra_data` is variable-length, so **the length prefix is the only
 authority for chunk boundaries** — do not derive one number from the other when
 checking a parser.
 
-### Context bytes: prefer re-emission, compute only as a fallback
+### Context bytes: prefer re-emission, compute only as a fallback — IMPLEMENTED
 
 `Eth-Consensus-Version` gives a fork *name*, and since EIP-7892 the fork digest
 is **not a function of the name**: it folds in the active blob parameters.
@@ -377,6 +377,17 @@ So: **re-emit the digest the source already framed** wherever one exists — whi
 the source supplies none (the single-object endpoints), and compute it for the
 *object's slot* via `fork_digest_bpo` against the network's blob schedule, not
 from the fork name.
+
+**Built** (`rust/roost/src/forks.rs`). The schedule — fork versions, activation
+epochs, `SLOTS_PER_EPOCH`, `BLOB_SCHEDULE` — is read from the upstream's
+`/eth/v1/config/spec`, so there is no per-network table to drift and gnosis's
+16-slot epochs need no special case. A bootstrap is stamped for the slot of the
+block it anchors to (looked up by root, since a pinned checkpoint can sit many
+epochs behind head); the per-slot objects are stamped for head, which they track
+to within a slot or two. `roost probe` checks the computed digest against the one
+the upstream framed on the wire — verified equal on sepolia at `0x74d01459`, and
+`myotis-net`'s pinned mainnet values (`0x82FAE541` base, `0x8C9F62FE` with BPO2)
+are reached through the same selection in unit tests.
 
 The blast radius of getting this wrong is asymmetric and worth knowing: myotis'
 own decoder skips the context bytes (`codec.rs`: "the payload's own fork sniffing

--- a/docs/lc-server-design.md
+++ b/docs/lc-server-design.md
@@ -251,6 +251,36 @@ Most of the server is written. In `rust/myotis-net`:
    - **Re-publish at fork *and* BPO boundaries.** Wallets filter discovered peers
      on `accepted_fork_digests` (`discovery.rs`), so a stale digest makes the
      server invisible to precisely the clients it exists for.
+   - **Handle the address changing while the server runs.** The deployment is a
+     residential Telekom line and the public IP is not guaranteed stable
+     (docs/dedicated-sepolia-node.md §7 and the pinned constants in
+     `NetworkConfig` have the same exposure). A published ENR carrying a dead
+     IP is worse than no ENR: wallets discover it, dial, fail, and spend their
+     three strikes to eviction (`clcache.rs`, `FAILURE_THRESHOLD = 3`) on a node
+     that is actually healthy — so the record must track the address rather than
+     be written once at boot.
+
+     The signal is already available and needs no third-party service: libp2p
+     **Identify** reports `observed_addr`, i.e. the address each peer sees us
+     on, and `myotis-net` already receives those events
+     (`identify::Event::Received` in `handle_behaviour_event`). Take a quorum
+     across several distinct recent peers rather than trusting one — a single
+     peer can lie, and one behind the same NAT can be honestly wrong. discv5's
+     own endpoint prediction is the same idea and is the mechanism Geth
+     (`--nat stun`) and Nimbus (`--enr-auto-update`) use.
+
+     On a confirmed change: bump the ENR sequence number (which must already be
+     persisted and monotonic, per the item above), re-publish, and log it
+     loudly. The sequence-number requirement and this one are the same
+     mechanism — an updated record that does not out-rank the cached one is
+     ignored by the DHT.
+
+     Note the ordering trap: the wallet-side pins in `NetworkConfig` are a
+     SEPARATE copy of the address with no such mechanism, which is why the
+     rollout replaces them with discovery (step 5) rather than leaving both.
+     Until that lands, an IP change still breaks the pinned path no matter what
+     the ENR says.
+
    - **Decide what `status.earliest_available_slot` should say.** OPEN, and it
      becomes load-bearing exactly here — once the ENR is published, non-myotis
      clients start dialling. The field is a **block** floor

--- a/rust/roost/README.md
+++ b/rust/roost/README.md
@@ -25,6 +25,10 @@ limits.
 - `store.rs` — the in-memory serving cache, holding **pre-encoded** libp2p
   responses so serving is a memcpy and a write. Bounded: spec update count,
   total response bytes, and a hard cap on bootstraps.
+- `forks.rs` — the chain's fork and blob schedule, read from the upstream's
+  `/eth/v1/config/spec`, and the fork digest for any slot. Context bytes are
+  **computed**, not guessed from a fork name — since EIP-7892 one fork name has
+  as many digests as it has BPO entries.
 - `archive.rs` — the durable, append-only archive (magic, version, per-record
   FNV-1a checksum), bound to a chain by its `genesis_validators_root`. Repairs a
   torn tail on open and scans past a corrupt record rather than losing every
@@ -47,10 +51,10 @@ re-published at fork *and* BPO boundaries) and the **back-archive** below the
 upstream node's light-client floor. Those are what stand between this and the
 design's rollout steps 4-5.
 
-Known interim: context bytes for the three single-object endpoints are copied
-from the newest update chunk. Correct except across a fork or BPO boundary.
-myotis' own decoder ignores context bytes; other CLs dispatch on them, so this
-must be computed via `fork_digest_bpo` before the ENR is published.
+Context bytes are now computed per object: `updates` re-emits the digest the
+source framed (the robust path), a bootstrap is stamped for the slot of the
+block it anchors to, and the per-slot objects for head. `roost probe` checks the
+computed value against the one the upstream actually put on the wire.
 
 ## Run
 

--- a/rust/roost/src/forks.rs
+++ b/rust/roost/src/forks.rs
@@ -1,0 +1,328 @@
+//! The chain's fork and blob schedule, and the fork digest for a given slot.
+//!
+//! # Why this exists
+//!
+//! Every fork-dependent light-client response carries 4 **context bytes** — the
+//! fork digest of the object being served. Until now roost re-used the digest
+//! from the newest `updates` chunk for everything, which is correct for the
+//! `updates` protocol (the source frames a real digest per chunk, and re-emitting
+//! it is the robust path) and an approximation everywhere else.
+//!
+//! It cannot be derived from a fork *name*. Since EIP-7892 the digest folds in
+//! the active blob parameters, so one fork name has as many digests as it has
+//! BPO entries — `myotis-net`'s own test pins mainnet Fulu at `0x82FAE541` base
+//! versus `0x8C9F62FE` with BPO2. A name→digest table built today would emit a
+//! stale digest indefinitely after the next blob-parameter-only fork, while the
+//! upstream kept returning 200s.
+//!
+//! So it is computed, per the spec:
+//!
+//! ```text
+//! fork_digest = (fork_data_root(fork_version, gvr)
+//!                XOR sha256(u64_le(bpo_epoch) || u64_le(max_blobs)))[0..4]
+//! ```
+//!
+//! with `fork_version` and `bpo_epoch`/`max_blobs` selected for the object's own
+//! epoch. `myotis-net::status::fork_digest_bpo` does the arithmetic; this module
+//! supplies the schedule and the selection.
+//!
+//! # Why the schedule comes from the upstream
+//!
+//! `/eth/v1/config/spec` is chain *configuration*, not consensus data: fork
+//! versions, activation epochs, `SLOTS_PER_EPOCH` and `BLOB_SCHEDULE`. Reading
+//! it from the node roost already follows means roost cannot disagree with its
+//! own upstream about what fork it is on, and it needs no per-network table here
+//! — which matters because gnosis has its own beacon chain with 16-slot epochs.
+//!
+//! A wrong digest is self-limiting rather than dangerous: peers answer a
+//! mismatched `status` with Goodbye(IrrelevantNetwork) and myotis wallets filter
+//! on `accepted_fork_digests`. It costs reachability, never correctness — no
+//! wallet accepts anything on the strength of a digest.
+
+use std::collections::BTreeMap;
+
+use anyhow::{anyhow, Context, Result};
+use myotis_net::status::fork_digest_bpo;
+
+use crate::rest::NimbusRest;
+
+/// A fork's activation epoch and version.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Fork {
+    pub epoch: u64,
+    pub version: [u8; 4],
+}
+
+/// An EIP-7892 blob-parameter-only entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BlobParams {
+    pub epoch: u64,
+    pub max_blobs: u64,
+}
+
+/// Everything needed to compute a fork digest for any slot on this chain.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ForkSchedule {
+    genesis_validators_root: [u8; 32],
+    /// Ascending by activation epoch.
+    forks: Vec<Fork>,
+    /// Ascending by activation epoch. Empty ⇒ no BPO active, pre-Fulu formula.
+    blob_schedule: Vec<BlobParams>,
+    slots_per_epoch: u64,
+}
+
+impl ForkSchedule {
+    /// Read the whole schedule — forks and blob parameters — from the
+    /// upstream's `/eth/v1/config/spec`, in one request.
+    pub async fn fetch(client: &NimbusRest, genesis_validators_root: [u8; 32]) -> Result<Self> {
+        let (spec, blobs) = client.config_spec().await?;
+        Ok(Self::from_spec(&spec, genesis_validators_root)?.with_blob_schedule(blobs))
+    }
+
+    /// Build from a decoded `config/spec` map.
+    ///
+    /// Forks are discovered by key shape (`<NAME>_FORK_VERSION` paired with
+    /// `<NAME>_FORK_EPOCH`) rather than from a hardcoded list, so a fork added
+    /// by a client upgrade is picked up without a code change here. A version
+    /// with no matching epoch key is treated as genesis (epoch 0), which is
+    /// exactly the `GENESIS_FORK_VERSION` case.
+    pub fn from_spec(
+        spec: &BTreeMap<String, String>,
+        genesis_validators_root: [u8; 32],
+    ) -> Result<Self> {
+        let mut forks: Vec<Fork> = Vec::new();
+        for (key, value) in spec {
+            let Some(name) = key.strip_suffix("_FORK_VERSION") else {
+                continue;
+            };
+            let version = parse_version(value)
+                .with_context(|| format!("parsing {key} = {value}"))?;
+            let epoch = match spec.get(&format!("{name}_FORK_EPOCH")) {
+                Some(e) => e
+                    .parse::<u64>()
+                    .with_context(|| format!("parsing {name}_FORK_EPOCH = {e}"))?,
+                None => 0, // GENESIS_FORK_VERSION has no epoch key
+            };
+            forks.push(Fork { epoch, version });
+        }
+        if forks.is_empty() {
+            return Err(anyhow!("config/spec exposed no *_FORK_VERSION entries"));
+        }
+        forks.sort_by_key(|f| f.epoch);
+
+        let slots_per_epoch = spec
+            .get("SLOTS_PER_EPOCH")
+            .ok_or_else(|| anyhow!("config/spec has no SLOTS_PER_EPOCH"))?
+            .parse::<u64>()
+            .context("parsing SLOTS_PER_EPOCH")?;
+        if slots_per_epoch == 0 {
+            return Err(anyhow!("config/spec reports SLOTS_PER_EPOCH = 0"));
+        }
+
+        Ok(Self {
+            genesis_validators_root,
+            forks,
+            blob_schedule: Vec::new(),
+            slots_per_epoch,
+        })
+    }
+
+    /// Attach the `BLOB_SCHEDULE` array, which `config/spec` returns as objects
+    /// rather than scalars and so arrives separately.
+    pub fn with_blob_schedule(mut self, mut entries: Vec<BlobParams>) -> Self {
+        entries.sort_by_key(|b| b.epoch);
+        self.blob_schedule = entries;
+        self
+    }
+
+    pub fn slots_per_epoch(&self) -> u64 {
+        self.slots_per_epoch
+    }
+
+    /// The fork active at `epoch` — the latest whose activation is not in the
+    /// future. Forks scheduled at `u64::MAX` (a placeholder for "not scheduled",
+    /// e.g. GLOAS today) never win, which falls out of the comparison.
+    pub fn fork_at_epoch(&self, epoch: u64) -> Fork {
+        self.forks
+            .iter()
+            .rfind(|f| f.epoch <= epoch)
+            .copied()
+            // Before the first scheduled fork, genesis governs.
+            .unwrap_or(self.forks[0])
+    }
+
+    /// The blob parameters active at `epoch`, if any.
+    pub fn blob_params_at_epoch(&self, epoch: u64) -> Option<BlobParams> {
+        self.blob_schedule
+            .iter()
+            .rfind(|b| b.epoch <= epoch)
+            .copied()
+    }
+
+    /// The fork digest an object in `epoch` must carry.
+    pub fn digest_for_epoch(&self, epoch: u64) -> [u8; 4] {
+        let fork = self.fork_at_epoch(epoch);
+        match self.blob_params_at_epoch(epoch) {
+            // epoch 0 is the sentinel fork_digest_bpo reads as "no BPO active",
+            // so a BPO genuinely scheduled at epoch 0 would be indistinguishable
+            // from none — harmless, since a BPO at genesis is the base case.
+            Some(bp) => fork_digest_bpo(
+                fork.version,
+                self.genesis_validators_root,
+                bp.epoch,
+                bp.max_blobs,
+            ),
+            None => fork_digest_bpo(fork.version, self.genesis_validators_root, 0, 0),
+        }
+    }
+
+    /// The fork digest an object at `slot` must carry.
+    pub fn digest_for_slot(&self, slot: u64) -> [u8; 4] {
+        self.digest_for_epoch(slot / self.slots_per_epoch)
+    }
+}
+
+fn parse_version(raw: &str) -> Result<[u8; 4]> {
+    let bytes = hex::decode(raw.trim().trim_start_matches("0x"))?;
+    bytes
+        .as_slice()
+        .try_into()
+        .map_err(|_| anyhow!("fork version is {} bytes, want 4", bytes.len()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hex32(s: &str) -> [u8; 32] {
+        let v = hex::decode(s).unwrap();
+        v.as_slice().try_into().unwrap()
+    }
+
+    fn sepolia_gvr() -> [u8; 32] {
+        hex32("d8ea171f3c94aea21ebc42a1ed61052acf3f9209c00e4efbaaddac09ed9b8078")
+    }
+
+    /// The spec keys zbox's Nimbus v26.7.0 actually returns for sepolia.
+    fn sepolia_spec() -> BTreeMap<String, String> {
+        [
+            ("GENESIS_FORK_VERSION", "0x90000069"),
+            ("ALTAIR_FORK_VERSION", "0x90000070"),
+            ("ALTAIR_FORK_EPOCH", "50"),
+            ("BELLATRIX_FORK_VERSION", "0x90000071"),
+            ("BELLATRIX_FORK_EPOCH", "100"),
+            ("CAPELLA_FORK_VERSION", "0x90000072"),
+            ("CAPELLA_FORK_EPOCH", "56832"),
+            ("DENEB_FORK_VERSION", "0x90000073"),
+            ("DENEB_FORK_EPOCH", "132608"),
+            ("ELECTRA_FORK_VERSION", "0x90000074"),
+            ("ELECTRA_FORK_EPOCH", "222464"),
+            ("FULU_FORK_VERSION", "0x90000075"),
+            ("FULU_FORK_EPOCH", "272640"),
+            ("GLOAS_FORK_VERSION", "0x07000000"),
+            ("GLOAS_FORK_EPOCH", "18446744073709551615"),
+            ("SLOTS_PER_EPOCH", "32"),
+        ]
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect()
+    }
+
+    fn sepolia() -> ForkSchedule {
+        ForkSchedule::from_spec(&sepolia_spec(), sepolia_gvr())
+            .unwrap()
+            .with_blob_schedule(vec![
+                BlobParams { epoch: 274_176, max_blobs: 15 },
+                BlobParams { epoch: 275_712, max_blobs: 21 },
+            ])
+    }
+
+    /// THE test: the digest computed from the schedule must equal the one the
+    /// live node framed on the wire. Observed on zbox at head slot 10,873,925
+    /// (epoch 339,810) — `0x74d01459`, straight out of the `updates` chunk.
+    #[test]
+    fn computed_digest_matches_the_live_sepolia_wire_value() {
+        assert_eq!(sepolia().digest_for_slot(10_873_925), [0x74, 0xd0, 0x14, 0x59]);
+    }
+
+    #[test]
+    fn selects_the_active_bpo_entry_not_merely_the_fork() {
+        let s = sepolia();
+        // Fulu is live from epoch 272640, but the digest changes twice more as
+        // each BPO activates — the whole reason a name→digest table is wrong.
+        let fulu_no_bpo = s.digest_for_epoch(272_640);
+        let bpo1 = s.digest_for_epoch(274_176);
+        let bpo2 = s.digest_for_epoch(275_712);
+        assert_ne!(fulu_no_bpo, bpo1, "BPO1 must change the digest");
+        assert_ne!(bpo1, bpo2, "BPO2 must change it again");
+        assert_eq!(bpo2, [0x74, 0xd0, 0x14, 0x59]);
+        // One epoch before each boundary still carries the previous value.
+        assert_eq!(s.digest_for_epoch(274_175), fulu_no_bpo);
+        assert_eq!(s.digest_for_epoch(275_711), bpo1);
+    }
+
+    #[test]
+    fn matches_the_mainnet_values_pinned_in_myotis_net() {
+        // myotis-net's own status.rs test pins mainnet Fulu at 0x82FAE541 base
+        // and 0x8C9F62FE with BPO2 (epoch 419072, 21 blobs). Reaching the same
+        // answers through the schedule proves the selection, not just the hash.
+        let gvr = hex32("4b363db94e286120d76eb905340fdd4e54bfe9f06bf33ff6cf5ad27f511bfe95");
+        let spec: BTreeMap<String, String> = [
+            ("FULU_FORK_VERSION", "0x06000000"),
+            ("FULU_FORK_EPOCH", "0"),
+            ("SLOTS_PER_EPOCH", "32"),
+        ]
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect();
+
+        let base = ForkSchedule::from_spec(&spec, gvr).unwrap();
+        assert_eq!(base.digest_for_epoch(1), [0x82, 0xFA, 0xE5, 0x41]);
+
+        let with_bpo = base.with_blob_schedule(vec![BlobParams {
+            epoch: 419_072,
+            max_blobs: 21,
+        }]);
+        assert_eq!(with_bpo.digest_for_epoch(419_072), [0x8C, 0x9F, 0x62, 0xFE]);
+        // Before BPO2 activates, the base digest still applies.
+        assert_eq!(with_bpo.digest_for_epoch(419_071), [0x82, 0xFA, 0xE5, 0x41]);
+    }
+
+    #[test]
+    fn an_unscheduled_fork_never_activates() {
+        // GLOAS sits at u64::MAX. It must not win for any real epoch, and must
+        // not panic at the boundary either.
+        let s = sepolia();
+        assert_eq!(s.fork_at_epoch(u64::MAX - 1).version, [0x90, 0, 0, 0x75]);
+        assert_eq!(s.fork_at_epoch(0).version, [0x90, 0, 0, 0x69]);
+    }
+
+    #[test]
+    fn honours_a_non_mainnet_epoch_length() {
+        // Gnosis runs 16-slot epochs on its own beacon chain, so slot→epoch is
+        // not a mainnet constant. Reading SLOTS_PER_EPOCH from the upstream is
+        // what keeps this network-agnostic.
+        let mut spec = sepolia_spec();
+        spec.insert("SLOTS_PER_EPOCH".into(), "16".into());
+        let s = ForkSchedule::from_spec(&spec, sepolia_gvr()).unwrap();
+        assert_eq!(s.slots_per_epoch(), 16);
+        assert_eq!(s.digest_for_slot(16), s.digest_for_epoch(1));
+    }
+
+    #[test]
+    fn refuses_a_spec_it_cannot_use() {
+        let empty: BTreeMap<String, String> = BTreeMap::new();
+        assert!(ForkSchedule::from_spec(&empty, sepolia_gvr()).is_err());
+
+        let mut no_epoch_len = sepolia_spec();
+        no_epoch_len.remove("SLOTS_PER_EPOCH");
+        assert!(ForkSchedule::from_spec(&no_epoch_len, sepolia_gvr()).is_err());
+
+        let mut zero = sepolia_spec();
+        zero.insert("SLOTS_PER_EPOCH".into(), "0".into());
+        assert!(
+            ForkSchedule::from_spec(&zero, sepolia_gvr()).is_err(),
+            "a zero epoch length would divide by zero in digest_for_slot"
+        );
+    }
+}

--- a/rust/roost/src/forks.rs
+++ b/rust/roost/src/forks.rs
@@ -83,9 +83,14 @@ impl ForkSchedule {
     ///
     /// Forks are discovered by key shape (`<NAME>_FORK_VERSION` paired with
     /// `<NAME>_FORK_EPOCH`) rather than from a hardcoded list, so a fork added
-    /// by a client upgrade is picked up without a code change here. A version
-    /// with no matching epoch key is treated as genesis (epoch 0), which is
-    /// exactly the `GENESIS_FORK_VERSION` case.
+    /// by a client upgrade is picked up without a code change here.
+    ///
+    /// `GENESIS_FORK_VERSION` is the ONLY version legitimately without an epoch
+    /// key. Any other unpaired version is refused rather than defaulted: a
+    /// partial or half-published fork entry silently defaulting to epoch 0 would
+    /// sort ahead of the real schedule and could win for early epochs, producing
+    /// a wrong digest instead of an obvious failure. An unusable schedule should
+    /// fail loudly — roost then falls back to the observed digest and says so.
     pub fn from_spec(
         spec: &BTreeMap<String, String>,
         genesis_validators_root: [u8; 32],
@@ -101,7 +106,13 @@ impl ForkSchedule {
                 Some(e) => e
                     .parse::<u64>()
                     .with_context(|| format!("parsing {name}_FORK_EPOCH = {e}"))?,
-                None => 0, // GENESIS_FORK_VERSION has no epoch key
+                None if name == "GENESIS" => 0,
+                None => {
+                    return Err(anyhow!(
+                        "config/spec has {key} but no {name}_FORK_EPOCH — refusing a schedule \
+                         that would silently activate {name} from genesis"
+                    ))
+                }
             };
             forks.push(Fork { epoch, version });
         }
@@ -307,6 +318,22 @@ mod tests {
         let s = ForkSchedule::from_spec(&spec, sepolia_gvr()).unwrap();
         assert_eq!(s.slots_per_epoch(), 16);
         assert_eq!(s.digest_for_slot(16), s.digest_for_epoch(1));
+    }
+
+    #[test]
+    fn refuses_a_fork_version_with_no_epoch() {
+        // A half-published fork entry must fail loudly, not default to genesis
+        // and quietly outrank the real schedule for early epochs.
+        let mut spec = sepolia_spec();
+        spec.insert("NEWFORK_FORK_VERSION".into(), "0x90000099".into());
+        let err = ForkSchedule::from_spec(&spec, sepolia_gvr()).unwrap_err().to_string();
+        assert!(err.contains("NEWFORK_FORK_EPOCH"), "got: {err}");
+
+        // GENESIS remains the one legitimate exception.
+        let mut only_genesis = sepolia_spec();
+        only_genesis.remove("ALTAIR_FORK_EPOCH");
+        only_genesis.remove("ALTAIR_FORK_VERSION");
+        assert!(ForkSchedule::from_spec(&only_genesis, sepolia_gvr()).is_ok());
     }
 
     #[test]

--- a/rust/roost/src/forks.rs
+++ b/rust/roost/src/forks.rs
@@ -95,7 +95,8 @@ impl ForkSchedule {
         spec: &BTreeMap<String, String>,
         genesis_validators_root: [u8; 32],
     ) -> Result<Self> {
-        let mut forks: Vec<Fork> = Vec::new();
+        // (fork, is_genesis) — the flag drives the tie-break below.
+        let mut forks: Vec<(Fork, bool)> = Vec::new();
         for (key, value) in spec {
             let Some(name) = key.strip_suffix("_FORK_VERSION") else {
                 continue;
@@ -114,12 +115,36 @@ impl ForkSchedule {
                     ))
                 }
             };
-            forks.push(Fork { epoch, version });
+            forks.push((Fork { epoch, version }, name == "GENESIS"));
         }
         if forks.is_empty() {
             return Err(anyhow!("config/spec exposed no *_FORK_VERSION entries"));
         }
-        forks.sort_by_key(|f| f.epoch);
+
+        // Tie-break: GENESIS sorts FIRST within an epoch, everything else after.
+        //
+        // `fork_at_epoch` takes the LAST entry with `epoch <= target`, and the
+        // input order is `BTreeMap` key order — lexicographic. Ethereum's fork
+        // names happen to be alphabetical in chronological order (ALTAIR <
+        // BELLATRIX < CAPELLA < DENEB < ELECTRA < FULU < GLOAS), so real forks
+        // tie correctly by luck. `GENESIS` is the one name that breaks it: it
+        // sorts between FULU and GLOAS, and its epoch is forced to 0.
+        //
+        // Without this, ANY chain with a non-genesis fork activated at epoch 0
+        // would resolve to GENESIS_FORK_VERSION for every epoch below the next
+        // distinctly-scheduled fork — the normal shape for a network launched
+        // after a fork rather than before it (a devnet with everything at 0
+        // would stamp every response, `status.fork_digest` included, with the
+        // genesis digest). mainnet/sepolia/gnosis are unaffected only because
+        // GENESIS alone sits at epoch 0 there.
+        //
+        // The residual assumption — that among NON-genesis forks tying at one
+        // epoch, lexicographic order matches chronological order — is left
+        // standing deliberately: encoding a fork-rank table here would
+        // reintroduce exactly the per-network hardcoding this module exists to
+        // avoid. It holds for every fork name shipped to date.
+        forks.sort_by_key(|(f, is_genesis)| (f.epoch, !*is_genesis));
+        let forks: Vec<Fork> = forks.into_iter().map(|(f, _)| f).collect();
 
         let slots_per_epoch = spec
             .get("SLOTS_PER_EPOCH")
@@ -297,6 +322,34 @@ mod tests {
         assert_eq!(with_bpo.digest_for_epoch(419_072), [0x8C, 0x9F, 0x62, 0xFE]);
         // Before BPO2 activates, the base digest still applies.
         assert_eq!(with_bpo.digest_for_epoch(419_071), [0x82, 0xFA, 0xE5, 0x41]);
+    }
+
+    #[test]
+    fn a_fork_activated_at_genesis_beats_the_genesis_version() {
+        // The shape of any network launched after a fork: several forks live
+        // from epoch 0. GENESIS must not win those ties, or every response
+        // below the next distinctly-scheduled fork carries the genesis digest.
+        let mut spec = sepolia_spec();
+        spec.insert("ALTAIR_FORK_EPOCH".into(), "0".into());
+        spec.insert("BELLATRIX_FORK_EPOCH".into(), "0".into());
+        spec.insert("CAPELLA_FORK_EPOCH".into(), "0".into());
+        spec.insert("DENEB_FORK_EPOCH".into(), "0".into());
+        let s = ForkSchedule::from_spec(&spec, sepolia_gvr()).unwrap();
+
+        // DENEB is the latest fork at epoch 0 and must win — not GENESIS, which
+        // sorts after FULU lexicographically and would otherwise take the tie.
+        assert_eq!(s.fork_at_epoch(0).version, [0x90, 0, 0, 0x73], "want DENEB");
+        assert_eq!(s.fork_at_epoch(1000).version, [0x90, 0, 0, 0x73]);
+        // The later, distinctly-scheduled forks still take over on time.
+        assert_eq!(s.fork_at_epoch(222_464).version, [0x90, 0, 0, 0x74]);
+    }
+
+    #[test]
+    fn genesis_still_wins_when_it_is_alone_at_epoch_zero() {
+        let s = sepolia();
+        assert_eq!(s.fork_at_epoch(0).version, [0x90, 0, 0, 0x69]);
+        assert_eq!(s.fork_at_epoch(49).version, [0x90, 0, 0, 0x69]);
+        assert_eq!(s.fork_at_epoch(50).version, [0x90, 0, 0, 0x70], "ALTAIR");
     }
 
     #[test]

--- a/rust/roost/src/main.rs
+++ b/rust/roost/src/main.rs
@@ -4,7 +4,8 @@
 //! the light-client store, the chain-view poller behind `status`, and ingestion
 //! in background tasks. `probe` verifies the upstream path and `ingest` fills
 //! the archive without listening. ENR publication and the back-archive below the
-//! upstream light-client floor are what remain.
+//! upstream light-client floor are what remain. Context bytes are computed from
+//! the chain's fork and blob schedule (`forks.rs`), not approximated.
 
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -12,6 +13,7 @@ use std::time::Duration;
 use anyhow::{anyhow, Result};
 
 mod archive;
+mod forks;
 mod framing;
 mod rest;
 mod serve;
@@ -193,6 +195,45 @@ async fn probe(rest_base: &str) -> Result<()> {
         chunks.len(),
         wire.len()
     );
+
+    // The check that keeps context bytes honest: what we COMPUTE from the
+    // chain's fork and blob schedule must equal what the upstream actually
+    // framed. Only the `updates` protocol carries a digest on the wire, so this
+    // is the one place the computation can be checked against ground truth —
+    // and it is what every other endpoint's context bytes now rest on.
+    println!("\n== fork digest ==");
+    let gvr = client.genesis_validators_root().await?;
+    match forks::ForkSchedule::fetch(&client, gvr).await {
+        Ok(schedule) => {
+            let computed = schedule.digest_for_slot(head_slot);
+            let observed = chunks[0].fork_digest;
+            let fork = schedule.fork_at_epoch(head_slot / schedule.slots_per_epoch());
+            println!(
+                "  fork      version 0x{} active from epoch {}",
+                hex::encode(fork.version),
+                fork.epoch
+            );
+            match schedule.blob_params_at_epoch(head_slot / schedule.slots_per_epoch()) {
+                Some(bp) => println!(
+                    "  blobs     BPO epoch {}, max {} per block",
+                    bp.epoch, bp.max_blobs
+                ),
+                None => println!("  blobs     no BPO active (pre-Fulu formula)"),
+            }
+            println!("  computed  0x{}", hex::encode(computed));
+            println!("  on wire   0x{}", hex::encode(observed));
+            if computed == observed {
+                println!("  MATCH     context bytes can be computed for any slot");
+            } else {
+                return Err(anyhow!(
+                    "computed digest 0x{} != wire digest 0x{} — the schedule and the chain disagree",
+                    hex::encode(computed),
+                    hex::encode(observed)
+                ));
+            }
+        }
+        Err(e) => println!("  unavailable — {e:#}"),
+    }
 
     let span = 3u64.min(head_period + 1);
     let multi = client.updates(head_period + 1 - span, span).await?;

--- a/rust/roost/src/main.rs
+++ b/rust/roost/src/main.rs
@@ -225,11 +225,17 @@ async fn probe(rest_base: &str) -> Result<()> {
             if computed == observed {
                 println!("  MATCH     context bytes can be computed for any slot");
             } else {
-                return Err(anyhow!(
-                    "computed digest 0x{} != wire digest 0x{} — the schedule and the chain disagree",
-                    hex::encode(computed),
-                    hex::encode(observed)
-                ));
+                // NOT an error. The wire digest belongs to the update's attested
+                // header, which can predate a fork or BPO boundary that head is
+                // already past — a period spans 256 epochs, so the two SHOULD
+                // differ during a transition. Failing here would make `probe`
+                // report a schedule fault precisely when the schedule is doing
+                // its job. `serve` treats the same signal the same way.
+                println!(
+                    "  DIFFER    expected across a fork/BPO boundary inside this period\n\
+                     \x20           (the wire digest is the update's attested header, not head);\n\
+                     \x20           otherwise it means the schedule and the chain disagree."
+                );
             }
         }
         Err(e) => println!("  unavailable — {e:#}"),

--- a/rust/roost/src/rest.rs
+++ b/rust/roost/src/rest.rs
@@ -311,8 +311,9 @@ impl NimbusRest {
     /// `/eth/v1/config/spec` — the chain's fork versions, activation epochs,
     /// `SLOTS_PER_EPOCH` and blob schedule.
     ///
-    /// Returns only the SCALAR entries; `BLOB_SCHEDULE` is an array of objects
-    /// and comes back from [`NimbusRest::blob_schedule`] instead.
+    /// Returns the scalar entries AND the `BLOB_SCHEDULE` array from ONE
+    /// request: they live in the same document, and fetching it twice would be
+    /// two round trips for one payload.
     ///
     /// This is chain CONFIGURATION, not consensus data — it decides what fork
     /// digest to stamp on a response, and a wrong one costs reachability rather
@@ -320,9 +321,6 @@ impl NimbusRest {
     /// Goodbye(IrrelevantNetwork)). Reading it from the node roost already
     /// follows is what stops roost disagreeing with its own upstream about which
     /// fork it is on.
-    /// Returns the scalars AND the blob schedule from ONE request — they live
-    /// in the same document, and fetching it twice would be two round trips for
-    /// one payload.
     pub async fn config_spec(
         &self,
     ) -> Result<(
@@ -343,6 +341,24 @@ impl NimbusRest {
 
 /// The EIP-7892 `BLOB_SCHEDULE` entries. Absent on a chain with none (pre-Fulu,
 /// or a client that does not expose it), which is not an error.
+/// A `u64` written either as a JSON string (what the Beacon API spec pins for
+/// scalars, and what Nimbus emits) or as a JSON number.
+///
+/// Accepting both is deliberate. `BLOB_SCHEDULE` is a nested array-of-objects
+/// added by Fusaka and is the least settled shape this feature depends on; a
+/// client emitting `{"EPOCH": 411072}` as a number would otherwise take roost's
+/// computed digests out entirely — the parse fails, the whole schedule is
+/// discarded, and serving silently drops to the observed fallback.
+fn json_u64(v: &serde_json::Value) -> Option<u64> {
+    v.as_u64()
+        .or_else(|| v.as_str().and_then(|s| s.trim().parse::<u64>().ok()))
+}
+
+/// Parse `BLOB_SCHEDULE`.
+///
+/// All-or-nothing on purpose: a PARTIAL blob schedule computes wrong digests
+/// silently, which is worse than no schedule at all — the caller falls back to
+/// the digest observed on the wire and says so.
 fn parse_blob_schedule(v: &serde_json::Value) -> Result<Vec<crate::forks::BlobParams>> {
     {
         let Some(entries) = v["data"]["BLOB_SCHEDULE"].as_array() else {
@@ -350,14 +366,11 @@ fn parse_blob_schedule(v: &serde_json::Value) -> Result<Vec<crate::forks::BlobPa
         };
         let mut out = Vec::with_capacity(entries.len());
         for e in entries {
-            let epoch = e["EPOCH"]
-                .as_str()
-                .and_then(|s| s.parse::<u64>().ok())
-                .ok_or_else(|| anyhow!("BLOB_SCHEDULE entry missing EPOCH"))?;
-            let max_blobs = e["MAX_BLOBS_PER_BLOCK"]
-                .as_str()
-                .and_then(|s| s.parse::<u64>().ok())
-                .ok_or_else(|| anyhow!("BLOB_SCHEDULE entry missing MAX_BLOBS_PER_BLOCK"))?;
+            let epoch = json_u64(&e["EPOCH"])
+                .ok_or_else(|| anyhow!("BLOB_SCHEDULE entry has no usable EPOCH"))?;
+            let max_blobs = json_u64(&e["MAX_BLOBS_PER_BLOCK"]).ok_or_else(|| {
+                anyhow!("BLOB_SCHEDULE entry has no usable MAX_BLOBS_PER_BLOCK")
+            })?;
             out.push(crate::forks::BlobParams { epoch, max_blobs });
         }
         Ok(out)
@@ -417,6 +430,56 @@ impl NimbusRest {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
+
+    /// The exact shape zbox's Nimbus v26.7.0 returns — strings.
+    #[test]
+    fn parses_the_live_nimbus_blob_schedule() {
+        let v = json!({"data": {"BLOB_SCHEDULE": [
+            {"EPOCH": "274176", "MAX_BLOBS_PER_BLOCK": "15"},
+            {"EPOCH": "275712", "MAX_BLOBS_PER_BLOCK": "21"}
+        ]}});
+        let got = parse_blob_schedule(&v).unwrap();
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[0].epoch, 274_176);
+        assert_eq!(got[0].max_blobs, 15);
+        assert_eq!(got[1].epoch, 275_712);
+        assert_eq!(got[1].max_blobs, 21);
+    }
+
+    /// A client emitting numbers instead of strings must not silently take the
+    /// computed digests out — BLOB_SCHEDULE's per-client encoding is the least
+    /// settled shape this feature rests on.
+    #[test]
+    fn parses_a_numeric_blob_schedule() {
+        let v = json!({"data": {"BLOB_SCHEDULE": [
+            {"EPOCH": 274176, "MAX_BLOBS_PER_BLOCK": 15}
+        ]}});
+        let got = parse_blob_schedule(&v).unwrap();
+        assert_eq!(got[0].epoch, 274_176);
+        assert_eq!(got[0].max_blobs, 15);
+    }
+
+    #[test]
+    fn a_chain_with_no_blob_schedule_is_not_an_error() {
+        // Pre-Fulu, or a client that does not expose the key.
+        let v = json!({"data": {"SLOTS_PER_EPOCH": "32"}});
+        assert_eq!(parse_blob_schedule(&v).unwrap(), vec![]);
+    }
+
+    #[test]
+    fn a_malformed_entry_fails_rather_than_yielding_a_partial_schedule() {
+        // A partial schedule computes wrong digests silently; failing drops us
+        // to the observed fallback, which announces itself.
+        let v = json!({"data": {"BLOB_SCHEDULE": [
+            {"EPOCH": "274176", "MAX_BLOBS_PER_BLOCK": "15"},
+            {"EPOCH": "275712"}
+        ]}});
+        assert!(parse_blob_schedule(&v).is_err());
+
+        let v = json!({"data": {"BLOB_SCHEDULE": [{"EPOCH": true, "MAX_BLOBS_PER_BLOCK": "15"}]}});
+        assert!(parse_blob_schedule(&v).is_err());
+    }
 
     #[test]
     fn period_math_matches_the_live_node() {

--- a/rust/roost/src/rest.rs
+++ b/rust/roost/src/rest.rs
@@ -308,6 +308,79 @@ impl NimbusRest {
         Ok((parse_root(root)?, epoch))
     }
 
+    /// `/eth/v1/config/spec` — the chain's fork versions, activation epochs,
+    /// `SLOTS_PER_EPOCH` and blob schedule.
+    ///
+    /// Returns only the SCALAR entries; `BLOB_SCHEDULE` is an array of objects
+    /// and comes back from [`NimbusRest::blob_schedule`] instead.
+    ///
+    /// This is chain CONFIGURATION, not consensus data — it decides what fork
+    /// digest to stamp on a response, and a wrong one costs reachability rather
+    /// than correctness (peers answer a mismatched `status` with
+    /// Goodbye(IrrelevantNetwork)). Reading it from the node roost already
+    /// follows is what stops roost disagreeing with its own upstream about which
+    /// fork it is on.
+    /// Returns the scalars AND the blob schedule from ONE request — they live
+    /// in the same document, and fetching it twice would be two round trips for
+    /// one payload.
+    pub async fn config_spec(
+        &self,
+    ) -> Result<(
+        std::collections::BTreeMap<String, String>,
+        Vec<crate::forks::BlobParams>,
+    )> {
+        let v = self.get_json("/eth/v1/config/spec").await?;
+        let obj = v["data"]
+            .as_object()
+            .ok_or_else(|| anyhow!("config/spec: data is not an object"))?;
+        let scalars = obj
+            .iter()
+            .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+            .collect();
+        Ok((scalars, parse_blob_schedule(&v)?))
+    }
+}
+
+/// The EIP-7892 `BLOB_SCHEDULE` entries. Absent on a chain with none (pre-Fulu,
+/// or a client that does not expose it), which is not an error.
+fn parse_blob_schedule(v: &serde_json::Value) -> Result<Vec<crate::forks::BlobParams>> {
+    {
+        let Some(entries) = v["data"]["BLOB_SCHEDULE"].as_array() else {
+            return Ok(Vec::new());
+        };
+        let mut out = Vec::with_capacity(entries.len());
+        for e in entries {
+            let epoch = e["EPOCH"]
+                .as_str()
+                .and_then(|s| s.parse::<u64>().ok())
+                .ok_or_else(|| anyhow!("BLOB_SCHEDULE entry missing EPOCH"))?;
+            let max_blobs = e["MAX_BLOBS_PER_BLOCK"]
+                .as_str()
+                .and_then(|s| s.parse::<u64>().ok())
+                .ok_or_else(|| anyhow!("BLOB_SCHEDULE entry missing MAX_BLOBS_PER_BLOCK"))?;
+            out.push(crate::forks::BlobParams { epoch, max_blobs });
+        }
+        Ok(out)
+    }
+}
+
+impl NimbusRest {
+    /// The slot of a block identified by root — how roost learns the epoch a
+    /// BOOTSTRAP belongs to without decoding SSZ (it is a byte cache, and
+    /// modelling light-client types is exactly what this design avoids).
+    pub async fn header_slot(&self, block_root: &[u8; 32]) -> Result<u64> {
+        let v = self
+            .get_json(&format!(
+                "/eth/v1/beacon/headers/0x{}",
+                hex::encode(block_root)
+            ))
+            .await?;
+        v["data"]["header"]["message"]["slot"]
+            .as_str()
+            .and_then(|s| s.parse::<u64>().ok())
+            .ok_or_else(|| anyhow!("headers/<root>: missing slot"))
+    }
+
     /// The chain's `genesis_validators_root` — the identity an archive is bound
     /// to, so a file collected for one network can never load for another.
     pub async fn genesis_validators_root(&self) -> Result<[u8; 32]> {

--- a/rust/roost/src/serve.rs
+++ b/rust/roost/src/serve.rs
@@ -28,6 +28,7 @@ use myotis_net::status::StatusMessage;
 
 use crate::archive::Archive;
 use crate::framing::split_updates;
+use crate::forks::ForkSchedule;
 use crate::rest::{period_of_slot, FetchError, NimbusRest, SLOTS_PER_PERIOD};
 use crate::store::LcStore;
 
@@ -42,6 +43,13 @@ const REFRESH: Duration = Duration::from_secs(12);
 /// cost here is a Noise session and a yamux stream — tens of KB — with no
 /// gossipsub mesh, no peer scoring and no per-peer computation.
 const MAX_INBOUND: u32 = 1024;
+
+/// How often to re-read the chain's fork/blob schedule, in ticks.
+///
+/// It is configuration and changes only when the upstream is upgraded — but it
+/// DOES change then (a client release can add a BPO entry), and a roost that
+/// cached it at startup would keep stamping the old digest. ~5 minutes.
+const SCHEDULE_REFRESH_TICKS: u32 = 25;
 
 /// Bootstrap misses fetched per tick. The rate limit the design asks for: a
 /// caller inventing roots costs us at most this many upstream requests per
@@ -149,6 +157,70 @@ async fn chain_view(
         head_slot,
         earliest_available_slot,
     })
+}
+
+/// Where a response's context bytes come from.
+///
+/// Computed from the chain's schedule when it is available, which is the
+/// correct answer for any slot. The observed fallback exists only so an
+/// upstream that cannot serve `/config/spec` degrades to the previous
+/// behaviour instead of taking the daemon down — it is the newest `updates`
+/// chunk's digest, which is right for the current fork and stale across a
+/// boundary.
+struct Digests {
+    schedule: Option<ForkSchedule>,
+    observed: [u8; 4],
+}
+
+impl Digests {
+    fn for_slot(&self, slot: u64) -> [u8; 4] {
+        match &self.schedule {
+            Some(s) => s.digest_for_slot(slot),
+            None => self.observed,
+        }
+    }
+
+    fn source(&self) -> &'static str {
+        if self.schedule.is_some() { "computed" } else { "observed (interim)" }
+    }
+}
+
+/// Log — loudly — when the digest we compute disagrees with one the upstream
+/// actually framed on the wire.
+///
+/// Deliberately does NOT fall back to the observed value. A disagreement has two
+/// causes and they pull in opposite directions:
+///
+/// - The schedule or the selection is wrong, in which case computed is wrong.
+/// - A fork or BPO boundary falls inside the current sync-committee period, in
+///   which case the two SHOULD differ: `observed` is the digest of that period's
+///   update, whose attested header may predate the boundary, while `computed` is
+///   for head. A period spans 256 epochs, so this is entirely possible.
+///
+/// Falling back would mean serving the stale digest during exactly the fork
+/// transition this whole module exists to handle. `computed` is derived from the
+/// chain's own configuration and is authoritative for a known slot, so it wins;
+/// the mismatch is surfaced for a human instead.
+fn report_digest_disagreement(digests: &Digests, observed: [u8; 4], head_slot: u64) {
+    if digests.schedule.is_none() {
+        return;
+    }
+    let computed = digests.for_slot(head_slot);
+    if computed != observed {
+        tracing::error!(
+            computed = %hex::encode(computed),
+            observed = %hex::encode(observed),
+            head_slot,
+            "computed fork digest disagrees with the newest digest seen on the wire — \
+             expected across a fork/BPO boundary inside the current period, otherwise a \
+             schedule bug. Serving the COMPUTED value."
+        );
+    }
+}
+
+/// Read the fork and blob schedule from the upstream.
+async fn fetch_schedule(client: &NimbusRest, gvr: [u8; 32]) -> Result<ForkSchedule> {
+    ForkSchedule::fetch(client, gvr).await
 }
 
 /// The fork digest to stamp on responses, taken from the newest update chunk.
@@ -279,7 +351,7 @@ pub async fn serve(
         Err(e) => println!("  filled    upstream probe failed: {e}; serving the archive"),
     }
 
-    let fork_digest = match resolve_fork_digest(&client, &store, head_period).await {
+    let observed = match resolve_fork_digest(&client, &store, head_period).await {
         Some(d) => d,
         None => {
             return Err(anyhow!(
@@ -288,11 +360,24 @@ pub async fn serve(
             ))
         }
     };
-    if let Err(e) = refresh_live(&client, &store, fork_digest).await {
+    let schedule = match fetch_schedule(&client, gvr).await {
+        Ok(s) => Some(s),
+        Err(e) => {
+            tracing::warn!(error = %e,
+                "could not read the fork/blob schedule — falling back to the observed digest, \
+                 which goes stale across a fork boundary; will retry");
+            None
+        }
+    };
+    let digests = Digests { schedule, observed };
+
+    report_digest_disagreement(&digests, observed, head_slot);
+
+    if let Err(e) = refresh_live(&client, &store, &digests, head_slot).await {
         tracing::warn!(error = %e, "initial live-object fetch failed; the ticker will retry");
     }
 
-    let status = LocalStatus::new(chain_view(&client, &store, fork_digest).await?);
+    let status = LocalStatus::new(chain_view(&client, &store, digests.for_slot(head_slot)).await?);
     let key_path = key_path.unwrap_or_else(|| archive_path.with_extension("key"));
     let keypair = load_or_create_key(&key_path)?;
 
@@ -315,12 +400,17 @@ pub async fn serve(
     println!("  identity  {} (persisted in {})", peer_id, key_path.display());
     println!("  multiaddr /ip4/127.0.0.1/tcp/{port}/p2p/{peer_id}");
     println!("  periods   {} ({:?}..={:?})", c.periods, c.lowest_period, c.highest_period);
-    println!("  digest    0x{} (interim)", hex::encode(fork_digest));
+    println!(
+        "  digest    0x{} ({})",
+        hex::encode(digests.for_slot(head_slot)),
+        digests.source()
+    );
     println!("  inbound   cap {MAX_INBOUND}");
     println!("\n  point a wallet at the multiaddr above; Ctrl-C to stop.\n");
 
+    let mut digests = digests;
     let mut swarm_task = swarm_task;
-    let mut fork_digest = fork_digest;
+    let mut ticks: u32 = 0;
     let mut ticker = tokio::time::interval(REFRESH);
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     loop {
@@ -348,50 +438,67 @@ pub async fn serve(
                 // degrade what we serve, never take the responder down. A stale
                 // relay surfaces to wallets as "not ready", which is the
                 // detectable failure the design accepts.
-                // Re-resolve the digest EVERY tick. It is not only context
-                // bytes: it is also `status.fork_digest`, which every peer's
-                // relevance check reads on the mandatory handshake. Held
-                // constant, a process that stays up across a fork or BPO
-                // boundary advertises the pre-fork digest indefinitely — other
-                // clients answer with Goodbye(IrrelevantNetwork), and myotis
-                // wallets filter us out on `accepted_fork_digests`, so we go
-                // invisible to exactly the clients we exist for.
-                match client.syncing().await {
-                    Ok((slot, _)) => {
-                        if let Some(d) = resolve_fork_digest(&client, &store, period_of_slot(slot)).await {
-                            if d != fork_digest {
-                                tracing::warn!(old = %hex::encode(fork_digest), new = %hex::encode(d),
-                                    "fork digest changed — fork or BPO boundary crossed");
-                                fork_digest = d;
+                ticks = ticks.wrapping_add(1);
+                let head_slot_hint = status.get().head_slot;
+
+                // Re-read the schedule periodically, and keep retrying while we
+                // are on the observed fallback. A client upgrade can add a BPO
+                // entry, and a roost that cached the schedule at startup would
+                // keep stamping the pre-BPO digest indefinitely.
+                if digests.schedule.is_none() || ticks.is_multiple_of(SCHEDULE_REFRESH_TICKS) {
+                    match fetch_schedule(&client, gvr).await {
+                        Ok(s) => {
+                            if digests.schedule.as_ref() != Some(&s) {
+                                tracing::info!("fork/blob schedule updated");
                             }
+                            digests.schedule = Some(s);
                         }
+                        Err(e) => tracing::warn!(error = %e, "re-reading the schedule failed"),
                     }
-                    Err(e) => tracing::warn!(error = %e, "polling head slot for the digest failed"),
+                    if let Some(observed) = store.newest_fork_digest() {
+                        // Re-check against the wire after every refresh, not only
+                        // at startup — otherwise a schedule rejected at boot would
+                        // be silently reinstated by the first refresh.
+                        report_digest_disagreement(&digests, observed, head_slot_hint);
+                    }
                 }
-                if let Err(e) = refresh_live(&client, &store, fork_digest).await {
+
+                let head_slot = match client.syncing().await {
+                    Ok((slot, _)) => slot,
+                    Err(e) => {
+                        tracing::warn!(error = %e, "polling head slot failed");
+                        continue;
+                    }
+                };
+
+                // status.fork_digest is not merely context bytes: it is what
+                // every peer's relevance check reads on the mandatory handshake.
+                // Computing it per tick from the head slot is what carries us
+                // across a fork or BPO boundary — held constant, other clients
+                // answer Goodbye(IrrelevantNetwork) and myotis wallets filter us
+                // out on `accepted_fork_digests`, making us invisible to exactly
+                // the clients we exist for.
+                let head_digest = digests.for_slot(head_slot);
+
+                if let Err(e) = refresh_live(&client, &store, &digests, head_slot).await {
                     tracing::warn!(error = %e, "refreshing live objects failed");
                 }
-                if let Err(e) = fill_bootstrap_misses(&client, &store, fork_digest).await {
+                if let Err(e) = fill_bootstrap_misses(&client, &store, &digests, head_slot).await {
                     tracing::warn!(error = %e, "filling bootstrap misses failed");
                 }
-                match chain_view(&client, &store, fork_digest).await {
+                match chain_view(&client, &store, head_digest).await {
                     Ok(view) => status.set(view),
                     Err(e) => tracing::warn!(error = %e, "refreshing the chain view failed"),
                 }
                 // A new period turns over every ~27 hours; checking each slot is
                 // free next to the HTTP calls above.
-                match client.syncing().await {
-                    Ok((slot, _)) => {
-                        let p = period_of_slot(slot);
-                        if !store.has_period(p) {
-                            match fill_periods(&client, &store, &mut archive, p, p).await {
-                                Ok(n) if n > 0 => tracing::info!(period = p, "archived a new period"),
-                                Ok(_) => {}
-                                Err(e) => tracing::warn!(error = %e, "filling the new period failed"),
-                            }
-                        }
+                let p = period_of_slot(head_slot);
+                if !store.has_period(p) {
+                    match fill_periods(&client, &store, &mut archive, p, p).await {
+                        Ok(n) if n > 0 => tracing::info!(period = p, "archived a new period"),
+                        Ok(_) => {}
+                        Err(e) => tracing::warn!(error = %e, "filling the new period failed"),
                     }
-                    Err(e) => tracing::warn!(error = %e, "polling head slot failed"),
                 }
             }
         }
@@ -399,20 +506,59 @@ pub async fn serve(
 }
 
 /// Refresh the per-slot objects and the checkpoint bootstrap.
-async fn refresh_live(client: &NimbusRest, store: &LcStore, fork_digest: [u8; 4]) -> Result<()> {
-    let fin = client.finality_update().await?;
-    store.set_finality(fork_digest, &fin.bytes);
-    let opt = client.optimistic_update().await?;
-    store.set_optimistic(fork_digest, &opt.bytes);
+///
+/// The per-slot objects are stamped with the digest for the HEAD slot at fetch
+/// time. roost is a byte cache and does not decode SSZ, so it cannot read the
+/// object's own attested-header slot without the light-client type modelling
+/// this design exists to avoid — and head is what these objects track, to
+/// within a slot or two. The residual error is confined to the handful of slots
+/// straddling a fork or BPO boundary, and self-corrects on the next tick because
+/// both objects are refetched every slot.
+///
+/// A BOOTSTRAP is different: it is keyed by an arbitrary root that may be far
+/// from head, so its epoch is looked up exactly.
+async fn refresh_live(
+    client: &NimbusRest,
+    store: &LcStore,
+    digests: &Digests,
+    head_slot: u64,
+) -> Result<()> {
+    let head_digest = digests.for_slot(head_slot);
 
-    // The current finalized root is pre-populated; anything else arrives through
-    // the miss queue below, which is what keeps this key space bounded.
+    let fin = client.finality_update().await?;
+    store.set_finality(head_digest, &fin.bytes);
+    let opt = client.optimistic_update().await?;
+    store.set_optimistic(head_digest, &opt.bytes);
+
     let finalized = client.finalized_root().await?;
     if store.bootstrap(&finalized).is_none() {
         let bs = client.bootstrap(&finalized).await?;
-        store.insert_bootstrap(finalized, fork_digest, &bs.bytes);
+        let digest = bootstrap_digest(client, digests, &finalized, head_slot).await;
+        store.insert_bootstrap(finalized, digest, &bs.bytes);
     }
     Ok(())
+}
+
+/// The digest for a bootstrap, from the slot of the block it anchors to.
+///
+/// A pinned checkpoint can sit many epochs behind head — potentially across a
+/// fork boundary — so stamping it with head's digest would be wrong for exactly
+/// the wallets that are furthest behind. Falls back to head only if the header
+/// lookup fails, which is strictly better than refusing to serve.
+async fn bootstrap_digest(
+    client: &NimbusRest,
+    digests: &Digests,
+    root: &[u8; 32],
+    head_slot: u64,
+) -> [u8; 4] {
+    match client.header_slot(root).await {
+        Ok(slot) => digests.for_slot(slot),
+        Err(e) => {
+            tracing::warn!(root = %hex::encode(&root[..8]), error = %e,
+                "could not resolve a bootstrap's slot — stamping it with head's digest");
+            digests.for_slot(head_slot)
+        }
+    }
 }
 
 /// Fetch bootstraps that callers asked for and we did not have.
@@ -424,13 +570,15 @@ async fn refresh_live(client: &NimbusRest, store: &LcStore, fork_digest: [u8; 4]
 async fn fill_bootstrap_misses(
     client: &NimbusRest,
     store: &LcStore,
-    fork_digest: [u8; 4],
+    digests: &Digests,
+    head_slot: u64,
 ) -> Result<usize> {
     let mut filled = 0;
     for root in store.take_bootstrap_misses(MISS_FETCHES_PER_TICK) {
         match client.bootstrap_classified(&root).await {
             Ok(bs) => {
-                store.insert_bootstrap(root, fork_digest, &bs.bytes);
+                let digest = bootstrap_digest(client, digests, &root, head_slot).await;
+                store.insert_bootstrap(root, digest, &bs.bytes);
                 filled += 1;
                 tracing::info!(root = %hex::encode(&root[..8]), bytes = bs.bytes.len(),
                     "filled a requested bootstrap");

--- a/rust/roost/src/serve.rs
+++ b/rust/roost/src/serve.rs
@@ -51,9 +51,14 @@ const MAX_INBOUND: u32 = 1024;
 /// cached it at startup would keep stamping the old digest. ~5 minutes.
 const SCHEDULE_REFRESH_TICKS: u32 = 25;
 
-/// Bootstrap misses fetched per tick. The rate limit the design asks for: a
-/// caller inventing roots costs us at most this many upstream requests per
-/// slot, no matter how fast it asks.
+/// Bootstrap misses fetched per tick — the rate limit the design asks for.
+///
+/// A caller inventing roots costs us at most this many upstream fetches per
+/// slot, no matter how fast it asks. Note each SUCCESSFUL fill is up to two
+/// loopback requests — the bootstrap itself plus the `header_slot` lookup that
+/// resolves its epoch — so the ceiling is 2x this number. Invented roots 404 on
+/// the bootstrap and never reach the header lookup, so the ABUSE ceiling is
+/// unchanged at one request each.
 const MISS_FETCHES_PER_TICK: usize = 4;
 
 /// Load a persisted identity, or create and persist one.
@@ -223,15 +228,14 @@ async fn fetch_schedule(client: &NimbusRest, gvr: [u8; 32]) -> Result<ForkSchedu
     ForkSchedule::fetch(client, gvr).await
 }
 
-/// The fork digest to stamp on responses, taken from the newest update chunk.
+/// The digest observed on the wire, from the newest update chunk.
 ///
-/// INTERIM, and the one place roost is knowingly not spec-perfect: since
-/// EIP-7892 the digest is not a function of the fork name, so it cannot be
-/// derived from `Eth-Consensus-Version`; it has to be computed for the object's
-/// slot via `fork_digest_bpo`. Re-using the newest period's digest is correct
-/// except across a fork or BPO boundary. myotis' own decoder ignores context
-/// bytes, so our wallets are unaffected; other CLs dispatch on them, which is
-/// why this must be fixed before the ENR is published.
+/// This is now the FALLBACK, used only when the chain's schedule cannot be read
+/// (see [`Digests`]); [`crate::forks::ForkSchedule`] computes the primary value
+/// for an object's own slot. It remains useful because it is ground truth for
+/// the current fork — the upstream framed it — and it is what the computed value
+/// is checked against. It is stale across a fork or BPO boundary, which is
+/// exactly why it is no longer the primary.
 async fn interim_fork_digest(client: &NimbusRest, head_period: u64) -> Result<[u8; 4]> {
     let resp = client.updates(head_period, 1).await?;
     split_updates(&resp.bytes)?
@@ -467,18 +471,26 @@ pub async fn serve(
                         Err(e) => tracing::warn!(error = %e, "re-reading the schedule failed"),
                     }
                     if let Some(observed) = store.newest_fork_digest() {
-                        // Re-check against the wire after every refresh, not only
-                        // at startup — otherwise a schedule rejected at boot would
-                        // be silently reinstated by the first refresh.
+                        // Re-check after every refresh, not only at boot, so a
+                        // schedule that STARTS disagreeing with the wire keeps
+                        // being reported rather than being noticed once and
+                        // never again.
                         report_digest_disagreement(&digests, observed, head_slot_hint);
                     }
                 }
 
+                // A failed head poll must not skip the rest of the tick: the
+                // live objects are still worth refreshing, and the last known
+                // head is good enough to pick a digest with (it only changes at
+                // an epoch boundary). Skipping was a behaviour change against
+                // the code this replaced, where a failed poll warned and carried
+                // on.
                 let head_slot = match client.syncing().await {
                     Ok((slot, _)) => slot,
                     Err(e) => {
-                        tracing::warn!(error = %e, "polling head slot failed");
-                        continue;
+                        tracing::warn!(error = %e,
+                            "polling head slot failed — continuing with the last known head");
+                        head_slot_hint
                     }
                 };
 

--- a/rust/roost/src/serve.rs
+++ b/rust/roost/src/serve.rs
@@ -450,8 +450,19 @@ pub async fn serve(
                         Ok(s) => {
                             if digests.schedule.as_ref() != Some(&s) {
                                 tracing::info!("fork/blob schedule updated");
+                                digests.schedule = Some(s);
+                                // Bootstraps are encoded once and then kept, so
+                                // any cached under the previous schedule carry
+                                // stale context bytes. The per-slot objects
+                                // refetch every tick and periods carry the
+                                // digest their source framed, so only these need
+                                // invalidating.
+                                let dropped = store.clear_bootstraps();
+                                if dropped > 0 {
+                                    tracing::info!(dropped,
+                                        "dropped cached bootstraps so they are re-stamped");
+                                }
                             }
-                            digests.schedule = Some(s);
                         }
                         Err(e) => tracing::warn!(error = %e, "re-reading the schedule failed"),
                     }
@@ -470,6 +481,24 @@ pub async fn serve(
                         continue;
                     }
                 };
+
+                // While we are on the fallback, the observed digest must keep
+                // tracking the chain. It is assigned at startup, so leaving it
+                // alone would freeze `status.fork_digest` at the boot value —
+                // and after a fork or BPO boundary every peer would drop us,
+                // which is the exact failure this module exists to prevent,
+                // reintroduced through the degraded path.
+                if digests.schedule.is_none() {
+                    if let Some(d) =
+                        resolve_fork_digest(&client, &store, period_of_slot(head_slot)).await
+                    {
+                        if d != digests.observed {
+                            tracing::warn!(old = %hex::encode(digests.observed), new = %hex::encode(d),
+                                "observed fork digest changed (no schedule available)");
+                            digests.observed = d;
+                        }
+                    }
+                }
 
                 // status.fork_digest is not merely context bytes: it is what
                 // every peer's relevance check reads on the mandatory handshake.

--- a/rust/roost/src/store.rs
+++ b/rust/roost/src/store.rs
@@ -213,6 +213,30 @@ impl LcStore {
         evicted
     }
 
+    /// Drop every cached bootstrap, so they are refetched and re-stamped.
+    ///
+    /// Called when the fork schedule changes. Bootstraps are the only objects
+    /// encoded ONCE and then kept: the per-slot objects are refetched every
+    /// tick and periods carry the digest their source framed, but a bootstrap
+    /// cached under an old schedule would keep its stale context bytes until
+    /// FIFO eviction pushed it out — potentially hours, for the pinned
+    /// checkpoint a cold wallet actually asks for.
+    ///
+    /// Clears the attempted markers with them, for the same reason eviction
+    /// does: a root that is uncached but still marked attempted is refused with
+    /// no re-fetch.
+    pub fn clear_bootstraps(&self) -> usize {
+        let mut inner = self.write();
+        let dropped = inner.bootstraps.len();
+        for root in inner.bootstrap_order.clone() {
+            inner.bootstrap_attempted.remove(&root);
+            inner.bootstrap_attempted_order.retain(|r| r != &root);
+        }
+        inner.bootstraps.clear();
+        inner.bootstrap_order.clear();
+        dropped
+    }
+
     /// Queue a root for the background filler. Returns false when the queue is
     /// full or the root was already attempted — both mean "do not fetch".
     pub fn record_bootstrap_miss(&self, root: [u8; 32]) -> bool {
@@ -555,6 +579,22 @@ mod tests {
             s.insert_bootstrap(root_n(i), D, &[1u8; 32]);
         }
         assert!(!s.record_bootstrap_miss(root), "never cached, so still blocked");
+    }
+
+    #[test]
+    fn clearing_bootstraps_makes_them_refetchable() {
+        let s = LcStore::new();
+        let root = root_n(3);
+        assert!(s.record_bootstrap_miss(root));
+        s.take_bootstrap_misses(1);
+        s.insert_bootstrap(root, D, &[1u8; 32]);
+
+        assert_eq!(s.clear_bootstraps(), 1);
+        assert!(s.bootstrap(&root).is_none());
+        assert!(
+            s.record_bootstrap_miss(root),
+            "a cleared root must be re-queued, or it is refused forever with no re-fetch"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Replaces roost's interim context bytes with a value **computed for each object's own slot**. Targets `feat/lc-server`; `main` stays untouched until roost is finished.

This is the prerequisite for ENR publication — the item both reviewers flagged on #327 as the thing that must be settled before roost faces a public address.

## The problem

Until now every fork-dependent response was stamped with the digest lifted from the newest `updates` chunk. That is right for `updates` itself (the source frames a real digest per chunk, and re-emitting it is the robust path) and an approximation everywhere else: it goes stale the moment a fork or BPO boundary is crossed.

It cannot be fixed with a fork-name table either. **Since EIP-7892 the digest is not a function of the fork name** — it folds in the active blob parameters, so one name has as many digests as it has BPO entries. `myotis-net`'s own test pins mainnet Fulu at `0x82FAE541` base against `0x8C9F62FE` with BPO2: same fork, two digests. A table built today would emit a stale value indefinitely after the next blob-parameter-only fork, while the upstream kept answering 200.

Our own decoder skips context bytes (`codec.rs`: "the payload's own fork sniffing governs decode"), so myotis wallets never noticed. Every other CL dispatches deserialization on them.

## What this adds

`forks.rs` — the schedule and the selection:

- Read from the upstream's `/eth/v1/config/spec`: fork versions, activation epochs, `SLOTS_PER_EPOCH`, `BLOB_SCHEDULE`. This is chain *configuration*, not consensus data, and taking it from the node roost already follows means roost cannot disagree with its own upstream about which fork it is on. No per-network table to drift — and `SLOTS_PER_EPOCH` from the wire is what makes gnosis's 16-slot epochs work without a special case.
- Forks are discovered by key shape (`<NAME>_FORK_VERSION` paired with `<NAME>_FORK_EPOCH`), so a fork added by a client upgrade is picked up with no code change here. An unscheduled fork parked at `u64::MAX` (GLOAS today) never activates.
- Re-read every ~5 minutes: a client upgrade can add a BPO entry, and a roost that cached the schedule at startup would keep stamping the pre-BPO digest.

Applied per object, deliberately differently:

| Object | Digest from |
|---|---|
| `updates_by_range` | unchanged — the per-chunk digest the source framed |
| `bootstrap` | the slot of the block it anchors to, resolved by root |
| `finality` / `optimistic` / `status.fork_digest` | head |

The bootstrap case is the one worth spelling out: a pinned checkpoint can sit many epochs behind head, potentially across a boundary, so stamping it with head's digest would be wrong for precisely the wallets that are furthest behind. The per-slot objects track head to within a slot or two, and roost is a byte cache — reading an object's own attested-header slot would require the light-client type modelling this design exists to avoid.

## Verification

The check that matters is against ground truth, not against my own arithmetic. `updates` is the only protocol that carries a digest on the wire, so `roost probe` computes the digest for the head slot and compares:

```
== fork digest ==
  fork      version 0x90000075 active from epoch 272640
  blobs     BPO epoch 275712, max 21 per block
  computed  0x74d01459
  on wire   0x74d01459
  MATCH     context bytes can be computed for any slot
```

Unit tests reach `myotis-net`'s pinned **mainnet** values (`0x82FAE541` base, `0x8C9F62FE` with BPO2) through the schedule rather than by calling the hash directly, so the *selection* is covered and not just the arithmetic. Also covered: each BPO boundary changes the digest and the epoch before it does not; an unscheduled fork never activates; a non-mainnet `SLOTS_PER_EPOCH`; and a spec missing or zeroing `SLOTS_PER_EPOCH` is refused rather than dividing by zero.

End to end unchanged: the wallet bootstraps and reaches SYNCED from roost alone, now reporting `digest 0x74d01459 (computed)`.

39 tests, clippy clean.

## One deliberate non-behaviour

A computed/observed disagreement is logged loudly but **not acted on**. It has two possible causes pulling opposite ways: the schedule is wrong (computed is wrong), or a boundary falls inside the current sync-committee period, in which case they *should* differ — `observed` is that period's update, whose attested header may predate the boundary, while `computed` is for head. A period spans 256 epochs, so that is entirely possible. Falling back to `observed` would mean serving the stale digest during exactly the fork transition this module exists to handle, so the computed value wins and the mismatch is surfaced for a human.

An earlier draft did fall back, and also re-enabled the schedule silently on the next refresh — caught in internal review before this was pushed.

## Still open after this

ENR publication (persisted discv5 key and sequence number, re-published at fork *and* BPO boundaries — the digest half of which this PR supplies), the back-archive below the upstream's light-client floor, and the `status.earliest_available_slot` decision deferred from #327.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYVwpfHg77oibuD2733jPj