### PR TITLE
chore: bump versions to 0.1.7 for the next pre-release

### DIFF
--- a/android-app/build.gradle.kts
+++ b/android-app/build.gradle.kts
@@ -107,7 +107,7 @@ android {
         // Stays a manual literal: a monotonic install counter with no relation
         // to semver, so there is nothing to derive it from. Bump it on every
         // release or the new APK won't install over the previous one.
-        versionCode = 7
+        versionCode = 8
         versionName = releaseVersion
         buildConfigField("String", "RPC_UPSTREAM", "\"$rpcUpstream\"")
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ plugins {
 
 allprojects {
     group = "com.jaeckel.ethp2p"
-    version = "0.1.6-SNAPSHOT"
+    version = "0.1.7-SNAPSHOT"
 }
 
 // The release version — project.version minus the -SNAPSHOT suffix — exactly as

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/messages/HelloMessage.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/messages/HelloMessage.java
@@ -41,7 +41,7 @@ public final class HelloMessage {
             // client id from CARGO_PKG_VERSION, so this literal is the release
             // sweep's one remaining hand-edited client id. Dedicated
             // myotis-serving nodes admit peers by matching "myotis" here.
-            writer.writeString("myotis/0.1.6");
+            writer.writeString("myotis/0.1.7");
             writer.writeList(capWriter -> {
                 // Capabilities must be ascending (name, then version). eth/66 is the
                 // floor: it has request-IDs (which our GetBlockHeaders/snap requests

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4084,7 +4084,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-bls"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "blst",
  "jni",
@@ -4092,7 +4092,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-consensus"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "myotis-bls",
  "sha2",
@@ -4100,7 +4100,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-core"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "k256",
  "sha3 0.10.9",
@@ -4108,7 +4108,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-engine"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "myotis-consensus",
  "myotis-core",
@@ -4124,7 +4124,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-evm"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "myotis-core",
  "revm",
@@ -4132,7 +4132,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-net"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "aes",
  "arti-client",
@@ -4160,7 +4160,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-node"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "myotis-engine",
  "napi",

--- a/rust/myotis-bls/Cargo.lock
+++ b/rust/myotis-bls/Cargo.lock
@@ -134,7 +134,7 @@ checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "myotis-bls"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "blst",
  "jni",

--- a/rust/myotis-bls/Cargo.toml
+++ b/rust/myotis-bls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "myotis-bls"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 description = "Native BLS12-381 fast-aggregate-verify (blst) behind a JNI shim for Myotis"
 license = "MIT OR Apache-2.0"

--- a/rust/myotis-consensus/Cargo.toml
+++ b/rust/myotis-consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "myotis-consensus"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 description = "Myotis sync-committee light client (pure Rust; grows through the Rust-engine PRs)"
 license = "MIT OR Apache-2.0"

--- a/rust/myotis-core/Cargo.toml
+++ b/rust/myotis-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "myotis-core"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 description = "Myotis execution-layer primitives: keccak-256, RLP, secp256k1 identity, BlockHeader, ENR (sans-I/O; grows through the EL-phase PRs)"
 license = "MIT OR Apache-2.0"

--- a/rust/myotis-engine/Cargo.toml
+++ b/rust/myotis-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "myotis-engine"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 description = "Rust implementation of the io.myotis.api engine contract (JNI cdylib)"
 license = "MIT OR Apache-2.0"

--- a/rust/myotis-evm/Cargo.toml
+++ b/rust/myotis-evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "myotis-evm"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 description = "Myotis EVM: view-call / gas-estimation over SNAP-proof-verified state (revm behind a SnapStateOracle trait; sans-I/O). Grows through the EL-phase Milestone-C PRs (docs/reimplementation/07)."
 license = "MIT OR Apache-2.0"

--- a/rust/myotis-net/Cargo.toml
+++ b/rust/myotis-net/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "myotis-net"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 description = "Myotis consensus-layer networking: discv5 discovery + libp2p eth2 req/resp + the light-client sync loop (ALL I/O lives here; myotis-consensus stays sans-I/O)"
 license = "MIT OR Apache-2.0"

--- a/rust/myotis-node/Cargo.toml
+++ b/rust/myotis-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "myotis-node"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 description = "Node.js (napi-rs) binding over the myotis-engine C ABI — for Electron/Node hosts"
 license = "MIT OR Apache-2.0"

--- a/rust/roost/Cargo.lock
+++ b/rust/roost/Cargo.lock
@@ -3088,14 +3088,14 @@ dependencies = [
 
 [[package]]
 name = "myotis-bls"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "blst",
 ]
 
 [[package]]
 name = "myotis-consensus"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "myotis-bls",
  "sha2",
@@ -3103,7 +3103,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-core"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "k256",
  "sha3 0.10.9",
@@ -3111,7 +3111,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-evm"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "myotis-core",
  "revm",
@@ -3119,7 +3119,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-net"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "aes",
  "async-trait",

--- a/rust/tor-poc/Cargo.lock
+++ b/rust/tor-poc/Cargo.lock
@@ -3848,14 +3848,14 @@ dependencies = [
 
 [[package]]
 name = "myotis-bls"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "blst",
 ]
 
 [[package]]
 name = "myotis-consensus"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "myotis-bls",
  "sha2",
@@ -3863,7 +3863,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-core"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "k256",
  "sha3 0.10.9",
@@ -3871,7 +3871,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-evm"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "myotis-core",
  "revm",
@@ -3879,7 +3879,7 @@ dependencies = [
 
 [[package]]
 name = "myotis-net"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "aes",
  "async-trait",


### PR DESCRIPTION
Same sweep as the 0.1.6 one, minus the Rust client-id literals: those now
derive from CARGO_PKG_VERSION (678413a), so bumping the crate versions moves
the devp2p Hello id and the libp2p agent version with them. What is left is the
root Gradle version (what :app-desktop and :android-app package, and what the
release guard compares the tag against), android versionCode 7 -> 8 (monotonic
install counter, unrelated to semver), the Java engine's Hello client id — still
a literal, and the one that has to be kept in step with the Rust one by hand —
the seven myotis-* crate versions, and the four Cargo.locks.

rust/myotis-bls/Cargo.lock is bumped by hand: myotis-bls is a member of the
rust/ workspace, so cargo run from that directory resolves to the parent and
rewrites rust/Cargo.lock instead of the crate's own lock.

Verified: `printReleaseVersion` reports 0.1.7, `verifyCrateVersions` passes,
`cargo metadata --locked` resolves in all four lock directories, and
myotis-net's hello_round_trip plus :networking:test are green.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UQJz98oMrHpKQubzATaLSP