### PR TITLE
el: on-demand log-index tail fill for head-edge eth_getLogs

### DIFF
--- a/rust/myotis-engine/src/host.rs
+++ b/rust/myotis-engine/src/host.rs
@@ -2502,15 +2502,22 @@ fn get_logs_json_impl(handle: i64, filter_json: &str) -> String {
     // yet — a wallet takes `toBlock` from `eth_blockNumber`, which follows the
     // anchored head the log index trails by up to a tick. That block IS verified
     // and moments from indexed, so rather than refuse the query, drive one
-    // catch-up tick and retry once. Bounded to the head edge (at most
-    // `LOG_INDEX_LATEST_SLACK` above coverage, never above the head) so a deeper
-    // lag stays the bridge's job rather than a synchronous fetch here.
-    if matches!(result, Some(Err(QueryError::OutOfCoverage { .. })))
-        && filter.to_block <= head
-        && reader
-            .log_index_covered_high()
-            .is_some_and(|top| filter.to_block > top && filter.to_block - top <= LOG_INDEX_LATEST_SLACK)
-    {
+    // catch-up tick and retry once. Fire ONLY when the missing part is the HIGH
+    // edge of the erroring address's coverage — `toBlock` at most
+    // `LOG_INDEX_LATEST_SLACK` above the covered top and never above the head. A
+    // shortfall on the LOW side (fromBlock below the index floor) cannot be
+    // helped by advancing the tail, and a deeper high-side lag is the bridge's
+    // job; neither should spend a synchronous network tick here.
+    let needs_fill = matches!(
+        &result,
+        Some(Err(QueryError::OutOfCoverage { covered, .. }))
+            if covered.span.is_some_and(|(_low, high)| {
+                filter.to_block <= head
+                    && filter.to_block > high
+                    && filter.to_block - high <= LOG_INDEX_LATEST_SLACK
+            })
+    );
+    if needs_fill {
         engine.rt.block_on(async { reader.advance_log_index_tail_now().await });
         result = reader.with_log_index(|ix| ix.query(&filter));
     }

--- a/rust/myotis-engine/src/host.rs
+++ b/rust/myotis-engine/src/host.rs
@@ -2496,7 +2496,24 @@ fn get_logs_json_impl(handle: i64, filter_json: &str) -> String {
         Ok(f) => f,
         Err(msg) => return eljson::error_json(&msg),
     };
-    let result = reader.with_log_index(|ix| ix.query(&filter));
+    let mut result = reader.with_log_index(|ix| ix.query(&filter));
+    // On-demand tail fill. An explicit `toBlock` at the very head can land one
+    // block past the covered top while the 6s appender tick hasn't recorded it
+    // yet — a wallet takes `toBlock` from `eth_blockNumber`, which follows the
+    // anchored head the log index trails by up to a tick. That block IS verified
+    // and moments from indexed, so rather than refuse the query, drive one
+    // catch-up tick and retry once. Bounded to the head edge (at most
+    // `LOG_INDEX_LATEST_SLACK` above coverage, never above the head) so a deeper
+    // lag stays the bridge's job rather than a synchronous fetch here.
+    if matches!(result, Some(Err(QueryError::OutOfCoverage { .. })))
+        && filter.to_block <= head
+        && reader
+            .log_index_covered_high()
+            .is_some_and(|top| filter.to_block > top && filter.to_block - top <= LOG_INDEX_LATEST_SLACK)
+    {
+        engine.rt.block_on(async { reader.advance_log_index_tail_now().await });
+        result = reader.with_log_index(|ix| ix.query(&filter));
+    }
     match result {
         None => eljson::error_json("log index is not configured on this network"),
         Some(Ok(logs)) => eljson::get_logs_json(&logs),

--- a/rust/myotis-engine/src/host.rs
+++ b/rust/myotis-engine/src/host.rs
@@ -2511,14 +2511,20 @@ fn get_logs_json_impl(handle: i64, filter_json: &str) -> String {
     let needs_fill = matches!(
         &result,
         Some(Err(QueryError::OutOfCoverage { covered, .. }))
-            if covered.span.is_some_and(|(_low, high)| {
-                filter.to_block <= head
+            if covered.span.is_some_and(|(low, high)| {
+                // The fill helps ONLY when the high edge is the sole shortfall.
+                // A fromBlock below the covered low (the classic full-history
+                // scan while backfill is still running) cannot be served by
+                // advancing the tail — firing there would spend a synchronous
+                // network tick per poll for nothing.
+                filter.from_block >= low
+                    && filter.to_block <= head
                     && filter.to_block > high
                     && filter.to_block - high <= LOG_INDEX_LATEST_SLACK
             })
     );
     if needs_fill {
-        engine.rt.block_on(async { reader.advance_log_index_tail_now().await });
+        engine.rt.block_on(async { reader.advance_log_index_tail_now(filter.to_block).await });
         result = reader.with_log_index(|ix| ix.query(&filter));
     }
     match result {

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -918,12 +918,17 @@ impl ElReader {
                     return; // reader torn down; the appender dies with it
                 };
                 {
-                    // Serialize against on-demand fills (advance_log_index_tail_now):
-                    // both advance coverage and touch the tail reorg record.
+                    // Serialize only the coverage-advancing tick against
+                    // on-demand fills (advance_log_index_tail_now): both mutate
+                    // coverage + the tail reorg record. The backfill step works
+                    // the low-side cursor only (never the tail record), so it
+                    // runs OUTSIDE the lock — holding it there would make an
+                    // on-demand caller (a synchronous FFI thread) wait behind the
+                    // backfill budget for nothing.
                     let _drive = reader.log_index_drive.lock().await;
                     reader.log_index_append_tick(&mut since_persist, ticks).await;
-                    reader.log_index_backfill_step(ticks, &mut backfill_ok).await;
                 }
+                reader.log_index_backfill_step(ticks, &mut backfill_ok).await;
                 ticks = ticks.wrapping_add(1);
             }
         }));

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -639,6 +639,12 @@ pub struct ElReader {
     log_index_path: Option<std::path::PathBuf>,
     /// The head-follow appender task (spawned on enable, aborted on stop).
     log_index_task: std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
+    /// Serializes coverage-advancing ticks. The background appender and an
+    /// on-demand fill ([`Self::advance_log_index_tail_now`]) both mutate
+    /// coverage and the tail's `(number, hash)` reorg record; running them
+    /// concurrently would race that bookkeeping. Async mutex: held across the
+    /// tick's network awaits.
+    log_index_drive: tokio::sync::Mutex<()>,
 }
 
 /// The scan-cursor map plus its last TTL sweep — one lock covers both, so the
@@ -785,6 +791,7 @@ impl ElReader {
             log_index_pipeline_full: std::sync::atomic::AtomicBool::new(true),
             log_index_path: cfg.log_index_path,
             log_index_task: std::sync::Mutex::new(None),
+            log_index_drive: tokio::sync::Mutex::new(()),
         })
     }
 
@@ -910,8 +917,13 @@ impl ElReader {
                 let Some(reader) = weak.upgrade() else {
                     return; // reader torn down; the appender dies with it
                 };
-                reader.log_index_append_tick(&mut since_persist, ticks).await;
-                reader.log_index_backfill_step(ticks, &mut backfill_ok).await;
+                {
+                    // Serialize against on-demand fills (advance_log_index_tail_now):
+                    // both advance coverage and touch the tail reorg record.
+                    let _drive = reader.log_index_drive.lock().await;
+                    reader.log_index_append_tick(&mut since_persist, ticks).await;
+                    reader.log_index_backfill_step(ticks, &mut backfill_ok).await;
+                }
                 ticks = ticks.wrapping_add(1);
             }
         }));
@@ -1009,6 +1021,22 @@ impl ElReader {
             self.persist_log_index(self.finalized_block_number());
             *since_persist = 0;
         }
+    }
+
+    /// Drive ONE coverage-advancing tick on demand, serialized against the
+    /// background appender.
+    ///
+    /// Purpose: close the 0-1 block gap between the anchored head — what
+    /// `eth_blockNumber` reports, and what a wallet then passes as an explicit
+    /// `toBlock` — and the log index's covered top, which the 6s appender tick
+    /// leaves trailing for up to a tick. A head-reaching `eth_getLogs` would
+    /// otherwise be refused for those few seconds even though the block is
+    /// verified and about to be indexed. This runs the SAME verified machinery
+    /// as the background tick (no new trust path); it just runs it now.
+    pub async fn advance_log_index_tail_now(&self) {
+        let _drive = self.log_index_drive.lock().await;
+        let mut since_persist = 0u32;
+        self.log_index_append_tick(&mut since_persist, 0).await;
     }
 
     /// Follow the OPTIMISTIC tail: keep coverage running from finality up to

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -1038,10 +1038,27 @@ impl ElReader {
     /// otherwise be refused for those few seconds even though the block is
     /// verified and about to be indexed. This runs the SAME verified machinery
     /// as the background tick (no new trust path); it just runs it now.
-    pub async fn advance_log_index_tail_now(&self) {
-        let _drive = self.log_index_drive.lock().await;
-        let mut since_persist = 0u32;
-        self.log_index_append_tick(&mut since_persist, 0).await;
+    /// `target`: the block the caller needs covered. Bounded by a hard deadline —
+    /// this sits on a wallet-facing request path, and in degraded peer conditions
+    /// an unbounded lock-wait + tick could turn a microsecond refusal into a
+    /// minutes-long stall. On timeout the caller just re-queries and serves the
+    /// original refusal; the wallet already handles retry.
+    pub async fn advance_log_index_tail_now(&self, target: u64) {
+        const FILL_DEADLINE: std::time::Duration = std::time::Duration::from_secs(5);
+        let fill = async {
+            let _drive = self.log_index_drive.lock().await;
+            // Re-check under the lock: the background tick — or another caller's
+            // fill that just finished — may already cover the target. Skipping
+            // saves a full header-window fetch per queued caller.
+            if self.log_index_covered_high().is_some_and(|top| top >= target) {
+                return;
+            }
+            let mut since_persist = 0u32;
+            self.log_index_append_tick(&mut since_persist, 0).await;
+        };
+        // Cancellation at an await point is safe: coverage and the tail record
+        // mutate only synchronously under the index lock (append_block).
+        let _ = tokio::time::timeout(FILL_DEADLINE, fill).await;
     }
 
     /// Follow the OPTIMISTIC tail: keep coverage running from finality up to


### PR DESCRIPTION
## Problem

A wallet reads the head from \`eth_blockNumber\` (the anchored optimistic head) and immediately calls \`eth_getLogs\` with that block as an explicit \`toBlock\`. The log index's covered top trails the anchored head by up to one 6s appender tick, so the query lands one block past coverage and is refused with \`-32000 "requested range is not indexed yet"\` — even though the block is verified and moments from being indexed.

Observed in the wild: Kohaku's Railgun unshield scans the Railgun contract with exactly this shape and treats the first \`-32000\` as fatal, so every shielded→unshielded withdrawal died with "Something went wrong" whenever the wallet's head poll outran the appender tick.

## Fix

- \`reader.rs\`: new \`advance_log_index_tail_now()\` — drives ONE coverage-advancing tick on demand, using the SAME verified machinery as the background appender (receipts fetched from a peer, verified against the header's receiptsRoot, then appended; no new trust path). A new \`log_index_drive\` async mutex serializes it against the background tick so the two never race coverage or the tail's \`(number, hash)\` reorg record. The background loop holds the lock only around \`log_index_append_tick\`; the backfill step (low-side cursor only) runs outside it.
- \`host.rs\` \`get_logs_json_impl\`: on \`OutOfCoverage\`, if the shortfall is on the HIGH edge — \`toBlock\` at most \`LOG_INDEX_LATEST_SLACK\` (4) above the erroring address's covered top and not above the head — drive one fill and retry the query once. Low-side shortfalls (fromBlock below the index floor) and deeper lags never trigger it (those stay the bridge's job).

## Verification

- \`cargo check\` clean; all log-index unit tests pass (22 in myotis-net, 2 in myotis-engine).
- Independent no-context review done; both actionable findings addressed in the second commit (high-edge-only trigger via the error's \`covered.span\`; narrowed drive-lock scope).
- Live validation against the desktop app on sepolia: 25/25 \`eth_getLogs\` at the just-reported head served with 0 refusals (previously refused ~every other poll), and the previously-failing Kohaku Railgun scan now completes against this node with zero \`-32000\`s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPnTFwmAVMypWYtoioAXQT