### PR TITLE
rpc: serve a reverting eth_call as code 3 with revert data, not -32000 (fee-screen hang)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The Android and desktop apps and the desktop daemon run an embedded JSON-RPC ser
 
 - `-32601` — the method isn't served verified at all (the wallet can stop asking).
 - `-32000` — the method is implemented but can't be answered right now (not synced, no snap peer, or the head isn't beacon-anchored yet — retryable).
+- `3` — `eth_call` executed over verified state and the contract REVERTED: the standard `execution reverted` error, with the raw revert payload in `error.data` and the decoded `Error(string)` reason in the message when present. This is a verified chain answer (not retryable) — wallets rely on it, e.g. MetaMask's ERC-165 token-standard probe expects a revert on plain ERC-20s.
 - `-32602` — the request's parameters are structurally valid but unsupported by this node, and no retry will change that. Today this is `eth_call` / `eth_estimateGas` carrying a state override (`params[2]`) or block override (`params[3]`): the node does not apply them, and answering without them would return a well-formed result computed against different state than you asked about. Fall back to a request without overrides, or use an upstream that applies them.
 
 > **Security:** the server binds **loopback only** by default — the wallet is a same-device client, and the endpoint is unauthenticated with no TLS or rate limiting (and `eth_sendRawTransaction` relays whatever signed bytes it's handed), so it is deliberately not reachable from other devices. Exposing it on a routable interface would require an explicit, opt-in change.

--- a/app-ios/src/iosMain/kotlin/io/myotis/ios/IosRpcBackend.kt
+++ b/app-ios/src/iosMain/kotlin/io/myotis/ios/IosRpcBackend.kt
@@ -1,6 +1,7 @@
 package io.myotis.ios
 
 import io.myotis.jsonrpc.RpcBackend
+import io.myotis.jsonrpc.RpcCallResult
 import io.myotis.jsonrpc.RpcBlockWindow
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject

--- a/app-ios/src/iosMain/kotlin/io/myotis/ios/IosRpcBackend.kt
+++ b/app-ios/src/iosMain/kotlin/io/myotis/ios/IosRpcBackend.kt
@@ -107,10 +107,53 @@ class IosRpcBackend(
             valueWei ?: "",
             block,
         )) ?: return null
-        // Only "ok" carries a result; a revert or unavailable outcome is "no
-        // answer" → null (a reverting eth_call is a JSON-RPC null, not -32000).
+        // Only "ok" carries a result here; callDetailed carries the revert payload.
         if (o.engineString("status") != "ok") return null
         return hexToBytes(o.engineString("resultHex"))
+    }
+
+    override fun callDetailed(
+        from: ByteArray?,
+        to: ByteArray?,
+        data: ByteArray,
+        valueWei: String?,
+        block: String,
+        stateOverridesJson: String?,
+    ): RpcCallResult {
+        // Same guards as call()/callWithOverrides(); all are "cannot answer", not reverts.
+        if (!isServableBlock(block)) return RpcCallResult.unavailable("block not servable")
+        if (to != null && to.size != 20) return RpcCallResult.unavailable("malformed to")
+        if (from != null && from.size != 20) return RpcCallResult.unavailable("malformed from")
+        val handle = handleProvider() ?: return RpcCallResult.unavailable("engine not running")
+        val json =
+            if (stateOverridesJson.isNullOrEmpty()) {
+                RustEngine.ethCallJson(
+                    handle,
+                    from?.let(::hex) ?: "",
+                    to?.let(::hex) ?: "",
+                    if (data.isEmpty()) "" else hex(data),
+                    valueWei ?: "",
+                    block,
+                )
+            } else {
+                RustEngine.ethCallOverridesJson(
+                    handle,
+                    from?.let(::hex) ?: "",
+                    to?.let(::hex) ?: "",
+                    if (data.isEmpty()) "" else hex(data),
+                    valueWei ?: "",
+                    block,
+                    stateOverridesJson,
+                )
+            }
+        val o = resultOrNull(json) ?: return RpcCallResult.unavailable("engine error")
+        return when (o.engineString("status")) {
+            // A revert is a VERIFIED chain answer — the router serves it as the
+            // standard code-3 execution-reverted error with the payload attached.
+            "ok" -> RpcCallResult.ok(hexToBytes(o.engineString("resultHex")) ?: ByteArray(0))
+            "revert" -> RpcCallResult.reverted(hexToBytes(o.engineString("dataHex")) ?: ByteArray(0))
+            else -> RpcCallResult.unavailable(o.engineString("reason"))
+        }
     }
 
     override fun supportsStateOverrides(): Boolean = true   // the revm executor applies them

--- a/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/RpcBackend.kt
+++ b/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/RpcBackend.kt
@@ -15,6 +15,27 @@ import kotlinx.serialization.json.JsonObject
  *  meaning); the jvmMain adapter maps 1:1. */
 enum class RpcSyncState { SYNCING, CATCHING_UP, SYNCED }
 
+/**
+ * `io.myotis.api.CallResult`'s pure-Kotlin mirror: the three-way outcome of a
+ * detailed `eth_call`. REVERTED is a VERIFIED chain answer (the contract said
+ * no) and carries the raw revert payload; the router maps it to the standard
+ * `{code: 3, "execution reverted", data}` wallets parse. UNAVAILABLE keeps the
+ * retryable -32000 path.
+ */
+class RpcCallResult private constructor(
+    val kind: Kind,
+    val data: ByteArray?,
+    val detail: String?,
+) {
+    enum class Kind { OK, REVERTED, UNAVAILABLE }
+
+    companion object {
+        fun ok(data: ByteArray): RpcCallResult = RpcCallResult(Kind.OK, data, null)
+        fun reverted(data: ByteArray): RpcCallResult = RpcCallResult(Kind.REVERTED, data, null)
+        fun unavailable(detail: String? = null): RpcCallResult = RpcCallResult(Kind.UNAVAILABLE, null, detail)
+    }
+}
+
 interface RpcBackend {
     fun chainId(): Long
     fun headBlockNumber(): Long?
@@ -30,9 +51,10 @@ interface RpcBackend {
     /**
      * Whether this backend can APPLY state overrides. Distinguishes "overrides
      * unsupported" (permanent → -32602) from an ordinary null answer such as
-     * not-synced or a revert (transient → -32000, retryable). Collapsing the two
-     * would tell a client to stop asking over a condition that clears in
-     * seconds.
+     * not-synced (transient → -32000, retryable). Collapsing the two would tell
+     * a client to stop asking over a condition that clears in seconds. (A
+     * contract REVERT is neither — it rides [callDetailed] as a verified answer
+     * with its own error shape.)
      */
     fun supportsStateOverrides(): Boolean = false
 
@@ -60,6 +82,29 @@ interface RpcBackend {
         block: String,
         stateOverridesJson: String,
     ): ByteArray? = null
+
+    /**
+     * [call]/[callWithOverrides] with the three-way [RpcCallResult] outcome, so
+     * a contract revert is not conflated with "cannot answer verified right
+     * now". Default wraps the nullable methods (a revert stays UNAVAILABLE),
+     * keeping every existing backend's behaviour until it overrides this to
+     * surface the revert payload.
+     *
+     * @param stateOverridesJson override object as JSON; null ⇒ plain call
+     */
+    fun callDetailed(
+        from: ByteArray?,
+        to: ByteArray?,
+        data: ByteArray,
+        valueWei: String?,
+        block: String,
+        stateOverridesJson: String?,
+    ): RpcCallResult {
+        val out =
+            if (stateOverridesJson.isNullOrEmpty()) call(from, to, data, valueWei, block)
+            else callWithOverrides(from, to, data, valueWei, block, stateOverridesJson)
+        return if (out == null) RpcCallResult.unavailable() else RpcCallResult.ok(out)
+    }
     fun getBalance(address: ByteArray, block: String): String?
     fun getTransactionCount(address: ByteArray, block: String): Long?
     fun getCode(address: ByteArray, block: String): ByteArray?

--- a/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/RpcRouter.kt
+++ b/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/RpcRouter.kt
@@ -270,9 +270,11 @@ class RpcRouter(
             // applied here: an unsupported KIND (blockOverrides, estimateGas), or
             // a backend that cannot apply overrides at all. A capable backend
             // that returned null did so for an ordinary reason — not synced, no
-            // peer, out-of-window block, a plain revert — and those are
+            // peer, out-of-window block — and those are
             // transient, so they must fall through to the retryable -32000
-            // below. Getting this wrong tells a wallet to stop asking and pin
+            // below. (A contract REVERT is neither: it is a verified answer,
+            // served as code 3 by the eth_call handler and never reaching
+            // here.) Getting this wrong tells a wallet to stop asking and pin
             // its public-node fallback for the session, which is the behaviour
             // #314 exists to remove.
             // NOTE the outer guard: only a request that actually CARRIES an
@@ -435,14 +437,25 @@ class RpcRouter(
                 } else null
                 val block = p.blockTag(1)
                 // VerifiedReads takes wei as a decimal string (FFI-neutral boundary).
-                val out = withContext(rpcIoDispatcher) {
-                    if (overrideJson != null) {
-                        b.callWithOverrides(from, to, data, value, block, overrideJson)
-                    } else {
-                        b.call(from, to, data, value, block)
-                    }
-                } ?: return null
-                resultEnvelope(id, JsonPrimitive(hexData(out)))
+                val outcome = withContext(rpcIoDispatcher) {
+                    b.callDetailed(from, to, data, value, block, overrideJson)
+                }
+                when (outcome.kind) {
+                    RpcCallResult.Kind.OK ->
+                        resultEnvelope(id, JsonPrimitive(hexData(outcome.data ?: ByteArray(0))))
+                    // A revert is a VERIFIED chain answer (the contract said no),
+                    // not a failure to answer: return the standard shape wallets
+                    // parse — geth's code 3 with the raw revert payload attached.
+                    // Falling through to -32000 here made clients treat a normal
+                    // negative answer (e.g. an ERC-165 probe on a plain ERC-20)
+                    // as a node outage — MetaMask's token-standard detection then
+                    // aborts and its confirmation screen never renders.
+                    RpcCallResult.Kind.REVERTED ->
+                        revertEnvelope(id, outcome.data ?: ByteArray(0))
+                    // No verified answer right now — fall through to the strict
+                    // retryable -32000 (or the dev proxy), exactly as before.
+                    RpcCallResult.Kind.UNAVAILABLE -> return null
+                }
             }
             "eth_getBalance" -> {
                 val p = root.params()
@@ -866,4 +879,60 @@ class RpcRouter(
                 put("message", JsonPrimitive(message))
             })
         })
+
+    /**
+     * The standard execution-reverted error (geth's shape, what ethers/viem/
+     * MetaMask parse): code 3, `data` = the raw revert payload, and the message
+     * suffixed with the decoded `Error(string)` reason when one is present.
+     */
+    private fun revertEnvelope(id: JsonElement, revertData: ByteArray): String =
+        json.encodeToString(JsonObject.serializer(), buildJsonObject {
+            put("jsonrpc", JsonPrimitive("2.0"))
+            put("id", id)
+            put("error", buildJsonObject {
+                put("code", JsonPrimitive(3))
+                val reason = decodeRevertReason(revertData)
+                put("message", JsonPrimitive(
+                    if (reason != null) "execution reverted: $reason" else "execution reverted"))
+                put("data", JsonPrimitive(hexData(revertData)))
+            })
+        })
+
+    /**
+     * Best-effort human reason from a revert payload: the Solidity
+     * `Error(string)` shape (selector 0x08c379a0 + ABI-encoded string) and
+     * `Panic(uint256)` (0x4e487b71). Anything else — custom errors, empty data —
+     * decodes to null and the message stays the bare "execution reverted"; the
+     * raw payload is always in `data` for the client to decode itself.
+     */
+    private fun decodeRevertReason(d: ByteArray): String? {
+        fun be(b: ByteArray, off: Int, len: Int): Long {
+            var v = 0L
+            for (i in off until off + len) v = (v shl 8) or (b[i].toLong() and 0xff)
+            return v
+        }
+        if (d.size >= 4 + 32 && d[0] == 0x4e.toByte() && d[1] == 0x48.toByte() &&
+            d[2] == 0x7b.toByte() && d[3] == 0x71.toByte()
+        ) {
+            return "panic 0x" + be(d, 4 + 24, 8).toString(16)
+        }
+        if (d.size < 4 + 64) return null
+        if (d[0] != 0x08.toByte() || d[1] != 0xc3.toByte() ||
+            d[2] != 0x79.toByte() || d[3] != 0xa0.toByte()
+        ) {
+            return null
+        }
+        // 4-byte selector ‖ offset(32) ‖ len(32) ‖ bytes. Bounds are attacker-
+        // controlled: validate every step and give up (null) on anything odd.
+        val off = be(d, 4 + 24, 8)
+        if (off < 0 || off > d.size.toLong()) return null
+        val lenPos = 4 + off.toInt()
+        if (lenPos + 32 > d.size) return null
+        val len = be(d, lenPos + 24, 8)
+        if (len < 0 || len > 1024 || lenPos + 32 + len > d.size) return null
+        val bytes = d.copyOfRange(lenPos + 32, lenPos + 32 + len.toInt())
+        val s = bytes.decodeToString()
+        // Control characters could forge log lines / confuse clients — keep it printable.
+        return s.map { if (it.code in 32..126 || it.code > 160) it else ' ' }.joinToString("")
+    }
 }

--- a/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/RpcRouter.kt
+++ b/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/RpcRouter.kt
@@ -910,15 +910,21 @@ class RpcRouter(
      * raw payload is always in `data` for the client to decode itself.
      */
     private fun decodeRevertReason(d: ByteArray): String? {
-        fun be(b: ByteArray, off: Int, len: Int): Long {
+        // A full 32-byte ABI word as a Long — null unless the high 24 bytes are
+        // zero, so an invalid-ABI payload (which canonical decoders reject)
+        // never decodes to a plausible reason here that disagrees with the
+        // wallet's own decode of `data`.
+        fun word(b: ByteArray, wordStart: Int): Long? {
+            for (i in wordStart until wordStart + 24) if (b[i] != 0.toByte()) return null
             var v = 0L
-            for (i in off until off + len) v = (v shl 8) or (b[i].toLong() and 0xff)
+            for (i in wordStart + 24 until wordStart + 32) v = (v shl 8) or (b[i].toLong() and 0xff)
             return v
         }
         if (d.size >= 4 + 32 && d[0] == 0x4e.toByte() && d[1] == 0x48.toByte() &&
             d[2] == 0x7b.toByte() && d[3] == 0x71.toByte()
         ) {
-            return "panic 0x" + be(d, 4 + 24, 8).toULong().toString(16)
+            val code = word(d, 4) ?: return null
+            return "panic 0x" + code.toULong().toString(16)
         }
         if (d.size < 4 + 64) return null
         if (d[0] != 0x08.toByte() || d[1] != 0xc3.toByte() ||
@@ -928,11 +934,11 @@ class RpcRouter(
         }
         // 4-byte selector ‖ offset(32) ‖ len(32) ‖ bytes. Bounds are attacker-
         // controlled: validate every step and give up (null) on anything odd.
-        val off = be(d, 4 + 24, 8)
+        val off = word(d, 4) ?: return null
         if (off < 0 || off > d.size.toLong()) return null
         val lenPos = 4 + off.toInt()
         if (lenPos + 32 > d.size) return null
-        val len = be(d, lenPos + 24, 8)
+        val len = word(d, lenPos) ?: return null
         if (len < 0 || len > 1024 || lenPos + 32 + len > d.size) return null
         val bytes = d.copyOfRange(lenPos + 32, lenPos + 32 + len.toInt())
         val s = bytes.decodeToString()

--- a/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/RpcRouter.kt
+++ b/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/RpcRouter.kt
@@ -250,6 +250,10 @@ class RpcRouter(
             val label =
                 if (takesOverrides(method) && stateOverrideJson(root) != null) "SIMULATED"
                 else "VERIFIED"
+            // NB a code-3 REVERT response counts here too, deliberately: the
+            // revert is a verified (or simulated) ANSWER, not a failure to
+            // answer — coverage tracks "could we serve this", not "did the
+            // contract say yes".
             logger.record(method!!, idStr, label, elapsedMs(t0))
             return verified
         }
@@ -914,7 +918,7 @@ class RpcRouter(
         if (d.size >= 4 + 32 && d[0] == 0x4e.toByte() && d[1] == 0x48.toByte() &&
             d[2] == 0x7b.toByte() && d[3] == 0x71.toByte()
         ) {
-            return "panic 0x" + be(d, 4 + 24, 8).toString(16)
+            return "panic 0x" + be(d, 4 + 24, 8).toULong().toString(16)
         }
         if (d.size < 4 + 64) return null
         if (d[0] != 0x08.toByte() || d[1] != 0xc3.toByte() ||
@@ -932,7 +936,9 @@ class RpcRouter(
         if (len < 0 || len > 1024 || lenPos + 32 + len > d.size) return null
         val bytes = d.copyOfRange(lenPos + 32, lenPos + 32 + len.toInt())
         val s = bytes.decodeToString()
-        // Control characters could forge log lines / confuse clients — keep it printable.
-        return s.map { if (it.code in 32..126 || it.code > 160) it else ' ' }.joinToString("")
+        // The reason is attacker-authored display text: keep it printable ASCII so
+        // it can neither forge log lines (\n) nor visually spoof UIs (RTL override,
+        // line separators). The raw bytes are always in `data` for exact decoding.
+        return s.map { if (it.code in 32..126) it else ' ' }.joinToString("")
     }
 }

--- a/jsonrpc-server/src/jvmMain/kotlin/io/myotis/jsonrpc/ApiAdapters.kt
+++ b/jsonrpc-server/src/jvmMain/kotlin/io/myotis/jsonrpc/ApiAdapters.kt
@@ -53,6 +53,22 @@ class VerifiedReadsBackend(private val v: io.myotis.api.VerifiedReads) : RpcBack
         block: String,
         stateOverridesJson: String,
     ): ByteArray? = v.callWithOverrides(from, to, data, valueWei, block, stateOverridesJson)
+
+    override fun callDetailed(
+        from: ByteArray?,
+        to: ByteArray?,
+        data: ByteArray,
+        valueWei: String?,
+        block: String,
+        stateOverridesJson: String?,
+    ): RpcCallResult {
+        val r = v.callDetailed(from, to, data, valueWei, block, stateOverridesJson)
+        return when (r.status()!!) {
+            io.myotis.api.CallResult.Status.OK -> RpcCallResult.ok(r.data() ?: ByteArray(0))
+            io.myotis.api.CallResult.Status.REVERTED -> RpcCallResult.reverted(r.data() ?: ByteArray(0))
+            io.myotis.api.CallResult.Status.UNAVAILABLE -> RpcCallResult.unavailable(r.detail())
+        }
+    }
     override fun getBalance(address: ByteArray, block: String): String? = v.getBalance(address, block)
     override fun getTransactionCount(address: ByteArray, block: String): Long? = v.getTransactionCount(address, block)
     override fun getCode(address: ByteArray, block: String): ByteArray? = v.getCode(address, block)

--- a/jsonrpc-server/src/jvmTest/kotlin/io/myotis/jsonrpc/RpcRouterTest.kt
+++ b/jsonrpc-server/src/jvmTest/kotlin/io/myotis/jsonrpc/RpcRouterTest.kt
@@ -161,6 +161,23 @@ class RpcRouterTest {
         assertTrue(err["data"]!!.jsonPrimitive.content.startsWith("0x08c379a0"))
     }
 
+    @Test fun ethCall_nonCanonicalAbiWords_areNotDecoded() {
+        // Offset word with non-zero HIGH bytes (2^64 + 0x20): invalid ABI that
+        // canonical decoders reject — our message must not decode a "plausible"
+        // reason they would disagree with. Bare message, raw data untouched.
+        val b = FakeBackend(applyOverrides = true)
+        b.revertData = ("08c379a0" +
+            "0000000000000000000000000000000000000000000000010000000000000020" +
+            "0000000000000000000000000000000000000000000000000000000000000004" +
+            "6e6f7065" + "00".repeat(28)).chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+        val resp = route(b,
+            """{"jsonrpc":"2.0","id":1,"method":"eth_call",
+               "params":[{"to":"0x0000000000000000000000000000000000696969","data":"0x01ffc9a7"},"latest"]}""")
+        assertEquals(3, errorCode(resp))
+        val err = Json.parseToJsonElement(resp).jsonObject["error"]!!.jsonObject
+        assertEquals("execution reverted", err["message"]!!.jsonPrimitive.content)
+    }
+
     @Test fun ethCall_revertReasonWithControlChars_isSanitizedInMessageOnly() {
         // A newline in the reason could forge access-log lines; RTL overrides
         // could spoof wallet UIs. The message is printable-ASCII-only — the

--- a/jsonrpc-server/src/jvmTest/kotlin/io/myotis/jsonrpc/RpcRouterTest.kt
+++ b/jsonrpc-server/src/jvmTest/kotlin/io/myotis/jsonrpc/RpcRouterTest.kt
@@ -129,6 +129,59 @@ class RpcRouterTest {
         assertEquals("0xdeadbeef", err["data"]!!.jsonPrimitive.content)
     }
 
+    @Test fun ethCall_panicRevert_decodesTheUnsignedCode() {
+        // Panic(uint256): 0x4e487b71 + code. 0x11 = arithmetic overflow.
+        val b = FakeBackend(applyOverrides = true)
+        b.revertData = ("4e487b71" +
+            "0000000000000000000000000000000000000000000000000000000000000011")
+            .chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+        val resp = route(b,
+            """{"jsonrpc":"2.0","id":1,"method":"eth_call",
+               "params":[{"to":"0x0000000000000000000000000000000000696969","data":"0x01ffc9a7"},"latest"]}""")
+        assertEquals(3, errorCode(resp))
+        val err = Json.parseToJsonElement(resp).jsonObject["error"]!!.jsonObject
+        assertEquals("execution reverted: panic 0x11", err["message"]!!.jsonPrimitive.content)
+    }
+
+    @Test fun ethCall_truncatedOrHostileErrorString_staysBareButKeepsData() {
+        // Error(string) selector with a hostile length word pointing past the
+        // payload: the decoder must give up (bare message), never crash or
+        // over-read; the raw bytes still reach the client via `data`.
+        val b = FakeBackend(applyOverrides = true)
+        b.revertData = ("08c379a0" +
+            "0000000000000000000000000000000000000000000000000000000000000020" +
+            "00000000000000000000000000000000000000000000000000000000ffffffff")
+            .chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+        val resp = route(b,
+            """{"jsonrpc":"2.0","id":1,"method":"eth_call",
+               "params":[{"to":"0x0000000000000000000000000000000000696969","data":"0x01ffc9a7"},"latest"]}""")
+        assertEquals(3, errorCode(resp))
+        val err = Json.parseToJsonElement(resp).jsonObject["error"]!!.jsonObject
+        assertEquals("execution reverted", err["message"]!!.jsonPrimitive.content)
+        assertTrue(err["data"]!!.jsonPrimitive.content.startsWith("0x08c379a0"))
+    }
+
+    @Test fun ethCall_revertReasonWithControlChars_isSanitizedInMessageOnly() {
+        // A newline in the reason could forge access-log lines; RTL overrides
+        // could spoof wallet UIs. The message is printable-ASCII-only — the
+        // exact bytes stay available in `data`.
+        val reason = "no\u0000pe\nline"
+        val rb = reason.encodeToByteArray()
+        val padded = rb + ByteArray((32 - rb.size % 32) % 32)
+        val b = FakeBackend(applyOverrides = true)
+        b.revertData = ("08c379a0" +
+            "0000000000000000000000000000000000000000000000000000000000000020" +
+            rb.size.toString(16).padStart(64, '0'))
+            .chunked(2).map { it.toInt(16).toByte() }.toByteArray() + padded
+        val resp = route(b,
+            """{"jsonrpc":"2.0","id":1,"method":"eth_call",
+               "params":[{"to":"0x0000000000000000000000000000000000696969","data":"0x01ffc9a7"},"latest"]}""")
+        val err = Json.parseToJsonElement(resp).jsonObject["error"]!!.jsonObject
+        val msg = err["message"]!!.jsonPrimitive.content
+        assertTrue(msg.startsWith("execution reverted: "))
+        assertTrue(!msg.contains('\n') && !msg.contains('\u0000'))
+    }
+
     @Test fun ethCall_revert_doesNotFallThroughToTheDevProxy() {
         // The revert IS the verified answer — in dev mode it must be served, not
         // proxied to an upstream that would answer from unverified state.

--- a/jsonrpc-server/src/jvmTest/kotlin/io/myotis/jsonrpc/RpcRouterTest.kt
+++ b/jsonrpc-server/src/jvmTest/kotlin/io/myotis/jsonrpc/RpcRouterTest.kt
@@ -82,7 +82,7 @@ class RpcRouterTest {
 
     @Test fun capableBackendReturningNull_getsTheRETRYABLEcode_notPermanent() {
         // A capable backend returns null for ordinary reasons — not synced, no
-        // peer, out-of-window block, a plain revert. Those are transient, so the
+        // peer, out-of-window block. Those are transient, so the
         // client must be told to retry; -32602 would make a wallet stop asking
         // and pin its public-node fallback for the session.
         val b = FakeBackend(callResult = null, applyOverrides = true)
@@ -92,6 +92,56 @@ class RpcRouterTest {
                          "latest",
                          {"0x0000000000000000000000000000000000696969":{"code":"0x6080"}}]}""")
         assertEquals(-32000, errorCode(resp))
+    }
+
+    @Test fun ethCall_revert_isServedAsCode3WithDataAndDecodedReason() {
+        // A revert is a VERIFIED chain answer, not "cannot answer": geth's shape
+        // (code 3, raw payload in `data`, Error(string) reason decoded into the
+        // message) is what ethers/viem/MetaMask parse. Reporting -32000 instead
+        // made wallets treat a normal negative answer (an ERC-165 probe on a
+        // plain ERC-20) as a node outage and stall their confirmation screens.
+        val b = FakeBackend(applyOverrides = true)
+        // Error("nope"): selector 08c379a0 ‖ offset 0x20 ‖ len 4 ‖ "nope" padded.
+        b.revertData = ("08c379a0" +
+            "0000000000000000000000000000000000000000000000000000000000000020" +
+            "0000000000000000000000000000000000000000000000000000000000000004" +
+            "6e6f7065" + "00".repeat(28)).chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+        val resp = route(b,
+            """{"jsonrpc":"2.0","id":1,"method":"eth_call",
+               "params":[{"to":"0x0000000000000000000000000000000000696969","data":"0x01ffc9a7"},"latest"]}""")
+        assertEquals(3, errorCode(resp))
+        val err = Json.parseToJsonElement(resp).jsonObject["error"]!!.jsonObject
+        assertEquals("execution reverted: nope", err["message"]!!.jsonPrimitive.content)
+        assertTrue(err["data"]!!.jsonPrimitive.content.startsWith("0x08c379a0"))
+    }
+
+    @Test fun ethCall_revertWithOpaqueData_keepsBareMessageAndRawData() {
+        // Custom errors / raw payloads don't decode — the message stays bare and
+        // the client gets the untouched bytes to decode itself.
+        val b = FakeBackend(applyOverrides = true)
+        b.revertData = byteArrayOf(0xde.toByte(), 0xad.toByte(), 0xbe.toByte(), 0xef.toByte())
+        val resp = route(b,
+            """{"jsonrpc":"2.0","id":1,"method":"eth_call",
+               "params":[{"to":"0x0000000000000000000000000000000000696969","data":"0x01ffc9a7"},"latest"]}""")
+        assertEquals(3, errorCode(resp))
+        val err = Json.parseToJsonElement(resp).jsonObject["error"]!!.jsonObject
+        assertEquals("execution reverted", err["message"]!!.jsonPrimitive.content)
+        assertEquals("0xdeadbeef", err["data"]!!.jsonPrimitive.content)
+    }
+
+    @Test fun ethCall_revert_doesNotFallThroughToTheDevProxy() {
+        // The revert IS the verified answer — in dev mode it must be served, not
+        // proxied to an upstream that would answer from unverified state.
+        val b = FakeBackend(applyOverrides = true)
+        b.revertData = ByteArray(0)
+        val resp = route(b,
+            """{"jsonrpc":"2.0","id":1,"method":"eth_call",
+               "params":[{"to":"0x0000000000000000000000000000000000696969","data":"0x01ffc9a7"},"latest"]}""",
+            proxy = UpstreamProxy("http://127.0.0.1:1"))   // unreachable: a fall-through would error differently
+        assertEquals(3, errorCode(resp))
+        val err = Json.parseToJsonElement(resp).jsonObject["error"]!!.jsonObject
+        assertEquals("execution reverted", err["message"]!!.jsonPrimitive.content)
+        assertEquals("0x", err["data"]!!.jsonPrimitive.content)
     }
 
     @Test fun anImplementationThatDoesNotOverride_inheritsUnsupported() {
@@ -215,6 +265,15 @@ class RpcRouterTest {
             if (!applyOverrides) return null   // the interface default: unsupported
             lastOverrides = stateOverridesJson
             return callResult
+        }
+
+        /** When set, callDetailed reports a REVERT carrying these bytes. */
+        var revertData: ByteArray? = null
+        override fun callDetailed(from: ByteArray?, to: ByteArray?, data: ByteArray,
+                                  valueWei: String?, block: String,
+                                  stateOverridesJson: String?): io.myotis.api.CallResult {
+            revertData?.let { return io.myotis.api.CallResult.reverted(it) }
+            return super.callDetailed(from, to, data, valueWei, block, stateOverridesJson)
         }
         override fun getBalance(address: ByteArray, block: String): String? = balance?.toString()
         override fun getTransactionCount(address: ByteArray, block: String): Long? = nonce

--- a/myotis-api/src/main/java/io/myotis/api/CallResult.java
+++ b/myotis-api/src/main/java/io/myotis/api/CallResult.java
@@ -26,6 +26,10 @@ package io.myotis.api;
  */
 public record CallResult(Status status, byte[] data, String detail) {
 
+    public CallResult {
+        java.util.Objects.requireNonNull(status, "status");
+    }
+
     public enum Status { OK, REVERTED, UNAVAILABLE }
 
     public static CallResult ok(byte[] data) {

--- a/myotis-api/src/main/java/io/myotis/api/CallResult.java
+++ b/myotis-api/src/main/java/io/myotis/api/CallResult.java
@@ -1,0 +1,42 @@
+package io.myotis.api;
+
+/**
+ * The detailed outcome of a verified {@code eth_call} — distinguishes the three
+ * cases the single nullable {@code byte[]} of {@link VerifiedReads#call} cannot:
+ *
+ * <ul>
+ *   <li>{@link Status#OK} — executed, {@code data} is the ABI return bytes
+ *       (possibly empty).</li>
+ *   <li>{@link Status#REVERTED} — executed <em>successfully as a verification
+ *       matter</em> and the contract reverted; {@code data} is the raw revert
+ *       payload (possibly empty). This is a verified chain answer, not a
+ *       failure: hosts map it to the standard JSON-RPC
+ *       {@code {code: 3, message: "execution reverted…", data: 0x…}} that
+ *       wallets parse. Reporting it as "cannot answer" makes wallets treat a
+ *       normal negative answer (e.g. an ERC-165 probe on a plain ERC-20) as a
+ *       node outage.</li>
+ *   <li>{@link Status#UNAVAILABLE} — no verified answer right now (not synced /
+ *       no peer / out-of-window block); retryable, hosts keep the existing
+ *       -32000 mapping. {@code detail} may carry a diagnostic reason.</li>
+ * </ul>
+ *
+ * <p>Flat record over FFI-portable types (enum, {@code byte[]}, {@code String})
+ * per the engine-contract rules; {@code data}/{@code detail} are null when not
+ * applicable to the status.
+ */
+public record CallResult(Status status, byte[] data, String detail) {
+
+    public enum Status { OK, REVERTED, UNAVAILABLE }
+
+    public static CallResult ok(byte[] data) {
+        return new CallResult(Status.OK, data == null ? new byte[0] : data, null);
+    }
+
+    public static CallResult reverted(byte[] revertData) {
+        return new CallResult(Status.REVERTED, revertData == null ? new byte[0] : revertData, null);
+    }
+
+    public static CallResult unavailable(String detail) {
+        return new CallResult(Status.UNAVAILABLE, null, detail);
+    }
+}

--- a/myotis-api/src/main/java/io/myotis/api/VerifiedReads.java
+++ b/myotis-api/src/main/java/io/myotis/api/VerifiedReads.java
@@ -102,6 +102,33 @@ public interface VerifiedReads {
         return null;
     }
 
+    /**
+     * {@link #call} (or {@link #callWithOverrides} when {@code stateOverridesJson}
+     * is non-empty) with a three-way outcome, so a contract REVERT — a verified
+     * chain answer — is distinguishable from "cannot answer verified right now".
+     * Hosts map {@link CallResult.Status#REVERTED} to the standard JSON-RPC
+     * execution-reverted error (code 3, revert data attached) instead of the
+     * retryable -32000, which wallets misread as a node outage.
+     *
+     * <p>Default: wraps the nullable methods, so every existing engine keeps its
+     * exact behaviour (a revert stays UNAVAILABLE) until it overrides this to
+     * surface the revert payload it already has.
+     *
+     * @param stateOverridesJson override object as JSON; null/empty ⇒ plain call
+     */
+    default CallResult callDetailed(
+            byte[] from,
+            byte[] to,
+            byte[] data,
+            String valueWei,
+            String block,
+            String stateOverridesJson) {
+        byte[] out = (stateOverridesJson == null || stateOverridesJson.isEmpty())
+                ? call(from, to, data, valueWei, block)
+                : callWithOverrides(from, to, data, valueWei, block, stateOverridesJson);
+        return out == null ? CallResult.unavailable(null) : CallResult.ok(out);
+    }
+
     /** Balance in decimal wei, or null. */
     String getBalance(byte[] address, String block);
 

--- a/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
@@ -759,17 +759,51 @@ final class RustChainHandle implements ChainHandle, NodeStatusReads {
                 handle, fromHex, toHex, dataHex, valueDecimal, block, stateOverridesJson)));
     }
 
-    /** Package-private test seam: call JSON → result bytes (or null) without JNI. */
+    /** {@link #ethCallVerified} with the engine's three-way outcome — a revert
+     *  carries its payload instead of collapsing to null. Same JNI native. */
+    io.myotis.api.CallResult ethCallVerifiedDetailed(
+            String fromHex, String toHex, String dataHex, String valueDecimal, String block) {
+        return callDetailedFromJson(gated(() -> RustEngineNative.nativeEthCallJson(
+                handle, fromHex, toHex, dataHex, valueDecimal, block)));
+    }
+
+    /** {@link #ethCallVerifiedDetailed} with the state-override object as JSON. */
+    io.myotis.api.CallResult ethCallVerifiedDetailedWithOverrides(
+            String fromHex,
+            String toHex,
+            String dataHex,
+            String valueDecimal,
+            String block,
+            String stateOverridesJson) {
+        return callDetailedFromJson(gated(() -> RustEngineNative.nativeEthCallOverridesJson(
+                handle, fromHex, toHex, dataHex, valueDecimal, block, stateOverridesJson)));
+    }
+
+    /** Package-private test seam: call JSON → result bytes (or null) without JNI.
+     *  The legacy two-state view of {@link #callDetailedFromJson}: only "ok"
+     *  carries bytes; a revert or unavailable outcome reads as null. */
     static byte[] callResultFromJson(String json) {
+        io.myotis.api.CallResult r = callDetailedFromJson(json);
+        return r.status() == io.myotis.api.CallResult.Status.OK ? r.data() : null;
+    }
+
+    /** Package-private test seam: call JSON → the engine's three-way outcome.
+     *  The Rust side emits {@code {"status":"ok","resultHex"}} /
+     *  {@code {"status":"revert","dataHex"}} / {@code {"status":"unavailable",
+     *  "reason"}} (pinned by the eljson golden tests); a revert is a VERIFIED
+     *  answer whose payload the host serves as the standard code-3 error. */
+    static io.myotis.api.CallResult callDetailedFromJson(String json) {
         JsonObject o = parseResultOrThrow(json, "call");
         try {
-            // Only "ok" carries a result. A revert or an unavailable/unverifiable
-            // outcome is "no answer" → null, mirroring the reference engine (a
-            // reverting or unverifiable eth_call returns a JSON-RPC null, not -32000).
-            if ("ok".equals(stringOrNull(o, "status"))) {
-                return hexToBytes(stringOrNull(o, "resultHex")); // 0x / empty → empty bytes
+            String status = stringOrNull(o, "status");
+            if ("ok".equals(status)) {
+                // 0x / empty → empty bytes
+                return io.myotis.api.CallResult.ok(hexToBytes(stringOrNull(o, "resultHex")));
             }
-            return null;
+            if ("revert".equals(status)) {
+                return io.myotis.api.CallResult.reverted(hexToBytes(stringOrNull(o, "dataHex")));
+            }
+            return io.myotis.api.CallResult.unavailable(stringOrNull(o, "reason"));
         } catch (RuntimeException e) {
             throw new EngineException("malformed call JSON from the Rust engine: " + e.getMessage(), e);
         }

--- a/myotis-engines/src/main/java/io/myotis/engines/RustVerifiedReads.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustVerifiedReads.java
@@ -210,7 +210,7 @@ final class RustVerifiedReads implements VerifiedReads {
         try {
             // 'from' empty → anonymous zero sender; the revm executor runs the call
             // over verified state and returns the result bytes (or null on a revert /
-            // unverifiable outcome, matching the reference engine).
+            // unverifiable outcome — callDetailed carries the revert payload).
             return handle.ethCallVerified(
                     from == null ? "" : toHex(from),
                     to == null ? "" : toHex(to),
@@ -220,6 +220,29 @@ final class RustVerifiedReads implements VerifiedReads {
         } catch (RuntimeException e) {
             log.debug("[engines] verified eth_call unavailable: {}", e.getMessage());
             return null;
+        }
+    }
+
+    @Override
+    public io.myotis.api.CallResult callDetailed(byte[] from, byte[] to, byte[] data,
+                                                 String valueWei, String block,
+                                                 String stateOverridesJson) {
+        // Same guards as call()/callWithOverrides(); all are "cannot answer", not reverts.
+        if (!isServableBlock(block)) return io.myotis.api.CallResult.unavailable("block not servable");
+        if (to != null && to.length != 20) return io.myotis.api.CallResult.unavailable("malformed to");
+        if (from != null && from.length != 20) return io.myotis.api.CallResult.unavailable("malformed from");
+        try {
+            String fromHex = from == null ? "" : toHex(from);
+            String toHex20 = to == null ? "" : toHex(to);
+            String dataHex = data == null ? "" : toHex(data);
+            String value = valueWei == null ? "" : valueWei;
+            return (stateOverridesJson == null || stateOverridesJson.isEmpty())
+                    ? handle.ethCallVerifiedDetailed(fromHex, toHex20, dataHex, value, block)
+                    : handle.ethCallVerifiedDetailedWithOverrides(
+                            fromHex, toHex20, dataHex, value, block, stateOverridesJson);
+        } catch (RuntimeException e) {
+            log.debug("[engines] verified eth_call (detailed) unavailable: {}", e.getMessage());
+            return io.myotis.api.CallResult.unavailable(e.getMessage());
         }
     }
 

--- a/myotis-engines/src/test/java/io/myotis/engines/RustVerifiedReadJsonTest.java
+++ b/myotis-engines/src/test/java/io/myotis/engines/RustVerifiedReadJsonTest.java
@@ -227,7 +227,8 @@ class RustVerifiedReadJsonTest {
 
     @Test
     void revertedCallIsNull() {
-        // A revert carries data but is "no answer" at the RPC layer → null.
+        // The LEGACY two-state view stays null on a revert; the payload rides
+        // callDetailedFromJson (below) so the router can serve code 3.
         String json = "{\"status\":\"revert\",\"dataHex\":\"0x08c379a0\"}";
         assertNull(RustChainHandle.callResultFromJson(json));
     }
@@ -236,6 +237,33 @@ class RustVerifiedReadJsonTest {
     void unavailableCallIsNull() {
         assertNull(RustChainHandle.callResultFromJson(
                 "{\"status\":\"unavailable\",\"reason\":\"out of gas\"}"));
+    }
+
+    @Test
+    void detailedCall_okCarriesBytes() {
+        io.myotis.api.CallResult r = RustChainHandle.callDetailedFromJson(
+                "{\"status\":\"ok\",\"resultHex\":\"0x2a\"}");
+        org.junit.jupiter.api.Assertions.assertEquals(io.myotis.api.CallResult.Status.OK, r.status());
+        org.junit.jupiter.api.Assertions.assertArrayEquals(new byte[]{0x2a}, r.data());
+    }
+
+    @Test
+    void detailedCall_revertCarriesThePayload() {
+        // The whole point of the detailed seam: the revert is a VERIFIED answer
+        // and its payload must survive to the router's code-3 envelope.
+        io.myotis.api.CallResult r = RustChainHandle.callDetailedFromJson(
+                "{\"status\":\"revert\",\"dataHex\":\"0x08c379a0\"}");
+        org.junit.jupiter.api.Assertions.assertEquals(io.myotis.api.CallResult.Status.REVERTED, r.status());
+        org.junit.jupiter.api.Assertions.assertArrayEquals(
+                new byte[]{0x08, (byte) 0xc3, 0x79, (byte) 0xa0}, r.data());
+    }
+
+    @Test
+    void detailedCall_unavailableCarriesTheReason() {
+        io.myotis.api.CallResult r = RustChainHandle.callDetailedFromJson(
+                "{\"status\":\"unavailable\",\"reason\":\"no snap peer\"}");
+        org.junit.jupiter.api.Assertions.assertEquals(io.myotis.api.CallResult.Status.UNAVAILABLE, r.status());
+        org.junit.jupiter.api.Assertions.assertEquals("no snap peer", r.detail());
     }
 
     @Test

--- a/myotis-evm/src/main/java/io/myotis/evm/DefaultEvmExecutor.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/DefaultEvmExecutor.java
@@ -182,8 +182,9 @@ public final class DefaultEvmExecutor implements EvmExecutor {
         }
         String detail = "halt=" + halt.map(ExceptionalHaltReason::name).orElse("UNKNOWN")
                 + " state=" + frame.getState();
-        throw new EvmExecutionException(
-                new EvmExecutionError.Reverted(detail.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
+        // Halted, NOT Reverted: there is no chain-produced payload here, and hosts
+        // serve Reverted's bytes verbatim as JSON-RPC revert data.
+        throw new EvmExecutionException(new EvmExecutionError.Halted(detail));
     }
 
     /** EIP-7702 delegation designator prefix: an EOA whose code is
@@ -333,7 +334,7 @@ public final class DefaultEvmExecutor implements EvmExecutor {
                     new EvmExecutionError.Reverted(frame.getRevertReason().get().toArrayUnsafe()));
         }
         // Halt without an explicit revert payload: map the halt reason to
-        // OutOfGas where applicable, otherwise surface a Reverted with a
+        // OutOfGas where applicable, otherwise surface a Halted with a
         // human-readable detail so the failure isn't opaque.
         var halt = frame.getExceptionalHaltReason();
         if (halt.isPresent() && halt.get() == ExceptionalHaltReason.INSUFFICIENT_GAS) {
@@ -341,8 +342,9 @@ public final class DefaultEvmExecutor implements EvmExecutor {
         }
         String detail = "halt=" + halt.map(ExceptionalHaltReason::name).orElse("UNKNOWN")
                 + " state=" + frame.getState();
-        throw new EvmExecutionException(
-                new EvmExecutionError.Reverted(detail.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
+        // Halted, NOT Reverted: there is no chain-produced payload here, and hosts
+        // serve Reverted's bytes verbatim as JSON-RPC revert data.
+        throw new EvmExecutionException(new EvmExecutionError.Halted(detail));
     }
 
     /** Accessors used by {@code PrefetchingEvmExecutor} to share configuration. */

--- a/myotis-evm/src/main/java/io/myotis/evm/EvmExecutionError.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/EvmExecutionError.java
@@ -56,6 +56,17 @@ public sealed interface EvmExecutionError {
     /** Estimation: execution exceeded the configured gas ceiling. */
     record OutOfGas() implements EvmExecutionError {}
 
+    /**
+     * EVM halted exceptionally WITHOUT a revert payload (invalid opcode, stack
+     * violation, the deliberate BLOCKHASH gap, …). Distinct from
+     * {@link Reverted} on purpose: a revert is a verified chain answer whose
+     * payload hosts serve verbatim (JSON-RPC code 3), while a halt's
+     * {@code detail} is a local diagnostic string the chain never produced —
+     * conflating them would serve fabricated revert data for calls that may
+     * succeed on a full node.
+     */
+    record Halted(String detail) implements EvmExecutionError {}
+
     /** Prefetch loop did not converge within the iteration cap. */
     record IterationLimitExceeded(int cap) implements EvmExecutionError {}
 

--- a/node-core/src/main/java/io/myotis/node/GatedVerifiedReads.java
+++ b/node-core/src/main/java/io/myotis/node/GatedVerifiedReads.java
@@ -76,6 +76,17 @@ final class GatedVerifiedReads implements VerifiedReads {
     }
 
     @Override
+    public io.myotis.api.CallResult callDetailed(byte[] from, byte[] to, byte[] data,
+                                                 String valueWei, String block,
+                                                 String stateOverridesJson) {
+        io.myotis.api.CallResult r =
+                guarded(d -> d.callDetailed(from, to, data, valueWei, block, stateOverridesJson));
+        // guarded() returns null when no backend is available (paused / torn down)
+        // — that is the retryable case, not a revert.
+        return r != null ? r : io.myotis.api.CallResult.unavailable("stack not ready");
+    }
+
+    @Override
     public String getBalance(byte[] address, String block) {
         return guarded(d -> d.getBalance(address, block));
     }

--- a/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
+++ b/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
@@ -805,6 +805,19 @@ public final class VerifiedRpcBackend implements io.myotis.api.VerifiedReads,
     }
 
     @Override
+    public io.myotis.api.CallResult callDetailed(byte[] from, byte[] to, byte[] data,
+                                                 String valueWei, String block,
+                                                 String stateOverridesJson) {
+        // The override path keeps the wrapping default (this engine's override
+        // support is a separate surface); the plain path surfaces the revert.
+        if (stateOverridesJson != null && !stateOverridesJson.isEmpty()) {
+            return io.myotis.api.VerifiedReads.super.callDetailed(
+                    from, to, data, valueWei, block, stateOverridesJson);
+        }
+        return rpcCallDetailed(from, to, data, parseWei(valueWei), block);
+    }
+
+    @Override
     public String getBalance(byte[] address, String block) {
         io.myotis.evm.world.AccountState a = rpcAccountState(address, block);
         return a == null ? null : a.balance().toString();
@@ -1941,23 +1954,33 @@ public final class VerifiedRpcBackend implements io.myotis.api.VerifiedReads,
     // Verified reads (eth_call / accounts / code / storage / sendRaw)
     // ---------------------------------------------------------------------
 
-    /** eth_call over the shared anchored head. Returns raw ABI bytes, or null to error. */
+    /** eth_call over the shared anchored head. Returns raw ABI bytes, or null to error
+     *  (the legacy two-state view of {@link #rpcCallDetailed} — a revert reads as null). */
     private byte[] rpcCall(byte[] from, byte[] to, byte[] data,
                            java.math.BigInteger value, String block) {
+        io.myotis.api.CallResult r = rpcCallDetailed(from, to, data, value, block);
+        return r.status() == io.myotis.api.CallResult.Status.OK ? r.data() : null;
+    }
+
+    /** eth_call over the shared anchored head, three-way: OK bytes, REVERTED with the
+     *  revert payload (a verified answer — the EVM ran and the contract said no), or
+     *  UNAVAILABLE (no verified head / no peer / timeout — the retryable case). */
+    private io.myotis.api.CallResult rpcCallDetailed(byte[] from, byte[] to, byte[] data,
+                                                     java.math.BigInteger value, String block) {
         // Keep the early-rejection logs correlatable with the wallet call that triggered
         // them: include target + 4-byte selector, matching the richer `desc` logging below.
         String callCtx = " to=" + (to != null && to.length == 20 ? Bytes.wrap(to).toHexString() : "?")
                 + " sel=" + (data != null && data.length >= 4 ? Bytes.wrap(data, 0, 4).toHexString() : "0x");
         if (from != null && from.length != 20) {
             log.info("[rpc] eth_call -> malformed from (len=" + from.length + ")" + callCtx);
-            return null;
+            return io.myotis.api.CallResult.unavailable("malformed from");
         }
         // Defence in depth (the router already screens this): wei is non-negative, and a
         // negative value would throw IllegalArgumentException in Wei.of down in the executor.
         // Return null so the router centrally manages the fallback instead.
         if (value != null && value.signum() < 0) {
             log.info("[rpc] eth_call -> negative value (" + value + ")" + callCtx);
-            return null;
+            return io.myotis.api.CallResult.unavailable("negative value");
         }
         // Identify the call up front: caller + target + 4-byte selector + calldata size
         // + block tag. eth_call failures were undiagnosable as "eth_call -> proxy:
@@ -1996,12 +2019,12 @@ public final class VerifiedRpcBackend implements io.myotis.api.VerifiedReads,
         // not dispatch at all; this is the belt-and-braces half.
         if (to == null || to.length != 20) {
             log.info("[rpc] eth_call " + desc + " -> contract creation is not served by this engine");
-            return null;
+            return io.myotis.api.CallResult.unavailable("contract creation not served");
         }
         RpcCallContext h = verifiedHeadFor(block);
         if (h == null) {
             log.info("[rpc] eth_call " + desc + " -> no verified head for block tag");
-            return null;
+            return io.myotis.api.CallResult.unavailable("no verified head");
         }
         long t0 = clock.elapsedMillis();
         // SINGLE-FLIGHT identical calls. MetaMask fires the same eth_call 4-6x
@@ -2029,7 +2052,8 @@ public final class VerifiedRpcBackend implements io.myotis.api.VerifiedReads,
         if (cached != null) {
             log.info("[rpc] eth_call " + desc + " ok in "
                     + (clock.elapsedMillis() - t0) + "ms (cached)");
-            return cached.clone();   // hand each reader its own copy; never expose the cached array
+            // hand each reader its own copy; never expose the cached array
+            return io.myotis.api.CallResult.ok(cached.clone());
         }
         // Route small calls onto the reserved EVM lane so a confirm screen's tiny
         // probes/simulations never queue behind a ~32KB token-sweep storm. The hint
@@ -2090,16 +2114,43 @@ public final class VerifiedRpcBackend implements io.myotis.api.VerifiedReads,
             byte[] out = flight.get(RPC_CALL_TIMEOUT_SEC, TimeUnit.SECONDS);
             log.info("[rpc] eth_call " + desc + " ok in "
                     + (clock.elapsedMillis() - t0) + "ms" + (leader ? "" : " (deduped)"));
-            return out;
+            return out == null
+                    ? io.myotis.api.CallResult.unavailable("execution returned no result")
+                    : io.myotis.api.CallResult.ok(out);
         } catch (Exception e) {
+            // A REVERT is not an error: the EVM ran to completion over verified
+            // state and the contract answered no. Surface its payload so the
+            // router can serve the standard code-3 shape instead of claiming
+            // the node is unsynced (which stalls wallets' token-standard
+            // detection and with it the whole confirmation screen).
+            byte[] revert = revertDataOf(e);
+            if (revert != null) {
+                log.info("[rpc] eth_call " + desc + " -> reverted (" + revert.length
+                        + " bytes) after " + (clock.elapsedMillis() - t0) + "ms"
+                        + (leader ? "" : " (deduped)"));
+                return io.myotis.api.CallResult.reverted(revert);
+            }
             log.info("[rpc] eth_call " + desc + " -> error after "
                     + (clock.elapsedMillis() - t0) + "ms"
                     + (leader ? "" : " (deduped)") + ": " + describeEvmError(e));
             if (isStateUnavailable(e)) evictUnservableHead(h);
-            return null;
+            return io.myotis.api.CallResult.unavailable(describeEvmError(e));
         } finally {
             if (smallLane) EVM_SMALL_LANE.remove();
         }
+    }
+
+    /** The revert payload carried by the throwable chain, or null when the chain
+     *  holds no {@link io.myotis.evm.EvmExecutionError.Reverted} (the same
+     *  cause-walk shape as {@link #isStateUnavailable}). */
+    private static byte[] revertDataOf(Throwable t) {
+        for (Throwable c = t; c != null; c = c.getCause()) {
+            if (c instanceof io.myotis.evm.EvmExecutionException ee
+                    && ee.error() instanceof io.myotis.evm.EvmExecutionError.Reverted r) {
+                return r.data();
+            }
+        }
+        return null;
     }
 
     /** In-flight eth_call executions keyed by (stateRoot, to, keccak(calldata)) so

--- a/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
+++ b/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
@@ -3978,11 +3978,15 @@ public final class VerifiedRpcBackend implements io.myotis.api.VerifiedReads,
         return new java.math.BigInteger(1, be);
     }
 
-    /** Render an estimate/call failure, decoding EvmExecutionException revert data —
-     *  the estimator packs halt diagnostics ("halt=... state=...") into Reverted bytes,
-     *  which the default toString prints as an opaque [B@hash. */
+    /** Render an estimate/call failure, decoding EvmExecutionException revert data
+     *  (the default toString prints Reverted's bytes as an opaque [B@hash) and the
+     *  Halted diagnostic string. */
     private static String describeEvmError(Throwable e) {
         for (Throwable t = e; t != null; t = t.getCause()) {
+            if (t instanceof io.myotis.evm.EvmExecutionException he
+                    && he.error() instanceof io.myotis.evm.EvmExecutionError.Halted halted) {
+                return "Halted: " + halted.detail();
+            }
             if (t instanceof io.myotis.evm.EvmExecutionException ee
                     && ee.error() instanceof io.myotis.evm.EvmExecutionError.Reverted rev) {
                 byte[] d = rev.data();

--- a/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
+++ b/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
@@ -2125,6 +2125,10 @@ public final class VerifiedRpcBackend implements io.myotis.api.VerifiedReads,
             // detection and with it the whole confirmation screen).
             byte[] revert = revertDataOf(e);
             if (revert != null) {
+                // Follow-up: reverted results are as deterministic per stateRoot as OK
+                // ones but are not yet stored in callResultCache (it holds bare bytes),
+                // so a wallet's repeated revert probes re-execute; single-flight still
+                // dedups concurrent copies.
                 log.info("[rpc] eth_call " + desc + " -> reverted (" + revert.length
                         + " bytes) after " + (clock.elapsedMillis() - t0) + "ms"
                         + (leader ? "" : " (deduped)"));
@@ -2142,8 +2146,9 @@ public final class VerifiedRpcBackend implements io.myotis.api.VerifiedReads,
 
     /** The revert payload carried by the throwable chain, or null when the chain
      *  holds no {@link io.myotis.evm.EvmExecutionError.Reverted} (the same
-     *  cause-walk shape as {@link #isStateUnavailable}). */
-    private static byte[] revertDataOf(Throwable t) {
+     *  cause-walk shape as {@link #isStateUnavailable}). Package-private as a
+     *  test seam. */
+    static byte[] revertDataOf(Throwable t) {
         for (Throwable c = t; c != null; c = c.getCause()) {
             if (c instanceof io.myotis.evm.EvmExecutionException ee
                     && ee.error() instanceof io.myotis.evm.EvmExecutionError.Reverted r) {

--- a/rpc-backend/src/test/java/io/myotis/rpc/RevertDataOfTest.java
+++ b/rpc-backend/src/test/java/io/myotis/rpc/RevertDataOfTest.java
@@ -1,0 +1,43 @@
+package io.myotis.rpc;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import io.myotis.evm.EvmExecutionError;
+import io.myotis.evm.EvmExecutionException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the Java engine's production revert path: {@code rpcCallDetailed} maps a
+ * throwable chain carrying {@link EvmExecutionError.Reverted} to a REVERTED
+ * result via this cause-walk — the payload must survive, and non-revert errors
+ * must NOT read as reverts (they stay retryable UNAVAILABLE).
+ */
+class RevertDataOfTest {
+
+    @Test
+    void findsTheRevertPayloadThroughWrappedCauses() {
+        byte[] payload = {0x08, (byte) 0xc3, 0x79, (byte) 0xa0, 0x01};
+        // The shape the dedup path produces: ExecutionException(RuntimeException(EvmExecutionException)).
+        Exception chain = new java.util.concurrent.ExecutionException(
+                new RuntimeException(
+                        new EvmExecutionException(new EvmExecutionError.Reverted(payload))));
+        assertArrayEquals(payload, VerifiedRpcBackend.revertDataOf(chain));
+    }
+
+    @Test
+    void directRevertAndEmptyPayload() {
+        assertArrayEquals(new byte[0], VerifiedRpcBackend.revertDataOf(
+                new EvmExecutionException(new EvmExecutionError.Reverted(new byte[0]))));
+    }
+
+    @Test
+    void nonRevertErrorsAreNotReverts() {
+        assertNull(VerifiedRpcBackend.revertDataOf(new RuntimeException("timeout")));
+        assertNull(VerifiedRpcBackend.revertDataOf(
+                new EvmExecutionException(new EvmExecutionError.OutOfGas())));
+        assertNull(VerifiedRpcBackend.revertDataOf(new java.util.concurrent.ExecutionException(
+                new EvmExecutionException(
+                        new EvmExecutionError.StateUnavailable(new byte[32], null, null)))));
+    }
+}

--- a/rpc-backend/src/test/java/io/myotis/rpc/RevertDataOfTest.java
+++ b/rpc-backend/src/test/java/io/myotis/rpc/RevertDataOfTest.java
@@ -36,6 +36,11 @@ class RevertDataOfTest {
         assertNull(VerifiedRpcBackend.revertDataOf(new RuntimeException("timeout")));
         assertNull(VerifiedRpcBackend.revertDataOf(
                 new EvmExecutionException(new EvmExecutionError.OutOfGas())));
+        // An exceptional halt carries a LOCAL diagnostic, not chain-produced
+        // revert data — it must never surface as a code-3 revert.
+        assertNull(VerifiedRpcBackend.revertDataOf(
+                new EvmExecutionException(
+                        new EvmExecutionError.Halted("halt=INVALID_OPERATION state=EXCEPTIONAL_HALT"))));
         assertNull(VerifiedRpcBackend.revertDataOf(new java.util.concurrent.ExecutionException(
                 new EvmExecutionException(
                         new EvmExecutionError.StateUnavailable(new byte[32], null, null)))));


### PR DESCRIPTION
## The bug

A reverting `eth_call` was answered with:

```
-32000 "method 'eth_call' cannot be served verified right now (no peer / not synced)"
```

The engine contract's single nullable `byte[]` channel could not distinguish a contract REVERT — a *verified chain answer* — from a genuinely unavailable one, so both collapsed to `null` and the router picked the retryable outage error.

**User-visible consequence (found via the MetaMask×Myotis send matrix):** MetaMask's token-standard detection probes ERC-165 `supportsInterface`, which reverts on plain ERC-20s by design. Getting an RPC error instead of a revert, it logs `Unable to determine contract standard` and never creates the transaction — the confirmation screen hangs on skeletons at `#/confirm-transaction?loader=send` with no tx id and no `eth_estimateGas` ever issued. Reproduced deterministically with mainnet OWL (`0x1a5f9352…82e4`); the same misreport occurs on every network (sepolia WETH9 `transfer(2^256-1)` → same -32000). All other matrix cells (sepolia native + WETH, gnosis xDai, mainnet native) confirm and mine normally.

## The fix

The revert payload already survived to the last hop on both engines — Besu's typed `EvmExecutionError.Reverted`, and the Rust engine's `{"status":"revert","dataHex"}` JSON (pinned by the eljson golden tests) — and was dropped in the adapters.

- **`io.myotis.api.CallResult`** (new): flat FFI-portable record, `OK / REVERTED / UNAVAILABLE`.
- **`VerifiedReads.callDetailed(...)`** — a *default* method wrapping the nullable path, so every implementor keeps compiling and behaving identically until it opts in. Mirrored as `RpcBackend.callDetailed` / `RpcCallResult` in the pure-Kotlin router seam.
- **Overridden where the payload exists:** Java engine (`VerifiedRpcBackend` — cause-chain walk, same shape as `isStateUnavailable`), Rust→JVM adapter (`RustChainHandle`/`RustVerifiedReads` — parses the JSON it already receives), iOS backend, and the pause/resume gate (`GatedVerifiedReads`).
- **Router:** `REVERTED` → the standard `{code: 3, "execution reverted[: reason]", data: 0x…}` that ethers/viem/MetaMask parse. `Error(string)` and `Panic(uint256)` are decoded into the message (printable-ASCII-only; raw payload always in `data`); the response never falls through to the dev proxy — the revert IS the verified answer. `UNAVAILABLE` keeps the retryable -32000 exactly as before.

No Rust/ABI change (the engine JSON was already three-way). No trust-model change: a revert is a verified execution result.

## Verification

- New tests: router revert envelope (Error(string) decode, opaque data, Panic, hostile length word, control-char sanitization, no-proxy-fallthrough), the Rust JSON adapter three-way parse, and the Java engine's `revertDataOf` cause-walk (incl. the deduped `ExecutionException` shape; OutOfGas/StateUnavailable stay non-reverts).
- Full suites green: `:jsonrpc-server:jvmTest`, `:rpc-backend:test`, `:myotis-engines:test`, `:node-core:test`, `:myotis-api:test`; all downstream consumers compile.
- Independent no-context review: no blockers; its hardening findings are folded into the second commit.

## Follow-ups (deliberately out of scope)

- `eth_estimateGas` has the same revert/unavailable ambiguity, but on the Rust side the payload is destroyed a layer earlier (`GasOutcome::Unavailable(e.to_string())`) — fixing it needs a new JSON field + engine ABI bump.
- Reverted results could join `callResultCache` (they are as deterministic per stateRoot as OK results); noted in-code.
- `README.md` documents the new code-3 contract; note `tools/mm-replay` retry-on--32000 semantics now correctly exclude reverts.

Live check after merge: `curl` `supportsInterface` against a running node should answer code 3 with `data`, and the previously-hanging `mainnet-erc20` matrix cell should render its confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPnTFwmAVMypWYtoioAXQT
