### PR TITLE
roost: chain-derived slot/period geometry, and gnosis + mainnet Nimbus units

### DIFF
--- a/deploy/install-multichain-nimbus.sh
+++ b/deploy/install-multichain-nimbus.sh
@@ -30,6 +30,14 @@ declare -A CHECKPOINT_ALT=(
   [gnosis]="https://rpc-gbc.gnosischain.com"
   [mainnet]="https://sync-mainnet.beaconcha.in"
 )
+# gnosis is NOT a built-in network name in this Nimbus build — `--network` takes
+# mainnet, hoodi, sepolia or a PATH. The chain config is vendored in the
+# nimbus-eth2 source; copy it somewhere stable so the unit does not depend on a
+# home directory. Override GNOSIS_CONFIG_SRC if your checkout lives elsewhere.
+GNOSIS_CONFIG_SRC="${GNOSIS_CONFIG_SRC:-$HOME/myotis-node/nimbus-eth2/vendor/gnosis-chain-configs/mainnet}"
+GNOSIS_CONFIG_DST=/etc/myotis/gnosis-chain-config
+
+declare -A NETWORK=([gnosis]="$GNOSIS_CONFIG_DST" [mainnet]=mainnet)
 declare -A PORT=([gnosis]=9106 [mainnet]=9107)
 declare -A REST=([gnosis]=5053 [mainnet]=5054)
 
@@ -39,11 +47,30 @@ CHAINS=(${CHAINS[*]})
 
 id nimbus >/dev/null 2>&1 || useradd --system --home /data/nimbus --shell /usr/sbin/nologin nimbus
 
+# Chains are installed independently: one failing must not skip the other, which
+# is what `set -e` did the first time gnosis could not find its config. Failures
+# are collected and reported, and the script still exits non-zero.
+failed=()
+installed=()
+
 for chain in "${CHAINS[@]}"; do
   case "$chain" in gnosis|mainnet) ;; *) echo "unknown chain '$chain'"; exit 1 ;; esac
 
   dir="/data/nimbus-$chain"
   echo "=== $chain -> $dir (p2p ${PORT[$chain]}, rest 127.0.0.1:${REST[$chain]}) ==="
+
+  if [ "$chain" = gnosis ]; then
+    if [ ! -f "$GNOSIS_CONFIG_SRC/config.yaml" ]; then
+      echo "!!! gnosis chain config not found at $GNOSIS_CONFIG_SRC"
+      echo "    set GNOSIS_CONFIG_SRC=<nimbus-eth2>/vendor/gnosis-chain-configs/mainnet"
+      failed+=("gnosis")
+      continue
+    fi
+    mkdir -p "$GNOSIS_CONFIG_DST"
+    cp -a "$GNOSIS_CONFIG_SRC/." "$GNOSIS_CONFIG_DST/"
+    chmod -R a+rX "$GNOSIS_CONFIG_DST"
+    echo "--- gnosis chain config installed to $GNOSIS_CONFIG_DST"
+  fi
   mkdir -p "$dir"
   chown -R nimbus:nimbus "$dir"
   chmod 700 "$dir"
@@ -58,24 +85,28 @@ for chain in "${CHAINS[@]}"; do
   # the sync on the next run and enable a node with an incomplete database. The
   # marker is written only after trustedNodeSync returns 0.
   marker="$dir/.checkpoint-synced"
-  if [ ! -f "$marker" ]; then
-    echo "--- checkpoint sync from ${CHECKPOINT[$chain]}"
-    sudo -u nimbus "$NIMBUS" trustedNodeSync \
-      --network="$chain" \
-      --data-dir="$dir" \
-      --trusted-node-url="${CHECKPOINT[$chain]}" \
-      --backfill=false \
-      || {
-        echo "--- primary failed, retrying from ${CHECKPOINT_ALT[$chain]}"
-        sudo -u nimbus "$NIMBUS" trustedNodeSync \
-          --network="$chain" \
-          --data-dir="$dir" \
-          --trusted-node-url="${CHECKPOINT_ALT[$chain]}" \
-          --backfill=false
-      }
-    sudo -u nimbus touch "$marker"
-  else
+  if [ -f "$marker" ]; then
     echo "--- already checkpoint-synced ($marker), skipping"
+  else
+    echo "--- checkpoint sync from ${CHECKPOINT[$chain]}"
+    if sudo -u nimbus "$NIMBUS" trustedNodeSync \
+         --network="${NETWORK[$chain]}" \
+         --data-dir="$dir" \
+         --trusted-node-url="${CHECKPOINT[$chain]}" \
+         --backfill=false \
+       || { echo "--- primary failed, retrying from ${CHECKPOINT_ALT[$chain]}"
+            sudo -u nimbus "$NIMBUS" trustedNodeSync \
+              --network="${NETWORK[$chain]}" \
+              --data-dir="$dir" \
+              --trusted-node-url="${CHECKPOINT_ALT[$chain]}" \
+              --backfill=false; }
+    then
+      sudo -u nimbus touch "$marker"
+    else
+      echo "!!! $chain checkpoint sync failed — leaving it uninstalled"
+      failed+=("$chain")
+      continue
+    fi
   fi
 
   if command -v ufw >/dev/null && ufw status | grep -q "Status: active"; then
@@ -85,10 +116,16 @@ for chain in "${CHAINS[@]}"; do
 
   install -o root -g root -m 0644 "$STAGE/nimbus-$chain.service" \
     "/etc/systemd/system/nimbus-$chain.service"
+  installed+=("$chain")
 done
 
 systemctl daemon-reload
-for chain in "${CHAINS[@]}"; do systemctl enable "nimbus-$chain.service"; done
+for chain in "${installed[@]:-}"; do [ -n "$chain" ] && systemctl enable "nimbus-$chain.service"; done
+
+if [ "${#failed[@]}" -gt 0 ]; then
+  echo
+  echo "!!! FAILED: ${failed[*]} — see above. Installed: ${installed[*]:-none}"
+fi
 
 cat <<'NOTE'
 

--- a/deploy/install-multichain-nimbus.sh
+++ b/deploy/install-multichain-nimbus.sh
@@ -7,8 +7,10 @@
 # These are LIGHT-CLIENT SOURCES, not validating nodes: no execution client, no
 # JWT, default history. See the unit files for why each of those is deliberate.
 #
-# Idempotent. The checkpoint sync is skipped when a db already exists, and the
-# netkey — which fixes the node's peer id — is never touched once created.
+# Idempotent. The checkpoint sync is gated on a success marker, not on the db
+# directory (Nimbus creates that before fetching, so a failed sync would
+# otherwise look done), and the netkey — which fixes the node's peer id — is
+# never touched once created.
 set -euo pipefail
 
 NIMBUS=/usr/bin/nimbus_beacon_node
@@ -49,7 +51,14 @@ for chain in "${CHAINS[@]}"; do
   # Checkpoint sync once. --backfill=false is what keeps this minutes rather
   # than days: it takes the finalized state and follows forward, leaving deep
   # history to roost's archive.
-  if [ ! -d "$dir/db" ]; then
+  #
+  # Gated on a SUCCESS MARKER, not on the db directory existing. Nimbus creates
+  # and opens the database before it fetches the checkpoint, so a sync that
+  # fails part-way leaves $dir/db behind — and a directory check would then skip
+  # the sync on the next run and enable a node with an incomplete database. The
+  # marker is written only after trustedNodeSync returns 0.
+  marker="$dir/.checkpoint-synced"
+  if [ ! -f "$marker" ]; then
     echo "--- checkpoint sync from ${CHECKPOINT[$chain]}"
     sudo -u nimbus "$NIMBUS" trustedNodeSync \
       --network="$chain" \
@@ -64,8 +73,9 @@ for chain in "${CHAINS[@]}"; do
           --trusted-node-url="${CHECKPOINT_ALT[$chain]}" \
           --backfill=false
       }
+    sudo -u nimbus touch "$marker"
   else
-    echo "--- db exists, skipping checkpoint sync"
+    echo "--- already checkpoint-synced ($marker), skipping"
   fi
 
   if command -v ufw >/dev/null && ufw status | grep -q "Status: active"; then

--- a/deploy/install-multichain-nimbus.sh
+++ b/deploy/install-multichain-nimbus.sh
@@ -34,7 +34,10 @@ declare -A CHECKPOINT_ALT=(
 # mainnet, hoodi, sepolia or a PATH. The chain config is vendored in the
 # nimbus-eth2 source; copy it somewhere stable so the unit does not depend on a
 # home directory. Override GNOSIS_CONFIG_SRC if your checkout lives elsewhere.
-GNOSIS_CONFIG_SRC="${GNOSIS_CONFIG_SRC:-$HOME/myotis-node/nimbus-eth2/vendor/gnosis-chain-configs/mainnet}"
+# $HOME is /root under sudo, not the invoking user's home — resolve the real one.
+INVOKING_USER="${SUDO_USER:-$(id -un)}"
+INVOKING_HOME="$(getent passwd "$INVOKING_USER" | cut -d: -f6)"
+GNOSIS_CONFIG_SRC="${GNOSIS_CONFIG_SRC:-$INVOKING_HOME/myotis-node/nimbus-eth2/vendor/gnosis-chain-configs/mainnet}"
 GNOSIS_CONFIG_DST=/etc/myotis/gnosis-chain-config
 
 declare -A NETWORK=([gnosis]="$GNOSIS_CONFIG_DST" [mainnet]=mainnet)

--- a/deploy/install-multichain-nimbus.sh
+++ b/deploy/install-multichain-nimbus.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Sudo-side installer for the gnosis and mainnet Nimbus nodes that back roost.
+#
+#   sudo bash deploy/install-multichain-nimbus.sh            # both
+#   sudo bash deploy/install-multichain-nimbus.sh gnosis     # one
+#
+# These are LIGHT-CLIENT SOURCES, not validating nodes: no execution client, no
+# JWT, default history. See the unit files for why each of those is deliberate.
+#
+# Idempotent. The checkpoint sync is skipped when a db already exists, and the
+# netkey — which fixes the node's peer id — is never touched once created.
+set -euo pipefail
+
+NIMBUS=/usr/bin/nimbus_beacon_node
+STAGE="$(cd "$(dirname "$0")" && pwd)"
+
+[ -x "$NIMBUS" ] || { echo "nimbus not installed at $NIMBUS"; exit 1; }
+
+# Two live providers per chain, so a sync can be re-run against the other if one
+# is down. Verified reachable 2026-08-09; beaconstate.info and
+# gnosis-beacon.publicnode.com were NOT (DNS failure / 404) — do not add them
+# back without checking /eth/v1/beacon/blocks/finalized/root first.
+declare -A CHECKPOINT=(
+  [gnosis]="https://checkpoint.gnosischain.com"
+  [mainnet]="https://mainnet-checkpoint-sync.attestant.io"
+)
+declare -A CHECKPOINT_ALT=(
+  [gnosis]="https://rpc-gbc.gnosischain.com"
+  [mainnet]="https://sync-mainnet.beaconcha.in"
+)
+declare -A PORT=([gnosis]=9106 [mainnet]=9107)
+declare -A REST=([gnosis]=5053 [mainnet]=5054)
+
+CHAINS=("${@:-gnosis mainnet}")
+# shellcheck disable=SC2206
+CHAINS=(${CHAINS[*]})
+
+id nimbus >/dev/null 2>&1 || useradd --system --home /data/nimbus --shell /usr/sbin/nologin nimbus
+
+for chain in "${CHAINS[@]}"; do
+  case "$chain" in gnosis|mainnet) ;; *) echo "unknown chain '$chain'"; exit 1 ;; esac
+
+  dir="/data/nimbus-$chain"
+  echo "=== $chain -> $dir (p2p ${PORT[$chain]}, rest 127.0.0.1:${REST[$chain]}) ==="
+  mkdir -p "$dir"
+  chown -R nimbus:nimbus "$dir"
+  chmod 700 "$dir"
+
+  # Checkpoint sync once. --backfill=false is what keeps this minutes rather
+  # than days: it takes the finalized state and follows forward, leaving deep
+  # history to roost's archive.
+  if [ ! -d "$dir/db" ]; then
+    echo "--- checkpoint sync from ${CHECKPOINT[$chain]}"
+    sudo -u nimbus "$NIMBUS" trustedNodeSync \
+      --network="$chain" \
+      --data-dir="$dir" \
+      --trusted-node-url="${CHECKPOINT[$chain]}" \
+      --backfill=false \
+      || {
+        echo "--- primary failed, retrying from ${CHECKPOINT_ALT[$chain]}"
+        sudo -u nimbus "$NIMBUS" trustedNodeSync \
+          --network="$chain" \
+          --data-dir="$dir" \
+          --trusted-node-url="${CHECKPOINT_ALT[$chain]}" \
+          --backfill=false
+      }
+  else
+    echo "--- db exists, skipping checkpoint sync"
+  fi
+
+  if command -v ufw >/dev/null && ufw status | grep -q "Status: active"; then
+    ufw allow "${PORT[$chain]}/tcp"
+    ufw allow "${PORT[$chain]}/udp"
+  fi
+
+  install -o root -g root -m 0644 "$STAGE/nimbus-$chain.service" \
+    "/etc/systemd/system/nimbus-$chain.service"
+done
+
+systemctl daemon-reload
+for chain in "${CHAINS[@]}"; do systemctl enable "nimbus-$chain.service"; done
+
+cat <<'NOTE'
+
+Installed and enabled, NOT started. Start when you are ready:
+
+  sudo systemctl start nimbus-gnosis nimbus-mainnet
+  journalctl -u nimbus-gnosis -f
+
+Expect "Running without execution client - validator features disabled" — that is
+the intended configuration, not a misconfiguration. These nodes follow the chain
+optimistically and never validate execution payloads; they exist to produce
+light-client data, which is derived from the beacon DAG.
+
+Forward these on the router (tcp AND udp), or the nodes stay behind NAT and find
+far fewer peers:
+  gnosis 9106   mainnet 9107
+
+Once each is following the chain, check the LC endpoints roost needs:
+  curl -s -H 'Accept: application/octet-stream' \
+    http://127.0.0.1:5053/eth/v1/beacon/light_client/finality_update | wc -c
+  curl -s http://127.0.0.1:5053/eth/v1/node/syncing
+
+BACK UP THE NETKEYS: /data/nimbus-<chain>/netkey. They fix each node's peer id.
+Without --netkey-file Nimbus mints a fresh one per restart, which is what made
+the sepolia pins die with InvalidRemotePubKey before it was set.
+
+NOTE

--- a/deploy/nimbus-gnosis.service
+++ b/deploy/nimbus-gnosis.service
@@ -25,8 +25,13 @@ User=nimbus
 # discv5 stays ON and peer limits stay stock. The sepolia node runs unlisted with
 # hand-fed anchors because it had to serve wallets directly; roost exists so this
 # one does not, and can go back to being an ordinary beacon node.
+# --network is a PATH, not a name: this Nimbus build knows mainnet, hoodi and
+# sepolia only ("config.yaml not found for network networkName=gnosis"). The
+# gnosis chain config is vendored in the nimbus-eth2 source and the installer
+# copies it here, so the unit does not depend on a user's home directory
+# surviving.
 ExecStart=/usr/bin/nimbus_beacon_node \
-  --network=gnosis \
+  --network=/etc/myotis/gnosis-chain-config \
   --data-dir=/data/nimbus-gnosis \
   --tcp-port=9106 --udp-port=9106 \
   --nat=any \

--- a/deploy/nimbus-gnosis.service
+++ b/deploy/nimbus-gnosis.service
@@ -1,0 +1,45 @@
+[Unit]
+Description=Nimbus Gnosis (myotis light-client source, no execution client)
+After=network-online.target
+Wants=network-online.target
+StartLimitIntervalSec=0
+
+[Service]
+User=nimbus
+# NO --el AND NO --jwt-secret, deliberately.
+#
+# This node exists to be roost's upstream, nothing else. Without an execution
+# client Nimbus logs "Running without execution client - validator features
+# disabled" and follows the chain optimistically: it can never mark execution
+# payloads valid. That costs nothing here, because light-client data is derived
+# from the beacon DAG (blockchain_dag_light_client.nim), not from the EL — and
+# because no wallet trusts this node anyway. Every update it produces is checked
+# against sync-committee signatures by the wallet that receives it.
+#
+# NO --history FLAG, so the default (prune) applies. Archive mode on a chain
+# this size is a multi-day, multi-hundred-GB commitment that buys a permanently
+# slower startup, and it is not how the deep archive is meant to be held:
+# docs/lc-server-design.md keeps periods below this node's floor in roost's own
+# ~36 MB append-only archive instead.
+#
+# discv5 stays ON and peer limits stay stock. The sepolia node runs unlisted with
+# hand-fed anchors because it had to serve wallets directly; roost exists so this
+# one does not, and can go back to being an ordinary beacon node.
+ExecStart=/usr/bin/nimbus_beacon_node \
+  --network=gnosis \
+  --data-dir=/data/nimbus-gnosis \
+  --tcp-port=9106 --udp-port=9106 \
+  --nat=any \
+  --enr-auto-update=true \
+  --netkey-file=/data/nimbus-gnosis/netkey \
+  --insecure-netkey-password=true \
+  --rest --rest-port=5053 \
+  --light-client-data-serve=true \
+  --light-client-data-import-mode=full
+Restart=on-failure
+RestartSec=5
+LimitNOFILE=65536
+TimeoutStopSec=300
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/nimbus-mainnet.service
+++ b/deploy/nimbus-mainnet.service
@@ -1,0 +1,46 @@
+[Unit]
+Description=Nimbus Mainnet (myotis light-client source, no execution client)
+After=network-online.target
+Wants=network-online.target
+StartLimitIntervalSec=0
+
+[Service]
+User=nimbus
+# NO --el AND NO --jwt-secret, deliberately.
+#
+# This node exists to be roost's upstream, nothing else. Without an execution
+# client Nimbus logs "Running without execution client - validator features
+# disabled" and follows the chain optimistically: it can never mark execution
+# payloads valid. That costs nothing here, because light-client data is derived
+# from the beacon DAG (blockchain_dag_light_client.nim), not from the EL — and
+# because no wallet trusts this node anyway. Every update it produces is checked
+# against sync-committee signatures by the wallet that receives it.
+#
+# NO --history FLAG, so the default (prune) applies. This matters most on
+# mainnet: archive mode here is a multi-terabyte, multi-day trustedNodeSync with
+# --reindex, and docs/lc-server-design.md argues against it explicitly — "Don't.
+# Archive in the LC server instead." roost holds periods below this node's floor
+# in its own append-only archive at roughly 36 MB, which is the whole reason it
+# has one.
+#
+# discv5 stays ON and peer limits stay stock. The sepolia node runs unlisted with
+# hand-fed anchors because it had to serve wallets directly; roost exists so this
+# one does not, and can go back to being an ordinary beacon node.
+ExecStart=/usr/bin/nimbus_beacon_node \
+  --network=mainnet \
+  --data-dir=/data/nimbus-mainnet \
+  --tcp-port=9107 --udp-port=9107 \
+  --nat=any \
+  --enr-auto-update=true \
+  --netkey-file=/data/nimbus-mainnet/netkey \
+  --insecure-netkey-password=true \
+  --rest --rest-port=5054 \
+  --light-client-data-serve=true \
+  --light-client-data-import-mode=full
+Restart=on-failure
+RestartSec=5
+LimitNOFILE=65536
+TimeoutStopSec=300
+
+[Install]
+WantedBy=multi-user.target

--- a/rust/roost/src/forks.rs
+++ b/rust/roost/src/forks.rs
@@ -44,7 +44,7 @@ use std::collections::BTreeMap;
 use anyhow::{anyhow, Context, Result};
 use myotis_net::status::fork_digest_bpo;
 
-use crate::rest::NimbusRest;
+use crate::rest::{ChainParams, NimbusRest};
 
 /// A fork's activation epoch and version.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -68,15 +68,39 @@ pub struct ForkSchedule {
     forks: Vec<Fork>,
     /// Ascending by activation epoch. Empty ⇒ no BPO active, pre-Fulu formula.
     blob_schedule: Vec<BlobParams>,
-    slots_per_epoch: u64,
+    /// The chain's geometry — NOT a second parse of SLOTS_PER_EPOCH. This type
+    /// used to read that key itself, which meant two independent readings of the
+    /// same document: this one governing `digest_for_slot` (and therefore
+    /// `status.fork_digest`), the other governing period math. They could not
+    /// disagree in practice, but nothing made that true.
+    params: ChainParams,
 }
 
 impl ForkSchedule {
-    /// Read the whole schedule — forks and blob parameters — from the
-    /// upstream's `/eth/v1/config/spec`, in one request.
-    pub async fn fetch(client: &NimbusRest, genesis_validators_root: [u8; 32]) -> Result<Self> {
+    /// Read the chain's geometry AND schedule from `/eth/v1/config/spec` in a
+    /// single request.
+    ///
+    /// The two have different failure policies, so they are returned separately:
+    /// the geometry is required (a chain roost cannot measure is one it must not
+    /// write records for), while the schedule may fail for narrower reasons — an
+    /// unpaired `*_FORK_VERSION`, an unparseable `BLOB_SCHEDULE` — and degrade to
+    /// the observed fork digest.
+    pub async fn fetch_with_params(
+        client: &NimbusRest,
+        genesis_validators_root: [u8; 32],
+    ) -> Result<(ChainParams, Result<Self>)> {
         let (spec, blobs) = client.config_spec().await?;
-        Ok(Self::from_spec(&spec, genesis_validators_root)?.with_blob_schedule(blobs))
+        let params = ChainParams::from_spec(&spec)?;
+        let schedule = Self::from_spec(&spec, genesis_validators_root, params)
+            .map(|s| s.with_blob_schedule(blobs));
+        Ok((params, schedule))
+    }
+
+    /// The schedule alone, for callers that already hold the geometry.
+    pub async fn fetch(client: &NimbusRest, genesis_validators_root: [u8; 32]) -> Result<Self> {
+        Self::fetch_with_params(client, genesis_validators_root)
+            .await?
+            .1
     }
 
     /// Build from a decoded `config/spec` map.
@@ -94,6 +118,7 @@ impl ForkSchedule {
     pub fn from_spec(
         spec: &BTreeMap<String, String>,
         genesis_validators_root: [u8; 32],
+        params: ChainParams,
     ) -> Result<Self> {
         // (fork, is_genesis) — the flag drives the tie-break below.
         let mut forks: Vec<(Fork, bool)> = Vec::new();
@@ -146,20 +171,11 @@ impl ForkSchedule {
         forks.sort_by_key(|(f, is_genesis)| (f.epoch, !*is_genesis));
         let forks: Vec<Fork> = forks.into_iter().map(|(f, _)| f).collect();
 
-        let slots_per_epoch = spec
-            .get("SLOTS_PER_EPOCH")
-            .ok_or_else(|| anyhow!("config/spec has no SLOTS_PER_EPOCH"))?
-            .parse::<u64>()
-            .context("parsing SLOTS_PER_EPOCH")?;
-        if slots_per_epoch == 0 {
-            return Err(anyhow!("config/spec reports SLOTS_PER_EPOCH = 0"));
-        }
-
         Ok(Self {
             genesis_validators_root,
             forks,
             blob_schedule: Vec::new(),
-            slots_per_epoch,
+            params,
         })
     }
 
@@ -172,8 +188,9 @@ impl ForkSchedule {
     }
 
     pub fn slots_per_epoch(&self) -> u64 {
-        self.slots_per_epoch
+        self.params.slots_per_epoch()
     }
+
 
     /// The fork active at `epoch` — the latest whose activation is not in the
     /// future. Forks scheduled at `u64::MAX` (a placeholder for "not scheduled",
@@ -290,7 +307,7 @@ impl ForkSchedule {
 
     /// The fork digest an object at `slot` must carry.
     pub fn digest_for_slot(&self, slot: u64) -> [u8; 4] {
-        self.digest_for_epoch(slot / self.slots_per_epoch)
+        self.digest_for_epoch(slot / self.params.slots_per_epoch())
     }
 }
 
@@ -305,6 +322,21 @@ fn parse_version(raw: &str) -> Result<[u8; 4]> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+
+    /// Geometry derived from the SAME spec the schedule is built from — which is
+    /// the property this change is about.
+    fn params_of(spec: &BTreeMap<String, String>) -> ChainParams {
+        ChainParams::from_spec(spec).unwrap()
+    }
+
+    fn mainnet_params() -> ChainParams {
+        let m: BTreeMap<String, String> = [
+            ("SLOTS_PER_EPOCH", "32"),
+            ("EPOCHS_PER_SYNC_COMMITTEE_PERIOD", "256"),
+        ].into_iter().map(|(k, v)| (k.to_string(), v.to_string())).collect();
+        ChainParams::from_spec(&m).unwrap()
+    }
 
     fn hex32(s: &str) -> [u8; 32] {
         let v = hex::decode(s).unwrap();
@@ -334,6 +366,7 @@ mod tests {
             ("GLOAS_FORK_VERSION", "0x07000000"),
             ("GLOAS_FORK_EPOCH", "18446744073709551615"),
             ("SLOTS_PER_EPOCH", "32"),
+            ("EPOCHS_PER_SYNC_COMMITTEE_PERIOD", "256"),
         ]
         .into_iter()
         .map(|(k, v)| (k.to_string(), v.to_string()))
@@ -341,7 +374,7 @@ mod tests {
     }
 
     fn sepolia() -> ForkSchedule {
-        ForkSchedule::from_spec(&sepolia_spec(), sepolia_gvr())
+        ForkSchedule::from_spec(&sepolia_spec(), sepolia_gvr(), params_of(&sepolia_spec()))
             .unwrap()
             .with_blob_schedule(vec![
                 BlobParams { epoch: 274_176, max_blobs: 15 },
@@ -383,12 +416,13 @@ mod tests {
             ("FULU_FORK_VERSION", "0x06000000"),
             ("FULU_FORK_EPOCH", "0"),
             ("SLOTS_PER_EPOCH", "32"),
+            ("EPOCHS_PER_SYNC_COMMITTEE_PERIOD", "256"),
         ]
         .into_iter()
         .map(|(k, v)| (k.to_string(), v.to_string()))
         .collect();
 
-        let base = ForkSchedule::from_spec(&spec, gvr).unwrap();
+        let base = ForkSchedule::from_spec(&spec, gvr, params_of(&spec)).unwrap();
         assert_eq!(base.digest_for_epoch(1), [0x82, 0xFA, 0xE5, 0x41]);
 
         let with_bpo = base.with_blob_schedule(vec![BlobParams {
@@ -410,7 +444,7 @@ mod tests {
         spec.insert("BELLATRIX_FORK_EPOCH".into(), "0".into());
         spec.insert("CAPELLA_FORK_EPOCH".into(), "0".into());
         spec.insert("DENEB_FORK_EPOCH".into(), "0".into());
-        let s = ForkSchedule::from_spec(&spec, sepolia_gvr()).unwrap();
+        let s = ForkSchedule::from_spec(&spec, sepolia_gvr(), params_of(&spec)).unwrap();
 
         // DENEB is the latest fork at epoch 0 and must win — not GENESIS, which
         // sorts after FULU lexicographically and would otherwise take the tie.
@@ -485,11 +519,12 @@ mod tests {
             ("FULU_FORK_VERSION", "0x90000075"),
             ("FULU_FORK_EPOCH", "272640"),
             ("SLOTS_PER_EPOCH", "32"),
+            ("EPOCHS_PER_SYNC_COMMITTEE_PERIOD", "256"),
         ]
         .into_iter()
         .map(|(k, v)| (k.to_string(), v.to_string()))
         .collect();
-        let s = ForkSchedule::from_spec(&spec, sepolia_gvr()).unwrap();
+        let s = ForkSchedule::from_spec(&spec, sepolia_gvr(), params_of(&spec)).unwrap();
         let id = s.enr_fork_id(300_000);
         assert_eq!(&id[4..8], &[0x90, 0, 0, 0x75], "current version, not zeros");
         assert_eq!(u64::from_le_bytes(id[8..].try_into().unwrap()), u64::MAX);
@@ -511,7 +546,7 @@ mod tests {
         // what keeps this network-agnostic.
         let mut spec = sepolia_spec();
         spec.insert("SLOTS_PER_EPOCH".into(), "16".into());
-        let s = ForkSchedule::from_spec(&spec, sepolia_gvr()).unwrap();
+        let s = ForkSchedule::from_spec(&spec, sepolia_gvr(), params_of(&spec)).unwrap();
         assert_eq!(s.slots_per_epoch(), 16);
         assert_eq!(s.digest_for_slot(16), s.digest_for_epoch(1));
     }
@@ -522,29 +557,39 @@ mod tests {
         // and quietly outrank the real schedule for early epochs.
         let mut spec = sepolia_spec();
         spec.insert("NEWFORK_FORK_VERSION".into(), "0x90000099".into());
-        let err = ForkSchedule::from_spec(&spec, sepolia_gvr()).unwrap_err().to_string();
+        let err = ForkSchedule::from_spec(&spec, sepolia_gvr(), params_of(&spec)).unwrap_err().to_string();
         assert!(err.contains("NEWFORK_FORK_EPOCH"), "got: {err}");
 
         // GENESIS remains the one legitimate exception.
         let mut only_genesis = sepolia_spec();
         only_genesis.remove("ALTAIR_FORK_EPOCH");
         only_genesis.remove("ALTAIR_FORK_VERSION");
-        assert!(ForkSchedule::from_spec(&only_genesis, sepolia_gvr()).is_ok());
+        assert!(ForkSchedule::from_spec(&only_genesis, sepolia_gvr(), params_of(&only_genesis)).is_ok());
     }
 
     #[test]
     fn refuses_a_spec_it_cannot_use() {
+        // A spec with no *_FORK_VERSION at all is this type's OWN refusal.
         let empty: BTreeMap<String, String> = BTreeMap::new();
-        assert!(ForkSchedule::from_spec(&empty, sepolia_gvr()).is_err());
+        assert!(ForkSchedule::from_spec(&empty, sepolia_gvr(), mainnet_params()).is_err());
 
+        // The geometry refusals — missing or zero SLOTS_PER_EPOCH — now belong
+        // to ChainParams (rest.rs), which is the single reading of them. This
+        // type is handed an already-validated ChainParams, so asserting them
+        // here would test nothing. Kept as an explicit note rather than deleted
+        // silently, because "the schedule validates the epoch length" was true
+        // until this change and someone will look for it.
         let mut no_epoch_len = sepolia_spec();
         no_epoch_len.remove("SLOTS_PER_EPOCH");
-        assert!(ForkSchedule::from_spec(&no_epoch_len, sepolia_gvr()).is_err());
+        assert!(
+            ChainParams::from_spec(&no_epoch_len).is_err(),
+            "the geometry refusal lives in ChainParams now"
+        );
 
         let mut zero = sepolia_spec();
         zero.insert("SLOTS_PER_EPOCH".into(), "0".into());
         assert!(
-            ForkSchedule::from_spec(&zero, sepolia_gvr()).is_err(),
+            ChainParams::from_spec(&zero).is_err(),
             "a zero epoch length would divide by zero in digest_for_slot"
         );
     }

--- a/rust/roost/src/main.rs
+++ b/rust/roost/src/main.rs
@@ -22,7 +22,7 @@ mod store;
 
 use archive::Archive;
 use framing::{split_updates, updates_to_wire};
-use rest::{period_of_slot, NimbusRest};
+use rest::NimbusRest;
 use store::LcStore;
 
 const DEFAULT_REST: &str = "http://127.0.0.1:5052";
@@ -146,9 +146,16 @@ async fn probe(rest_base: &str) -> Result<()> {
     println!("== upstream ==");
     println!("  rest      {rest_base}");
     println!("  version   {}", client.node_version().await?);
+    let params = client.chain_params().await?;
     let (head_slot, syncing) = client.syncing().await?;
-    let head_period = period_of_slot(head_slot);
+    let head_period = params.period_of_slot(head_slot);
     println!("  head      slot {head_slot} (period {head_period}), syncing={syncing}");
+    println!(
+        "  geometry  {} slots/epoch x {} epochs/period = {} slots per period",
+        params.slots_per_epoch,
+        params.epochs_per_sync_committee_period,
+        params.slots_per_period()
+    );
 
     println!("\n== single-object endpoints ==");
     for (name, resp) in [
@@ -322,10 +329,17 @@ async fn ingest(rest_base: &str, archive_path: &Path) -> Result<()> {
         store.insert_update(*period, rec.fork_digest, &rec.ssz);
     }
 
+    let params = client.chain_params().await?;
     let (head_slot, syncing) = client.syncing().await?;
-    let head_period = period_of_slot(head_slot);
+    let head_period = params.period_of_slot(head_slot);
     println!("\n== upstream ==");
     println!("  head      slot {head_slot} (period {head_period}), syncing={syncing}");
+    println!(
+        "  geometry  {} slots/epoch x {} epochs/period = {} slots per period",
+        params.slots_per_epoch,
+        params.epochs_per_sync_committee_period,
+        params.slots_per_period()
+    );
 
     let floor = match find_window_floor(&client, head_period).await? {
         Some(f) => f,
@@ -553,6 +567,7 @@ async fn show_enr(
     let client = NimbusRest::new(rest_base, Duration::from_secs(30))?;
     let gvr = client.genesis_validators_root().await?;
     let schedule = forks::ForkSchedule::fetch(&client, gvr).await?;
+    let params = client.chain_params().await?;
     let (head_slot, syncing) = client.syncing().await?;
     // A syncing upstream reports a head behind the real one, and if it is behind
     // the most recent fork or BPO boundary the digest computed from it is the
@@ -567,7 +582,9 @@ async fn show_enr(
              invisible to exactly the clients it is for."
         ));
     }
-    let epoch = head_slot / schedule.slots_per_epoch();
+    // One source for slot->epoch, so the ENR's fork id cannot disagree with the
+    // period math the rest of the daemon uses.
+    let epoch = params.epoch_of_slot(head_slot);
     let eth2 = schedule.enr_fork_id(epoch);
 
     // The SAME key the libp2p host authenticates with — including a --key

--- a/rust/roost/src/main.rs
+++ b/rust/roost/src/main.rs
@@ -146,16 +146,8 @@ async fn probe(rest_base: &str) -> Result<()> {
     println!("== upstream ==");
     println!("  rest      {rest_base}");
     println!("  version   {}", client.node_version().await?);
-    let params = client.chain_params().await?;
     let (head_slot, syncing) = client.syncing().await?;
-    let head_period = params.period_of_slot(head_slot);
-    println!("  head      slot {head_slot} (period {head_period}), syncing={syncing}");
-    println!(
-        "  geometry  {} slots/epoch x {} epochs/period = {} slots per period",
-        params.slots_per_epoch,
-        params.epochs_per_sync_committee_period,
-        params.slots_per_period()
-    );
+    println!("  head      slot {head_slot}, syncing={syncing}");
 
     println!("\n== single-object endpoints ==");
     for (name, resp) in [
@@ -178,6 +170,32 @@ async fn probe(rest_base: &str) -> Result<()> {
         bootstrap.consensus_version.as_deref().unwrap_or("-"),
         hex::encode(&finalized[..8]),
     );
+
+    // Geometry LAST of the things that can fail, and non-fatally. probe writes
+    // nothing, so unlike `serve` it should still report what it managed to
+    // learn: a failure here is exactly the run an operator makes when the
+    // upstream is already misbehaving, and aborting before the report is the
+    // least useful moment to abort.
+    println!("\n== geometry ==");
+    let params = match client.chain_params().await {
+        Ok(p) => {
+            println!(
+                "  {} slots/epoch x {} epochs/period = {} slots per period",
+                p.slots_per_epoch(),
+                p.epochs_per_sync_committee_period(),
+                p.slots_per_period()
+            );
+            p
+        }
+        Err(e) => {
+            println!("  unavailable — {e:#}");
+            println!("\n  skipping the period-dependent sections (updates framing, fork digest,");
+            println!("  servable window): every one of them is keyed by period.");
+            return Ok(());
+        }
+    };
+    let head_period = params.period_of_slot(head_slot);
+    println!("  head slot {head_slot} is in period {head_period}");
 
     println!("\n== updates: framing and re-encode ==");
     let resp = client.updates(head_period, 1).await?;
@@ -302,6 +320,11 @@ async fn probe(rest_base: &str) -> Result<()> {
 async fn ingest(rest_base: &str, archive_path: &Path) -> Result<()> {
     let client = NimbusRest::new(rest_base, Duration::from_secs(30))?;
     let gvr = client.genesis_validators_root().await?;
+    // Before Archive::open, matching `serve`. Archive::open is not read-only —
+    // it repairs a torn tail with an in-place set_len — so "a chain roost cannot
+    // measure is one it never touches records for" should hold on both write
+    // paths, not just the one where it was written down.
+    let params = client.chain_params().await?;
 
     println!("== archive ==");
     let (mut archive, records, report) = Archive::open(archive_path, &gvr)?;
@@ -329,15 +352,14 @@ async fn ingest(rest_base: &str, archive_path: &Path) -> Result<()> {
         store.insert_update(*period, rec.fork_digest, &rec.ssz);
     }
 
-    let params = client.chain_params().await?;
     let (head_slot, syncing) = client.syncing().await?;
     let head_period = params.period_of_slot(head_slot);
     println!("\n== upstream ==");
     println!("  head      slot {head_slot} (period {head_period}), syncing={syncing}");
     println!(
         "  geometry  {} slots/epoch x {} epochs/period = {} slots per period",
-        params.slots_per_epoch,
-        params.epochs_per_sync_committee_period,
+        params.slots_per_epoch(),
+        params.epochs_per_sync_committee_period(),
         params.slots_per_period()
     );
 
@@ -566,8 +588,10 @@ async fn show_enr(
 
     let client = NimbusRest::new(rest_base, Duration::from_secs(30))?;
     let gvr = client.genesis_validators_root().await?;
-    let schedule = forks::ForkSchedule::fetch(&client, gvr).await?;
-    let params = client.chain_params().await?;
+    // ONE fetch of /config/spec feeding both, so the epoch the ENR is built for
+    // cannot come from a different reading than the digest it carries.
+    let (params, schedule) = forks::ForkSchedule::fetch_with_params(&client, gvr).await?;
+    let schedule = schedule?;
     let (head_slot, syncing) = client.syncing().await?;
     // A syncing upstream reports a head behind the real one, and if it is behind
     // the most recent fork or BPO boundary the digest computed from it is the

--- a/rust/roost/src/rest.rs
+++ b/rust/roost/src/rest.rs
@@ -44,16 +44,31 @@ use anyhow::{anyhow, Context, Result};
 /// this, including the keys its **archive records are written under**. A wrong
 /// value does not fail — it mis-keys durable data, and the archive is the one
 /// thing here that cannot be regenerated.
+/// Fields are PRIVATE so [`ChainParams::from_spec`] is the only way in. They
+/// were `pub`, which meant `ChainParams { slots_per_epoch: 0, .. }` compiled and
+/// divided by zero in `period_of_slot` — unwinding out of `serve`'s main task,
+/// not a per-connection one. "Refuse anything unusable" is only a contract if
+/// the unusable value cannot be built at all.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ChainParams {
-    pub slots_per_epoch: u64,
-    pub epochs_per_sync_committee_period: u64,
+    slots_per_epoch: u64,
+    epochs_per_sync_committee_period: u64,
+    /// Validated once, at construction — see `from_spec`.
+    slots_per_period: u64,
 }
 
 impl ChainParams {
-    pub fn slots_per_period(&self) -> u64 {
+    pub fn slots_per_epoch(&self) -> u64 {
         self.slots_per_epoch
-            .saturating_mul(self.epochs_per_sync_committee_period)
+    }
+
+    pub fn epochs_per_sync_committee_period(&self) -> u64 {
+        self.epochs_per_sync_committee_period
+    }
+
+    /// Proven usable at construction, so this cannot saturate.
+    pub fn slots_per_period(&self) -> u64 {
+        self.slots_per_period
     }
 
     /// The sync-committee period a slot falls in.
@@ -81,9 +96,25 @@ impl ChainParams {
             }
             Ok(v)
         };
+        let slots_per_epoch = read("SLOTS_PER_EPOCH")?;
+        let epochs_per_sync_committee_period = read("EPOCHS_PER_SYNC_COMMITTEE_PERIOD")?;
+        // checked, not saturating: a saturating product answers u64::MAX, which
+        // makes period_of_slot answer 0 for every real slot — so every archive
+        // record would be written under period 0. Silently mis-keying
+        // unregenerable data is the exact failure this type exists to prevent,
+        // and saturation would have reintroduced it.
+        let slots_per_period = slots_per_epoch
+            .checked_mul(epochs_per_sync_committee_period)
+            .ok_or_else(|| {
+                anyhow!(
+                    "config/spec geometry overflows u64: {slots_per_epoch} x \
+                     {epochs_per_sync_committee_period}"
+                )
+            })?;
         Ok(Self {
-            slots_per_epoch: read("SLOTS_PER_EPOCH")?,
-            epochs_per_sync_committee_period: read("EPOCHS_PER_SYNC_COMMITTEE_PERIOD")?,
+            slots_per_epoch,
+            epochs_per_sync_committee_period,
+            slots_per_period,
         })
     }
 }
@@ -381,9 +412,21 @@ impl NimbusRest {
         let obj = v["data"]
             .as_object()
             .ok_or_else(|| anyhow!("config/spec: data is not an object"))?;
+        // Stringify NUMERIC scalars too, not just string ones. The Beacon API
+        // spec pins these as strings and Nimbus emits them that way, but a
+        // client emitting `"SLOTS_PER_EPOCH": 32` would otherwise arrive
+        // downstream as an ABSENT key — refused with "config/spec has no
+        // SLOTS_PER_EPOCH", which points at the wrong problem entirely. The
+        // same brittleness already bit BLOB_SCHEDULE; there it degraded to a
+        // fallback, here it is fatal to both serve and probe.
         let scalars = obj
             .iter()
-            .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+            .filter_map(|(k, v)| match v {
+                serde_json::Value::String(s) => Some((k.clone(), s.clone())),
+                serde_json::Value::Number(n) => Some((k.clone(), n.to_string())),
+                serde_json::Value::Bool(b) => Some((k.clone(), b.to_string())),
+                _ => None,
+            })
             .collect();
         Ok((scalars, parse_blob_schedule(&v)?))
     }
@@ -537,8 +580,19 @@ mod tests {
         assert!(parse_blob_schedule(&v).is_err());
     }
 
+    fn params(spe: u64, epp: u64) -> ChainParams {
+        let m: std::collections::BTreeMap<String, String> = [
+            ("SLOTS_PER_EPOCH", spe.to_string()),
+            ("EPOCHS_PER_SYNC_COMMITTEE_PERIOD", epp.to_string()),
+        ]
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), v))
+        .collect();
+        ChainParams::from_spec(&m).unwrap()
+    }
+
     fn mainnet_shaped() -> ChainParams {
-        ChainParams { slots_per_epoch: 32, epochs_per_sync_committee_period: 256 }
+        params(32, 256)
     }
 
     #[test]
@@ -558,7 +612,7 @@ mod tests {
         // 16-slot epochs, 512 epochs per period. The old constant (32 * 256)
         // landed on 8192 too — right answer, false derivation. This is the case
         // that would have made a differently-shaped chain wrong in silence.
-        let g = ChainParams { slots_per_epoch: 16, epochs_per_sync_committee_period: 512 };
+        let g = params(16, 512);
         assert_eq!(g.slots_per_period(), 8192);
         assert_eq!(g.epoch_of_slot(16), 1, "gnosis epochs are 16 slots, not 32");
         assert_ne!(g.epoch_of_slot(32), mainnet_shaped().epoch_of_slot(32));
@@ -567,7 +621,7 @@ mod tests {
     #[test]
     fn a_hypothetical_chain_with_different_factors_is_honoured() {
         // The point of reading it rather than assuming: nothing here says 8192.
-        let odd = ChainParams { slots_per_epoch: 8, epochs_per_sync_committee_period: 64 };
+        let odd = params(8, 64);
         assert_eq!(odd.slots_per_period(), 512);
         assert_eq!(odd.period_of_slot(512), 1);
     }
@@ -588,6 +642,12 @@ mod tests {
             vec![("SLOTS_PER_EPOCH", "0"), ("EPOCHS_PER_SYNC_COMMITTEE_PERIOD", "256")],
             vec![("SLOTS_PER_EPOCH", "32"), ("EPOCHS_PER_SYNC_COMMITTEE_PERIOD", "0")],
             vec![("SLOTS_PER_EPOCH", "x"), ("EPOCHS_PER_SYNC_COMMITTEE_PERIOD", "256")],
+            // Overflowing product: saturation would have made every slot land in
+            // period 0 rather than failing.
+            vec![
+                ("SLOTS_PER_EPOCH", "18446744073709551615"),
+                ("EPOCHS_PER_SYNC_COMMITTEE_PERIOD", "2"),
+            ],
         ] {
             let m: BTreeMap<String, String> =
                 bad.into_iter().map(|(k, v)| (k.to_string(), v.to_string())).collect();

--- a/rust/roost/src/rest.rs
+++ b/rust/roost/src/rest.rs
@@ -29,19 +29,69 @@ use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
 
-/// Slots per sync-committee period: `SLOTS_PER_EPOCH (32) *
-/// EPOCHS_PER_SYNC_COMMITTEE_PERIOD (256)`.
-pub const SLOTS_PER_PERIOD: u64 = 32 * 256;
+/// The chain's slot/period geometry, read from the upstream rather than assumed.
+///
+/// # Why this is not a constant
+///
+/// It was `32 * 256`, documented as `SLOTS_PER_EPOCH (32) *
+/// EPOCHS_PER_SYNC_COMMITTEE_PERIOD (256)`. Both factors are mainnet's.
+/// **Gnosis runs 16-slot epochs** — it reaches the same 8192 only because it
+/// pairs them with 512 epochs per period, so the old constant was right by
+/// coincidence and its stated derivation was false for that chain. A future
+/// network that pairs different factors would have broken it silently.
+///
+/// Silently is the operative word: every period number roost computes rests on
+/// this, including the keys its **archive records are written under**. A wrong
+/// value does not fail — it mis-keys durable data, and the archive is the one
+/// thing here that cannot be regenerated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChainParams {
+    pub slots_per_epoch: u64,
+    pub epochs_per_sync_committee_period: u64,
+}
+
+impl ChainParams {
+    pub fn slots_per_period(&self) -> u64 {
+        self.slots_per_epoch
+            .saturating_mul(self.epochs_per_sync_committee_period)
+    }
+
+    /// The sync-committee period a slot falls in.
+    pub fn period_of_slot(&self, slot: u64) -> u64 {
+        slot / self.slots_per_period()
+    }
+
+    pub fn epoch_of_slot(&self, slot: u64) -> u64 {
+        slot / self.slots_per_epoch
+    }
+
+    /// Parse from a decoded `config/spec` map, refusing anything unusable.
+    ///
+    /// Both values are REQUIRED and a zero is refused: defaulting either would
+    /// reintroduce exactly the silent-wrong-answer failure this type exists to
+    /// remove, and a zero would divide by zero.
+    pub fn from_spec(spec: &std::collections::BTreeMap<String, String>) -> Result<Self> {
+        let read = |key: &str| -> Result<u64> {
+            let raw = spec
+                .get(key)
+                .ok_or_else(|| anyhow!("config/spec has no {key}"))?;
+            let v: u64 = raw.parse().with_context(|| format!("parsing {key} = {raw}"))?;
+            if v == 0 {
+                return Err(anyhow!("config/spec reports {key} = 0"));
+            }
+            Ok(v)
+        };
+        Ok(Self {
+            slots_per_epoch: read("SLOTS_PER_EPOCH")?,
+            epochs_per_sync_committee_period: read("EPOCHS_PER_SYNC_COMMITTEE_PERIOD")?,
+        })
+    }
+}
 
 /// The spec's `MAX_REQUEST_LIGHT_CLIENT_UPDATES`. Enforced here as well as on
 /// the serving side: a caller-controlled count must never fan out into an
 /// unbounded upstream fetch.
 pub const MAX_REQUEST_LIGHT_CLIENT_UPDATES: u64 = 128;
-
-/// The sync-committee period a slot falls in.
-pub fn period_of_slot(slot: u64) -> u64 {
-    slot / SLOTS_PER_PERIOD
-}
 
 fn parse_root(s: &str) -> Result<[u8; 32]> {
     let raw = hex::decode(s.trim_start_matches("0x")).context("decoding a 32-byte root")?;
@@ -394,6 +444,12 @@ impl NimbusRest {
             .ok_or_else(|| anyhow!("headers/<root>: missing slot"))
     }
 
+    /// The chain's slot/period geometry.
+    pub async fn chain_params(&self) -> Result<ChainParams> {
+        let (spec, _) = self.config_spec().await?;
+        ChainParams::from_spec(&spec)
+    }
+
     /// The chain's `genesis_validators_root` — the identity an archive is bound
     /// to, so a file collected for one network can never load for another.
     pub async fn genesis_validators_root(&self) -> Result<[u8; 32]> {
@@ -481,15 +537,66 @@ mod tests {
         assert!(parse_blob_schedule(&v).is_err());
     }
 
+    fn mainnet_shaped() -> ChainParams {
+        ChainParams { slots_per_epoch: 32, epochs_per_sync_committee_period: 256 }
+    }
+
     #[test]
     fn period_math_matches_the_live_node() {
         // zbox head 10 873 925 sat in period 1327 while serving 1327 as its
         // newest update.
-        assert_eq!(period_of_slot(10_873_925), 1327);
-        // Boundaries.
-        assert_eq!(period_of_slot(0), 0);
-        assert_eq!(period_of_slot(SLOTS_PER_PERIOD - 1), 0);
-        assert_eq!(period_of_slot(SLOTS_PER_PERIOD), 1);
+        let p = mainnet_shaped();
+        assert_eq!(p.slots_per_period(), 8192);
+        assert_eq!(p.period_of_slot(10_873_925), 1327);
+        assert_eq!(p.period_of_slot(0), 0);
+        assert_eq!(p.period_of_slot(8191), 0);
+        assert_eq!(p.period_of_slot(8192), 1);
+    }
+
+    #[test]
+    fn gnosis_geometry_reaches_the_same_period_length_by_different_factors() {
+        // 16-slot epochs, 512 epochs per period. The old constant (32 * 256)
+        // landed on 8192 too — right answer, false derivation. This is the case
+        // that would have made a differently-shaped chain wrong in silence.
+        let g = ChainParams { slots_per_epoch: 16, epochs_per_sync_committee_period: 512 };
+        assert_eq!(g.slots_per_period(), 8192);
+        assert_eq!(g.epoch_of_slot(16), 1, "gnosis epochs are 16 slots, not 32");
+        assert_ne!(g.epoch_of_slot(32), mainnet_shaped().epoch_of_slot(32));
+    }
+
+    #[test]
+    fn a_hypothetical_chain_with_different_factors_is_honoured() {
+        // The point of reading it rather than assuming: nothing here says 8192.
+        let odd = ChainParams { slots_per_epoch: 8, epochs_per_sync_committee_period: 64 };
+        assert_eq!(odd.slots_per_period(), 512);
+        assert_eq!(odd.period_of_slot(512), 1);
+    }
+
+    #[test]
+    fn refuses_a_spec_it_cannot_use() {
+        use std::collections::BTreeMap;
+        let ok: BTreeMap<String, String> = [
+            ("SLOTS_PER_EPOCH", "16"),
+            ("EPOCHS_PER_SYNC_COMMITTEE_PERIOD", "512"),
+        ]
+        .into_iter().map(|(k, v)| (k.to_string(), v.to_string())).collect();
+        assert_eq!(ChainParams::from_spec(&ok).unwrap().slots_per_period(), 8192);
+
+        for bad in [
+            vec![("SLOTS_PER_EPOCH", "32")],                                  // missing the other
+            vec![("EPOCHS_PER_SYNC_COMMITTEE_PERIOD", "256")],                // missing the other
+            vec![("SLOTS_PER_EPOCH", "0"), ("EPOCHS_PER_SYNC_COMMITTEE_PERIOD", "256")],
+            vec![("SLOTS_PER_EPOCH", "32"), ("EPOCHS_PER_SYNC_COMMITTEE_PERIOD", "0")],
+            vec![("SLOTS_PER_EPOCH", "x"), ("EPOCHS_PER_SYNC_COMMITTEE_PERIOD", "256")],
+        ] {
+            let m: BTreeMap<String, String> =
+                bad.into_iter().map(|(k, v)| (k.to_string(), v.to_string())).collect();
+            assert!(
+                ChainParams::from_spec(&m).is_err(),
+                "an unusable spec must fail rather than default — a wrong period \
+                 length mis-keys archive records, which are not regenerable"
+            );
+        }
     }
 
     #[tokio::test]

--- a/rust/roost/src/serve.rs
+++ b/rust/roost/src/serve.rs
@@ -172,11 +172,17 @@ async fn chain_view(
 /// Where a response's context bytes come from.
 ///
 /// Computed from the chain's schedule when it is available, which is the
-/// correct answer for any slot. The observed fallback exists only so an
-/// upstream that cannot serve `/config/spec` degrades to the previous
-/// behaviour instead of taking the daemon down — it is the newest `updates`
-/// chunk's digest, which is right for the current fork and stale across a
-/// boundary.
+/// correct answer for any slot.
+///
+/// The observed fallback covers a NARROWER set than it once did. An upstream
+/// that cannot serve `/eth/v1/config/spec` at all now takes the daemon down
+/// before this is consulted, because the chain geometry is read from the same
+/// document and is required — a chain roost cannot measure is one it must not
+/// write archive records for. What still degrades here is a schedule that fails
+/// for its own reasons: an unpaired `*_FORK_VERSION`, an unparseable
+/// `BLOB_SCHEDULE`, or a spec with no fork versions at all. The fallback value
+/// is the newest `updates` chunk's digest — right for the current fork, stale
+/// across a boundary.
 struct Digests {
     schedule: Option<ForkSchedule>,
     observed: [u8; 4],
@@ -341,7 +347,7 @@ pub async fn serve(
     // REQUIRED, and fetched before the archive is opened: every period number
     // below — including the keys archive records are written under — depends on
     // it, and a wrong value mis-keys durable data rather than failing.
-    let params = client.chain_params().await?;
+    let (params, initial_schedule) = ForkSchedule::fetch_with_params(&client, gvr).await?;
 
     let (mut archive, records, report) = Archive::open(archive_path, &gvr)?;
     let store = Arc::new(LcStore::new());
@@ -389,7 +395,7 @@ pub async fn serve(
             ))
         }
     };
-    let schedule = match fetch_schedule(&client, gvr).await {
+    let schedule = match initial_schedule {
         Ok(s) => Some(s),
         Err(e) => {
             tracing::warn!(error = %e,

--- a/rust/roost/src/serve.rs
+++ b/rust/roost/src/serve.rs
@@ -33,7 +33,7 @@ use myotis_net::status::StatusMessage;
 use crate::archive::Archive;
 use crate::framing::split_updates;
 use crate::forks::ForkSchedule;
-use crate::rest::{period_of_slot, FetchError, NimbusRest, SLOTS_PER_PERIOD};
+use crate::rest::{ChainParams, FetchError, NimbusRest};
 use crate::store::LcStore;
 
 /// How often to refresh the chain view and the per-slot objects. One slot.
@@ -149,6 +149,7 @@ fn warn_if_group_or_world_readable(path: &Path) {
 async fn chain_view(
     client: &NimbusRest,
     store: &LcStore,
+    params: ChainParams,
     fork_digest: [u8; 4],
 ) -> Result<StatusMessage> {
     let (head_slot, head_root) = client.head_header().await?;
@@ -156,7 +157,7 @@ async fn chain_view(
     let earliest_available_slot = store
         .coverage()
         .lowest_period
-        .map(|p| p.saturating_mul(SLOTS_PER_PERIOD))
+        .map(|p| p.saturating_mul(params.slots_per_period()))
         .unwrap_or(0);
     Ok(StatusMessage {
         fork_digest,
@@ -337,6 +338,10 @@ pub async fn serve(
 ) -> Result<()> {
     let client = NimbusRest::new(rest_base, Duration::from_secs(30))?;
     let gvr = client.genesis_validators_root().await?;
+    // REQUIRED, and fetched before the archive is opened: every period number
+    // below — including the keys archive records are written under — depends on
+    // it, and a wrong value mis-keys durable data rather than failing.
+    let params = client.chain_params().await?;
 
     let (mut archive, records, report) = Archive::open(archive_path, &gvr)?;
     let store = Arc::new(LcStore::new());
@@ -352,7 +357,7 @@ pub async fn serve(
 
     // Initial fill, so the server is useful the moment it starts listening.
     let (head_slot, _) = client.syncing().await?;
-    let head_period = period_of_slot(head_slot);
+    let head_period = params.period_of_slot(head_slot);
     // Everything from here to `start_host_with` is BEST EFFORT. Startup must not
     // be able to fail on a transient upstream condition: at a period rollover
     // the head slot is already in period P while the newest servable update is
@@ -401,7 +406,7 @@ pub async fn serve(
         tracing::warn!(error = %e, "initial live-object fetch failed; the ticker will retry");
     }
 
-    let status = LocalStatus::new(chain_view(&client, &store, digests.for_slot(head_slot)).await?);
+    let status = LocalStatus::new(chain_view(&client, &store, params, digests.for_slot(head_slot)).await?);
     let key_path = key_path.unwrap_or_else(|| archive_path.with_extension("key"));
     let keypair = load_or_create_key(&key_path)?;
 
@@ -527,7 +532,7 @@ pub async fn serve(
                 // reintroduced through the degraded path.
                 if digests.schedule.is_none() {
                     if let Some(d) =
-                        resolve_fork_digest(&client, &store, period_of_slot(head_slot)).await
+                        resolve_fork_digest(&client, &store, params.period_of_slot(head_slot)).await
                     {
                         if d != digests.observed {
                             tracing::warn!(old = %hex::encode(digests.observed), new = %hex::encode(d),
@@ -552,7 +557,7 @@ pub async fn serve(
                 if let Err(e) = fill_bootstrap_misses(&client, &store, &digests, head_slot).await {
                     tracing::warn!(error = %e, "filling bootstrap misses failed");
                 }
-                match chain_view(&client, &store, head_digest).await {
+                match chain_view(&client, &store, params, head_digest).await {
                     Ok(view) => status.set(view),
                     Err(e) => tracing::warn!(error = %e, "refreshing the chain view failed"),
                 }
@@ -628,7 +633,7 @@ pub async fn serve(
 
                 // A new period turns over every ~27 hours; checking each slot is
                 // free next to the HTTP calls above.
-                let p = period_of_slot(head_slot);
+                let p = params.period_of_slot(head_slot);
                 if !store.has_period(p) {
                     match fill_periods(&client, &store, &mut archive, p, p).await {
                         Ok(n) if n > 0 => tracing::info!(period = p, "archived a new period"),


### PR DESCRIPTION
Steps 1 **and 2** of taking roost multichain. Targets `feat/lc-server`.

*(Scope note: the Nimbus units were pushed to this branch after the original description, which listed them as follow-up. The description below now matches the diff.)*

## 1. Chain-derived slot/period geometry — a real bug

roost read the genesis validators root, the fork schedule and `SLOTS_PER_EPOCH` from its upstream, but hardcoded:

```rust
/// SLOTS_PER_EPOCH (32) * EPOCHS_PER_SYNC_COMMITTEE_PERIOD (256)
pub const SLOTS_PER_PERIOD: u64 = 32 * 256;
```

Both factors are mainnet's. **Gnosis runs 16-slot epochs** and reaches the same 8192 by pairing them with 512 epochs — right answer, false derivation. It matters because **archive record keys are period numbers**: a wrong value doesn't fail, it mis-keys durable data that nothing can regenerate.

Now `ChainParams`, read from `/eth/v1/config/spec`, both factors required, product validated with `checked_mul`, fields private so the unusable value is unrepresentable, and fetched **before the archive is opened** on both write paths.

Found while checking whether roost was chain-agnostic *before* installing gnosis rather than after.

## 2. Nimbus units for gnosis and mainnet (`deploy/`)

Light-client **sources** for roost, not validating nodes:

- **No `--el`, no `--jwt-secret`.** Verified from the Nimbus source that this runs — it logs *"Running without execution client - validator features disabled"* and follows optimistically. Costs nothing here: LC data is derived from the beacon DAG (`blockchain_dag_light_client.nim`), and no wallet trusts these nodes anyway.
- **No `--history` flag** → default prune, per the owner's instruction. Archive on mainnet is a multi-terabyte, multi-day commitment, and `lc-server-design.md` argues against it outright — roost's own ~36 MB append-only archive is where deep periods belong.
- **discv5 on, stock peer limits.** These go straight to being ordinary beacon nodes; the unlisted/anchored contortion sepolia runs is what roost exists to make unnecessary.
- **`--netkey-file`** on both, without which Nimbus mints a fresh peer id per restart — the failure that killed the sepolia pins with `InvalidRemotePubKey`.
- Ports clear of what is bound: gnosis 9106 / rest 5053, mainnet 9107 / rest 5054.

Checkpoint providers were tested against `/eth/v1/beacon/blocks/finalized/root` rather than trusted from the existing list: **`beaconstate.info` is dead** (DNS failure) though `build.gradle.kts` still lists it for `refreshMainnetCheckpoint`, and `gnosis-beacon.publicnode.com` 404s. Two verified-live providers per chain, with automatic retry.

In the repo rather than untracked staging, following the #332 review: a deploy step nobody else can run is one whose asserted properties nothing keeps true.

## Verified

```
geometry  32 slots/epoch x 256 epochs/period = 8192 slots per period
```

read from the chain, and the `eth2` field byte-identical to before. Tests cover mainnet's geometry, gnosis's 16×512 reaching the same 8192 by different factors, a hypothetical chain with neither, overflow, and every unusable spec shape. 57 tests, clippy clean.

The units are **not installed** — `sudo bash deploy/install-multichain-nimbus.sh` is the owner's to run.

## Still to come

3. roost instances per chain (systemd template rather than three near-identical units).
4. Pin all three in both engines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYVwpfHg77oibuD2733jPj