### PR TITLE
fix: resolve /dns4/ pins at dial time so they work without a DNS transport

### DIFF
--- a/rust/myotis-net/src/reqresp.rs
+++ b/rust/myotis-net/src/reqresp.rs
@@ -432,10 +432,9 @@ impl ReqRespClient {
         // so `build_swarm` falls back to plain TCP and a /dns4/ address is
         // rejected outright with "Multiaddr is not supported").
         let dns_name = multiaddr_dns_name(&addr).map(|n| n.to_string());
+        // Never empty: a resolver failure yields the original address, so an
+        // already-connected peer is unaffected by a transient DNS blip.
         let addrs = resolve_dial_addrs(&addr).await;
-        if addrs.is_empty() {
-            return Err(RequestError::DialFailure);
-        }
         let (reply, rx) = oneshot::channel();
         self.tx
             .send(Command::Request { peer, dns_name, addrs, protocol, wire, reply })
@@ -697,7 +696,15 @@ async fn resolve_dial_addrs(addr: &Multiaddr) -> Vec<Multiaddr> {
     let Some(name) = multiaddr_dns_name(addr).map(|n| n.to_string()) else {
         return vec![addr.clone()];
     };
-    let port = multiaddr_port(addr).unwrap_or(0);
+    // Without a /tcp/ component there is nothing to rebuild around: `skip_while`
+    // would consume the whole iterator and every candidate would come out a bare
+    // /ip4/A — no port, no transport, no /p2p/ id — while `unwrap_or(0)` looked
+    // the name up on port 0. Hand the address back untouched instead and let the
+    // transport reject it on its own terms. Reaches here via /dnsaddr/ (which
+    // resolves to TXT records, not A/AAAA) and via a name with no transport.
+    let Some(port) = multiaddr_port(addr) else {
+        return vec![addr.clone()];
+    };
     let tail: Vec<Protocol> = addr
         .iter()
         .skip_while(|p| !matches!(p, Protocol::Tcp(_)))
@@ -723,6 +730,7 @@ async fn resolve_dial_addrs(addr: &Multiaddr) -> Vec<Multiaddr> {
             }
             if out.is_empty() {
                 tracing::warn!(%name, "DNS-PIN resolve EMPTY — name exists but has no A/AAAA record");
+                return vec![addr.clone()];
             } else {
                 let ips: Vec<String> =
                     out.iter().filter_map(|m| multiaddr_ip(m).map(|i| i.to_string())).collect();
@@ -731,38 +739,16 @@ async fn resolve_dial_addrs(addr: &Multiaddr) -> Vec<Multiaddr> {
             out
         }
         Err(e) => {
+            // Hand back the ORIGINAL rather than nothing. `request_raw` resolves
+            // before it can know whether a dial is even needed — connection state
+            // lives on the swarm task — so returning empty made a transient
+            // resolver blip fail requests on peers we were already connected to,
+            // where the candidates would never have been used. The failure is
+            // logged; if a dial really is required it fails on its own.
             tracing::warn!(%name, error = %e, "DNS-PIN resolve FAILED");
-            Vec::new()
+            vec![addr.clone()]
         }
     }
-}
-
-/// Log what a name currently resolves to, without blocking the swarm task.
-///
-/// libp2p resolves inside the transport and does not surface the answer — the
-/// established connection still reports the `/dns4/` address it was asked for —
-/// so the mapping is invisible unless we look it up ourselves. On a dynamic
-/// address that mapping is the operationally interesting fact: it is what says
-/// whether a pinned name is currently pointing at the right machine.
-///
-/// This is a SECOND lookup, not the one the transport used. With a ~30s TTL the
-/// two agree in practice, but treat it as "what the name says now" rather than
-/// "what this connection went to".
-fn log_resolution(name: &str, port: u16) {
-    let name = name.to_string();
-    tokio::spawn(async move {
-        match tokio::net::lookup_host((name.as_str(), port)).await {
-            Ok(addrs) => {
-                let ips: Vec<String> = addrs.map(|a| a.ip().to_string()).collect();
-                if ips.is_empty() {
-                    tracing::warn!(%name, "DNS-PIN resolve EMPTY — name exists but has no A/AAAA record");
-                } else {
-                    tracing::info!(%name, resolved = %ips.join(","), "DNS-PIN resolved");
-                }
-            }
-            Err(e) => tracing::warn!(%name, error = %e, "DNS-PIN resolve FAILED"),
-        }
-    });
 }
 
 /// One peer's report: where they reached us from, and what they see us as.
@@ -1189,7 +1175,7 @@ fn handle_swarm_event(swarm: &mut Swarm<Behaviour>, ctx: &mut SwarmCtx, event: S
                 // NOTE: not `endpoint.get_remote_address()` — for a dial by name
                 // that returns the /dns4/ address we asked for, not the address
                 // it resolved to, which makes it useless for exactly this. The
-                // answer is logged by `log_resolution` at dial time instead.
+                // answer is logged by `resolve_dial_addrs` at dial time instead.
                 tracing::info!(peer = %peer_id, %name, "DNS-PIN connected");
             }
             tracing::debug!(peer = %peer_id, remote = %endpoint.get_remote_address(),
@@ -1863,15 +1849,26 @@ mod dial_resolution_tests {
     }
 
     #[tokio::test]
-    async fn an_unresolvable_name_yields_no_candidates() {
-        // Empty, not the input: dialing a /dns4/ address on a DNS-less transport
-        // fails with a misleading "Multiaddr is not supported" rather than a
-        // resolution error. The caller turns this into DialFailure.
+    async fn an_unresolvable_name_falls_back_to_the_original() {
+        // NOT empty. `request_raw` resolves before it can know whether a dial is
+        // even needed, so returning nothing would fail requests on peers we are
+        // already connected to over a transient resolver blip. The failure is
+        // logged; a dial that genuinely needs the address fails on its own.
         let a: Multiaddr = "/dns4/no-such-host.invalid/tcp/9105/p2p/\
             16Uiu2HAkyDsNGDq5pbFCqdKTcJxp4Rd5caoy1Xe2KJVtyc94M8S5"
             .parse()
             .unwrap();
-        assert!(resolve_dial_addrs(&a).await.is_empty());
+        assert_eq!(resolve_dial_addrs(&a).await, vec![a.clone()]);
+    }
+
+    #[tokio::test]
+    async fn an_address_without_tcp_is_returned_untouched() {
+        // No /tcp/ means nothing to rebuild around: rewriting would drop the
+        // port, the transport and the /p2p/ id, leaving a bare /ip4/A.
+        for raw in ["/dnsaddr/example.com", "/dns4/localhost"] {
+            let a: Multiaddr = raw.parse().unwrap();
+            assert_eq!(resolve_dial_addrs(&a).await, vec![a.clone()], "{raw}");
+        }
     }
 
     #[tokio::test]

--- a/rust/myotis-net/src/reqresp.rs
+++ b/rust/myotis-net/src/reqresp.rs
@@ -371,7 +371,12 @@ impl std::error::Error for RequestError {}
 enum Command {
     Request {
         peer: PeerId,
-        addr: Multiaddr,
+        /// The DNS name these candidates came from, if any — logging only.
+        dns_name: Option<String>,
+        /// Dial candidates in RESOLVER ORDER — a DNS name expands to every
+        /// address it resolves to, and order is load-bearing (see
+        /// [`resolve_dial_addrs`]).
+        addrs: Vec<Multiaddr>,
         protocol: &'static str,
         wire: Vec<u8>,
         reply: oneshot::Sender<Result<Vec<u8>, RequestError>>,
@@ -421,9 +426,19 @@ impl ReqRespClient {
         protocol: &'static str,
         wire: Vec<u8>,
     ) -> Result<Vec<u8>, RequestError> {
+        // Resolve HERE, per request, in async context. The swarm task's dial
+        // path is synchronous, so it cannot await a lookup — and libp2p's own
+        // DNS transport is not always present (Android has no /etc/resolv.conf,
+        // so `build_swarm` falls back to plain TCP and a /dns4/ address is
+        // rejected outright with "Multiaddr is not supported").
+        let dns_name = multiaddr_dns_name(&addr).map(|n| n.to_string());
+        let addrs = resolve_dial_addrs(&addr).await;
+        if addrs.is_empty() {
+            return Err(RequestError::DialFailure);
+        }
         let (reply, rx) = oneshot::channel();
         self.tx
-            .send(Command::Request { peer, addr, protocol, wire, reply })
+            .send(Command::Request { peer, dns_name, addrs, protocol, wire, reply })
             .await
             .map_err(|_| RequestError::Shutdown)?;
         rx.await.map_err(|_| RequestError::Shutdown)?
@@ -656,6 +671,72 @@ fn multiaddr_dns_name(addr: &Multiaddr) -> Option<String> {
     })
 }
 
+/// Expand a dial address into concrete candidates, resolving any DNS component.
+///
+/// Returns the input unchanged when there is no name to resolve.
+///
+/// **Why we resolve rather than letting libp2p do it.** `build_swarm` layers in
+/// libp2p's DNS transport when a system resolver is configured, but that reads
+/// `/etc/resolv.conf`, which Android has not had since Oreo. There the swarm
+/// falls back to plain TCP and rejects a `/dns4/` address outright — "Multiaddr
+/// is not supported" — before any connection is attempted. `getaddrinfo`, which
+/// `lookup_host` uses, works on every platform we ship.
+///
+/// **Order is load-bearing.** `getaddrinfo` already sorts by RFC 6724
+/// destination-address selection, and every candidate is passed on in that
+/// order. On an IPv6-only mobile network with DNS64/NAT64 the synthesized
+/// `64:ff9b::/96` address sorts first and is the one that works, while the raw
+/// A record is unroutable there — so preferring IPv4 by hand would break
+/// exactly the networks this exists to support.
+///
+/// Substituting the address is safe: Noise still authenticates the remote
+/// against the `/p2p/` peer id, so a wrong or hostile answer cannot impersonate
+/// the pinned server — it can only fail to connect.
+async fn resolve_dial_addrs(addr: &Multiaddr) -> Vec<Multiaddr> {
+    use libp2p::multiaddr::Protocol;
+    let Some(name) = multiaddr_dns_name(addr).map(|n| n.to_string()) else {
+        return vec![addr.clone()];
+    };
+    let port = multiaddr_port(addr).unwrap_or(0);
+    let tail: Vec<Protocol> = addr
+        .iter()
+        .skip_while(|p| !matches!(p, Protocol::Tcp(_)))
+        .map(|p| p.acquire())
+        .collect();
+    match tokio::net::lookup_host(format!("{name}:{port}")).await {
+        Ok(found) => {
+            let mut out = Vec::new();
+            let mut seen = HashSet::new();
+            for sa in found {
+                if !seen.insert(sa.ip()) {
+                    continue;
+                }
+                let mut m = Multiaddr::empty();
+                m.push(match sa.ip() {
+                    IpAddr::V4(a) => Protocol::Ip4(a),
+                    IpAddr::V6(a) => Protocol::Ip6(a),
+                });
+                for p in &tail {
+                    m.push(p.clone());
+                }
+                out.push(m);
+            }
+            if out.is_empty() {
+                tracing::warn!(%name, "DNS-PIN resolve EMPTY — name exists but has no A/AAAA record");
+            } else {
+                let ips: Vec<String> =
+                    out.iter().filter_map(|m| multiaddr_ip(m).map(|i| i.to_string())).collect();
+                tracing::info!(%name, resolved = %ips.join(","), "DNS-PIN resolved");
+            }
+            out
+        }
+        Err(e) => {
+            tracing::warn!(%name, error = %e, "DNS-PIN resolve FAILED");
+            Vec::new()
+        }
+    }
+}
+
 /// Log what a name currently resolves to, without blocking the swarm task.
 ///
 /// libp2p resolves inside the transport and does not surface the answer — the
@@ -867,7 +948,7 @@ enum Pending {
 
 /// A request parked until the peer's Status handshake completes.
 struct QueuedRequest {
-    addr: Multiaddr,
+    addrs: Vec<Multiaddr>,
     protocol: &'static str,
     wire: Vec<u8>,
     reply: oneshot::Sender<Result<Vec<u8>, RequestError>>,
@@ -953,8 +1034,10 @@ async fn run_swarm(
                     tracing::info!("libp2p host stopping");
                     return;
                 }
-                Some(Command::Request { peer, addr, protocol, wire, reply }) => {
-                    submit_request(&mut swarm, &mut ctx, peer, addr, protocol, wire, reply);
+                Some(Command::Request { peer, dns_name, addrs, protocol, wire, reply }) => {
+                    submit_request(
+                        &mut swarm, &mut ctx, peer, dns_name, addrs, protocol, wire, reply,
+                    );
                 }
                 Some(Command::PeerCount { reply }) => {
                     let _ = reply.send(ctx.connected.len());
@@ -1004,7 +1087,9 @@ fn submit_request(
     swarm: &mut Swarm<Behaviour>,
     ctx: &mut SwarmCtx,
     peer: PeerId,
-    addr: Multiaddr,
+    dns_name: Option<String>,
+    // Candidates in resolver order — see `resolve_dial_addrs`.
+    addrs: Vec<Multiaddr>,
     protocol: &'static str,
     wire: Vec<u8>,
     reply: oneshot::Sender<Result<Vec<u8>, RequestError>>,
@@ -1014,7 +1099,7 @@ fn submit_request(
             let _ = reply.send(Err(RequestError::Io(format!("unknown protocol {protocol}"))));
             return;
         };
-        let id = rr.send_request_with_addresses(&peer, wire, vec![addr]);
+        let id = rr.send_request_with_addresses(&peer, wire, addrs);
         ctx.pending.insert(id, Pending::External(reply));
         return;
     }
@@ -1022,14 +1107,19 @@ fn submit_request(
     ctx.queued
         .entry(peer)
         .or_default()
-        .push(QueuedRequest { addr: addr.clone(), protocol, wire, reply });
+        .push(QueuedRequest { addrs: addrs.clone(), protocol, wire, reply });
     if !ctx.connected.contains(&peer) {
-        if let Some(name) = multiaddr_dns_name(&addr) {
-            log_resolution(&name, multiaddr_port(&addr).unwrap_or(0));
+        // The name is carried through rather than re-derived: by this point the
+        // candidates are concrete /ip4//ip6/ addresses, so the name only exists
+        // because the caller resolved it. Kept so a connection or dial failure
+        // can still be attributed to the pin that produced it.
+        if let Some(name) = dns_name {
             ctx.dns_dials.insert(peer, name);
         }
         use libp2p::swarm::dial_opts::DialOpts;
-        let opts = DialOpts::peer_id(peer).addresses(vec![addr]).build();
+        // EVERY candidate, in resolver order: libp2p tries them in turn, which
+        // is what makes a NAT64 network work without special-casing it.
+        let opts = DialOpts::peer_id(peer).addresses(addrs).build();
         match swarm.dial(opts) {
             Ok(()) => {}
             // Already dialing / connecting — the queued request rides along.
@@ -1075,7 +1165,7 @@ fn mark_status_done(swarm: &mut Swarm<Behaviour>, ctx: &mut SwarmCtx, peer: Peer
             let _ = q.reply.send(Err(RequestError::Io(format!("unknown protocol {}", q.protocol))));
             continue;
         };
-        let id = rr.send_request_with_addresses(&peer, q.wire, vec![q.addr]);
+        let id = rr.send_request_with_addresses(&peer, q.wire, q.addrs);
         ctx.pending.insert(id, Pending::External(q.reply));
     }
 }
@@ -1733,5 +1823,64 @@ mod external_address_tests {
         let no_ip: Multiaddr = "/dns4/example.com/tcp/9105".parse().unwrap();
         assert_eq!(multiaddr_ip(&no_ip), None);
         assert_eq!(multiaddr_port(&addr), Some(54321));
+    }
+}
+
+#[cfg(test)]
+mod dial_resolution_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn a_plain_ip_address_passes_through_untouched() {
+        let a: Multiaddr = "/ip4/87.154.209.161/tcp/9105/p2p/\
+            16Uiu2HAkyDsNGDq5pbFCqdKTcJxp4Rd5caoy1Xe2KJVtyc94M8S5"
+            .parse()
+            .unwrap();
+        assert_eq!(resolve_dial_addrs(&a).await, vec![a.clone()]);
+    }
+
+    #[tokio::test]
+    async fn a_name_becomes_concrete_candidates_keeping_port_and_peer_id() {
+        // localhost is the one name guaranteed resolvable in CI and offline.
+        let a: Multiaddr = "/dns4/localhost/tcp/9105/p2p/\
+            16Uiu2HAkyDsNGDq5pbFCqdKTcJxp4Rd5caoy1Xe2KJVtyc94M8S5"
+            .parse()
+            .unwrap();
+        let out = resolve_dial_addrs(&a).await;
+        assert!(!out.is_empty(), "localhost must resolve");
+        for m in &out {
+            // No DNS component survives — that is the whole point: the swarm's
+            // transport may have no DNS layer at all (Android), where a /dns4/
+            // address is rejected with "Multiaddr is not supported".
+            assert!(multiaddr_dns_name(m).is_none(), "{m} still carries a name");
+            assert!(multiaddr_ip(m).is_some(), "{m} has no IP");
+            assert_eq!(multiaddr_port(m), Some(9105), "port must survive");
+            assert!(
+                m.to_string().ends_with("16Uiu2HAkyDsNGDq5pbFCqdKTcJxp4Rd5caoy1Xe2KJVtyc94M8S5"),
+                "peer id must survive: {m}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn an_unresolvable_name_yields_no_candidates() {
+        // Empty, not the input: dialing a /dns4/ address on a DNS-less transport
+        // fails with a misleading "Multiaddr is not supported" rather than a
+        // resolution error. The caller turns this into DialFailure.
+        let a: Multiaddr = "/dns4/no-such-host.invalid/tcp/9105/p2p/\
+            16Uiu2HAkyDsNGDq5pbFCqdKTcJxp4Rd5caoy1Xe2KJVtyc94M8S5"
+            .parse()
+            .unwrap();
+        assert!(resolve_dial_addrs(&a).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn duplicate_addresses_are_collapsed() {
+        // localhost commonly resolves to 127.0.0.1 twice (once per socket type);
+        // dialing the same address twice buys nothing.
+        let a: Multiaddr = "/dns4/localhost/tcp/9105".parse().unwrap();
+        let out = resolve_dial_addrs(&a).await;
+        let ips: HashSet<_> = out.iter().filter_map(multiaddr_ip).collect();
+        assert_eq!(ips.len(), out.len(), "candidates must be unique by IP");
     }
 }


### PR DESCRIPTION
Follow-up to #337. **roost is currently unreachable on the Rust engine on Android, on all three networks.**

## The failure

```
DNS-PIN dial FAILED … error=Failed to negotiate transport protocol(s):
  Multiaddr is not supported: /dns4/be833f3590cd0388.dyndns.dappnode.io/tcp/9105/p2p/…
```

That is the **transport** talking, not DNS. `build_swarm` adds libp2p's DNS layer only when a system resolver is configured — it reads `/etc/resolv.conf`, which Android has not had since Oreo — so the documented fallback to plain TCP fires and a `/dns4/` address is rejected before any connection is attempted.

The fallback behaved exactly as designed. What made it fatal is that #337 dropped the literal IPs in favour of names, so the only pinned address became one that transport cannot dial. I flagged this risk in #337 and then removed the mitigation.

**Resolution was never broken.** `DNS-PIN resolved` kept appearing throughout, because that path uses tokio's `lookup_host` — getaddrinfo, which Android supports fine. The answer was already in hand; nothing used it.

## The fix

Resolve in `request_raw` — async, per request, so a changed address still self-heals — and pass **every** resolved address as a dial candidate. The swarm's DNS layer becomes irrelevant rather than required.

### Order is load-bearing

From the field log:

```
DNS-PIN resolved resolved=64:ff9b::579a:d1a1,87.154.209.161
```

`64:ff9b::/96` is the well-known **NAT64** prefix, and `579a:d1a1` is `87.154.209.161` encoded into it — an IPv6-only mobile network with DNS64. There the synthesized v6 address is the one that works and the raw A record is unroutable, so hand-preferring IPv4 would break exactly the networks this exists to fix. `getaddrinfo` already sorts by RFC 6724 destination-address selection; candidates are passed on in that order and libp2p tries them in turn.

### Safety

Substituting the address changes nothing about trust: Noise still authenticates the remote against the `/p2p/` peer id, so a wrong or hostile DNS answer can only fail to connect — it cannot impersonate the pinned server.

### Bonus

`DNS-PIN resolved` now comes from the lookup the dial actually used, rather than a second lookup done for logging. Previously it meant "what the name says now"; it now means what this connection went to. That removes the caveat #337 had to document.

## Testing

Four new tests: pass-through for plain IPs, name expansion preserving port and peer id with no DNS component surviving, empty result for an unresolvable name, and de-duplication by IP. Plus a live sepolia sync from the pinned `/dns4/` config — `DNS-PIN resolved` → `DNS-PIN connected` → bootstrap verified → committee current. 230 `myotis-net` tests and roost's 74 green.

**Not covered here:** verification on-device. The whole point is a platform I cannot run, so the acceptance test is @biafra23 seeing `DNS-PIN connected` in logcat.