### PR TITLE
roost: track the external address by quorum of Identify reports

### DIFF
--- a/rust/myotis-net/src/lib.rs
+++ b/rust/myotis-net/src/lib.rs
@@ -24,10 +24,12 @@
 // Re-exported so downstream crates (rust/roost) can build a `HostConfig`
 // without pinning their own libp2p version — the types in that config are
 // libp2p's, so version skew would be a confusing type error. Narrowed to the
-// two items a `HostConfig` actually needs rather than `pub use libp2p;`, which
-// would put the whole crate in this one's public surface for the sake of one
-// type.
-pub use libp2p::{identity, Multiaddr};
+// items a downstream actually needs — building a `HostConfig` (`identity`,
+// `Multiaddr`) and handling what `start_host_with` returns (`PeerId`), plus
+// `multiaddr` for constructing an address from its protocols. Deliberately not
+// `pub use libp2p;`, which would put the whole crate in this one's public
+// surface.
+pub use libp2p::{identity, multiaddr, Multiaddr, PeerId};
 
 pub mod clcache;
 pub mod codec;

--- a/rust/myotis-net/src/reqresp.rs
+++ b/rust/myotis-net/src/reqresp.rs
@@ -14,8 +14,8 @@
 //! "write nothing, just half-close" (finality/optimistic — see `requestFinalityUpdate`).
 
 use std::collections::{HashMap, HashSet};
-use std::net::IpAddr;
 use std::io;
+use std::net::IpAddr;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -519,8 +519,71 @@ pub const EXTERNAL_ADDR_QUORUM: usize = 3;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ExternalAddress {
     pub ip: IpAddr,
-    /// Distinct peers currently reporting this address.
+    /// The port reporters see, when it is meaningful — see
+    /// [`ExternalAddress::port`]'s note below.
+    ///
+    /// Populated ONLY from inbound connections, where the reporter dialed us and
+    /// their view of our port is the externally mapped one. On an outbound
+    /// connection the port they see is our ephemeral source port and says
+    /// nothing about where we listen, so it is discarded. A server that never
+    /// dials therefore gets a real answer here, which is what makes a NAT
+    /// rewriting the port detectable rather than invisible.
+    pub port: Option<u16>,
+    /// Distinct reporters behind the winning address.
     pub confirmations: usize,
+    /// Total distinct reporters. The denominator `confirmations` is out of —
+    /// without it a consumer cannot tell 3-of-3 from 3-of-200, nor implement a
+    /// majority rule without a second, racing round-trip.
+    pub reporters: usize,
+    /// Whether the winner is an address that could actually be reached from the
+    /// public internet. See [`is_routable`].
+    pub routable: bool,
+}
+
+impl ExternalAddress {
+    /// Whether the winner failed to clear half the reporters.
+    ///
+    /// A near-even split is the shape both a Sybil and a genuine mid-flight
+    /// address change produce, and the tie-break makes each CALL deterministic
+    /// without making the SEQUENCE stable — one more reporter can flip the
+    /// winner. A consumer that publishes a record should wait rather than act on
+    /// a contested answer.
+    pub fn is_contested(&self) -> bool {
+        self.confirmations * 2 <= self.reporters
+    }
+}
+
+/// Whether an address could be reached from the public internet.
+///
+/// `IpAddr::is_global()` is still unstable on the pinned toolchain, so the
+/// classes are spelled out. This exists because the mechanism will happily
+/// establish `127.0.0.1` or `192.168.x.x` — a couple of wallets on the same LAN
+/// can reach quorum before any internet peer does — and a record carrying a
+/// non-routable IP fails in exactly the way publishing an address is meant to
+/// prevent.
+pub fn is_routable(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            !(v4.is_loopback()
+                || v4.is_private()
+                || v4.is_link_local()
+                || v4.is_unspecified()
+                || v4.is_broadcast()
+                || v4.is_documentation()
+                || v4.is_multicast()
+                // 100.64.0.0/10, carrier-grade NAT — routable-looking, not reachable.
+                || (v4.octets()[0] == 100 && (64..128).contains(&v4.octets()[1])))
+        }
+        IpAddr::V6(v6) => {
+            !(v6.is_loopback()
+                || v6.is_unspecified()
+                || v6.is_multicast()
+                // fc00::/7 unique-local
+                || (v6.octets()[0] & 0xfe) == 0xfc
+                // fe80::/10 link-local
+                || (v6.octets()[0] == 0xfe && (v6.octets()[1] & 0xc0) == 0x80))
+        }
+    }
 }
 
 /// Extract the IP from a libp2p multiaddr.
@@ -536,6 +599,23 @@ fn multiaddr_ip(addr: &Multiaddr) -> Option<IpAddr> {
         Protocol::Ip6(v6) => Some(IpAddr::V6(v6)),
         _ => None,
     })
+}
+
+fn multiaddr_port(addr: &Multiaddr) -> Option<u16> {
+    use libp2p::multiaddr::Protocol;
+    addr.iter().find_map(|p| match p {
+        Protocol::Tcp(port) => Some(port),
+        _ => None,
+    })
+}
+
+/// One peer's report: where they reached us from, and what they see us as.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Observation {
+    source: IpAddr,
+    ip: IpAddr,
+    /// Only set for inbound connections — see [`ExternalAddress::port`].
+    port: Option<u16>,
 }
 
 /// A source of pre-encoded light-client responses.
@@ -688,10 +768,16 @@ struct SwarmCtx {
     /// wrong entry: the budget leaks until everything is refused.
     in_flight: HashMap<(&'static str, InboundRequestId), usize>,
     in_flight_bytes: usize,
-    /// The address each connected peer reports seeing us on, ONE entry per peer
-    /// so a single peer cannot stuff the ballot by reconnecting. Dropped with
-    /// the connection, so this is bounded by the connected set.
-    observed_ips: HashMap<PeerId, IpAddr>,
+    /// Per connected peer: (the address WE see them coming from, the address
+    /// THEY report seeing us on).
+    ///
+    /// The tally dedupes on the first element, not on the peer id — see
+    /// [`external_address`]. Dropped with the connection, so this is bounded by
+    /// the connected set.
+    observed_ips: HashMap<PeerId, Observation>,
+    /// Source address per peer plus whether THEY dialed US, learned at
+    /// connection time and needed before their Identify arrives.
+    peer_source_ips: HashMap<PeerId, (IpAddr, bool)>,
 }
 
 async fn run_swarm(
@@ -712,6 +798,7 @@ async fn run_swarm(
         in_flight: HashMap::new(),
         in_flight_bytes: 0,
         observed_ips: HashMap::new(),
+        peer_source_ips: HashMap::new(),
     };
     loop {
         tokio::select! {
@@ -834,6 +921,12 @@ fn mark_status_done(swarm: &mut Swarm<Behaviour>, ctx: &mut SwarmCtx, peer: Peer
 fn handle_swarm_event(swarm: &mut Swarm<Behaviour>, ctx: &mut SwarmCtx, event: SwarmEvent<BehaviourEvent>) {
     match event {
         SwarmEvent::ConnectionEstablished { peer_id, endpoint, .. } => {
+            // Remember where this peer reached us from: the external-address
+            // tally dedupes on it, so a host cannot vote more than once by
+            // minting extra peer ids.
+            if let Some(ip) = multiaddr_ip(endpoint.get_remote_address()) {
+                ctx.peer_source_ips.insert(peer_id, (ip, endpoint.is_listener()));
+            }
             let newly = ctx.connected.insert(peer_id);
             tracing::debug!(peer = %peer_id, remote = %endpoint.get_remote_address(),
                 "connection established");
@@ -858,6 +951,7 @@ fn handle_swarm_event(swarm: &mut Swarm<Behaviour>, ctx: &mut SwarmCtx, event: S
                 ctx.lc_servers.remove(&peer_id);
                 ctx.peer_earliest.remove(&peer_id);
                 ctx.observed_ips.remove(&peer_id);
+                ctx.peer_source_ips.remove(&peer_id);
                 fail_queued(ctx, &peer_id, RequestError::ConnectionClosed);
                 tracing::debug!(peer = %peer_id, "connection closed");
             }
@@ -885,8 +979,15 @@ fn handle_behaviour_event(swarm: &mut Swarm<Behaviour>, ctx: &mut SwarmCtx, even
             if lc {
                 ctx.lc_servers.insert(peer_id);
             }
-            if let Some(ip) = multiaddr_ip(&info.observed_addr) {
-                ctx.observed_ips.insert(peer_id, ip);
+            if let (Some(ip), Some((source, inbound))) = (
+                multiaddr_ip(&info.observed_addr),
+                ctx.peer_source_ips.get(&peer_id).copied(),
+            ) {
+                // The port is only meaningful when THEY dialed US: then what
+                // they see is our externally mapped port. On a connection we
+                // dialed it is our ephemeral source port.
+                let port = inbound.then(|| multiaddr_port(&info.observed_addr)).flatten();
+                ctx.observed_ips.insert(peer_id, Observation { source, ip, port });
             }
             tracing::debug!(peer = %peer_id, agent = %info.agent_version,
                 protocols = info.protocols.len(), lc_updates = lc, "identify received");
@@ -1166,16 +1267,37 @@ fn respond_inbound(ctx: &SwarmCtx, protocol: &'static str, peer: PeerId, raw: &[
     }
 }
 
-/// The address a quorum of distinct peers agrees on.
+/// The address a quorum of distinct SOURCES agrees on.
 ///
 /// Plurality among reports, then a floor: the winner must have at least
-/// [`EXTERNAL_ADDR_QUORUM`] distinct peers behind it. Below that we return
+/// [`EXTERNAL_ADDR_QUORUM`] distinct reporters behind it. Below that we return
 /// `None` rather than the leading candidate — "I do not know yet" is the honest
 /// answer for a server with few connections, and publishing a guess is how a
 /// record ends up pointing at an address nothing answers on.
-fn external_address(observed: &HashMap<PeerId, IpAddr>) -> Option<ExternalAddress> {
+///
+/// # Reporters are counted by source address, not by peer id
+///
+/// A peer id is a self-minted keypair that costs nothing, so counting distinct
+/// ids would let ONE host reach quorum alone with three fresh identities —
+/// out-voting every honest reporter whenever the honest set is small, which is
+/// precisely the state just after a restart, when the answer first settles.
+/// Deduping on the address the reporter reached us from raises that cost from
+/// "generate three keypairs" to "hold three distinct addresses".
+///
+/// Honest peers behind one NAT now count once between them. That makes quorum
+/// HARDER to reach, which is the safe direction for a value that will drive a
+/// published record: the failure mode becomes "we decline to claim an address",
+/// not "we claim the wrong one".
+fn external_address(observed: &HashMap<PeerId, Observation>) -> Option<ExternalAddress> {
+    // One vote per source address. A source reporting different values across
+    // its own connections collapses to one of them, which is the point.
+    let mut by_source: HashMap<IpAddr, (IpAddr, Option<u16>)> = HashMap::new();
+    for o in observed.values() {
+        by_source.insert(o.source, (o.ip, o.port));
+    }
+    let reporters = by_source.len();
     let mut counts: HashMap<IpAddr, usize> = HashMap::new();
-    for ip in observed.values() {
+    for (ip, _) in by_source.values() {
         *counts.entry(*ip).or_insert(0) += 1;
     }
     // Ties break on the IP itself, so the answer is deterministic rather than
@@ -1184,7 +1306,21 @@ fn external_address(observed: &HashMap<PeerId, IpAddr>) -> Option<ExternalAddres
     let (ip, confirmations) = counts
         .into_iter()
         .max_by(|a, b| a.1.cmp(&b.1).then_with(|| b.0.cmp(&a.0)))?;
-    (confirmations >= EXTERNAL_ADDR_QUORUM).then_some(ExternalAddress { ip, confirmations })
+    // The port agreed by the reporters who back the winning IP. Inbound-only,
+    // so a server that never dials gets a real answer and one that does gets
+    // None rather than an ephemeral port.
+    let port = by_source
+        .values()
+        .filter(|(seen, _)| *seen == ip)
+        .find_map(|(_, port)| *port);
+
+    (confirmations >= EXTERNAL_ADDR_QUORUM).then_some(ExternalAddress {
+        ip,
+        port,
+        confirmations,
+        reporters,
+        routable: is_routable(ip),
+    })
 }
 
 fn release_in_flight(ctx: &mut SwarmCtx, protocol: &'static str, request_id: InboundRequestId) {
@@ -1217,11 +1353,20 @@ mod external_address_tests {
         IpAddr::V4(Ipv4Addr::new(87, 154, 209, last))
     }
 
+    /// A report from a distinct host: source address `src`, seeing us as `seen`.
+    fn obs(src: u8, seen: IpAddr) -> Observation {
+        Observation {
+            source: IpAddr::V4(Ipv4Addr::new(10, 0, 0, src)),
+            ip: seen,
+            port: None,
+        }
+    }
+
     #[test]
     fn below_quorum_is_none_not_a_best_guess() {
         let mut observed = HashMap::new();
-        for i in 0..(EXTERNAL_ADDR_QUORUM - 1) {
-            observed.insert(peer(i as u8), ip(161));
+        for i in 0..(EXTERNAL_ADDR_QUORUM - 1) as u8 {
+            observed.insert(peer(i), obs(i, ip(161)));
         }
         assert_eq!(
             external_address(&observed),
@@ -1233,12 +1378,15 @@ mod external_address_tests {
     #[test]
     fn quorum_is_believed() {
         let mut observed = HashMap::new();
-        for i in 0..EXTERNAL_ADDR_QUORUM {
-            observed.insert(peer(i as u8), ip(161));
+        for i in 0..EXTERNAL_ADDR_QUORUM as u8 {
+            observed.insert(peer(i), obs(i, ip(161)));
         }
         let got = external_address(&observed).unwrap();
         assert_eq!(got.ip, ip(161));
         assert_eq!(got.confirmations, EXTERNAL_ADDR_QUORUM);
+        assert_eq!(got.reporters, EXTERNAL_ADDR_QUORUM);
+        assert!(got.routable);
+        assert!(!got.is_contested());
     }
 
     #[test]
@@ -1247,12 +1395,15 @@ mod external_address_tests {
         // honestly wrong behind the same NAT — must not win.
         let mut observed = HashMap::new();
         for i in 0..5u8 {
-            observed.insert(peer(i), ip(161));
+            observed.insert(peer(i), obs(i, ip(161)));
         }
         for i in 5..7u8 {
-            observed.insert(peer(i), ip(99));
+            observed.insert(peer(i), obs(i, ip(99)));
         }
-        assert_eq!(external_address(&observed).unwrap().ip, ip(161));
+        let got = external_address(&observed).unwrap();
+        assert_eq!(got.ip, ip(161));
+        assert_eq!(got.reporters, 7, "the denominator must be visible");
+        assert!(!got.is_contested(), "5 of 7 is not contested");
     }
 
     #[test]
@@ -1262,7 +1413,7 @@ mod external_address_tests {
         let mut observed = HashMap::new();
         let loud = peer(1);
         for _ in 0..10 {
-            observed.insert(loud, ip(99));
+            observed.insert(loud, obs(1, ip(99)));
         }
         assert_eq!(external_address(&observed), None, "one peer is not a quorum");
     }
@@ -1273,15 +1424,105 @@ mod external_address_tests {
         // flapping address — the thing this mechanism exists to detect.
         let mut observed = HashMap::new();
         for i in 0..EXTERNAL_ADDR_QUORUM as u8 {
-            observed.insert(peer(i), ip(1));
+            observed.insert(peer(i), obs(i, ip(1)));
         }
         for i in 0..EXTERNAL_ADDR_QUORUM as u8 {
-            observed.insert(peer(i + 50), ip(2));
+            observed.insert(peer(i + 50), obs(i + 50, ip(2)));
         }
         let first = external_address(&observed).unwrap().ip;
         for _ in 0..20 {
             assert_eq!(external_address(&observed).unwrap().ip, first);
         }
+    }
+
+    #[test]
+    fn one_host_cannot_stuff_the_ballot_with_free_keypairs() {
+        // The property the ENR actually needs. A peer id is a self-minted
+        // keypair costing nothing, so counting distinct IDS would let one
+        // machine reach quorum alone — most easily right after a restart, when
+        // the honest set is smallest and the answer first settles.
+        let mut observed = HashMap::new();
+        for i in 0..10u8 {
+            // Ten identities, ONE source address.
+            observed.insert(peer(i), obs(7, ip(99)));
+        }
+        assert_eq!(
+            external_address(&observed),
+            None,
+            "ten identities behind one address are one reporter"
+        );
+    }
+
+    #[test]
+    fn a_contested_plurality_is_flagged() {
+        // 3-vs-3 must not read as an established address: one more reporter
+        // flips the winner, and that is the shape both a Sybil and a genuine
+        // mid-flight address change produce.
+        let mut observed = HashMap::new();
+        for i in 0..3u8 {
+            observed.insert(peer(i), obs(i, ip(1)));
+        }
+        for i in 3..6u8 {
+            observed.insert(peer(i), obs(i, ip(2)));
+        }
+        let got = external_address(&observed).unwrap();
+        assert_eq!(got.reporters, 6);
+        assert_eq!(got.confirmations, 3);
+        assert!(got.is_contested(), "3 of 6 is contested");
+    }
+
+    #[test]
+    fn non_routable_winners_are_labelled() {
+        // The PR's own verification established 127.0.0.1 from three loopback
+        // wallets. The realistic version is RFC1918: LAN wallets reach quorum
+        // before internet peers do.
+        for addr in [
+            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            IpAddr::V4(Ipv4Addr::new(192, 168, 1, 5)),
+            IpAddr::V4(Ipv4Addr::new(10, 1, 2, 3)),
+            IpAddr::V4(Ipv4Addr::new(172, 16, 0, 1)),
+            IpAddr::V4(Ipv4Addr::new(169, 254, 1, 1)),
+            IpAddr::V4(Ipv4Addr::new(100, 64, 0, 1)), // carrier-grade NAT
+            IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
+        ] {
+            assert!(!is_routable(addr), "{addr} must not read as routable");
+        }
+        assert!(is_routable(ip(161)), "the pinned deployment's address is routable");
+        assert!(!is_routable("fd00::1".parse().unwrap()), "ULA");
+        assert!(!is_routable("fe80::1".parse().unwrap()), "link-local");
+        assert!(!is_routable("::1".parse().unwrap()), "v6 loopback");
+        assert!(is_routable("2001:db8::1".parse().unwrap()));
+
+        let mut observed = HashMap::new();
+        for i in 0..EXTERNAL_ADDR_QUORUM as u8 {
+            observed.insert(peer(i), obs(i, IpAddr::V4(Ipv4Addr::new(192, 168, 1, 5))));
+        }
+        assert!(!external_address(&observed).unwrap().routable);
+    }
+
+    #[test]
+    fn the_port_is_carried_only_from_inbound_reports() {
+        // Inbound: the reporter dialed us, so what they see IS our externally
+        // mapped port — the fact that makes a NAT rewriting it detectable.
+        let mut observed = HashMap::new();
+        for i in 0..EXTERNAL_ADDR_QUORUM as u8 {
+            observed.insert(
+                peer(i),
+                Observation {
+                    source: IpAddr::V4(Ipv4Addr::new(10, 0, 0, i)),
+                    ip: ip(161),
+                    port: Some(9105),
+                },
+            );
+        }
+        assert_eq!(external_address(&observed).unwrap().port, Some(9105));
+
+        // Outbound-only reports carry no port rather than an ephemeral one.
+        let mut outbound = HashMap::new();
+        for i in 0..EXTERNAL_ADDR_QUORUM as u8 {
+            outbound.insert(peer(i), obs(i, ip(161)));
+        }
+        assert_eq!(external_address(&outbound).unwrap().port, None);
     }
 
     #[test]
@@ -1295,5 +1536,6 @@ mod external_address_tests {
         assert!(multiaddr_ip(&addr6).is_some());
         let no_ip: Multiaddr = "/dns4/example.com/tcp/9105".parse().unwrap();
         assert_eq!(multiaddr_ip(&no_ip), None);
+        assert_eq!(multiaddr_port(&addr), Some(54321));
     }
 }

--- a/rust/myotis-net/src/reqresp.rs
+++ b/rust/myotis-net/src/reqresp.rs
@@ -14,6 +14,7 @@
 //! "write nothing, just half-close" (finality/optimistic — see `requestFinalityUpdate`).
 
 use std::collections::{HashMap, HashSet};
+use std::net::IpAddr;
 use std::io;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -382,6 +383,10 @@ enum Command {
     LcServers {
         reply: oneshot::Sender<HashSet<PeerId>>,
     },
+    /// The externally observed address, once EXTERNAL_ADDR_QUORUM peers agree.
+    ExternalAddress {
+        reply: oneshot::Sender<Option<ExternalAddress>>,
+    },
     /// One snapshot of both catch-up peer-selection inputs — the LC-server set
     /// and the per-peer `earliest_available_slot` map — so a round fetches them
     /// in a single swarm round-trip instead of two.
@@ -415,6 +420,21 @@ impl ReqRespClient {
             .await
             .map_err(|_| RequestError::Shutdown)?;
         rx.await.map_err(|_| RequestError::Shutdown)?
+    }
+
+    /// The address peers say they see us on, once at least
+    /// [`EXTERNAL_ADDR_QUORUM`] distinct peers agree on it.
+    ///
+    /// `None` until enough peers have reported — which is the honest answer, not
+    /// a failure: a server with too few connections genuinely does not know its
+    /// own address, and acting on a guess is how a published record ends up
+    /// pointing somewhere dead.
+    pub async fn external_address(&self) -> Option<ExternalAddress> {
+        let (reply, rx) = oneshot::channel();
+        if self.tx.send(Command::ExternalAddress { reply }).await.is_err() {
+            return None;
+        }
+        rx.await.ok().flatten()
     }
 
     pub async fn connected_peer_count(&self) -> usize {
@@ -469,6 +489,53 @@ impl LocalStatus {
     pub fn get(&self) -> StatusMessage {
         self.inner.lock().expect("status lock").clone()
     }
+}
+
+/// How many DISTINCT peers must report the same address before it is believed.
+///
+/// One peer's `observed_addr` is not evidence: it can lie, and a peer behind the
+/// same NAT can be honestly wrong. This is the same reasoning discv5's endpoint
+/// prediction uses, and the reason Geth's `--nat stun` and Nimbus's
+/// `--enr-auto-update` do not act on a single report.
+///
+/// # What this is not
+///
+/// A floor against accident, **not** a defence against a determined Sybil. The
+/// answer is a plurality among connected peers, so an attacker who can hold more
+/// simultaneous connections than the honest peers reporting the true address can
+/// move it. That is tolerable while the result is only logged; before it drives
+/// a PUBLISHED ENR it wants at least one of:
+///
+/// - a majority of currently connected peers rather than a fixed floor,
+/// - cross-checking against discv5's own endpoint prediction, which is a
+///   different peer set reached over a different transport, or
+/// - refusing to act on a change until it survives several rounds.
+///
+/// The cost of getting it wrong is reachability, not correctness: a wrong
+/// address makes us undialable, it cannot make a wallet accept bad data.
+pub const EXTERNAL_ADDR_QUORUM: usize = 3;
+
+/// The address other peers say they see us on, once enough of them agree.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ExternalAddress {
+    pub ip: IpAddr,
+    /// Distinct peers currently reporting this address.
+    pub confirmations: usize,
+}
+
+/// Extract the IP from a libp2p multiaddr.
+///
+/// Only the IP is meaningful. Identify reports the remote address of the
+/// connection as the reporter sees it, so for a connection WE dialed that is our
+/// source IP with an ephemeral port — the port says nothing about where we
+/// listen. Callers pair the IP with their own configured listen port.
+fn multiaddr_ip(addr: &Multiaddr) -> Option<IpAddr> {
+    use libp2p::multiaddr::Protocol;
+    addr.iter().find_map(|p| match p {
+        Protocol::Ip4(v4) => Some(IpAddr::V4(v4)),
+        Protocol::Ip6(v6) => Some(IpAddr::V6(v6)),
+        _ => None,
+    })
 }
 
 /// A source of pre-encoded light-client responses.
@@ -621,6 +688,10 @@ struct SwarmCtx {
     /// wrong entry: the budget leaks until everything is refused.
     in_flight: HashMap<(&'static str, InboundRequestId), usize>,
     in_flight_bytes: usize,
+    /// The address each connected peer reports seeing us on, ONE entry per peer
+    /// so a single peer cannot stuff the ballot by reconnecting. Dropped with
+    /// the connection, so this is bounded by the connected set.
+    observed_ips: HashMap<PeerId, IpAddr>,
 }
 
 async fn run_swarm(
@@ -640,6 +711,7 @@ async fn run_swarm(
         lc,
         in_flight: HashMap::new(),
         in_flight_bytes: 0,
+        observed_ips: HashMap::new(),
     };
     loop {
         tokio::select! {
@@ -666,6 +738,9 @@ async fn run_swarm(
                 }
                 Some(Command::LcServers { reply }) => {
                     let _ = reply.send(ctx.lc_servers.clone());
+                }
+                Some(Command::ExternalAddress { reply }) => {
+                    let _ = reply.send(external_address(&ctx.observed_ips));
                 }
                 Some(Command::CatchupMeta { reply }) => {
                     let _ = reply.send((ctx.lc_servers.clone(), ctx.peer_earliest.clone()));
@@ -782,6 +857,7 @@ fn handle_swarm_event(swarm: &mut Swarm<Behaviour>, ctx: &mut SwarmCtx, event: S
                 ctx.status_done.remove(&peer_id);
                 ctx.lc_servers.remove(&peer_id);
                 ctx.peer_earliest.remove(&peer_id);
+                ctx.observed_ips.remove(&peer_id);
                 fail_queued(ctx, &peer_id, RequestError::ConnectionClosed);
                 tracing::debug!(peer = %peer_id, "connection closed");
             }
@@ -808,6 +884,9 @@ fn handle_behaviour_event(swarm: &mut Swarm<Behaviour>, ctx: &mut SwarmCtx, even
                 .any(|p| p.as_ref().contains("light_client_updates_by_range"));
             if lc {
                 ctx.lc_servers.insert(peer_id);
+            }
+            if let Some(ip) = multiaddr_ip(&info.observed_addr) {
+                ctx.observed_ips.insert(peer_id, ip);
             }
             tracing::debug!(peer = %peer_id, agent = %info.agent_version,
                 protocols = info.protocols.len(), lc_updates = lc, "identify received");
@@ -1087,6 +1166,27 @@ fn respond_inbound(ctx: &SwarmCtx, protocol: &'static str, peer: PeerId, raw: &[
     }
 }
 
+/// The address a quorum of distinct peers agrees on.
+///
+/// Plurality among reports, then a floor: the winner must have at least
+/// [`EXTERNAL_ADDR_QUORUM`] distinct peers behind it. Below that we return
+/// `None` rather than the leading candidate — "I do not know yet" is the honest
+/// answer for a server with few connections, and publishing a guess is how a
+/// record ends up pointing at an address nothing answers on.
+fn external_address(observed: &HashMap<PeerId, IpAddr>) -> Option<ExternalAddress> {
+    let mut counts: HashMap<IpAddr, usize> = HashMap::new();
+    for ip in observed.values() {
+        *counts.entry(*ip).or_insert(0) += 1;
+    }
+    // Ties break on the IP itself, so the answer is deterministic rather than
+    // dependent on hash iteration order — a flapping answer would look exactly
+    // like a flapping address.
+    let (ip, confirmations) = counts
+        .into_iter()
+        .max_by(|a, b| a.1.cmp(&b.1).then_with(|| b.0.cmp(&a.0)))?;
+    (confirmations >= EXTERNAL_ADDR_QUORUM).then_some(ExternalAddress { ip, confirmations })
+}
+
 fn release_in_flight(ctx: &mut SwarmCtx, protocol: &'static str, request_id: InboundRequestId) {
     if let Some(bytes) = ctx.in_flight.remove(&(protocol, request_id)) {
         ctx.in_flight_bytes = ctx.in_flight_bytes.saturating_sub(bytes);
@@ -1097,4 +1197,103 @@ fn release_in_flight(ctx: &mut SwarmCtx, protocol: &'static str, request_id: Inb
 /// handler correct rather than a shortcut.
 fn resource_unavailable() -> Vec<u8> {
     codec::encode_error_response(codec::RESULT_RESOURCE_UNAVAILABLE, "ResourceUnavailable")
+}
+
+#[cfg(test)]
+mod external_address_tests {
+    use super::*;
+    use std::net::Ipv4Addr;
+
+    /// Deterministic distinct peer ids — a seeded key, not a random one, so a
+    /// failure reproduces.
+    fn peer(n: u8) -> PeerId {
+        let mut seed = [0u8; 32];
+        seed[0] = n;
+        let kp = libp2p::identity::Keypair::ed25519_from_bytes(seed).expect("seeded key");
+        PeerId::from(kp.public())
+    }
+
+    fn ip(last: u8) -> IpAddr {
+        IpAddr::V4(Ipv4Addr::new(87, 154, 209, last))
+    }
+
+    #[test]
+    fn below_quorum_is_none_not_a_best_guess() {
+        let mut observed = HashMap::new();
+        for i in 0..(EXTERNAL_ADDR_QUORUM - 1) {
+            observed.insert(peer(i as u8), ip(161));
+        }
+        assert_eq!(
+            external_address(&observed),
+            None,
+            "a server with too few reports genuinely does not know its own address"
+        );
+    }
+
+    #[test]
+    fn quorum_is_believed() {
+        let mut observed = HashMap::new();
+        for i in 0..EXTERNAL_ADDR_QUORUM {
+            observed.insert(peer(i as u8), ip(161));
+        }
+        let got = external_address(&observed).unwrap();
+        assert_eq!(got.ip, ip(161));
+        assert_eq!(got.confirmations, EXTERNAL_ADDR_QUORUM);
+    }
+
+    #[test]
+    fn a_minority_cannot_move_the_answer() {
+        // The point of the quorum: peers claiming something else — lying, or
+        // honestly wrong behind the same NAT — must not win.
+        let mut observed = HashMap::new();
+        for i in 0..5u8 {
+            observed.insert(peer(i), ip(161));
+        }
+        for i in 5..7u8 {
+            observed.insert(peer(i), ip(99));
+        }
+        assert_eq!(external_address(&observed).unwrap().ip, ip(161));
+    }
+
+    #[test]
+    fn one_peer_cannot_stuff_the_ballot() {
+        // Keyed by peer, so repeated reports from one peer replace rather than
+        // accumulate.
+        let mut observed = HashMap::new();
+        let loud = peer(1);
+        for _ in 0..10 {
+            observed.insert(loud, ip(99));
+        }
+        assert_eq!(external_address(&observed), None, "one peer is not a quorum");
+    }
+
+    #[test]
+    fn the_answer_is_deterministic_under_a_tie() {
+        // A tie resolved by hash iteration order would look exactly like a
+        // flapping address — the thing this mechanism exists to detect.
+        let mut observed = HashMap::new();
+        for i in 0..EXTERNAL_ADDR_QUORUM as u8 {
+            observed.insert(peer(i), ip(1));
+        }
+        for i in 0..EXTERNAL_ADDR_QUORUM as u8 {
+            observed.insert(peer(i + 50), ip(2));
+        }
+        let first = external_address(&observed).unwrap().ip;
+        for _ in 0..20 {
+            assert_eq!(external_address(&observed).unwrap().ip, first);
+        }
+    }
+
+    #[test]
+    fn extracts_the_ip_and_ignores_the_port() {
+        // Identify reports the connection's remote address, so for a connection
+        // WE dialed the port is our ephemeral source port and says nothing about
+        // where we listen.
+        let addr: Multiaddr = "/ip4/87.154.209.161/tcp/54321".parse().unwrap();
+        assert_eq!(multiaddr_ip(&addr), Some(ip(161)));
+        let addr6: Multiaddr = "/ip6/::1/tcp/9105".parse().unwrap();
+        assert!(multiaddr_ip(&addr6).is_some());
+        let no_ip: Multiaddr = "/dns4/example.com/tcp/9105".parse().unwrap();
+        assert_eq!(multiaddr_ip(&no_ip), None);
+    }
 }

--- a/rust/roost/README.md
+++ b/rust/roost/README.md
@@ -46,6 +46,11 @@ limits.
 - `roost serve` — the server itself. A myotis wallet bootstraps and stays synced
   from it alone (verified on sepolia with discovery disabled).
 
+roost tracks the address peers say they see it on, by quorum of libp2p Identify
+reports, and logs a change loudly. Nothing is published from it yet — it is the
+input the ENR will need, on a deployment whose public IP is not guaranteed
+stable.
+
 Not built yet: **ENR publication** (persisted discv5 key and sequence number,
 re-published at fork *and* BPO boundaries) and the **back-archive** below the
 upstream node's light-client floor. Those are what stand between this and the

--- a/rust/roost/src/serve.rs
+++ b/rust/roost/src/serve.rs
@@ -23,9 +23,11 @@ use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
 use myotis_net::identity::Keypair;
+use myotis_net::multiaddr::Protocol;
 use myotis_net::reqresp::{
     start_host_with, ExternalAddress, HostConfig, LocalStatus, EXTERNAL_ADDR_QUORUM,
 };
+use myotis_net::Multiaddr;
 use myotis_net::status::StatusMessage;
 
 use crate::archive::Archive;
@@ -225,6 +227,22 @@ fn report_digest_disagreement(digests: &Digests, observed: [u8; 4], head_slot: u
     }
 }
 
+/// Build the multiaddr an operator would dial.
+///
+/// Constructed from `Protocol::from(ip)` rather than formatted with a hardcoded
+/// `/ip4/`, which would emit an unparseable `/ip4/2001:db8::1/...` the moment an
+/// observation is IPv6 — in the one line someone would copy to test reachability.
+/// Not reachable today (the listener is v4-only and roost never dials), which is
+/// exactly why it is cheap to make impossible now.
+fn dialable(seen: &ExternalAddress, listen_port: u16, peer_id: myotis_net::PeerId) -> Multiaddr {
+    Multiaddr::empty()
+        .with(Protocol::from(seen.ip))
+        // The observed port when reporters supplied one (inbound connections
+        // see our externally mapped port); otherwise what we asked to listen on.
+        .with(Protocol::Tcp(seen.port.unwrap_or(listen_port)))
+        .with(Protocol::P2p(peer_id))
+}
+
 /// Read the fork and blob schedule from the upstream.
 async fn fetch_schedule(client: &NimbusRest, gvr: [u8; 32]) -> Result<ForkSchedule> {
     ForkSchedule::fetch(client, gvr).await
@@ -416,7 +434,7 @@ pub async fn serve(
         digests.source()
     );
     println!("  inbound   cap {MAX_INBOUND}");
-    println!("\n  point a wallet at the multiaddr above; Ctrl-C to stop.\n");
+    println!("\n  point a wallet at the loopback address above; Ctrl-C to stop.\n");
 
     let mut digests = digests;
     let mut external: Option<ExternalAddress> = None;
@@ -563,27 +581,48 @@ pub async fn serve(
                 // keeping the last known answer beats oscillating to "unknown"
                 // every time a peer disconnects.
                 if let Some(seen) = net.external_address().await {
-                    match external {
+                    let advertised = dialable(&seen, port, peer_id);
+                    let changed = external.map(|p: ExternalAddress| p.ip != seen.ip);
+                    match changed {
                         None => {
-                            tracing::info!(
-                                ip = %seen.ip, confirmations = seen.confirmations,
-                                multiaddr = %format!("/ip4/{}/tcp/{}/p2p/{}", seen.ip, port, peer_id),
-                                "external address established"
-                            );
+                            // First settle. Say plainly whether this is an
+                            // address anything outside could dial: a couple of
+                            // wallets on the same LAN can reach quorum before a
+                            // single internet peer does, and an ENR carrying an
+                            // RFC1918 address fails exactly the way publishing
+                            // an address is meant to prevent.
+                            if seen.routable && !seen.is_contested() {
+                                tracing::info!(
+                                    ip = %seen.ip, port = ?seen.port,
+                                    confirmations = seen.confirmations, reporters = seen.reporters,
+                                    multiaddr = %advertised, "external address established"
+                                );
+                            } else {
+                                tracing::warn!(
+                                    ip = %seen.ip, routable = seen.routable,
+                                    contested = seen.is_contested(),
+                                    confirmations = seen.confirmations, reporters = seen.reporters,
+                                    multiaddr = %advertised,
+                                    "external address seen but NOT usable for publication — \
+                                     non-routable and/or contested; treating it as provisional"
+                                );
+                            }
                             external = Some(seen);
                         }
-                        Some(prev) if prev.ip != seen.ip => {
+                        Some(true) => {
                             tracing::warn!(
-                                old = %prev.ip, new = %seen.ip,
-                                confirmations = seen.confirmations,
-                                multiaddr = %format!("/ip4/{}/tcp/{}/p2p/{}", seen.ip, port, peer_id),
+                                old = %external.map(|p| p.ip.to_string()).unwrap_or_default(),
+                                new = %seen.ip, routable = seen.routable,
+                                contested = seen.is_contested(),
+                                confirmations = seen.confirmations, reporters = seen.reporters,
+                                multiaddr = %advertised,
                                 "EXTERNAL ADDRESS CHANGED — anything pinning the old one is now \
                                  dialling a dead address; the ENR will need re-publishing with a \
                                  bumped sequence number once it exists"
                             );
                             external = Some(seen);
                         }
-                        Some(_) => external = Some(seen),
+                        Some(false) => external = Some(seen),
                     }
                 }
 

--- a/rust/roost/src/serve.rs
+++ b/rust/roost/src/serve.rs
@@ -23,7 +23,9 @@ use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
 use myotis_net::identity::Keypair;
-use myotis_net::reqresp::{start_host_with, HostConfig, LocalStatus};
+use myotis_net::reqresp::{
+    start_host_with, ExternalAddress, HostConfig, LocalStatus, EXTERNAL_ADDR_QUORUM,
+};
 use myotis_net::status::StatusMessage;
 
 use crate::archive::Archive;
@@ -388,7 +390,7 @@ pub async fn serve(
     let listen = format!("/ip4/0.0.0.0/tcp/{port}")
         .parse()
         .map_err(|e| anyhow!("bad listen address: {e}"))?;
-    let (_client, peer_id, swarm_task) = start_host_with(
+    let (net, peer_id, swarm_task) = start_host_with(
         status.clone(),
         HostConfig {
             listen,
@@ -402,7 +404,11 @@ pub async fn serve(
     let c = store.coverage();
     println!("\n== serving ==");
     println!("  identity  {} (persisted in {})", peer_id, key_path.display());
-    println!("  multiaddr /ip4/127.0.0.1/tcp/{port}/p2p/{peer_id}");
+    println!("  loopback  /ip4/127.0.0.1/tcp/{port}/p2p/{peer_id}");
+    println!(
+        "  public    unknown — needs {EXTERNAL_ADDR_QUORUM} peers to agree on what they see \
+         (logged when it settles)"
+    );
     println!("  periods   {} ({:?}..={:?})", c.periods, c.lowest_period, c.highest_period);
     println!(
         "  digest    0x{} ({})",
@@ -413,6 +419,7 @@ pub async fn serve(
     println!("\n  point a wallet at the multiaddr above; Ctrl-C to stop.\n");
 
     let mut digests = digests;
+    let mut external: Option<ExternalAddress> = None;
     let mut swarm_task = swarm_task;
     let mut ticks: u32 = 0;
     let mut ticker = tokio::time::interval(REFRESH);
@@ -531,6 +538,55 @@ pub async fn serve(
                     Ok(view) => status.set(view),
                     Err(e) => tracing::warn!(error = %e, "refreshing the chain view failed"),
                 }
+                // Track the address peers say they see us on.
+                //
+                // The PORT here is our configured listen port, not something
+                // observed: Identify reports the remote address of the
+                // connection, which for a connection we dialed carries an
+                // ephemeral source port. That is correct for the pinned
+                // deployment, where the router forwards the same port — but a
+                // NAT rewriting the port would make the advertised multiaddr
+                // wrong in a way this cannot detect. Worth revisiting when the
+                // ENR lands, where the port is published rather than logged.
+                //
+                // The deployment sits on a residential line whose public IP is
+                // not guaranteed stable, so this is not a startup question that
+                // gets answered once. It matters most for the ENR that is not
+                // published yet: a record carrying a dead IP is WORSE than no
+                // record, because wallets discover it, dial, fail, and spend
+                // their three strikes to eviction on a node that is actually
+                // healthy — taking the tokens that made it worth keeping. Until
+                // the ENR exists, this reports the dialable address and makes a
+                // change visible rather than silent.
+                // A `None` here is not an error and deliberately does nothing:
+                // below quorum simply means too few peers have reported yet, and
+                // keeping the last known answer beats oscillating to "unknown"
+                // every time a peer disconnects.
+                if let Some(seen) = net.external_address().await {
+                    match external {
+                        None => {
+                            tracing::info!(
+                                ip = %seen.ip, confirmations = seen.confirmations,
+                                multiaddr = %format!("/ip4/{}/tcp/{}/p2p/{}", seen.ip, port, peer_id),
+                                "external address established"
+                            );
+                            external = Some(seen);
+                        }
+                        Some(prev) if prev.ip != seen.ip => {
+                            tracing::warn!(
+                                old = %prev.ip, new = %seen.ip,
+                                confirmations = seen.confirmations,
+                                multiaddr = %format!("/ip4/{}/tcp/{}/p2p/{}", seen.ip, port, peer_id),
+                                "EXTERNAL ADDRESS CHANGED — anything pinning the old one is now \
+                                 dialling a dead address; the ENR will need re-publishing with a \
+                                 bumped sequence number once it exists"
+                            );
+                            external = Some(seen);
+                        }
+                        Some(_) => external = Some(seen),
+                    }
+                }
+
                 // A new period turns over every ~27 hours; checking each slot is
                 // free next to the HTTP calls above.
                 let p = period_of_slot(head_slot);


### PR DESCRIPTION
Implements the owner requirement that roost handle its **public IP changing while it runs** — the deployment is a residential line and the address is not guaranteed stable. Targets `feat/lc-server`.

This is the *input* half. Nothing is published from it yet, because roost has no ENR. That ordering is deliberate.

## Why this has to exist before the ENR, not after

A published ENR carrying a dead IP is **worse than no ENR**. Wallets discover it, dial, fail, and spend their three strikes to eviction (`clcache.rs`, `FAILURE_THRESHOLD = 3`) on a node that is actually healthy — taking the `lc` and period-range tokens that made the peer worth keeping. So the ENR milestone can't be "publish, then figure out address tracking"; the tracking is a prerequisite for the first publish.

It also pairs with the persisted sequence number the design already requires: a re-published record that doesn't out-rank the cached one is ignored by the DHT, so "detect the change" and "bump and re-publish" are one mechanism, not two.

## Mechanism

No third-party service, no STUN dependency. libp2p **Identify** already reports `observed_addr` — the address each peer sees us on — and `myotis-net` already receives those events; it was discarding them.

- `SwarmCtx` keeps `observed_ips`, **one entry per peer**, so a single peer cannot stuff the ballot by reconnecting. Dropped on disconnect alongside the other per-peer maps, so it stays bounded by the connected set.
- `external_address()` returns the plurality once `EXTERNAL_ADDR_QUORUM` (3) **distinct** peers agree, and `None` below that. `None` is the honest answer for a server with few connections — publishing a guess is exactly how a record ends up pointing somewhere dead.
- Ties break on the IP itself, so the answer is deterministic. Resolving them by hash iteration order would look precisely like a flapping address, which is the thing this exists to detect.
- Only the IP is taken. Identify reports the connection's remote address, so for a connection *we* dialed the port is our ephemeral source port and says nothing about where we listen.

roost logs the address when it settles, and warns loudly when it changes — naming the new dialable multiaddr and the fact that an ENR would need re-publishing with a bumped sequence number.

## Verified against the live daemon

Both directions, because proving only the refusal would be proving nothing:

```
one wallet connected   → 0 "external address established"   (below quorum, correctly silent)
three wallets connected → external address established ip=127.0.0.1 confirmations=3
                          multiaddr /ip4/127.0.0.1/tcp/9105/p2p/16Uiu2HAm2EQ2…
```

Six new tests: the quorum floor, a minority failing to move the answer, one peer failing to stuff the ballot, determinism under a tie, and IP-vs-port extraction. `myotis-net` 218 tests, roost 47, clippy clean.

## Two limits I want stated rather than discovered

Both are documented in the code, and both matter for the ENR rather than for logging:

1. **The quorum is a floor against accident, not a defence against a Sybil.** The answer is a plurality among connected peers, so an attacker holding more simultaneous connections than the honest peers reporting the true address can move it. Tolerable while the result is only logged. Before it drives a published ENR it wants a majority of currently-connected peers rather than a fixed floor, and/or cross-checking against discv5's endpoint prediction — a different peer set over a different transport — and/or refusing to act until a change survives several rounds. Worth noting the failure is reachability, never correctness: a wrong address makes us undialable, it cannot make a wallet accept bad data.

2. **The advertised port is our configured listen port**, not something observed. Correct for the pinned deployment, where the router forwards the same port; a NAT that rewrites the port would make the multiaddr wrong in a way this cannot detect.

## Not in this PR

ENR publication itself: the persisted discv5 key, the monotonic sequence number, the `eth2` field carrying the full 16-byte SSZ `ENRForkID`, discv5 in listed rather than client-only mode, and re-publication at fork *and* BPO boundaries. Also still open from earlier rounds: the `status.earliest_available_slot` decision, and the CLAUDE.md data-sources question raised on #328.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYVwpfHg77oibuD2733jPj