### PR TITLE
logindex: generic build / portable snapshots / import everywhere

### DIFF
--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/MainActivity.kt
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/MainActivity.kt
@@ -43,6 +43,17 @@ class MainActivity : ComponentActivity() {
         ActivityResultContracts.RequestPermission()
     ) { _ -> startNodeService() }
 
+    // Log-index snapshot import: the SAF picker's results must land in whatever
+    // callback the shared UI's Import action registered (one pick in flight at
+    // a time — the picker is modal).
+    private var pendingFilePick: ((List<android.net.Uri>) -> Unit)? = null
+    private val openDocumentsLauncher = registerForActivityResult(
+        ActivityResultContracts.OpenMultipleDocuments()
+    ) { uris ->
+        pendingFilePick?.invoke(uris ?: emptyList())
+        pendingFilePick = null
+    }
+
     private val connection = object : ServiceConnection {
         override fun onServiceConnected(name: ComponentName?, service: IBinder?) {
             val svc = (service as NodeService.LocalBinder).service()
@@ -70,6 +81,12 @@ class MainActivity : ComponentActivity() {
                     serviceProvider = { boundServiceState.value },
                     appContext = applicationContext,
                     onStartService = ::ensureNodeStarted,
+                    pickFiles = { onPicked ->
+                        pendingFilePick = onPicked
+                        // Snapshot files have no registered MIME type — accept
+                        // any and let the engine's format check refuse junk.
+                        openDocumentsLauncher.launch(arrayOf("*/*"))
+                    },
                 )
             }
             val settings = remember { AndroidSettings(applicationContext) }

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -261,13 +261,12 @@ public final class NodeService extends Service {
     }
 
     /** Raw log-index status JSON for a RUNNING network, or null when the
-     *  feature is off for it / the network isn't hosted (the Index tab shows
-     *  its waiting state then). */
+     *  network isn't hosted (the Index tab shows its waiting state then).
+     *  Deliberately NOT gated on the preference flag: an imported snapshot
+     *  activates engine-side without the flag ever being touched, and the
+     *  Java engine's stable disabled default keeps the call cheap. */
     public String logIndexStatusJsonOrNull(String network) {
         String net = canonicalNetwork(network);
-        if (!logIndexEnabled(this, net)) {
-            return null;
-        }
         ChainHandle handle;
         synchronized (handles) {
             handle = handles.get(net);
@@ -279,6 +278,35 @@ public final class NodeService extends Service {
             return handle.logIndexStatusJson();
         } catch (RuntimeException e) {
             return null;
+        }
+    }
+
+    /**
+     * Import portable log-index snapshots into a RUNNING network's index.
+     * {@code pathsJson} must name REAL files (the activity copies
+     * content: URIs into app storage first — the engine reads paths, not
+     * streams). Persists the enabled flag on success: importing is the
+     * opt-in, and the next start's config push must keep the index alive.
+     * Returns the engine's {@code {"ok":...}} / {@code {"error":...}} JSON.
+     */
+    public String importLogIndex(String network, String pathsJson) {
+        String net = canonicalNetwork(network);
+        ChainHandle handle;
+        synchronized (handles) {
+            handle = handles.get(net);
+        }
+        if (handle == null) {
+            return "{\"error\":\"" + net + " is not running\"}";
+        }
+        try {
+            String r = handle.importLogIndexFiles(pathsJson);
+            if (r.startsWith("{\"ok\":true")) {
+                setLogIndexEnabled(this, net, true);
+            }
+            return r;
+        } catch (RuntimeException e) {
+            String msg = e.getMessage() == null ? "import failed" : e.getMessage();
+            return "{\"error\":\"" + msg.replace("\\", "\\\\").replace("\"", "\\\"") + "\"}";
         }
     }
 

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -306,7 +306,8 @@ public final class NodeService extends Service {
             return r;
         } catch (RuntimeException e) {
             String msg = e.getMessage() == null ? "import failed" : e.getMessage();
-            return "{\"error\":\"" + msg.replace("\\", "\\\\").replace("\"", "\\\"") + "\"}";
+            return "{\"error\":\"" + msg.replace("\\", "\\\\").replace("\"", "\\\"")
+                    .replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t") + "\"}";
         }
     }
 

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/cmp/AndroidNodeBridge.kt
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/cmp/AndroidNodeBridge.kt
@@ -49,6 +49,10 @@ class AndroidNodeController(
     private val serviceProvider: () -> NodeService?,
     private val appContext: Context,
     private val onStartService: () -> Unit,
+    /** Launch the system document picker and hand back the chosen URIs (empty =
+     *  cancelled). Provided by the Activity (result launchers live there); null
+     *  on hosts without one, which hides the Index tab's Import button. */
+    private val pickFiles: (((List<android.net.Uri>) -> Unit) -> Unit)? = null,
 ) : NodeController {
 
     override val running: Boolean
@@ -101,6 +105,58 @@ class AndroidNodeController(
     override fun setTargetSnapPeers(target: Int) { serviceProvider()?.setTargetSnapPeers(target) }
     override fun setServedBlockWindow(blocks: Int) { serviceProvider()?.setServedBlockWindow(blocks) }
     override fun applyLogIndex(network: String) { serviceProvider()?.applyLogIndex(network) }
+
+    override val canImportLogIndex: Boolean get() = pickFiles != null
+
+    override fun importLogIndexSnapshots(network: String, onResult: (String) -> Unit): Boolean {
+        val picker = pickFiles ?: return false
+        picker { uris ->
+            if (uris.isEmpty()) {
+                onResult("Import cancelled.")
+                return@picker
+            }
+            // Copy + engine merge off the UI thread (snapshots can be large).
+            Thread({
+                try {
+                    val svc = serviceProvider()
+                    if (svc == null || !NodeService.isRunning()) {
+                        onResult("Node is not running — start it first.")
+                        return@Thread
+                    }
+                    // The engine reads file paths, not streams: materialize each
+                    // content: URI into app-private storage first.
+                    val temps = uris.mapIndexed { i, uri ->
+                        val f = File(appContext.cacheDir, "logindex-import-$i.db")
+                        appContext.contentResolver.openInputStream(uri).use { input ->
+                            requireNotNull(input) { "cannot read $uri" }
+                            f.outputStream().use { out -> input.copyTo(out) }
+                        }
+                        f
+                    }
+                    try {
+                        val pathsJson = temps.joinToString(",", "[", "]") {
+                            "\"${it.absolutePath.replace("\\", "\\\\").replace("\"", "\\\"")}\""
+                        }
+                        val r = svc.importLogIndex(network, pathsJson)
+                        if (r.startsWith("{\"ok\":true")) {
+                            onResult(
+                                "Imported ${uris.size} snapshot${if (uris.size == 1) "" else "s"} — catch-up started."
+                            )
+                        } else {
+                            val err = Regex("\"error\":\"((?:[^\"\\\\]|\\\\.)*)\"").find(r)
+                                ?.groupValues?.get(1) ?: r
+                            onResult("Import failed: $err")
+                        }
+                    } finally {
+                        temps.forEach { it.delete() }
+                    }
+                } catch (e: Exception) {
+                    onResult("Import failed: ${e.message ?: e.javaClass.simpleName}")
+                }
+            }, "log-index-import").apply { isDaemon = true }.start()
+        }
+        return true
+    }
     override fun applyBlsBackend() { NodeService.applyBlsBackend(appContext) }
     override fun applyEngineChoice() { NodeService.applyEngineChoice(appContext) }
     override fun clearCaches(network: String) { serviceProvider()?.clearCaches(network) }

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/cmp/AndroidNodeBridge.kt
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/cmp/AndroidNodeBridge.kt
@@ -124,16 +124,19 @@ class AndroidNodeController(
                         return@Thread
                     }
                     // The engine reads file paths, not streams: materialize each
-                    // content: URI into app-private storage first.
-                    val temps = uris.mapIndexed { i, uri ->
-                        val f = File(appContext.cacheDir, "logindex-import-$i.db")
-                        appContext.contentResolver.openInputStream(uri).use { input ->
-                            requireNotNull(input) { "cannot read $uri" }
-                            f.outputStream().use { out -> input.copyTo(out) }
-                        }
-                        f
-                    }
+                    // content: URI into app-private storage first. Unique temp
+                    // names (imports on two networks can overlap) and cleanup
+                    // that also covers a failure mid-copy.
+                    val temps = mutableListOf<File>()
                     try {
+                        uris.forEach { uri ->
+                            val f = File.createTempFile("logindex-import-", ".db", appContext.cacheDir)
+                            temps.add(f)
+                            appContext.contentResolver.openInputStream(uri).use { input ->
+                                requireNotNull(input) { "cannot read $uri" }
+                                f.outputStream().use { out -> input.copyTo(out) }
+                            }
+                        }
                         val pathsJson = temps.joinToString(",", "[", "]") {
                             "\"${it.absolutePath.replace("\\", "\\\\").replace("\"", "\\\"")}\""
                         }

--- a/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
@@ -272,10 +272,52 @@ class DesktopNodeController(
     }
 
     /** Raw log-index status JSON, fetched ONCE per snapshot (both the status
-     *  line and the Index tab derive from it), or null when off/unavailable. */
-    private fun logIndexRawFor(network: String): String? {
-        if (!settings.logIndexEnabled(network)) return null
-        return runCatching { engine.get(network)?.logIndexStatusJson() }.getOrNull()
+     *  line and the Index tab derive from it), or null when unavailable.
+     *  Deliberately NOT gated on the Settings flag: an imported or dropped-in
+     *  snapshot activates engine-side without the flag ever being touched,
+     *  and the Java engine's stable disabled default keeps this cheap. */
+    private fun logIndexRawFor(network: String): String? =
+        runCatching { engine.get(network)?.logIndexStatusJson() }.getOrNull()
+
+    override val canImportLogIndex: Boolean get() = true
+
+    override fun importLogIndexSnapshots(network: String, onResult: (String) -> Unit): Boolean {
+        val canonical = engine.canonicalNetworkName(network)
+        // AWT file dialog wants the EDT; the import itself (engine-side merge
+        // of possibly-GB snapshots) then moves to a worker thread.
+        java.awt.EventQueue.invokeLater {
+            val dialog = java.awt.FileDialog(null as java.awt.Frame?, "Import log-index snapshots", java.awt.FileDialog.LOAD)
+            dialog.isMultipleMode = true
+            dialog.isVisible = true
+            val files = dialog.files?.toList().orEmpty()
+            if (files.isEmpty()) {
+                onResult("Import cancelled.")
+                return@invokeLater
+            }
+            Thread({
+                val handle = engine.get(canonical)
+                if (handle == null) {
+                    onResult("$canonical is not running — start it first.")
+                    return@Thread
+                }
+                val pathsJson = files.joinToString(",", "[", "]") {
+                    "\"${it.absolutePath.replace("\\", "\\\\").replace("\"", "\\\"")}\""
+                }
+                val result = runCatching { handle.importLogIndexFiles(pathsJson) }
+                    .getOrElse { "{\"error\":\"${it.message}\"}" }
+                if (result.startsWith("{\"ok\":true")) {
+                    // Importing is the opt-in: persist the flag so the next
+                    // start's config push keeps the index enabled.
+                    settings.setLogIndexEnabled(canonical, true)
+                    onResult("Imported ${files.size} snapshot${if (files.size == 1) "" else "s"} — catch-up started.")
+                } else {
+                    val err = Regex("\"error\":\"((?:[^\"\\\\]|\\\\.)*)\"").find(result)
+                        ?.groupValues?.get(1) ?: result
+                    onResult("Import failed: $err")
+                }
+            }, "log-index-import-$canonical").apply { isDaemon = true }.start()
+        }
+        return true
     }
 
     override fun applyTorMode() {

--- a/app-ios/src/iosMain/kotlin/io/myotis/ios/IosFilePicker.kt
+++ b/app-ios/src/iosMain/kotlin/io/myotis/ios/IosFilePicker.kt
@@ -1,0 +1,63 @@
+package io.myotis.ios
+
+import platform.Foundation.NSURL
+import platform.UIKit.UIApplication
+import platform.UIKit.UIDocumentPickerDelegateProtocol
+import platform.UIKit.UIDocumentPickerViewController
+import platform.UIKit.UIViewController
+import platform.UniformTypeIdentifiers.UTTypeItem
+import platform.darwin.NSObject
+
+/**
+ * The system document picker, presented from the Compose host's root view
+ * controller — the seam behind [io.myotis.ui.NodeController.importLogIndexSnapshots]
+ * on this host. `asCopy = true` makes UIKit hand back plain readable copies in
+ * the app's tmp container, so no security-scoped-resource dance is needed and
+ * the returned paths can go straight to the engine (which reads paths, not
+ * streams). Must be called on the main thread (Compose click handlers are).
+ */
+internal object IosFilePicker {
+
+    // UIKit holds its delegate weakly — keep the active one alive until the
+    // picker resolves (picked or cancelled), one pick in flight at a time
+    // (the picker is modal).
+    private var active: PickerDelegate? = null
+
+    fun pickFiles(onPicked: (List<String>) -> Unit) {
+        val root = rootViewController() ?: run {
+            onPicked(emptyList())
+            return
+        }
+        val delegate = PickerDelegate { paths ->
+            active = null
+            onPicked(paths)
+        }
+        active = delegate
+        val picker = UIDocumentPickerViewController(
+            forOpeningContentTypes = listOf(UTTypeItem), // snapshots have no registered type
+            asCopy = true,
+        )
+        picker.allowsMultipleSelection = true
+        picker.delegate = delegate
+        root.presentViewController(picker, animated = true, completion = null)
+    }
+
+    private fun rootViewController(): UIViewController? =
+        UIApplication.sharedApplication.keyWindow?.rootViewController
+
+    private class PickerDelegate(
+        private val onDone: (List<String>) -> Unit,
+    ) : NSObject(), UIDocumentPickerDelegateProtocol {
+
+        override fun documentPicker(
+            controller: UIDocumentPickerViewController,
+            didPickDocumentsAtURLs: List<*>,
+        ) {
+            onDone(didPickDocumentsAtURLs.mapNotNull { (it as? NSURL)?.path })
+        }
+
+        override fun documentPickerWasCancelled(controller: UIDocumentPickerViewController) {
+            onDone(emptyList())
+        }
+    }
+}

--- a/app-ios/src/iosMain/kotlin/io/myotis/ios/IosNodeController.kt
+++ b/app-ios/src/iosMain/kotlin/io/myotis/ios/IosNodeController.kt
@@ -192,6 +192,45 @@ class IosNodeController(
         }
     }
 
+    override val canImportLogIndex: Boolean get() = true
+
+    override fun importLogIndexSnapshots(network: String, onResult: (String) -> Unit): Boolean {
+        val net = canonical(network)
+        // Picker on the main thread (we're in a Compose click handler); the
+        // engine-side merge then moves to the lifecycle lane like every other
+        // mutating op.
+        IosFilePicker.pickFiles { paths ->
+            if (paths.isEmpty()) {
+                onResult("Import cancelled.")
+                return@pickFiles
+            }
+            scope.launch(lifecycleLane) {
+                val handle = locked { handles[net] }
+                if (handle == null) {
+                    onResult("$net is not running — start it first.")
+                    return@launch
+                }
+                val pathsJson = paths.joinToString(",", "[", "]") {
+                    "\"${it.replace("\\", "\\\\").replace("\"", "\\\"")}\""
+                }
+                val r = RustEngine.importLogIndexFiles(handle, pathsJson)
+                if (r.startsWith("{\"ok\":true")) {
+                    // Importing is the opt-in: persist the flag so the next
+                    // start's config push keeps the index enabled.
+                    settings.setLogIndexEnabled(net, true)
+                    onResult(
+                        "Imported ${paths.size} snapshot${if (paths.size == 1) "" else "s"} — catch-up started."
+                    )
+                } else {
+                    val err = Regex("\"error\":\"((?:[^\"\\\\]|\\\\.)*)\"").find(r)
+                        ?.groupValues?.get(1) ?: r
+                    onResult("Import failed: $err")
+                }
+            }
+        }
+        return true
+    }
+
 
     /** Blocking create+start; caller holds [bootMutex] and runs on IO. */
     private fun boot(net: String) {
@@ -469,7 +508,10 @@ class IosNodeController(
             }
         }
 
-        val logIndexRaw = if (settings.logIndexEnabled(network)) RustEngine.logIndexStatusJson(handle) else null
+        // NOT gated on the Settings flag: an imported snapshot activates
+        // engine-side without the flag ever being touched, and the engine's
+        // stable disabled default keeps the call cheap.
+        val logIndexRaw = RustEngine.logIndexStatusJson(handle)
         return NodeSnapshot(
             running = running,
             lifecycle = if (running) "RUNNING" else if (paused) "PAUSED" else "STOPPED",

--- a/app-ios/src/iosMain/kotlin/io/myotis/ios/RustEngine.kt
+++ b/app-ios/src/iosMain/kotlin/io/myotis/ios/RustEngine.kt
@@ -18,6 +18,7 @@ import io.myotis.engine.capi.myotis_get_code_json
 import io.myotis.engine.capi.myotis_get_storage_at_json
 import io.myotis.engine.capi.myotis_get_transaction_by_hash_json
 import io.myotis.engine.capi.myotis_get_transaction_receipt_json
+import io.myotis.engine.capi.myotis_import_log_index_files
 import io.myotis.engine.capi.myotis_log_index_status_json
 import io.myotis.engine.capi.myotis_set_log_index_config
 import io.myotis.engine.capi.myotis_send_raw_transaction_json
@@ -139,6 +140,13 @@ object RustEngine {
     fun logIndexStatusJson(handle: Long): String {
         requireAbi()
         return take(myotis_log_index_status_json(handle)) ?: """{"enabled":false}"""
+    }
+
+    /** Import portable log-index snapshots ({"ok":...} / {"error":...}). */
+    fun importLogIndexFiles(handle: Long, pathsJson: String): String {
+        requireAbi()
+        return take(myotis_import_log_index_files(handle, pathsJson))
+            ?: """{"error":"engine returned no result"}"""
     }
 
     fun statusJson(handle: Long): String {

--- a/app/src/main/java/com/jaeckel/ethp2p/app/CommandHandler.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/CommandHandler.java
@@ -81,6 +81,8 @@ public class CommandHandler {
                 case "stop"                    -> handleStop();
                 case "beacon-status"           -> handleBeaconStatus();
                 case "import-logindex"         -> handleImportLogIndex(jsonLine);
+                case "export-logindex"         -> handleExportLogIndex(jsonLine);
+                case "build-logindex"          -> handleBuildLogIndex(jsonLine);
                 case "logindex-status"         -> handle.logIndexStatusJson();
                 default                        -> jsonError("Unknown command: " + cmd);
             };
@@ -269,6 +271,96 @@ public class CommandHandler {
      */
     private String handleImportLogIndex(String jsonLine) {
         return handle.importLogIndexFiles(extractArray(jsonLine, "paths"));
+    }
+
+    /**
+     * Export the current log index as a portable snapshot
+     * ({@code {"cmd":"export-logindex","path":"/abs/out.db"}}) — the
+     * generator's output step. Finality-clamped and self-describing;
+     * partial coverage exports honestly (check {@code logindex-status} for
+     * "complete" first if that matters). Engine JSON is the response.
+     */
+    private String handleExportLogIndex(String jsonLine) {
+        return handle.exportLogIndex(extractString(jsonLine, "path"));
+    }
+
+    /**
+     * The generic log-index GENERATOR
+     * ({@code {"cmd":"build-logindex","fromBlock":N,"addresses":["0x..",...]}}):
+     * subscribe the given contract addresses — no preset involved — and let
+     * the engine's backfill build the database. The config push is ADDITIVE
+     * engine-side (existing subscriptions/coverage survive) and runs at max
+     * download speed, since a generator daemon exists to finish the walk.
+     * Each address gets a best-effort ENS reverse name (forward-verified by
+     * {@link EnsApi#reverseResolve}) baked in as its display name; failures
+     * just leave the entry unnamed. Poll {@code logindex-status} until
+     * complete, then {@code export-logindex <path>}. Rust engine only.
+     *
+     * <p>{@code fromBlock} is a TRUST ASSERTION, not a hint: the engine
+     * serves a query once coverage reaches it, so a value LATER than the
+     * real deployment makes earlier events vanish without an error.
+     * Undershooting (the default 0) cannot lie — it only walks further.
+     */
+    private String handleBuildLogIndex(String jsonLine) {
+        String addressesJson = extractArray(jsonLine, "addresses");
+        long fromBlock;
+        try {
+            fromBlock = extractLong(jsonLine, "fromBlock");
+        } catch (IllegalArgumentException e) {
+            fromBlock = 0;
+        }
+        if (fromBlock < 0) return jsonError("fromBlock must be >= 0");
+        java.util.List<String> addresses = new java.util.ArrayList<>();
+        java.util.regex.Matcher m =
+                java.util.regex.Pattern.compile("\"(0x[0-9a-fA-F]{40})\"").matcher(addressesJson);
+        while (m.find()) addresses.add(m.group(1));
+        // Count the raw elements too: a malformed address must be an error,
+        // never silently dropped from the subscription (a well-formed result
+        // for a different question — the rule from CLAUDE.md §Trust).
+        int rawElements = addressesJson.replaceAll("[^\"]", "").length() / 2;
+        if (addresses.isEmpty() || addresses.size() != rawElements) {
+            return jsonError("addresses must be a non-empty array of 0x-prefixed 20-byte hex addresses");
+        }
+        StringBuilder watch = new StringBuilder();
+        StringBuilder named = new StringBuilder();
+        for (int i = 0; i < addresses.size(); i++) {
+            String addr = addresses.get(i);
+            String name = reverseNameOrNull(addr);
+            if (i > 0) {
+                watch.append(',');
+                named.append(',');
+            }
+            watch.append("{\"address\":\"").append(addr)
+                 .append("\",\"fromBlock\":").append(fromBlock);
+            if (name != null) {
+                watch.append(",\"name\":\"").append(escapeJson(name)).append('"');
+            }
+            watch.append('}');
+            named.append("{\"address\":\"").append(addr).append('"');
+            if (name != null) {
+                named.append(",\"name\":\"").append(escapeJson(name)).append('"');
+            }
+            named.append('}');
+        }
+        String config = "{\"enabled\":true,\"maxSpeed\":true,\"watch\":[" + watch + "]}";
+        if (!handle.setLogIndexConfig(config)) {
+            return jsonError("log index config rejected (is this daemon on the Rust engine? start with -Pengine=rust)");
+        }
+        return "{\"ok\":true,\"building\":[" + named + "]"
+                + ",\"note\":\"poll logindex-status until complete, then export-logindex <path>\"}";
+    }
+
+    /** Best-effort ENS reverse name (forward-verified engine-side); null on
+     *  any failure — a name must never gate indexing. */
+    private String reverseNameOrNull(String address) {
+        try {
+            EnsApi ens = handle.ens();
+            if (ens == null) return null;
+            EnsResolutionResult r = ens.reverseResolve(address);
+            return r != null ? r.name() : null;
+        } catch (RuntimeException e) {
+            return null;
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/app/src/main/java/com/jaeckel/ethp2p/app/CommandHandler.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/CommandHandler.java
@@ -291,10 +291,11 @@ public class CommandHandler {
      * the engine's backfill build the database. The config push is ADDITIVE
      * engine-side (existing subscriptions/coverage survive) and runs at max
      * download speed, since a generator daemon exists to finish the walk.
-     * Each address gets a best-effort ENS reverse name (forward-verified by
-     * {@link EnsApi#reverseResolve}) baked in as its display name; failures
-     * just leave the entry unnamed. Poll {@code logindex-status} until
-     * complete, then {@code export-logindex <path>}. Rust engine only.
+     * Entries are written UNNAMED on purpose: display names are cosmetic,
+     * for the importing wallet's Index tab, and the wallet fills them in
+     * itself (the engine's ENS reverse-naming pass) — the generator has no
+     * naming duties. Poll {@code logindex-status} until complete, then
+     * {@code export-logindex <path>}. Rust engine only.
      *
      * <p>{@code fromBlock} is a TRUST ASSERTION, not a hint: the engine
      * serves a query once coverage reaches it, so a value LATER than the
@@ -303,12 +304,11 @@ public class CommandHandler {
      */
     private String handleBuildLogIndex(String jsonLine) {
         String addressesJson = extractArray(jsonLine, "addresses");
-        long fromBlock;
-        try {
-            fromBlock = extractLong(jsonLine, "fromBlock");
-        } catch (IllegalArgumentException e) {
-            fromBlock = 0;
-        }
+        // Absent → 0 (undershooting cannot lie). PRESENT-but-malformed must
+        // refuse, not default: a parameter that can change the answer is
+        // applied or refused, never silently replaced (CLAUDE.md §Trust) —
+        // extractLong's throw propagates to the caller's jsonError.
+        long fromBlock = jsonLine.contains("\"fromBlock\"") ? extractLong(jsonLine, "fromBlock") : 0;
         if (fromBlock < 0) return jsonError("fromBlock must be >= 0");
         java.util.List<String> addresses = new java.util.ArrayList<>();
         java.util.regex.Matcher m =
@@ -322,45 +322,17 @@ public class CommandHandler {
             return jsonError("addresses must be a non-empty array of 0x-prefixed 20-byte hex addresses");
         }
         StringBuilder watch = new StringBuilder();
-        StringBuilder named = new StringBuilder();
         for (int i = 0; i < addresses.size(); i++) {
-            String addr = addresses.get(i);
-            String name = reverseNameOrNull(addr);
-            if (i > 0) {
-                watch.append(',');
-                named.append(',');
-            }
-            watch.append("{\"address\":\"").append(addr)
-                 .append("\",\"fromBlock\":").append(fromBlock);
-            if (name != null) {
-                watch.append(",\"name\":\"").append(escapeJson(name)).append('"');
-            }
-            watch.append('}');
-            named.append("{\"address\":\"").append(addr).append('"');
-            if (name != null) {
-                named.append(",\"name\":\"").append(escapeJson(name)).append('"');
-            }
-            named.append('}');
+            if (i > 0) watch.append(',');
+            watch.append("{\"address\":\"").append(addresses.get(i))
+                 .append("\",\"fromBlock\":").append(fromBlock).append('}');
         }
         String config = "{\"enabled\":true,\"maxSpeed\":true,\"watch\":[" + watch + "]}";
         if (!handle.setLogIndexConfig(config)) {
             return jsonError("log index config rejected (is this daemon on the Rust engine? start with -Pengine=rust)");
         }
-        return "{\"ok\":true,\"building\":[" + named + "]"
+        return "{\"ok\":true,\"building\":" + addressesJson
                 + ",\"note\":\"poll logindex-status until complete, then export-logindex <path>\"}";
-    }
-
-    /** Best-effort ENS reverse name (forward-verified engine-side); null on
-     *  any failure — a name must never gate indexing. */
-    private String reverseNameOrNull(String address) {
-        try {
-            EnsApi ens = handle.ens();
-            if (ens == null) return null;
-            EnsResolutionResult r = ens.reverseResolve(address);
-            return r != null ? r.name() : null;
-        } catch (RuntimeException e) {
-            return null;
-        }
     }
 
     // -------------------------------------------------------------------------
@@ -917,8 +889,13 @@ public class CommandHandler {
         if (keyIdx < 0) throw new IllegalArgumentException("Missing field: " + field);
         int colon = json.indexOf(':', keyIdx + key.length());
         if (colon < 0) throw new IllegalArgumentException("Malformed JSON near field: " + field);
-        int open = json.indexOf('[', colon + 1);
-        if (open < 0) throw new IllegalArgumentException("Field '" + field + "' value is not an array");
+        // The bracket must be the field's own value: scanning forward past a
+        // non-array value would silently capture a LATER array in the line.
+        int open = colon + 1;
+        while (open < json.length() && Character.isWhitespace(json.charAt(open))) open++;
+        if (open >= json.length() || json.charAt(open) != '[') {
+            throw new IllegalArgumentException("Field '" + field + "' value is not an array");
+        }
         int depth = 0;
         boolean inString = false;
         for (int i = open; i < json.length(); i++) {

--- a/app/src/main/java/com/jaeckel/ethp2p/app/CommandHandler.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/CommandHandler.java
@@ -80,6 +80,8 @@ public class CommandHandler {
                 case "resume"                  -> handleResume();
                 case "stop"                    -> handleStop();
                 case "beacon-status"           -> handleBeaconStatus();
+                case "import-logindex"         -> handleImportLogIndex(jsonLine);
+                case "logindex-status"         -> handle.logIndexStatusJson();
                 default                        -> jsonError("Unknown command: " + cmd);
             };
         } catch (Exception e) {
@@ -252,6 +254,21 @@ public class CommandHandler {
     private static String truncatePeerId(String peerId) {
         return peerId != null && peerId.length() > 16
                 ? peerId.substring(0, 16) + "..." : peerId;
+    }
+
+    /**
+     * Import portable log-index snapshot files
+     * ({@code {"cmd":"import-logindex","paths":["/abs/file.db",...]}}). The
+     * paths array is handed to the engine VERBATIM — it validates format and
+     * chain identity per file and merges all-or-nothing; its own
+     * {@code {"ok":...}} / {@code {"error":...}} JSON is the response. Rust
+     * engine only: the Java engine answers its stable not-supported error.
+     * (The zero-effort alternative stays available too: drop the file at
+     * {@code dataDir/logindex[-network].db} before start and the engine
+     * activates it by itself.)
+     */
+    private String handleImportLogIndex(String jsonLine) {
+        return handle.importLogIndexFiles(extractArray(jsonLine, "paths"));
     }
 
     // -------------------------------------------------------------------------
@@ -795,5 +812,36 @@ public class CommandHandler {
         while (end < json.length() && (Character.isDigit(json.charAt(end)) || json.charAt(end) == '-')) end++;
         if (start == end) throw new IllegalArgumentException("Field '" + field + "' is not a number");
         return Long.parseLong(json.substring(start, end));
+    }
+
+    /**
+     * Extract a JSON ARRAY value verbatim (brackets included). The scan is
+     * string-and-escape aware — a {@code ]} inside a quoted element (file
+     * paths can contain one) must not terminate the match early.
+     */
+    static String extractArray(String json, String field) {
+        String key = "\"" + field + "\"";
+        int keyIdx = json.indexOf(key);
+        if (keyIdx < 0) throw new IllegalArgumentException("Missing field: " + field);
+        int colon = json.indexOf(':', keyIdx + key.length());
+        if (colon < 0) throw new IllegalArgumentException("Malformed JSON near field: " + field);
+        int open = json.indexOf('[', colon + 1);
+        if (open < 0) throw new IllegalArgumentException("Field '" + field + "' value is not an array");
+        int depth = 0;
+        boolean inString = false;
+        for (int i = open; i < json.length(); i++) {
+            char c = json.charAt(i);
+            if (inString) {
+                if (c == '\\') i++; // skip the escaped char
+                else if (c == '"') inString = false;
+            } else if (c == '"') {
+                inString = true;
+            } else if (c == '[') {
+                depth++;
+            } else if (c == ']' && --depth == 0) {
+                return json.substring(open, i + 1);
+            }
+        }
+        throw new IllegalArgumentException("Unterminated array for field: " + field);
     }
 }

--- a/app/src/main/java/com/jaeckel/ethp2p/app/CommandHandler.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/CommandHandler.java
@@ -321,18 +321,32 @@ public class CommandHandler {
         if (addresses.isEmpty() || addresses.size() != rawElements) {
             return jsonError("addresses must be a non-empty array of 0x-prefixed 20-byte hex addresses");
         }
+        // De-duplicate (case-insensitively — hex casing is display-only): a
+        // repeated address in a build command is harmless intent, but the
+        // engine's LogIndex::new rejects duplicate watch entries, and the
+        // resulting false would be misblamed on the engine choice below.
+        java.util.LinkedHashMap<String, String> unique = new java.util.LinkedHashMap<>();
+        for (String a : addresses) unique.putIfAbsent(a.toLowerCase(), a);
         StringBuilder watch = new StringBuilder();
-        for (int i = 0; i < addresses.size(); i++) {
-            if (i > 0) watch.append(',');
-            watch.append("{\"address\":\"").append(addresses.get(i))
+        StringBuilder building = new StringBuilder();
+        for (String a : unique.values()) {
+            if (watch.length() > 0) {
+                watch.append(',');
+                building.append(',');
+            }
+            watch.append("{\"address\":\"").append(a)
                  .append("\",\"fromBlock\":").append(fromBlock).append('}');
+            building.append('"').append(a).append('"');
         }
         String config = "{\"enabled\":true,\"maxSpeed\":true,\"watch\":[" + watch + "]}";
         if (!handle.setLogIndexConfig(config)) {
-            return jsonError("log index config rejected (is this daemon on the Rust engine? start with -Pengine=rust)");
+            // False has several causes; name them all rather than misdirect.
+            return jsonError("log index config rejected — not the Rust engine "
+                    + "(start with -Pengine=rust), engine not running, or the config "
+                    + "conflicts with the existing subscription's topic restrictions");
         }
-        return "{\"ok\":true,\"building\":" + addressesJson
-                + ",\"note\":\"poll logindex-status until complete, then export-logindex <path>\"}";
+        return "{\"ok\":true,\"building\":[" + building
+                + "],\"note\":\"poll logindex-status until complete, then export-logindex <path>\"}";
     }
 
     // -------------------------------------------------------------------------

--- a/app/src/main/java/com/jaeckel/ethp2p/app/DaemonClient.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/DaemonClient.java
@@ -166,6 +166,19 @@ public class DaemonClient {
                 yield "{\"cmd\":\"resolve-ens-interface\",\"name\":\"" + esc(args[1])
                     + "\",\"interfaceId\":\"" + esc(args[2]) + "\"}";
             }
+            case "import-logindex" -> {
+                if (args.length < 2) throw new IllegalArgumentException(
+                    "Usage: import-logindex <file> [<file> ...]");
+                StringBuilder sb = new StringBuilder("{\"cmd\":\"import-logindex\",\"paths\":[");
+                for (int i = 1; i < args.length; i++) {
+                    if (i > 1) sb.append(',');
+                    // Absolute: the daemon's working directory is not the caller's.
+                    sb.append('"')
+                      .append(esc(java.nio.file.Path.of(args[i]).toAbsolutePath().normalize().toString()))
+                      .append('"');
+                }
+                yield sb.append("]}").toString();
+            }
             default -> "{\"cmd\":\"" + esc(cmd) + "\"}";
         };
     }

--- a/app/src/main/java/com/jaeckel/ethp2p/app/DaemonClient.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/DaemonClient.java
@@ -179,6 +179,33 @@ public class DaemonClient {
                 }
                 yield sb.append("]}").toString();
             }
+            case "export-logindex" -> {
+                if (args.length < 2) throw new IllegalArgumentException(
+                    "Usage: export-logindex <outFile>");
+                yield "{\"cmd\":\"export-logindex\",\"path\":\""
+                    + esc(java.nio.file.Path.of(args[1]).toAbsolutePath().normalize().toString()) + "\"}";
+            }
+            case "build-logindex" -> {
+                // build-logindex <0xAddr> [<0xAddr> ...] [--from <block>]
+                long from = 0;
+                StringBuilder addrs = new StringBuilder();
+                for (int i = 1; i < args.length; i++) {
+                    if ("--from".equals(args[i])) {
+                        if (i + 1 >= args.length) throw new IllegalArgumentException(
+                            "--from needs a block number");
+                        from = Long.parseLong(args[++i]);
+                    } else {
+                        if (addrs.length() > 0) addrs.append(',');
+                        addrs.append('"').append(esc(args[i])).append('"');
+                    }
+                }
+                if (addrs.length() == 0) throw new IllegalArgumentException(
+                    "Usage: build-logindex <0xAddr> [<0xAddr> ...] [--from <deploymentBlock>]\n"
+                    + "  --from defaults to 0 (undershooting cannot lie, it only walks further;\n"
+                    + "  pass the earliest deployment block to bound the backfill)");
+                yield "{\"cmd\":\"build-logindex\",\"fromBlock\":" + from
+                    + ",\"addresses\":[" + addrs + "]}";
+            }
             default -> "{\"cmd\":\"" + esc(cmd) + "\"}";
         };
     }

--- a/docs/eth-getlogs-design.md
+++ b/docs/eth-getlogs-design.md
@@ -1,10 +1,12 @@
 # eth_getLogs: scoped, verified log index (design)
 
-Status: accepted design, implementation in progress on `feat/eth-getlogs`.
+Status: accepted design, implemented (iteration 1 on `feat/eth-getlogs`;
+generic build/import/export on `feat/logindex-import` — see §Import below).
 Scope decision (2026-08-01): **iteration 1 sources everything from EL/CL peers**;
-shipping pre-built index seeds with an app is a later optimization layered on the
-same store. The feature is **opt-in** per network and scoped to a configured
-**watch-list** of contracts (kohaku's privacy contracts are the motivating set).
+scope extension (2026-08-14): the index is **generic** — any address set can be
+indexed (`build-logindex`), exported as a portable snapshot, and imported on
+any host of the same chain. The feature is **opt-in** per network; the shipped
+**watch-list** preset (kohaku's privacy contracts) is one config among many.
 
 ## Why
 
@@ -187,6 +189,73 @@ router/API changes in this design already accommodate it.
 4. Backfill walker (batch header walk, bloom skip, peer rotation/backoff,
    checkpointing) + Sepolia end-to-end run against the kohaku preset.
 5. Hosts: settings plumbing + opt-in UI + kohaku preset data.
-6. Follow-ups (separate): index-seed import/export (the bundling
-   optimization), Unchained-Index-assisted discovery, JVM twin, `watch`-channel
-   head notifications, EIP-7745 alignment.
+6. Generic build / import / export — DONE (2026-08-14), see §Import below.
+7. Follow-ups (separate): Unchained-Index-assisted discovery, JVM twin,
+   `watch`-channel head notifications, EIP-7745 alignment, per-entry
+   frontiers (see §Import, canonical-shape note).
+
+## Import: generic build, portable snapshots, merge (v2 format)
+
+The snapshot format is **self-describing** (`MLIX` v2): the frame carries a
+**chain tag** (network id + EL genesis hash, checked on every load — logs are
+keyed by block-global `(block, log_index)`, so a foreign chain's file would
+silently collide keys and fabricate coverage) and the full **watch-table**
+(address, from_block, topic0s, display name), so a file can be imported on a
+host that has never seen its config. v1 files (fingerprint-keyed) still load
+for upgrade — the next checkpoint rewrites them as v2 — but are refused on the
+portable path: they name no subscription set.
+
+**Generator (daemon, Rust engine):**
+
+    ./gradlew :app:run -Pengine=rust                    # generator daemon
+    :app:run -Pargs="build-logindex 0xAAA… 0xBBB… --from 14173129"
+    :app:run -Pargs=logindex-status                     # poll to complete
+    :app:run -Pargs="export-logindex /tmp/mainnet-privacy.db"
+
+`build-logindex` takes plain addresses (no preset), subscribes them at max
+download speed, and bakes a best-effort **ENS reverse name** into each entry
+(forward-verified via `EnsApi.reverseResolve`; a failed lookup leaves the
+entry unnamed and never gates indexing). `--from` is a trust assertion:
+`LogIndex::query` clamps its coverage requirement to it, so overshooting the
+real deployment silently hides events; undershooting (the default 0) only
+walks further.
+
+**Import** (`import_log_index_files`, ABI v23): hosts pick snapshot files
+(desktop AWT dialog / Android SAF / iOS document picker; the daemon has
+`import-logindex <file>…` plus the zero-effort drop-in — a portable file at
+`dataDir/logindex[-net].db` activates itself at start). The engine merges
+all-or-nothing with its current index and starts catch-up immediately for
+every imported address via the existing walker/bridge/appender. Trust: an
+imported file is data CLAIMED VERIFIED by whoever generated it — the same
+standing as the node's own snapshot — so import is a deliberate user act on
+the hosts, never something fetched.
+
+**Merge rules** (`LogIndex::merge`): watch union (same address requires equal
+topic0 sets — a span's meaning includes the restriction it was indexed under;
+`from_block` = min; name = first non-empty), coverage clamped to the MINIMUM
+of the sources' own highs and unioned per address, logs kept only inside the
+merged span, cursor = the deepest trust edge. The output is **canonical** —
+every present span shares one global high, cursor at the global low — because
+that is the only shape the appender/walker pair can resume (`append_block`
+demands each new block adjoin EVERY live entry's span; per-entry frontiers
+would wedge the appender). The min-high clamp is also what resolves
+same-address disjoint spans: the lower, deployment-anchored history survives
+and the band above re-indexes — re-fetched, never trusted from the staler
+file. Redundant sources (subset coverage, nothing new) are pruned first so a
+stale re-import cannot drag the merged high back in time. Lifting the
+canonical-shape constraint (true per-entry frontiers) is the tracked follow-up
+that would make merges lossless; it needs append/bridge machinery per entry.
+
+**Additive config (behavior change in v23):** `set_log_index_config` unions
+the pushed config with the already-subscribed set (live index, or on boot the
+portable snapshot's own watch-table). Without this, every host restart's
+preset push would fingerprint-mismatch an imported index into a full
+re-index. Coverage survives bit flips, renames, and LOWERED from_blocks; a
+genuinely new address or changed topic set still re-indexes under the union.
+
+**Naming:** the generator bakes ENS reverse names at build time; for
+snapshots that arrive unnamed, a naming pass inside the appender task
+resolves one unnamed address per tick (forward-verified `EnsQuery::Reverse`,
+30s-bounded, ≤3 attempts each) and fills ONLY empty names — a baked-in or
+host-pushed name outranks a late lookup. Names are excluded from the config
+fingerprint: renaming never costs a re-index.

--- a/docs/eth-getlogs-design.md
+++ b/docs/eth-getlogs-design.md
@@ -212,10 +212,11 @@ portable path: they name no subscription set.
     :app:run -Pargs=logindex-status                     # poll to complete
     :app:run -Pargs="export-logindex /tmp/mainnet-privacy.db"
 
-`build-logindex` takes plain addresses (no preset), subscribes them at max
-download speed, and bakes a best-effort **ENS reverse name** into each entry
-(forward-verified via `EnsApi.reverseResolve`; a failed lookup leaves the
-entry unnamed and never gates indexing). `--from` is a trust assertion:
+`build-logindex` takes plain addresses (no preset) and subscribes them at max
+download speed. Entries are written UNNAMED by design — display names are
+cosmetic, exist purely so the Index tab shows which contracts' logs are
+available, and are filled in by the importing wallet itself (see §Naming
+below); the generator has no naming duties. `--from` is a trust assertion:
 `LogIndex::query` clamps its coverage requirement to it, so overshooting the
 real deployment silently hides events; undershooting (the default 0) only
 walks further.
@@ -234,28 +235,43 @@ the hosts, never something fetched.
 topic0 sets — a span's meaning includes the restriction it was indexed under;
 `from_block` = min; name = first non-empty), coverage clamped to the MINIMUM
 of the sources' own highs and unioned per address, logs kept only inside the
-merged span, cursor = the deepest trust edge. The output is **canonical** —
-every present span shares one global high, cursor at the global low — because
-that is the only shape the appender/walker pair can resume (`append_block`
-demands each new block adjoin EVERY live entry's span; per-entry frontiers
-would wedge the appender). The min-high clamp is also what resolves
-same-address disjoint spans: the lower, deployment-anchored history survives
-and the band above re-indexes — re-fetched, never trusted from the staler
-file. Redundant sources (subset coverage, nothing new) are pruned first so a
-stale re-import cannot drag the merged high back in time. Lifting the
-canonical-shape constraint (true per-entry frontiers) is the tracked follow-up
-that would make merges lossless; it needs append/bridge machinery per entry.
+merged span, cursor = the deepest source trust edge the walk can RESUME from
+(`walk_resumable`: every incomplete span must sit at or below the cursor —
+the walker only descends, so a hole above it is unreachable forever; when no
+source cursor qualifies, the cursor is dropped and the appender re-seeds it
+at the top, making the walker re-descend through the kept spans — headers-only
+where the bloom misses — until every hole closes). The output is **canonical**
+— every present span shares one global high — because that is the only shape
+the appender/walker pair can resume (`append_block` demands each new block
+adjoin EVERY live entry's span; per-entry frontiers would wedge the appender).
+A residual gap at apply time self-heals the same way: the walker drops its
+cursor and re-descends rather than re-fetching the same batch forever. The
+min-high clamp is also what resolves same-address disjoint spans: the lower,
+deployment-anchored history survives and the band above re-indexes —
+re-fetched, never trusted from the staler file. Redundant sources (subset
+coverage, nothing new) are pruned first so a stale re-import cannot drag the
+merged high back in time. Lifting the canonical-shape constraint (true
+per-entry frontiers) is the tracked follow-up that would make merges lossless;
+it needs append/bridge machinery per entry.
 
 **Additive config (behavior change in v23):** `set_log_index_config` unions
 the pushed config with the already-subscribed set (live index, or on boot the
 portable snapshot's own watch-table). Without this, every host restart's
 preset push would fingerprint-mismatch an imported index into a full
-re-index. Coverage survives bit flips, renames, and LOWERED from_blocks; a
-genuinely new address or changed topic set still re-indexes under the union.
+re-index. Coverage survives bit flips, renames, LOWERED from_blocks (the
+cursor drops when the new hole sits above it — the walk re-descends), and
+even genuinely NEW addresses (the push merges with the existing index as a
+config-only source, so a preset that grew — or a preset pushed on top of a
+dropped-in snapshot — keeps the accumulated coverage and re-descends for the
+new entries). Only a changed topic set replaces outright: a span's meaning
+includes its restriction, nothing is mergeable.
 
-**Naming:** the generator bakes ENS reverse names at build time; for
-snapshots that arrive unnamed, a naming pass inside the appender task
-resolves one unnamed address per tick (forward-verified `EnsQuery::Reverse`,
-30s-bounded, ≤3 attempts each) and fills ONLY empty names — a baked-in or
-host-pushed name outranks a late lookup. Names are excluded from the config
+**Naming:** display names are cosmetic — they exist so the Index tab shows
+which contracts' logs are available — and they are resolved IN THE IMPORTING
+WALLET, not at generation (owner's call, 2026-08-14: the generator writes
+unnamed entries). A naming pass inside the appender task resolves one
+unnamed address per tick (forward-verified `EnsQuery::Reverse` against the
+Auto root ladder, 30s-bounded, ≤3 attempts each) and fills ONLY empty
+names — a host-pushed preset label outranks a late lookup, and a name that
+cannot resolve just stays an address. Names are excluded from the config
 fingerprint: renaming never costs a re-index.

--- a/docs/eth-getlogs-design.md
+++ b/docs/eth-getlogs-design.md
@@ -192,7 +192,9 @@ router/API changes in this design already accommodate it.
 6. Generic build / import / export — DONE (2026-08-14), see §Import below.
 7. Follow-ups (separate): Unchained-Index-assisted discovery, JVM twin,
    `watch`-channel head notifications, EIP-7745 alignment, per-entry
-   frontiers (see §Import, canonical-shape note).
+   frontiers (see §Import, canonical-shape note), snapshot provenance
+   (imported-coverage marker / signed snapshots) and an explicit
+   unsubscribe surface (see §Import, trust notes).
 
 ## Import: generic build, portable snapshots, merge (v2 format)
 
@@ -221,7 +223,7 @@ below); the generator has no naming duties. `--from` is a trust assertion:
 real deployment silently hides events; undershooting (the default 0) only
 walks further.
 
-**Import** (`import_log_index_files`, ABI v23): hosts pick snapshot files
+**Import** (`import_log_index_files`, ABI v24): hosts pick snapshot files
 (desktop AWT dialog / Android SAF / iOS document picker; the daemon has
 `import-logindex <file>…` plus the zero-effort drop-in — a portable file at
 `dataDir/logindex[-net].db` activates itself at start). The engine merges
@@ -229,7 +231,14 @@ all-or-nothing with its current index and starts catch-up immediately for
 every imported address via the existing walker/bridge/appender. Trust: an
 imported file is data CLAIMED VERIFIED by whoever generated it — the same
 standing as the node's own snapshot — so import is a deliberate user act on
-the hosts, never something fetched.
+the hosts, never something fetched. Two properties to state plainly
+(review, 2026-08-14): served logs do not distinguish locally-verified from
+imported coverage (a provenance marker in the status JSON, or a signed
+snapshot format, is tracked follow-up hardening); and subscriptions are
+currently ADD-ONLY — config pushes union and imports merge, so an address
+can only leave the index via a topic-conflict replace or a cache wipe. An
+explicit unsubscribe/replace surface is follow-up work; until then, note
+that an imported subscription is sticky.
 
 **Merge rules** (`LogIndex::merge`): watch union (same address requires equal
 topic0 sets — a span's meaning includes the restriction it was indexed under;

--- a/myotis-api/src/main/java/io/myotis/api/ChainHandle.java
+++ b/myotis-api/src/main/java/io/myotis/api/ChainHandle.java
@@ -186,6 +186,18 @@ public interface ChainHandle {
     }
 
     /**
+     * Export the current log index as a portable snapshot file at
+     * {@code path} (finality-clamped, self-describing — importable via
+     * {@link #importLogIndexFiles} anywhere on the same chain; partial
+     * coverage exports honestly, the importer's catch-up finishes the walk).
+     * Returns {@code {"ok":true}} or {@code {"error":...}}. Default: a
+     * stable not-supported error (the Java engine has no log index).
+     */
+    default String exportLogIndex(String path) {
+        return "{\"error\":\"log-index export is not supported by this engine\"}";
+    }
+
+    /**
      * Dial one specific EL peer by endpoint + secp256k1 public key (operator
      * debugging). Returns immediately after the connect is initiated.
      *

--- a/myotis-api/src/main/java/io/myotis/api/ChainHandle.java
+++ b/myotis-api/src/main/java/io/myotis/api/ChainHandle.java
@@ -172,6 +172,20 @@ public interface ChainHandle {
     }
 
     /**
+     * Import portable log-index snapshot files: {@code pathsJson} is a JSON
+     * array of absolute file paths, each a self-describing snapshot of this
+     * chain (produced by the daemon's {@code build-logindex} tool or another
+     * node's export). All-or-nothing merge into the node's index; importing
+     * is the opt-in, so catch-up for every imported address starts
+     * immediately. Returns {@code {"ok":true,"status":...}} or
+     * {@code {"error":...}}. Default: a stable not-supported error (the Java
+     * engine has no log index).
+     */
+    default String importLogIndexFiles(String pathsJson) {
+        return "{\"error\":\"log-index import is not supported by this engine\"}";
+    }
+
+    /**
      * Dial one specific EL peer by endpoint + secp256k1 public key (operator
      * debugging). Returns immediately after the connect is initiated.
      *

--- a/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
@@ -1050,6 +1050,12 @@ final class RustChainHandle implements ChainHandle, NodeStatusReads {
         return gated(() -> RustEngineNative.nativeImportLogIndexFiles(handle, pathsJson));
     }
 
+    /** Export the log index as a portable snapshot ({"ok":true} / {"error":...}). */
+    @Override
+    public String exportLogIndex(String path) {
+        return gated(() -> RustEngineNative.nativeExportLogIndex(handle, path));
+    }
+
     /**
      * Verified eth_getBlockReceipts: the receipts ARRAY JSON, the literal
      * {@code "null"} (verified unknown/future block or a never-verified hash),

--- a/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
@@ -1044,6 +1044,12 @@ final class RustChainHandle implements ChainHandle, NodeStatusReads {
         return gated(() -> RustEngineNative.nativeLogIndexStatusJson(handle));
     }
 
+    /** Import portable log-index snapshots ({"ok":...} / {"error":...}). */
+    @Override
+    public String importLogIndexFiles(String pathsJson) {
+        return gated(() -> RustEngineNative.nativeImportLogIndexFiles(handle, pathsJson));
+    }
+
     /**
      * Verified eth_getBlockReceipts: the receipts ARRAY JSON, the literal
      * {@code "null"} (verified unknown/future block or a never-verified hash),

--- a/myotis-engines/src/main/java/io/myotis/engines/RustEngineNative.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustEngineNative.java
@@ -37,7 +37,7 @@ final class RustEngineNative {
     private static final Logger log = LoggerFactory.getLogger(RustEngineNative.class);
 
     /** Must match {@code ABI_VERSION} in rust/myotis-engine/src/lib.rs. */
-    static final int EXPECTED_ABI_VERSION = 23; // 23: estimateGas JSON gained {"status":"revert","dataHex"}
+    static final int EXPECTED_ABI_VERSION = 24; // 24: + importLogIndexFiles (portable snapshot import)
 
     private static final boolean AVAILABLE = load();
 
@@ -337,6 +337,11 @@ final class RustEngineNative {
     /** Log-index status JSON (enabled, counts, coverage per entry). */
     static String nativeLogIndexStatusJson(long handle) {
         return Myotis_engineKt.logIndexStatusJson(handle);
+    }
+
+    /** Import portable log-index snapshots ({"ok":true,...} / {"error":...}). */
+    static String nativeImportLogIndexFiles(long handle, String pathsJson) {
+        return Myotis_engineKt.importLogIndexFiles(handle, nz(pathsJson));
     }
 
     /** Verified {@code eth_feeHistory} (feeHistory JSON / error). */

--- a/myotis-engines/src/main/java/io/myotis/engines/RustEngineNative.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustEngineNative.java
@@ -344,6 +344,11 @@ final class RustEngineNative {
         return Myotis_engineKt.importLogIndexFiles(handle, nz(pathsJson));
     }
 
+    /** Export the log index as a portable snapshot ({"ok":true} / {"error":...}). */
+    static String nativeExportLogIndex(long handle, String path) {
+        return Myotis_engineKt.exportLogIndex(handle, nz(path));
+    }
+
     /** Verified {@code eth_feeHistory} (feeHistory JSON / error). */
     static String nativeFeeHistoryJson(
             long handle, long blockCount, String newestBlockTag, String percentilesJson) {

--- a/myotis-engines/src/main/kotlin/uniffi/myotis_engine/myotis_engine.kt
+++ b/myotis-engines/src/main/kotlin/uniffi/myotis_engine/myotis_engine.kt
@@ -690,6 +690,8 @@ internal object IntegrityCheckingUniffiLib {
     ): Int
     external fun uniffi_myotis_engine_checksum_func_eth_call_overrides_json(
     ): Int
+    external fun uniffi_myotis_engine_checksum_func_export_log_index(
+    ): Int
     external fun uniffi_myotis_engine_checksum_func_fee_estimate_json(
     ): Int
     external fun uniffi_myotis_engine_checksum_func_fee_history_json(
@@ -772,6 +774,8 @@ internal object UniffiLib {
     external fun uniffi_myotis_engine_fn_func_eth_call_json(`handle`: Long,`from`: RustBuffer.ByValue,`to`: RustBuffer.ByValue,`data`: RustBuffer.ByValue,`value`: RustBuffer.ByValue,`block`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
     external fun uniffi_myotis_engine_fn_func_eth_call_overrides_json(`handle`: Long,`from`: RustBuffer.ByValue,`to`: RustBuffer.ByValue,`data`: RustBuffer.ByValue,`value`: RustBuffer.ByValue,`block`: RustBuffer.ByValue,`stateOverrides`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+    ): RustBuffer.ByValue
+    external fun uniffi_myotis_engine_fn_func_export_log_index(`handle`: Long,`path`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
     external fun uniffi_myotis_engine_fn_func_fee_estimate_json(`handle`: Long,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
@@ -969,6 +973,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_myotis_engine_checksum_func_eth_call_overrides_json() != 2974) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_myotis_engine_checksum_func_export_log_index() != 2966) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_myotis_engine_checksum_func_fee_estimate_json() != 39989) {
@@ -1448,6 +1455,22 @@ public object FfiConverterOptionalString: FfiConverterRustBuffer<kotlin.String?>
         FfiConverterString.lower(`value`),
         FfiConverterString.lower(`block`),
         FfiConverterString.lower(`stateOverrides`),_status)
+}
+    )
+    }
+    
+
+        /**
+         * Export the current log index as a portable snapshot file (the generator's
+         * output; finality-clamped, self-describing). `{"ok":true}` or `{"error":…}`.
+         */ fun `exportLogIndex`(`handle`: kotlin.Long, `path`: kotlin.String): kotlin.String {
+            return FfiConverterString.lift(
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_myotis_engine_fn_func_export_log_index(
+    
+        
+        FfiConverterLong.lower(`handle`),
+        FfiConverterString.lower(`path`),_status)
 }
     )
     }

--- a/myotis-engines/src/main/kotlin/uniffi/myotis_engine/myotis_engine.kt
+++ b/myotis-engines/src/main/kotlin/uniffi/myotis_engine/myotis_engine.kt
@@ -712,6 +712,8 @@ internal object IntegrityCheckingUniffiLib {
     ): Int
     external fun uniffi_myotis_engine_checksum_func_get_transaction_receipt_json(
     ): Int
+    external fun uniffi_myotis_engine_checksum_func_import_log_index_files(
+    ): Int
     external fun uniffi_myotis_engine_checksum_func_log_index_status_json(
     ): Int
     external fun uniffi_myotis_engine_checksum_func_pause_handle(
@@ -792,6 +794,8 @@ internal object UniffiLib {
     external fun uniffi_myotis_engine_fn_func_get_transaction_by_hash_json(`handle`: Long,`txHashHex`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
     external fun uniffi_myotis_engine_fn_func_get_transaction_receipt_json(`handle`: Long,`txHashHex`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+    ): RustBuffer.ByValue
+    external fun uniffi_myotis_engine_fn_func_import_log_index_files(`handle`: Long,`pathsJson`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
     external fun uniffi_myotis_engine_fn_func_log_index_status_json(`handle`: Long,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
@@ -998,6 +1002,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_myotis_engine_checksum_func_get_transaction_receipt_json() != 56168) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_myotis_engine_checksum_func_import_log_index_files() != 14078) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_myotis_engine_checksum_func_log_index_status_json() != 7764) {
@@ -1620,6 +1627,24 @@ public object FfiConverterOptionalString: FfiConverterRustBuffer<kotlin.String?>
         
         FfiConverterLong.lower(`handle`),
         FfiConverterString.lower(`txHashHex`),_status)
+}
+    )
+    }
+    
+
+        /**
+         * Import portable log-index snapshots (JSON array of absolute file paths;
+         * each file must be a self-describing snapshot of this handle's chain).
+         * All-or-nothing merge into the node's index; importing is the opt-in, so
+         * catch-up starts immediately. `{"ok":true,"status":…}` or `{"error":…}`.
+         */ fun `importLogIndexFiles`(`handle`: kotlin.Long, `pathsJson`: kotlin.String): kotlin.String {
+            return FfiConverterString.lift(
+    uniffiRustCall() { _status ->
+    UniffiLib.uniffi_myotis_engine_fn_func_import_log_index_files(
+    
+        
+        FfiConverterLong.lower(`handle`),
+        FfiConverterString.lower(`pathsJson`),_status)
 }
     )
     }

--- a/rust/include/myotis_engine.h
+++ b/rust/include/myotis_engine.h
@@ -164,6 +164,9 @@ char *myotis_log_index_status_json(int64_t handle);
  * chain; all-or-nothing merge, importing is the opt-in (catch-up starts
  * immediately). {"ok":true,"status":...} or {"error":...}. */
 char *myotis_import_log_index_files(int64_t handle, const char *paths_json);
+/* v23: export the current index as a portable snapshot at path
+ * (finality-clamped, self-describing). {"ok":true} or {"error":...}. */
+char *myotis_export_log_index(int64_t handle, const char *path);
 
 #ifdef __cplusplus
 }

--- a/rust/include/myotis_engine.h
+++ b/rust/include/myotis_engine.h
@@ -28,7 +28,7 @@ extern "C" {
  * rust/myotis-engine/src/lib.rs and is pinned to it by a capi.rs unit test
  * (header_pins_the_current_abi_version), so a bump that forgets this file
  * fails `cargo test`. Gate on this macro — do not copy the number. */
-#define MYOTIS_ABI_VERSION 23
+#define MYOTIS_ABI_VERSION 24
 
 /* Availability + ABI handshake. Installs the log ring subscriber (idempotent)
  * and returns the engine's ABI version; refuse to call anything else if it
@@ -158,6 +158,12 @@ void myotis_string_free(char *s);
 char *myotis_get_logs_json(int64_t handle, const char *filter_json);
 bool myotis_set_log_index_config(int64_t handle, const char *config_json);
 char *myotis_log_index_status_json(int64_t handle);
+
+/* v24: import portable log-index snapshots. paths_json is a JSON array of
+ * absolute file paths, each a self-describing snapshot of this handle's
+ * chain; all-or-nothing merge, importing is the opt-in (catch-up starts
+ * immediately). {"ok":true,"status":...} or {"error":...}. */
+char *myotis_import_log_index_files(int64_t handle, const char *paths_json);
 
 #ifdef __cplusplus
 }

--- a/rust/include/myotis_engine.h
+++ b/rust/include/myotis_engine.h
@@ -164,7 +164,7 @@ char *myotis_log_index_status_json(int64_t handle);
  * chain; all-or-nothing merge, importing is the opt-in (catch-up starts
  * immediately). {"ok":true,"status":...} or {"error":...}. */
 char *myotis_import_log_index_files(int64_t handle, const char *paths_json);
-/* v23: export the current index as a portable snapshot at path
+/* v24: export the current index as a portable snapshot at path
  * (finality-clamped, self-describing). {"ok":true} or {"error":...}. */
 char *myotis_export_log_index(int64_t handle, const char *path);
 

--- a/rust/myotis-engine/src/capi.rs
+++ b/rust/myotis-engine/src/capi.rs
@@ -642,3 +642,16 @@ pub unsafe extern "C" fn myotis_import_log_index_files(
         None => std::ptr::null_mut(),
     }
 }
+
+/// Export the log index as a portable snapshot (see ffi::export_log_index).
+/// Returned string must be freed with `myotis_string_free`.
+#[no_mangle]
+pub unsafe extern "C" fn myotis_export_log_index(
+    handle: i64,
+    path: *const std::os::raw::c_char,
+) -> *mut std::os::raw::c_char {
+    match read_string(path) {
+        Some(p) => into_c(crate::host::export_log_index(handle, &p)),
+        None => std::ptr::null_mut(),
+    }
+}

--- a/rust/myotis-engine/src/capi.rs
+++ b/rust/myotis-engine/src/capi.rs
@@ -629,3 +629,16 @@ pub unsafe extern "C" fn myotis_set_log_index_config(
 pub unsafe extern "C" fn myotis_log_index_status_json(handle: i64) -> *mut std::os::raw::c_char {
     into_c(crate::host::log_index_status_json(handle))
 }
+
+/// Import portable log-index snapshots (see ffi::import_log_index_files).
+/// Returned string must be freed with `myotis_string_free`.
+#[no_mangle]
+pub unsafe extern "C" fn myotis_import_log_index_files(
+    handle: i64,
+    paths_json: *const std::os::raw::c_char,
+) -> *mut std::os::raw::c_char {
+    match read_string(paths_json) {
+        Some(p) => into_c(crate::host::import_log_index_files(handle, &p)),
+        None => std::ptr::null_mut(),
+    }
+}

--- a/rust/myotis-engine/src/ffi.rs
+++ b/rust/myotis-engine/src/ffi.rs
@@ -306,3 +306,10 @@ pub fn log_index_status_json(handle: i64) -> String {
 pub fn import_log_index_files(handle: i64, paths_json: String) -> String {
     crate::host::import_log_index_files(handle, &paths_json)
 }
+
+/// Export the current log index as a portable snapshot file (the generator's
+/// output; finality-clamped, self-describing). `{"ok":true}` or `{"error":…}`.
+#[uniffi::export]
+pub fn export_log_index(handle: i64, path: String) -> String {
+    crate::host::export_log_index(handle, &path)
+}

--- a/rust/myotis-engine/src/ffi.rs
+++ b/rust/myotis-engine/src/ffi.rs
@@ -297,3 +297,12 @@ pub fn set_log_index_config(handle: i64, config_json: String) -> bool {
 pub fn log_index_status_json(handle: i64) -> String {
     crate::host::log_index_status_json(handle)
 }
+
+/// Import portable log-index snapshots (JSON array of absolute file paths;
+/// each file must be a self-describing snapshot of this handle's chain).
+/// All-or-nothing merge into the node's index; importing is the opt-in, so
+/// catch-up starts immediately. `{"ok":true,"status":…}` or `{"error":…}`.
+#[uniffi::export]
+pub fn import_log_index_files(handle: i64, paths_json: String) -> String {
+    crate::host::import_log_index_files(handle, &paths_json)
+}

--- a/rust/myotis-engine/src/host.rs
+++ b/rust/myotis-engine/src/host.rs
@@ -337,6 +337,12 @@ fn spin_up(handle: i64, from: SpinUpFrom) -> bool {
                 reader.set_served_block_window(w);
             }
         }
+        // Activate a portable log-index snapshot found on disk (the drop-in
+        // path): its presence in the engine's own data dir is the opt-in —
+        // the daemon has no settings surface at all, and hosts that do have
+        // one push their config right after start, which unions with (and
+        // can disable) what this activated.
+        reader.activate_log_index_from_disk(engine.rt.handle());
     }
     // Re-lock and publish ONLY if the entry is still the same Created/Paused one
     // we spun up from: a concurrent stop() may have removed it, or a racing
@@ -2237,6 +2243,34 @@ fn parse_log_index_config(
         }
     }
     Some(myotis_net::el::logindex::LogIndexConfig { enabled, max_speed, watch })
+}
+
+/// Import portable log-index snapshots: `paths_json` is a JSON array of
+/// absolute file paths (each a v2 self-describing snapshot of THIS handle's
+/// chain). They merge with the node's current index (all-or-nothing), the
+/// result is persisted + installed, and — since importing IS the opt-in —
+/// the appender is spawned so catch-up starts immediately.
+/// Returns `{"ok":true,"status":<status json>}` or `{"error":"..."}`.
+pub fn import_log_index_files(handle: i64, paths_json: &str) -> String {
+    let paths = match serde_json::from_str::<Vec<String>>(paths_json) {
+        Ok(p) if !p.is_empty() && p.iter().all(|s| !s.trim().is_empty()) => {
+            p.into_iter().map(std::path::PathBuf::from).collect::<Vec<_>>()
+        }
+        _ => return eljson::error_json("expected a non-empty JSON array of file paths"),
+    };
+    let Some(engine) = engine() else {
+        return eljson::error_json("engine unavailable");
+    };
+    let Ok((reader, _, _)) = snapshot_reader(engine, handle) else {
+        return eljson::error_json("node is not running");
+    };
+    match reader.import_log_index(&paths) {
+        Ok(()) => {
+            reader.ensure_log_index_appender(engine.rt.handle());
+            format!("{{\"ok\":true,\"status\":{}}}", log_index_status_json(handle))
+        }
+        Err(e) => eljson::error_json(&e),
+    }
 }
 
 /// Index status for hosts/UI: enabled, log count, backfill cursor, and per

--- a/rust/myotis-engine/src/host.rs
+++ b/rust/myotis-engine/src/host.rs
@@ -2273,6 +2273,25 @@ pub fn import_log_index_files(handle: i64, paths_json: &str) -> String {
     }
 }
 
+/// Export the current index as a portable snapshot at `path` (the
+/// generator's output; finality-clamped, self-describing v2 — importable
+/// anywhere on the same chain). `{"ok":true}` or `{"error":"..."}`.
+pub fn export_log_index(handle: i64, path: &str) -> String {
+    if path.trim().is_empty() {
+        return eljson::error_json("empty export path");
+    }
+    let Some(engine) = engine() else {
+        return eljson::error_json("engine unavailable");
+    };
+    let Ok((reader, _, _)) = snapshot_reader(engine, handle) else {
+        return eljson::error_json("node is not running");
+    };
+    match reader.export_log_index(std::path::Path::new(path)) {
+        Ok(()) => "{\"ok\":true}".to_string(),
+        Err(e) => eljson::error_json(&e),
+    }
+}
+
 /// Index status for hosts/UI: enabled, log count, backfill cursor, and per
 /// watch entry the covered span (absent while nothing is indexed).
 pub fn log_index_status_json(handle: i64) -> String {

--- a/rust/myotis-engine/src/host.rs
+++ b/rust/myotis-engine/src/host.rs
@@ -2176,8 +2176,8 @@ mod tests {
 // ---------------------------------------------------------------------------
 
 /// Install the watch-list config: `{"enabled":bool,"watch":[{"address":"0x..",
-/// "fromBlock":n,"topic0s":["0x..",..]?}]}`. False on malformed input,
-/// duplicate addresses, or an unavailable reader.
+/// "fromBlock":n,"topic0s":["0x..",..]?,"name":"..."?}]}`. False on malformed
+/// input, duplicate addresses, or an unavailable reader.
 pub fn set_log_index_config_json(handle: i64, config_json: &str) -> bool {
     let Ok(v) = serde_json::from_str::<serde_json::Value>(config_json) else {
         return false;
@@ -2227,7 +2227,13 @@ fn parse_log_index_config(
                     topic0s.push(t.as_str().and_then(parse_word32)?);
                 }
             }
-            watch.push(myotis_net::el::logindex::WatchEntry { address, from_block, topic0s });
+            // Optional cosmetic label (empty = unnamed). A non-string name is
+            // malformed like any other wrong type — never silently coerced.
+            if e.get("name").is_some_and(|n| !n.is_string() && !n.is_null()) {
+                return None;
+            }
+            let name = e.get("name").and_then(|n| n.as_str()).unwrap_or("").to_string();
+            watch.push(myotis_net::el::logindex::WatchEntry { address, from_block, topic0s, name });
         }
     }
     Some(myotis_net::el::logindex::LogIndexConfig { enabled, max_speed, watch })
@@ -2314,6 +2320,14 @@ fn build_log_index_status(
             }
             s.push_str("\",\"fromBlock\":");
             s.push_str(&w.from_block.to_string());
+            if !w.name.is_empty() {
+                // serde_json handles the escaping (names come from hosts or
+                // ENS reverse records — arbitrary strings).
+                if let Ok(quoted) = serde_json::to_string(&w.name) {
+                    s.push_str(",\"name\":");
+                    s.push_str(&quoted);
+                }
+            }
             if let Some((low, high)) = c.span {
                 s.push_str(",\"coveredLow\":");
                 s.push_str(&low.to_string());
@@ -2569,11 +2583,33 @@ mod log_index_json_tests {
     }
 
     #[test]
+    fn parses_optional_names_and_reflects_them_in_status() {
+        let addr = format!("0x{}", "11".repeat(20));
+        let named = cfg(&format!(
+            r#"{{"enabled":true,"watch":[{{"address":"{addr}","fromBlock":5,"name":"tornado.registry.eth"}}]}}"#
+        ))
+        .unwrap();
+        assert_eq!(named.watch[0].name, "tornado.registry.eth");
+        // Absent name → empty (unnamed); a non-string name is malformed.
+        let unnamed = cfg(&format!(r#"{{"enabled":true,"watch":[{{"address":"{addr}","fromBlock":5}}]}}"#)).unwrap();
+        assert!(unnamed.watch[0].name.is_empty());
+        assert!(cfg(&format!(r#"{{"enabled":true,"watch":[{{"address":"{addr}","fromBlock":5,"name":7}}]}}"#)).is_none());
+        // Status carries the name for named entries and omits the key for
+        // unnamed ones (shape-stable for pre-name hosts).
+        let ix = myotis_net::el::logindex::LogIndex::new(named).unwrap();
+        let s = build_log_index_status(&ix, None, 0);
+        assert!(s.contains("\"name\":\"tornado.registry.eth\""), "{s}");
+        let ix = myotis_net::el::logindex::LogIndex::new(unnamed).unwrap();
+        assert!(!build_log_index_status(&ix, None, 0).contains("\"name\""));
+    }
+
+    #[test]
     fn status_json_carries_progress_keys() {
         let w = myotis_net::el::logindex::WatchEntry {
             address: [0x11; 20],
             from_block: 100,
             topic0s: vec![],
+            name: String::new(),
         };
         let cfg = myotis_net::el::logindex::LogIndexConfig {
             enabled: true,

--- a/rust/myotis-engine/src/lib.rs
+++ b/rust/myotis-engine/src/lib.rs
@@ -75,7 +75,11 @@ uniffi::setup_scaffolding!();
 /// v23: nativeEstimateGasJson may now return `{"status":"revert","dataHex"}`
 ///      for an estimated transaction that reverts (a verified answer the host
 ///      serves as JSON-RPC code 3) — a payload extension, no signature change.
-pub const ABI_VERSION: i32 = 23;
+/// v24: added import_log_index_files (merge portable log-index snapshots into
+///      the node's index — the generic import path, docs/eth-getlogs-design.md).
+///      set_log_index_config became ADDITIVE (unions with the stored
+///      subscription set) — a behavior change, no signature change.
+pub const ABI_VERSION: i32 = 24;
 
 // Keep the workspace edge alive so `cargo build -p myotis-engine` type-checks the
 // consensus crate too.

--- a/rust/myotis-engine/src/lib.rs
+++ b/rust/myotis-engine/src/lib.rs
@@ -75,8 +75,8 @@ uniffi::setup_scaffolding!();
 /// v23: nativeEstimateGasJson may now return `{"status":"revert","dataHex"}`
 ///      for an estimated transaction that reverts (a verified answer the host
 ///      serves as JSON-RPC code 3) — a payload extension, no signature change.
-/// v24: added import_log_index_files (merge portable log-index snapshots into
-///      the node's index — the generic import path, docs/eth-getlogs-design.md).
+/// v24: added import_log_index_files + export_log_index (portable log-index
+///      snapshots: the generic import/export path, docs/eth-getlogs-design.md).
 ///      set_log_index_config became ADDITIVE (unions with the stored
 ///      subscription set) — a behavior change, no signature change.
 pub const ABI_VERSION: i32 = 24;

--- a/rust/myotis-net/src/el/logindex.rs
+++ b/rust/myotis-net/src/el/logindex.rs
@@ -781,6 +781,209 @@ impl LogIndex {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Merge: combine self-describing snapshots (import). The output is CANONICAL —
+// every present span shares one global high and the cursor sits at the global
+// low — because that is the only shape the appender/walker pair can resume:
+// `append_block` demands each new block adjoin EVERY live entry's span, so
+// per-entry frontiers at different heights would wedge the appender on its
+// first tick. Canonicalization is what turns "import then catch up" into the
+// machinery that already exists (walker descends to the new lows, bridge +
+// appender close the top) instead of new per-entry reconciliation code.
+// ---------------------------------------------------------------------------
+
+/// Why a set of snapshots cannot be merged.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MergeError {
+    /// No sources given.
+    Empty,
+    /// A source belongs to another network. Merging it would key logs of a
+    /// foreign chain into this chain's block numbers — fabricated coverage.
+    ChainMismatch { expected: ChainTag, got: ChainTag },
+    /// Two sources watch the same address under DIFFERENT topic0 sets. A
+    /// coverage span's meaning includes the topic restriction it was indexed
+    /// under; unioning restrictions would claim logs nobody stored. Refused
+    /// rather than resolved — re-generate one source with matching topics.
+    TopicConflict([u8; 20]),
+}
+
+impl LogIndex {
+    /// Merge portable snapshots (all of one chain) into a single canonical
+    /// index. Rules:
+    ///
+    /// - watch union — same address requires equal topic0 sets
+    ///   ([`MergeError::TopicConflict`]); `from_block` = min (undershooting
+    ///   cannot lie); name = first non-empty in input order.
+    /// - sources that contribute nothing (no new address, no lower
+    ///   `from_block`, no coverage extension) are dropped FIRST, so a stale
+    ///   re-import cannot drag the global high back in time.
+    /// - coverage: global high `H` = min over contributing sources' own
+    ///   highs; every span is clamped to `H` (one whose low is above `H`
+    ///   vanishes — its blocks re-index later) and unioned per address. With
+    ///   canonical inputs every surviving span contains `H`, so the union is
+    ///   contiguous and single-span coverage suffices. The band above `H` is
+    ///   re-covered by the existing bridge/appender — re-fetched, never
+    ///   trusted from the staler file.
+    /// - logs: kept iff inside the merged span of their address's entry —
+    ///   anything else is unreachable by the coverage-honest query anyway.
+    /// - cursor: the lowest source cursor (the deepest verified trust edge).
+    ///
+    /// Non-canonical inputs (hand-crafted files) degrade safely: a span that
+    /// cannot share `H` goes dormant (None — re-indexed), a cursor above some
+    /// span's low is dropped (the appender re-seeds it).
+    ///
+    /// The output's `enabled`/`max_speed` are false: runtime bits the
+    /// installing host decides, never file content.
+    pub fn merge(sources: Vec<(ChainTag, LogIndex)>) -> Result<(ChainTag, LogIndex), MergeError> {
+        let Some(expected) = sources.first().map(|(t, _)| *t) else {
+            return Err(MergeError::Empty);
+        };
+        if let Some((got, _)) = sources.iter().find(|(t, _)| *t != expected) {
+            return Err(MergeError::ChainMismatch { expected, got: *got });
+        }
+        let mut sources: Vec<LogIndex> = sources.into_iter().map(|(_, ix)| ix).collect();
+        // Topic conflicts are structural — check before any pruning so a
+        // conflicting pair is refused even when one side would be pruned.
+        for (i, a) in sources.iter().enumerate() {
+            for b in sources.iter().skip(i + 1) {
+                for wa in &a.config.watch {
+                    if let Some(wb) = b.config.watch.iter().find(|w| w.address == wa.address) {
+                        let mut ta = wa.topic0s.clone();
+                        let mut tb = wb.topic0s.clone();
+                        ta.sort_unstable();
+                        tb.sort_unstable();
+                        if ta != tb {
+                            return Err(MergeError::TopicConflict(wa.address));
+                        }
+                    }
+                }
+            }
+        }
+        // Drop redundant sources: everything they declare and cover is
+        // already declared and covered (at least as deeply) by the rest.
+        loop {
+            let redundant = (0..sources.len()).find(|&i| {
+                sources.len() > 1 && {
+                    let rest: Vec<&LogIndex> = sources
+                        .iter()
+                        .enumerate()
+                        .filter(|(j, _)| *j != i)
+                        .map(|(_, s)| s)
+                        .collect();
+                    sources[i].config.watch.iter().all(|w| {
+                        rest.iter().any(|r| {
+                            r.config.watch.iter().zip(r.coverage.iter()).any(|(rw, rc)| {
+                                rw.address == w.address
+                                    && rw.from_block <= w.from_block
+                                    && match sources[i].coverage_of(&w.address).and_then(|c| c.span) {
+                                        None => true,
+                                        Some((low, high)) => matches!(
+                                            rc.span,
+                                            Some((rl, rh)) if rl <= low && high <= rh
+                                        ),
+                                    }
+                            })
+                        })
+                    })
+                }
+            });
+            match redundant {
+                Some(i) => {
+                    sources.remove(i);
+                }
+                None => break,
+            }
+        }
+        // Union the watch-lists (config order: first source first).
+        let mut watch: Vec<WatchEntry> = Vec::new();
+        for s in &sources {
+            for w in &s.config.watch {
+                match watch.iter_mut().find(|m| m.address == w.address) {
+                    Some(m) => {
+                        m.from_block = m.from_block.min(w.from_block);
+                        if m.name.is_empty() && !w.name.is_empty() {
+                            m.name = w.name.clone();
+                        }
+                    }
+                    None => watch.push(w.clone()),
+                }
+            }
+        }
+        // Global high H: the minimum of the contributing sources' own highs.
+        // A source without any coverage contributes config only and does not
+        // constrain H.
+        let h = sources
+            .iter()
+            .filter_map(|s| s.coverage.iter().filter_map(|c| c.span.map(|(_, hi)| hi)).max())
+            .min();
+        // Per entry: clamp every source span to H, union what overlaps or
+        // adjoins, and if disjoint pieces survive (non-canonical inputs only)
+        // keep the lowest — deployment-anchored history is the part a
+        // cold-syncing wallet cannot rebuild from the head.
+        let coverage: Vec<Coverage> = watch
+            .iter()
+            .map(|w| {
+                let mut pieces: Vec<(u64, u64)> = sources
+                    .iter()
+                    .filter_map(|s| s.coverage_of(&w.address).and_then(|c| c.span))
+                    .filter_map(|(low, high)| {
+                        let h = h.expect("a span exists, so H exists");
+                        (low <= h).then_some((low, high.min(h)))
+                    })
+                    .collect();
+                pieces.sort_unstable();
+                let merged = pieces.into_iter().fold(Vec::<(u64, u64)>::new(), |mut acc, p| {
+                    match acc.last_mut() {
+                        Some(last) if p.0 <= last.1.saturating_add(1) => last.1 = last.1.max(p.1),
+                        _ => acc.push(p),
+                    }
+                    acc
+                });
+                Coverage { span: merged.first().copied() }
+            })
+            .collect();
+        // Canonical output invariant: every present span ends at the same
+        // high. A piece that cannot (non-canonical input) goes dormant.
+        let out_high = coverage.iter().filter_map(|c| c.span.map(|(_, hi)| hi)).max();
+        let coverage: Vec<Coverage> = coverage
+            .into_iter()
+            .map(|c| Coverage { span: c.span.filter(|(_, hi)| Some(*hi) == out_high) })
+            .collect();
+        // Cursor: the deepest verified trust edge — canonical inputs put it
+        // at the merged global low. If it sits above some span's low (weird
+        // input), drop it: the appender re-seeds, the walker re-descends.
+        let cursor = sources
+            .iter()
+            .filter_map(|s| s.cursor)
+            .min_by_key(|(n, _)| *n)
+            .filter(|(n, _)| {
+                coverage.iter().all(|c| match c.span {
+                    Some((low, _)) => *n <= low,
+                    None => true,
+                })
+            });
+        // Logs: only what the merged coverage can actually serve.
+        let mut logs = BTreeMap::new();
+        for s in &mut sources {
+            let taken = std::mem::take(&mut s.logs);
+            for (key, log) in taken {
+                let served = watch
+                    .iter()
+                    .zip(coverage.iter())
+                    .find(|(w, _)| w.address == log.address)
+                    .is_some_and(|(_, c)| c.contains(log.block_number, log.block_number));
+                if served {
+                    logs.insert(key, log);
+                }
+            }
+        }
+        let config = LogIndexConfig { enabled: false, max_speed: false, watch };
+        // Duplicates are impossible post-union; new() also re-validates.
+        let ix = Self::new(config).expect("union has unique addresses");
+        Ok((expected, Self { coverage, logs, cursor, ..ix }))
+    }
+}
+
 /// A fully parsed v2 frame (tag + fingerprint + watch-table + body), before
 /// any policy decision about configs or tags.
 struct ParsedV2 {
@@ -1361,6 +1564,169 @@ mod tests {
         // Same guards as ever: wrong fingerprint or truncation → None.
         assert!(LogIndex::deserialize(&config(vec![watch_all(addr(1), 101)]), &tag(), &v1).is_none());
         assert!(LogIndex::deserialize(&cfg, &tag(), &v1[..v1.len() - 1]).is_none());
+    }
+
+    /// Build a canonical index over `cfg` covering `low..=high` (appender
+    /// seed at the top, walker descent to the bottom — cursor ends at `low`),
+    /// with `logs` inserted at their blocks along the way.
+    fn span_ix(cfg: LogIndexConfig, low: u64, high: u64, logs: Vec<StoredLog>) -> LogIndex {
+        let mut ix = LogIndex::new(cfg).unwrap();
+        let at = |b: u64| logs.iter().filter(|l| l.block_number == b).cloned().collect::<Vec<_>>();
+        ix.append_block(high, [high as u8; 32], at(high)).unwrap();
+        for b in (low..high).rev() {
+            ix.backfill_block(b, [b as u8; 32], at(b)).unwrap();
+        }
+        ix
+    }
+
+    #[test]
+    fn merge_unions_addresses_and_clamps_to_the_min_high() {
+        // A: tornado history, generated earlier (high 300). B: railgun,
+        // generated later (high 500). The union must not claim (300, 500]
+        // for A's address — that band re-indexes via the bridge.
+        let a = span_ix(config(vec![watch_all(addr(1), 100)]), 100, 300, vec![log(200, 0, addr(1), vec![])]);
+        let b = span_ix(config(vec![watch_all(addr(2), 400)]), 400, 500, vec![log(450, 0, addr(2), vec![])]);
+        let (t, m) = LogIndex::merge(vec![(tag(), a), (tag(), b)]).unwrap();
+        assert_eq!(t, tag());
+        assert_eq!(m.coverage_of(&addr(1)).unwrap().span, Some((100, 300)));
+        // B's span lies entirely above H=300 → dormant, its log dropped
+        // (unreachable by the coverage-honest query anyway).
+        assert_eq!(m.coverage_of(&addr(2)).unwrap().span, None);
+        assert_eq!(m.log_count(), 1);
+        // Config is the union; runtime bits are the installer's.
+        assert_eq!(m.config().watch.len(), 2);
+        assert!(!m.config().enabled);
+        // Cursor: the deepest trust edge.
+        assert_eq!(m.cursor, Some((100, [100; 32])));
+    }
+
+    #[test]
+    fn merge_same_address_unions_overlapping_spans() {
+        let a = span_ix(config(vec![watch_all(addr(1), 50)]), 50, 200, vec![log(60, 0, addr(1), vec![])]);
+        let b = span_ix(config(vec![watch_all(addr(1), 50)]), 150, 260, vec![log(250, 0, addr(1), vec![])]);
+        let (_, mut m) = LogIndex::merge(vec![(tag(), a), (tag(), b)]).unwrap();
+        // H = min(200, 260) = 200; spans [50,200] ∪ [150,200] = [50,200].
+        assert_eq!(m.coverage_of(&addr(1)).unwrap().span, Some((50, 200)));
+        // B's log at 250 is above the merged span → dropped; A's at 60 kept.
+        assert_eq!(m.log_count(), 1);
+        m.set_enabled(true); // the installer's decision, made here for the query
+        assert_eq!(m.query(&filter(50, 200, addr(1))).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn merge_same_address_disjoint_spans_keep_the_lower() {
+        // A reaches only [50,120]; B covers [300,400]. H = 120 makes B's
+        // piece vanish — the deployment-anchored lower history survives and
+        // catch-up re-indexes upward from 120.
+        let a = span_ix(config(vec![watch_all(addr(1), 50)]), 50, 120, vec![log(70, 0, addr(1), vec![])]);
+        let b = span_ix(config(vec![watch_all(addr(1), 50)]), 300, 400, vec![log(350, 0, addr(1), vec![])]);
+        let (_, mut m) = LogIndex::merge(vec![(tag(), a), (tag(), b)]).unwrap();
+        assert_eq!(m.coverage_of(&addr(1)).unwrap().span, Some((50, 120)));
+        assert_eq!(m.log_count(), 1);
+        m.set_enabled(true); // the installer's decision, made here for the query
+        assert!(matches!(m.query(&filter(300, 400, addr(1))), Err(QueryError::OutOfCoverage { .. })));
+    }
+
+    #[test]
+    fn merge_refuses_other_chains_and_topic_conflicts() {
+        let a = span_ix(config(vec![watch_all(addr(1), 50)]), 50, 100, vec![]);
+        let b = span_ix(config(vec![watch_all(addr(2), 50)]), 50, 100, vec![]);
+        let sepolia = ChainTag { network_id: 11_155_111, genesis_hash: [0x25; 32] };
+        assert!(matches!(
+            LogIndex::merge(vec![(tag(), a), (sepolia, b)]),
+            Err(MergeError::ChainMismatch { .. })
+        ));
+        assert!(matches!(LogIndex::merge(vec![]), Err(MergeError::Empty)));
+        // Same address under different topic restrictions: a span's meaning
+        // includes what it indexed — refuse, never widen.
+        let all = span_ix(config(vec![watch_all(addr(1), 50)]), 50, 100, vec![]);
+        let restricted = span_ix(
+            config(vec![WatchEntry { address: addr(1), from_block: 50, topic0s: vec![topic(7)], name: String::new() }]),
+            50,
+            100,
+            vec![],
+        );
+        assert!(matches!(
+            LogIndex::merge(vec![(tag(), all), (tag(), restricted)]),
+            Err(MergeError::TopicConflict(a)) if a == addr(1)
+        ));
+    }
+
+    #[test]
+    fn merge_takes_min_from_block_and_first_nonempty_name() {
+        let mut named = watch_all(addr(1), 200);
+        named.name = "tornado.registry.eth".to_string();
+        let a = span_ix(config(vec![watch_all(addr(1), 400)]), 400, 500, vec![]);
+        let b = span_ix(config(vec![named]), 400, 500, vec![]);
+        let (_, m) = LogIndex::merge(vec![(tag(), a), (tag(), b)]).unwrap();
+        let w = &m.config().watch[0];
+        assert_eq!(w.from_block, 200);
+        assert_eq!(w.name, "tornado.registry.eth");
+    }
+
+    #[test]
+    fn merge_prunes_a_stale_source_instead_of_rewinding_the_fresh_one() {
+        // Re-importing an old file whose coverage is a subset must NOT drag
+        // the merged high back to the old file's high.
+        let fresh = span_ix(config(vec![watch_all(addr(1), 100)]), 100, 500, vec![log(450, 0, addr(1), vec![])]);
+        let stale = span_ix(config(vec![watch_all(addr(1), 100)]), 100, 300, vec![]);
+        let (_, m) = LogIndex::merge(vec![(tag(), stale), (tag(), fresh)]).unwrap();
+        assert_eq!(m.coverage_of(&addr(1)).unwrap().span, Some((100, 500)));
+        assert_eq!(m.log_count(), 1);
+    }
+
+    #[test]
+    fn merge_output_is_canonical_and_never_fabricates_coverage() {
+        // Pseudo-random source shapes (fixed LCG seed — deterministic): the
+        // merged result must (a) never claim a block for an address that no
+        // source covered for that address, and (b) stay canonical: all
+        // present spans share one high, the cursor sits at/below every low.
+        let mut state: u64 = 0x5eed;
+        let mut rng = move |bound: u64| {
+            state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            (state >> 33) % bound
+        };
+        for _ in 0..50 {
+            let n_sources = 1 + rng(3);
+            let mut sources = Vec::new();
+            for _ in 0..n_sources {
+                let n_watch = 1 + rng(3) as u8;
+                let entries: Vec<WatchEntry> = (1..=n_watch).map(|k| watch_all(addr(k), 10)).collect();
+                let low = 10 + rng(50);
+                let high = low + rng(60);
+                sources.push(span_ix(config(entries), low, high, vec![]));
+            }
+            let originals: Vec<LogIndex> = sources
+                .iter()
+                .map(|s| {
+                    let cfg = s.config().clone();
+                    let mut c = LogIndex::new(cfg).unwrap();
+                    c.coverage = s.coverage.clone();
+                    c
+                })
+                .collect();
+            let (_, m) = LogIndex::merge(sources.into_iter().map(|s| (tag(), s)).collect()).unwrap();
+            let highs: Vec<u64> =
+                m.coverage_entries().iter().filter_map(|(_, c)| c.span.map(|(_, h)| h)).collect();
+            assert!(highs.windows(2).all(|w| w[0] == w[1]), "unequal highs: {highs:?}");
+            if let Some((n, _)) = m.cursor {
+                for (_, c) in m.coverage_entries() {
+                    if let Some((low, _)) = c.span {
+                        assert!(n <= low, "cursor {n} above a span low {low}");
+                    }
+                }
+            }
+            for (w, c) in m.coverage_entries() {
+                if let Some((low, high)) = c.span {
+                    for b in low..=high {
+                        let covered_somewhere = originals.iter().any(|s| {
+                            s.coverage_of(&w.address).is_some_and(|sc| sc.contains(b, b))
+                        });
+                        assert!(covered_somewhere, "merged claims block {b} for an address no source covered");
+                    }
+                }
+            }
+        }
     }
 
     #[test]

--- a/rust/myotis-net/src/el/logindex.rs
+++ b/rust/myotis-net/src/el/logindex.rs
@@ -305,12 +305,15 @@ impl LogIndex {
     /// Swap in `config` while keeping ALL accumulated state — the additive
     /// re-apply path. Adoptable iff it subscribes exactly this index's
     /// address set under the same topic0 restrictions: then coverage still
-    /// describes every entry (re-paired by address, since order may differ),
-    /// and the only substantive change a caller can make is LOWERING a
-    /// `from_block` (a deeper walk target — the walker just keeps
-    /// descending; nothing accumulated is invalidated). Names and runtime
-    /// bits ride along. False (and untouched state) for a new/removed
-    /// address or a changed topic set — those need a re-index.
+    /// describes every entry (re-paired by address, since order may differ).
+    /// Names and runtime bits ride along. A LOWERED `from_block` adopts too:
+    /// while the walk is mid-descent that is just a deeper target, and when
+    /// it drops below an already-complete span's low (a hole the descending
+    /// walk could never reach — see [`walk_resumable`]) the cursor is
+    /// DROPPED so the appender re-seeds at the top and the walker
+    /// re-descends: coverage survives, the hole closes, nothing wedges.
+    /// False (and untouched state) for a new/removed address or a changed
+    /// topic set — those need a re-index (or a merge).
     pub fn adopt_config(&mut self, config: LogIndexConfig) -> bool {
         if config.watch.len() != self.config.watch.len() {
             return false;
@@ -328,6 +331,9 @@ impl LogIndex {
                 return false;
             }
             coverage.push(self.coverage[i]);
+        }
+        if !walk_resumable(&config.watch, &coverage, self.cursor) {
+            self.cursor = None;
         }
         self.config = config;
         self.coverage = coverage;
@@ -1052,19 +1058,18 @@ impl LogIndex {
             .into_iter()
             .map(|c| Coverage { span: c.span.filter(|(_, hi)| Some(*hi) == out_high) })
             .collect();
-        // Cursor: the deepest verified trust edge — canonical inputs put it
-        // at the merged global low. If it sits above some span's low (weird
-        // input), drop it: the appender re-seeds, the walker re-descends.
-        let cursor = sources
-            .iter()
-            .filter_map(|s| s.cursor)
-            .min_by_key(|(n, _)| *n)
-            .filter(|(n, _)| {
-                coverage.iter().all(|c| match c.span {
-                    Some((low, _)) => *n <= low,
-                    None => true,
-                })
-            });
+        // Cursor: the DEEPEST source trust edge the walk can actually resume
+        // from (see [`walk_resumable`] — every incomplete span must sit at or
+        // below it; the walk re-descends THROUGH deeper spans, it can never
+        // reach a hole above itself). When no source cursor qualifies, no
+        // cursor at all: the appender re-seeds at the top and the walker
+        // re-descends through the merged spans — headers-only where the
+        // bloom misses, and every hole closes on the way down.
+        let mut candidates: Vec<(u64, [u8; 32])> = sources.iter().filter_map(|s| s.cursor).collect();
+        candidates.sort_unstable_by_key(|(n, _)| *n);
+        let cursor = candidates
+            .into_iter()
+            .find(|c| walk_resumable(&watch, &coverage, Some(*c)));
         // Logs: only what the merged coverage can actually serve.
         let mut logs = BTreeMap::new();
         for s in &mut sources {
@@ -1085,6 +1090,44 @@ impl LogIndex {
         let ix = Self::new(config).expect("union has unique addresses");
         Ok((expected, Self { coverage, logs, cursor, ..ix }))
     }
+}
+
+/// Can the single-cursor walk, resuming from `cursor`, eventually complete
+/// every entry? The walker only DESCENDS: from `cursor - 1` down to the
+/// lowest `from_block`, extending each entry it passes. So a hole that sits
+/// ABOVE the cursor is unreachable forever, and `backfill_block`'s gap check
+/// wedges outright on an incomplete span whose low is above the walk. The
+/// resumable states are exactly:
+///
+/// - `cursor == None`: always resumable — the appender seeds the cursor at
+///   the top on its next append (extending every present span and every
+///   absent one together, so the all-highs-equal invariant holds) and the
+///   walker re-descends through everything; costly, never wrong.
+/// - `cursor == Some(n)`: every present span is either complete
+///   (`low <= from_block` — the walker skips it below its from_block) or
+///   reachable (`low <= n` — the walk passes through it on the way down),
+///   AND every ABSENT span belongs to an entry starting above the frontier
+///   (`from_block > H` — the appender's job); an absent span with
+///   `from_block <= H` has its whole range above the descending walk.
+///
+/// This is the invariant [`LogIndex::merge`] and [`LogIndex::adopt_config`]
+/// preserve; getting it backwards (cursor at/below every low) was a
+/// walk-wedging bug — the walker demands the OPPOSITE half.
+fn walk_resumable(
+    watch: &[WatchEntry],
+    coverage: &[Coverage],
+    cursor: Option<(u64, [u8; 32])>,
+) -> bool {
+    let Some((n, _)) = cursor else {
+        return true;
+    };
+    let Some(h) = coverage.iter().filter_map(|c| c.span.map(|(_, hi)| hi)).max() else {
+        return false; // a cursor with nothing covered: nothing seeded it
+    };
+    watch.iter().zip(coverage.iter()).all(|(w, c)| match c.span {
+        Some((low, _)) => low <= w.from_block || low <= n,
+        None => w.from_block > h,
+    })
 }
 
 /// A fully parsed v2 frame (tag + fingerprint + watch-table + body), before
@@ -1738,6 +1781,37 @@ mod tests {
         assert!(!ix.adopt_config(retopiced));
     }
 
+    /// Drive the (simulated) appender + walker over `ix` to completion,
+    /// panicking if either wedges: one append at the edge (which also
+    /// re-seeds a dropped cursor — exactly what the real appender does),
+    /// then the walker's descent to the lowest from_block. Hashes are
+    /// synthetic — the coverage state machine is what's under test. Ends by
+    /// asserting every entry is COMPLETE (low <= from_block): the branch's
+    /// promise that catch-up finishes every imported address.
+    fn assert_catch_up_completes(ix: &mut LogIndex) {
+        let top = ix.append_edge().unwrap_or(10_000);
+        ix.append_block(top, [1; 32], vec![])
+            .unwrap_or_else(|g| panic!("appender wedged at {top}: {g:?}"));
+        let target = ix.config().watch.iter().map(|w| w.from_block).min().expect("entries");
+        let mut steps = 0u32;
+        while let Some((n, _)) = ix.cursor {
+            if n <= target {
+                break;
+            }
+            let b = n - 1;
+            ix.backfill_block(b, [2; 32], vec![])
+                .unwrap_or_else(|g| panic!("walker wedged at {b}: {g:?}"));
+            steps += 1;
+            assert!(steps < 100_000, "walk did not terminate");
+        }
+        for (w, c) in ix.coverage_entries() {
+            let (low, _) = c.span.unwrap_or_else(|| {
+                panic!("entry 0x{:02x}.. never covered", w.address[0])
+            });
+            assert!(low <= w.from_block, "entry incomplete: low {low} > from {}", w.from_block);
+        }
+    }
+
     /// Build a canonical index over `cfg` covering `low..=high` (appender
     /// seed at the top, walker descent to the bottom — cursor ends at `low`),
     /// with `logs` inserted at their blocks along the way.
@@ -1848,6 +1922,67 @@ mod tests {
     }
 
     #[test]
+    fn merge_into_a_mid_backfill_index_resumes_and_completes() {
+        // The flagship import case that once wedged: own index mid-backfill
+        // (X from 20, covered [1000,1100], cursor at 1000) + a deep imported
+        // snapshot (Y from 50, covered [50,1100], cursor at 50). The naive
+        // "deepest cursor" (50) leaves X's hole [20,1000) ABOVE the walk —
+        // backfill_block gap-errors every tick, forever. The resumable
+        // choice is the cursor at the MAX incomplete low (X's 1000): the
+        // walk re-descends through Y's covered span and closes both holes.
+        let own = span_ix(config(vec![watch_all(addr(1), 20)]), 1000, 1100, vec![]);
+        let imported = span_ix(config(vec![watch_all(addr(2), 50)]), 50, 1100, vec![]);
+        let (_, mut m) = LogIndex::merge(vec![(tag(), own), (tag(), imported)]).unwrap();
+        assert_eq!(m.cursor.map(|(n, _)| n), Some(1000), "must resume at the max incomplete low");
+        assert_catch_up_completes(&mut m);
+    }
+
+    #[test]
+    fn merge_with_a_config_only_source_drops_the_cursor_and_completes() {
+        // A config-only source (new address, no coverage — the preset-grew
+        // case): its whole range sits above any source cursor, so NO cursor
+        // is resumable; the merge must drop it (appender re-seeds at the
+        // top, walker re-descends) rather than strand the new entry.
+        let covered = span_ix(config(vec![watch_all(addr(1), 50)]), 50, 300, vec![]);
+        let config_only = LogIndex::new(config(vec![watch_all(addr(2), 100)])).unwrap();
+        let (_, mut m) = LogIndex::merge(vec![(tag(), config_only), (tag(), covered)]).unwrap();
+        assert_eq!(m.cursor, None, "no cursor can reach the new entry's hole");
+        // Coverage survived the union.
+        assert_eq!(m.coverage_of(&addr(1)).unwrap().span, Some((50, 300)));
+        assert_catch_up_completes(&mut m);
+    }
+
+    #[test]
+    fn adopt_lowering_from_block_below_a_complete_span_drops_the_cursor() {
+        // Regression: pre-import builds re-indexed on any from_block change;
+        // the additive path must not instead wedge. Two entries, walk at
+        // 150: X1 (from 200) is COMPLETE at low 200, X2 (from 100) is
+        // mid-descent at the cursor. Lowering X1's from_block to 50 opens
+        // the hole [50,200) ABOVE the cursor — unreachable by the descent —
+        // so the adopt keeps all coverage but drops the cursor and the walk
+        // re-descends.
+        let mut ix = span_ix(
+            config(vec![watch_all(addr(1), 200), watch_all(addr(2), 100)]),
+            150,
+            300,
+            vec![],
+        );
+        assert_eq!(ix.cursor.map(|(n, _)| n), Some(150));
+        assert_eq!(ix.coverage_of(&addr(1)).unwrap().span, Some((200, 300)));
+        let lowered = config(vec![watch_all(addr(1), 50), watch_all(addr(2), 100)]);
+        assert!(ix.adopt_config(lowered));
+        assert_eq!(ix.cursor, None, "X1's hole [50,200) sits above the old cursor");
+        assert_eq!(ix.coverage_of(&addr(1)).unwrap().span, Some((200, 300)), "coverage kept");
+        assert_catch_up_completes(&mut ix);
+        // Mid-descent lowering (span low == cursor) keeps the cursor: the
+        // walk just runs deeper.
+        let mut mid = span_ix(config(vec![watch_all(addr(3), 150)]), 200, 300, vec![]);
+        assert!(mid.adopt_config(config(vec![watch_all(addr(3), 100)])));
+        assert_eq!(mid.cursor.map(|(n, _)| n), Some(200));
+        assert_catch_up_completes(&mut mid);
+    }
+
+    #[test]
     fn merge_output_is_canonical_and_never_fabricates_coverage() {
         // Pseudo-random source shapes (fixed LCG seed — deterministic): the
         // merged result must (a) never claim a block for an address that no
@@ -1877,17 +2012,16 @@ mod tests {
                     c
                 })
                 .collect();
-            let (_, m) = LogIndex::merge(sources.into_iter().map(|s| (tag(), s)).collect()).unwrap();
+            let (_, mut m) = LogIndex::merge(sources.into_iter().map(|s| (tag(), s)).collect()).unwrap();
             let highs: Vec<u64> =
                 m.coverage_entries().iter().filter_map(|(_, c)| c.span.map(|(_, h)| h)).collect();
             assert!(highs.windows(2).all(|w| w[0] == w[1]), "unequal highs: {highs:?}");
-            if let Some((n, _)) = m.cursor {
-                for (_, c) in m.coverage_entries() {
-                    if let Some((low, _)) = c.span {
-                        assert!(n <= low, "cursor {n} above a span low {low}");
-                    }
-                }
-            }
+            // The RESUMABILITY invariant — the walker demands every
+            // incomplete low at/below the cursor (asserting the inverted
+            // "cursor at/below every low" here is exactly the bug this
+            // branch once had).
+            let (watch, coverage): (Vec<_>, Vec<_>) = m.coverage_entries().into_iter().unzip();
+            assert!(walk_resumable(&watch, &coverage, m.cursor), "merge emitted a non-resumable state");
             for (w, c) in m.coverage_entries() {
                 if let Some((low, high)) = c.span {
                     for b in low..=high {
@@ -1898,6 +2032,9 @@ mod tests {
                     }
                 }
             }
+            // And the invariant is not just declared — the pipeline actually
+            // runs to completion from the merged state.
+            assert_catch_up_completes(&mut m);
         }
     }
 

--- a/rust/myotis-net/src/el/logindex.rs
+++ b/rust/myotis-net/src/el/logindex.rs
@@ -74,6 +74,39 @@ impl LogIndexConfig {
         })
     }
 
+    /// Union this (pushed) config with an already-subscribed watch-list —
+    /// what keeps an imported subscription alive across host preset pushes:
+    /// a host re-applying its shipped preset must EXTEND the stored set, not
+    /// replace it, or every restart would fingerprint-mismatch the imported
+    /// index into a full re-index. Same-address entries take the MIN
+    /// `from_block` (undershooting cannot lie) and the pushed name when
+    /// non-empty (the host is authoritative for cosmetics); addresses only
+    /// in `stored` are appended behind the pushed ones. `enabled`/`max_speed`
+    /// come from `self` — they are the push's whole point. None on a topic0
+    /// conflict (the caller falls back to replace semantics).
+    pub fn union_with(&self, stored: &[WatchEntry]) -> Option<LogIndexConfig> {
+        let mut watch = self.watch.clone();
+        for s in stored {
+            match watch.iter_mut().find(|w| w.address == s.address) {
+                Some(w) => {
+                    let mut ta = w.topic0s.clone();
+                    let mut tb = s.topic0s.clone();
+                    ta.sort_unstable();
+                    tb.sort_unstable();
+                    if ta != tb {
+                        return None;
+                    }
+                    w.from_block = w.from_block.min(s.from_block);
+                    if w.name.is_empty() && !s.name.is_empty() {
+                        w.name = s.name.clone();
+                    }
+                }
+                None => watch.push(s.clone()),
+            }
+        }
+        Some(LogIndexConfig { enabled: self.enabled, max_speed: self.max_speed, watch })
+    }
+
     /// Order-insensitive fingerprint of the watch-list. A changed fingerprint
     /// on load invalidates the persisted index (derived data — re-index
     /// rather than risk serving under a stale subscription set).
@@ -267,6 +300,38 @@ impl LogIndex {
     /// host re-applies a config whose watch-list fingerprint is unchanged).
     pub fn set_enabled(&mut self, enabled: bool) {
         self.config.enabled = enabled;
+    }
+
+    /// Swap in `config` while keeping ALL accumulated state — the additive
+    /// re-apply path. Adoptable iff it subscribes exactly this index's
+    /// address set under the same topic0 restrictions: then coverage still
+    /// describes every entry (re-paired by address, since order may differ),
+    /// and the only substantive change a caller can make is LOWERING a
+    /// `from_block` (a deeper walk target — the walker just keeps
+    /// descending; nothing accumulated is invalidated). Names and runtime
+    /// bits ride along. False (and untouched state) for a new/removed
+    /// address or a changed topic set — those need a re-index.
+    pub fn adopt_config(&mut self, config: LogIndexConfig) -> bool {
+        if config.watch.len() != self.config.watch.len() {
+            return false;
+        }
+        let mut coverage = Vec::with_capacity(config.watch.len());
+        for w in &config.watch {
+            let Some(i) = self.config.watch.iter().position(|o| o.address == w.address) else {
+                return false;
+            };
+            let mut ta = w.topic0s.clone();
+            let mut tb = self.config.watch[i].topic0s.clone();
+            ta.sort_unstable();
+            tb.sort_unstable();
+            if ta != tb {
+                return false;
+            }
+            coverage.push(self.coverage[i]);
+        }
+        self.config = config;
+        self.coverage = coverage;
+        true
     }
 
     /// Flip the backfill pacing bit without touching accumulated state (same
@@ -805,6 +870,26 @@ pub enum MergeError {
     /// under; unioning restrictions would claim logs nobody stored. Refused
     /// rather than resolved — re-generate one source with matching topics.
     TopicConflict([u8; 20]),
+}
+
+impl std::fmt::Display for MergeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MergeError::Empty => write!(f, "nothing to merge"),
+            MergeError::ChainMismatch { expected, got } => write!(
+                f,
+                "snapshot belongs to another chain (network id {}, expected {})",
+                got.network_id, expected.network_id
+            ),
+            MergeError::TopicConflict(a) => {
+                write!(f, "0x")?;
+                for b in a {
+                    write!(f, "{b:02x}")?;
+                }
+                write!(f, " is watched under conflicting topic restrictions")
+            }
+        }
+    }
 }
 
 impl LogIndex {
@@ -1564,6 +1649,60 @@ mod tests {
         // Same guards as ever: wrong fingerprint or truncation → None.
         assert!(LogIndex::deserialize(&config(vec![watch_all(addr(1), 101)]), &tag(), &v1).is_none());
         assert!(LogIndex::deserialize(&cfg, &tag(), &v1[..v1.len() - 1]).is_none());
+    }
+
+    #[test]
+    fn union_with_extends_stored_and_keeps_pushed_bits() {
+        // The additive re-apply: a preset push must extend an imported
+        // subscription, never replace it.
+        let mut stored_extra = watch_all(addr(2), 300);
+        stored_extra.name = "imported.eth".to_string();
+        let stored = vec![watch_all(addr(1), 200), stored_extra.clone()];
+        let pushed = LogIndexConfig {
+            enabled: true,
+            max_speed: true,
+            watch: vec![{
+                let mut w = watch_all(addr(1), 100); // lower from_block
+                w.name = "preset name".to_string();
+                w
+            }],
+        };
+        let eff = pushed.union_with(&stored).unwrap();
+        assert!(eff.enabled && eff.max_speed);
+        assert_eq!(eff.watch.len(), 2);
+        assert_eq!(eff.watch[0].from_block, 100); // min wins
+        assert_eq!(eff.watch[0].name, "preset name"); // push is authoritative
+        assert_eq!(eff.watch[1], stored_extra); // imported entry survives
+        // Topic conflict → None (caller replaces instead).
+        let restricted = vec![WatchEntry { address: addr(1), from_block: 100, topic0s: vec![topic(7)], name: String::new() }];
+        assert!(pushed.union_with(&restricted).is_none());
+    }
+
+    #[test]
+    fn adopt_config_keeps_state_only_for_the_same_subscription_set() {
+        let mut ix = LogIndex::new(config(vec![watch_all(addr(1), 200), watch_all(addr(2), 200)])).unwrap();
+        ix.append_block(500, [5; 32], vec![log(500, 0, addr(1), vec![])]).unwrap();
+        // Reordered + renamed + lowered from_block + flipped bits: adoptable,
+        // and coverage re-pairs by address.
+        let mut renamed = watch_all(addr(2), 150);
+        renamed.name = "renamed.eth".to_string();
+        let eff = LogIndexConfig { enabled: true, max_speed: true, watch: vec![renamed, watch_all(addr(1), 200)] };
+        assert!(ix.adopt_config(eff));
+        assert!(ix.config().enabled && ix.config().max_speed);
+        assert_eq!(ix.config().watch[0].from_block, 150);
+        assert_eq!(ix.coverage_of(&addr(1)).unwrap().span, Some((500, 500)));
+        assert_eq!(ix.log_count(), 1);
+        // A new address is NOT adoptable (needs a re-index), and the failed
+        // attempt leaves everything untouched.
+        let wider = config(vec![watch_all(addr(1), 200), watch_all(addr(2), 150), watch_all(addr(3), 0)]);
+        assert!(!ix.adopt_config(wider));
+        assert_eq!(ix.config().watch.len(), 2);
+        // A changed topic set is NOT adoptable either.
+        let retopiced = config(vec![
+            WatchEntry { address: addr(1), from_block: 200, topic0s: vec![topic(9)], name: String::new() },
+            watch_all(addr(2), 150),
+        ]);
+        assert!(!ix.adopt_config(retopiced));
     }
 
     /// Build a canonical index over `cfg` covering `low..=high` (appender

--- a/rust/myotis-net/src/el/logindex.rs
+++ b/rust/myotis-net/src/el/logindex.rs
@@ -344,6 +344,24 @@ impl LogIndex {
         &self.config
     }
 
+    /// Fill in a display name for a watched address IF it is still unnamed —
+    /// the post-import naming pass. Never overwrites: a name baked into a
+    /// snapshot (or pushed by a host) outranks a late lookup. Cosmetic only
+    /// (names are fingerprint-neutral); persists with the next checkpoint.
+    /// Returns whether anything changed.
+    pub fn set_name(&mut self, address: &[u8; 20], name: &str) -> bool {
+        if name.is_empty() {
+            return false;
+        }
+        match self.config.watch.iter_mut().find(|w| &w.address == address) {
+            Some(w) if w.name.is_empty() => {
+                w.name = name.to_string();
+                true
+            }
+            _ => false,
+        }
+    }
+
     pub fn coverage_of(&self, address: &[u8; 20]) -> Option<Coverage> {
         self.config
             .watch
@@ -1649,6 +1667,21 @@ mod tests {
         // Same guards as ever: wrong fingerprint or truncation → None.
         assert!(LogIndex::deserialize(&config(vec![watch_all(addr(1), 101)]), &tag(), &v1).is_none());
         assert!(LogIndex::deserialize(&cfg, &tag(), &v1[..v1.len() - 1]).is_none());
+    }
+
+    #[test]
+    fn set_name_fills_only_unnamed_entries() {
+        let mut named = watch_all(addr(1), 0);
+        named.name = "baked.eth".to_string();
+        let mut ix = LogIndex::new(config(vec![named, watch_all(addr(2), 0)])).unwrap();
+        // A baked-in name outranks a late lookup; empty names never install.
+        assert!(!ix.set_name(&addr(1), "late.eth"));
+        assert_eq!(ix.config().watch[0].name, "baked.eth");
+        assert!(!ix.set_name(&addr(2), ""));
+        assert!(ix.set_name(&addr(2), "resolved.eth"));
+        assert_eq!(ix.config().watch[1].name, "resolved.eth");
+        // Unknown address: no-op.
+        assert!(!ix.set_name(&addr(9), "nobody.eth"));
     }
 
     #[test]

--- a/rust/myotis-net/src/el/logindex.rs
+++ b/rust/myotis-net/src/el/logindex.rs
@@ -670,12 +670,40 @@ impl LogIndex {
         self.serialize_with_clamp(tag, None)
     }
 
+    /// Export as a portable snapshot with the display names STRIPPED — the
+    /// generator's output path. Naming is the IMPORTING wallet's job (owner
+    /// decision, 2026-08-14), but the naming pass runs wherever an index is
+    /// enabled — a long-running generator daemon would otherwise bake its
+    /// own resolutions into the file and, since `set_name` fills only EMPTY
+    /// names, become authoritative for every importer. Blanked at write
+    /// time, never by cloning the (possibly GB-scale) store. `clamp` as in
+    /// [`Self::persist_clamped`] (None = unclamped, the zero-finality case).
+    pub fn export_unnamed(
+        &self,
+        tag: &ChainTag,
+        path: &Path,
+        clamp: Option<u64>,
+    ) -> std::io::Result<()> {
+        let tmp: PathBuf = path.with_extension(format!("tmp.{}", std::process::id()));
+        {
+            let mut f = std::fs::File::create(&tmp)?;
+            f.write_all(&self.serialize_impl(tag, clamp, true))?;
+            f.sync_all()?;
+        }
+        std::fs::rename(&tmp, path)
+    }
+
+    fn serialize_with_clamp(&self, tag: &ChainTag, clamp: Option<u64>) -> Vec<u8> {
+        self.serialize_impl(tag, clamp, false)
+    }
+
     /// The one serializer (always writes VERSION 2). `clamp` bounds what is
     /// written (see [`Self::serialize_clamped`]) and filters DURING the
     /// write: the tail keeps coverage above finality at all times, so a clamp
     /// that cloned the index would deep-copy the whole log store on every
-    /// checkpoint, under the index lock, on a 10s cadence.
-    fn serialize_with_clamp(&self, tag: &ChainTag, clamp: Option<u64>) -> Vec<u8> {
+    /// checkpoint, under the index lock, on a 10s cadence. `strip_names`
+    /// blanks the watch-table names (see [`Self::export_unnamed`]).
+    fn serialize_impl(&self, tag: &ChainTag, clamp: Option<u64>, strip_names: bool) -> Vec<u8> {
         let mut out = Vec::with_capacity(128 + self.logs.len() * 200);
         out.extend_from_slice(MAGIC);
         put_u32(&mut out, VERSION);
@@ -695,7 +723,7 @@ impl LogIndex {
             for t in &w.topic0s {
                 out.extend_from_slice(t);
             }
-            put_bytes(&mut out, w.name.as_bytes());
+            put_bytes(&mut out, if strip_names { b"" } else { w.name.as_bytes() });
         }
         // Coverage spans + cursor.
         put_u32(&mut out, self.coverage.len() as u32);
@@ -848,6 +876,23 @@ impl LogIndex {
     pub fn load_portable(path: &Path) -> Option<(ChainTag, Self)> {
         let data = std::fs::read(path).ok()?;
         Self::deserialize_portable(&data)
+    }
+
+    /// Does `path` hold a LEGACY (v1) snapshot? Distinguishes "not portable
+    /// because it predates the self-describing format" (real accumulated
+    /// coverage — refuse to overwrite it) from "not portable because it's
+    /// corrupt" (dead bytes — safe to replace). Only the frame header is
+    /// read.
+    pub fn is_legacy_snapshot(path: &Path) -> bool {
+        let mut header = [0u8; 8];
+        let Ok(mut f) = std::fs::File::open(path) else {
+            return false;
+        };
+        use std::io::Read as _;
+        if f.read_exact(&mut header).is_err() {
+            return false;
+        }
+        header[..4] == *MAGIC && u32::from_le_bytes([header[4], header[5], header[6], header[7]]) == VERSION_LEGACY
     }
 
     /// Atomic best-effort persist: temp file (pid-suffixed) + rename, the
@@ -1635,6 +1680,52 @@ mod tests {
         assert_eq!(back.coverage_of(&addr(1)).unwrap().span, Some((199, 200)));
         assert_eq!(back.cursor, Some((199, [9; 32])));
         assert_eq!(back.log_count(), 1);
+    }
+
+    #[test]
+    fn export_unnamed_strips_names_and_keeps_everything_else() {
+        let dir = std::env::temp_dir().join(format!("logindex-export-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("export.db");
+        let mut named = watch_all(addr(1), 100);
+        named.name = "generator-resolved.eth".to_string();
+        let mut ix = LogIndex::new(config(vec![named])).unwrap();
+        ix.append_block(200, [0xbb; 32], vec![log(200, 0, addr(1), vec![])]).unwrap();
+        ix.export_unnamed(&tag(), &path, None).unwrap();
+        let (t, back) = LogIndex::load_portable(&path).expect("portable");
+        assert_eq!(t, tag());
+        // The name did NOT travel — the importing wallet resolves its own —
+        // but coverage, logs and from_block all did.
+        assert!(back.config().watch[0].name.is_empty());
+        assert_eq!(back.config().watch[0].from_block, 100);
+        assert_eq!(back.coverage_of(&addr(1)).unwrap().span, Some((200, 200)));
+        assert_eq!(back.log_count(), 1);
+        // The clamp behaves like every checkpoint's.
+        ix.append_block(201, [0xbc; 32], vec![]).unwrap();
+        ix.export_unnamed(&tag(), &path, Some(200)).unwrap();
+        let (_, clamped) = LogIndex::load_portable(&path).unwrap();
+        assert_eq!(clamped.coverage_of(&addr(1)).unwrap().span, Some((200, 200)));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn is_legacy_snapshot_detects_only_v1_frames() {
+        let dir = std::env::temp_dir().join(format!("logindex-legacy-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let cfg = config(vec![watch_all(addr(1), 0)]);
+        let mut ix = LogIndex::new(cfg).unwrap();
+        ix.append_block(5, [5; 32], vec![]).unwrap();
+        let v1 = dir.join("v1.db");
+        std::fs::write(&v1, serialize_v1(&ix)).unwrap();
+        assert!(LogIndex::is_legacy_snapshot(&v1));
+        let v2 = dir.join("v2.db");
+        ix.persist(&tag(), &v2).unwrap();
+        assert!(!LogIndex::is_legacy_snapshot(&v2));
+        let junk = dir.join("junk.db");
+        std::fs::write(&junk, b"nonsense").unwrap();
+        assert!(!LogIndex::is_legacy_snapshot(&junk));
+        assert!(!LogIndex::is_legacy_snapshot(&dir.join("absent.db")));
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]

--- a/rust/myotis-net/src/el/logindex.rs
+++ b/rust/myotis-net/src/el/logindex.rs
@@ -26,6 +26,25 @@ pub struct WatchEntry {
     pub address: [u8; 20],
     pub from_block: u64,
     pub topic0s: Vec<[u8; 32]>,
+    /// Human-readable label (ENS reverse name or a host-supplied one), purely
+    /// cosmetic: displayed by hosts, carried by the portable v2 snapshot, and
+    /// deliberately EXCLUDED from [`LogIndexConfig::fingerprint`] — renaming
+    /// an entry must never invalidate accumulated coverage. Empty = unnamed.
+    pub name: String,
+}
+
+/// The network a snapshot belongs to. Persisted in every v2 file and checked
+/// on load: logs are keyed by block-global `(block_number, log_index)`, so
+/// merging or loading a file from another chain would silently collide keys
+/// and fabricate coverage for blocks nobody verified on THIS chain. The
+/// filename suffix (`logindex-sepolia.db`) is a convention, not a guarantee —
+/// the bytes carry their own identity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChainTag {
+    /// EL network id (1 mainnet, 11155111 sepolia, 100 gnosis).
+    pub network_id: u64,
+    /// EL genesis block hash — distinguishes forks sharing a network id.
+    pub genesis_hash: [u8; 32],
 }
 
 /// The host-supplied index configuration (crosses the FFI as JSON, parsed
@@ -58,6 +77,8 @@ impl LogIndexConfig {
     /// Order-insensitive fingerprint of the watch-list. A changed fingerprint
     /// on load invalidates the persisted index (derived data — re-index
     /// rather than risk serving under a stale subscription set).
+    /// `name` is deliberately not encoded: it is cosmetic (see [`WatchEntry`])
+    /// and renaming must not cost a re-index.
     pub fn fingerprint(&self) -> u64 {
         // FNV-1a over sorted entry encodings: stable, dependency-free, and
         // this is a cache-invalidation tag, not a security boundary.
@@ -464,7 +485,20 @@ impl LogIndex {
 // ---------------------------------------------------------------------------
 
 const MAGIC: &[u8; 4] = b"MLIX";
-const VERSION: u32 = 1;
+/// v1: config-keyed blob (fingerprint only — unreadable without the exact
+///     watch-list that produced it; still LOADED for upgrade, never written).
+/// v2: self-describing — adds the chain tag and the full watch-table
+///     (address, from_block, topic0s, name), so a file can be imported on a
+///     host that has never seen its config, and cannot cross networks.
+const VERSION: u32 = 2;
+const VERSION_LEGACY: u32 = 1;
+
+/// Byte offset of the v2 checksum field: magic(4) + version(4) +
+/// network_id(8) + genesis_hash(32) + fingerprint(8). The checksum covers
+/// everything AFTER itself.
+const V2_CHECKSUM_AT: usize = 56;
+/// v1 layout: magic(4) + version(4) + fingerprint(8).
+const V1_CHECKSUM_AT: usize = 16;
 
 /// FNV-1a (same primitive as the config fingerprint): integrity tag for the
 /// snapshot payload — bit-rot detection, not a security boundary.
@@ -528,36 +562,52 @@ impl LogIndex {
     /// verifiable against the in-memory tail record, which does not survive a
     /// restart, so persisting it would leave a later run holding coverage it
     /// can never re-check.
-    pub fn serialize_clamped(&self, max_block: u64) -> Vec<u8> {
-        self.serialize_with_clamp(Some(max_block))
+    pub fn serialize_clamped(&self, tag: &ChainTag, max_block: u64) -> Vec<u8> {
+        self.serialize_with_clamp(tag, Some(max_block))
     }
 
     /// [`Self::persist`] with the same clamp as [`Self::serialize_clamped`].
-    pub fn persist_clamped(&self, path: &Path, max_block: u64) -> std::io::Result<()> {
+    pub fn persist_clamped(&self, tag: &ChainTag, path: &Path, max_block: u64) -> std::io::Result<()> {
         let tmp: PathBuf = path.with_extension(format!("tmp.{}", std::process::id()));
         {
             let mut f = std::fs::File::create(&tmp)?;
-            f.write_all(&self.serialize_clamped(max_block))?;
+            f.write_all(&self.serialize_clamped(tag, max_block))?;
             f.sync_all()?;
         }
         std::fs::rename(&tmp, path)
     }
 
-    pub fn serialize(&self) -> Vec<u8> {
-        self.serialize_with_clamp(None)
+    pub fn serialize(&self, tag: &ChainTag) -> Vec<u8> {
+        self.serialize_with_clamp(tag, None)
     }
 
-    /// The one serializer. `clamp` bounds what is written (see
-    /// [`Self::serialize_clamped`]) and filters DURING the write: the tail
-    /// keeps coverage above finality at all times, so a clamp that cloned the
-    /// index would deep-copy the whole log store on every checkpoint, under
-    /// the index lock, on a 10s cadence.
-    fn serialize_with_clamp(&self, clamp: Option<u64>) -> Vec<u8> {
-        let mut out = Vec::with_capacity(64 + self.logs.len() * 200);
+    /// The one serializer (always writes VERSION 2). `clamp` bounds what is
+    /// written (see [`Self::serialize_clamped`]) and filters DURING the
+    /// write: the tail keeps coverage above finality at all times, so a clamp
+    /// that cloned the index would deep-copy the whole log store on every
+    /// checkpoint, under the index lock, on a 10s cadence.
+    fn serialize_with_clamp(&self, tag: &ChainTag, clamp: Option<u64>) -> Vec<u8> {
+        let mut out = Vec::with_capacity(128 + self.logs.len() * 200);
         out.extend_from_slice(MAGIC);
         put_u32(&mut out, VERSION);
+        put_u64(&mut out, tag.network_id);
+        out.extend_from_slice(&tag.genesis_hash);
         put_u64(&mut out, self.config.fingerprint());
         put_u64(&mut out, 0); // checksum placeholder, patched below
+        // The watch-table, in config order (coverage below is parallel to
+        // it): what makes the file self-describing — an importer reconstructs
+        // the subscription set from the bytes instead of needing the exact
+        // config that produced them.
+        put_u32(&mut out, self.config.watch.len() as u32);
+        for w in &self.config.watch {
+            out.extend_from_slice(&w.address);
+            put_u64(&mut out, w.from_block);
+            put_u32(&mut out, w.topic0s.len() as u32);
+            for t in &w.topic0s {
+                out.extend_from_slice(t);
+            }
+            put_bytes(&mut out, w.name.as_bytes());
+        }
         // Coverage spans + cursor.
         put_u32(&mut out, self.coverage.len() as u32);
         for c in &self.coverage {
@@ -617,88 +667,211 @@ impl LogIndex {
         // structural framing catches truncation, this catches bit-rot inside
         // otherwise-valid frames — either way a bad load means re-index, never
         // serving corrupted logs as verified.
-        let sum = fnv64(&out[24..]);
-        if let Some(slot) = out.get_mut(16..24) {
+        let sum = fnv64(&out[V2_CHECKSUM_AT + 8..]);
+        if let Some(slot) = out.get_mut(V2_CHECKSUM_AT..V2_CHECKSUM_AT + 8) {
             slot.copy_from_slice(&sum.to_le_bytes());
         }
         out
     }
 
     /// Rebuild from bytes for the given config. Any mismatch or corruption
-    /// → None (re-index).
-    pub fn deserialize(config: &LogIndexConfig, data: &[u8]) -> Option<Self> {
+    /// → None (re-index). Accepts the current v2 layout (tag-checked) and the
+    /// legacy v1 layout (pre-tag files written by earlier builds — loading
+    /// them preserves accumulated coverage across the upgrade; the next
+    /// checkpoint rewrites the file as v2).
+    pub fn deserialize(config: &LogIndexConfig, tag: &ChainTag, data: &[u8]) -> Option<Self> {
         let mut c = Cursor { d: data, pos: 0 };
-        if c.take(4)? != MAGIC || c.u32()? != VERSION || c.u64()? != config.fingerprint() {
+        if c.take(4)? != MAGIC {
+            return None;
+        }
+        match c.u32()? {
+            VERSION_LEGACY => Self::deserialize_v1(config, data, c),
+            VERSION => {
+                let parsed = parse_v2(data, c)?;
+                if parsed.tag != *tag || parsed.fingerprint != config.fingerprint() {
+                    return None;
+                }
+                // The file's coverage vec parallels the file's watch order;
+                // the given config may list the same set in another order
+                // (the fingerprint is order-insensitive). Re-pair coverage by
+                // ADDRESS so a reordered-but-equal config cannot attach a
+                // span to the wrong entry. The config (not the file) supplies
+                // the names — the host is authoritative for cosmetics.
+                let mut coverage = Vec::with_capacity(config.watch.len());
+                for w in &config.watch {
+                    let j = parsed.watch.iter().position(|f| f.address == w.address)?;
+                    coverage.push(parsed.coverage[j]);
+                }
+                Some(Self { config: config.clone(), coverage, logs: parsed.logs, cursor: parsed.cursor })
+            }
+            _ => None,
+        }
+    }
+
+    /// The legacy (v1) layout: fingerprint-keyed, no chain tag, no
+    /// watch-table, coverage parallel to the SUPPLIED config's order.
+    fn deserialize_v1(config: &LogIndexConfig, data: &[u8], mut c: Cursor) -> Option<Self> {
+        if c.u64()? != config.fingerprint() {
             return None;
         }
         let stored_sum = c.u64()?;
-        if fnv64(data.get(24..)?) != stored_sum {
+        if fnv64(data.get(V1_CHECKSUM_AT + 8..)?) != stored_sum {
             return None;
         }
         let n_cov = c.u32()? as usize;
         if n_cov != config.watch.len() {
             return None;
         }
-        let mut coverage = Vec::with_capacity(n_cov);
-        for _ in 0..n_cov {
-            coverage.push(match c.take(1)?.first().copied()? {
-                0 => Coverage::default(),
-                1 => Coverage { span: Some((c.u64()?, c.u64()?)) },
-                _ => return None,
-            });
-        }
-        let cursor = match c.take(1)?.first().copied()? {
-            0 => None,
-            1 => Some((c.u64()?, c.arr::<32>()?)),
-            _ => return None,
-        };
-        let n_logs = c.u64()?;
-        let mut logs = BTreeMap::new();
-        for _ in 0..n_logs {
-            let block_number = c.u64()?;
-            let block_hash = c.arr::<32>()?;
-            let tx_hash = c.arr::<32>()?;
-            let tx_index = c.u32()?;
-            let log_index = c.u32()?;
-            let address = c.arr::<20>()?;
-            let n_topics = c.u32()? as usize;
-            if n_topics > 4 {
-                return None;
-            }
-            let mut topics = Vec::with_capacity(n_topics);
-            for _ in 0..n_topics {
-                topics.push(c.arr::<32>()?);
-            }
-            let data = c.bytes()?.to_vec();
-            logs.insert(
-                (block_number, log_index),
-                StoredLog { block_number, block_hash, tx_hash, tx_index, log_index, address, topics, data },
-            );
-        }
+        let (coverage, cursor, logs) = parse_body(&mut c, n_cov)?;
         if c.pos != data.len() {
             return None; // trailing garbage → treat as corrupt
         }
         Some(Self { config: config.clone(), coverage, logs, cursor })
     }
 
+    /// Self-describing read (v2 only): reconstruct the subscription set from
+    /// the file's own watch-table instead of requiring the config that wrote
+    /// it — the import path. Returns the file's chain tag so the importer can
+    /// refuse a file from another network, and the index carrying the file's
+    /// watch entries (names included) with `enabled`/`max_speed` false: those
+    /// are runtime bits the receiving host decides, never file content.
+    pub fn deserialize_portable(data: &[u8]) -> Option<(ChainTag, Self)> {
+        let mut c = Cursor { d: data, pos: 0 };
+        if c.take(4)? != MAGIC || c.u32()? != VERSION {
+            return None; // v1 files are not self-describing — not importable
+        }
+        let parsed = parse_v2(data, c)?;
+        let config =
+            LogIndexConfig { enabled: false, max_speed: false, watch: parsed.watch };
+        // The stored fingerprint must actually match the stored watch-table —
+        // a mismatch means the frame is inconsistent with itself.
+        if parsed.fingerprint != config.fingerprint() {
+            return None;
+        }
+        let ix = Self::new(config).ok()?;
+        Some((
+            parsed.tag,
+            Self { coverage: parsed.coverage, logs: parsed.logs, cursor: parsed.cursor, ..ix },
+        ))
+    }
+
+    /// [`Self::deserialize_portable`] from a file.
+    pub fn load_portable(path: &Path) -> Option<(ChainTag, Self)> {
+        let data = std::fs::read(path).ok()?;
+        Self::deserialize_portable(&data)
+    }
+
     /// Atomic best-effort persist: temp file (pid-suffixed) + rename, the
     /// `persist_snapshot` pattern. A failed write costs a re-index on the
     /// affected range, never correctness.
-    pub fn persist(&self, path: &Path) -> std::io::Result<()> {
+    pub fn persist(&self, tag: &ChainTag, path: &Path) -> std::io::Result<()> {
         let tmp: PathBuf = path.with_extension(format!("tmp.{}", std::process::id()));
         {
             let mut f = std::fs::File::create(&tmp)?;
-            f.write_all(&self.serialize())?;
+            f.write_all(&self.serialize(tag))?;
             f.sync_all()?;
         }
         std::fs::rename(&tmp, path)
     }
 
     /// Load a persisted index for `config`; None on absence or any mismatch.
-    pub fn load(config: &LogIndexConfig, path: &Path) -> Option<Self> {
+    pub fn load(config: &LogIndexConfig, tag: &ChainTag, path: &Path) -> Option<Self> {
         let data = std::fs::read(path).ok()?;
-        Self::deserialize(config, &data)
+        Self::deserialize(config, tag, &data)
     }
+}
+
+/// A fully parsed v2 frame (tag + fingerprint + watch-table + body), before
+/// any policy decision about configs or tags.
+struct ParsedV2 {
+    tag: ChainTag,
+    fingerprint: u64,
+    watch: Vec<WatchEntry>,
+    coverage: Vec<Coverage>,
+    cursor: Option<(u64, [u8; 32])>,
+    logs: BTreeMap<(u64, u32), StoredLog>,
+}
+
+/// Parse a v2 frame from just past the version field. Verifies the checksum
+/// and structural framing; policy checks (tag, fingerprint-vs-config) are the
+/// caller's.
+fn parse_v2(data: &[u8], mut c: Cursor) -> Option<ParsedV2> {
+    let network_id = c.u64()?;
+    let genesis_hash = c.arr::<32>()?;
+    let fingerprint = c.u64()?;
+    let stored_sum = c.u64()?;
+    if fnv64(data.get(V2_CHECKSUM_AT + 8..)?) != stored_sum {
+        return None;
+    }
+    let n_watch = c.u32()? as usize;
+    let mut watch = Vec::with_capacity(n_watch.min(1024));
+    for _ in 0..n_watch {
+        let address = c.arr::<20>()?;
+        let from_block = c.u64()?;
+        let n_topics = c.u32()? as usize;
+        let mut topic0s = Vec::with_capacity(n_topics.min(64));
+        for _ in 0..n_topics {
+            topic0s.push(c.arr::<32>()?);
+        }
+        let name = String::from_utf8(c.bytes()?.to_vec()).ok()?;
+        watch.push(WatchEntry { address, from_block, topic0s, name });
+    }
+    // Coverage is parallel to the watch-table by construction of the writer —
+    // a count disagreeing with the table is an inconsistent frame.
+    let n_cov = c.u32()? as usize;
+    if n_cov != n_watch {
+        return None;
+    }
+    let (coverage, cursor, logs) = parse_body(&mut c, n_cov)?;
+    if c.pos != data.len() {
+        return None; // trailing garbage → treat as corrupt
+    }
+    Some(ParsedV2 { tag: ChainTag { network_id, genesis_hash }, fingerprint, watch, coverage, cursor, logs })
+}
+
+/// Parse the coverage + cursor + log body shared by v1 and v2 frames.
+#[allow(clippy::type_complexity)]
+fn parse_body(
+    c: &mut Cursor,
+    n_cov: usize,
+) -> Option<(Vec<Coverage>, Option<(u64, [u8; 32])>, BTreeMap<(u64, u32), StoredLog>)> {
+    let mut coverage = Vec::with_capacity(n_cov.min(1024));
+    for _ in 0..n_cov {
+        coverage.push(match c.take(1)?.first().copied()? {
+            0 => Coverage::default(),
+            1 => Coverage { span: Some((c.u64()?, c.u64()?)) },
+            _ => return None,
+        });
+    }
+    let cursor = match c.take(1)?.first().copied()? {
+        0 => None,
+        1 => Some((c.u64()?, c.arr::<32>()?)),
+        _ => return None,
+    };
+    let n_logs = c.u64()?;
+    let mut logs = BTreeMap::new();
+    for _ in 0..n_logs {
+        let block_number = c.u64()?;
+        let block_hash = c.arr::<32>()?;
+        let tx_hash = c.arr::<32>()?;
+        let tx_index = c.u32()?;
+        let log_index = c.u32()?;
+        let address = c.arr::<20>()?;
+        let n_topics = c.u32()? as usize;
+        if n_topics > 4 {
+            return None;
+        }
+        let mut topics = Vec::with_capacity(n_topics);
+        for _ in 0..n_topics {
+            topics.push(c.arr::<32>()?);
+        }
+        let data = c.bytes()?.to_vec();
+        logs.insert(
+            (block_number, log_index),
+            StoredLog { block_number, block_hash, tx_hash, tx_index, log_index, address, topics, data },
+        );
+    }
+    Some((coverage, cursor, logs))
 }
 
 #[cfg(test)]
@@ -706,7 +879,7 @@ mod tests {
 
     #[test]
     fn max_speed_is_fingerprint_neutral_and_flippable() {
-        let w = WatchEntry { address: [7u8; 20], from_block: 5, topic0s: vec![] };
+        let w = WatchEntry { address: [7u8; 20], from_block: 5, topic0s: vec![], name: String::new() };
         let a = LogIndexConfig { enabled: true, max_speed: false, watch: vec![w.clone()] };
         let b = LogIndexConfig { enabled: true, max_speed: true, watch: vec![w] };
         // Flipping pacing must never invalidate accumulated coverage.
@@ -741,7 +914,12 @@ mod tests {
     }
 
     fn watch_all(a: [u8; 20], from: u64) -> WatchEntry {
-        WatchEntry { address: a, from_block: from, topic0s: vec![] }
+        WatchEntry { address: a, from_block: from, topic0s: vec![], name: String::new() }
+    }
+
+    /// The chain tag every test persists under (arbitrary but fixed).
+    fn tag() -> ChainTag {
+        ChainTag { network_id: 1, genesis_hash: [0xd4; 32] }
     }
 
     fn config(entries: Vec<WatchEntry>) -> LogIndexConfig {
@@ -797,7 +975,7 @@ mod tests {
 
     #[test]
     fn topic_restricted_watch_rejects_wildcard_queries() {
-        let w = WatchEntry { address: addr(1), from_block: 0, topic0s: vec![topic(7)] };
+        let w = WatchEntry { address: addr(1), from_block: 0, topic0s: vec![topic(7)], name: String::new() };
         let mut ix = LogIndex::new(config_ok(vec![w])).unwrap();
         ix.append_block(5, [0xbb; 32], vec![log(5, 0, addr(1), vec![topic(7)])]).unwrap();
         // Wildcard topic0 would deserve unindexed signatures → error.
@@ -848,15 +1026,15 @@ mod tests {
         // Finality at 12: blocks 13-14 are optimistic and must not persist —
         // a later run has no way to re-check them, and once finality moves
         // past them nothing would ever rewind them.
-        ix.persist_clamped(&path, 12).unwrap();
-        let loaded = LogIndex::load(&cfg, &path).unwrap();
+        ix.persist_clamped(&tag(), &path, 12).unwrap();
+        let loaded = LogIndex::load(&cfg, &tag(), &path).unwrap();
         assert_eq!(loaded.coverage_of(&addr(1)).unwrap().span, Some((10, 12)));
         assert_eq!(loaded.log_count(), 3);
         // The live index is untouched — the clamp is a serialization concern.
         assert_eq!(ix.coverage_of(&addr(1)).unwrap().span, Some((10, 14)));
         assert_eq!(ix.log_count(), 5);
         // Nothing above the clamp → byte-identical to a plain serialize.
-        assert_eq!(ix.serialize_clamped(14), ix.serialize());
+        assert_eq!(ix.serialize_clamped(&tag(), 14), ix.serialize(&tag()));
         let _ = std::fs::remove_file(&path);
     }
 
@@ -869,13 +1047,13 @@ mod tests {
         }
         // A span entirely above the clamp disappears; one that straddles it is
         // written with the clamped high; the live index is untouched either way.
-        let bytes = ix.serialize_clamped(12);
-        let loaded = LogIndex::deserialize(&cfg, &bytes).unwrap();
+        let bytes = ix.serialize_clamped(&tag(), 12);
+        let loaded = LogIndex::deserialize(&cfg, &tag(), &bytes).unwrap();
         assert_eq!(loaded.coverage_of(&addr(1)).unwrap().span, Some((10, 12)));
         assert_eq!(loaded.log_count(), 3);
         assert_eq!(ix.coverage_of(&addr(1)).unwrap().span, Some((10, 14)));
         assert_eq!(ix.log_count(), 5);
-        let below = LogIndex::deserialize(&cfg, &ix.serialize_clamped(9)).unwrap();
+        let below = LogIndex::deserialize(&cfg, &tag(), &ix.serialize_clamped(&tag(), 9)).unwrap();
         assert_eq!(below.coverage_of(&addr(1)).unwrap().span, None);
         assert_eq!(below.log_count(), 0);
     }
@@ -890,10 +1068,10 @@ mod tests {
         // Clamped below it, the cursor must NOT persist: it is a hash, and
         // above the clamp it may name a block that was never re-checked — a
         // reloading walker would parent-chain into it.
-        let below = LogIndex::deserialize(&cfg, &ix.serialize_clamped(15)).unwrap();
+        let below = LogIndex::deserialize(&cfg, &tag(), &ix.serialize_clamped(&tag(), 15)).unwrap();
         assert_eq!(below.cursor, None);
         // At or above the cursor, it survives.
-        let at = LogIndex::deserialize(&cfg, &ix.serialize_clamped(20)).unwrap();
+        let at = LogIndex::deserialize(&cfg, &tag(), &ix.serialize_clamped(&tag(), 20)).unwrap();
         assert_eq!(at.cursor, Some((20, [20; 32])));
     }
 
@@ -924,24 +1102,28 @@ mod tests {
         let dir = std::env::temp_dir().join(format!("logindex-test-{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
         let path = dir.join("logindex-test.db");
-        let cfg = config(vec![watch_all(addr(1), 100), WatchEntry { address: addr(2), from_block: 0, topic0s: vec![topic(7)] }]);
+        let cfg = config(vec![watch_all(addr(1), 100), WatchEntry { address: addr(2), from_block: 0, topic0s: vec![topic(7)], name: String::new() }]);
         let mut ix = LogIndex::new(cfg.clone()).unwrap();
         ix.append_block(200, [0xbb; 32], vec![log(200, 3, addr(1), vec![topic(7), topic(8)])]).unwrap();
         ix.backfill_block(199, [7; 32], vec![]).unwrap();
-        ix.persist(&path).unwrap();
+        ix.persist(&tag(), &path).unwrap();
 
-        let back = LogIndex::load(&cfg, &path).expect("roundtrip");
+        let back = LogIndex::load(&cfg, &tag(), &path).expect("roundtrip");
         assert_eq!(back.coverage_of(&addr(1)).unwrap().span, Some((199, 200)));
         assert_eq!(back.cursor, Some((199, [7; 32])));
         assert_eq!(back.query(&filter(199, 200, addr(1))).unwrap(), ix.query(&filter(199, 200, addr(1))).unwrap());
 
         // Changed watch-list → fingerprint mismatch → None (re-index).
         let changed = config(vec![watch_all(addr(1), 101)]);
-        assert!(LogIndex::load(&changed, &path).is_none());
+        assert!(LogIndex::load(&changed, &tag(), &path).is_none());
+        // Another network's tag → None, even for the very config that wrote
+        // the file: the bytes carry their own chain identity.
+        let other = ChainTag { network_id: 11_155_111, genesis_hash: [0x25; 32] };
+        assert!(LogIndex::load(&cfg, &other, &path).is_none());
         // Truncated file → None.
         let data = std::fs::read(&path).unwrap();
         std::fs::write(&path, &data[..data.len() - 1]).unwrap();
-        assert!(LogIndex::load(&cfg, &path).is_none());
+        assert!(LogIndex::load(&cfg, &tag(), &path).is_none());
         std::fs::remove_dir_all(&dir).ok();
     }
 
@@ -967,29 +1149,33 @@ mod tests {
         let cfg = config(vec![watch_all(addr(1), 0)]);
         let mut ix = LogIndex::new(cfg.clone()).unwrap();
         ix.append_block(7, [0xbb; 32], vec![log(7, 0, addr(1), vec![topic(1), topic(2)])]).unwrap();
-        let good = ix.serialize();
-        assert!(LogIndex::deserialize(&cfg, &good).is_some());
+        let good = ix.serialize(&tag());
+        assert!(LogIndex::deserialize(&cfg, &tag(), &good).is_some());
         // Every single-byte mutation must yield Some-or-None, never panic,
-        // and structural fields must not produce a bogus accepted index.
+        // and structural fields must not produce a bogus accepted index —
+        // on the config-keyed AND the self-describing path.
         for i in 0..good.len() {
             let mut bad = good.clone();
             bad[i] ^= 0xff;
-            let _ = LogIndex::deserialize(&cfg, &bad);
+            let _ = LogIndex::deserialize(&cfg, &tag(), &bad);
+            let _ = LogIndex::deserialize_portable(&bad);
         }
         // Every truncation length likewise.
         for n in 0..good.len() {
-            assert!(LogIndex::deserialize(&cfg, &good[..n]).is_none());
+            assert!(LogIndex::deserialize(&cfg, &tag(), &good[..n]).is_none());
+            assert!(LogIndex::deserialize_portable(&good[..n]).is_none());
         }
         // Huge length prefixes must fail cleanly (no allocation bomb).
         let mut huge = good.clone();
         let tail = huge.len() - 4;
         huge[tail..].copy_from_slice(&u32::MAX.to_le_bytes());
-        let _ = LogIndex::deserialize(&cfg, &huge);
+        let _ = LogIndex::deserialize(&cfg, &tag(), &huge);
+        let _ = LogIndex::deserialize_portable(&huge);
     }
 
     #[test]
     fn duplicate_watch_addresses_are_rejected() {
-        let dup = config(vec![watch_all(addr(1), 0), WatchEntry { address: addr(1), from_block: 50, topic0s: vec![] }]);
+        let dup = config(vec![watch_all(addr(1), 0), WatchEntry { address: addr(1), from_block: 50, topic0s: vec![], name: String::new() }]);
         assert!(matches!(LogIndex::new(dup), Err(DuplicateWatchAddress(a)) if a == addr(1)));
     }
 
@@ -1027,13 +1213,14 @@ mod tests {
         let cfg = config(vec![watch_all(addr(1), 0)]);
         let mut ix = LogIndex::new(cfg.clone()).unwrap();
         ix.append_block(7, [0xbb; 32], vec![log(7, 0, addr(1), vec![topic(1)])]).unwrap();
-        let good = ix.serialize();
-        // Flip one bit inside every payload byte (past the 24-byte header):
+        let good = ix.serialize(&tag());
+        // Flip one bit inside every payload byte (past the checksum field):
         // the checksum must reject each one.
-        for i in 24..good.len() {
+        for i in V2_CHECKSUM_AT + 8..good.len() {
             let mut bad = good.clone();
             bad[i] ^= 0x01;
-            assert!(LogIndex::deserialize(&cfg, &bad).is_none(), "bitflip at {i} accepted");
+            assert!(LogIndex::deserialize(&cfg, &tag(), &bad).is_none(), "bitflip at {i} accepted");
+            assert!(LogIndex::deserialize_portable(&bad).is_none(), "portable bitflip at {i} accepted");
         }
     }
 
@@ -1053,14 +1240,148 @@ mod tests {
     #[test]
     fn fingerprint_is_order_insensitive_but_content_sensitive() {
         let a = watch_all(addr(1), 5);
-        let b = WatchEntry { address: addr(2), from_block: 9, topic0s: vec![topic(3), topic(4)] };
+        let b = WatchEntry { address: addr(2), from_block: 9, topic0s: vec![topic(3), topic(4)], name: String::new() };
         let mut b_rev = b.clone();
         b_rev.topic0s.reverse();
         let c1 = config(vec![a.clone(), b.clone()]);
         let c2 = config(vec![b_rev, a.clone()]);
         assert_eq!(c1.fingerprint(), c2.fingerprint());
-        let c3 = config(vec![a, WatchEntry { address: addr(2), from_block: 10, topic0s: vec![topic(3), topic(4)] }]);
+        let c3 = config(vec![a, WatchEntry { address: addr(2), from_block: 10, topic0s: vec![topic(3), topic(4)], name: String::new() }]);
         assert_ne!(c1.fingerprint(), c3.fingerprint());
+    }
+
+    #[test]
+    fn names_are_fingerprint_neutral_and_never_cost_a_reindex() {
+        let unnamed = config(vec![watch_all(addr(1), 100)]);
+        let mut named_entry = watch_all(addr(1), 100);
+        named_entry.name = "tornado.registry.eth".to_string();
+        let named = config(vec![named_entry]);
+        assert_eq!(unnamed.fingerprint(), named.fingerprint());
+        // A file written unnamed loads under a renamed config (and the
+        // config's name wins — the host is authoritative for cosmetics).
+        let mut ix = LogIndex::new(unnamed).unwrap();
+        ix.append_block(200, [0xbb; 32], vec![]).unwrap();
+        let back = LogIndex::deserialize(&named, &tag(), &ix.serialize(&tag())).unwrap();
+        assert_eq!(back.config().watch[0].name, "tornado.registry.eth");
+        assert_eq!(back.coverage_of(&addr(1)).unwrap().span, Some((200, 200)));
+    }
+
+    #[test]
+    fn portable_roundtrip_reconstructs_config_from_the_bytes() {
+        let mut w1 = watch_all(addr(1), 100);
+        w1.name = "tornado.registry.eth".to_string();
+        let w2 = WatchEntry { address: addr(2), from_block: 50, topic0s: vec![topic(7)], name: String::new() };
+        let mut ix = LogIndex::new(config(vec![w1.clone(), w2.clone()])).unwrap();
+        ix.append_block(200, [0xbb; 32], vec![log(200, 0, addr(1), vec![topic(7)])]).unwrap();
+        ix.backfill_block(199, [9; 32], vec![]).unwrap();
+
+        let (got_tag, back) = LogIndex::deserialize_portable(&ix.serialize(&tag())).expect("portable");
+        assert_eq!(got_tag, tag());
+        // The watch-list — names included — comes from the FILE, no config
+        // supplied. Runtime bits are the receiving host's decision.
+        assert_eq!(back.config().watch, vec![w1, w2]);
+        assert!(!back.config().enabled);
+        assert!(!back.config().max_speed);
+        // Coverage, cursor, and logs all survive.
+        assert_eq!(back.coverage_of(&addr(1)).unwrap().span, Some((199, 200)));
+        assert_eq!(back.cursor, Some((199, [9; 32])));
+        assert_eq!(back.log_count(), 1);
+    }
+
+    #[test]
+    fn v1_files_are_not_portable() {
+        let ix = LogIndex::new(config_ok(vec![watch_all(addr(1), 0)])).unwrap();
+        let mut v1 = ix.serialize(&tag());
+        v1[4..8].copy_from_slice(&1u32.to_le_bytes());
+        // (Bogus v1 framing after the version field — the point is only that
+        // the version gate itself refuses before parsing anything.)
+        assert!(LogIndex::deserialize_portable(&v1).is_none());
+    }
+
+    /// Serialize `ix` in the LEGACY v1 layout (what pre-v2 builds wrote):
+    /// magic, version 1, fingerprint, checksum over the rest, coverage,
+    /// cursor, logs — no chain tag, no watch-table.
+    fn serialize_v1(ix: &LogIndex) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(MAGIC);
+        put_u32(&mut out, VERSION_LEGACY);
+        put_u64(&mut out, ix.config().fingerprint());
+        put_u64(&mut out, 0); // checksum placeholder
+        put_u32(&mut out, ix.coverage.len() as u32);
+        for c in &ix.coverage {
+            match c.span {
+                None => out.push(0),
+                Some((low, high)) => {
+                    out.push(1);
+                    put_u64(&mut out, low);
+                    put_u64(&mut out, high);
+                }
+            }
+        }
+        match ix.cursor {
+            None => out.push(0),
+            Some((n, h)) => {
+                out.push(1);
+                put_u64(&mut out, n);
+                out.extend_from_slice(&h);
+            }
+        }
+        put_u64(&mut out, ix.logs.len() as u64);
+        for log in ix.logs.values() {
+            put_u64(&mut out, log.block_number);
+            out.extend_from_slice(&log.block_hash);
+            out.extend_from_slice(&log.tx_hash);
+            put_u32(&mut out, log.tx_index);
+            put_u32(&mut out, log.log_index);
+            out.extend_from_slice(&log.address);
+            put_u32(&mut out, log.topics.len() as u32);
+            for t in &log.topics {
+                out.extend_from_slice(t);
+            }
+            put_bytes(&mut out, &log.data);
+        }
+        let sum = fnv64(&out[V1_CHECKSUM_AT + 8..]);
+        out[V1_CHECKSUM_AT..V1_CHECKSUM_AT + 8].copy_from_slice(&sum.to_le_bytes());
+        out
+    }
+
+    #[test]
+    fn legacy_v1_files_still_load_preserving_coverage() {
+        // The upgrade path: a file written by a pre-v2 build must load (months
+        // of phone backfill must not re-index just because the code updated).
+        let cfg = config(vec![watch_all(addr(1), 100)]);
+        let mut ix = LogIndex::new(cfg.clone()).unwrap();
+        ix.append_block(200, [0xbb; 32], vec![log(200, 0, addr(1), vec![topic(7)])]).unwrap();
+        ix.backfill_block(199, [9; 32], vec![]).unwrap();
+        let v1 = serialize_v1(&ix);
+        let back = LogIndex::deserialize(&cfg, &tag(), &v1).expect("v1 upgrade load");
+        assert_eq!(back.coverage_of(&addr(1)).unwrap().span, Some((199, 200)));
+        assert_eq!(back.cursor, Some((199, [9; 32])));
+        assert_eq!(back.log_count(), 1);
+        // Same guards as ever: wrong fingerprint or truncation → None.
+        assert!(LogIndex::deserialize(&config(vec![watch_all(addr(1), 101)]), &tag(), &v1).is_none());
+        assert!(LogIndex::deserialize(&cfg, &tag(), &v1[..v1.len() - 1]).is_none());
+    }
+
+    #[test]
+    fn reordered_config_pairs_coverage_by_address() {
+        // The fingerprint is order-insensitive, so a host may re-apply the
+        // same watch-set in a different order. v2 stores the watch-table and
+        // re-pairs coverage by ADDRESS — entry order must not migrate a span
+        // to the wrong contract.
+        let w1 = watch_all(addr(1), 100);
+        let w2 = watch_all(addr(2), 300);
+        let mut ix = LogIndex::new(config(vec![w1.clone(), w2.clone()])).unwrap();
+        // Blocks 200..=210: only addr(1)'s entry is live (addr(2) starts at 300).
+        for b in 200..=210 {
+            ix.append_block(b, [0xbb; 32], vec![]).unwrap();
+        }
+        let bytes = ix.serialize(&tag());
+        let reordered = config(vec![w2, w1]);
+        assert_eq!(reordered.fingerprint(), ix.config().fingerprint());
+        let back = LogIndex::deserialize(&reordered, &tag(), &bytes).unwrap();
+        assert_eq!(back.coverage_of(&addr(1)).unwrap().span, Some((200, 210)));
+        assert_eq!(back.coverage_of(&addr(2)).unwrap().span, None);
     }
 }
 
@@ -1074,7 +1395,7 @@ mod bloom_match_tests {
         fn addr(b: u8) -> [u8; 20] {
             [b; 20]
         }
-        let watch = WatchEntry { address: addr(1), from_block: 100, topic0s: vec![[7; 32]] };
+        let watch = WatchEntry { address: addr(1), from_block: 100, topic0s: vec![[7; 32]], name: String::new() };
         let ix = LogIndex::new(LogIndexConfig { enabled: true, max_speed: false, watch: vec![watch] }).unwrap();
         let mut hit = EMPTY_BLOOM;
         accrue(&mut hit, &addr(1));

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -1105,6 +1105,8 @@ impl ElReader {
             let mut since_persist = 0u32;
             let mut ticks = 0u64;
             let mut backfill_ok = 0u64;
+            let mut name_attempts: std::collections::HashMap<[u8; 20], (u8, u64)> =
+                std::collections::HashMap::new();
             loop {
                 tick.tick().await;
                 let Some(reader) = weak.upgrade() else {
@@ -1122,9 +1124,75 @@ impl ElReader {
                     reader.log_index_append_tick(&mut since_persist, ticks).await;
                 }
                 reader.log_index_backfill_step(ticks, &mut backfill_ok).await;
+                reader.log_index_name_tick(&mut name_attempts, ticks).await;
                 ticks = ticks.wrapping_add(1);
             }
         }));
+    }
+
+    /// Best-effort ENS reverse naming for UNNAMED watch entries — the
+    /// imported-snapshot half of the naming story (the generator bakes names
+    /// at build time, but a file can arrive unnamed). Runs inside the
+    /// appender task so it dies with it at teardown (the Arc::try_unwrap
+    /// discipline). One address per tick, forward-verified engine-side
+    /// ([`EnsQuery::Reverse`]), and never gating indexing: an address whose
+    /// name cannot resolve just stays unnamed. Up to 3 attempts per address,
+    /// re-eligible every ~10 minutes — the first attempts often predate a
+    /// usable EVM state and must not be the last.
+    async fn log_index_name_tick(
+        &self,
+        attempts: &mut std::collections::HashMap<[u8; 20], (u8, u64)>,
+        ticks: u64,
+    ) {
+        if !self.with_log_index(|ix| ix.config().enabled).unwrap_or(false) {
+            return;
+        }
+        // Nothing can resolve before the anchor serves EVM reads at all.
+        if self.head_block_number().is_none() {
+            return;
+        }
+        let unnamed = self
+            .with_log_index(|ix| {
+                ix.config()
+                    .watch
+                    .iter()
+                    .filter(|w| w.name.is_empty())
+                    .map(|w| w.address)
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        let Some(address) = unnamed.into_iter().find(|a| match attempts.get(a) {
+            None => true,
+            Some((n, last)) => *n < 3 && ticks.saturating_sub(*last) >= 100,
+        }) else {
+            return;
+        };
+        let entry = attempts.entry(address).or_insert((0, 0));
+        entry.0 += 1;
+        entry.1 = ticks;
+        // network_id == chain id on every hosted network (1 / 11155111 / 100).
+        let chain_id = self.eth_cfg.network_id;
+        // Bounded well under the ENS API's own deadline: this shares the
+        // appender loop, and a stalled resolution must not starve appends.
+        let out = tokio::time::timeout(
+            std::time::Duration::from_secs(30),
+            self.resolve_ens_query(EnsQuery::Reverse { address }, chain_id, EnsRootMode::Auto),
+        )
+        .await;
+        if let Ok(Ok(EnsQueryOutcome::Value { value: EnsRecordValue::Name(name), .. })) = out {
+            if let Ok(mut slot) = self.log_index.lock() {
+                if let Some(ix) = slot.as_mut() {
+                    if ix.set_name(&address, &name) {
+                        tracing::info!(
+                            name = %name,
+                            "log index: named an imported watch entry via ENS reverse lookup"
+                        );
+                    }
+                }
+            }
+        }
+        // NoRecord / Offchain / errors: leave unnamed (attempt bookkeeping
+        // above bounds the churn).
     }
 
     /// One appender tick: record finalized blocks from the append edge up to

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -833,15 +833,15 @@ impl ElReader {
                 if ix.adopt_config(eff) {
                     // Nothing accumulated was invalidated: coverage, the
                     // mapped gap and the tail record still describe this
-                    // index. Bits/names/walk-target updated in place.
+                    // index (a from_block lowered below a complete span only
+                    // drops the walk cursor — the appender re-seeds it).
                     reset_rate();
                     return true;
                 }
             }
-            // New address or topic conflict → the union (or, on conflict,
-            // the pushed config alone) REPLACES the index below, which
-            // invalidates bridge and tail: neither describes the new
-            // coverage.
+            // New address or topic conflict: the index below is REPLACED,
+            // which invalidates bridge and tail — neither describes the new
+            // coverage shape.
             self.clear_log_index_bridge();
             if let Ok(mut t) = self.log_index_tail.lock() {
                 t.clear();
@@ -857,10 +857,49 @@ impl ElReader {
                     ix.persist_clamped(&tag, p, finalized_now)
                 };
             }
-            let effective = config.union_with(&ix.config().watch).unwrap_or(config);
-            let fresh = match crate::el::logindex::LogIndex::new(effective) {
-                Ok(fresh) => fresh,
-                Err(_) => return false,
+            let effective = config.union_with(&ix.config().watch);
+            let old = slot.take().expect("checked Some above");
+            let fresh = match effective {
+                // New addresses: MERGE the union config (an empty source)
+                // with the old index, so accumulated coverage — an imported
+                // snapshot's months of backfill included — survives a preset
+                // that merely grew. The merge drops the cursor when the new
+                // entries' holes sit above it; the walker then re-descends
+                // through the kept spans and closes them.
+                Some(eff) => {
+                    let pushed = match crate::el::logindex::LogIndex::new(eff.clone()) {
+                        Ok(p) => p,
+                        Err(_) => {
+                            *slot = Some(old);
+                            return false;
+                        }
+                    };
+                    match crate::el::logindex::LogIndex::merge(vec![(tag, pushed), (tag, old)]) {
+                        Ok((_, mut merged)) => {
+                            merged.set_enabled(eff.enabled);
+                            merged.set_max_speed(eff.max_speed);
+                            merged
+                        }
+                        // Unreachable in practice (union_with already vetted
+                        // the topic sets); degrade to replace semantics.
+                        Err(_) => match crate::el::logindex::LogIndex::new(config) {
+                            Ok(f) => f,
+                            Err(_) => return false,
+                        },
+                    }
+                }
+                // Topic conflict: replace with the push alone — a span's
+                // meaning includes its restriction, nothing can be kept.
+                None => {
+                    tracing::warn!(
+                        "log-index config conflicts with the live subscription's topic \
+                         restrictions; replacing — accumulated coverage re-indexes"
+                    );
+                    match crate::el::logindex::LogIndex::new(config) {
+                        Ok(f) => f,
+                        Err(_) => return false,
+                    }
+                }
             };
             *slot = Some(fresh);
             reset_rate();
@@ -882,13 +921,36 @@ impl ElReader {
                     .is_some_and(|eff| stored_ix.adopt_config(eff));
                 if adopted {
                     stored_ix
+                } else if let Some(eff) = config.union_with(&stored_ix.config().watch) {
+                    // Genuinely new addresses (e.g. a host preset pushed on
+                    // top of a dropped-in generator snapshot): MERGE instead
+                    // of discarding — the snapshot's coverage survives, the
+                    // new entries re-index via the walker's re-descent (the
+                    // merge drops the cursor for exactly that).
+                    let merged = crate::el::logindex::LogIndex::new(eff.clone())
+                        .ok()
+                        .and_then(|pushed| {
+                            crate::el::logindex::LogIndex::merge(vec![(tag, pushed), (tag, stored_ix)]).ok()
+                        });
+                    match merged {
+                        Some((_, mut m)) => {
+                            m.set_enabled(eff.enabled);
+                            m.set_max_speed(eff.max_speed);
+                            m
+                        }
+                        None => match crate::el::logindex::LogIndex::new(config) {
+                            Ok(fresh) => fresh,
+                            Err(_) => return false,
+                        },
+                    }
                 } else {
-                    // Conflict or a genuinely new address: re-index under
-                    // the union when there is one (keep the imported
-                    // subscriptions — they re-cover), else the push alone.
-                    let effective =
-                        config.union_with(&stored_ix.config().watch).unwrap_or(config);
-                    match crate::el::logindex::LogIndex::new(effective) {
+                    // Topic conflict with the stored subscription: replace
+                    // with the push alone (nothing mergeable to keep).
+                    tracing::warn!(
+                        "stored log-index snapshot conflicts with the pushed config's topic \
+                         restrictions; replacing — its accumulated coverage re-indexes"
+                    );
+                    match crate::el::logindex::LogIndex::new(config) {
                         Ok(fresh) => fresh,
                         Err(_) => return false,
                     }
@@ -1030,26 +1092,39 @@ impl ElReader {
         }
         let (_, mut merged) =
             crate::el::logindex::LogIndex::merge(sources).map_err(|e| e.to_string())?;
-        // A snapshot generated by a node further along may carry coverage
-        // above THIS node's current finality. That data is finalized on the
-        // network (the generator clamps at its own finality) — local
-        // finality just hasn't caught up — so it persists as-is under the
-        // trusted-import premise above.
         merged.set_enabled(true);
         merged.set_max_speed(max_speed);
+        // Rewound to LOCAL finality like every other checkpoint: a snapshot
+        // from a node further along may carry coverage above it, but the
+        // tail's fork scan rewinds above-finality coverage this run did not
+        // append (unknown hashes are rewound, never trusted), so keeping the
+        // band would only hold data the first tail tick discards — the
+        // rewind makes the installed index, the persisted file, and the tail
+        // rule tell one story. The appender/tail re-fetch the band promptly.
+        let finalized_now = self.finalized_block_number();
+        if finalized_now > 0 {
+            merged.rewind_above(finalized_now);
+        }
         merged
             .persist(&tag, &own_path)
             .map_err(|e| format!("could not write {}: {e}", own_path.display()))?;
-        // Install: the bridge and tail describe the OLD coverage shape.
-        self.clear_log_index_bridge();
-        if let Ok(mut t) = self.log_index_tail.lock() {
-            t.clear();
-        }
-        if let Ok(mut rate) = self.log_index_rate.lock() {
-            *rate = None;
-        }
         match self.log_index.lock() {
-            Ok(mut slot) => *slot = Some(merged),
+            Ok(mut slot) => {
+                // Bridge/tail/rate describe the OLD coverage shape. Cleared
+                // under the SAME hold that swaps the index (the order
+                // set_log_index_config uses): the tail tick appends and
+                // records while holding this lock, so no record seeded
+                // against the old index can slip in between the clear and
+                // the install.
+                self.clear_log_index_bridge();
+                if let Ok(mut t) = self.log_index_tail.lock() {
+                    t.clear();
+                }
+                if let Ok(mut rate) = self.log_index_rate.lock() {
+                    *rate = None;
+                }
+                *slot = Some(merged);
+            }
             Err(_) => return Err("log index unavailable".to_string()),
         }
         Ok(())
@@ -2495,8 +2570,26 @@ impl ElReader {
                         break; // unprocessed candidate — resume here next tick
                     }
                     let logs = logs_by_block.remove(&n).unwrap_or_default();
-                    ix.backfill_block(n, vh.hash, logs)
-                        .map_err(|g| format!("backfill gap at {} (edge {})", g.block, g.edge))?;
+                    if let Err(g) = ix.backfill_block(n, vh.hash, logs) {
+                        // A gap here means the walk state cannot resume — a
+                        // shape no merge/adopt should produce (belt and
+                        // braces for `walk_resumable`). Without the reset the
+                        // walker would re-fetch and re-verify the same batch
+                        // against the same wall every tick, forever. Dropping
+                        // the cursor makes the appender re-seed at the top
+                        // and the walker re-descend through the spans —
+                        // coverage survives, the wedge cannot.
+                        tracing::warn!(
+                            block = g.block,
+                            edge = g.edge,
+                            "backfill gap; resetting the walk cursor to re-descend"
+                        );
+                        ix.cursor = None;
+                        return Err(format!(
+                            "backfill gap at {} (edge {}); walk reset",
+                            g.block, g.edge
+                        ));
+                    }
                 }
                 Ok(())
             }

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -1020,20 +1020,20 @@ impl ElReader {
     /// (optimistic coverage is only verifiable against this run's tail
     /// record); the v2 frame carries the watch-table + chain tag, so the file
     /// imports anywhere on the same chain. Partial coverage exports honestly
-    /// — the importer's catch-up finishes the walk.
+    /// — the importer's catch-up finishes the walk. Display names are
+    /// STRIPPED from the export: naming is the importing wallet's job, and
+    /// the naming pass runs wherever an index is enabled — a long-running
+    /// generator daemon must not bake its own resolutions into a file whose
+    /// importers would then never re-resolve (`set_name` fills only empty
+    /// names).
     pub fn export_log_index(&self, path: &std::path::Path) -> Result<(), String> {
         let tag = self.chain_tag();
         let finalized = self.finalized_block_number();
         match self.log_index.lock() {
             Ok(slot) => match slot.as_ref() {
-                Some(ix) => {
-                    let r = if finalized == 0 {
-                        ix.persist(&tag, path)
-                    } else {
-                        ix.persist_clamped(&tag, path, finalized)
-                    };
-                    r.map_err(|e| format!("could not write {}: {e}", path.display()))
-                }
+                Some(ix) => ix
+                    .export_unnamed(&tag, path, (finalized > 0).then_some(finalized))
+                    .map_err(|e| format!("could not write {}: {e}", path.display())),
                 None => Err("no log index is configured".to_string()),
             },
             Err(_) => Err("log index unavailable".to_string()),
@@ -1081,13 +1081,55 @@ impl ElReader {
         // Checkpoint the live index (finality-clamped, v2) and merge THROUGH
         // THE FILE rather than cloning the live store: the store is fully
         // resident and can be GBs — a clone would double it under the lock.
-        self.persist_log_index(self.finalized_block_number());
+        // STRICTLY, unlike the periodic best-effort checkpoints: a swallowed
+        // write failure here would merge from a stale file, install the
+        // result, and silently drop the live index's recent coverage — on
+        // the one path whose contract says nothing changes on failure.
+        {
+            let finalized = self.finalized_block_number();
+            let Ok(slot) = self.log_index.lock() else {
+                return Err("log index unavailable".to_string());
+            };
+            if let Some(ix) = slot.as_ref() {
+                let r = if finalized == 0 {
+                    ix.persist(&tag, &own_path)
+                } else {
+                    ix.persist_clamped(&tag, &own_path, finalized)
+                };
+                r.map_err(|e| {
+                    format!("could not checkpoint the current index before merging: {e}")
+                })?;
+            }
+        }
         let max_speed = self.with_log_index(|ix| ix.config().max_speed).unwrap_or(false);
         if own_path.exists() {
-            if let Some((t, ix)) = crate::el::logindex::LogIndex::load_portable(&own_path) {
-                if t == tag {
-                    sources.push((t, ix));
+            match crate::el::logindex::LogIndex::load_portable(&own_path) {
+                Some((t, ix)) if t == tag => sources.push((t, ix)),
+                Some(_) => {
+                    // A file for another chain at OUR canonical path — never
+                    // merge it, never overwrite it: someone put it there.
+                    return Err(format!(
+                        "{}: existing snapshot belongs to another chain; refusing to touch it",
+                        own_path.display()
+                    ));
                 }
+                // A legacy v1 checkpoint that nothing upgraded yet (no
+                // config push this run — the drop-in path skips v1, so
+                // the strict checkpoint above had nothing to write).
+                // Overwriting it would silently destroy its accumulated
+                // coverage; upgrading it needs the config only a push
+                // carries.
+                None if crate::el::logindex::LogIndex::is_legacy_snapshot(&own_path) => {
+                    return Err(format!(
+                        "{}: existing checkpoint predates the portable format (v1); \
+                         apply the log-index config once (host toggle / preset push) to \
+                         upgrade it, then re-import",
+                        own_path.display()
+                    ));
+                }
+                // Corrupt/unreadable: dead bytes — a load would discard them
+                // just the same; the merged result may replace them.
+                None => {}
             }
         }
         let (_, mut merged) =
@@ -1205,20 +1247,28 @@ impl ElReader {
         }));
     }
 
-    /// Best-effort ENS reverse naming for UNNAMED watch entries — the
-    /// imported-snapshot half of the naming story (the generator bakes names
-    /// at build time, but a file can arrive unnamed). Runs inside the
-    /// appender task so it dies with it at teardown (the Arc::try_unwrap
-    /// discipline). One address per tick, forward-verified engine-side
-    /// ([`EnsQuery::Reverse`]), and never gating indexing: an address whose
-    /// name cannot resolve just stays unnamed. Up to 3 attempts per address,
-    /// re-eligible every ~10 minutes — the first attempts often predate a
-    /// usable EVM state and must not be the last.
+    /// Best-effort ENS reverse naming for UNNAMED watch entries — imports
+    /// carry no names by design (the generator strips them; naming is the
+    /// importing wallet's job). Runs inside the appender task so it dies
+    /// with it at teardown (the Arc::try_unwrap discipline). Forward-verified
+    /// engine-side ([`EnsQuery::Reverse`]) and never gating indexing: an
+    /// address whose name cannot resolve just stays unnamed. Up to 3
+    /// attempts per address, re-eligible every ~10 minutes — the first
+    /// attempts often predate a usable EVM state and must not be the last.
+    ///
+    /// THROTTLED so cosmetics cannot starve indexing (this loop is also the
+    /// appender + backfill): one address per 5th tick (~30s cadence) and an
+    /// 8s bound per attempt — a cold resolution that needs longer just gets
+    /// retried once the EVM state is warm. Worst case the naming pass costs
+    /// the pipeline 8s in 30, instead of 30s per 6s tick.
     async fn log_index_name_tick(
         &self,
         attempts: &mut std::collections::HashMap<[u8; 20], (u8, u64)>,
         ticks: u64,
     ) {
+        if ticks % 5 != 0 {
+            return;
+        }
         if !self.with_log_index(|ix| ix.config().enabled).unwrap_or(false) {
             return;
         }
@@ -1247,10 +1297,10 @@ impl ElReader {
         entry.1 = ticks;
         // network_id == chain id on every hosted network (1 / 11155111 / 100).
         let chain_id = self.eth_cfg.network_id;
-        // Bounded well under the ENS API's own deadline: this shares the
+        // Tightly bounded (see the throttle note above): this shares the
         // appender loop, and a stalled resolution must not starve appends.
         let out = tokio::time::timeout(
-            std::time::Duration::from_secs(30),
+            std::time::Duration::from_secs(8),
             self.resolve_ens_query(EnsQuery::Reverse { address }, chain_id, EnsRootMode::Auto),
         )
         .await;

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -795,14 +795,21 @@ impl ElReader {
         })
     }
 
-    /// Install (or replace) the eth_getLogs watch-list config: reload the
-    /// persisted index when it matches the config's fingerprint, else start
-    /// empty (re-index). See docs/eth-getlogs-design.md.
+    /// Install the eth_getLogs watch-list config — ADDITIVELY: the pushed
+    /// config is unioned with what this node already subscribes (the live
+    /// index, or on boot the persisted snapshot's own watch-table), so a
+    /// host re-applying its shipped preset EXTENDS an imported subscription
+    /// instead of replacing it. Without this, every restart's preset push
+    /// would fingerprint-mismatch the imported index into a full re-index
+    /// (see docs/eth-getlogs-design.md §import).
+    ///
+    /// Accumulated coverage survives whenever the union changes nothing an
+    /// index can't absorb in place (bit flips, renames, a LOWERED
+    /// from_block). A genuinely new address or changed topic set still
+    /// checkpoints the old index and re-indexes under the union — per-entry
+    /// frontiers at different heights would wedge the appender.
     /// Returns false (and installs nothing) for an invalid config
-    /// (duplicate watch addresses). Re-applying a config whose watch-list
-    /// fingerprint matches the installed one only updates the enabled bit —
-    /// in-memory progress survives settings pokes; a genuinely changed
-    /// watch-list checkpoints the old index before replacing it.
+    /// (duplicate watch addresses).
     pub fn set_log_index_config(&self, config: crate::el::logindex::LogIndexConfig) -> bool {
         let finalized_now = self.finalized_block_number();
         // A SUCCESSFUL config apply invalidates the rate anchor: a pacing
@@ -814,22 +821,27 @@ impl ElReader {
                 *rate = None;
             }
         };
+        let tag = self.chain_tag();
         let Ok(mut slot) = self.log_index.lock() else {
             return false;
         };
         if let Some(ix) = slot.as_mut() {
-            if ix.config().fingerprint() == config.fingerprint() {
-                // Same watch-list: the index (and so the mapped gap and the
-                // tail record) still describes this coverage. Toggling enable
-                // or max-speed must not cost a full re-descent and a tail
-                // rewind back to finality.
-                ix.set_enabled(config.enabled);
-                ix.set_max_speed(config.max_speed);
-                reset_rate();
-                return true;
+            // Union against the LIVE watch-list. The live set always
+            // contains the persisted file's set (it was built from it), so
+            // no disk read is needed on a settings poke.
+            if let Some(eff) = config.union_with(&ix.config().watch) {
+                if ix.adopt_config(eff) {
+                    // Nothing accumulated was invalidated: coverage, the
+                    // mapped gap and the tail record still describe this
+                    // index. Bits/names/walk-target updated in place.
+                    reset_rate();
+                    return true;
+                }
             }
-            // A different watch-list REPLACES the index below, which
-            // invalidates both: neither describes the new coverage.
+            // New address or topic conflict → the union (or, on conflict,
+            // the pushed config alone) REPLACES the index below, which
+            // invalidates bridge and tail: neither describes the new
+            // coverage.
             self.clear_log_index_bridge();
             if let Ok(mut t) = self.log_index_tail.lock() {
                 t.clear();
@@ -839,28 +851,183 @@ impl ElReader {
                 // only verifiable against this run's tail record. A zero
                 // finality means no anchor (so nothing optimistic exists) —
                 // clamping there would erase the file.
-                let tag = self.chain_tag();
                 let _ = if finalized_now == 0 {
                     ix.persist(&tag, p)
                 } else {
                     ix.persist_clamped(&tag, p, finalized_now)
                 };
             }
+            let effective = config.union_with(&ix.config().watch).unwrap_or(config);
+            let fresh = match crate::el::logindex::LogIndex::new(effective) {
+                Ok(fresh) => fresh,
+                Err(_) => return false,
+            };
+            *slot = Some(fresh);
+            reset_rate();
+            return true;
         }
-        let loaded = self
+        // Boot: no live index yet. A portable (v2) snapshot on disk names
+        // its own subscription set — union the push with it and adopt its
+        // coverage; imports survive restarts this way. A legacy v1 file
+        // (config-keyed, pre-import builds) still loads the old way.
+        let stored = self
             .log_index_path
             .as_deref()
-            .and_then(|p| crate::el::logindex::LogIndex::load(&config, &self.chain_tag(), p));
-        let ix = match loaded {
-            Some(ix) => ix,
-            None => match crate::el::logindex::LogIndex::new(config) {
-                Ok(ix) => ix,
-                Err(_) => return false,
-            },
+            .and_then(crate::el::logindex::LogIndex::load_portable)
+            .filter(|(t, _)| *t == tag);
+        let ix = match stored {
+            Some((_, mut stored_ix)) => {
+                let adopted = config
+                    .union_with(&stored_ix.config().watch)
+                    .is_some_and(|eff| stored_ix.adopt_config(eff));
+                if adopted {
+                    stored_ix
+                } else {
+                    // Conflict or a genuinely new address: re-index under
+                    // the union when there is one (keep the imported
+                    // subscriptions — they re-cover), else the push alone.
+                    let effective =
+                        config.union_with(&stored_ix.config().watch).unwrap_or(config);
+                    match crate::el::logindex::LogIndex::new(effective) {
+                        Ok(fresh) => fresh,
+                        Err(_) => return false,
+                    }
+                }
+            }
+            None => {
+                let loaded = self
+                    .log_index_path
+                    .as_deref()
+                    .and_then(|p| crate::el::logindex::LogIndex::load(&config, &tag, p));
+                match loaded {
+                    Some(ix) => ix,
+                    None => match crate::el::logindex::LogIndex::new(config) {
+                        Ok(ix) => ix,
+                        Err(_) => return false,
+                    },
+                }
+            }
         };
         *slot = Some(ix);
         reset_rate();
         true
+    }
+
+    /// Activate a portable log-index snapshot found at this reader's own
+    /// path (the drop-in path, docs/eth-getlogs-design.md): a
+    /// self-describing file in the data dir IS an opt-in — someone put it
+    /// there deliberately, and the daemon has no settings surface to say so
+    /// otherwise. Enabled on activation; a host's config push right after
+    /// start unions with this and applies the host's own runtime bits (a
+    /// disabled toggle wins). No-op without a path, without a portable file
+    /// (legacy v1 files activate only through a config push — they name no
+    /// subscription set), for a foreign chain's file, or once a config has
+    /// already arrived.
+    pub fn activate_log_index_from_disk(self: &Arc<Self>, rt: &tokio::runtime::Handle) {
+        let Some(path) = self.log_index_path.as_deref() else {
+            return;
+        };
+        let Some((t, mut ix)) = crate::el::logindex::LogIndex::load_portable(path) else {
+            return;
+        };
+        if t != self.chain_tag() {
+            tracing::warn!(
+                path = %path.display(),
+                file_network = t.network_id,
+                own_network = self.eth_cfg.network_id,
+                "log-index snapshot on disk belongs to another chain; ignoring it"
+            );
+            return;
+        }
+        {
+            let Ok(mut slot) = self.log_index.lock() else {
+                return;
+            };
+            if slot.is_some() {
+                return; // a config already arrived — it wins
+            }
+            ix.set_enabled(true);
+            *slot = Some(ix);
+        }
+        tracing::info!(path = %path.display(), "activated log-index snapshot from disk");
+        self.ensure_log_index_appender(rt);
+    }
+
+    /// Import portable log-index snapshots (docs/eth-getlogs-design.md):
+    /// every file must be a v2 self-describing snapshot of THIS chain; they
+    /// merge with the node's current index (checkpointed first so nothing
+    /// in-memory is lost), the merged result is persisted and installed, and
+    /// the ordinary appender/bridge/walker machinery catches the union up —
+    /// new lows via the walker, the band above the merged high via bridge +
+    /// appender. All-or-nothing: any unreadable or foreign file fails the
+    /// whole import with nothing changed.
+    ///
+    /// Trust: an imported file is DATA CLAIMED VERIFIED by whoever generated
+    /// it (the same standing as the node's own snapshot — both were verified
+    /// at index time, neither is re-verified at load). Import is therefore a
+    /// deliberate, user-initiated act on the hosts, never something fetched.
+    ///
+    /// Importing enables the index (it is the opt-in, explicitly) and leaves
+    /// the pacing bit as it was.
+    pub fn import_log_index(&self, paths: &[std::path::PathBuf]) -> Result<(), String> {
+        let Some(own_path) = self.log_index_path.clone() else {
+            return Err("this node runs without a log-index path (no data dir)".to_string());
+        };
+        let tag = self.chain_tag();
+        let mut sources = Vec::new();
+        for p in paths {
+            let (t, ix) = crate::el::logindex::LogIndex::load_portable(p)
+                .ok_or_else(|| format!("{}: not a portable log-index snapshot", p.display()))?;
+            if t != tag {
+                return Err(format!(
+                    "{}: belongs to another chain (network id {}, this node is {})",
+                    p.display(),
+                    t.network_id,
+                    tag.network_id
+                ));
+            }
+            sources.push((t, ix));
+        }
+        if sources.is_empty() {
+            return Err("no files given".to_string());
+        }
+        // Checkpoint the live index (finality-clamped, v2) and merge THROUGH
+        // THE FILE rather than cloning the live store: the store is fully
+        // resident and can be GBs — a clone would double it under the lock.
+        self.persist_log_index(self.finalized_block_number());
+        let max_speed = self.with_log_index(|ix| ix.config().max_speed).unwrap_or(false);
+        if own_path.exists() {
+            if let Some((t, ix)) = crate::el::logindex::LogIndex::load_portable(&own_path) {
+                if t == tag {
+                    sources.push((t, ix));
+                }
+            }
+        }
+        let (_, mut merged) =
+            crate::el::logindex::LogIndex::merge(sources).map_err(|e| e.to_string())?;
+        // A snapshot generated by a node further along may carry coverage
+        // above THIS node's current finality. That data is finalized on the
+        // network (the generator clamps at its own finality) — local
+        // finality just hasn't caught up — so it persists as-is under the
+        // trusted-import premise above.
+        merged.set_enabled(true);
+        merged.set_max_speed(max_speed);
+        merged
+            .persist(&tag, &own_path)
+            .map_err(|e| format!("could not write {}: {e}", own_path.display()))?;
+        // Install: the bridge and tail describe the OLD coverage shape.
+        self.clear_log_index_bridge();
+        if let Ok(mut t) = self.log_index_tail.lock() {
+            t.clear();
+        }
+        if let Ok(mut rate) = self.log_index_rate.lock() {
+            *rate = None;
+        }
+        match self.log_index.lock() {
+            Ok(mut slot) => *slot = Some(merged),
+            Err(_) => return Err("log index unavailable".to_string()),
+        }
+        Ok(())
     }
 
     /// The beacon-anchored head block number, if the anchor is ready — the

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -839,17 +839,18 @@ impl ElReader {
                 // only verifiable against this run's tail record. A zero
                 // finality means no anchor (so nothing optimistic exists) —
                 // clamping there would erase the file.
+                let tag = self.chain_tag();
                 let _ = if finalized_now == 0 {
-                    ix.persist(p)
+                    ix.persist(&tag, p)
                 } else {
-                    ix.persist_clamped(p, finalized_now)
+                    ix.persist_clamped(&tag, p, finalized_now)
                 };
             }
         }
         let loaded = self
             .log_index_path
             .as_deref()
-            .and_then(|p| crate::el::logindex::LogIndex::load(&config, p));
+            .and_then(|p| crate::el::logindex::LogIndex::load(&config, &self.chain_tag(), p));
         let ix = match loaded {
             Some(ix) => ix,
             None => match crate::el::logindex::LogIndex::new(config) {
@@ -1368,17 +1369,28 @@ impl ElReader {
     fn persist_log_index(&self, finalized: u64) {
         if let (Some(path), Ok(slot)) = (self.log_index_path.as_deref(), self.log_index.lock()) {
             if let Some(ix) = slot.as_ref() {
+                let tag = self.chain_tag();
                 if finalized == 0 {
                     // No beacon anchor yet. There is no optimistic coverage to
                     // clamp either (the tail only runs below a real finality),
                     // and clamping AT ZERO would rewind the whole index and
                     // rename an empty file over a good checkpoint — losing, on
                     // a phone, months of backfill. Write it as it stands.
-                    let _ = ix.persist(path);
+                    let _ = ix.persist(&tag, path);
                 } else {
-                    let _ = ix.persist_clamped(path, finalized);
+                    let _ = ix.persist_clamped(&tag, path, finalized);
                 }
             }
+        }
+    }
+
+    /// The chain identity stamped into (and demanded of) every log-index
+    /// snapshot: this reader's own network, straight from its eth Status
+    /// config — never a filename convention.
+    pub fn chain_tag(&self) -> crate::el::logindex::ChainTag {
+        crate::el::logindex::ChainTag {
+            network_id: self.eth_cfg.network_id,
+            genesis_hash: self.eth_cfg.genesis_hash,
         }
     }
 

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -953,6 +953,31 @@ impl ElReader {
         self.ensure_log_index_appender(rt);
     }
 
+    /// Export the current index as a portable snapshot at `path` — the
+    /// generator's output. Clamped at finality like every checkpoint
+    /// (optimistic coverage is only verifiable against this run's tail
+    /// record); the v2 frame carries the watch-table + chain tag, so the file
+    /// imports anywhere on the same chain. Partial coverage exports honestly
+    /// — the importer's catch-up finishes the walk.
+    pub fn export_log_index(&self, path: &std::path::Path) -> Result<(), String> {
+        let tag = self.chain_tag();
+        let finalized = self.finalized_block_number();
+        match self.log_index.lock() {
+            Ok(slot) => match slot.as_ref() {
+                Some(ix) => {
+                    let r = if finalized == 0 {
+                        ix.persist(&tag, path)
+                    } else {
+                        ix.persist_clamped(&tag, path, finalized)
+                    };
+                    r.map_err(|e| format!("could not write {}: {e}", path.display()))
+                }
+                None => Err("no log index is configured".to_string()),
+            },
+            Err(_) => Err("log index unavailable".to_string()),
+        }
+    }
+
     /// Import portable log-index snapshots (docs/eth-getlogs-design.md):
     /// every file must be a v2 self-describing snapshot of THIS chain; they
     /// merge with the node's current index (checkpointed first so nothing

--- a/ui/src/commonMain/kotlin/io/myotis/ui/KohakuPreset.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/KohakuPreset.kt
@@ -68,7 +68,11 @@ object KohakuPreset {
     fun configJson(network: String, enabled: Boolean, maxSpeed: Boolean = false): String? {
         val watch = byNetwork[network] ?: return null
         val entries = watch.joinToString(",") {
-            """{"address":"${it.address}","fromBlock":${it.fromBlock}}"""
+            // Labels ride along as the entry's display name (they are fixed
+            // ASCII literals above — nothing to escape). The engine keeps
+            // names out of the config fingerprint, so they never invalidate
+            // accumulated coverage.
+            """{"address":"${it.address}","fromBlock":${it.fromBlock},"name":"${it.label}"}"""
         }
         return """{"enabled":$enabled,"maxSpeed":$maxSpeed,"watch":[$entries]}"""
     }

--- a/ui/src/commonMain/kotlin/io/myotis/ui/LogIndexStatus.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/LogIndexStatus.kt
@@ -13,6 +13,8 @@ object LogIndexStatus {
         val fromBlock: Long,
         val coveredLow: Long?,
         val coveredHigh: Long?,
+        /** Display name (ENS reverse name or host label); null when unnamed. */
+        val name: String? = null,
     )
 
     data class Parsed(
@@ -41,13 +43,15 @@ object LogIndexStatus {
         val logCount = Regex("\"logCount\":(\\d+)").find(json)?.groupValues?.get(1)?.toLongOrNull() ?: 0L
         val entries = Regex(
             "\\{\"address\":\"(0x[0-9a-fA-F]{40})\",\"fromBlock\":(\\d+)" +
+                "(?:,\"name\":\"((?:[^\"\\\\]|\\\\.)*)\")?" +
                 "(?:,\"coveredLow\":(\\d+),\"coveredHigh\":(\\d+))?\\}"
         ).findAll(json).map { m ->
             Entry(
                 address = m.groupValues[1].lowercase(),
                 fromBlock = m.groupValues[2].toLongOrNull() ?: 0L,
-                coveredLow = m.groupValues[3].takeIf { it.isNotEmpty() }?.toLongOrNull(),
-                coveredHigh = m.groupValues[4].takeIf { it.isNotEmpty() }?.toLongOrNull(),
+                coveredLow = m.groupValues[4].takeIf { it.isNotEmpty() }?.toLongOrNull(),
+                coveredHigh = m.groupValues[5].takeIf { it.isNotEmpty() }?.toLongOrNull(),
+                name = m.groupValues[3].takeIf { it.isNotEmpty() }?.let(::unescapeJson),
             )
         }.toList()
         val targetLow = Regex("\"targetLow\":(\\d+)").find(json)?.groupValues?.get(1)?.toLongOrNull()
@@ -100,6 +104,39 @@ object LogIndexStatus {
             return "${grouped(done)} / ${grouped(total)} blocks"
         }
         return "${grouped(remaining)} blocks remaining"
+    }
+
+    /** Minimal JSON string unescape for display names (\" \\ and the rare
+     *  \uXXXX from serde's escaping; anything else passes through). */
+    private fun unescapeJson(s: String): String {
+        if ('\\' !in s) return s
+        val out = StringBuilder(s.length)
+        var i = 0
+        while (i < s.length) {
+            val c = s[i]
+            if (c == '\\' && i + 1 < s.length) {
+                when (val n = s[i + 1]) {
+                    'u' -> {
+                        val hex = s.drop(i + 2).take(4)
+                        val cp = hex.takeIf { it.length == 4 }?.toIntOrNull(16)
+                        if (cp != null) {
+                            out.append(cp.toChar())
+                            i += 6
+                            continue
+                        }
+                        out.append(n); i += 2; continue
+                    }
+                    'n' -> out.append('\n')
+                    't' -> out.append('\t')
+                    else -> out.append(n)
+                }
+                i += 2
+            } else {
+                out.append(c)
+                i++
+            }
+        }
+        return out.toString()
     }
 
     /** One decimal below 10 (a slow walk must not read as "0 blk/s"),

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeController.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeController.kt
@@ -83,6 +83,22 @@ interface NodeController {
     fun applyLogIndex(network: String) {}
 
     /**
+     * Let the user pick portable log-index snapshot files (the host's native
+     * file picker) and import them into [network]'s index — the engine merges
+     * them with what it already holds and starts catch-up for every imported
+     * address immediately. On success the host also persists the enabled
+     * flag (importing is the opt-in). [onResult] gets one human-readable
+     * line — success summary or error — on the UI's thread. Returns false
+     * when this host cannot pick/import files (the Index tab hides the
+     * button; Rust engine only).
+     */
+    fun importLogIndexSnapshots(network: String, onResult: (String) -> Unit): Boolean = false
+
+    /** Whether [importLogIndexSnapshots] can work on this host (shows the
+     *  Index tab's Import button). Default false. */
+    val canImportLogIndex: Boolean get() = false
+
+    /**
      * Wipe a network's peer caches — clear the live stack's backoff/blacklist and delete the
      * on-disk EL/CL peer cache files — so discovery starts from a fresh slate. Safe whether or
      * not the network is currently running.

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeController.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeController.kt
@@ -88,9 +88,10 @@ interface NodeController {
      * them with what it already holds and starts catch-up for every imported
      * address immediately. On success the host also persists the enabled
      * flag (importing is the opt-in). [onResult] gets one human-readable
-     * line — success summary or error — on the UI's thread. Returns false
-     * when this host cannot pick/import files (the Index tab hides the
-     * button; Rust engine only).
+     * line — success summary or error — and may be invoked FROM A WORKER
+     * THREAD; callers must only touch thread-safe state in it (Compose
+     * snapshot state qualifies). Returns false when this host cannot
+     * pick/import files (the Index tab hides the button; Rust engine only).
      */
     fun importLogIndexSnapshots(network: String, onResult: (String) -> Unit): Boolean = false
 

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
@@ -110,13 +110,17 @@ fun NodeScreen(
     val snapshots by snapshotsFlow.collectAsState(initial = emptyMap())
     val onlineFlow = remember(netStatus) { netStatus.online() }
     val online by onlineFlow.collectAsState(initial = true)
-    // The Index tab only exists while the Kohaku log index reads as enabled in Settings —
-    // which is what its switch displays: the persisted per-network flags AND the Rust
-    // engine (without it the switch shows off/disabled and no engine serves the index).
-    // Both are plain settings reads, so the toggles that change them bump logIndexRev.
+    // The Index tab exists while the log index reads as enabled in Settings (the
+    // persisted per-network flags AND the Rust engine — without it the switch shows
+    // off/disabled and no engine serves the index), OR while any live engine reports
+    // an enabled index: an imported/dropped-in snapshot activates engine-side without
+    // any Settings flag ever having been touched, and hiding a running index would
+    // leave its progress unreachable. Settings are plain reads, so the toggles that
+    // change them bump logIndexRev; the engine side re-derives from `snapshots`.
     var logIndexRev by remember { mutableStateOf(0) }
-    val showIndexTab = remember(logIndexRev) {
-        settings.rustEngineEnabled() && KohakuPreset.byNetwork.keys.any { settings.logIndexEnabled(it) }
+    val showIndexTab = remember(logIndexRev, snapshots) {
+        (settings.rustEngineEnabled() && KohakuPreset.byNetwork.keys.any { settings.logIndexEnabled(it) }) ||
+            snapshots.values.any { it.logIndexJson?.contains("\"enabled\":true") == true }
     }
     val tabs = remember(showIndexTab) {
         if (showIndexTab) listOf("Status", "Query", "Logs", "Index", "Settings")
@@ -1673,26 +1677,24 @@ private fun IndexTab(
         modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        if (preset == null) {
-            Text("No Kohaku contract preset for $network.")
-            return@Column
-        }
         var collecting by remember(network) { mutableStateOf(settings.logIndexEnabled(network)) }
-        SwitchRow(
-            label = "Collect Kohaku contract logs on $network",
-            checked = collecting,
-            enabled = true,
-            onChange = { on ->
-                collecting = on
-                settings.setLogIndexEnabled(network, on)
-                controller.applyLogIndex(network)
-                onLogIndexChanged()
-            },
-        )
-        Text(
-            "Indexes and serves eth_getLogs for the Kohaku privacy contracts — verified " +
-                "against receipt roots, backfilling to each contract's deployment block.",
-        )
+        if (preset != null) {
+            SwitchRow(
+                label = "Collect Kohaku contract logs on $network",
+                checked = collecting,
+                enabled = true,
+                onChange = { on ->
+                    collecting = on
+                    settings.setLogIndexEnabled(network, on)
+                    controller.applyLogIndex(network)
+                    onLogIndexChanged()
+                },
+            )
+            Text(
+                "Indexes and serves eth_getLogs for the Kohaku privacy contracts — verified " +
+                    "against receipt roots, backfilling to each contract's deployment block.",
+            )
+        }
         if (collecting) {
             var maxSpeed by remember(network) { mutableStateOf(settings.logIndexMaxSpeed(network)) }
             SwitchRow(
@@ -1712,31 +1714,57 @@ private fun IndexTab(
                 else "Nice background pace — one small batch every few seconds.",
             )
         }
+        // Import: merge portable snapshot files (built by the daemon's
+        // build-logindex tool, or exported by another node) into this
+        // network's index \u2014 works with or without a preset.
+        if (controller.canImportLogIndex) {
+            var importResult by remember(network) { mutableStateOf<String?>(null) }
+            var importing by remember(network) { mutableStateOf(false) }
+            Button(
+                enabled = !importing,
+                onClick = {
+                    importing = true
+                    importResult = null
+                    val started = controller.importLogIndexSnapshots(network) { line ->
+                        importResult = line
+                        importing = false
+                        // Importing is the opt-in \u2014 reflect the flag the host persisted.
+                        collecting = settings.logIndexEnabled(network)
+                        onLogIndexChanged()
+                    }
+                    if (!started) importing = false
+                },
+            ) { Text(if (importing) "Importing\u2026" else "Import log-index snapshot\u2026") }
+            importResult?.let { Text(it) }
+        }
         val parsed = snapshot?.logIndexJson?.let { LogIndexStatus.parse(it) }
         when {
-            !collecting -> Text("Collection is off.")
-            parsed == null || !parsed.enabled ->
-                Text("Waiting for the engine (start the network with the Rust engine).")
-            else -> {
+            parsed?.enabled == true -> {
                 Text("${parsed.logCount} logs collected")
                 LogIndexStatus.progressLine(parsed)?.let { Text("Backfill: $it") }
-                preset.forEach { watch ->
-                    val e = parsed.entries.firstOrNull { it.address == watch.address.lowercase() }
-                    val low = e?.coveredLow
-                    val high = e?.coveredHigh
+                // The ENGINE's entry list is authoritative \u2014 it includes
+                // imported subscriptions the preset knows nothing about.
+                // Labels prefer the engine name (imports carry baked-in
+                // names), then the preset label, then the raw address.
+                parsed.entries.forEach { e ->
+                    val label = e.name
+                        ?: preset?.firstOrNull { it.address.lowercase() == e.address }?.label
+                        ?: e.address
+                    val low = e.coveredLow
+                    val high = e.coveredHigh
                     Column {
-                        Text(watch.label)
+                        Text(label)
                         if (low == null || high == null) {
-                            Text("waiting \u2014 target block ${watch.fromBlock}")
+                            Text("waiting \u2014 target block ${e.fromBlock}")
                             LinearProgressIndicator(progress = { 0f }, modifier = Modifier.fillMaxWidth())
                         } else {
-                            val total = (high - watch.fromBlock + 1).coerceAtLeast(1)
+                            val total = (high - e.fromBlock + 1).coerceAtLeast(1)
                             val done = (high - low + 1).coerceIn(0, total)
                             val pct = done.toFloat() / total.toFloat()
-                            val complete = low <= watch.fromBlock
+                            val complete = low <= e.fromBlock
                             Text(
-                                if (complete) "complete \u2014 blocks ${watch.fromBlock}\u2013$high"
-                                else "blocks $low\u2013$high \u00b7 target ${watch.fromBlock} \u00b7 ${(pct * 100).toInt()}%"
+                                if (complete) "complete \u2014 blocks ${e.fromBlock}\u2013$high"
+                                else "blocks $low\u2013$high \u00b7 target ${e.fromBlock} \u00b7 ${(pct * 100).toInt()}%"
                             )
                             LinearProgressIndicator(
                                 progress = { if (complete) 1f else pct },
@@ -1745,7 +1773,25 @@ private fun IndexTab(
                         }
                     }
                 }
+                // Preset entries the engine hasn't picked up yet (config not
+                // pushed / engine restarting): keep their waiting rows visible.
+                preset?.filter { p -> parsed.entries.none { it.address == p.address.lowercase() } }
+                    ?.forEach { watch ->
+                        Column {
+                            Text(watch.label)
+                            Text("waiting \u2014 target block ${watch.fromBlock}")
+                            LinearProgressIndicator(progress = { 0f }, modifier = Modifier.fillMaxWidth())
+                        }
+                    }
             }
+            collecting ->
+                Text("Waiting for the engine (start the network with the Rust engine).")
+            preset == null ->
+                Text(
+                    "No contract preset for $network. Import a log-index snapshot to " +
+                        "collect and serve eth_getLogs for its contracts."
+                )
+            else -> Text("Collection is off.")
         }
     }
 }


### PR DESCRIPTION
## What

Reworks the log index from a hardcoded-preset feature into a generic one: a tool that takes **plain contract addresses** and produces a **portable database** any Myotis host of the same chain can import — with catch-up completing automatically for every imported address, and human-readable names in the Index tab.

### The pieces

- **Self-describing v2 snapshot format** (`MLIX` v2): the frame now carries a **chain tag** (network id + EL genesis hash, checked on every load — logs are keyed by block-global `(block, log_index)`, so a foreign chain's file would silently collide keys and fabricate coverage) and the full **watch-table** (address, from_block, topic0s, display name). v1 files still load for upgrade (next checkpoint rewrites them); they're refused on the portable path since they name no subscription set.
- **Generator** (Rust-engine daemon): `build-logindex 0xA… 0xB… [--from N]` → poll `logindex-status` → `export-logindex <path>`. No preset involved; `--from` documented as a trust assertion (undershooting cannot lie, overshooting silently hides events); a malformed address errors the whole command rather than being dropped.
- **Import everywhere**: desktop AWT dialog, Android SAF picker, iOS document picker, daemon `import-logindex <file>…` — plus the zero-effort drop-in (a portable file at `dataDir/logindex[-net].db` self-activates at start). Multiple files per import, all-or-nothing, `ABI_VERSION` 24 (main took 23 for the estimateGas revert payload while this branch was in flight).
- **Canonical merge with a proven resumability invariant** (`walk_resumable`): coverage clamps to the minimum source high and unions per address; the cursor is the deepest source trust edge the walk can actually resume from, or none — a dropped cursor makes the appender re-seed at the top and the walker re-descend until every hole closes. Same-address disjoint spans resolve to the lower (deployment-anchored) history, per the owner's decision; the band above re-indexes, re-fetched, never trusted from the staler file.
- **Additive config** (behavior change, no signature change): `set_log_index_config` unions with the already-subscribed set, so a host preset push after restart *extends* an imported subscription instead of fingerprint-invalidating it; preset growth now **merges** (coverage survives) instead of re-indexing.
- **Naming, wallet-side only** (owner decision 2026-08-14): the generator writes unnamed entries. The importing wallet's engine fills names in — one unnamed address per appender tick, forward-verified `EnsQuery::Reverse`, ≤3 attempts, 30s-bounded — purely so the Index tab shows which contracts' logs are available. Preset labels outrank late lookups; names are fingerprint-neutral.

### Trust

Coverage honesty is preserved everywhere: no path fabricates coverage or serves an unverified block; every degradation is "re-index" or an honest error. An imported file is data claimed verified by whoever generated it — the same standing as the node's own snapshot — so import is a deliberate user act, never fetched.

## Review

An independent internal review ran before this PR. Its HIGH finding (the merge/adopt cursor rule enforced the *inverted* half of the walk-resumability invariant, which could permanently wedge the backfill when importing into a mid-backfill index) is fixed with regression tests that drive every merged shape through a simulated appender+walker to completion; its atomicity, drop-in-discard, clamping, and host-hygiene findings are all addressed (`4e066e19`).

## Testing

- `cargo test --workspace`: green (40 logindex unit tests incl. a seeded merge property test + catch-up simulation, corruption/bitflip sweeps on both load paths, v1-upgrade and chain-tag refusal).
- `./gradlew test -PskipRustEngine`: green (UniFFI bindings regenerated from source; ABI mirror test pins v24 on both sides).
- **Not compile-verified**: the iOS Kotlin/Native additions (`IosFilePicker.kt`, `IosNodeController`/`RustEngine` changes) — no macOS toolchain on this machine; the C-ABI side is tested and the header pin test passes.

## Follow-ups (tracked in docs/eth-getlogs-design.md §Slices)

Per-entry frontiers (lossless merges), Unchained-Index-assisted discovery, JVM engine twin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
