### PR TITLE
ci(roost): fail on broken rustdoc links

### DIFF
--- a/.github/workflows/roost.yml
+++ b/.github/workflows/roost.yml
@@ -59,4 +59,13 @@ jobs:
       - name: Rustdoc links
         env:
           RUSTDOCFLAGS: -D rustdoc::broken_intra_doc_links
-        run: cargo doc --manifest-path rust/roost/Cargo.toml --no-deps --locked
+        # --document-private-items explicitly: most of this crate's
+        # reasoning-carrying doc comments are on PRIVATE items (`Digests`,
+        # `interim_fork_digest`, `NimbusRest::get_ssz`), and they are covered
+        # today only because Cargo adds the flag automatically for a bin-only
+        # package. If roost ever grows a [lib] target — plausible for a daemon
+        # whose codec is already shared by path — the gate would silently narrow
+        # to the public surface and stop checking most of the crate. That is the
+        # same "silently stops resolving" failure this step exists to prevent,
+        # one level up. A no-op today, verified.
+        run: cargo doc --manifest-path rust/roost/Cargo.toml --no-deps --locked --document-private-items

--- a/.github/workflows/roost.yml
+++ b/.github/workflows/roost.yml
@@ -50,3 +50,13 @@ jobs:
         run: cargo test --manifest-path rust/roost/Cargo.toml --locked
       - name: Clippy
         run: cargo clippy --manifest-path rust/roost/Cargo.toml --all-targets -- -D warnings
+      # Neither build, test nor clippy checks rustdoc links, so a broken
+      # intra-doc link is invisible to CI — one shipped in #328 and was caught by
+      # a human reading the diff rather than by a machine. The class matters here
+      # because this crate's doc comments carry the reasoning (why the ENR key
+      # must be the host key, why a BPO counts as a transition), and a link that
+      # silently stops resolving takes a reader away from it.
+      - name: Rustdoc links
+        env:
+          RUSTDOCFLAGS: -D rustdoc::broken_intra_doc_links
+        run: cargo doc --manifest-path rust/roost/Cargo.toml --no-deps --locked


### PR DESCRIPTION
Small follow-up from the #328 and #330 reviews. Targets `feat/lc-server`.

## Why

The roost workflow runs build, test and `clippy -D warnings` — **none of which check rustdoc links**. So a broken intra-doc link shipped in #328 (`[NimbusRest::blob_schedule]`, left behind when that method was folded into `config_spec`) and was caught by a human reading the diff, not by CI.

The class matters more in this crate than in most. Its doc comments carry the *reasoning* rather than restating the code — why the ENR key must be the libp2p host key, why a BPO counts as a transition, why a corrupt sequence file is a hard error instead of a reset. A link that silently stops resolving takes a reader away from exactly that.

## Verified both directions

Not just "it's green today" — confirmed it fails on the thing it exists to catch:

```
$ # with [NimbusRest::blob_schedule] reintroduced
error: unresolved link to `NimbusRest::blob_schedule`
error: could not document `roost`

$ # with it removed
exit 0
```

## What this deliberately does not add

`cargo fmt --check`, which was the other half of the same review note. **The crate does not currently satisfy rustfmt — 43 diff hunks.** Adding the gate therefore means reformatting the whole crate first, which is:

- a repo-wide stylistic decision, not a CI fix;
- a large mechanical diff that degrades `git blame` across files whose history is currently one-change-per-commit.

That's @biafra23's call rather than a side effect of adding a doc-link check, so it's left out and flagged here. The import-order nit that prompted the note was fixed directly in #330.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYVwpfHg77oibuD2733jPj