### PR TITLE
Uptime counts from the start request, not from when the boot finished

### DIFF
--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -1708,7 +1708,14 @@ public final class NodeService extends Service {
                     // here — the guard above deliberately spares bookkeeping that isn't
                     // provably this attempt's — but the boot stamps ARE ours: left
                     // behind, a later boot's "already hosted" recovery would render an
-                    // uptime counting from this failed attempt.
+                    // uptime counting from this failed attempt. (One interleaving
+                    // excepted: a full boot completing while this catch waited for the
+                    // lock, followed by a rebootNetwork — whose handles.remove
+                    // deliberately leaves its stamps for the reboot's buildAndStart to
+                    // overwrite — lands this remove on the pending reboot's stamps
+                    // instead. Still harmless: nothing renders while handles has no
+                    // entry, and the reboot overwrite-stamps or bails through
+                    // forgetStack.)
                     stackStartMs.remove(n);
                     stackStartNano.remove(n);
                 }

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -1645,11 +1645,13 @@ public final class NodeService extends Service {
                 // finished. Overwriting the old run's stamps here also keeps a mid-boot
                 // snapshot from showing the old run's uptime (plus downtime); it reads
                 // the seconds since this boot began instead. The same stamps give the
-                // fresh stack its full idle window and start the sync-run ceiling; every
-                // bail path below runs forgetStack, which removes them again. Stamped
-                // INSIDE the bootLock: written outside it, a racing stopNetwork's
-                // forgetStack could remove them first and have these puts leak them
-                // back for a dead network.
+                // fresh stack its full idle window and start the sync-run ceiling. The
+                // bail paths below run forgetStack, which removes them again (the catch
+                // handles the threw-before-publish case itself); a stopNetwork racing
+                // this boot may remove them concurrently (its forgetStack runs without
+                // the bootLock) — harmless: nothing below re-puts them, and the
+                // stop-generation re-check after start() runs forgetStack under this
+                // lock hold, tearing down whatever this boot published.
                 stackStartMs.put(n, System.currentTimeMillis());
                 stackStartNano.put(n, System.nanoTime());   // monotonic clock for the sync-run ceiling
                 // Apply the Settings served-block window (before start(), so the very first
@@ -1700,6 +1702,15 @@ public final class NodeService extends Service {
                     if (created != null && ENGINE.get(n) == created) {
                         try { ENGINE.stop(n); } catch (Throwable ignored) {}
                     }
+                } else if (created != null && current == null) {
+                    // This attempt stamped (the stamps land right after create()) but
+                    // threw before publishing its handle. forgetStack would over-reach
+                    // here — the guard above deliberately spares bookkeeping that isn't
+                    // provably this attempt's — but the boot stamps ARE ours: left
+                    // behind, a later boot's "already hosted" recovery would render an
+                    // uptime counting from this failed attempt.
+                    stackStartMs.remove(n);
+                    stackStartNano.remove(n);
                 }
             }
             // service-stop check happens in the boot worker's finally, after the in-flight count drops
@@ -1805,9 +1816,9 @@ public final class NodeService extends Service {
         // deliberately NOT cleared here (it's static, per-network, and owned by boots): a
         // whole-service stop may leave stale entries, but they're invisible — handles was
         // cleared above so no snapshot is rendered — and the next boot of each network
-        // removes its stamp before publishing the handle, then re-stamps after start()
-        // succeeds. Clearing here would race a quick Stop->Start's fresh boot (the old
-        // service-global startTimeMs had exactly that clobber bug).
+        // overwrite-stamps its entry before publishing the handle. Clearing here would
+        // race a quick Stop->Start's fresh boot (the old service-global startTimeMs had
+        // exactly that clobber bug).
         reachedSynced.clear();
         LogBuffer.i(TAG, "node shutdown complete");
     }

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -1157,8 +1157,8 @@ public final class NodeService extends Service {
             String lifecycle,         // "RUNNING" | "PAUSED" | "STOPPED" — PAUSED is the
                                       // idle sleep state: networking off, RPC listening,
                                       // warm state retained, first request wakes it
-            long startTimeMs,         // start stamp of THIS network's stack (per engine
-                                      // start; resets on every network/engine reboot),
+            long startTimeMs,         // boot stamp of THIS network's stack (taken when its
+                                      // boot BEGINS; resets on every network/engine reboot),
                                       // 0 when the stack isn't live — drives the UI uptime
             int discoveredPeers,
             int connectedPeers,
@@ -1638,13 +1638,20 @@ public final class NodeService extends Service {
 
                 ChainHandle handle = ENGINE.create(config, ports);
                 created = handle;
-                // Drop the previous run's start stamps BEFORE publishing the handle: the
-                // UI poll renders a snapshot as soon as handles has an entry, and start()
-                // below blocks for seconds — a stale stamp would show the old run's
-                // uptime (plus downtime) until the fresh stamp lands. Removed-then-
-                // restamped, a mid-boot snapshot reads 0s instead.
-                stackStartMs.remove(n);
-                stackStartNano.remove(n);
+                // Stamp THIS boot BEFORE publishing the handle (the UI poll renders a
+                // snapshot as soon as handles has an entry) and BEFORE start() blocks:
+                // uptime counts from the moment the start was requested — the Status
+                // button press or the service cold boot — not from when the boot
+                // finished. Overwriting the old run's stamps here also keeps a mid-boot
+                // snapshot from showing the old run's uptime (plus downtime); it reads
+                // the seconds since this boot began instead. The same stamps give the
+                // fresh stack its full idle window and start the sync-run ceiling; every
+                // bail path below runs forgetStack, which removes them again. Stamped
+                // INSIDE the bootLock: written outside it, a racing stopNetwork's
+                // forgetStack could remove them first and have these puts leak them
+                // back for a dead network.
+                stackStartMs.put(n, System.currentTimeMillis());
+                stackStartNano.put(n, System.nanoTime());   // monotonic clock for the sync-run ceiling
                 // Apply the Settings served-block window (before start(), so the very first
                 // eth/69 Status advertises the configured size) and publish the handle under
                 // the handles monitor, with the pref read INSIDE it: setServedBlockWindow's
@@ -1674,12 +1681,6 @@ public final class NodeService extends Service {
                 // the raced-stop guard, so a condemned stack never pays for
                 // the index install / appender spin-up.
                 pushLogIndexConfig(n, handle);
-                // A freshly-booted stack gets a full idle window before the controller
-                // may pause it (its engine activity clock starts at 0). Stamped INSIDE the
-                // bootLock: written outside it, a racing stopNetwork's forgetStack could
-                // remove the stamp first and have this put leak it back for a dead network.
-                stackStartMs.put(n, System.currentTimeMillis());
-                stackStartNano.put(n, System.nanoTime());   // monotonic clock for the sync-run ceiling
             }
             updateNotification();
             LogBuffer.i(TAG, "[" + n + "] node stack started (RPC " + rpcPort + ")");
@@ -1898,11 +1899,11 @@ public final class NodeService extends Service {
      *  the string this UI has always shown pre-beacon). */
     private Snapshot snapshotOf(String network, ChainHandle h) {
         boolean running = RUNNING.get();
-        // Uptime is per-ENGINE-START, not per-service-start: stackStartMs is removed when a
-        // fresh boot publishes its handle and re-stamped once its start() succeeds (and
-        // removed again on per-network teardown), so a network restart — including an
-        // engine-toggle reboot — restarts the UI's uptime counter from zero, reading 0s
-        // while the new stack is still starting. A service-global stamp would keep
+        // Uptime is per-ENGINE-START, not per-service-start: stackStartMs is re-stamped
+        // when a fresh boot begins — before its start() blocks, so the counter covers the
+        // boot itself — and removed on per-network teardown. A network restart — including
+        // an engine-toggle reboot — therefore restarts the UI's uptime counter from zero,
+        // counting through the new stack's boot. A service-global stamp would keep
         // counting across chain restarts.
         long chainStartMs = stackStartMs.getOrDefault(network, 0L);
         StatusSnapshot s = h.status();

--- a/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
@@ -110,11 +110,6 @@ class DesktopNodeController(
         Thread({
             synchronized(bootLock(canonical)) {
                 if (engine.get(canonical) != null) return@synchronized
-                // Anchor uptime to the start REQUEST: create()+start() below block through
-                // key load, DNS resolution, and socket binds — the counter must already be
-                // running while that happens (it becomes visible once create() registers
-                // the handle). Every failure path runs dropNetwork, which clears it.
-                startNsByNetwork[canonical] = System.nanoTime()
                 val suffix = if (canonical == "mainnet") "" else "-$canonical"
                 val peerCache = PeerCache(dataDir.resolve("peers$suffix.cache"))
                 val clPeerCache = CLPeerCache(dataDir.resolve("cl-peers$suffix.cache"))
@@ -141,6 +136,13 @@ class DesktopNodeController(
                     JavaHttpCcipGateway(),
                     null, null,              // engine default logger/clock
                 )
+                // Anchor uptime to the start REQUEST: create()+start() below block through
+                // key load, DNS resolution, and socket binds — the counter must already be
+                // running while that happens (it becomes visible once create() registers
+                // the handle). Stamped immediately before the try so the invariant is
+                // structural, not dependent on earlier lines staying non-throwing: every
+                // failure path from here on runs dropNetwork, which clears it.
+                startNsByNetwork[canonical] = System.nanoTime()
                 // create() is all-or-nothing (nothing registered on failure), so on a throw
                 // dropNetwork only forgets the cache instances retained above — leaving them
                 // would hand clearCaches a live-looking instance for a network that never

--- a/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
@@ -151,20 +151,22 @@ class DesktopNodeController(
                     dropNetwork(canonical)
                     throw t
                 }
-                // Apply the Settings served-block window before start() (so the very first
-                // eth/69 Status advertises the configured size), reading the setting INSIDE
-                // servedWindowApplyLock: the Save fan-out takes the same lock, and create()
-                // above already made this handle visible to hostedNetworks() — so either the
-                // fan-out reaches this handle, or our read observes its already-persisted
-                // value. Without the pairing a Save landing between our read and apply
-                // would be overwritten, leaving the live window one Save behind settings.
-                synchronized(servedWindowApplyLock) {
-                    handle.setServedBlockWindow(settings.servedBlockWindow())
-                }
                 // start() is fault-isolated: false (resources closed) on failure rather than a
                 // throw. Either way, drop the network so a later enable can retry — leaving a
-                // dead entry would report "running" forever and block retries.
+                // dead entry would report "running" forever and block retries. The served-window
+                // apply shares the try: a throw there would otherwise leave a registered-but-
+                // never-started network behind, uptime stamp included.
                 val ok = try {
+                    // Apply the Settings served-block window before start() (so the very first
+                    // eth/69 Status advertises the configured size), reading the setting INSIDE
+                    // servedWindowApplyLock: the Save fan-out takes the same lock, and create()
+                    // above already made this handle visible to hostedNetworks() — so either the
+                    // fan-out reaches this handle, or our read observes its already-persisted
+                    // value. Without the pairing a Save landing between our read and apply
+                    // would be overwritten, leaving the live window one Save behind settings.
+                    synchronized(servedWindowApplyLock) {
+                        handle.setServedBlockWindow(settings.servedBlockWindow())
+                    }
                     handle.start()
                 } catch (t: Throwable) {
                     dropNetwork(canonical)

--- a/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
@@ -61,9 +61,11 @@ class DesktopNodeController(
 
     private val log = org.slf4j.LoggerFactory.getLogger(DesktopNodeController::class.java)
 
-    // Per-network engine-start stamp driving the UI uptime: stamped on each successful
-    // start (any engine, Java or Rust) and cleared on drop, so the uptime counter restarts
-    // from zero on every network/engine (re)boot — it is NOT the controller's (app's) lifetime.
+    // Per-network boot stamp driving the UI uptime: stamped when a boot BEGINS (any engine,
+    // Java or Rust) — uptime counts from the start request (Status button / app-launch
+    // auto-start), not from when the blocking start() finished — and cleared on drop
+    // (every failure path runs dropNetwork), so the counter restarts from zero on every
+    // network/engine (re)boot; it is NOT the controller's (app's) lifetime.
     // nanoTime, not currentTimeMillis: wall-clock / NTP steps must not skew uptime.
     private val startNsByNetwork = ConcurrentHashMap<String, Long>()
     // Per-network boot locks keyed by CANONICAL name, mirroring Android's NodeService.bootLocks:
@@ -108,6 +110,11 @@ class DesktopNodeController(
         Thread({
             synchronized(bootLock(canonical)) {
                 if (engine.get(canonical) != null) return@synchronized
+                // Anchor uptime to the start REQUEST: create()+start() below block through
+                // key load, DNS resolution, and socket binds — the counter must already be
+                // running while that happens (it becomes visible once create() registers
+                // the handle). Every failure path runs dropNetwork, which clears it.
+                startNsByNetwork[canonical] = System.nanoTime()
                 val suffix = if (canonical == "mainnet") "" else "-$canonical"
                 val peerCache = PeerCache(dataDir.resolve("peers$suffix.cache"))
                 val clPeerCache = CLPeerCache(dataDir.resolve("cl-peers$suffix.cache"))
@@ -165,7 +172,6 @@ class DesktopNodeController(
                 }
                 if (!ok) dropNetwork(canonical)
                 else {
-                    startNsByNetwork[canonical] = System.nanoTime() // uptime anchors to THIS start
                     // Boot-time apply of the log-index preset — AFTER start:
                     // the engine only accepts the config on a running handle
                     // (its reader owns the index). Re-pushed on every

--- a/app-ios/src/iosMain/kotlin/io/myotis/ios/IosNodeController.kt
+++ b/app-ios/src/iosMain/kotlin/io/myotis/ios/IosNodeController.kt
@@ -196,19 +196,25 @@ class IosNodeController(
     /** Blocking create+start; caller holds [bootMutex] and runs on IO. */
     private fun boot(net: String) {
         if (locked { net in handles }) return
+        // Anchor uptime to the start REQUEST (Status button / app-launch auto-start):
+        // create()+start() below block, and the counter must already be running while
+        // they do (it becomes visible once the handle is published). Both failure
+        // paths remove the mark; drop() removes it on teardown.
+        locked { startMarks[net] = TimeSource.Monotonic.markNow() }
         val handle = RustEngine.create(net, dataDir)
         if (handle < 1) {
             logs.append("ERROR failed to create the $net stack (sentinel $handle)")
+            locked { startMarks.remove(net) }
             return
         }
         if (!RustEngine.start(handle)) {
             RustEngine.stop(handle)
             logs.append("ERROR failed to start the $net stack")
+            locked { startMarks.remove(net) }
             return
         }
         locked {
             handles[net] = handle
-            startMarks[net] = TimeSource.Monotonic.markNow()
         }
         // Boot-time apply of the log-index preset — AFTER start (the engine
         // only accepts config on a running handle). Cures restart dormancy;

--- a/myotis-api/src/main/java/io/myotis/api/NodeStatusReads.java
+++ b/myotis-api/src/main/java/io/myotis/api/NodeStatusReads.java
@@ -23,6 +23,7 @@ public interface NodeStatusReads {
     /** CL light-client view (the {@code beacon-status} command's source). */
     BeaconStatus beaconStatus();
 
-    /** Node uptime in seconds; {@code 0} before the first start. */
+    /** Node uptime in seconds, anchored to when the start was REQUESTED (so the boot
+     *  itself counts); {@code 0} until the first start succeeds. */
     long uptimeSeconds();
 }

--- a/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
@@ -71,8 +71,10 @@ final class RustChainHandle implements ChainHandle, NodeStatusReads {
     /** The running JSON-RPC server, or null when disabled / not started. */
     private volatile io.myotis.jsonrpc.MyotisRpcServer rpcServer;
 
-    /** Monotonic start time (ns) of the current run; drives {@link #uptimeSeconds()}. Paired
-     *  with {@link #started} because nanoTime()'s origin is arbitrary (0 is a valid reading). */
+    /** Monotonic time (ns) the current run's start() was ENTERED — uptime counts the native
+     *  boot itself, not just the time since it finished; drives {@link #uptimeSeconds()}.
+     *  Paired with {@link #started} because nanoTime()'s origin is arbitrary (0 is a valid
+     *  reading). */
     private volatile long startedAtNs;
     private volatile boolean started;
 
@@ -120,11 +122,14 @@ final class RustChainHandle implements ChainHandle, NodeStatusReads {
 
     @Override
     public synchronized boolean start() {
+        // Entry stamp for uptime: count from the start request, including the native
+        // boot itself — anchored below only when the start succeeds.
+        long startRequestNs = System.nanoTime();
         boolean ok = RustEngineNative.nativeStart(handle);
         // Only expose the verified JSON-RPC endpoint once the native stack is up.
         if (ok) {
             // Anchor uptime to this successful start (cleared in stop() so a restart re-anchors).
-            if (!started) { startedAtNs = System.nanoTime(); started = true; }
+            if (!started) { startedAtNs = startRequestNs; started = true; }
             startRpc();
         }
         return ok;

--- a/node-core/src/main/java/io/myotis/node/ChainStack.java
+++ b/node-core/src/main/java/io/myotis/node/ChainStack.java
@@ -175,8 +175,10 @@ public final class ChainStack {
     /** Status source for the JSON-RPC myotis_status / myotis_beaconStatus methods; the
      *  wrapping handle late-binds it (see {@link #setStatusReads}) before start(). */
     private volatile io.myotis.api.NodeStatusReads statusReads;
-    /** Monotonic start time (ns) of the first start; drives {@link #uptimeSeconds()}. Paired
-     *  with {@link #started} because nanoTime()'s origin is arbitrary (0 is a valid reading). */
+    /** Monotonic time (ns) the first successful {@link #start()} was ENTERED — uptime counts
+     *  the boot itself (DNS resolution, dials, binds), not just the time since it finished;
+     *  drives {@link #uptimeSeconds()}. Paired with {@link #started} because nanoTime()'s
+     *  origin is arbitrary (0 is a valid reading). */
     private volatile long startedAtNs;
     private volatile boolean started;
 
@@ -257,6 +259,10 @@ public final class ChainStack {
      */
     public synchronized boolean start() {
         if (!phase.compareAndSet(STOPPED, RUNNING)) return true; // already started
+        // Entry stamp for uptime: the counter must cover the whole boot below (DNS
+        // resolution, dials, binds), not start once it finished. Anchored at the
+        // bottom, only when the start fully succeeded.
+        long startRequestNs = System.nanoTime();
         try {
             log.info("[{}] Node ID: {}", network.name(), nodeKey.nodeId().toHexString());
 
@@ -303,10 +309,11 @@ public final class ChainStack {
             if (maintainerEnabled) startPeerMaintainer();
 
             // Anchor uptime only after a fully successful start (a failed start below tears
-            // the stack down via shutdown(), which clears `started` so a later start re-anchors).
+            // the stack down via shutdown(), which clears `started` so a later start
+            // re-anchors) — but anchor it TO the entry stamp, so the boot itself counts.
             // The serve counters share the same epoch: reset here (first start and any
             // start-after-shutdown), never on pause/resume — matching uptime exactly.
-            if (!started) { startedAtNs = System.nanoTime(); started = true; serveStats.reset(); }
+            if (!started) { startedAtNs = startRequestNs; started = true; serveStats.reset(); }
             return true;
         } catch (Throwable t) {
             log.error("[{}] stack failed to start: {}", network.name(), t.toString());
@@ -523,8 +530,9 @@ public final class ChainStack {
     /** Late-bind the JSON-RPC status source (the wrapping handle), before {@link #start()}. */
     public void setStatusReads(io.myotis.api.NodeStatusReads statusReads) { this.statusReads = statusReads; }
 
-    /** Node uptime in seconds since the first start; 0 before then. Monotonic (nanoTime),
-     *  so it's immune to wall-clock/NTP adjustments. */
+    /** Node uptime in seconds since the first start was requested (start() entry, so the
+     *  boot itself counts); 0 until that start succeeds. Monotonic (nanoTime), so it's
+     *  immune to wall-clock/NTP adjustments. */
     public long uptimeSeconds() {
         return !started ? 0L : (System.nanoTime() - startedAtNs) / 1_000_000_000L;
     }

--- a/node-core/src/main/java/io/myotis/node/ChainStack.java
+++ b/node-core/src/main/java/io/myotis/node/ChainStack.java
@@ -311,8 +311,9 @@ public final class ChainStack {
             // Anchor uptime only after a fully successful start (a failed start below tears
             // the stack down via shutdown(), which clears `started` so a later start
             // re-anchors) — but anchor it TO the entry stamp, so the boot itself counts.
-            // The serve counters share the same epoch: reset here (first start and any
-            // start-after-shutdown), never on pause/resume — matching uptime exactly.
+            // The serve counters reset at the same anchor (first start and any
+            // start-after-shutdown), never on pause/resume — one epoch per run, though
+            // theirs starts a boot-duration after uptime's entry stamp.
             if (!started) { startedAtNs = startRequestNs; started = true; serveStats.reset(); }
             return true;
         } catch (Throwable t) {


### PR DESCRIPTION
## Problem

The Status screen's Uptime counter only began counting after the blocking engine `start()` returned. `ChainStack.start()` runs DNS enrtree resolution (10 s deadline + grace), the initial dial burst, discv4/discv5 binds, and the beacon client spin-up before it returns — so on every host the counter sat at 0 through the whole boot and visibly started around the time the warm-start sync landed. Uptime should count from the moment the start is requested: the Status page's Start button, or the app-launch auto-start.

## Change

**Hosts** (the stamps the shared `NodeScreen` renders):
- **Desktop** (`DesktopNode.kt`): `startNsByNetwork` is stamped when the boot begins, before `create()`/`start()`. Every failure path runs `dropNetwork`, which clears it — the served-window apply now shares `start()`'s try so a throw there can no longer leave a registered-but-never-started network (and its counting stamp) behind.
- **Android** (`NodeService.java`): `stackStartMs`/`stackStartNano` are overwrite-stamped where the old stamps used to be removed — before the handle is published — so a mid-boot snapshot reads the seconds since this boot began instead of 0 s. This also closes the window where a RUNNING-mid-boot stack had no stamp and `syncRunCeilingReached`'s absent-stamp fallback treated the ceiling as reached. The boot's catch now removes the attempt's own stamps when it threw before publishing its handle (the one bail path `forgetStack` deliberately doesn't cover).
- **iOS** (`IosNodeController.kt`): `startMarks` stamped at boot begin; both failure paths remove the mark.

**Engines** (the `NodeStatusReads.uptimeSeconds()` behind `myotis_status` / IPC):
- `ChainStack` and `RustChainHandle` capture the anchor at `start()` entry and apply it only on success — a failed start still reads 0, an in-flight first start still reads 0, and the anchored value then counts from the request, matching the hosts' counters. Pause/resume semantics are untouched (a pause is not a restart).

## Notes

- Behavior on redundant starts is unchanged: every host bails before stamping when the network is already hosted, so a live counter is never clobbered.
- An independent no-context review of the diff ran before this PR; its two findings (stamp-leak windows on throw-before-publish paths, desktop + Android) and three comment-accuracy nits are addressed in the second commit.

## Testing

- `:myotis-api` `:node-core` `:myotis-engines` `:app-desktop` compile; `:android-app:compileDebugJavaWithJavac` (Java engine); `:app-ios:compileKotlinIosSimulatorArm64`.
- `:node-core:test`, `:myotis-engines:test`, `:app-desktop:test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)