### PR TITLE
feat(java): targeted discv5 lookups toward the pinned servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ ios-app/DerivedData/
 # binary would drift from the Rust source and silently ship a dead engine.
 # `-PskipRustEngine` omits them (the app falls back to the Java engine).
 /android-app/src/main/jniLibs/*/libmyotis_*.so
+logindex-*.db

--- a/core/src/main/java/com/jaeckel/ethp2p/core/enr/Enr.java
+++ b/core/src/main/java/com/jaeckel/ethp2p/core/enr/Enr.java
@@ -266,6 +266,52 @@ public final class Enr {
         return base58Encode(multihash);
     }
 
+    /**
+     * The discv5 node id a libp2p peer id will present — the REVERSE of
+     * {@link #derivePeerId}: base58 → identity multihash → libp2p crypto
+     * protobuf → compressed secp256k1 key → keccak256 of the uncompressed
+     * point's 64 coordinate bytes.
+     *
+     * <p>Works because secp256k1 peer ids are identity-multihashed (the 37-byte
+     * protobuf is ≤ 42, so the key travels inline), and roost signs its ENR
+     * with its libp2p host key — one key, two identities. This is what lets
+     * discovery walk the DHT <em>toward</em> a pinned server instead of hoping
+     * a random walk lands in its bucket. Empty for ids that don't inline a
+     * secp256k1 key (sha256-multihashed RSA/ed25519 ids can't be reversed).
+     */
+    public static Optional<Bytes> nodeIdForPeerId(String base58PeerId) {
+        try {
+            byte[] multihash = base58Decode(base58PeerId);
+            // identity multihash: code=0x00, length, payload
+            if (multihash.length < 2 || multihash[0] != 0x00
+                    || (multihash[1] & 0xFF) != multihash.length - 2) {
+                return Optional.empty();
+            }
+            // libp2p crypto protobuf: 0x08 <type> 0x12 <len> <key>; Secp256k1=2
+            byte[] pb = java.util.Arrays.copyOfRange(multihash, 2, multihash.length);
+            if (pb.length < 4 || pb[0] != 0x08 || pb[1] != 0x02 || pb[2] != 0x12
+                    || (pb[3] & 0xFF) != pb.length - 4) {
+                return Optional.empty();
+            }
+            byte[] compressed = java.util.Arrays.copyOfRange(pb, 4, pb.length);
+            org.bouncycastle.math.ec.ECPoint point =
+                org.bouncycastle.asn1.sec.SECNamedCurves.getByName("secp256k1")
+                    .getCurve().decodePoint(compressed);
+            byte[] uncompressed = point.getEncoded(false); // 0x04 || x || y
+            // BouncyCastle's lightweight digest, deliberately: tuweni's
+            // Hash.keccak256 goes through the JCA and throws unless the BC
+            // PROVIDER happens to be registered by some earlier caller.
+            org.bouncycastle.crypto.digests.KeccakDigest keccak =
+                new org.bouncycastle.crypto.digests.KeccakDigest(256);
+            keccak.update(uncompressed, 1, 64);
+            byte[] nodeId = new byte[32];
+            keccak.doFinal(nodeId, 0);
+            return Optional.of(Bytes.wrap(nodeId));
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+    }
+
     private static final String BASE58_ALPHABET =
             "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
 
@@ -291,6 +337,27 @@ public final class Enr {
 
         for (int i = 0; i < zeros; i++) sb.append('1');
         return sb.reverse().toString();
+    }
+
+    /** Inverse of {@link #base58Encode}; throws on characters outside the alphabet. */
+    static byte[] base58Decode(String input) {
+        BigInteger value = BigInteger.ZERO;
+        BigInteger fiftyEight = BigInteger.valueOf(58);
+        for (int i = 0; i < input.length(); i++) {
+            int digit = BASE58_ALPHABET.indexOf(input.charAt(i));
+            if (digit < 0) {
+                throw new IllegalArgumentException("not base58: '" + input.charAt(i) + "'");
+            }
+            value = value.multiply(fiftyEight).add(BigInteger.valueOf(digit));
+        }
+        int zeros = 0;
+        while (zeros < input.length() && input.charAt(zeros) == '1') zeros++;
+        byte[] num = value.equals(BigInteger.ZERO) ? new byte[0] : value.toByteArray();
+        // toByteArray may prepend a sign byte — strip it.
+        int start = (num.length > 0 && num[0] == 0) ? 1 : 0;
+        byte[] out = new byte[zeros + num.length - start];
+        System.arraycopy(num, start, out, zeros, num.length - start);
+        return out;
     }
 
     public long seq() { return seq; }

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/discv5/DiscV5Service.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/discv5/DiscV5Service.java
@@ -241,12 +241,22 @@ public final class DiscV5Service implements AutoCloseable {
     // Targeted lookups (#347) — walk TOWARD the pinned servers
     // -------------------------------------------------------------------------
 
-    /** Queries per walk round (Kademlia α). */
-    private static final int WALK_ALPHA = 3;
-    /** Rounds per walk before giving up (each round queries α nodes). */
-    private static final int WALK_MAX_ROUNDS = 4;
+    /** Total FINDNODE queries per walk. Termination is spec-Kademlia — stop
+     *  when the near window has no unqueried nodes left — and this budget is
+     *  the hard cap. Sized from live tuning: round-based variants with early
+     *  "no progress" breaks stalled at logDistance ~244-252 of 256; a
+     *  closest-first budgeted loop converges or proves absence within ~24. */
+    private static final int WALK_QUERY_BUDGET = 32;
+    // (No near-window cutoff: live runs showed the records CLOSEST to a target
+    // are often stale/dead entries — 13 of 16 timed out — and a "closest-16
+    // all queried → unreachable" rule gave up with budget left while alive
+    // nodes slightly farther out held the target's record. Closest-first over
+    // the whole frontier, bounded by the budget, is the rule that finds it.)
     /** Per-query answer budget; a silent node must not stall the walk. */
-    private static final long WALK_QUERY_TIMEOUT_MS = 3_000;
+    private static final long WALK_QUERY_TIMEOUT_MS = 1_500;
+    // Live tuning: answered queries return in ~100 ms; the walk's wall time is
+    // dominated by timeouts on dead frontier entries (15 of 20 on one run), so
+    // a short budget beats a generous one.
     /** Pause between opening-pass walks (each pinned id once, quickly). */
     private static final long WALK_OPENING_GAP_MS = 2_000;
     /** Pause between steady-state revisits (round-robin, one per gap). */
@@ -257,6 +267,15 @@ public final class DiscV5Service implements AutoCloseable {
      *  walk resumes from the best-known frontier instead of the bootnodes.
      *  Walker-thread only. */
     private final java.util.Map<org.apache.tuweni.bytes.Bytes, List<NodeRecord>> learnedFrontier =
+            new java.util.HashMap<>();
+    /** Pinned records already FOUND, reused as first-query seeds for the other
+     *  walks. The pinned servers know each other better than the wider DHT
+     *  does — roost's discv5 bootstraps THROUGH the co-located beacon node, so
+     *  the established pin's table holds the young pin long before the young
+     *  record has propagated widely (observed live: every walk toward roost
+     *  converged and stalled while nimbus — found in 9 queries every run — had
+     *  the record all along). Walker-thread only. */
+    private final java.util.Map<org.apache.tuweni.bytes.Bytes, NodeRecord> foundPinned =
             new java.util.HashMap<>();
 
     /**
@@ -276,6 +295,16 @@ public final class DiscV5Service implements AutoCloseable {
             return;
         }
         walker = new Thread(() -> {
+            // The opening pass is worthless against an empty table (observed:
+            // walk 1 fired ~2 s after start, before any bootnode answered, and
+            // burned the first slot on frontier=0). Wait briefly for the table.
+            for (int w = 0; w < 20 && system.streamLiveNodes().findAny().isEmpty(); w++) {
+                try {
+                    Thread.sleep(1_000);
+                } catch (InterruptedException gone) {
+                    return;
+                }
+            }
             int i = 0;
             while (!Thread.currentThread().isInterrupted()) {
                 org.apache.tuweni.bytes.Bytes target = pinnedNodeIds.get(i % pinnedNodeIds.size());
@@ -317,61 +346,172 @@ public final class DiscV5Service implements AutoCloseable {
      * #347/#348 review).
      */
     private void targetedWalk(org.apache.tuweni.bytes.Bytes target) {
-        java.util.Comparator<NodeRecord> byDistance = java.util.Comparator.comparing(
-                nr -> org.ethereum.beacon.discovery.util.Functions.distance(target, nr.getNodeId()));
+        // NOT Functions.distance: that helper reads the XOR as LITTLE-endian
+        // (toUnsignedBigInteger(LITTLE_ENDIAN)), so ordering by it sorts on the
+        // XOR's LOW bytes — near-random with respect to actual closeness, which
+        // scrambled the closest-first selection on the first live runs (the
+        // walk queried 256-distance nodes while 249s sat in the frontier).
+        // logDistance is the spec bucket index and interops with the wire.
+        java.util.Comparator<NodeRecord> byDistance = java.util.Comparator
+                .comparingInt((NodeRecord nr) -> org.ethereum.beacon.discovery.util.Functions
+                        .logDistance(nr.getNodeId(), target))
+                .thenComparing(nr -> new java.math.BigInteger(
+                        1, nr.getNodeId().xor(target).toArray()));
         java.util.Map<org.apache.tuweni.bytes.Bytes, NodeRecord> frontier = new java.util.HashMap<>();
         system.streamLiveNodes().forEach(nr -> frontier.put(nr.getNodeId(), nr));
         for (NodeRecord nr : learnedFrontier.getOrDefault(target, List.of())) {
             frontier.putIfAbsent(nr.getNodeId(), nr);
         }
         Set<org.apache.tuweni.bytes.Bytes> queried = new HashSet<>();
+        int answered = 0;
+        int failed = 0;
 
-        for (int round = 0; round < WALK_MAX_ROUNDS; round++) {
-            List<NodeRecord> candidates = frontier.values().stream()
-                    .filter(nr -> !queried.contains(nr.getNodeId()))
-                    .sorted(byDistance)
-                    .limit(WALK_ALPHA)
-                    .toList();
-            if (candidates.isEmpty()) {
+        // Phase -1 — ask the pinned servers already FOUND (see foundPinned):
+        // they are session-verified responders and the likeliest tables to
+        // hold a sibling pin's young record.
+        for (NodeRecord sibling : List.copyOf(foundPinned.values())) {
+            if (sibling.getNodeId().equals(target) || queried.contains(sibling.getNodeId())) {
+                continue;
+            }
+            queried.add(sibling.getNodeId());
+            int d = org.ethereum.beacon.discovery.util.Functions.logDistance(
+                    sibling.getNodeId(), target);
+            List<Integer> distances = java.util.stream.IntStream.rangeClosed(d - 4, d)
+                    .filter(x -> x >= 1 && x <= 256).boxed()
+                    .sorted(java.util.Collections.reverseOrder()).toList();
+            java.util.Collection<NodeRecord> answers;
+            try {
+                answers = system.findNodes(sibling, distances)
+                        .get(WALK_QUERY_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+                answered++;
+            } catch (Exception unresponsive) {
+                failed++;
+                continue;
+            }
+            for (NodeRecord nr : answers) {
+                if (nr.getNodeId().equals(target)) {
+                    log.info("[discv5] targeted walk toward {}… : FOUND at a sibling pin (seq={})",
+                            target.slice(0, 4), nr.getSeq());
+                    foundPinned.put(nr.getNodeId(), nr);
+                    emitFromWalker(nr);
+                    rememberFrontier(target, frontier.values(), byDistance);
+                    return;
+                }
+                frontier.putIfAbsent(nr.getNodeId(), nr);
+            }
+        }
+
+        // Phase 0 — ask the BOOTNODES first, at the target's bucket as each of
+        // them sees it. Their tables are the largest and freshest in the
+        // network, and a server that pinged them at startup is often in them
+        // directly: the sigp verifier finds roost in its FIRST round precisely
+        // because a fresh sigp table contains only bootnodes. A closest-first
+        // walk would never ask them (they sit at random distance from any
+        // target), which is how it can converge to logDistance ~237 through a
+        // cluster of stale near-records and still miss a record the bootnodes
+        // are holding (observed live).
+        for (NodeRecord bootnode : bootnodeRecords()) {
+            if (queried.size() >= 6) {
                 break;
             }
-            boolean progressed = false;
-            for (NodeRecord candidate : candidates) {
-                queried.add(candidate.getNodeId());
-                int d = org.ethereum.beacon.discovery.util.Functions.logDistance(
-                        candidate.getNodeId(), target);
-                List<Integer> distances = java.util.stream.IntStream.of(d - 1, d, d + 1)
-                        .filter(x -> x >= 1 && x <= 256).distinct().boxed().toList();
-                java.util.Collection<NodeRecord> answers;
-                try {
-                    answers = system.findNodes(candidate, distances)
-                            .get(WALK_QUERY_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-                } catch (Exception unresponsive) {
-                    continue;
-                }
-                for (NodeRecord nr : answers) {
-                    if (nr.getNodeId().equals(target)) {
-                        log.info("[discv5] targeted walk toward {}… : FOUND (round={} seq={})",
-                                target.slice(0, 4), round, nr.getSeq());
-                        emitFromWalker(nr);
-                        rememberFrontier(target, frontier.values(), byDistance);
-                        return;
-                    }
-                    if (frontier.putIfAbsent(nr.getNodeId(), nr) == null) {
-                        progressed = true;
-                    }
-                }
+            if (bootnode.getNodeId().equals(target) || queried.contains(bootnode.getNodeId())) {
+                continue;
             }
-            if (!progressed) {
-                break; // converged without finding — record not propagated (yet)
+            queried.add(bootnode.getNodeId());
+            int d = org.ethereum.beacon.discovery.util.Functions.logDistance(
+                    bootnode.getNodeId(), target);
+            List<Integer> distances = java.util.stream.IntStream.rangeClosed(d - 4, d)
+                    .filter(x -> x >= 1 && x <= 256).boxed()
+                    .sorted(java.util.Collections.reverseOrder()).toList();
+            java.util.Collection<NodeRecord> answers;
+            try {
+                answers = system.findNodes(bootnode, distances)
+                        .get(WALK_QUERY_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+                answered++;
+            } catch (Exception unresponsive) {
+                failed++;
+                continue;
+            }
+            for (NodeRecord nr : answers) {
+                if (nr.getNodeId().equals(target)) {
+                    log.info("[discv5] targeted walk toward {}… : FOUND at a bootnode (seq={})",
+                            target.slice(0, 4), nr.getSeq());
+                    foundPinned.put(nr.getNodeId(), nr);
+                    emitFromWalker(nr);
+                    rememberFrontier(target, frontier.values(), byDistance);
+                    return;
+                }
+                frontier.putIfAbsent(nr.getNodeId(), nr);
+            }
+        }
+
+        // Closest-first, budgeted: always query the closest node not yet asked,
+        // stop when the WALK_WINDOW closest have all been asked (they are the
+        // ones that would hold the target) or the budget runs out. Deliberately
+        // no "no progress this round" break: live tuning showed any such round
+        // heuristic either never terminates (any new node counts) or gives up
+        // while still ~250 bits out (closer-node-required) — spec-Kademlia
+        // termination is the one that actually converges.
+        for (int q = 0; q < WALK_QUERY_BUDGET; q++) {
+            NodeRecord candidate = frontier.values().stream()
+                    .filter(nr -> !queried.contains(nr.getNodeId()))
+                    .min(byDistance)
+                    .orElse(null);
+            if (candidate == null) {
+                break; // frontier exhausted — the target is not reachable today
+            }
+            queried.add(candidate.getNodeId());
+            int d = org.ethereum.beacon.discovery.util.Functions.logDistance(
+                    candidate.getNodeId(), target);
+            // The bucket at d contains the target's neighborhood as this
+            // candidate sees it; the lower buckets sample strictly closer
+            // halves. Five buckets per query: the responder caps the reply at
+            // 16 records total anyway, so a wider ask mines each RESPONSIVE
+            // node harder — which matters when the target's nearest neighbors
+            // are dead entries and answers are scarce.
+            List<Integer> distances = java.util.stream.IntStream.rangeClosed(d - 4, d)
+                    .filter(x -> x >= 1 && x <= 256).boxed().sorted(java.util.Collections.reverseOrder())
+                    .toList();
+            java.util.Collection<NodeRecord> answers;
+            try {
+                answers = system.findNodes(candidate, distances)
+                        .get(WALK_QUERY_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+                answered++;
+            } catch (Exception unresponsive) {
+                failed++;
+                continue;
+            }
+            if (log.isDebugEnabled()) {
+                java.util.IntSummaryStatistics stats = answers.stream()
+                        .mapToInt(nr -> org.ethereum.beacon.discovery.util.Functions.logDistance(
+                                nr.getNodeId(), target))
+                        .summaryStatistics();
+                log.debug("[discv5] walk query: candidateDist={} asked={} answers={} answerDistToTarget=[{}..{}]",
+                        d, distances, answers.size(),
+                        stats.getCount() == 0 ? -1 : stats.getMin(),
+                        stats.getCount() == 0 ? -1 : stats.getMax());
+            }
+            for (NodeRecord nr : answers) {
+                if (nr.getNodeId().equals(target)) {
+                    log.info("[discv5] targeted walk toward {}… : FOUND (queries={} seq={})",
+                            target.slice(0, 4), answered + failed, nr.getSeq());
+                    foundPinned.put(nr.getNodeId(), nr);
+                    emitFromWalker(nr);
+                    rememberFrontier(target, frontier.values(), byDistance);
+                    return;
+                }
+                frontier.putIfAbsent(nr.getNodeId(), nr);
             }
         }
         rememberFrontier(target, frontier.values(), byDistance);
         // One line per completed walk, kept at INFO deliberately: with the
         // found-path logging living behind the emit dedupe, a silent walker is
         // indistinguishable from a dead one (observed on the first live run).
-        log.info("[discv5] targeted walk toward {}… : not found (queried={} frontier={})",
-                target.slice(0, 4), queried.size(), frontier.size());
+        int closest = frontier.keySet().stream()
+                .mapToInt(id -> org.ethereum.beacon.discovery.util.Functions.logDistance(id, target))
+                .min().orElse(-1);
+        log.info("[discv5] targeted walk toward {}… : not found (answered={} failed={} frontier={} closestLogDist={})",
+                target.slice(0, 4), answered, failed, frontier.size(), closest);
     }
 
     /** Keep the closest few learned records so the next revisit resumes there. */

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/discv5/DiscV5Service.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/discv5/DiscV5Service.java
@@ -242,41 +242,64 @@ public final class DiscV5Service implements AutoCloseable {
     // Targeted lookups (#347) — walk TOWARD the pinned servers
     // -------------------------------------------------------------------------
 
-    /** Total FINDNODE queries per walk. Termination is spec-Kademlia — stop
-     *  when the near window has no unqueried nodes left — and this budget is
-     *  the hard cap. Sized from live tuning: round-based variants with early
-     *  "no progress" breaks stalled at logDistance ~244-252 of 256; a
-     *  closest-first budgeted loop converges or proves absence within ~24. */
+    /** Total FINDNODE queries per walk's budgeted convergence loop. Termination
+     *  is spec-Kademlia — stop when the frontier has no unqueried nodes — and
+     *  this budget is the hard cap. Sized from live tuning: round-based
+     *  variants with early "no progress" breaks stalled at logDistance
+     *  ~244-252 of 256; a closest-first budgeted loop converges or proves
+     *  absence well within it. (No near-window cutoff either: the records
+     *  CLOSEST to a target are often stale/dead — 13 of 16 timed out on one
+     *  run — and a closest-16 rule gave up with budget left while alive nodes
+     *  slightly farther out held the record.) */
     private static final int WALK_QUERY_BUDGET = 32;
-    // (No near-window cutoff: live runs showed the records CLOSEST to a target
-    // are often stale/dead entries — 13 of 16 timed out — and a "closest-16
-    // all queried → unreachable" rule gave up with budget left while alive
-    // nodes slightly farther out held the target's record. Closest-first over
-    // the whole frontier, bounded by the budget, is the rule that finds it.)
-    /** Per-query answer budget; a silent node must not stall the walk. */
+    /** Per-query answer budget; a silent node must not stall the walk. Live
+     *  tuning: answers arrive in ~100 ms; wall time is dominated by timeouts
+     *  on dead frontier entries, so a short budget beats a generous one. */
     private static final long WALK_QUERY_TIMEOUT_MS = 1_500;
-    // Live tuning: answered queries return in ~100 ms; the walk's wall time is
-    // dominated by timeouts on dead frontier entries (15 of 20 on one run), so
-    // a short budget beats a generous one.
+    /** Sibling-phase cap. Mainnet pins ~19 peers; iterating every found
+     *  sibling before the real walk would burn most of a walk's wall time on
+     *  the front phase (the bootnode phase is capped for the same reason). */
+    private static final int WALK_SIBLING_CAP = 4;
+    /** Bootnode-phase cap (politeness toward the public seed set). */
+    private static final int WALK_BOOTNODE_CAP = 6;
     /** Pause between opening-pass walks (each pinned id once, quickly). */
     private static final long WALK_OPENING_GAP_MS = 2_000;
     /** Pause between steady-state revisits (round-robin, one per gap). */
     private static final long WALK_REVISIT_GAP_MS = 60_000;
 
+    /** Guards walker lifecycle: startWalker() runs on the discovery library's
+     *  completion thread while close() runs on a host thread (ChainStack
+     *  pause/resume cycles both routinely), and without a common lock two
+     *  interleavings leak a walker that nothing will ever interrupt: close()
+     *  landing between the poll scheduling and startWalker(), and close()'s
+     *  read of the walker field simply not seeing the callback's write (no
+     *  happens-before edge; Android/ARM is a first-class target). Both
+     *  synchronize on this object, and closed is checked under the lock. */
+    private final Object walkerLock = new Object();
+    private boolean walkerClosed;
     private Thread walker;
+
     /** Closest records learned per target, carried across revisits so each
      *  walk resumes from the best-known frontier instead of the bootnodes.
      *  Walker-thread only. */
     private final java.util.Map<org.apache.tuweni.bytes.Bytes, List<NodeRecord>> learnedFrontier =
             new java.util.HashMap<>();
     /** Pinned records already FOUND, reused as first-query seeds for the other
-     *  walks. The pinned servers know each other better than the wider DHT
-     *  does — roost's discv5 bootstraps THROUGH the co-located beacon node, so
-     *  the established pin's table holds the young pin long before the young
-     *  record has propagated widely (observed live: every walk toward roost
-     *  converged and stalled while nimbus — found in 9 queries every run — had
-     *  the record all along). Walker-thread only. */
+     *  walks — the pinned servers know each other better than the wider DHT
+     *  does (roost's discv5 bootstraps THROUGH the co-located beacon node).
+     *  A sibling whose query fails is EVICTED and re-added on its next find,
+     *  so a found-then-offline pin cannot become a permanent 1.5 s tax at the
+     *  front of every walk. Walker-thread only. */
     private final java.util.Map<org.apache.tuweni.bytes.Bytes, NodeRecord> foundPinned =
+            new java.util.HashMap<>();
+    /** Last EMITTED seq per pinned id — the same strictly-newer gate the Rust
+     *  engine applies to its pinned re-emissions (#348 review): ENR signatures
+     *  do not expire, so a laggard or adversarial table can serve a pinned
+     *  server's OLDER record, and the string-keyed seen-set alone would
+     *  re-emit it (exact-string dedupe is direction-blind). Walker finds pass
+     *  through this gate; the poll path is unchanged (it surfaces the local
+     *  table, which keeps the highest seq it has seen). Walker-thread only. */
+    private final java.util.Map<org.apache.tuweni.bytes.Bytes, Long> emittedPinnedSeq =
             new java.util.HashMap<>();
 
     /**
@@ -292,63 +315,151 @@ public final class DiscV5Service implements AutoCloseable {
     }
 
     private void startWalker() {
-        if (pinnedNodeIds.isEmpty()) {
+        synchronized (walkerLock) {
+            if (walkerClosed || pinnedNodeIds.isEmpty() || walker != null) {
+                return;
+            }
+            walker = new Thread(this::walkForever, "discv5-target");
+            walker.setDaemon(true);
+            walker.start();
+        }
+    }
+
+    private void walkForever() {
+        // The opening pass is worthless against an empty table (observed:
+        // walk 1 fired ~2 s after start, before any bootnode answered, and
+        // burned the first slot on frontier=0). Wait briefly for the table.
+        for (int w = 0; w < 20; w++) {
+            DiscoverySystem sys = system;
+            if (sys == null || sys.streamLiveNodes().findAny().isPresent()) {
+                break;
+            }
+            try {
+                Thread.sleep(1_000);
+            } catch (InterruptedException gone) {
+                return;
+            }
+        }
+        int i = 0;
+        while (!Thread.currentThread().isInterrupted()) {
+            // Snapshot: close() nulls the system field on a host thread; a walk
+            // against the snapshot either completes or fails fast, and the
+            // interrupt (sent under walkerLock) ends the loop.
+            DiscoverySystem sys = system;
+            if (sys == null) {
+                return;
+            }
+            org.apache.tuweni.bytes.Bytes target = pinnedNodeIds.get(i % pinnedNodeIds.size());
+            try {
+                targetedWalk(sys, target);
+            } catch (Throwable e) {
+                // Throwable, not Exception: a linkage error on the walker
+                // thread would otherwise kill it with no trace, and the
+                // walker never logging again reads as "working, no finds".
+                log.warn("[discv5] targeted walk failed: {}", e.toString());
+            }
+            try {
+                Thread.sleep(walkDelayMs(i, pinnedNodeIds.size()));
+            } catch (InterruptedException gone) {
+                return;
+            }
+            i++;
+        }
+    }
+
+    /** Outcome of one {@link #queryToward} call. */
+    private enum QueryOutcome { FOUND, MERGED, FAILED, INTERRUPTED }
+
+    /**
+     * Query one node for {@code target}'s bucket neighborhood and merge what it
+     * returns into {@code frontier}. THE one copy of the query rules, kept
+     * together because each is load-bearing:
+     *
+     * <ul>
+     *   <li>Distances {@code d-4..d}: the bucket at d contains the target's
+     *       neighborhood as the queried node sees it, the lower buckets sample
+     *       strictly closer halves, and the responder caps the reply at 16
+     *       records total — a wider ask mines each RESPONSIVE node harder,
+     *       which matters when the target's nearest neighbors are dead.</li>
+     *   <li>{@code InterruptedException} must re-interrupt and surface as
+     *       {@link QueryOutcome#INTERRUPTED}: swallowing it (the generic catch
+     *       would) clears the flag, and the walker then keeps walking a
+     *       stopped system forever — one leaked thread per ChainStack restart.
+     *       Caught once by the internal review; kept in one place since.</li>
+     *   <li>A found record passes the strictly-newer seq gate before emission
+     *       (see {@link #emittedPinnedSeq}).</li>
+     * </ul>
+     */
+    private QueryOutcome queryToward(DiscoverySystem sys, NodeRecord node,
+                                     org.apache.tuweni.bytes.Bytes target,
+                                     java.util.Map<org.apache.tuweni.bytes.Bytes, NodeRecord> frontier,
+                                     String foundWhere) {
+        int d = org.ethereum.beacon.discovery.util.Functions.logDistance(node.getNodeId(), target);
+        List<Integer> distances = java.util.stream.IntStream.rangeClosed(d - 4, d)
+                .filter(x -> x >= 1 && x <= 256).boxed()
+                .sorted(java.util.Collections.reverseOrder()).toList();
+        java.util.Collection<NodeRecord> answers;
+        try {
+            answers = sys.findNodes(node, distances)
+                    .get(WALK_QUERY_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException shutdown) {
+            Thread.currentThread().interrupt();
+            return QueryOutcome.INTERRUPTED;
+        } catch (Exception unresponsive) {
+            return QueryOutcome.FAILED;
+        }
+        if (log.isDebugEnabled()) {
+            java.util.IntSummaryStatistics stats = answers.stream()
+                    .mapToInt(nr -> org.ethereum.beacon.discovery.util.Functions.logDistance(
+                            nr.getNodeId(), target))
+                    .summaryStatistics();
+            log.debug("[discv5] walk query: candidateDist={} asked={} answers={} answerDistToTarget=[{}..{}]",
+                    d, distances, answers.size(),
+                    stats.getCount() == 0 ? -1 : stats.getMin(),
+                    stats.getCount() == 0 ? -1 : stats.getMax());
+        }
+        for (NodeRecord nr : answers) {
+            if (nr.getNodeId().equals(target)) {
+                foundTarget(nr, foundWhere);
+                return QueryOutcome.FOUND;
+            }
+            frontier.putIfAbsent(nr.getNodeId(), nr);
+        }
+        return QueryOutcome.MERGED;
+    }
+
+    /** Record + (seq-gated) emit a found pinned record. Walker thread. */
+    private void foundTarget(NodeRecord nr, String where) {
+        long seq = nr.getSeq().toLong();
+        Long last = emittedPinnedSeq.get(nr.getNodeId());
+        if (last != null && seq <= last) {
+            log.debug("[discv5] targeted walk: {} record seq={} not newer than emitted {} — not re-emitted",
+                    where, seq, last);
+            foundPinned.put(nr.getNodeId(), nr);
             return;
         }
-        walker = new Thread(() -> {
-            // The opening pass is worthless against an empty table (observed:
-            // walk 1 fired ~2 s after start, before any bootnode answered, and
-            // burned the first slot on frontier=0). Wait briefly for the table.
-            for (int w = 0; w < 20 && system.streamLiveNodes().findAny().isEmpty(); w++) {
-                try {
-                    Thread.sleep(1_000);
-                } catch (InterruptedException gone) {
-                    return;
-                }
-            }
-            int i = 0;
-            while (!Thread.currentThread().isInterrupted()) {
-                org.apache.tuweni.bytes.Bytes target = pinnedNodeIds.get(i % pinnedNodeIds.size());
-                try {
-                    targetedWalk(target);
-                } catch (Throwable e) {
-                    // Throwable, not Exception: a linkage error on the walker
-                    // thread would otherwise kill it with no trace, and the
-                    // walker never logging again reads as "working, no finds".
-                    log.warn("[discv5] targeted walk failed: {}", e.toString());
-                }
-                try {
-                    Thread.sleep(walkDelayMs(i, pinnedNodeIds.size()));
-                } catch (InterruptedException gone) {
-                    return;
-                }
-                i++;
-            }
-        }, "discv5-target");
-        walker.setDaemon(true);
-        walker.start();
+        log.info("[discv5] targeted walk: FOUND pinned server {} (seq={}, {})",
+                nr.getNodeId().slice(0, 4), seq, where);
+        emittedPinnedSeq.put(nr.getNodeId(), seq);
+        foundPinned.put(nr.getNodeId(), nr);
+        emitFromWalker(nr);
     }
 
     /**
      * One bounded iterative Kademlia walk toward {@code target}: seed from
      * sibling pins and bootnodes, then repeatedly query the closest unqueried
-     * frontier node for the target's bucket neighborhood, merging what each
-     * returns. Runs entirely on the walker thread; queries are sequential with
-     * a short timeout each, so a full walk is bounded at roughly
-     * {@code (seeds + WALK_QUERY_BUDGET) × WALK_QUERY_TIMEOUT_MS} worst-case,
-     * a few seconds typically.
+     * frontier node, merging what each returns. Runs entirely on the walker
+     * thread; queries are sequential with a short timeout each.
      *
      * <p>A found record is handed to the poll scheduler for emission, so the
-     * seen-set and the caller's consumer stay single-threaded. Re-notification
-     * semantics come free from the existing dedupe: the seen-set keys on the
-     * full ENR string, so a REPUBLISHED record (new seq, new address) is a new
-     * string and re-emits, while the same record stays deduped — the Java
-     * equivalent of the Rust engine's seq gate. The pool side is naturally
-     * name-wins: {@code addPeer} only ever ADDS a new multiaddr entry; the
-     * configured {@code /dns4} pin is never overwritten (parity contract,
-     * #347/#348 review).
+     * seen-set and the caller's consumer stay single-threaded. Walker finds
+     * are gated on a STRICTLY NEWER seq per pinned id ({@link #emittedPinnedSeq}
+     * — the Rust engine's gate, #348 review); the poll path's string-keyed
+     * dedupe is unchanged. The pool side is naturally name-wins: {@code addPeer}
+     * only ever ADDS a new multiaddr entry; the configured {@code /dns4} pin is
+     * never overwritten (parity contract, #347/#348 review).
      */
-    private void targetedWalk(org.apache.tuweni.bytes.Bytes target) {
+    private void targetedWalk(DiscoverySystem sys, org.apache.tuweni.bytes.Bytes target) {
         // NOT Functions.distance: that helper reads the XOR as LITTLE-endian
         // (toUnsignedBigInteger(LITTLE_ENDIAN)), so ordering by it sorts on the
         // XOR's LOW bytes — near-random with respect to actual closeness, which
@@ -361,7 +472,7 @@ public final class DiscV5Service implements AutoCloseable {
                 .thenComparing(nr -> new java.math.BigInteger(
                         1, nr.getNodeId().xor(target).toArray()));
         java.util.Map<org.apache.tuweni.bytes.Bytes, NodeRecord> frontier = new java.util.HashMap<>();
-        system.streamLiveNodes().forEach(nr -> frontier.put(nr.getNodeId(), nr));
+        sys.streamLiveNodes().forEach(nr -> frontier.put(nr.getNodeId(), nr));
         for (NodeRecord nr : learnedFrontier.getOrDefault(target, List.of())) {
             frontier.putIfAbsent(nr.getNodeId(), nr);
         }
@@ -369,102 +480,64 @@ public final class DiscV5Service implements AutoCloseable {
         int answered = 0;
         int failed = 0;
 
-        // Phase -1 — ask the pinned servers already FOUND (see foundPinned):
-        // they are session-verified responders and the likeliest tables to
-        // hold a sibling pin's young record.
-        for (NodeRecord sibling : List.copyOf(foundPinned.values())) {
-            if (sibling.getNodeId().equals(target) || queried.contains(sibling.getNodeId())) {
+        // Phase -1 — the CLOSEST few sibling pins already found: session-
+        // verified responders, and the likeliest tables to hold a sibling's
+        // young record (observed live: every walk toward the young roost pin
+        // stalled while the established pin had the record all along). Capped,
+        // and closest-to-target first: on a ~19-pin network an uncapped pass
+        // would burn most of the walk on this phase.
+        List<NodeRecord> siblings = foundPinned.values().stream()
+                .filter(nr -> !nr.getNodeId().equals(target))
+                .sorted(byDistance)
+                .limit(WALK_SIBLING_CAP)
+                .toList();
+        for (NodeRecord sibling : siblings) {
+            if (!queried.add(sibling.getNodeId())) {
                 continue;
             }
-            queried.add(sibling.getNodeId());
-            int d = org.ethereum.beacon.discovery.util.Functions.logDistance(
-                    sibling.getNodeId(), target);
-            List<Integer> distances = java.util.stream.IntStream.rangeClosed(d - 4, d)
-                    .filter(x -> x >= 1 && x <= 256).boxed()
-                    .sorted(java.util.Collections.reverseOrder()).toList();
-            java.util.Collection<NodeRecord> answers;
-            try {
-                answers = system.findNodes(sibling, distances)
-                        .get(WALK_QUERY_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-                answered++;
-            } catch (InterruptedException shutdown) {
-                // close() interrupts the walker; the flag must SURVIVE this
-                // catch or the outer loop never sees it and the thread keeps
-                // walking a stopped system forever (ChainStack stop/start
-                // cycles would leak one such thread per restart).
-                Thread.currentThread().interrupt();
+            QueryOutcome outcome = queryToward(sys, sibling, target, frontier, "at a sibling pin");
+            if (outcome == QueryOutcome.FOUND || outcome == QueryOutcome.INTERRUPTED) {
+                rememberFrontier(target, frontier.values(), byDistance);
                 return;
-            } catch (Exception unresponsive) {
-                failed++;
-                continue;
             }
-            for (NodeRecord nr : answers) {
-                if (nr.getNodeId().equals(target)) {
-                    log.info("[discv5] targeted walk toward {}… : FOUND at a sibling pin (seq={})",
-                            target.slice(0, 4), nr.getSeq());
-                    foundPinned.put(nr.getNodeId(), nr);
-                    emitFromWalker(nr);
-                    rememberFrontier(target, frontier.values(), byDistance);
-                    return;
-                }
-                frontier.putIfAbsent(nr.getNodeId(), nr);
+            if (outcome == QueryOutcome.FAILED) {
+                failed++;
+                // Evict: a dead sibling must not tax the front of every walk;
+                // its next find re-adds it.
+                foundPinned.remove(sibling.getNodeId());
+            } else {
+                answered++;
             }
         }
 
-        // Phase 0 — ask the BOOTNODES first, at the target's bucket as each of
-        // them sees it. Their tables are the largest and freshest in the
-        // network, and a server that pinged them at startup is often in them
-        // directly: the sigp verifier finds roost in its FIRST round precisely
-        // because a fresh sigp table contains only bootnodes. A closest-first
-        // walk would never ask them (they sit at random distance from any
-        // target), which is how it can converge to logDistance ~237 through a
-        // cluster of stale near-records and still miss a record the bootnodes
-        // are holding (observed live).
+        // Phase 0 — a few BOOTNODES, at the target's bucket as each sees it.
+        // Their tables are the largest and freshest in the network, and a
+        // server that pinged them at startup is often in them directly: the
+        // closest-first loop below would never ask them (they sit at random
+        // distance from any target), which is how a walk can converge to
+        // logDistance ~237 through a cluster of stale near-records and still
+        // miss a record a bootnode is holding (observed live).
         for (NodeRecord bootnode : bootnodeRecords()) {
-            if (queried.size() >= 6) {
+            if (queried.size() >= WALK_SIBLING_CAP + WALK_BOOTNODE_CAP) {
                 break;
             }
-            if (bootnode.getNodeId().equals(target) || queried.contains(bootnode.getNodeId())) {
+            if (bootnode.getNodeId().equals(target) || !queried.add(bootnode.getNodeId())) {
                 continue;
             }
-            queried.add(bootnode.getNodeId());
-            int d = org.ethereum.beacon.discovery.util.Functions.logDistance(
-                    bootnode.getNodeId(), target);
-            List<Integer> distances = java.util.stream.IntStream.rangeClosed(d - 4, d)
-                    .filter(x -> x >= 1 && x <= 256).boxed()
-                    .sorted(java.util.Collections.reverseOrder()).toList();
-            java.util.Collection<NodeRecord> answers;
-            try {
-                answers = system.findNodes(bootnode, distances)
-                        .get(WALK_QUERY_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-                answered++;
-            } catch (InterruptedException shutdown) {
-                Thread.currentThread().interrupt(); // see the sibling-phase note
+            QueryOutcome outcome = queryToward(sys, bootnode, target, frontier, "at a bootnode");
+            if (outcome == QueryOutcome.FOUND || outcome == QueryOutcome.INTERRUPTED) {
+                rememberFrontier(target, frontier.values(), byDistance);
                 return;
-            } catch (Exception unresponsive) {
-                failed++;
-                continue;
             }
-            for (NodeRecord nr : answers) {
-                if (nr.getNodeId().equals(target)) {
-                    log.info("[discv5] targeted walk toward {}… : FOUND at a bootnode (seq={})",
-                            target.slice(0, 4), nr.getSeq());
-                    foundPinned.put(nr.getNodeId(), nr);
-                    emitFromWalker(nr);
-                    rememberFrontier(target, frontier.values(), byDistance);
-                    return;
-                }
-                frontier.putIfAbsent(nr.getNodeId(), nr);
+            if (outcome == QueryOutcome.FAILED) {
+                failed++;
+            } else {
+                answered++;
             }
         }
 
-        // Closest-first, budgeted: always query the closest node not yet asked,
-        // stop when the WALK_WINDOW closest have all been asked (they are the
-        // ones that would hold the target) or the budget runs out. Deliberately
-        // no "no progress this round" break: live tuning showed any such round
-        // heuristic either never terminates (any new node counts) or gives up
-        // while still ~250 bits out (closer-node-required) — spec-Kademlia
-        // termination is the one that actually converges.
+        // Budgeted closest-first convergence: always query the closest node not
+        // yet asked, stop when the frontier is exhausted or the budget is spent.
         for (int q = 0; q < WALK_QUERY_BUDGET; q++) {
             NodeRecord candidate = frontier.values().stream()
                     .filter(nr -> !queried.contains(nr.getNodeId()))
@@ -475,59 +548,21 @@ public final class DiscV5Service implements AutoCloseable {
             }
             if (candidate.getNodeId().equals(target)) {
                 // The frontier already HOLDS the target's record (e.g. it sits
-                // in the local live table) — that IS the find. Asking it for
-                // "bucket 0" would also produce an empty distances list below.
-                log.info("[discv5] targeted walk toward {}… : FOUND in local frontier (seq={})",
-                        target.slice(0, 4), candidate.getSeq());
-                foundPinned.put(candidate.getNodeId(), candidate);
-                emitFromWalker(candidate);
+                // in the local live table) — that IS the find.
+                foundTarget(candidate, "in local frontier");
                 rememberFrontier(target, frontier.values(), byDistance);
                 return;
             }
             queried.add(candidate.getNodeId());
-            int d = org.ethereum.beacon.discovery.util.Functions.logDistance(
-                    candidate.getNodeId(), target);
-            // The bucket at d contains the target's neighborhood as this
-            // candidate sees it; the lower buckets sample strictly closer
-            // halves. Five buckets per query: the responder caps the reply at
-            // 16 records total anyway, so a wider ask mines each RESPONSIVE
-            // node harder — which matters when the target's nearest neighbors
-            // are dead entries and answers are scarce.
-            List<Integer> distances = java.util.stream.IntStream.rangeClosed(d - 4, d)
-                    .filter(x -> x >= 1 && x <= 256).boxed().sorted(java.util.Collections.reverseOrder())
-                    .toList();
-            java.util.Collection<NodeRecord> answers;
-            try {
-                answers = system.findNodes(candidate, distances)
-                        .get(WALK_QUERY_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-                answered++;
-            } catch (InterruptedException shutdown) {
-                Thread.currentThread().interrupt(); // see the sibling-phase note
+            QueryOutcome outcome = queryToward(sys, candidate, target, frontier, "via the walk");
+            if (outcome == QueryOutcome.FOUND || outcome == QueryOutcome.INTERRUPTED) {
+                rememberFrontier(target, frontier.values(), byDistance);
                 return;
-            } catch (Exception unresponsive) {
+            }
+            if (outcome == QueryOutcome.FAILED) {
                 failed++;
-                continue;
-            }
-            if (log.isDebugEnabled()) {
-                java.util.IntSummaryStatistics stats = answers.stream()
-                        .mapToInt(nr -> org.ethereum.beacon.discovery.util.Functions.logDistance(
-                                nr.getNodeId(), target))
-                        .summaryStatistics();
-                log.debug("[discv5] walk query: candidateDist={} asked={} answers={} answerDistToTarget=[{}..{}]",
-                        d, distances, answers.size(),
-                        stats.getCount() == 0 ? -1 : stats.getMin(),
-                        stats.getCount() == 0 ? -1 : stats.getMax());
-            }
-            for (NodeRecord nr : answers) {
-                if (nr.getNodeId().equals(target)) {
-                    log.info("[discv5] targeted walk toward {}… : FOUND (queries={} seq={})",
-                            target.slice(0, 4), answered + failed, nr.getSeq());
-                    foundPinned.put(nr.getNodeId(), nr);
-                    emitFromWalker(nr);
-                    rememberFrontier(target, frontier.values(), byDistance);
-                    return;
-                }
-                frontier.putIfAbsent(nr.getNodeId(), nr);
+            } else {
+                answered++;
             }
         }
         rememberFrontier(target, frontier.values(), byDistance);
@@ -559,17 +594,15 @@ public final class DiscV5Service implements AutoCloseable {
         }
         try {
             s.execute(() -> {
-            if (!seenEnrs.add(enrStr)) {
-                return; // same record already surfaced (poll or earlier walk)
-            }
-            try {
-                Enr parsed = Enr.fromEnrString(enrStr);
-                log.info("[discv5] targeted lookup found pinned server (seq={}): {}",
-                        parsed.seq(), enrStr.substring(0, Math.min(40, enrStr.length())));
-                onPeerDiscovered.accept(parsed);
-            } catch (Exception e) {
-                log.warn("[discv5] failed to parse walked ENR: {}", e.getMessage());
-            }
+                if (!seenEnrs.add(enrStr)) {
+                    return; // same record already surfaced (poll or earlier walk)
+                }
+                try {
+                    Enr parsed = Enr.fromEnrString(enrStr);
+                    onPeerDiscovered.accept(parsed);
+                } catch (Exception e) {
+                    log.warn("[discv5] failed to parse walked ENR: {}", e.getMessage());
+                }
             });
         } catch (java.util.concurrent.RejectedExecutionException shutdownRace) {
             // close() won the race between the isShutdown check and execute —
@@ -695,9 +728,16 @@ public final class DiscV5Service implements AutoCloseable {
 
     @Override
     public void close() {
-        if (walker != null) {
-            walker.interrupt();
-            walker = null;
+        // Under walkerLock, and closed is set FIRST: a startWalker() racing on
+        // the library's completion thread either sees closed and refuses, or
+        // finishes first and its walker is interrupted here — no interleaving
+        // leaves a walker that nothing will ever stop (see walkerLock's doc).
+        synchronized (walkerLock) {
+            walkerClosed = true;
+            if (walker != null) {
+                walker.interrupt();
+                walker = null;
+            }
         }
         if (scheduler != null) {
             scheduler.shutdownNow();

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/discv5/DiscV5Service.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/discv5/DiscV5Service.java
@@ -76,8 +76,9 @@ public final class DiscV5Service implements AutoCloseable {
     // handful of public CL bootnodes 4x as often for the life of the process.)
     private static final int RESEED_EMPTY_POLLS = 4;
     private int consecutiveEmptyPolls;
-    // Bootnode ENRs parsed once, on the first re-seed (malformed entries are
-    // logged once and dropped, not re-swallowed every fire). Poll-thread only.
+    // Bootnode ENRs parsed once, on first use (malformed entries are logged
+    // once and dropped, not re-swallowed every fire). Guarded by
+    // bootnodeRecords()'s synchronization — poll thread and walker both call it.
     private List<NodeRecord> bootnodeRecords;
 
     public DiscV5Service(NodeKey nodeKey, List<String> bootnodeEnrs,
@@ -329,11 +330,13 @@ public final class DiscV5Service implements AutoCloseable {
     }
 
     /**
-     * One bounded iterative Kademlia walk toward {@code target}: query the α
-     * closest known nodes for the target's bucket (±1), merge what they return,
-     * repeat while progress is made. Runs entirely on the walker thread;
-     * queries are sequential with a short timeout each, so a full walk is
-     * bounded at roughly {@code WALK_MAX_ROUNDS × α × timeout}.
+     * One bounded iterative Kademlia walk toward {@code target}: seed from
+     * sibling pins and bootnodes, then repeatedly query the closest unqueried
+     * frontier node for the target's bucket neighborhood, merging what each
+     * returns. Runs entirely on the walker thread; queries are sequential with
+     * a short timeout each, so a full walk is bounded at roughly
+     * {@code (seeds + WALK_QUERY_BUDGET) × WALK_QUERY_TIMEOUT_MS} worst-case,
+     * a few seconds typically.
      *
      * <p>A found record is handed to the poll scheduler for emission, so the
      * seen-set and the caller's consumer stay single-threaded. Re-notification
@@ -384,6 +387,13 @@ public final class DiscV5Service implements AutoCloseable {
                 answers = system.findNodes(sibling, distances)
                         .get(WALK_QUERY_TIMEOUT_MS, TimeUnit.MILLISECONDS);
                 answered++;
+            } catch (InterruptedException shutdown) {
+                // close() interrupts the walker; the flag must SURVIVE this
+                // catch or the outer loop never sees it and the thread keeps
+                // walking a stopped system forever (ChainStack stop/start
+                // cycles would leak one such thread per restart).
+                Thread.currentThread().interrupt();
+                return;
             } catch (Exception unresponsive) {
                 failed++;
                 continue;
@@ -428,6 +438,9 @@ public final class DiscV5Service implements AutoCloseable {
                 answers = system.findNodes(bootnode, distances)
                         .get(WALK_QUERY_TIMEOUT_MS, TimeUnit.MILLISECONDS);
                 answered++;
+            } catch (InterruptedException shutdown) {
+                Thread.currentThread().interrupt(); // see the sibling-phase note
+                return;
             } catch (Exception unresponsive) {
                 failed++;
                 continue;
@@ -460,6 +473,17 @@ public final class DiscV5Service implements AutoCloseable {
             if (candidate == null) {
                 break; // frontier exhausted — the target is not reachable today
             }
+            if (candidate.getNodeId().equals(target)) {
+                // The frontier already HOLDS the target's record (e.g. it sits
+                // in the local live table) — that IS the find. Asking it for
+                // "bucket 0" would also produce an empty distances list below.
+                log.info("[discv5] targeted walk toward {}… : FOUND in local frontier (seq={})",
+                        target.slice(0, 4), candidate.getSeq());
+                foundPinned.put(candidate.getNodeId(), candidate);
+                emitFromWalker(candidate);
+                rememberFrontier(target, frontier.values(), byDistance);
+                return;
+            }
             queried.add(candidate.getNodeId());
             int d = org.ethereum.beacon.discovery.util.Functions.logDistance(
                     candidate.getNodeId(), target);
@@ -477,6 +501,9 @@ public final class DiscV5Service implements AutoCloseable {
                 answers = system.findNodes(candidate, distances)
                         .get(WALK_QUERY_TIMEOUT_MS, TimeUnit.MILLISECONDS);
                 answered++;
+            } catch (InterruptedException shutdown) {
+                Thread.currentThread().interrupt(); // see the sibling-phase note
+                return;
             } catch (Exception unresponsive) {
                 failed++;
                 continue;
@@ -530,7 +557,8 @@ public final class DiscV5Service implements AutoCloseable {
         if (s == null || s.isShutdown()) {
             return;
         }
-        s.execute(() -> {
+        try {
+            s.execute(() -> {
             if (!seenEnrs.add(enrStr)) {
                 return; // same record already surfaced (poll or earlier walk)
             }
@@ -542,7 +570,11 @@ public final class DiscV5Service implements AutoCloseable {
             } catch (Exception e) {
                 log.warn("[discv5] failed to parse walked ENR: {}", e.getMessage());
             }
-        });
+            });
+        } catch (java.util.concurrent.RejectedExecutionException shutdownRace) {
+            // close() won the race between the isShutdown check and execute —
+            // the record is simply dropped, like every other in-flight find.
+        }
     }
 
     // -------------------------------------------------------------------------
@@ -620,8 +652,11 @@ public final class DiscV5Service implements AutoCloseable {
                 RESEED_EMPTY_POLLS, bootnodes.size());
     }
 
-    /** The bootnode ENRs parsed to records, once; malformed entries warn once and drop. */
-    private List<NodeRecord> bootnodeRecords() {
+    /** The bootnode ENRs parsed to records, once; malformed entries warn once
+     *  and drop. Synchronized: the re-seed path calls this on the poll thread
+     *  and the walker's bootnode phase calls it on the walker thread — an
+     *  unsynchronized lazy init would race the two into an unsafe publication. */
+    private synchronized List<NodeRecord> bootnodeRecords() {
         if (bootnodeRecords == null) {
             bootnodeRecords = new java.util.ArrayList<>(bootnodeEnrs.size());
             for (String enr : bootnodeEnrs) {

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/discv5/DiscV5Service.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/discv5/DiscV5Service.java
@@ -40,6 +40,13 @@ public final class DiscV5Service implements AutoCloseable {
     private final NodeKey nodeKey;
     private final List<String> bootnodeEnrs;
     private final Consumer<Enr> onPeerDiscovered;
+    /** discv5 node ids of the chain's PINNED peers (derived from their libp2p
+     *  peer ids — {@code Enr.nodeIdForPeerId}). Lookups walk TOWARD these ids
+     *  instead of hoping a random walk lands in their bucket, which on the
+     *  mainnet DHT it rarely does. Same design as the Rust engine's
+     *  {@code pinned_targets} (parity contract, #347): a stale pinned address
+     *  heals through third-party tables in bounded time. */
+    private final List<org.apache.tuweni.bytes.Bytes> pinnedNodeIds;
 
     private DiscoverySystem system;
     private ScheduledExecutorService scheduler;
@@ -75,8 +82,15 @@ public final class DiscV5Service implements AutoCloseable {
 
     public DiscV5Service(NodeKey nodeKey, List<String> bootnodeEnrs,
                          Consumer<Enr> onPeerDiscovered) {
+        this(nodeKey, bootnodeEnrs, List.of(), onPeerDiscovered);
+    }
+
+    public DiscV5Service(NodeKey nodeKey, List<String> bootnodeEnrs,
+                         List<org.apache.tuweni.bytes.Bytes> pinnedNodeIds,
+                         Consumer<Enr> onPeerDiscovered) {
         this.nodeKey = nodeKey;
         this.bootnodeEnrs = bootnodeEnrs;
+        this.pinnedNodeIds = List.copyOf(pinnedNodeIds);
         this.onPeerDiscovered = onPeerDiscovered;
     }
 
@@ -163,6 +177,10 @@ public final class DiscV5Service implements AutoCloseable {
             // First poll at 5s to pick up fast bootnode responses; then every
             // 15s (same cadence as discv4-refresh) to surface new peers.
             scheduler.scheduleAtFixedRate(this::pollAndNotify, 5, 15, TimeUnit.SECONDS);
+            // Targeted lookups toward the pinned servers (#347) run on their
+            // own thread — a full walk blocks for up to ~30 s worst-case, which
+            // must not stall the poll cadence.
+            startWalker();
         });
     }
 
@@ -217,6 +235,174 @@ public final class DiscV5Service implements AutoCloseable {
      */
     public int liveNodeCount() {
         return system == null ? 0 : (int) system.streamLiveNodes().count();
+    }
+
+    // -------------------------------------------------------------------------
+    // Targeted lookups (#347) — walk TOWARD the pinned servers
+    // -------------------------------------------------------------------------
+
+    /** Queries per walk round (Kademlia α). */
+    private static final int WALK_ALPHA = 3;
+    /** Rounds per walk before giving up (each round queries α nodes). */
+    private static final int WALK_MAX_ROUNDS = 4;
+    /** Per-query answer budget; a silent node must not stall the walk. */
+    private static final long WALK_QUERY_TIMEOUT_MS = 3_000;
+    /** Pause between opening-pass walks (each pinned id once, quickly). */
+    private static final long WALK_OPENING_GAP_MS = 2_000;
+    /** Pause between steady-state revisits (round-robin, one per gap). */
+    private static final long WALK_REVISIT_GAP_MS = 60_000;
+
+    private Thread walker;
+    /** Closest records learned per target, carried across revisits so each
+     *  walk resumes from the best-known frontier instead of the bootnodes.
+     *  Walker-thread only. */
+    private final java.util.Map<org.apache.tuweni.bytes.Bytes, List<NodeRecord>> learnedFrontier =
+            new java.util.HashMap<>();
+
+    /**
+     * Milliseconds to sleep after the {@code completedWalks}-th walk. The first
+     * {@code nTargets} walks are the OPENING PASS — each pinned id visited once,
+     * near back-to-back, so a wallet finds its servers in the first minute even
+     * on the mainnet DHT — then revisits go round-robin at a polite cadence
+     * (the revisit is what heals a stale pinned address after the server
+     * republishes). Package-private for tests.
+     */
+    static long walkDelayMs(int completedWalks, int nTargets) {
+        return completedWalks < nTargets ? WALK_OPENING_GAP_MS : WALK_REVISIT_GAP_MS;
+    }
+
+    private void startWalker() {
+        if (pinnedNodeIds.isEmpty()) {
+            return;
+        }
+        walker = new Thread(() -> {
+            int i = 0;
+            while (!Thread.currentThread().isInterrupted()) {
+                org.apache.tuweni.bytes.Bytes target = pinnedNodeIds.get(i % pinnedNodeIds.size());
+                try {
+                    targetedWalk(target);
+                } catch (Throwable e) {
+                    // Throwable, not Exception: a linkage error on the walker
+                    // thread would otherwise kill it with no trace, and the
+                    // walker never logging again reads as "working, no finds".
+                    log.warn("[discv5] targeted walk failed: {}", e.toString());
+                }
+                try {
+                    Thread.sleep(walkDelayMs(i, pinnedNodeIds.size()));
+                } catch (InterruptedException gone) {
+                    return;
+                }
+                i++;
+            }
+        }, "discv5-target");
+        walker.setDaemon(true);
+        walker.start();
+    }
+
+    /**
+     * One bounded iterative Kademlia walk toward {@code target}: query the α
+     * closest known nodes for the target's bucket (±1), merge what they return,
+     * repeat while progress is made. Runs entirely on the walker thread;
+     * queries are sequential with a short timeout each, so a full walk is
+     * bounded at roughly {@code WALK_MAX_ROUNDS × α × timeout}.
+     *
+     * <p>A found record is handed to the poll scheduler for emission, so the
+     * seen-set and the caller's consumer stay single-threaded. Re-notification
+     * semantics come free from the existing dedupe: the seen-set keys on the
+     * full ENR string, so a REPUBLISHED record (new seq, new address) is a new
+     * string and re-emits, while the same record stays deduped — the Java
+     * equivalent of the Rust engine's seq gate. The pool side is naturally
+     * name-wins: {@code addPeer} only ever ADDS a new multiaddr entry; the
+     * configured {@code /dns4} pin is never overwritten (parity contract,
+     * #347/#348 review).
+     */
+    private void targetedWalk(org.apache.tuweni.bytes.Bytes target) {
+        java.util.Comparator<NodeRecord> byDistance = java.util.Comparator.comparing(
+                nr -> org.ethereum.beacon.discovery.util.Functions.distance(target, nr.getNodeId()));
+        java.util.Map<org.apache.tuweni.bytes.Bytes, NodeRecord> frontier = new java.util.HashMap<>();
+        system.streamLiveNodes().forEach(nr -> frontier.put(nr.getNodeId(), nr));
+        for (NodeRecord nr : learnedFrontier.getOrDefault(target, List.of())) {
+            frontier.putIfAbsent(nr.getNodeId(), nr);
+        }
+        Set<org.apache.tuweni.bytes.Bytes> queried = new HashSet<>();
+
+        for (int round = 0; round < WALK_MAX_ROUNDS; round++) {
+            List<NodeRecord> candidates = frontier.values().stream()
+                    .filter(nr -> !queried.contains(nr.getNodeId()))
+                    .sorted(byDistance)
+                    .limit(WALK_ALPHA)
+                    .toList();
+            if (candidates.isEmpty()) {
+                break;
+            }
+            boolean progressed = false;
+            for (NodeRecord candidate : candidates) {
+                queried.add(candidate.getNodeId());
+                int d = org.ethereum.beacon.discovery.util.Functions.logDistance(
+                        candidate.getNodeId(), target);
+                List<Integer> distances = java.util.stream.IntStream.of(d - 1, d, d + 1)
+                        .filter(x -> x >= 1 && x <= 256).distinct().boxed().toList();
+                java.util.Collection<NodeRecord> answers;
+                try {
+                    answers = system.findNodes(candidate, distances)
+                            .get(WALK_QUERY_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+                } catch (Exception unresponsive) {
+                    continue;
+                }
+                for (NodeRecord nr : answers) {
+                    if (nr.getNodeId().equals(target)) {
+                        log.info("[discv5] targeted walk toward {}… : FOUND (round={} seq={})",
+                                target.slice(0, 4), round, nr.getSeq());
+                        emitFromWalker(nr);
+                        rememberFrontier(target, frontier.values(), byDistance);
+                        return;
+                    }
+                    if (frontier.putIfAbsent(nr.getNodeId(), nr) == null) {
+                        progressed = true;
+                    }
+                }
+            }
+            if (!progressed) {
+                break; // converged without finding — record not propagated (yet)
+            }
+        }
+        rememberFrontier(target, frontier.values(), byDistance);
+        // One line per completed walk, kept at INFO deliberately: with the
+        // found-path logging living behind the emit dedupe, a silent walker is
+        // indistinguishable from a dead one (observed on the first live run).
+        log.info("[discv5] targeted walk toward {}… : not found (queried={} frontier={})",
+                target.slice(0, 4), queried.size(), frontier.size());
+    }
+
+    /** Keep the closest few learned records so the next revisit resumes there. */
+    private void rememberFrontier(org.apache.tuweni.bytes.Bytes target,
+                                  java.util.Collection<NodeRecord> frontier,
+                                  java.util.Comparator<NodeRecord> byDistance) {
+        learnedFrontier.put(target,
+                frontier.stream().sorted(byDistance).limit(8).toList());
+    }
+
+    /** Marshal a walker-found record onto the poll thread: the seen-set and the
+     *  downstream consumer are single-threaded by design. */
+    private void emitFromWalker(NodeRecord nr) {
+        String enrStr = nr.asEnr();
+        ScheduledExecutorService s = scheduler;
+        if (s == null || s.isShutdown()) {
+            return;
+        }
+        s.execute(() -> {
+            if (!seenEnrs.add(enrStr)) {
+                return; // same record already surfaced (poll or earlier walk)
+            }
+            try {
+                Enr parsed = Enr.fromEnrString(enrStr);
+                log.info("[discv5] targeted lookup found pinned server (seq={}): {}",
+                        parsed.seq(), enrStr.substring(0, Math.min(40, enrStr.length())));
+                onPeerDiscovered.accept(parsed);
+            } catch (Exception e) {
+                log.warn("[discv5] failed to parse walked ENR: {}", e.getMessage());
+            }
+        });
     }
 
     // -------------------------------------------------------------------------
@@ -334,6 +520,10 @@ public final class DiscV5Service implements AutoCloseable {
 
     @Override
     public void close() {
+        if (walker != null) {
+            walker.interrupt();
+            walker = null;
+        }
         if (scheduler != null) {
             scheduler.shutdownNow();
             scheduler = null;

--- a/networking/src/test/java/com/jaeckel/ethp2p/networking/discv5/PinnedNodeIdDerivationTest.java
+++ b/networking/src/test/java/com/jaeckel/ethp2p/networking/discv5/PinnedNodeIdDerivationTest.java
@@ -1,0 +1,74 @@
+package com.jaeckel.ethp2p.networking.discv5;
+
+import com.jaeckel.ethp2p.core.enr.Enr;
+import org.apache.tuweni.bytes.Bytes;
+import org.ethereum.beacon.discovery.schema.NodeRecord;
+import org.ethereum.beacon.discovery.schema.NodeRecordFactory;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The Java twin of the Rust engine's {@code node_id_for_peer} derivation and
+ * its {@code pinned_roost_identity_matches_its_seeded_enr} invariant: the
+ * discv5 node id derived from a pinned libp2p peer id must equal the node id
+ * of the record that peer actually publishes. Uses roost's real published
+ * records as golden vectors — the same key signs both identities, which is the
+ * property the targeted-lookup fast path stands on (#347). If these fail,
+ * either the derivation drifted from the Rust engine's or roost split its
+ * keys — both must be a red build, not a silent fallback to random-walk luck.
+ */
+class PinnedNodeIdDerivationTest {
+
+    /** (pinned libp2p peer id, the ENR that node published on 2026-08-10). */
+    private static final String[][] ROOST_VECTORS = {
+        { // mainnet, tcp 9109
+            "16Uiu2HAmAj4D6YGK1kvVL2ZtnoCjp3hdz3j6QLCNh6afhSuwYjLC",
+            "enr:-KG4QCbsE9s7xHdLK_32iZh-P840CxuQ3rbJAtuoFgh3IVLqQP0-Hhkllnv-k9qLfZb47V4sxPw0Ynmj4UaabQ3-RjkChGV0aDKQjJ9i_gYAAAD__________4JpZIJ2NIJpcIRXmtGhiXNlY3AyNTZrMaEC41NP_bzrL7-rq6KmsQIeTl2Nw9yvIlgEvz-Pjz2dwTmDdGNwgiOVg3VkcIIjlQ"
+        },
+        { // sepolia, tcp 9105
+            "16Uiu2HAkyDsNGDq5pbFCqdKTcJxp4Rd5caoy1Xe2KJVtyc94M8S5",
+            "enr:-KG4QGERMtMCoXY2T1Jwp3zk2fpdn9e-Q8p9IeUCuJ1ZA7JjVLXvrtuxMHqP6iRWbkO3O2eWETkvMBcIRAV3SkBgKAADhGV0aDKQdNAUWZAAAHX__________4JpZIJ2NIJpcIRXmtGhiXNlY3AyNTZrMaECOGinXjNuey5xwLNiO0Cd-MB7I3zLqCC5rbLWG6Bo9rqDdGNwgiORg3VkcIIjkQ"
+        },
+        { // gnosis, tcp 9108
+            "16Uiu2HAmG76htC8Bht97af8tEoH5yeNbPatxz6zeHpWoYc4cHdzh",
+            "enr:-KG4QM_0UweYmWFjBAaZ1JnMTeUkeGgHWEVp3N2vewhkzNtlRlnObTaz3ki1RP1lNvOvMBh_iOu0-LnEacfdZN8dx4IChGV0aDKQMjfatgYAAGT__________4JpZIJ2NIJpcIRXmtGhiXNlY3AyNTZrMaEDM0NY9iNV9hZMrtkoRrPEKj7tm2TLriwZv-m1ctszvvKDdGNwgiOUg3VkcIIjlA"
+        },
+    };
+
+    @Test
+    void derivedNodeIdMatchesThePublishedRecord() {
+        for (String[] vector : ROOST_VECTORS) {
+            String peerId = vector[0];
+            NodeRecord published = NodeRecordFactory.DEFAULT.fromEnr(vector[1]);
+            Optional<Bytes> derived = Enr.nodeIdForPeerId(peerId);
+            assertTrue(derived.isPresent(), peerId + ": derivation must succeed");
+            assertEquals(published.getNodeId(), derived.get(),
+                    peerId + ": derived discv5 node id != the published record's — "
+                    + "either the derivation drifted from the Rust twin or roost split "
+                    + "its libp2p and discv5 keys");
+        }
+    }
+
+    @Test
+    void nonSecp256k1IdsDeriveNothing() {
+        // An RSA/ed25519-style peer id is sha256-multihashed (Qm…, base58 of
+        // 0x12 0x20 …) — the key is not recoverable, and the derivation must
+        // say so rather than return garbage.
+        assertTrue(Enr.nodeIdForPeerId("QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N").isEmpty());
+        assertTrue(Enr.nodeIdForPeerId("not-base58-at-all-0OIl").isEmpty());
+        assertTrue(Enr.nodeIdForPeerId("").isEmpty());
+    }
+
+    @Test
+    void openingPassIsFastAndRevisitsArePolite() {
+        // Opening pass: one quick walk per pinned id; then polite revisits.
+        assertEquals(2_000, DiscV5Service.walkDelayMs(0, 3));
+        assertEquals(2_000, DiscV5Service.walkDelayMs(2, 3));
+        assertEquals(60_000, DiscV5Service.walkDelayMs(3, 3));
+        assertEquals(60_000, DiscV5Service.walkDelayMs(100, 3));
+    }
+}

--- a/node-core/src/main/java/io/myotis/node/ChainStack.java
+++ b/node-core/src/main/java/io/myotis/node/ChainStack.java
@@ -870,7 +870,20 @@ public final class ChainStack {
         List<byte[]> acceptedForkDigests = network.acceptedForkDigests();
         AtomicInteger mismatchesLogged = new AtomicInteger();
 
-        this.discV5 = new DiscV5Service(nodeKey, network.clDiscv5Bootnodes(), enr -> {
+        // Targeted lookups (#347): derive the discv5 node ids of the pinned CL
+        // peers from their libp2p peer ids (same key on both identities — the
+        // invariant roost maintains and the Rust engine's parity test pins), so
+        // discovery can walk TOWARD them instead of waiting on random-walk luck.
+        List<org.apache.tuweni.bytes.Bytes> pinnedNodeIds = network.clPeerMultiaddrs().stream()
+                .map(ma -> {
+                    int i = ma.lastIndexOf("/p2p/");
+                    return i < 0 ? null : ma.substring(i + "/p2p/".length());
+                })
+                .filter(java.util.Objects::nonNull)
+                .map(com.jaeckel.ethp2p.core.enr.Enr::nodeIdForPeerId)
+                .flatMap(java.util.Optional::stream)
+                .toList();
+        this.discV5 = new DiscV5Service(nodeKey, network.clDiscv5Bootnodes(), pinnedNodeIds, enr -> {
             var eth2 = enr.eth2();
             if (eth2.isEmpty()) return;
             byte[] peerDigest = eth2.get().forkDigest();

--- a/node-core/src/main/java/io/myotis/node/ChainStack.java
+++ b/node-core/src/main/java/io/myotis/node/ChainStack.java
@@ -874,15 +874,25 @@ public final class ChainStack {
         // peers from their libp2p peer ids (same key on both identities — the
         // invariant roost maintains and the Rust engine's parity test pins), so
         // discovery can walk TOWARD them instead of waiting on random-walk luck.
-        List<org.apache.tuweni.bytes.Bytes> pinnedNodeIds = network.clPeerMultiaddrs().stream()
+        List<String> pinnedPeerIds = network.clPeerMultiaddrs().stream()
                 .map(ma -> {
                     int i = ma.lastIndexOf("/p2p/");
                     return i < 0 ? null : ma.substring(i + "/p2p/".length());
                 })
                 .filter(java.util.Objects::nonNull)
-                .map(com.jaeckel.ethp2p.core.enr.Enr::nodeIdForPeerId)
-                .flatMap(java.util.Optional::stream)
                 .toList();
+        List<org.apache.tuweni.bytes.Bytes> pinnedNodeIds = new ArrayList<>(pinnedPeerIds.size());
+        for (String peerId : pinnedPeerIds) {
+            com.jaeckel.ethp2p.core.enr.Enr.nodeIdForPeerId(peerId).ifPresentOrElse(
+                    pinnedNodeIds::add,
+                    // A pin that does not derive silently loses targeted lookups
+                    // (it is still DIALED via its configured multiaddr) — say so,
+                    // or the degradation to random-walk luck is invisible.
+                    () -> log.warn("[{}][discv5] pinned peer id {} does not derive a discv5 node id — "
+                            + "no targeted lookups for it", network.name(), peerId));
+        }
+        log.info("[{}][discv5] derived {} of {} pinned ids for targeted lookup",
+                network.name(), pinnedNodeIds.size(), pinnedPeerIds.size());
         this.discV5 = new DiscV5Service(nodeKey, network.clDiscv5Bootnodes(), pinnedNodeIds, enr -> {
             var eth2 = enr.eth2();
             if (eth2.isEmpty()) return;


### PR DESCRIPTION
Closes #347 — the Java half of the fast-discovery mechanism (#348 did the Rust engine). `DiscV5Service` now walks the DHT **toward** the pinned CL peers instead of hoping the library's random-walk search lands in their bucket, which on the mainnet DHT it rarely does.

## Design

- **`Enr.nodeIdForPeerId`** (core): the reverse of the existing `derivePeerId` — base58 peer id → identity multihash → libp2p crypto protobuf → compressed secp256k1 → keccak256 of the uncompressed point. Uses BouncyCastle's lightweight `KeccakDigest` deliberately: tuweni's `Hash.keccak256` goes through the JCA and throws unless the BC *provider* happens to be registered by an earlier caller. Golden vectors: roost's three published records — the same pairs the Rust engine's `pinned_roost_identity_matches_its_seeded_enr` pins, so the two derivations cannot drift apart silently.
- **Walker thread** in `DiscV5Service`: one bounded closest-first walk per pinned target (32-query budget, 1.5 s per-query timeout, `findNodes` at buckets `d−4..d`), seeded from **sibling pins already found** and the **bootnodes**, with a learned frontier carried across revisits. Opening pass visits each pinned id once, then 60 s round-robin revisits. Its own thread because a walk can block ~30 s worst-case, which must not stall the 15 s poll cadence.
- **Parity contract from the #348 review holds by construction**: the seen-set keys on the full ENR string, so a *republished* record (new seq) re-emits while the same record dedupes — the Java seq gate — and `addPeer` only ever ADDS entries, so the `/dns4` pin is never overwritten (name wins).
- `ChainStack` derives the pinned node ids from `clPeerMultiaddrs`; walker finds are marshalled to the poll thread and flow through the existing fork-digest filter → peer cache → live pool path. No new trust: a record for a pinned node id cannot be forged without its key, and identity is enforced again at the libp2p handshake.

## Live-tuned, not just compiled

The walk was debugged against the real sepolia DHT with the daemon running, and three of its rules exist because the first attempts failed observably:

- **`Functions.distance` is a trap**: it reads the XOR as **little-endian**, so sorting by it scrambles closest-first selection (walks queried 256-distance nodes while 249s sat in the frontier). The comparator uses `logDistance` (verified spec-correct big-endian against the library bytecode) with a big-endian XOR tie-break.
- **No "no progress" early break and no closest-16 window**: both round-based variants stalled at logDistance ~244–252 — the records nearest a target are often stale/dead (13/16 timeouts observed), and any window rule gives up with budget left. Spec-Kademlia termination (frontier exhausted or budget) is what converges.
- **Walk outcomes log at INFO** (answered/failed/frontier/closestLogDist): a silent walker is indistinguishable from a dead one — observed, and these counters are what made every fix above findable.

End state: the established pin found in 9–17 queries on every run, and this morning the walker found **roost itself** (the young pin that was genuinely absent from third-party tables last night — see #349) in 8 queries once its DHT presence thickened.

## Internal review pass (pre-PR)

Four findings, fixed in `6bc45316`: `InterruptedException` was swallowed at the query sites (clearing the flag — `close()` would leak a walker looping against a stopped system, once per `ChainStack` restart); `bootnodeRecords()` lazy init raced poll thread vs walker; a candidate equal to the target produced an empty distances list instead of short-circuiting as a find; and a shutdown race in `emitFromWalker` could throw instead of dropping.

## Verified

- `:core` / `:networking` / `:node-core` / `:consensus` suites green.
- Golden-vector derivation test green against all three published roost records; non-secp256k1 ids correctly derive nothing.
- Live: pinned peers found end-to-end through the real DHT (see above), emissions land in the pool via the normal filter path.
- Rust twin untouched; the schedule constants deliberately mirror #348 (`opening pass, then every-Nth revisit`) — divergences, if the reviewer finds any, are #342 material.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYVwpfHg77oibuD2733jPj