### PR TITLE
iOS: MyotisEngine.xcframework — build script, CI gate, release asset

### DIFF
--- a/.github/workflows/ios-xcframework.yml
+++ b/.github/workflows/ios-xcframework.yml
@@ -1,0 +1,109 @@
+# MyotisEngine.xcframework: the Rust engine's plain C ABI packaged as an iOS
+# static framework (device + fat simulator slices), for Swift hosts embedding
+# the engine directly — see rust/build-xcframework.sh. The build job is the
+# CI gate that keeps the iOS targets compiling on every rust/ change (a dep
+# bump with a platform-specific feature is all it takes to silently break
+# them); on `v*` tags the release job attaches the zip + SHA256 to the
+# GitHub Release next to the napi addons, with the engine ABI version in the
+# notes so hosts can gate on myotis_init().
+name: ios-xcframework
+
+on:
+  # Same scoping as the sibling asset workflows (node-binding/android-apk):
+  # builds stay green on main, `v*` tags publish the release asset. The
+  # paths filter only trims branch pushes — GitHub does not evaluate paths
+  # filters for tag pushes, so `v*` release runs always fire.
+  push:
+    branches: [ "main" ]
+    tags: [ "v*" ]
+    paths: ['rust/**', '.github/workflows/ios-xcframework.yml']
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build MyotisEngine.xcframework
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install iOS rust targets
+        run: rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust
+      - name: Build xcframework
+        run: rust/build-xcframework.sh
+      - name: Zip + checksum
+        run: |
+          set -eu
+          cd rust/target/ios-xcframework
+          # ditto preserves the framework bundle structure the way Xcode and
+          # SwiftPM binaryTarget consumers expect (plain zip loses resource
+          # forks / symlink layout on some setups).
+          ditto -c -k --sequesterRsrc --keepParent \
+            MyotisEngine.xcframework MyotisEngine.xcframework.zip
+          shasum -a 256 MyotisEngine.xcframework.zip | tee MyotisEngine.xcframework.zip.sha256
+      - uses: actions/upload-artifact@v4
+        with:
+          name: MyotisEngine.xcframework.zip
+          path: |
+            rust/target/ios-xcframework/MyotisEngine.xcframework.zip
+            rust/target/ios-xcframework/MyotisEngine.xcframework.zip.sha256
+          if-no-files-found: error
+
+  # Attach to the tag's GitHub Release. The android/desktop/node workflows
+  # publish to the SAME release for the same tag; whichever job runs first
+  # creates it and the others just add their assets — the create step
+  # tolerates that race. Gated on the REF, not the event, so a
+  # workflow_dispatch targeting a tag ref is the manual republish path.
+  release:
+    name: Publish xcframework to release
+    needs: [build]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      # Checked out because the ABI version is read from its source of truth
+      # in myotis-engine; this also gives gh its repo context.
+      - uses: actions/checkout@v4
+      - name: Download xcframework artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: MyotisEngine.xcframework.zip
+          path: dist
+      - name: Publish to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -eu
+          tag="${GITHUB_REF_NAME}"
+          abi=$(sed -n 's/^pub const ABI_VERSION: i32 = \([0-9][0-9]*\);.*$/\1/p' \
+            rust/myotis-engine/src/lib.rs)
+          [ -n "$abi" ] || { echo "::error::could not extract ABI_VERSION"; exit 1; }
+          section=$(mktemp)
+          cat > "$section" <<'SECTION'
+          **iOS (`MyotisEngine.xcframework.zip`)** — the Rust engine's C ABI as a
+          static xcframework (device arm64 + simulator arm64/x64) for Swift hosts
+          embedding the engine directly. Verify against
+          `MyotisEngine.xcframework.zip.sha256`. Engine ABI version: **__ABI__** —
+          hosts must gate on `myotis_init()` returning exactly __ABI__.
+          SECTION
+          sed -i "s/__ABI__/$abi/g" "$section"
+          # Tolerate the create/append race with the sibling asset workflows,
+          # and keep the append idempotent for manual republish runs.
+          if ! gh release view "$tag" > /dev/null 2>&1; then
+            gh release create "$tag" --title "$tag" --prerelease \
+              --notes "Pre-release build of the Myotis wallet apps." || true
+          fi
+          existing=$(gh release view "$tag" --json body --jq .body)
+          if ! grep -q 'MyotisEngine.xcframework.zip' <<<"$existing"; then
+            printf '%s\n\n%s\n' "$existing" "$(cat "$section")" > notes.md
+            gh release edit "$tag" --notes-file notes.md
+          fi
+          gh release upload "$tag" --clobber \
+            dist/MyotisEngine.xcframework.zip \
+            dist/MyotisEngine.xcframework.zip.sha256

--- a/README.md
+++ b/README.md
@@ -149,6 +149,14 @@ const ens = JSON.parse(await myotis.resolveEnsJson(h, 'vitalik.eth'));
 
 This is how the [Freedom browser](https://github.com/solardev-xyz/freedom-browser) is integrating Myotis ([PR #181](https://github.com/solardev-xyz/freedom-browser/pull/181)): an invisible background node — alongside the browser's Swarm and IPFS nodes — behind an experimental tier that serves fully-P2P verified `.eth` resolution with no prover service and no RPC provider in the loop.
 
+### Embedding: iOS / Swift
+
+For Swift hosts that embed the engine **without** the Kotlin/Native `MyotisKit` framework, [`rust/build-xcframework.sh`](rust/build-xcframework.sh) packages the engine's plain C ABI as a static **`MyotisEngine.xcframework`** (device arm64 + fat simulator slice, header + Clang modulemap included — `import MyotisEngine` from Swift). Releases ship the zip + SHA256 alongside the napi addons, and CI builds the iOS targets on every `rust/` change so they stay green.
+
+The host contract is the same as everywhere else: gate on `myotis_init()` returning the header's `MYOTIS_ABI_VERSION`, run the blocking verified reads off the main thread, free every returned string with `myotis_string_free`, and treat `myotis_pause`/`myotis_resume` as the scenePhase background/foreground hooks (warm resume is ~10 s back to `SYNCED`). Wait for `statusJson` to report `beaconState == "SYNCED"` **and** `snapPeers > 0` before attempting reads — right after sync the EL side can still be hunting a snap peer and reads fail with "state unavailable".
+
+One caveat: an app that already links **another** Rust staticlib (another embedded node) must not add this xcframework next to it — two Rust staticlibs in one binary collide on the runtime/allocator. Build a single aggregator staticlib crate that depends on both engines as rlibs and re-exports their C symbols instead (one std/allocator/tokio/libp2p). That is how the Freedom iOS browser embeds Myotis alongside its Swarm and IPFS nodes: [freedom-mobile-ffi](https://github.com/solardev-xyz/freedom-mobile-ffi).
+
 ### Desktop daemon
 
 The daemon discovers peers, maintains connections, and listens for CLI commands on a Unix domain socket (`/tmp/ethp2p.sock`); it exposes the verified operations as CLI commands (`get-account`, `get-storage`, `resolve-ens`, …) alongside the same verified JSON-RPC server the apps run (mainnet on `127.0.0.1:8545`). A **client** invocation sends a single command to the running daemon and exits.

--- a/rust/build-xcframework.sh
+++ b/rust/build-xcframework.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Build MyotisEngine.xcframework: the Rust engine as a plain-C-ABI static
+# library packaged for iOS device + simulator, for Swift hosts that embed the
+# engine directly (wallets/browsers) without the Kotlin/Native MyotisKit
+# framework. The C surface is rust/include/myotis_engine.h (see capi.rs);
+# hosts must gate on myotis_init() returning MYOTIS_ABI_VERSION.
+#
+# Slices: aarch64-apple-ios (device) and a fat simulator slice
+# (aarch64-apple-ios-sim + x86_64-apple-ios via lipo). macOS only (needs
+# xcodebuild + lipo).
+#
+# One-time setup:
+#   rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios
+#
+# Then: rust/build-xcframework.sh
+#   -> rust/target/ios-xcframework/MyotisEngine.xcframework
+#
+# NOTE for apps that already embed another Rust staticlib (e.g. another
+# embedded node): two Rust staticlibs in one binary collide on the Rust
+# runtime/allocator. Don't link this xcframework next to another one — build
+# ONE aggregator staticlib crate that depends on both engines as rlibs and
+# re-exports their C symbols, so there is a single compilation graph (one
+# std/allocator/tokio/libp2p). This xcframework is for hosts where Myotis is
+# the only Rust member.
+set -euo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+out="$here/target/ios-xcframework"
+hdrs="$out/headers"
+framework="$out/MyotisEngine.xcframework"
+libname=libmyotis_engine.a
+
+DEVICE=aarch64-apple-ios
+SIM_ARM=aarch64-apple-ios-sim
+SIM_X86=x86_64-apple-ios
+
+# Match the iOS host app's deployment target (ios-app/project.yml).
+export IPHONEOS_DEPLOYMENT_TARGET=15.2
+
+cd "$here"
+echo "==> Building release staticlibs"
+# crate-type in myotis-engine's Cargo.toml is cdylib+rlib (Android/JNI and
+# in-workspace consumers); --crate-type staticlib overrides it for the iOS
+# slices, which is the documented path (see the Cargo.toml comment).
+for t in "$DEVICE" "$SIM_ARM" "$SIM_X86"; do
+  echo "    - $t"
+  cargo rustc -p myotis-engine --release --crate-type staticlib --target "$t"
+done
+
+echo "==> Staging header + modulemap"
+rm -rf "$out"
+mkdir -p "$hdrs" "$out/sim"
+cp "$here/include/myotis_engine.h" "$hdrs/myotis_engine.h"
+# One Clang module over the C header so Swift hosts `import MyotisEngine`.
+# Linked frameworks are what the engine's networking stack pulls on Apple
+# platforms: rustls keychain roots (Security), if-watch interface monitoring
+# (SystemConfiguration), and CoreFoundation underneath both.
+cat > "$hdrs/module.modulemap" <<'EOF'
+module MyotisEngine {
+    header "myotis_engine.h"
+    link framework "Security"
+    link framework "SystemConfiguration"
+    link framework "CoreFoundation"
+    export *
+}
+EOF
+
+echo "==> lipo fat simulator slice"
+lipo -create -output "$out/sim/$libname" \
+  "$here/target/$SIM_ARM/release/$libname" \
+  "$here/target/$SIM_X86/release/$libname"
+
+echo "==> Assembling xcframework"
+xcodebuild -create-xcframework \
+  -library "$here/target/$DEVICE/release/$libname" -headers "$hdrs" \
+  -library "$out/sim/$libname" -headers "$hdrs" \
+  -output "$framework"
+
+echo "==> Done: $framework"


### PR DESCRIPTION
Adds a **direct-Swift embedding path** for the Rust engine, beside the Kotlin/Native `MyotisKit` framework — the README already points iOS wallets at embedding the engine's C ABI as a library; this makes that path a packaged, CI-guarded artifact.

## What's included

- **`rust/build-xcframework.sh`** — packages `myotis-engine` as a static `MyotisEngine.xcframework` (device arm64 + fat simulator arm64/x64 slice) with `myotis_engine.h` and a Clang modulemap, so Swift hosts `import MyotisEngine` and call the capi surface directly. Uses the `cargo rustc --crate-type staticlib` override your Cargo.toml comment already blesses. Style mirrors `build-android.sh`.
- **`.github/workflows/ios-xcframework.yml`** — a build-only CI gate that keeps the three iOS targets compiling on every `rust/` change (a dep bump with a platform-specific feature is all it takes to break them silently), plus a `v*`-tag release job that attaches `MyotisEngine.xcframework.zip` + SHA256 next to the napi addons, with the engine ABI version in the notes (same create-race tolerance and republish idempotency as `node-binding.yml`).
- **README** — an *Embedding: iOS / Swift* section documenting the host contract: gate on `myotis_init()` == `MYOTIS_ABI_VERSION`, blocking reads off the main thread, `myotis_string_free` ownership, `myotis_pause`/`myotis_resume` as the scenePhase background/foreground hooks, and waiting for `SYNCED` **and** `snapPeers > 0` before reads. Includes the one-Rust-staticlib-per-app caveat with the aggregator pattern as the fix.

## Validation

- Script run locally against current `main` (ABI 23): all three targets build, xcframework assembles, 156 `myotis_*` symbols exported from the device slice, header + modulemap staged.
- The same engine (at v0.1.7) is already running in production-shaped form inside the Freedom iOS browser via this C ABI — embedded alongside its Swarm and IPFS nodes in one aggregator staticlib ([freedom-mobile-ffi](https://github.com/solardev-xyz/freedom-mobile-ffi)), serving fully-P2P verified `.eth` resolution as the first tier of its resolution ladder (the mobile sibling of freedom-browser [PR #181](https://github.com/solardev-xyz/freedom-browser/pull/181)). Observed on-device: cold mainnet sync to `SYNCED` in ~40 s, warm resume ~10 s, verified reads gated on the snap-peer readiness described in the README section.

## A note on exact version pins (no change in this PR)

`myotis-engine`'s workspace exact-pins some deps (`tokio = "=1.52.3"`, `async-trait`, …). For standalone builds that's fine, but a host that links the engine into a larger Cargo graph — the aggregator pattern above — can't satisfy `=1.52.3` alongside another member's newer lock entry without regenerating its lockfile. Caret requirements (`tokio = "1.52"`) would keep those graphs resolvable while your committed `Cargo.lock` still pins your own builds exactly. Deliberately **not** changed here to keep this PR mechanical — happy to send it as a small follow-up if you agree.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)