### PR TITLE
chore: bump versions to 0.1.6 for the next pre-release

### DIFF
--- a/android-app/build.gradle.kts
+++ b/android-app/build.gradle.kts
@@ -107,7 +107,7 @@ android {
         // Stays a manual literal: a monotonic install counter with no relation
         // to semver, so there is nothing to derive it from. Bump it on every
         // release or the new APK won't install over the previous one.
-        versionCode = 6
+        versionCode = 7
         versionName = releaseVersion
         buildConfigField("String", "RPC_UPSTREAM", "\"$rpcUpstream\"")
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ plugins {
 
 allprojects {
     group = "com.jaeckel.ethp2p"
-    version = "0.1.5-SNAPSHOT"
+    version = "0.1.6-SNAPSHOT"
 }
 
 // The release version — project.version minus the -SNAPSHOT suffix — exactly as

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/messages/HelloMessage.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/messages/HelloMessage.java
@@ -39,7 +39,7 @@ public final class HelloMessage {
             // Keep in sync with the Rust engine's Hello client id
             // (rust/myotis-net/src/el/rlpx/transport.rs) — dedicated
             // myotis-serving nodes admit peers by matching "myotis" here.
-            writer.writeString("myotis/0.1.5");
+            writer.writeString("myotis/0.1.6");
             writer.writeList(capWriter -> {
                 // Capabilities must be ascending (name, then version). eth/66 is the
                 // floor: it has request-IDs (which our GetBlockHeaders/snap requests

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4084,7 +4084,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-bls"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "blst",
  "jni",
@@ -4092,7 +4092,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-consensus"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "myotis-bls",
  "sha2",
@@ -4100,7 +4100,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-core"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "k256",
  "sha3 0.10.9",
@@ -4108,7 +4108,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-engine"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "myotis-consensus",
  "myotis-core",
@@ -4124,7 +4124,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-evm"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "myotis-core",
  "revm",
@@ -4132,7 +4132,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-net"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "aes",
  "arti-client",
@@ -4160,7 +4160,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-node"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "myotis-engine",
  "napi",

--- a/rust/myotis-bls/Cargo.lock
+++ b/rust/myotis-bls/Cargo.lock
@@ -134,7 +134,7 @@ checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "myotis-bls"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "blst",
  "jni",

--- a/rust/myotis-bls/Cargo.toml
+++ b/rust/myotis-bls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "myotis-bls"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 description = "Native BLS12-381 fast-aggregate-verify (blst) behind a JNI shim for Myotis"
 license = "MIT OR Apache-2.0"

--- a/rust/myotis-consensus/Cargo.toml
+++ b/rust/myotis-consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "myotis-consensus"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 description = "Myotis sync-committee light client (pure Rust; grows through the Rust-engine PRs)"
 license = "MIT OR Apache-2.0"

--- a/rust/myotis-core/Cargo.toml
+++ b/rust/myotis-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "myotis-core"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 description = "Myotis execution-layer primitives: keccak-256, RLP, secp256k1 identity, BlockHeader, ENR (sans-I/O; grows through the EL-phase PRs)"
 license = "MIT OR Apache-2.0"

--- a/rust/myotis-engine/Cargo.toml
+++ b/rust/myotis-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "myotis-engine"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 description = "Rust implementation of the io.myotis.api engine contract (JNI cdylib)"
 license = "MIT OR Apache-2.0"

--- a/rust/myotis-evm/Cargo.toml
+++ b/rust/myotis-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "myotis-evm"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 description = "Myotis EVM: view-call / gas-estimation over SNAP-proof-verified state (revm behind a SnapStateOracle trait; sans-I/O). Grows through the EL-phase Milestone-C PRs (docs/reimplementation/07)."
 license = "MIT OR Apache-2.0"

--- a/rust/myotis-net/Cargo.toml
+++ b/rust/myotis-net/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "myotis-net"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 description = "Myotis consensus-layer networking: discv5 discovery + libp2p eth2 req/resp + the light-client sync loop (ALL I/O lives here; myotis-consensus stays sans-I/O)"
 license = "MIT OR Apache-2.0"

--- a/rust/myotis-net/src/el/rlpx/transport.rs
+++ b/rust/myotis-net/src/el/rlpx/transport.rs
@@ -320,7 +320,7 @@ pub fn encode_hello(node_pubkey: &[u8; 64], listen_port: u16) -> Vec<u8> {
     };
     rlp::encode(&Item::List(vec![
         Item::Bytes(rlp::u64_to_minimal_be(5)), // protocol version
-        Item::Bytes(b"myotis/0.1.5".to_vec()),
+        Item::Bytes(b"myotis/0.1.6".to_vec()),
         Item::List(vec![
             cap("eth", 66),
             cap("eth", 67),
@@ -392,7 +392,7 @@ mod tests {
         let body = encode_hello(&pubkey, 30303);
         let hello = decode_hello(&body).unwrap();
         assert_eq!(hello.protocol_version, 5);
-        assert_eq!(hello.client_id, "myotis/0.1.5");
+        assert_eq!(hello.client_id, "myotis/0.1.6");
         assert_eq!(hello.listen_port, 30303);
         assert_eq!(hello.node_id, pubkey.to_vec());
         assert_eq!(hello.capabilities.len(), 5);

--- a/rust/myotis-net/src/reqresp.rs
+++ b/rust/myotis-net/src/reqresp.rs
@@ -309,7 +309,7 @@ impl Behaviour {
             ),
             identify: identify::Behaviour::new(
                 identify::Config::new("eth2/1.0.0".into(), local_public_key)
-                    .with_agent_version("myotis/0.1.5-rs".into()),
+                    .with_agent_version("myotis/0.1.6-rs".into()),
             ),
             status_v2: rr(protocols::STATUS_V2, ProtocolSupport::Full, RESP_TIMEOUT),
             status_v1: rr(protocols::STATUS_V1, ProtocolSupport::Full, RESP_TIMEOUT),

--- a/rust/myotis-node/Cargo.toml
+++ b/rust/myotis-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "myotis-node"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 description = "Node.js (napi-rs) binding over the myotis-engine C ABI — for Electron/Node hosts"
 license = "MIT OR Apache-2.0"

--- a/rust/roost/Cargo.lock
+++ b/rust/roost/Cargo.lock
@@ -3088,14 +3088,14 @@ dependencies = [
 
 [[package]]
 name = "myotis-bls"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "blst",
 ]
 
 [[package]]
 name = "myotis-consensus"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "myotis-bls",
  "sha2",
@@ -3103,7 +3103,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-core"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "k256",
  "sha3 0.10.9",
@@ -3111,7 +3111,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-evm"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "myotis-core",
  "revm",
@@ -3119,7 +3119,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-net"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "aes",
  "async-trait",

--- a/rust/tor-poc/Cargo.lock
+++ b/rust/tor-poc/Cargo.lock
@@ -3848,14 +3848,14 @@ dependencies = [
 
 [[package]]
 name = "myotis-bls"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "blst",
 ]
 
 [[package]]
 name = "myotis-consensus"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "myotis-bls",
  "sha2",
@@ -3863,7 +3863,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-core"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "k256",
  "sha3 0.10.9",
@@ -3871,7 +3871,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-evm"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "myotis-core",
  "revm",
@@ -3879,7 +3879,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-net"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "aes",
  "async-trait",


### PR DESCRIPTION
Version sweep preparing the v0.1.6 tag, following the 0.1.5 precedent (#323). After merge, the merge commit gets tagged `v0.1.6`, which triggers the five publishing workflows behind the release version guard.

**The sweep:**
- `build.gradle.kts`: `0.1.5-SNAPSHOT` → `0.1.6-SNAPSHOT` (the one version `:app-desktop` / `:android-app` package and `printReleaseVersion` reports to the guard)
- `android-app`: `versionCode` 6 → 7 (monotonic install counter, not derivable from semver; the guard does not check it)
- devp2p Hello client ids in both engines: `myotis/0.1.6` (`HelloMessage.java`, `transport.rs` + its round-trip test) and the libp2p agent `myotis/0.1.6-rs` (`reqresp.rs`)
- the seven `myotis-*` crate versions
- **four** Cargo.locks regenerated, not three as in the 0.1.5 sweep: `rust/roost/Cargo.lock` is new since then and roost CI builds `--locked`, so a stale myotis-* pin there fails the roost workflow. Caught by the internal no-context review; all four locks verified to resolve clean under `--locked`, with version-only diffs (zero dependency churn).

**Verified:** `./gradlew -q :printReleaseVersion` → `releaseVersion=0.1.6`; `:networking:compileJava` clean; the Rust hello round-trip test passes.

**Pre-existing, not touched:** `ios-app/Myotis/Info.plist` still says 1.0/1 — it has never been part of the sweep and no release workflow publishes iOS assets, so nothing ships mislabeled. Worth folding into a future sweep once iOS assets are released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)