### PR TITLE
el: snap-query roots from the beacon anchor, not stale handshake heads (fixes #355)

### DIFF
--- a/myotis-api/src/main/java/io/myotis/api/AccountProofResult.java
+++ b/myotis-api/src/main/java/io/myotis/api/AccountProofResult.java
@@ -18,7 +18,12 @@ import java.util.List;
  * @param storageRootHex        from the proof-verified leaf when available (never
  *                              the peer's slim body in that case), else peer-claimed
  * @param codeHashHex           same provenance rule as {@code storageRootHex}
- * @param blockNumber           peer-reported block the proof anchors to
+ * @param blockNumber           block the proof anchors to. Java engine (and the
+ *                              Rust engine's Tor path): the serving peer's reported
+ *                              head. Rust engine clearnet path: the beacon anchor's
+ *                              optimistic head when the query ran against the
+ *                              anchored root (the preferred path since the #355
+ *                              fix), the peer's head only on its fallback
  * @param peerStateRootHex      the peer's state root the proof was checked against
  * @param peerProofValid        the MPT proof verifies against {@code peerStateRoot}
  * @param beaconChainVerified   {@code peerStateRoot} ties to a beacon-attested root

--- a/myotis-api/src/main/java/io/myotis/api/StorageProofResult.java
+++ b/myotis-api/src/main/java/io/myotis/api/StorageProofResult.java
@@ -27,7 +27,12 @@ import java.util.List;
  * @param matchedBeaconSlot     slot of the matching beacon attestation; -1 if none
  * @param verifyMethod          "stateRootMatch" / "headerChain" / null
  * @param failReason            null when verified; otherwise a stable reason token
- * @param peerBlockNumber       peer-reported block the account proof anchors to
+ * @param peerBlockNumber       block the account proof anchors to. Java engine (and
+ *                              the Rust engine's Tor path): the serving peer's
+ *                              reported head. Rust engine clearnet path: the beacon
+ *                              anchor's optimistic head when the query ran against
+ *                              the anchored root (preferred since the #355 fix),
+ *                              the peer's head only on its fallback
  * @param finalizedBlockNumber  finalized execution block number (0 if none)
  * @param optimisticBlockNumber optimistic-head execution block number (0 if none)
  * @param finalizedSlot         finalized beacon slot (0 if none)

--- a/rust/myotis-net/src/el/anchor.rs
+++ b/rust/myotis-net/src/el/anchor.rs
@@ -155,6 +155,19 @@ impl ExecAnchor {
         self.inner.lock().expect("anchor mutex").optimistic_block_number
     }
 
+    /// The optimistic execution `(block_number, state_root)` read atomically —
+    /// the CURRENT beacon-attested head state, at most a couple of slots old.
+    /// `None` until the first optimistic update lands. This is the root snap
+    /// queries should prefer: it is BLS-verified and recent enough that every
+    /// honest synced peer still retains it in its snap serve window (unlike a
+    /// peer's handshake-time head, which post-merge never refreshes).
+    pub fn optimistic_execution(&self) -> Option<(u64, [u8; 32])> {
+        let inner = self.inner.lock().expect("anchor mutex");
+        inner
+            .optimistic_state_root
+            .map(|root| (inner.optimistic_block_number, root))
+    }
+
     /// The `stateRootMatch` fast-path lookup: is `state_root` a root the beacon
     /// client already recorded? Searches NEWEST-first (twin of
     /// `findStateRoot`'s `descendingIterator`) so the freshest/best match wins.
@@ -209,6 +222,14 @@ mod tests {
     }
 
     #[test]
+    fn optimistic_execution_none_until_first_update() {
+        let anchor = ExecAnchor::new();
+        // Before the first optimistic update the accessor must be None — the
+        // snap-root selection falls back to the peer handshake head then.
+        assert_eq!(anchor.optimistic_execution(), None);
+    }
+
+    #[test]
     fn finalized_and_optimistic_updates() {
         let anchor = ExecAnchor::new();
         assert_eq!(anchor.finalized_execution(), None);
@@ -224,6 +245,8 @@ mod tests {
         anchor.update_optimistic(102, 21_000_005, root(0xf2), root(2));
         assert_eq!(anchor.optimistic_block_hash(), Some(root(0xf2)));
         assert_eq!(anchor.optimistic_block_number(), 21_000_005);
+        // The atomic (number, root) pair snap queries prefer (issue #355).
+        assert_eq!(anchor.optimistic_execution(), Some((21_000_005, root(2))));
 
         // Both roots are in the fast-path window.
         assert!(anchor.find_state_root(&root(1)).is_some());

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -2345,7 +2345,10 @@ impl ElReader {
     /// is the anchor's optimistic number (consistent with `eth_blockNumber`),
     /// not a peer-head claim — the FFI `peerBlockNumber` field follows. This
     /// is deliberate; the Java engine still reports the peer's handshake head
-    /// there.
+    /// there, and so does this engine's TOR read path
+    /// ([`Self::account_from_tor_session`] — a fresh session per read, so its
+    /// handshake head is seconds old and #355 does not apply; preferring the
+    /// anchor root there too is a follow-up).
     async fn snap_account_at_best_root(
         &self,
         peer: &ManagedPeer,
@@ -2354,12 +2357,15 @@ impl ElReader {
         if let Some((number, root)) = self.anchor.optimistic_execution() {
             match peer.snap_get_account(&root, &address).await {
                 Ok(outcome) => return Ok((root, number, outcome)),
-                // The peer ANSWERED but cannot prove at the anchored root
-                // (pruned it / trails the anchor): its own head may still be
+                // The peer ANSWERED but could not prove at the anchored root —
+                // pruned it, trails the anchor, OR served a malformed/hostile
+                // proof (every ProofResult::Invalid shape matches; a bad-proof
+                // peer thus earns exactly one bounded fallback attempt before
+                // the outer loop strikes it). Its own head may still be
                 // servable — fall back, and carry BOTH causes so the surfaced
                 // "all N peers failed" error names the primary path's failure,
                 // not just the fallback symptom.
-                Err(e) if e.contains("proof invalid") => {
+                Err(e) if crate::el::snap::fetch::is_unservable_root_error(&e) => {
                     let fb = |e2: String| {
                         format!("anchor-root query failed ({e}); handshake-head fallback: {e2}")
                     };

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -2315,15 +2315,73 @@ impl ElReader {
         peer: &ManagedPeer,
         address: [u8; 20],
     ) -> Result<VerifiedAccount, String> {
-        let (state_root, block_number) = fresh_head(peer).await?;
-        // Verify-on-fetch: snap_get_account MPT-verifies against state_root and
-        // returns Present/Absent only when the proof holds.
-        let outcome = peer.snap_get_account(&state_root, &address).await?;
-        // Anchor the (proof-valid) peer state root to the beacon chain.
+        let (state_root, block_number, outcome) =
+            self.snap_account_at_best_root(peer, address).await?;
+        // Anchor the (proof-valid) state root to the beacon chain. The anchor
+        // path's root short-circuits via the stateRootMatch fast path; the
+        // fallback path's peer root runs the full ladder.
         let verdict = peer
             .verified_state_root(&self.anchor, &state_root, to_ladder_block(block_number), true)
             .await;
         Ok(self.build_verified_account(address, state_root, block_number, outcome, verdict))
+    }
+
+    /// Fetch + MPT-verify one account against the best available state root:
+    /// the beacon anchor's CURRENT optimistic root first, the peer's
+    /// handshake-time head as fallback.
+    ///
+    /// The fallback exists for two cases only — the anchor not yet synced, and
+    /// a peer trailing the anchor by more than its snap window. The old
+    /// always-handshake-head behavior was issue #355: post-merge the eth
+    /// subprotocol has no block gossip, so `peer_status.best_hash` never
+    /// refreshes after the handshake; on an aged session every peer's "head"
+    /// names state all of them have long pruned, and every read collapses to
+    /// "empty proof for non-empty root" ×N. The anchor root is BLS-verified
+    /// and at most a couple of slots old, so honest synced peers always
+    /// retain it — and a peer that STILL can't serve it is genuinely useless
+    /// for reads, which makes the outer loop's failure strike an honest
+    /// quality signal instead of punishment for our own stale query root.
+    /// NOTE on result semantics: on the anchor path the returned block number
+    /// is the anchor's optimistic number (consistent with `eth_blockNumber`),
+    /// not a peer-head claim — the FFI `peerBlockNumber` field follows. This
+    /// is deliberate; the Java engine still reports the peer's handshake head
+    /// there.
+    async fn snap_account_at_best_root(
+        &self,
+        peer: &ManagedPeer,
+        address: [u8; 20],
+    ) -> Result<([u8; 32], u64, AccountOutcome), String> {
+        if let Some((number, root)) = self.anchor.optimistic_execution() {
+            match peer.snap_get_account(&root, &address).await {
+                Ok(outcome) => return Ok((root, number, outcome)),
+                // The peer ANSWERED but cannot prove at the anchored root
+                // (pruned it / trails the anchor): its own head may still be
+                // servable — fall back, and carry BOTH causes so the surfaced
+                // "all N peers failed" error names the primary path's failure,
+                // not just the fallback symptom.
+                Err(e) if e.contains("proof invalid") => {
+                    let fb = |e2: String| {
+                        format!("anchor-root query failed ({e}); handshake-head fallback: {e2}")
+                    };
+                    let (root, number) = fresh_head(peer).await.map_err(fb)?;
+                    let outcome =
+                        peer.snap_get_account(&root, &address).await.map_err(fb)?;
+                    return Ok((root, number, outcome));
+                }
+                // Transport-shaped failure (timeout/disconnect): a second
+                // query against the same peer would pay the same timeout
+                // again — propagate so the outer loop moves to the next peer.
+                // (Without this, a dead peer costs up to three timeouts per
+                // read instead of one.)
+                Err(e) => return Err(e),
+            }
+        }
+        // Anchor not yet synced: the peer's handshake head is all we have.
+        let (root, number) = fresh_head(peer).await?;
+        // Verify-on-fetch: snap_get_account MPT-verifies against the root and
+        // returns Present/Absent only when the proof holds.
+        let outcome = peer.snap_get_account(&root, &address).await?;
+        Ok((root, number, outcome))
     }
 
     /// Assemble a `VerifiedAccount` from the proof-verified outcome + the beacon
@@ -2531,12 +2589,13 @@ impl ElReader {
         holder: Option<[u8; 20]>,
         storage_key: [u8; 32],
     ) -> Result<VerifiedStorage, String> {
-        let (state_root, block_number) = fresh_head(peer).await?;
+        // Step 1: the proof-verified account gives the trusted storage root.
+        // Root selection prefers the beacon anchor's current optimistic root
+        // (issue #355 — see snap_account_at_best_root).
+        let (state_root, block_number, outcome) =
+            self.snap_account_at_best_root(peer, address).await?;
 
         let slot_key_hash = keccak256(&storage_key);
-
-        // Step 1: the proof-verified account gives the trusted storage root.
-        let outcome = peer.snap_get_account(&state_root, &address).await?;
 
         let (fin_num, opt_num, synced) = self.anchor_diagnostics();
         let mut result = VerifiedStorage {

--- a/rust/myotis-net/src/el/snap/fetch.rs
+++ b/rust/myotis-net/src/el/snap/fetch.rs
@@ -35,6 +35,25 @@ pub enum AccountOutcome {
     Absent,
 }
 
+/// Marker shared by every proof-verification failure message. LOAD-BEARING:
+/// `reader::snap_account_at_best_root` classifies anchor-root failures by this
+/// substring — "the peer answered but could not prove at that root" (pruned /
+/// trailing / malformed proof) takes the handshake-head fallback, while
+/// transport-shaped errors propagate immediately. Keep the format strings
+/// below built from this constant, and keep
+/// [`is_unservable_root_error`] + its tests in sync.
+pub const PROOF_INVALID_MARKER: &str = "proof invalid";
+
+/// Does this fetch error mean "the peer responded, but the proof did not
+/// verify against the requested root"? True for a pruned/unknown root (empty
+/// proof), a trailing peer, or a malformed/hostile proof — all cases where a
+/// retry against a DIFFERENT root can still succeed. False for
+/// transport-shaped failures (timeout/disconnect), where a second query
+/// against the same peer would just pay the same timeout again.
+pub fn is_unservable_root_error(error: &str) -> bool {
+    error.contains(PROOF_INVALID_MARKER)
+}
+
 /// Verify an AccountRange response for `address` against the trusted
 /// `state_root`. A single-account query (`starting = keccak(address)`) yields a
 /// left-boundary proof that is exactly the Merkle proof for `keccak(address)`.
@@ -48,7 +67,7 @@ pub fn verify_account(
         ProofResult::Found(leaf) => Ok(AccountOutcome::Present(decode_account_leaf(&leaf)?)),
         ProofResult::Absent => Ok(AccountOutcome::Absent),
         ProofResult::Invalid(reason) => {
-            Err(CoreError(format!("account proof invalid: {reason}")))
+            Err(CoreError(format!("account {PROOF_INVALID_MARKER}: {reason}")))
         }
     }
 }
@@ -70,7 +89,7 @@ pub fn verify_storage(
         ProofResult::Found(value) => decode_storage_leaf(&value),
         ProofResult::Absent => Ok(Vec::new()),
         ProofResult::Invalid(reason) => {
-            Err(CoreError(format!("storage proof invalid: {reason}")))
+            Err(CoreError(format!("storage {PROOF_INVALID_MARKER}: {reason}")))
         }
     }
 }
@@ -147,6 +166,36 @@ mod tests {
             }
             AccountOutcome::Absent => panic!("expected Present"),
         }
+    }
+
+    #[test]
+    fn unservable_root_classification_pins_the_real_error_shapes() {
+        // The exact #355 failure: a peer that pruned (or never had) the root
+        // answers with an EMPTY proof against a non-empty root. The resulting
+        // error MUST classify as unservable-root (→ handshake-head fallback in
+        // reader::snap_account_at_best_root), or the fallback silently dies.
+        let address = [0x33u8; 20];
+        let response = AccountRange { request_id: 1, accounts: vec![], proof: vec![] };
+        let err = verify_account(&[0x42u8; 32], &address, &response).unwrap_err();
+        assert!(
+            is_unservable_root_error(&err.0),
+            "empty-proof error must take the fallback: {}",
+            err.0
+        );
+        // A garbage proof (ProofResult::Invalid of another shape) also counts:
+        // the peer answered; a different root may still be servable.
+        let response = AccountRange {
+            request_id: 1,
+            accounts: vec![],
+            proof: vec![vec![0xde, 0xad, 0xbe, 0xef]],
+        };
+        let err = verify_account(&[0x42u8; 32], &address, &response).unwrap_err();
+        assert!(is_unservable_root_error(&err.0), "garbage proof: {}", err.0);
+        // Transport-shaped failures must NOT take the fallback — a second
+        // query against the same dead peer just pays the same timeout again.
+        assert!(!is_unservable_root_error("request timed out"));
+        assert!(!is_unservable_root_error("peer disconnected"));
+        assert!(!is_unservable_root_error("connection reset by peer"));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #355.

## Root cause (differs from the issue's hypothesis)

The issue guessed a stale *beacon anchor*; the code says otherwise. `get_account`/`get_storage` built their snap-query root from `fresh_head(peer)` → `peer_status.best_hash` — **the head from the eth handshake STATUS message**. Post-merge the eth subprotocol has no block gossip, so that snapshot never refreshes. On an hours-old session every peer's "head" names state all of them have long pruned → unanimous `empty proof for non-empty root` → *"all 6 snap peer(s) failed to serve a verifiable account"*. Explains the observed degrade-with-session-age pattern. Bonus defect: each failure struck the peer in the quality cache — punishing peers for **our** stale query root and poisoning peer ordering.

## Fix

- `ExecAnchor::optimistic_execution()`: atomic `(block_number, state_root)` of the BLS-verified **current** optimistic head.
- `snap_account_at_best_root` (shared by account + storage paths): query at the anchor root first — always within honest synced peers' snap windows, and verdict-wise strictly **stronger** (stateRootMatch fast path instead of trusting a peer head claim). Handshake-head path remains only as fallback: anchor not yet synced, or the peer answered but can't prove at the anchored root (`proof invalid`-shaped errors). Transport failures propagate immediately (dead peer = one timeout, not three). Fallback errors carry both causes for honest diagnostics.
- Rotation (the issue's ask): unchanged pool machinery now *works as intended* — with a current root, a strike finally means "peer can't serve current state", so deprioritization + hunt see honest signals.

## Deliberate semantics change (Rust engine only)

On the anchor path the result's block number (FFI `peerBlockNumber`) is the anchored optimistic number — consistent with `eth_blockNumber` — no longer the serving peer's handshake head. Java engine keeps the old meaning; flagged for the next A/B comparison.

## Review

Independent no-context review done; addressed: fallback bounded to proof-shaped failures (was: any error → up to 3 timeouts per dead peer), both-cause error attribution, semantics documented, unsupported latency claim dropped from the commit message. Noted as follow-ups (low): bounding fallback-root age relative to the anchor; a sync-side test for the zero-block-hash guard.

## Validation

`cargo test -p myotis-net --lib`: 239 passed (incl. new anchor coverage). Live validation note: the failure mode needs an **aged** session (hours) to manifest, so the meaningful check is a desktop node keeping verifiable reads overnight on this build — the pre-fix node reproducibly degraded within ~4-5 h.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPnTFwmAVMypWYtoioAXQT