### PR TITLE
feat: pin roost as sepolia's first CL peer

### DIFF
--- a/docs/dedicated-sepolia-node.md
+++ b/docs/dedicated-sepolia-node.md
@@ -461,7 +461,8 @@ client tries it first.
 | layer | identity |
 |---|---|
 | EL | `enode://cfd3572b…c37e1b2c@87.154.209.161:30405` |
-| CL | `/ip4/87.154.209.161/tcp/9104/p2p/16Uiu2HAkvYx58piGw1oxz34CUoeTv8nNQwTwE2cZZh4jR4wVMYy6` |
+| CL (roost, first) | `/ip4/87.154.209.161/tcp/9105/p2p/16Uiu2HAkyDsNGDq5pbFCqdKTcJxp4Rd5caoy1Xe2KJVtyc94M8S5` |
+| CL (Nimbus, fallback) | `/ip4/87.154.209.161/tcp/9104/p2p/16Uiu2HAkvYx58piGw1oxz34CUoeTv8nNQwTwE2cZZh4jR4wVMYy6` |
 
 Both are only stable because of the key-persistence flags above (Geth's
 datadir `nodekey`, Nimbus's `--netkey-file`). The **IP** in both entries is

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/NetworkConfig.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/NetworkConfig.java
@@ -198,16 +198,28 @@ public record NetworkConfig(
             // No prior-fork fallback (same rationale as mainnet: stale digests
             // wouldn't help us sync to the current head anyway).
             null,
-            // CL peer multiaddrs for sepolia. First entry is the dedicated
-            // myotis-serving Nimbus (docs/dedicated-sepolia-node.md): it serves
-            // light_client_bootstrap / updates_by_range default-on, and being
-            // first means the light client tries it before the discovered pool.
-            // Its peer-id is stable only because the node pins --netkey-file;
-            // Nimbus otherwise mints a new one per restart, which invalidates
-            // this entry with InvalidRemotePubKey (see the doc's §5 note).
+            // CL peer multiaddrs for sepolia. First entry is roost, the
+            // dedicated light-client server (rust/roost, docs/lc-server-design.md),
+            // and being first means the light client tries it before the
+            // discovered pool. It is first on purpose: it exists because a
+            // general-purpose beacon node is structurally bad at serving wallets
+            // — one connection semaphore shared between inbound and outbound,
+            // and a trimmer that drops light clients first.
+            //
+            // The dedicated Nimbus follows it, so a roost fault degrades to
+            // exactly the previous behaviour rather than to nothing. That entry's
+            // peer-id is stable only because the node pins --netkey-file; Nimbus
+            // otherwise mints a new one per restart, which invalidates it with
+            // InvalidRemotePubKey (see the doc's §5 note). roost has no such
+            // mode — its identity is persisted by construction.
+            //
+            // Both literal IPs carry the same exposure: the line is residential
+            // and the address is not guaranteed stable. ENR publication
+            // (lc-server-design §7) is what removes the need to pin at all.
             prependLocal(
-                    "/ip4/87.154.209.161/tcp/9104/p2p/16Uiu2HAkvYx58piGw1oxz34CUoeTv8nNQwTwE2cZZh4jR4wVMYy6",
+                    "/ip4/87.154.209.161/tcp/9105/p2p/16Uiu2HAkyDsNGDq5pbFCqdKTcJxp4Rd5caoy1Xe2KJVtyc94M8S5",
                     List.of(
+                            "/ip4/87.154.209.161/tcp/9104/p2p/16Uiu2HAkvYx58piGw1oxz34CUoeTv8nNQwTwE2cZZh4jR4wVMYy6",
                             "/ip4/18.185.193.198/tcp/9000/p2p/16Uiu2HAm3mfkjmLPtqnSJzNtKxbDuVjVRXidz5UinaZNpjCCKAkS"
                     )),
             null,

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/NetworkConfig.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/NetworkConfig.java
@@ -199,14 +199,36 @@ public record NetworkConfig(
             // wouldn't help us sync to the current head anyway).
             null,
             // CL peer multiaddrs for sepolia. First entry is roost, the
-            // dedicated light-client server (rust/roost, docs/lc-server-design.md),
-            // and being first means the light client tries it before the
-            // discovered pool. It is first on purpose: it exists because a
-            // general-purpose beacon node is structurally bad at serving wallets
-            // — one connection semaphore shared between inbound and outbound,
-            // and a trimmer that drops light clients first.
+            // dedicated light-client server (rust/roost, docs/lc-server-design.md).
+            // It is first because it exists precisely for this: a general-purpose
+            // beacon node is structurally bad at serving wallets — one connection
+            // semaphore shared between inbound and outbound, and a trimmer that
+            // scores light clients at zero and drops them first.
             //
-            // The dedicated Nimbus follows it, so a roost fault degrades to
+            // BUT ORDER HERE IS A PREFERENCE, NOT A PRIORITY, on this engine.
+            // ChainStack loads the peer CACHE first and appends these after
+            // (ChainStack.buildAndStartBeacon), bootstrap fans out to every peer
+            // in parallel with first-valid-response-wins (BeaconLightClient
+            // ~:1419), and addPeer inserts discovered peers at index 1. So being
+            // element 0 does not mean "tried first" — it means "in the initial
+            // list, ahead of the other pins".
+            //
+            // AND NOTE WHAT A HEALTHY ROOST COSTS THIS ENGINE. The fallback below
+            // only engages when roost FAILS. roost serves no blocks —
+            // beacon_blocks_by_range is not among the nine protocols in
+            // rust/myotis-net/src/protocols.rs — while the steady-state chain
+            // fill follows the finality-poll WINNER with no per-peer fallback
+            // (fillChainStateRoots(win.peer(), ...)). A pre-encoded byte cache
+            // wins that race most rounds, so the fill fails every cycle and is
+            // swallowed at debug level: the state-root window then grows ~2 roots
+            // per poll instead of 40-80, the stateRootMatch fast path stops
+            // hitting, and verified reads pay the headerChain EL walk instead.
+            // Bounded, not a correctness break — headerChain anchors on the
+            // finalized execution block hash, not the window — but it is a
+            // silent regression on the DEFAULT engine, and the reason
+            // lc-server-design rollout step 3 wants this settled.
+            //
+            // The dedicated Nimbus follows it, so a roost OUTAGE degrades to
             // exactly the previous behaviour rather than to nothing. That entry's
             // peer-id is stable only because the node pins --netkey-file; Nimbus
             // otherwise mints a new one per restart, which invalidates it with

--- a/networking/src/test/java/com/jaeckel/ethp2p/networking/NetworkConfigGnosisTest.java
+++ b/networking/src/test/java/com/jaeckel/ethp2p/networking/NetworkConfigGnosisTest.java
@@ -167,11 +167,16 @@ class NetworkConfigGnosisTest {
         String enode = NetworkConfig.SEPOLIA.elBootEnodes().get(0);
         assertTrue(enode.endsWith("@87.154.209.161:30405"), enode);
 
+        // roost, the dedicated light-client server, is tried first — that is the
+        // point of having it. The dedicated Nimbus stays behind it as fallback,
+        // so a roost fault degrades to the previous behaviour.
         String cl = NetworkConfig.SEPOLIA.clPeerMultiaddrs().get(0);
-        assertEquals("/ip4/87.154.209.161/tcp/9104/p2p/"
-                        + "16Uiu2HAkvYx58piGw1oxz34CUoeTv8nNQwTwE2cZZh4jR4wVMYy6", cl,
-                "the dedicated Nimbus must be the first CL peer tried");
-        assertTrue(NetworkConfig.SEPOLIA.clPeerMultiaddrs().size() > 1,
+        assertEquals("/ip4/87.154.209.161/tcp/9105/p2p/16Uiu2HAkyDsNGDq5pbFCqdKTcJxp4Rd5caoy1Xe2KJVtyc94M8S5", cl,
+                "roost must be the first CL peer tried");
+        assertTrue(NetworkConfig.SEPOLIA.clPeerMultiaddrs().stream()
+                        .anyMatch(a -> a.contains("16Uiu2HAkvYx58piGw1oxz34CUoeTv8nNQwTwE2cZZh4jR4wVMYy6")),
+                "the dedicated Nimbus must remain as fallback");
+        assertTrue(NetworkConfig.SEPOLIA.clPeerMultiaddrs().size() > 2,
                 "pinning must not drop the existing CL peers");
     }
 }

--- a/networking/src/test/java/com/jaeckel/ethp2p/networking/NetworkConfigGnosisTest.java
+++ b/networking/src/test/java/com/jaeckel/ethp2p/networking/NetworkConfigGnosisTest.java
@@ -173,9 +173,16 @@ class NetworkConfigGnosisTest {
         String cl = NetworkConfig.SEPOLIA.clPeerMultiaddrs().get(0);
         assertEquals("/ip4/87.154.209.161/tcp/9105/p2p/16Uiu2HAkyDsNGDq5pbFCqdKTcJxp4Rd5caoy1Xe2KJVtyc94M8S5", cl,
                 "roost must be the first CL peer tried");
-        assertTrue(NetworkConfig.SEPOLIA.clPeerMultiaddrs().stream()
-                        .anyMatch(a -> a.contains("16Uiu2HAkvYx58piGw1oxz34CUoeTv8nNQwTwE2cZZh4jR4wVMYy6")),
-                "the dedicated Nimbus must remain as fallback");
+        // POSITION, not presence: the Rust twin asserts index 1, and index is
+        // load-bearing on this side in particular — addPeer inserts every
+        // discovered peer at Math.min(1, size()), i.e. exactly the slot the
+        // Nimbus occupies, so "somewhere in the list" is a weaker guarantee here
+        // than anywhere else.
+        assertEquals("/ip4/87.154.209.161/tcp/9104/p2p/"
+                        + "16Uiu2HAkvYx58piGw1oxz34CUoeTv8nNQwTwE2cZZh4jR4wVMYy6",
+                NetworkConfig.SEPOLIA.clPeerMultiaddrs().get(1),
+                "the dedicated Nimbus must remain SECOND as fallback — a roost outage "
+                        + "then degrades to exactly the previous behaviour");
         assertTrue(NetworkConfig.SEPOLIA.clPeerMultiaddrs().size() > 2,
                 "pinning must not drop the existing CL peers");
     }

--- a/rust/myotis-net/src/sync.rs
+++ b/rust/myotis-net/src/sync.rs
@@ -298,6 +298,21 @@ fn hex32(s: &str) -> [u8; 32] {
 /// only because that node pins `--netkey-file`; Nimbus otherwise mints a new one per
 /// restart, which invalidates this entry with `InvalidRemotePubKey`.
 const SEPOLIA_STATIC_PEERS: &[&str] = &[
+    // roost, the dedicated light-client server (rust/roost, docs/lc-server-design.md).
+    // FIRST on purpose: it exists because a general-purpose beacon node is
+    // structurally bad at serving wallets — one connection semaphore shared
+    // between inbound and outbound, and a trimmer that drops light clients
+    // first. Nimbus stays below it, so a roost fault degrades to exactly
+    // today's behaviour rather than to nothing.
+    //
+    // Its peer id comes from /data/roost/sepolia.key and is stable across
+    // restarts by construction; unlike the Nimbus entry there is no flag to
+    // forget, because roost has no mode in which it mints a fresh one.
+    //
+    // Pinning a literal IP has the same exposure as the entries below: the line
+    // is residential and the address is not guaranteed stable. ENR publication
+    // (design §7) is what removes it.
+    "/ip4/87.154.209.161/tcp/9105/p2p/16Uiu2HAkyDsNGDq5pbFCqdKTcJxp4Rd5caoy1Xe2KJVtyc94M8S5",
     "/ip4/87.154.209.161/tcp/9104/p2p/16Uiu2HAkvYx58piGw1oxz34CUoeTv8nNQwTwE2cZZh4jR4wVMYy6",
     "/ip4/18.185.193.198/tcp/9000/p2p/16Uiu2HAm3mfkjmLPtqnSJzNtKxbDuVjVRXidz5UinaZNpjCCKAkS",
 ];
@@ -2553,12 +2568,23 @@ mod tests {
         // NetworkConfig.SEPOLIA.currentForkDigest() — BPO2 folded in).
         assert_eq!(c.current_fork_digest(), [0x74, 0xD0, 0x14, 0x59]);
         assert_eq!(c.accepted_fork_digests(), vec![[0x74, 0xD0, 0x14, 0x59]]);
-        // Two pinned LC peers, the dedicated serving node FIRST — same list and
-        // order as the Java NetworkConfig.SEPOLIA.clPeerMultiaddrs.
-        assert_eq!(c.static_peers.len(), 2);
-        assert!(c.static_peers[0].ends_with(
-            "/tcp/9104/p2p/16Uiu2HAkvYx58piGw1oxz34CUoeTv8nNQwTwE2cZZh4jR4wVMYy6"
-        ));
+        // Three pinned LC peers, roost FIRST — same list and order as the Java
+        // NetworkConfig.SEPOLIA.clPeerMultiaddrs. This assertion is the only
+        // thing keeping the two engines' lists in step; they are hand-maintained
+        // copies, so a change to one that skips the other fails here.
+        assert_eq!(c.static_peers.len(), 3);
+        assert!(
+            c.static_peers[0].ends_with(
+                "/tcp/9105/p2p/16Uiu2HAkyDsNGDq5pbFCqdKTcJxp4Rd5caoy1Xe2KJVtyc94M8S5"
+            ),
+            "roost is the dedicated LC server and is tried first"
+        );
+        assert!(
+            c.static_peers[1].ends_with(
+                "/tcp/9104/p2p/16Uiu2HAkvYx58piGw1oxz34CUoeTv8nNQwTwE2cZZh4jR4wVMYy6"
+            ),
+            "the dedicated Nimbus remains as fallback"
+        );
         assert_eq!(c.bootstrap_enrs.len(), 9);
     }
 

--- a/rust/myotis-net/src/sync.rs
+++ b/rust/myotis-net/src/sync.rs
@@ -290,13 +290,12 @@ fn hex32(s: &str) -> [u8; 32] {
 }
 
 /// Pinned sepolia LC-serving peer multiaddrs (Java `NetworkConfig.SEPOLIA.clPeerMultiaddrs`
-/// — keep the two lists and their ORDER in step).
+/// — keep the two lists, their ORDER and their addresses in step;
+/// `sepolia_config_matches_networkconfig_java` pins this side, and the Java
+/// `NetworkConfigGnosisTest` pins that one).
 ///
-/// First is the dedicated myotis-serving Nimbus (docs/dedicated-sepolia-node.md): it
-/// serves `light_client_bootstrap` / `updates_by_range` default-on, and being first
-/// means the light client tries it before the discovered pool. Its peer-id is stable
-/// only because that node pins `--netkey-file`; Nimbus otherwise mints a new one per
-/// restart, which invalidates this entry with `InvalidRemotePubKey`.
+/// First is roost, the dedicated light-client server. The per-entry comments below
+/// carry the reasoning and each entry's own stability caveat.
 const SEPOLIA_STATIC_PEERS: &[&str] = &[
     // roost, the dedicated light-client server (rust/roost, docs/lc-server-design.md).
     // FIRST on purpose: it exists because a general-purpose beacon node is
@@ -2568,23 +2567,34 @@ mod tests {
         // NetworkConfig.SEPOLIA.currentForkDigest() — BPO2 folded in).
         assert_eq!(c.current_fork_digest(), [0x74, 0xD0, 0x14, 0x59]);
         assert_eq!(c.accepted_fork_digests(), vec![[0x74, 0xD0, 0x14, 0x59]]);
-        // Three pinned LC peers, roost FIRST — same list and order as the Java
-        // NetworkConfig.SEPOLIA.clPeerMultiaddrs. This assertion is the only
-        // thing keeping the two engines' lists in step; they are hand-maintained
-        // copies, so a change to one that skips the other fails here.
-        assert_eq!(c.static_peers.len(), 3);
-        assert!(
-            c.static_peers[0].ends_with(
-                "/tcp/9105/p2p/16Uiu2HAkyDsNGDq5pbFCqdKTcJxp4Rd5caoy1Xe2KJVtyc94M8S5"
-            ),
-            "roost is the dedicated LC server and is tried first"
+        // The full list, in order, addresses included — NOT a suffix match.
+        //
+        // This does NOT read the Java config: the two are hand-maintained copies
+        // and nothing mechanically compares them. What it does is fail whenever
+        // THIS side changes, which pairs with the Java `NetworkConfigGnosisTest`
+        // failing whenever THAT side changes — so an edit to one is caught by
+        // the other's test only if the editor runs both suites. Treat it as a
+        // tripwire, not an enforced invariant.
+        //
+        // The addresses matter as much as the order. The Java twin asserts full
+        // strings; matching only the `/tcp/<port>/p2p/<peer-id>` suffix here
+        // would let an IP rotation be fixed on the Java side while this list
+        // kept a dead address — and this list is the ONLY one iOS has, since
+        // :app-ios runs the Rust engine exclusively.
+        assert_eq!(
+            c.static_peers,
+            vec![
+                "/ip4/87.154.209.161/tcp/9105/p2p/16Uiu2HAkyDsNGDq5pbFCqdKTcJxp4Rd5caoy1Xe2KJVtyc94M8S5",
+                "/ip4/87.154.209.161/tcp/9104/p2p/16Uiu2HAkvYx58piGw1oxz34CUoeTv8nNQwTwE2cZZh4jR4wVMYy6",
+                "/ip4/18.185.193.198/tcp/9000/p2p/16Uiu2HAm3mfkjmLPtqnSJzNtKxbDuVjVRXidz5UinaZNpjCCKAkS",
+            ],
+            "roost first (the dedicated LC server), the dedicated Nimbus second as \
+             fallback — same list, order AND addresses as the Java \
+             NetworkConfig.SEPOLIA.clPeerMultiaddrs"
         );
-        assert!(
-            c.static_peers[1].ends_with(
-                "/tcp/9104/p2p/16Uiu2HAkvYx58piGw1oxz34CUoeTv8nNQwTwE2cZZh4jR4wVMYy6"
-            ),
-            "the dedicated Nimbus remains as fallback"
-        );
+        // A malformed pin would otherwise reach run_sync and surface only as a
+        // "skipping unparseable static peer multiaddr" warn.
+        assert!(c.static_peers.iter().all(|p| parse_static_peer(p).is_some()));
         assert_eq!(c.bootstrap_enrs.len(), 9);
     }
 


### PR DESCRIPTION
roost is deployed on zbox and serving. Pinning it is how wallets reach it without discovery, which it does not have yet — ENR publication is design §7.

## roost first, Nimbus second

That ordering is the point of the exercise. roost exists because a general-purpose beacon node is structurally bad at serving wallets: one connection semaphore shared between inbound and outbound, and a trimmer that scores light clients at zero and drops them first. Putting it behind Nimbus would mean it never gets used and we learn nothing.

Keeping the dedicated Nimbus **second** means a roost fault degrades to exactly the previous behaviour rather than to nothing.

## Both engines

The two lists are hand-maintained copies:

- `rust/myotis-net/src/sync.rs` → `SEPOLIA_STATIC_PEERS`
- `networking/.../NetworkConfig.java` → `clPeerMultiaddrs`

`sepolia_config_matches_networkconfig_java` is the only thing keeping them in step — and it earned its keep here, failing mid-edit when only the Java side had been updated. Extended from a bare count to asserting roost is first and Nimbus is retained, so the *intent* is pinned rather than the arity.

`NetworkConfigGnosisTest` asserted the Nimbus entry must be first; updated, with the reasoning in the test rather than only in the commit.

## Verified against the deployed service

Not a dev build — the installed `roost-sepolia.service`, dialled over its **public** address, with the pinned list alone and discv5 disabled so nothing else could have served it:

```
sync starting  chain=sepolia static_peers=3 fork_digest=74d01459
bootstrap verified and applied  peer=16Uiu2HAkyDsN… slot=10851360 period=1324
updates_by_range served         peer=16Uiu2HAkyDsN… served=3 raw_len=80837
SYNCED period=1327
```

That is `docs/lc-server-design.md` rollout step 2 on the Rust engine.

## What this does not fix

A literal IP on a residential line goes stale if the address rotates — the same exposure the existing entries already carry. ENR publication plus the address tracking from #329 is what removes the need to pin at all.

Also worth stating: rollout step 2 asks for **both engines**. This is the Rust one. The Java engine — which is the default, and the one the Android app uses — is still untested against roost, and the design flags `beacon_blocks_by_range/2` as the known asymmetry there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYVwpfHg77oibuD2733jPj