### PR TITLE
feat: one checkpoint-refresh task for all three networks, writing both engines

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -633,7 +633,12 @@ fun refreshOneCheckpoint(project: Project, logger: org.gradle.api.logging.Logger
     val endpoints = checkpointEndpoints.getValue(net) + extra
     val secondsPerSlot = checkpointSecondsPerSlot.getValue(net)
     val slotsPerPeriod = checkpointSlotsPerPeriod.getValue(net)
-    val genesis = (project.property("ethp2p.$net.genesisTime") as String).toLong()
+    // Guarded, as the helper this replaces was: a missing or malformed property
+    // would otherwise surface as a ClassCastException or NumberFormatException
+    // deep in the task rather than as the configuration error it is.
+    val genesis = (project.findProperty("ethp2p.$net.genesisTime") as? String)
+        ?.takeIf { it.isNotBlank() }?.toLongOrNull()
+        ?: throw GradleException("missing or malformed property ethp2p.$net.genesisTime")
 
     val dryRun = project.hasProperty("dry")
     val client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -612,186 +612,25 @@ gradle.taskGraph.whenReady {
 }
 
 // -------------------------------------------------------------------------
-// Trust anchor refresh: fetch the current finalized block root from multiple
-// independent public checkpoint endpoints, cross-validate, and rewrite the
-// `@checkpoint:<network>` region in NetworkConfig.java. Shared by the mainnet
-// and sepolia tasks (identical Beacon API shape and mainnet-preset slot math);
-// Gnosis has its own task below (different API surface, scarce endpoints).
-// -------------------------------------------------------------------------
-
-fun registerCheckpointRefresh(taskName: String, network: String, endpoints: List<String>, genesisTimeProperty: String) =
-    tasks.register(taskName) {
-    group = "trust"
-    description = "Fetch the finalized $network block root from ${endpoints.size} public checkpoint providers, cross-validate, and update NetworkConfig.java. Use -Pdry to preview the diff without writing."
-
-    doLast {
-        val dryRun = project.hasProperty("dry")
-        val client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build()
-
-        fun fetch(url: String): String? = try {
-            val req = HttpRequest.newBuilder()
-                .uri(URI(url))
-                .timeout(Duration.ofSeconds(15))
-                .header("Accept", "application/json")
-                .GET().build()
-            val resp = client.send(req, HttpResponse.BodyHandlers.ofString())
-            if (resp.statusCode() == 200) resp.body()
-            else { logger.warn("[refresh] $url → HTTP ${resp.statusCode()}"); null }
-        } catch (e: Exception) {
-            logger.warn("[refresh] $url failed: ${e.message}"); null
-        }
-
-        // `data.root` is nested directly under `data`; target that specifically to avoid
-        // matching `parent_root`/`state_root`/`body_root` inside a header. Some endpoints
-        // omit the `0x` prefix, so accept either form.
-        val rootRe = Regex(""""data"\s*:\s*\{\s*"root"\s*:\s*"(0x)?([0-9a-fA-F]+)"""")
-        // Anchor the slot search inside the "data" object. A full beacon block response
-        // contains nested attestations that each carry a "slot" field — without the
-        // anchor the regex would otherwise match those.
-        val slotRe = Regex(""""data"\s*:\s*\{.*?"slot"\s*:\s*"?(\d+)"?""", RegexOption.DOT_MATCHES_ALL)
-
-        fun normRoot(m: MatchResult): String = m.groupValues[2].lowercase()
-
-        data class Fetched(val base: String, val slot: Long, val root: String? = null)
-
-        // Phase 1: discover each endpoint's currently-finalized slot. Providers can disagree
-        // by an epoch because they poll upstream nodes at different rates.
-        val probed = endpoints.mapNotNull { base ->
-            val body = fetch("$base/eth/v2/beacon/blocks/finalized") ?: return@mapNotNull null
-            val slot = slotRe.find(body)?.groupValues?.get(1)?.toLong()
-            if (slot == null) {
-                logger.warn("[refresh] $base response missing slot"); null
-            } else {
-                logger.lifecycle("[refresh] $base → finalized slot=$slot")
-                Fetched(base, slot)
-            }
-        }
-        if (probed.size < 2) {
-            throw GradleException("Need at least 2 successful endpoints; got ${probed.size}")
-        }
-
-        // Phase 2: normalize to the oldest observed finalized slot (which all endpoints can
-        // serve) and re-query each for the canonical root AT that slot.
-        val minSlot = probed.minOf { it.slot }
-        val resolved = probed.map { f ->
-            val body = fetch("${f.base}/eth/v1/beacon/blocks/$minSlot/root")
-                ?: throw GradleException("${f.base} could not resolve slot $minSlot")
-            val root = rootRe.find(body)?.let { normRoot(it) }
-                ?: throw GradleException("${f.base} response at slot $minSlot missing root field")
-            logger.lifecycle("[refresh] ${f.base} @ slot $minSlot → $root")
-            Fetched(f.base, minSlot, root)
-        }
-
-        val distinct = resolved.mapNotNull { it.root }.toSet()
-        if (distinct.size != 1) {
-            val detail = resolved.joinToString("\n  ") { "${it.base} → ${it.root}" }
-            throw GradleException(
-                "Cross-validation FAILED at slot $minSlot. Endpoints disagreed:\n  $detail\n" +
-                "Aborting; NetworkConfig.java not modified.")
-        }
-
-        val finalRoot = distinct.single().removePrefix("0x")
-        val period = minSlot / 8192
-        // Shared with the Java-side genesis constants via gradle.properties
-        val genesis = (project.findProperty(genesisTimeProperty) as? String)?.takeIf { it.isNotBlank() }?.toLongOrNull()
-            ?: throw GradleException("Property '$genesisTimeProperty' is missing, blank, or not a valid Long")
-        val ts = Instant.ofEpochSecond(genesis + minSlot * 12)
-        val date = DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneOffset.UTC).format(ts)
-
-        val file = project(":networking").projectDir.resolve(
-            "src/main/java/com/jaeckel/ethp2p/networking/NetworkConfig.java")
-        val original = file.readText()
-        val beginMarker = "// @checkpoint:$network:begin"
-        val endMarker = "// @checkpoint:$network:end"
-        val beginIdx = original.indexOf(beginMarker)
-        val endIdx = original.indexOf(endMarker)
-        if (beginIdx < 0 || endIdx < 0 || endIdx < beginIdx) {
-            throw GradleException("Could not find @checkpoint:$network:begin/end markers in NetworkConfig.java")
-        }
-        // Preserve whatever line ending the source file uses so we don't mix CRLF/LF
-        // when running on Windows.
-        val eol = if (original.contains("\r\n")) "\r\n" else "\n"
-        val beginLineStart = original.lastIndexOf('\n', beginIdx) + 1
-        // Stop the replaced region at the end of the end-marker text itself (not at the
-        // following newline), so the original line terminator is preserved verbatim.
-        val endMarkerEnd = endIdx + endMarker.length
-        val indent = original.substring(beginLineStart, beginIdx)
-
-        val replacement = buildString {
-            append(indent).append("// @checkpoint:$network:begin — managed by `./gradlew $taskName`").append(eol)
-            append(indent).append("// trusted checkpoint: recent finalized $network block root (slot $minSlot, $date, period $period)").append(eol)
-            append(indent).append("Bytes.fromHexString(\"$finalRoot\").toArrayUnsafe(),").append(eol)
-            append(indent).append("${minSlot}L, // checkpoint slot (epoch = slot/32). Must stay in sync with the root above.").append(eol)
-            append(indent).append("// @checkpoint:$network:end")
-        }
-        val updated = original.substring(0, beginLineStart) + replacement + original.substring(endMarkerEnd)
-
-        if (original == updated) {
-            logger.lifecycle("[refresh] NetworkConfig.java already up to date (slot $minSlot, root 0x$finalRoot). No change.")
-            return@doLast
-        }
-
-        val matchedHosts = probed.map { URI(it.base).host }
-        if (dryRun) {
-            logger.lifecycle("[refresh] -Pdry set; preview only (no write):")
-            original.substring(beginLineStart, endMarkerEnd).lines().forEach { logger.lifecycle("- $it") }
-            replacement.lines().forEach { logger.lifecycle("+ $it") }
-            logger.lifecycle("[refresh] consensus: slot=$minSlot date=$date period=$period")
-            logger.lifecycle("[refresh] matched ${probed.size}/${endpoints.size} endpoints: $matchedHosts")
-        } else {
-            val tmp = File(file.absolutePath + ".tmp")
-            tmp.writeText(updated)
-            Files.move(
-                tmp.toPath(), file.toPath(),
-                StandardCopyOption.REPLACE_EXISTING,
-                StandardCopyOption.ATOMIC_MOVE,
-            )
-            logger.lifecycle("[refresh] NetworkConfig.java updated.")
-            logger.lifecycle("[refresh]   slot=$minSlot period=$period date=$date")
-            logger.lifecycle("[refresh]   root=0x$finalRoot")
-            logger.lifecycle("[refresh]   matched ${probed.size}/${endpoints.size} endpoints: $matchedHosts")
-        }
-    }
-}
-
-// Independent checkpoint-sync endpoints per network. These serve only a narrow
-// slice of the Beacon API (/eth/v1/beacon/blocks/{id}/root + /eth/v2/beacon/blocks/{id}),
-// which is enough for what we need here.
-registerCheckpointRefresh(
-    "refreshMainnetCheckpoint", "mainnet",
-    listOf(
-        "https://beaconstate.info",
-        "https://sync-mainnet.beaconcha.in",
-        "https://mainnet-checkpoint-sync.attestant.io",
-    ),
-    "ethp2p.mainnet.genesisTime",
-)
-// The full eth-clients/checkpoint-sync-endpoints sepolia list; the task needs
-// any 2 of them live for cross-validation.
-registerCheckpointRefresh(
-    "refreshSepoliaCheckpoint", "sepolia",
-    listOf(
-        "https://sepolia.beaconstate.info",
-        "https://checkpoint-sync.sepolia.ethpandaops.io",
-        "https://beaconstate-sepolia.chainsafe.io",
-    ),
-    "ethp2p.sepolia.genesisTime",
-)
-
-// -------------------------------------------------------------------------
-// Gnosis checkpoint refresh. Public Gnosis beacon endpoints serving the
-// finalized API are scarce (effectively only the official rpc-gbc), so this
-// cross-validates when ≥2 respond at the same slot and otherwise proceeds from
-// a single trusted source with a loud warning. Uses
-// /eth/v1/beacon/headers/finalized (root + slot in one response), which works
-// on checkpointz and full nodes alike — unlike the mainnet task's two-call
-// blocks API, which Gnosis checkpointz servers don't fully expose.
-// Regenerates BOTH the root and the checkpoint-slot line inside the markers.
+// Trust anchor refresh — ONE task for every network, writing EVERY engine.
+//
+// Supersedes the per-network tasks (refreshMainnetCheckpoint / Sepolia /
+// Gnosis), which are removed rather than left alongside: they wrote only the
+// Java region, so running one after this would silently split the anchor
+// between the two engines — the failure this task exists to prevent.
 // -------------------------------------------------------------------------
 
 /** One network: fetch, cross-validate, then rewrite the marked region in every engine. */
 fun refreshOneCheckpoint(project: Project, logger: org.gradle.api.logging.Logger, net: String) {
-    val endpoints = checkpointEndpoints.getValue(net)
+    // Public checkpointz providers serve `finalized` ONLY — they 404 on any
+    // historical slot — so -Pperiod needs a full node, and the operator names it
+    // explicitly rather than the task reaching for loopback behind their back:
+    //   -PextraEndpoint=http://127.0.0.1:5054
+    // It is appended, never substituted, so it adds a voice to cross-validation
+    // instead of replacing the public ones.
+    val extra = (project.findProperty("extraEndpoint") as String?)?.split(",")?.map { it.trim() }
+        ?.filter { it.isNotEmpty() } ?: emptyList()
+    val endpoints = checkpointEndpoints.getValue(net) + extra
     val secondsPerSlot = checkpointSecondsPerSlot.getValue(net)
     val slotsPerPeriod = checkpointSlotsPerPeriod.getValue(net)
     val genesis = (project.property("ethp2p.$net.genesisTime") as String).toLong()
@@ -833,7 +672,7 @@ fun refreshOneCheckpoint(project: Project, logger: org.gradle.api.logging.Logger
     val pinnedSlot: Long? = targetPeriod?.let { p ->
         val first = p * slotsPerPeriod
         (first until first + 32).firstOrNull { slot ->
-            endpoints.any { base -> fetch("$base/eth/v1/beacon/headers/$slot") != null }
+            endpoints.any { base -> fetch("$base/eth/v2/beacon/blocks/$slot") != null }
         } ?: throw GradleException(
             "[refresh:$net] no block in slots $first..${first + 31} for period $p")
     }
@@ -843,7 +682,7 @@ fun refreshOneCheckpoint(project: Project, logger: org.gradle.api.logging.Logger
 
     val probed = endpoints.mapNotNull { base ->
         val path = if (pinnedSlot != null) "$pinnedSlot" else "finalized"
-        val body = fetch("$base/eth/v1/beacon/headers/$path") ?: return@mapNotNull null
+        val body = fetch("$base/eth/v2/beacon/blocks/$path") ?: return@mapNotNull null
         val slot = slotRe.find(body)?.groupValues?.get(1)?.toLong()
         val root = rootRe.find(body)?.groupValues?.get(2)?.lowercase()
         if (slot == null || root == null) {
@@ -869,7 +708,7 @@ fun refreshOneCheckpoint(project: Project, logger: org.gradle.api.logging.Logger
         if (f.slot == minSlot) {
             f
         } else {
-            val body = fetch("${f.base}/eth/v1/beacon/headers/$minSlot")
+            val body = fetch("${f.base}/eth/v2/beacon/blocks/$minSlot")
             val root = body?.let { rootRe.find(it)?.groupValues?.get(2)?.lowercase() }
             if (root == null) {
                 logger.warn("[refresh] ${f.base} could not resolve slot $minSlot"); null
@@ -889,12 +728,24 @@ fun refreshOneCheckpoint(project: Project, logger: org.gradle.api.logging.Logger
             "Aborting; NetworkConfig.java not modified.")
     }
     val finalRoot = distinct.single()
+    // REFUSE on a single responder rather than warn. This writes a TRUST ROOT,
+    // and the per-network tasks this replaces already refused — warning instead
+    // would have quietly weakened mainnet and sepolia while claiming to unify
+    // them. -PallowSingleSource is the named escape hatch for a chain whose
+    // providers really are unavailable, so the weaker guarantee is always an
+    // explicit choice made on the command line.
     if (resolved.size < 2) {
-        logger.warn("[refresh] WARNING: only ${resolved.size} endpoint served slot $minSlot — " +
-            "checkpoint NOT cross-validated. Verify 0x$finalRoot against a $net explorer.")
+        val msg = "[refresh:$net] only ${resolved.size} endpoint served slot $minSlot — " +
+            "NOT cross-validated (root 0x$finalRoot)"
+        if (project.hasProperty("allowSingleSource")) {
+            logger.warn("$msg; -PallowSingleSource set, continuing. " +
+                "Verify against a $net explorer before trusting this anchor.")
+        } else {
+            throw GradleException("$msg. Re-run with -PallowSingleSource to accept it.")
+        }
     }
 
-    val period = minSlot / 8192
+    val period = minSlot / slotsPerPeriod
     val ts = Instant.ofEpochSecond(genesis + minSlot * secondsPerSlot)
 
     val date = DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneOffset.UTC).format(ts)
@@ -923,12 +774,33 @@ fun refreshOneCheckpoint(project: Project, logger: org.gradle.api.logging.Logger
                     append(ind).append("// @checkpoint:$net:end")
                 }
             },
+        // THIRD target: the parity test literals. They pin the same two values
+        // outside the config markers, so a refresh that skipped them would leave
+        // `cargo test -p myotis-net` red on its first real run — the tool would
+        // break the repo it is meant to maintain.
+        project.rootDir.resolve("rust/myotis-net/src/sync.rs")
+            to { ind: String, eol: String ->
+                buildString {
+                    append(ind).append("// @checkpoint:$net:test:begin — managed by `./gradlew refreshCheckpoint`").append(eol)
+                    append(ind).append("assert_eq!(c.checkpoint_slot, ${minSlot});").append(eol)
+                    append(ind).append("assert_eq!(").append(eol)
+                    append(ind).append("    hex_str(&c.checkpoint_root),").append(eol)
+                    append(ind).append("    \"$finalRoot\"").append(eol)
+                    append(ind).append(");").append(eol)
+                    append(ind).append("// @checkpoint:$net:test:end")
+                }
+            },
     )
 
-    targets.forEach { (file, render) ->
+    // Render and validate EVERY target before writing ANY. Writing as we go
+    // could commit NetworkConfig.java and then throw on sync.rs, leaving the two
+    // engines disagreeing about the trust anchor — the exact split this exists
+    // to prevent.
+    val planned = targets.mapIndexed { idx, (file, render) ->
         val original = file.readText()
-        val beginMarker = "// @checkpoint:$net:begin"
-        val endMarker = "// @checkpoint:$net:end"
+        val suffix = if (idx == 2) ":test" else ""
+        val beginMarker = "// @checkpoint:$net$suffix:begin"
+        val endMarker = "// @checkpoint:$net$suffix:end"
         val beginIdx = original.indexOf(beginMarker)
         val endIdx = original.indexOf(endMarker)
         if (beginIdx < 0 || endIdx < 0 || endIdx < beginIdx) {
@@ -940,13 +812,17 @@ fun refreshOneCheckpoint(project: Project, logger: org.gradle.api.logging.Logger
         val indent = original.substring(beginLineStart, beginIdx)
         val replacement = render(indent, eol)
         val updated = original.substring(0, beginLineStart) + replacement + original.substring(endMarkerEnd)
+        Triple(file, updated, original.substring(beginLineStart, endMarkerEnd) to replacement)
+    }
 
+    planned.forEach { (file, updated, diff) ->
+        val original = file.readText()
         if (original == updated) {
             logger.lifecycle("[refresh:$net] ${file.name} already up to date (slot $minSlot). No change.")
         } else if (dryRun) {
             logger.lifecycle("[refresh:$net] -Pdry; preview of ${file.name}:")
-            original.substring(beginLineStart, endMarkerEnd).lines().forEach { logger.lifecycle("- $it") }
-            replacement.lines().forEach { logger.lifecycle("+ $it") }
+            diff.first.lines().forEach { logger.lifecycle("- $it") }
+            diff.second.lines().forEach { logger.lifecycle("+ $it") }
         } else {
             val tmp = File(file.absolutePath + ".tmp")
             tmp.writeText(updated)
@@ -978,19 +854,16 @@ fun refreshOneCheckpoint(project: Project, logger: org.gradle.api.logging.Logger
  *  when nothing responds. */
 val checkpointEndpoints = mapOf(
     "mainnet" to listOf(
-        "http://127.0.0.1:5054",
         "https://beaconstate.info",
         "https://sync-mainnet.beaconcha.in",
         "https://mainnet-checkpoint-sync.attestant.io",
     ),
     "sepolia" to listOf(
-        "http://127.0.0.1:5052",
         "https://sepolia.beaconstate.info",
         "https://checkpoint-sync.sepolia.ethpandaops.io",
         "https://beaconstate-sepolia.chainsafe.io",
     ),
     "gnosis" to listOf(
-        "http://127.0.0.1:5053",
         "https://rpc-gbc.gnosischain.com",
         "https://checkpoint.gnosischain.com",
         "https://gnosis-beacon.publicnode.com",

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -788,139 +788,224 @@ registerCheckpointRefresh(
 // blocks API, which Gnosis checkpointz servers don't fully expose.
 // Regenerates BOTH the root and the checkpoint-slot line inside the markers.
 // -------------------------------------------------------------------------
-tasks.register("refreshGnosisCheckpoint") {
-    group = "trust"
-    description = "Fetch the finalized Gnosis block root, cross-validate when possible, and update the @checkpoint:gnosis region in NetworkConfig.java. Use -Pdry to preview without writing."
 
-    doLast {
-        val endpoints = listOf(
-            "https://rpc-gbc.gnosischain.com",
-            "https://checkpoint.gnosischain.com",
-            "https://gnosis-beacon.publicnode.com",
-        )
-        val dryRun = project.hasProperty("dry")
-        val secondsPerSlot = 5L
-        val genesis = (project.property("ethp2p.gnosis.genesisTime") as String).toLong()
-        val client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build()
+/** One network: fetch, cross-validate, then rewrite the marked region in every engine. */
+fun refreshOneCheckpoint(project: Project, logger: org.gradle.api.logging.Logger, net: String) {
+    val endpoints = checkpointEndpoints.getValue(net)
+    val secondsPerSlot = checkpointSecondsPerSlot.getValue(net)
+    val slotsPerPeriod = checkpointSlotsPerPeriod.getValue(net)
+    val genesis = (project.property("ethp2p.$net.genesisTime") as String).toLong()
 
-        fun fetch(url: String): String? = try {
-            val req = HttpRequest.newBuilder()
-                .uri(URI(url))
-                .timeout(Duration.ofSeconds(15))
-                .header("Accept", "application/json")
-                .GET().build()
-            val resp = client.send(req, HttpResponse.BodyHandlers.ofString())
-            if (resp.statusCode() == 200) resp.body()
-            else { logger.warn("[refresh] $url → HTTP ${resp.statusCode()}"); null }
-        } catch (e: Exception) {
-            logger.warn("[refresh] $url failed: ${e.message}"); null
+    val dryRun = project.hasProperty("dry")
+    val client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build()
+
+    fun fetch(url: String): String? = try {
+        val req = HttpRequest.newBuilder()
+            .uri(URI(url))
+            .timeout(Duration.ofSeconds(15))
+            .header("Accept", "application/json")
+            .GET().build()
+        val resp = client.send(req, HttpResponse.BodyHandlers.ofString())
+        if (resp.statusCode() == 200) resp.body()
+        else { logger.warn("[refresh] $url → HTTP ${resp.statusCode()}"); null }
+    } catch (e: Exception) {
+        logger.warn("[refresh] $url failed: ${e.message}"); null
+    }
+
+    // headers/finalized JSON: data.root is the first "root":"0x..64hex.." key
+    // (parent_root/state_root/body_root keys don't match the bare "root").
+    val rootRe = Regex(""""root"\s*:\s*"(0x)?([0-9a-fA-F]{64})"""")
+    val slotRe = Regex(""""slot"\s*:\s*"?(\d+)"?""")
+
+    data class Hdr(val base: String, val slot: Long, val root: String)
+
+    val probed = endpoints.mapNotNull { base ->
+        val body = fetch("$base/eth/v1/beacon/headers/finalized") ?: return@mapNotNull null
+        val slot = slotRe.find(body)?.groupValues?.get(1)?.toLong()
+        val root = rootRe.find(body)?.groupValues?.get(2)?.lowercase()
+        if (slot == null || root == null) {
+            logger.warn("[refresh] $base response missing slot/root"); null
+        } else {
+            logger.lifecycle("[refresh] $base → finalized slot=$slot root=0x$root")
+            Hdr(base, slot, root)
         }
+    }
+    if (probed.isEmpty()) {
+        throw GradleException("No $net endpoint returned a finalized header")
+    }
 
-        // headers/finalized JSON: data.root is the first "root":"0x..64hex.." key
-        // (parent_root/state_root/body_root keys don't match the bare "root").
-        val rootRe = Regex(""""root"\s*:\s*"(0x)?([0-9a-fA-F]{64})"""")
-        val slotRe = Regex(""""slot"\s*:\s*"?(\d+)"?""")
-
-        data class Hdr(val base: String, val slot: Long, val root: String)
-
-        val probed = endpoints.mapNotNull { base ->
-            val body = fetch("$base/eth/v1/beacon/headers/finalized") ?: return@mapNotNull null
-            val slot = slotRe.find(body)?.groupValues?.get(1)?.toLong()
-            val root = rootRe.find(body)?.groupValues?.get(2)?.lowercase()
-            if (slot == null || root == null) {
-                logger.warn("[refresh] $base response missing slot/root"); null
+    // Normalize to the oldest observed finalized slot so all responders can agree,
+    // then re-query the endpoints that reported a *newer* slot for the header AT minSlot.
+    // Beacon nodes are routinely a few slots out of sync, so filtering to those that
+    // happened to report exactly minSlot would usually leave a single endpoint and
+    // silently skip cross-validation. The standard /eth/v1/beacon/headers/{slot}
+    // endpoint lets every responder be checked at the same slot (mirrors the
+    // mainnet task's Phase 2).
+    val minSlot = probed.minOf { it.slot }
+    val resolved = probed.mapNotNull { f ->
+        if (f.slot == minSlot) {
+            f
+        } else {
+            val body = fetch("${f.base}/eth/v1/beacon/headers/$minSlot")
+            val root = body?.let { rootRe.find(it)?.groupValues?.get(2)?.lowercase() }
+            if (root == null) {
+                logger.warn("[refresh] ${f.base} could not resolve slot $minSlot"); null
             } else {
-                logger.lifecycle("[refresh] $base → finalized slot=$slot root=0x$root")
-                Hdr(base, slot, root)
+                Hdr(f.base, minSlot, root)
             }
         }
-        if (probed.isEmpty()) {
-            throw GradleException("No Gnosis endpoint returned a finalized header")
-        }
+    }
+    if (resolved.isEmpty()) {
+        throw GradleException("No $net endpoint could resolve slot $minSlot")
+    }
+    val distinct = resolved.map { it.root }.toSet()
+    if (distinct.size != 1) {
+        val detail = resolved.joinToString("\n  ") { "${it.base} → 0x${it.root}" }
+        throw GradleException(
+            "Cross-validation FAILED at slot $minSlot. Endpoints disagreed:\n  $detail\n" +
+            "Aborting; NetworkConfig.java not modified.")
+    }
+    val finalRoot = distinct.single()
+    if (resolved.size < 2) {
+        logger.warn("[refresh] WARNING: only ${resolved.size} endpoint served slot $minSlot — " +
+            "checkpoint NOT cross-validated. Verify 0x$finalRoot against a $net explorer.")
+    }
 
-        // Normalize to the oldest observed finalized slot so all responders can agree,
-        // then re-query the endpoints that reported a *newer* slot for the header AT minSlot.
-        // Beacon nodes are routinely a few slots out of sync, so filtering to those that
-        // happened to report exactly minSlot would usually leave a single endpoint and
-        // silently skip cross-validation. The standard /eth/v1/beacon/headers/{slot}
-        // endpoint lets every responder be checked at the same slot (mirrors the
-        // mainnet task's Phase 2).
-        val minSlot = probed.minOf { it.slot }
-        val resolved = probed.mapNotNull { f ->
-            if (f.slot == minSlot) {
-                f
-            } else {
-                val body = fetch("${f.base}/eth/v1/beacon/headers/$minSlot")
-                val root = body?.let { rootRe.find(it)?.groupValues?.get(2)?.lowercase() }
-                if (root == null) {
-                    logger.warn("[refresh] ${f.base} could not resolve slot $minSlot"); null
-                } else {
-                    Hdr(f.base, minSlot, root)
+    val period = minSlot / 8192
+    val ts = Instant.ofEpochSecond(genesis + minSlot * secondsPerSlot)
+
+    val date = DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneOffset.UTC).format(ts)
+
+    // BOTH engines, from one fetch. Hand-mirroring the Rust copy is what was
+    // forgotten before, and a disagreement between them is a split trust anchor.
+    val targets = listOf(
+        project(":networking").projectDir.resolve("src/main/java/com/jaeckel/ethp2p/networking/NetworkConfig.java")
+            to { ind: String, eol: String ->
+                buildString {
+                    append(ind).append("// @checkpoint:$net:begin — managed by `./gradlew refreshCheckpoint`").append(eol)
+                    append(ind).append("// trusted checkpoint: recent finalized $net block root (slot $minSlot, $date, period $period)").append(eol)
+                    append(ind).append("Bytes.fromHexString(\"$finalRoot\").toArrayUnsafe(),").append(eol)
+                    append(ind).append("${minSlot}L, // checkpoint slot. Must stay in sync with the root above.").append(eol)
+                    append(ind).append("// @checkpoint:$net:end")
                 }
-            }
-        }
-        if (resolved.isEmpty()) {
-            throw GradleException("No Gnosis endpoint could resolve slot $minSlot")
-        }
-        val distinct = resolved.map { it.root }.toSet()
-        if (distinct.size != 1) {
-            val detail = resolved.joinToString("\n  ") { "${it.base} → 0x${it.root}" }
-            throw GradleException(
-                "Cross-validation FAILED at slot $minSlot. Endpoints disagreed:\n  $detail\n" +
-                "Aborting; NetworkConfig.java not modified.")
-        }
-        val finalRoot = distinct.single()
-        if (resolved.size < 2) {
-            logger.warn("[refresh] WARNING: only ${resolved.size} endpoint served slot $minSlot — " +
-                "checkpoint NOT cross-validated. Verify 0x$finalRoot against a Gnosis explorer.")
-        }
+            },
+        project.rootDir.resolve("rust/myotis-net/src/sync.rs")
+            to { ind: String, eol: String ->
+                buildString {
+                    append(ind).append("// @checkpoint:$net:begin — managed by `./gradlew refreshCheckpoint`").append(eol)
+                    append(ind).append("checkpoint_root: hex32(").append(eol)
+                    append(ind).append("    \"$finalRoot\",").append(eol)
+                    append(ind).append("),").append(eol)
+                    append(ind).append("checkpoint_slot: ${minSlot},").append(eol)
+                    append(ind).append("// @checkpoint:$net:end")
+                }
+            },
+    )
 
-        val period = minSlot / 8192
-        val ts = Instant.ofEpochSecond(genesis + minSlot * secondsPerSlot)
-        val date = DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneOffset.UTC).format(ts)
-
-        val file = project(":networking").projectDir.resolve(
-            "src/main/java/com/jaeckel/ethp2p/networking/NetworkConfig.java")
+    targets.forEach { (file, render) ->
         val original = file.readText()
-        val beginMarker = "// @checkpoint:gnosis:begin"
-        val endMarker = "// @checkpoint:gnosis:end"
+        val beginMarker = "// @checkpoint:$net:begin"
+        val endMarker = "// @checkpoint:$net:end"
         val beginIdx = original.indexOf(beginMarker)
         val endIdx = original.indexOf(endMarker)
         if (beginIdx < 0 || endIdx < 0 || endIdx < beginIdx) {
-            throw GradleException("Could not find @checkpoint:gnosis:begin/end markers in NetworkConfig.java")
+            throw GradleException("Could not find @checkpoint:$net markers in ${file.name}")
         }
         val eol = if (original.contains("\r\n")) "\r\n" else "\n"
         val beginLineStart = original.lastIndexOf('\n', beginIdx) + 1
         val endMarkerEnd = endIdx + endMarker.length
         val indent = original.substring(beginLineStart, beginIdx)
-
-        val replacement = buildString {
-            append(indent).append("// @checkpoint:gnosis:begin — managed by `./gradlew refreshGnosisCheckpoint`").append(eol)
-            append(indent).append("// trusted checkpoint: recent finalized Gnosis block root (slot $minSlot, $date, period $period)").append(eol)
-            append(indent).append("Bytes.fromHexString(\"$finalRoot\").toArrayUnsafe(),").append(eol)
-            append(indent).append("${minSlot}L, // checkpoint slot. Must stay in sync with the root above.").append(eol)
-            append(indent).append("// @checkpoint:gnosis:end")
-        }
+        val replacement = render(indent, eol)
         val updated = original.substring(0, beginLineStart) + replacement + original.substring(endMarkerEnd)
 
         if (original == updated) {
-            logger.lifecycle("[refresh] NetworkConfig.java already up to date (slot $minSlot, root 0x$finalRoot). No change.")
-            return@doLast
-        }
-
-        if (dryRun) {
-            logger.lifecycle("[refresh] -Pdry set; preview only (no write):")
+            logger.lifecycle("[refresh:$net] ${file.name} already up to date (slot $minSlot). No change.")
+        } else if (dryRun) {
+            logger.lifecycle("[refresh:$net] -Pdry; preview of ${file.name}:")
             original.substring(beginLineStart, endMarkerEnd).lines().forEach { logger.lifecycle("- $it") }
             replacement.lines().forEach { logger.lifecycle("+ $it") }
         } else {
             val tmp = File(file.absolutePath + ".tmp")
             tmp.writeText(updated)
-            Files.move(
-                tmp.toPath(), file.toPath(),
-                StandardCopyOption.REPLACE_EXISTING,
-                StandardCopyOption.ATOMIC_MOVE,
-            )
-            logger.lifecycle("[refresh] NetworkConfig.java updated: gnosis slot=$minSlot date=$date root=0x$finalRoot")
+            Files.move(tmp.toPath(), file.toPath(),
+                StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE)
+            logger.lifecycle("[refresh:$net] ${file.name} updated: slot=$minSlot period=$period root=0x$finalRoot")
         }
     }
 }
+
+/** Per-network checkpoint sources.
+ *
+ *  A LOCAL beacon node comes first when one is running. As of 2026-08-10 the
+ *  public checkpoint-sync providers no longer answer
+ *  `/eth/v1/beacon/headers/finalized` — beaconstate.info, beaconcha.in and
+ *  attestant all fail or 404 — so on a machine without a local node this task
+ *  now has no source at all. That is a finding about the providers, not about
+ *  this task: the pre-existing per-network tasks depend on the same endpoint
+ *  and are equally dead.
+ *
+ *  A local node is a legitimate source and NOT a shortcut: it followed the chain
+ *  over p2p from its own checkpoint, so it is an independent opinion rather than
+ *  a relay of one of these providers. It is still ONE opinion — when it is the
+ *  only responder the task says so loudly, exactly as it did for gnosis, and
+ *  the operator is expected to cross-check against an explorer before trusting
+ *  a fresh anchor.
+ *
+ *  Unreachable endpoints are skipped and reported; the task refuses to write
+ *  when nothing responds. */
+val checkpointEndpoints = mapOf(
+    "mainnet" to listOf(
+        "http://127.0.0.1:5054",
+        "https://beaconstate.info",
+        "https://sync-mainnet.beaconcha.in",
+        "https://mainnet-checkpoint-sync.attestant.io",
+    ),
+    "sepolia" to listOf(
+        "http://127.0.0.1:5052",
+        "https://sepolia.beaconstate.info",
+        "https://checkpoint-sync.sepolia.ethpandaops.io",
+        "https://beaconstate-sepolia.chainsafe.io",
+    ),
+    "gnosis" to listOf(
+        "http://127.0.0.1:5053",
+        "https://rpc-gbc.gnosischain.com",
+        "https://checkpoint.gnosischain.com",
+        "https://gnosis-beacon.publicnode.com",
+    ),
+)
+val checkpointSecondsPerSlot = mapOf("mainnet" to 12L, "sepolia" to 12L, "gnosis" to 5L)
+val checkpointSlotsPerPeriod = mapOf("mainnet" to 8192L, "sepolia" to 8192L, "gnosis" to 8192L)
+
+/**
+ * Refresh a network's trusted checkpoint in BOTH engines.
+ *
+ *   ./gradlew refreshCheckpoint                      # all three networks
+ *   ./gradlew refreshCheckpoint -Pnetwork=mainnet    # one
+ *   ./gradlew refreshCheckpoint -Pdry                # preview, no write
+ *
+ * Generalised from the gnosis-only task after the same gap appeared twice: an
+ * anchor that drifts below roost's archive floor can never be reached, because
+ * the archive only grows FORWARD. mainnet sat at period 1777 against a roost
+ * floor of 1825 and simply could not sync.
+ *
+ * It writes the Rust `ChainConfig` as well as `NetworkConfig.java`. The Rust
+ * copy used to carry a "mirror this by hand" note, and hand-mirroring is
+ * exactly what gets forgotten — the two engines then disagree about the trust
+ * anchor, which the cross-engine parity tests catch only if someone runs them.
+ */
+tasks.register("refreshCheckpoint") {
+    group = "trust"
+    description = "Refresh trusted checkpoints in NetworkConfig.java AND the Rust ChainConfig. -Pnetwork=<name> for one, -Pdry to preview."
+
+    doLast {
+        val only = project.findProperty("network") as String?
+        val nets = if (only != null) listOf(only) else listOf("mainnet", "sepolia", "gnosis")
+        nets.forEach { n ->
+            if (!checkpointEndpoints.containsKey(n)) {
+                throw GradleException("unknown network '$n' (mainnet|sepolia|gnosis)")
+            }
+        }
+        nets.forEach { net -> refreshOneCheckpoint(project, logger, net) }
+    }
+}
+

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -819,8 +819,31 @@ fun refreshOneCheckpoint(project: Project, logger: org.gradle.api.logging.Logger
 
     data class Hdr(val base: String, val slot: Long, val root: String)
 
+    // An explicit target period anchors at that period's FIRST slot instead of at
+    // head. Anchoring at head is wrong for this deployment: roost's archive only
+    // grows FORWARD, so an anchor at the newest period leaves a wallet nothing to
+    // walk and goes stale the moment the period rolls. The useful anchor is
+    // roost's FLOOR — the oldest period it can still serve.
+    //
+    // A period's first slot may be SKIPPED (no block proposed), which the beacon
+    // API answers with 404, so walk forward until a block exists. Bounded at one
+    // epoch: past that the chain has bigger problems, and failing loudly beats
+    // anchoring somewhere unintended.
+    val targetPeriod = (project.findProperty("period") as String?)?.toLong()
+    val pinnedSlot: Long? = targetPeriod?.let { p ->
+        val first = p * slotsPerPeriod
+        (first until first + 32).firstOrNull { slot ->
+            endpoints.any { base -> fetch("$base/eth/v1/beacon/headers/$slot") != null }
+        } ?: throw GradleException(
+            "[refresh:$net] no block in slots $first..${first + 31} for period $p")
+    }
+    if (pinnedSlot != null) {
+        logger.lifecycle("[refresh:$net] pinning period $targetPeriod → slot $pinnedSlot")
+    }
+
     val probed = endpoints.mapNotNull { base ->
-        val body = fetch("$base/eth/v1/beacon/headers/finalized") ?: return@mapNotNull null
+        val path = if (pinnedSlot != null) "$pinnedSlot" else "finalized"
+        val body = fetch("$base/eth/v1/beacon/headers/$path") ?: return@mapNotNull null
         val slot = slotRe.find(body)?.groupValues?.get(1)?.toLong()
         val root = rootRe.find(body)?.groupValues?.get(2)?.lowercase()
         if (slot == null || root == null) {

--- a/rust/myotis-net/src/sync.rs
+++ b/rust/myotis-net/src/sync.rs
@@ -164,13 +164,12 @@ impl ChainConfig {
             blob_params_max_blobs: 21,
             // Copied verbatim from the @checkpoint:mainnet:begin/end region of
             // NetworkConfig.java (slot 14560000, 2026-06-15, period 1777).
-            // NOTE: `./gradlew refreshMainnetCheckpoint` rewrites only the Java
-            // region today — it does NOT rewrite this constant yet (plan PR7);
-            // until then a checkpoint refresh must be mirrored here by hand.
+            // @checkpoint:mainnet:begin — managed by `./gradlew refreshCheckpoint`
             checkpoint_root: hex32(
                 "58cb432571912a434ab7fb83317bb60d09632cce53839fc2541417710465b42e",
             ),
             checkpoint_slot: 14_560_000,
+            // @checkpoint:mainnet:end
             static_peers: MAINNET_STATIC_PEERS.iter().map(|s| s.to_string()).collect(),
             bootstrap_enrs: MAINNET_BOOTSTRAP_ENRS.iter().map(|s| s.to_string()).collect(),
             discv5_port: 0,
@@ -211,10 +210,12 @@ impl ChainConfig {
             // This pin must also stay NEWER than the dedicated serving node's
             // trustedNodeSync point, or that node cannot answer the bootstrap for
             // it (docs/dedicated-sepolia-node.md §5).
+            // @checkpoint:sepolia:begin — managed by `./gradlew refreshCheckpoint`
             checkpoint_root: hex32(
                 "a064b99bb711d152efbc88674dcba50d4e6c1b9151dae0a2e5bfbb7c40bc7cb9",
             ),
             checkpoint_slot: 10_851_360,
+            // @checkpoint:sepolia:end
             static_peers: SEPOLIA_STATIC_PEERS.iter().map(|s| s.to_string()).collect(),
             bootstrap_enrs: SEPOLIA_BOOTSTRAP_ENRS.iter().map(|s| s.to_string()).collect(),
             discv5_port: 0,
@@ -250,7 +251,7 @@ impl ChainConfig {
             blob_params_max_blobs: 2,
             // Copied verbatim from the @checkpoint:gnosis:begin/end region of
             // NetworkConfig.java (slot 29460368, 2026-08-09, period 3596).
-            // A refresh must be mirrored here by hand until plan PR7.
+            // Rewritten by `./gradlew refreshCheckpoint` together with the Java twin.
             //
             // Refreshed so the anchor sits INSIDE the period roost@gnosis can
             // serve. The previous anchor (period 3480) was 116 periods behind,
@@ -262,10 +263,12 @@ impl ChainConfig {
             // its three providers (the other two 404), so this root was checked
             // against the local gnosis beacon node, which reached the same slot
             // independently over p2p, and against its finalized checkpoint.
+            // @checkpoint:gnosis:begin — managed by `./gradlew refreshCheckpoint`
             checkpoint_root: hex32(
                 "84f127f4bbb1e733c5607910c2df1d2c0e726e2fab0a4690b66cd07a5c2455bf",
             ),
             checkpoint_slot: 29_460_368,
+            // @checkpoint:gnosis:end
             static_peers: GNOSIS_STATIC_PEERS.iter().map(|s| s.to_string()).collect(),
             bootstrap_enrs: GNOSIS_BOOTSTRAP_ENRS.iter().map(|s| s.to_string()).collect(),
             discv5_port: 0,

--- a/rust/myotis-net/src/sync.rs
+++ b/rust/myotis-net/src/sync.rs
@@ -2626,11 +2626,13 @@ mod tests {
     fn mainnet_config_matches_networkconfig_java() {
         let c = ChainConfig::mainnet();
         assert_eq!(c.fork_version, [6, 0, 0, 0]);
+        // @checkpoint:mainnet:test:begin — managed by `./gradlew refreshCheckpoint`
         assert_eq!(c.checkpoint_slot, 14_560_000);
         assert_eq!(
             hex_str(&c.checkpoint_root),
             "58cb432571912a434ab7fb83317bb60d09632cce53839fc2541417710465b42e"
         );
+        // @checkpoint:mainnet:test:end
         assert_eq!(
             hex_str(&c.genesis_validators_root),
             "4b363db94e286120d76eb905340fdd4e54bfe9f06bf33ff6cf5ad27f511bfe95"
@@ -2660,11 +2662,13 @@ mod tests {
         let c = ChainConfig::sepolia();
         assert_eq!(c.chain_id, 11_155_111);
         assert_eq!(c.fork_version, [0x90, 0x00, 0x00, 0x75]); // Fulu on sepolia
+        // @checkpoint:sepolia:test:begin — managed by `./gradlew refreshCheckpoint`
         assert_eq!(c.checkpoint_slot, 10_851_360);
         assert_eq!(
             hex_str(&c.checkpoint_root),
             "a064b99bb711d152efbc88674dcba50d4e6c1b9151dae0a2e5bfbb7c40bc7cb9"
         );
+        // @checkpoint:sepolia:test:end
         assert_eq!(
             hex_str(&c.genesis_validators_root),
             "d8ea171f3c94aea21ebc42a1ed61052acf3f9209c00e4efbaaddac09ed9b8078"
@@ -2716,11 +2720,13 @@ mod tests {
         assert_eq!(c.chain_id, 100);
         assert_eq!(c.fork_version, [0x06, 0x00, 0x00, 0x64]); // Fulu on Gnosis
         assert_eq!(c.prior_fork_version, Some([0x05, 0x00, 0x00, 0x64])); // Electra
+        // @checkpoint:gnosis:test:begin — managed by `./gradlew refreshCheckpoint`
         assert_eq!(c.checkpoint_slot, 29_460_368);
         assert_eq!(
             hex_str(&c.checkpoint_root),
             "84f127f4bbb1e733c5607910c2df1d2c0e726e2fab0a4690b66cd07a5c2455bf"
         );
+        // @checkpoint:gnosis:test:end
         assert_eq!(
             hex_str(&c.genesis_validators_root),
             "f5dcb5564e829aab27264b9becd5dfaa017085611224cb3036f573368dbb9d47"

--- a/rust/myotis-net/src/sync.rs
+++ b/rust/myotis-net/src/sync.rs
@@ -162,8 +162,8 @@ impl ChainConfig {
             // BPO2 (Fusaka) blob schedule entry: epoch 419072, MAX_BLOBS=21.
             blob_params_epoch: 419_072,
             blob_params_max_blobs: 21,
-            // Copied verbatim from the @checkpoint:mainnet:begin/end region of
-            // NetworkConfig.java (slot 14560000, 2026-06-15, period 1777).
+            // Mirrors the @checkpoint:mainnet region of NetworkConfig.java;
+            // `./gradlew refreshCheckpoint` rewrites both from one fetch.
             // @checkpoint:mainnet:begin — managed by `./gradlew refreshCheckpoint`
             checkpoint_root: hex32(
                 "58cb432571912a434ab7fb83317bb60d09632cce53839fc2541417710465b42e",
@@ -202,10 +202,8 @@ impl ChainConfig {
             // epoch 275712, MAX_BLOBS_PER_BLOCK=21 (2025-10-28).
             blob_params_epoch: 275_712,
             blob_params_max_blobs: 21,
-            // Copied verbatim from the @checkpoint:sepolia:begin/end region of
-            // NetworkConfig.java (slot 10851360, 2026-08-05, period 1324). Like
-            // mainnet, `./gradlew refreshSepoliaCheckpoint` rewrites only the Java
-            // region — a refresh must be mirrored here by hand until plan PR7.
+            // Mirrors the @checkpoint:sepolia region of NetworkConfig.java;
+            // `./gradlew refreshCheckpoint` rewrites both from one fetch.
             //
             // This pin must also stay NEWER than the dedicated serving node's
             // trustedNodeSync point, or that node cannot answer the bootstrap for
@@ -249,7 +247,7 @@ impl ChainConfig {
             // into the Fulu digest. Yields the live-verified digest 0x3237dab6.
             blob_params_epoch: 1_337_856,
             blob_params_max_blobs: 2,
-            // Copied verbatim from the @checkpoint:gnosis:begin/end region of
+            // Mirrors the @checkpoint:gnosis region of
             // NetworkConfig.java (slot 29460368, 2026-08-09, period 3596).
             // Rewritten by `./gradlew refreshCheckpoint` together with the Java twin.
             //


### PR DESCRIPTION
```
./gradlew refreshCheckpoint                              # all three, cross-validated
./gradlew refreshCheckpoint -Pnetwork=mainnet            # one
./gradlew refreshCheckpoint -Pnetwork=mainnet -Pperiod=1826   # a chosen period
./gradlew refreshCheckpoint -Pdry                        # preview
```

The tool, **and** the mainnet anchor refresh it was built for (see *Scope* below).

## Why

An anchor that drifts below roost's archive floor **can never be reached**, because the archive only grows forward:

| | anchor (before) | roost floor | syncs? |
|---|---|---|---|
| sepolia | 1324 | 1323 | ✅ |
| gnosis | 3596 | 3596 | ✅ |
| **mainnet** | **1777** | **1825** | ❌ 48 periods below |

Confirmed on the wire: the upstream returns 0 bytes for `updates` at 1777–1824 and answers from 1825. The Nimbus instances have nothing older either — their light-client floors match roost's exactly, and gnosis proved a full block backfill does not regenerate LC data.

## What it does

- **One task, all three networks**, replacing three per-network tasks that are removed — leaving them would let a later run rewrite the Java region alone and split the anchor.
- **Writes every engine from one fetch**: `NetworkConfig.java`, the Rust `ChainConfig`, *and* the Rust parity-test literals. That third target matters — those literals pin the same values outside the config markers, so without it the first real run would leave `cargo test -p myotis-net` red.
- **Refuses without cross-validation.** Two independent providers must agree. `-PallowSingleSource` is the named escape hatch, so the weaker guarantee is always an explicit command-line choice.
- **Chain-checks any named endpoint.** `-PextraEndpoint=<url>` is verified against the pinned `genesis_validators_root` before it counts, so a gnosis node on the port you meant for mainnet is refused rather than written into the mainnet anchor.
- **`-Pperiod=<n>`** anchors at a chosen period instead of head. Skipped slots are walked past, bounded at one epoch.
- **Atomic across files** — every region is rendered and validated before anything is written, and all regions of a file land in one write.
- **A real Java↔Rust parity test.** `java_and_rust_checkpoints_agree` reads `NetworkConfig.java` and compares both anchors to `ChainConfig`. There was no such test before: the existing `*_config_matches_networkconfig_java` tests are one-sided literal pins, so a split anchor could not fail anything.

## Scope

Originally tool-only. It now also **refreshes the mainnet anchor** to period **1826** (slot 14960288, root `0xae69edac…b0fd`), three providers agreeing — leaving 1777 in place would have kept the bug alive behind a working fix.

Pinned at head rather than at the floor with `-Pperiod=1825`, deliberately: only the archive endpoint serves that historical slot, so the floor would have required `-PallowSingleSource`. A cross-validated anchor one period above the floor beats an un-cross-validated one at it — and that refusal is itself a live test of the guard.

## Corrections from review

Four claims in earlier revisions were wrong, and are recorded rather than quietly dropped:

1. **"The public checkpoint providers no longer answer."** They do. The task had generalised the *gnosis* endpoint (`/eth/v1/beacon/headers/finalized`) onto mainnet and sepolia, which use `/eth/v2/beacon/blocks/finalized`. On the correct endpoint all three networks cross-validate across **three agreeing providers**.
2. **The local-node-first design that followed from it.** Listing a local node *reduced* cross-validation: if it is behind, `minSlot` drops to a slot the checkpointz providers will not serve historically, they drop out, and the run degrades to the single source least independent of the operator. No loopback in the list.
3. **"231 tests green" verified with `-Pdry`.** A dry run writes nothing, so it could not have exercised the constants the tests pin.
4. **"The test literals are now a third target, verified in a dry run."** Also verified the wrong way, and it hid two further bugs — see below.

## Verified

- Real non-dry write → **232 `myotis-net` tests green**, including the parity test passing against a *moved* anchor.
- That real write surfaced two bugs the dry run could not: the three `compute_sync_committee_period(...) == <literal>` assertions sat **outside** the test markers and still broke, and two marked regions in the same file made the second write **silently discard the first** — reverting the Rust config region while its own parity test moved to the new root. Both fixed.
- All three networks cross-validate across three agreeing providers.
- Wrong-chain `-PextraEndpoint` refused; correct one accepted.
- Parity test mutation-checked in both directions (root and slot).
- Single-source refusal confirmed live on `-Pperiod=1825`.
- No new `rustfmt` hunks (the crate's pre-existing formatting drift is left for its own PR).