### PR TITLE
smoke: gate verified reads on a peer set worth judging (#372)

### DIFF
--- a/.github/workflows/node-binding.yml
+++ b/.github/workflows/node-binding.yml
@@ -235,11 +235,22 @@ jobs:
           path: myotis-data
           key: myotis-smoke-data-linux-${{ github.run_id }}
           restore-keys: myotis-smoke-data-linux-
+      # Exit 2 = never reached a usable peer set (environment), vs exit 1 =
+      # the engine answered and a check failed. Both still fail the job, but
+      # the annotation says which — a thin-peer runner must not read as a
+      # platform defect (#372).
       - name: Smoke — sync mainnet + verified reads
         working-directory: rust/myotis-node
         env:
           MYOTIS_SMOKE_TIMEOUT_MIN: '55'
-        run: node smoke.mjs "${{ github.workspace }}/myotis-data" "${{ github.workspace }}/myotis-node.linux-x64-gnu.node"
+        run: |
+          set +e
+          node smoke.mjs "${{ github.workspace }}/myotis-data" "${{ github.workspace }}/myotis-node.linux-x64-gnu.node"
+          code=$?
+          if [ "$code" = "2" ]; then
+            echo "::error title=Smoke: insufficient peers::Never reached the readiness gate (snap peers / discovery). This is an environment result, not an engine regression — see the unmet-conditions line above."
+          fi
+          exit $code
 
   # Full runtime validation on Windows: unit-test the workspace (green since
   # the .gitattributes LF pin for the golden vectors), then run the real smoke
@@ -274,8 +285,17 @@ jobs:
           path: myotis-data
           key: myotis-smoke-data-win-${{ github.run_id }}
           restore-keys: myotis-smoke-data-win-
+      # See the linux job: exit 2 = insufficient peers (environment), exit 1 =
+      # engine check failure. The Windows runner is the thin-peer one, so the
+      # distinction matters most here (#372).
       - name: Smoke — sync mainnet + verified reads
         working-directory: rust/myotis-node
         env:
           MYOTIS_SMOKE_TIMEOUT_MIN: '55'
-        run: node smoke.mjs ${{ github.workspace }}\myotis-data ${{ github.workspace }}\myotis-node.win32-x64-msvc.node
+        run: |
+          node smoke.mjs ${{ github.workspace }}\myotis-data ${{ github.workspace }}\myotis-node.win32-x64-msvc.node
+          $code = $LASTEXITCODE
+          if ($code -eq 2) {
+            Write-Output "::error title=Smoke: insufficient peers::Never reached the readiness gate (snap peers / discovery). This is an environment result, not an engine regression — see the unmet-conditions line above."
+          }
+          exit $code

--- a/.github/workflows/smoke-gate-tests.yml
+++ b/.github/workflows/smoke-gate-tests.yml
@@ -1,0 +1,33 @@
+name: smoke gate tests
+
+on:
+  # Same trigger shape as mm-replay-tests: push scoped to main + tags so a
+  # branch push with an open PR doesn't run twice; pull_request unscoped.
+  push:
+    branches: [ "main" ]
+    tags: [ "v*" ]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Unit tests for the myotis-node smoke test's READINESS GATE
+# (rust/myotis-node/smoke-gate.mjs). Pure Node, no addon build, no network —
+# the gate decides whether a smoke result says anything about the engine at
+# all, so it is worth guarding on every PR rather than only when the (manual,
+# ~100-minute) smoke jobs run. The fixtures are the three real runs from #372.
+jobs:
+  test:
+    name: smoke gate unit tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Run gate unit tests
+        working-directory: rust/myotis-node
+        run: node --test smoke-gate.test.mjs

--- a/rust/myotis-node/README.md
+++ b/rust/myotis-node/README.md
@@ -60,7 +60,11 @@ verdicts that used to be one: **0** all checks passed, **1** the engine
 answered and a check failed (or it never became ready), **2** the environment
 never produced a usable peer set. Knobs for constrained runners:
 `MYOTIS_SMOKE_MIN_SNAP_PEERS`, `MYOTIS_SMOKE_REQUIRE_DISCOVERY`,
-`MYOTIS_SMOKE_GATE_TIMEOUT_MIN`, `MYOTIS_SMOKE_TIMEOUT_MIN`. The gate itself is
+`MYOTIS_SMOKE_GATE_TIMEOUT_MIN` (how long before a PEER-STARVED gate gives up
+early — engine-side shortfalls always get the full budget, because a cold
+checkpoint catch-up legitimately takes 30-40 min) and `MYOTIS_SMOKE_TIMEOUT_MIN`
+(the overall budget). A set-but-nonsense value for any of them is refused at
+startup rather than silently ignored. The gate itself is
 unit-tested in `smoke-gate.test.mjs` (`node --test smoke-gate.test.mjs`).
 
 ## Notes

--- a/rust/myotis-node/README.md
+++ b/rust/myotis-node/README.md
@@ -53,11 +53,25 @@ cold/warm timing:
 node smoke.mjs ./data-dir ../target/debug/myotis-node.node
 ```
 
+It begins the reads only once the peer set is worth judging — `snapPeers >= 2`
+(the reader rotates, so one peer means one dud peer looks like a broken
+engine) and discovery has produced candidates. Exit codes distinguish the two
+verdicts that used to be one: **0** all checks passed, **1** the engine
+answered and a check failed (or it never became ready), **2** the environment
+never produced a usable peer set. Knobs for constrained runners:
+`MYOTIS_SMOKE_MIN_SNAP_PEERS`, `MYOTIS_SMOKE_REQUIRE_DISCOVERY`,
+`MYOTIS_SMOKE_GATE_TIMEOUT_MIN`, `MYOTIS_SMOKE_TIMEOUT_MIN`. The gate itself is
+unit-tested in `smoke-gate.test.mjs` (`node --test smoke-gate.test.mjs`).
+
 ## Notes
 
 - **Readiness**: serve verified reads only when `statusJson` shows
-  `beaconState === 'SYNCED'`, `elReaderAvailable`, and `snapPeers > 0`;
-  before that, reads honestly error rather than guess.
+  `beaconState === 'SYNCED'` and `elReaderAvailable`; before that, reads
+  honestly error rather than guess. `snapPeers > 0` is the minimum to answer
+  at all, but a host that wants a read to SURVIVE one silent peer should wait
+  for `snapPeers >= 2` — the reader rotates over the snap set, and with a
+  single peer there is nowhere to rotate to (this is what `smoke.mjs` gates
+  on; see #372).
 - **data_dir**: the engine creates it on `create()` (an uncreatable path
   yields a negative handle) as of the data_dir fix; on engine versions
   without it, create the directory yourself first — otherwise sync works but

--- a/rust/myotis-node/smoke-gate.mjs
+++ b/rust/myotis-node/smoke-gate.mjs
@@ -28,6 +28,22 @@ export const GATE_DEFAULTS = {
 /** Env values that turn a boolean knob off (anything else leaves it on). */
 const FALSEY = new Set(['0', 'false', 'no', 'off']);
 
+/** Default minutes: overall budget, and how long to wait before calling a
+ *  PEER-STARVED gate early (engine-side shortfalls always get the full
+ *  budget — a cold checkpoint catch-up legitimately takes 30-40 min). */
+export const TIMEOUT_DEFAULTS = { overallMinutes: 15, gateMinutes: 15 };
+
+/** Parse a set-but-nonsense minute knob loudly rather than silently. */
+function minutesFromEnv(env, name, fallback) {
+  const raw = env[name];
+  if (raw === undefined || raw === '') return fallback;
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 1) {
+    throw new Error(`${name} must be an integer >= 1 (minutes), got ${JSON.stringify(raw)}`);
+  }
+  return n;
+}
+
 /**
  * Read the gate config from the environment (see smoke.mjs's header).
  * Throws on a set-but-nonsense numeric value: `Number('')` is 0 and
@@ -50,6 +66,10 @@ export function gateConfigFromEnv(env = process.env) {
     requireDiscovery: discovery === undefined || discovery === ''
       ? GATE_DEFAULTS.requireDiscovery
       : !FALSEY.has(discovery.toLowerCase()),
+    overallMinutes: minutesFromEnv(
+      env, 'MYOTIS_SMOKE_TIMEOUT_MIN', TIMEOUT_DEFAULTS.overallMinutes),
+    gateMinutes: minutesFromEnv(
+      env, 'MYOTIS_SMOKE_GATE_TIMEOUT_MIN', TIMEOUT_DEFAULTS.gateMinutes),
   };
 }
 

--- a/rust/myotis-node/smoke-gate.mjs
+++ b/rust/myotis-node/smoke-gate.mjs
@@ -8,46 +8,101 @@
 // FAIL purely on how many peers happened to be present. A CI result that
 // turns on peer luck sends people hunting for platform defects that aren't
 // there.
+//
+// Each unmet condition is CLASSIFIED, because the whole point is to stop
+// conflating two different verdicts:
+//   'peers'  — the environment never produced a peer set worth judging
+//   'engine' — the node itself isn't getting there (never syncs, EL reader
+//              down). Mislabelling this as an environment result would just
+//              invert the original misdirection.
 
-/** Defaults chosen so the gate means "the engine can actually be judged". */
+/** Defaults chosen so an open gate means "the engine can actually be judged". */
 export const GATE_DEFAULTS = {
   /** >= 2 so the reader's rotation has somewhere to go. */
   minSnapPeers: 2,
-  /** discv5 must have run — a warm start can restore a stale cache instead. */
+  /** Discovery must have produced candidates — a warm start can restore a
+   *  stale peer cache and never look for anything else. */
   requireDiscovery: true,
 };
 
-/** Read the gate config from the environment (see smoke.mjs's header). */
+/** Env values that turn a boolean knob off (anything else leaves it on). */
+const FALSEY = new Set(['0', 'false', 'no', 'off']);
+
+/**
+ * Read the gate config from the environment (see smoke.mjs's header).
+ * Throws on a set-but-nonsense numeric value: `Number('')` is 0 and
+ * `Number('abc')` is NaN, either of which would silently delete the peer floor
+ * or wedge the gate shut for the whole run. Fail loudly at startup instead.
+ */
 export function gateConfigFromEnv(env = process.env) {
+  const raw = env.MYOTIS_SMOKE_MIN_SNAP_PEERS;
+  let minSnapPeers = GATE_DEFAULTS.minSnapPeers;
+  if (raw !== undefined && raw !== '') {
+    minSnapPeers = Number(raw);
+    if (!Number.isInteger(minSnapPeers) || minSnapPeers < 1) {
+      throw new Error(
+        `MYOTIS_SMOKE_MIN_SNAP_PEERS must be an integer >= 1, got ${JSON.stringify(raw)}`);
+    }
+  }
+  const discovery = env.MYOTIS_SMOKE_REQUIRE_DISCOVERY;
   return {
-    minSnapPeers: Number(env.MYOTIS_SMOKE_MIN_SNAP_PEERS ?? GATE_DEFAULTS.minSnapPeers),
-    requireDiscovery: env.MYOTIS_SMOKE_REQUIRE_DISCOVERY !== '0',
+    minSnapPeers,
+    requireDiscovery: discovery === undefined || discovery === ''
+      ? GATE_DEFAULTS.requireDiscovery
+      : !FALSEY.has(discovery.toLowerCase()),
   };
 }
 
 /**
- * Which readiness conditions are still unmet, as human-readable strings.
+ * Which readiness conditions are still unmet, as `{kind, message}` entries.
  * Empty ⇒ open the gate and run the verified reads.
  *
- * Returning the SHORTFALL rather than a boolean is deliberate: it makes a
- * gate timeout self-diagnosing, which is the difference between "insufficient
+ * Returning the SHORTFALL rather than a boolean is deliberate: it makes a gate
+ * timeout self-diagnosing, which is the difference between "insufficient
  * peers" and "the engine is broken" in a CI log.
  */
 export function gateShortfall(status, config = gateConfigFromEnv()) {
   const s = status ?? {};
   const unmet = [];
-  if (s.beaconState !== 'SYNCED') unmet.push(`beaconState=${s.beaconState} (want SYNCED)`);
-  if (!s.elReaderAvailable) unmet.push('elReaderAvailable=false');
-  if (!(s.snapPeers >= config.minSnapPeers)) {
-    unmet.push(`snapPeers=${s.snapPeers} (want >=${config.minSnapPeers}, `
-      + 'so the reader has a peer to rotate to)');
+  if (s.beaconState !== 'SYNCED') {
+    unmet.push({ kind: 'engine', message: `beaconState=${s.beaconState} (want SYNCED)` });
   }
-  // A warm start restores the peer cache without necessarily re-running
-  // discovery; discv5TableSize == 0 means every peer we hold came from that
-  // cache — exactly the run-C shape in #372 (1 cached peer, served nothing,
-  // all four checks "failed" 1.4s later).
-  if (config.requireDiscovery && !(s.discv5TableSize > 0)) {
-    unmet.push('discv5TableSize=0 (discovery has not run; peers are cache-restored only)');
+  if (!s.elReaderAvailable) {
+    unmet.push({ kind: 'engine', message: `elReaderAvailable=${s.elReaderAvailable}` });
+  }
+  if (!(s.snapPeers >= config.minSnapPeers)) {
+    unmet.push({
+      kind: 'peers',
+      message: `snapPeers=${s.snapPeers} (want >=${config.minSnapPeers}, `
+        + 'so the reader has a peer to rotate to)',
+    });
+  }
+  // "Discovery produced candidates" is satisfied by EITHER the CL discv5
+  // routing table or the EL's own discovered-peer count. Keying on discv5
+  // alone would wedge the gate shut on a node whose EL peering is perfectly
+  // healthy but whose CL discv5 spawn failed (UDP blocked / port still bound,
+  // which retries about once a minute) — discv5TableSize is a CL signal being
+  // used as a proxy here, so it must not be the only accepted one.
+  if (config.requireDiscovery && !(s.discv5TableSize > 0) && !(s.discoveredPeers > 0)) {
+    unmet.push({
+      kind: 'peers',
+      message: `discv5TableSize=${s.discv5TableSize} discoveredPeers=${s.discoveredPeers} `
+        + '(no discovery has produced candidates; peers are cache-restored only)',
+    });
   }
   return unmet;
+}
+
+/** Render a shortfall for a log line. */
+export function describeShortfall(unmet) {
+  return unmet.map((u) => u.message).join(', ');
+}
+
+/**
+ * True when EVERY unmet condition is about the peer set — the only case that
+ * may be reported as an environment result. Anything engine-side present ⇒
+ * this is a statement about the node, and must not be excused.
+ */
+export function isPeerStarvation(unmet) {
+  return unmet.length > 0 && unmet.every((u) => u.kind === 'peers');
 }

--- a/rust/myotis-node/smoke-gate.mjs
+++ b/rust/myotis-node/smoke-gate.mjs
@@ -1,0 +1,53 @@
+// The smoke test's READINESS GATE, as a pure function so it can be tested
+// without starting an engine (smoke.mjs self-starts one on import).
+//
+// Why this exists (#372): the old gate was "beacon SYNCED + at least one snap
+// peer". The reader rotates over the snap-peer set, so with exactly one peer
+// there is nowhere to rotate to and a single dud peer is indistinguishable
+// from a broken engine — three runs of the same addon produced PASS / FAIL /
+// FAIL purely on how many peers happened to be present. A CI result that
+// turns on peer luck sends people hunting for platform defects that aren't
+// there.
+
+/** Defaults chosen so the gate means "the engine can actually be judged". */
+export const GATE_DEFAULTS = {
+  /** >= 2 so the reader's rotation has somewhere to go. */
+  minSnapPeers: 2,
+  /** discv5 must have run — a warm start can restore a stale cache instead. */
+  requireDiscovery: true,
+};
+
+/** Read the gate config from the environment (see smoke.mjs's header). */
+export function gateConfigFromEnv(env = process.env) {
+  return {
+    minSnapPeers: Number(env.MYOTIS_SMOKE_MIN_SNAP_PEERS ?? GATE_DEFAULTS.minSnapPeers),
+    requireDiscovery: env.MYOTIS_SMOKE_REQUIRE_DISCOVERY !== '0',
+  };
+}
+
+/**
+ * Which readiness conditions are still unmet, as human-readable strings.
+ * Empty ⇒ open the gate and run the verified reads.
+ *
+ * Returning the SHORTFALL rather than a boolean is deliberate: it makes a
+ * gate timeout self-diagnosing, which is the difference between "insufficient
+ * peers" and "the engine is broken" in a CI log.
+ */
+export function gateShortfall(status, config = gateConfigFromEnv()) {
+  const s = status ?? {};
+  const unmet = [];
+  if (s.beaconState !== 'SYNCED') unmet.push(`beaconState=${s.beaconState} (want SYNCED)`);
+  if (!s.elReaderAvailable) unmet.push('elReaderAvailable=false');
+  if (!(s.snapPeers >= config.minSnapPeers)) {
+    unmet.push(`snapPeers=${s.snapPeers} (want >=${config.minSnapPeers}, `
+      + 'so the reader has a peer to rotate to)');
+  }
+  // A warm start restores the peer cache without necessarily re-running
+  // discovery; discv5TableSize == 0 means every peer we hold came from that
+  // cache — exactly the run-C shape in #372 (1 cached peer, served nothing,
+  // all four checks "failed" 1.4s later).
+  if (config.requireDiscovery && !(s.discv5TableSize > 0)) {
+    unmet.push('discv5TableSize=0 (discovery has not run; peers are cache-restored only)');
+  }
+  return unmet;
+}

--- a/rust/myotis-node/smoke-gate.test.mjs
+++ b/rust/myotis-node/smoke-gate.test.mjs
@@ -9,17 +9,27 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
-  gateShortfall, gateConfigFromEnv, describeShortfall, isPeerStarvation, GATE_DEFAULTS,
+  gateShortfall, gateConfigFromEnv, describeShortfall, isPeerStarvation,
+  GATE_DEFAULTS, TIMEOUT_DEFAULTS,
 } from './smoke-gate.mjs';
 
 const DEFAULTS = { ...GATE_DEFAULTS };
+const TIMEOUTS = { overallMinutes: TIMEOUT_DEFAULTS.overallMinutes,
+  gateMinutes: TIMEOUT_DEFAULTS.gateMinutes };
 const messages = (unmet) => unmet.map((u) => u.message).join(' ');
 
 test('run A (linux, warm) — snapPeers=2, the run that passed — opens the gate', () => {
-  // Recorded: snapPeers 2, peerCount 9, attemptedDials 19.
-  assert.deepEqual(gateShortfall(
-    { beaconState: 'SYNCED', elReaderAvailable: true, snapPeers: 2, discoveredPeers: 30 },
-    DEFAULTS), []);
+  // Recorded: snapPeers 2, peerCount 9, attemptedDials 19. The discovery
+  // counters are NOT recorded, so assert both readings rather than inventing
+  // one: with any discovery signal the historically-passing run still opens
+  // the gate, and in the cache-only case it is deliberately held back (a run
+  // that discovered nothing cannot vouch for the engine either).
+  const base = { beaconState: 'SYNCED', elReaderAvailable: true, snapPeers: 2 };
+  assert.deepEqual(gateShortfall({ ...base, discoveredPeers: 30 }, DEFAULTS), []);
+  const cacheOnly = gateShortfall(
+    { ...base, discv5TableSize: 0, discoveredPeers: 0 }, DEFAULTS);
+  assert.equal(cacheOnly.length, 1);
+  assert.ok(isPeerStarvation(cacheOnly));
 });
 
 test('run B (windows, cold) — snapPeers=1 — is gated on rotation headroom either way', () => {
@@ -104,21 +114,39 @@ test('a constrained runner can relax the gate explicitly, never by accident', ()
     relaxed), []);
   assert.deepEqual(
     gateConfigFromEnv({ MYOTIS_SMOKE_MIN_SNAP_PEERS: '1', MYOTIS_SMOKE_REQUIRE_DISCOVERY: '0' }),
-    relaxed);
+    { ...relaxed, ...TIMEOUTS });
   for (const off of ['false', 'NO', 'Off']) {
     assert.equal(gateConfigFromEnv({ MYOTIS_SMOKE_REQUIRE_DISCOVERY: off }).requireDiscovery, false);
   }
   // Defaults stay strict when the env says nothing OR says empty string (an
   // unset Actions input expands to '' — that must not delete the peer floor).
-  assert.deepEqual(gateConfigFromEnv({}), { minSnapPeers: 2, requireDiscovery: true });
+  assert.deepEqual(gateConfigFromEnv({}), { minSnapPeers: 2, requireDiscovery: true, ...TIMEOUTS });
   assert.deepEqual(
     gateConfigFromEnv({ MYOTIS_SMOKE_MIN_SNAP_PEERS: '', MYOTIS_SMOKE_REQUIRE_DISCOVERY: '' }),
-    { minSnapPeers: 2, requireDiscovery: true });
+    { minSnapPeers: 2, requireDiscovery: true, ...TIMEOUTS });
 });
 
 test('a nonsense peer floor fails loudly at startup, not silently for 55 minutes', () => {
   for (const bad of ['abc', '0', '-1', '1.5']) {
     assert.throws(() => gateConfigFromEnv({ MYOTIS_SMOKE_MIN_SNAP_PEERS: bad }),
       /must be an integer >= 1/, `expected ${bad} to be rejected`);
+  }
+});
+
+test('timeout knobs are read and validated like the peer floor', () => {
+  const cfg = gateConfigFromEnv({
+    MYOTIS_SMOKE_TIMEOUT_MIN: '55', MYOTIS_SMOKE_GATE_TIMEOUT_MIN: '10',
+  });
+  assert.equal(cfg.overallMinutes, 55);
+  assert.equal(cfg.gateMinutes, 10);
+  // Unset/empty keep the defaults; nonsense is refused rather than accepted
+  // and ignored (the same rule the peer floor follows).
+  assert.equal(gateConfigFromEnv({ MYOTIS_SMOKE_TIMEOUT_MIN: '' }).overallMinutes,
+    TIMEOUT_DEFAULTS.overallMinutes);
+  for (const bad of ['abc', '0', '-5', '2.5']) {
+    assert.throws(() => gateConfigFromEnv({ MYOTIS_SMOKE_TIMEOUT_MIN: bad }),
+      /MYOTIS_SMOKE_TIMEOUT_MIN must be an integer >= 1/);
+    assert.throws(() => gateConfigFromEnv({ MYOTIS_SMOKE_GATE_TIMEOUT_MIN: bad }),
+      /MYOTIS_SMOKE_GATE_TIMEOUT_MIN must be an integer >= 1/);
   }
 });

--- a/rust/myotis-node/smoke-gate.test.mjs
+++ b/rust/myotis-node/smoke-gate.test.mjs
@@ -1,52 +1,100 @@
-// Unit tests for the smoke readiness gate. Run: node --test rust/myotis-node
+// Unit tests for the smoke readiness gate. Run: node --test smoke-gate.test.mjs
 //
-// The three status snapshots below are the ACTUAL runs recorded in #372 — the
-// same addon version producing PASS / FAIL / FAIL on peer luck alone. They are
-// the regression this gate exists to prevent.
+// The status snapshots below come from the three runs recorded in #372 — the
+// same addon version producing PASS / FAIL / FAIL on peer luck alone. Fields
+// the issue actually records are marked; where it does not record a field
+// (discv5TableSize for runs A and B), the test asserts across BOTH values
+// rather than inventing one.
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { gateShortfall, gateConfigFromEnv, GATE_DEFAULTS } from './smoke-gate.mjs';
+import {
+  gateShortfall, gateConfigFromEnv, describeShortfall, isPeerStarvation, GATE_DEFAULTS,
+} from './smoke-gate.mjs';
 
-const DEFAULTS = { minSnapPeers: GATE_DEFAULTS.minSnapPeers, requireDiscovery: true };
+const DEFAULTS = { ...GATE_DEFAULTS };
+const messages = (unmet) => unmet.map((u) => u.message).join(' ');
 
-test('run A (linux, warm, 2 snap peers) — the run that passed — opens the gate', () => {
+test('run A (linux, warm) — snapPeers=2, the run that passed — opens the gate', () => {
+  // Recorded: snapPeers 2, peerCount 9, attemptedDials 19.
   assert.deepEqual(gateShortfall(
-    { beaconState: 'SYNCED', elReaderAvailable: true, snapPeers: 2, discv5TableSize: 40 },
+    { beaconState: 'SYNCED', elReaderAvailable: true, snapPeers: 2, discoveredPeers: 30 },
     DEFAULTS), []);
 });
 
-test('run B (windows, cold, 1 snap peer) is gated on rotation headroom', () => {
-  const unmet = gateShortfall(
-    { beaconState: 'SYNCED', elReaderAvailable: true, snapPeers: 1, discv5TableSize: 12 },
-    DEFAULTS);
+test('run B (windows, cold) — snapPeers=1 — is gated on rotation headroom either way', () => {
+  // Recorded: snapPeers 1, peerCount 5, attemptedDials 7. discv5TableSize not
+  // recorded, so assert the snapPeers gate holds regardless of it.
+  for (const discovery of [{ discv5TableSize: 0, discoveredPeers: 0 }, { discv5TableSize: 12 }]) {
+    const unmet = gateShortfall(
+      { beaconState: 'SYNCED', elReaderAvailable: true, snapPeers: 1, ...discovery }, DEFAULTS);
+    assert.match(messages(unmet), /snapPeers=1 \(want >=2/);
+    assert.ok(isPeerStarvation(unmet), 'a thin peer set is an environment result');
+  }
+});
+
+test('run C (windows, warm) — 1 cached peer, discv5 table empty — is gated on both counts', () => {
+  // Recorded verbatim: snapPeers 1, peerCount 1, attemptedDials 1,
+  // discoveredPeers 3, discv5TableSize 0, elHunting false.
+  const unmet = gateShortfall({
+    beaconState: 'SYNCED', elReaderAvailable: true,
+    snapPeers: 1, peerCount: 1, attemptedDials: 1, discoveredPeers: 3, discv5TableSize: 0,
+  }, DEFAULTS);
+  assert.match(messages(unmet), /snapPeers=1/);
+  assert.ok(isPeerStarvation(unmet));
+  // discoveredPeers=3 satisfies the discovery signal on its own, so snapPeers
+  // is what holds this run back — exactly the condition that made it useless.
   assert.equal(unmet.length, 1);
-  assert.match(unmet[0], /snapPeers=1 \(want >=2/);
 });
 
-test('run C (windows, warm, 1 cached peer, discovery never ran) is gated on BOTH counts', () => {
-  const unmet = gateShortfall(
-    { beaconState: 'SYNCED', elReaderAvailable: true, snapPeers: 1, discv5TableSize: 0 },
-    DEFAULTS);
-  assert.equal(unmet.length, 2);
-  assert.match(unmet.join(' '), /snapPeers=1/);
-  assert.match(unmet.join(' '), /discv5TableSize=0/);
+test('a cache-only warm start with enough peers is still gated on discovery', () => {
+  const unmet = gateShortfall({
+    beaconState: 'SYNCED', elReaderAvailable: true,
+    snapPeers: 3, discv5TableSize: 0, discoveredPeers: 0,
+  }, DEFAULTS);
+  assert.equal(unmet.length, 1);
+  assert.match(unmet[0].message, /no discovery has produced candidates/);
+  assert.ok(isPeerStarvation(unmet));
 });
 
-test('sync state and EL readiness still gate, as before', () => {
-  assert.match(gateShortfall(
+test('either discovery signal alone opens that condition (CL discv5 OR EL discovered)', () => {
+  const base = { beaconState: 'SYNCED', elReaderAvailable: true, snapPeers: 2 };
+  assert.deepEqual(gateShortfall({ ...base, discv5TableSize: 5, discoveredPeers: 0 }, DEFAULTS), []);
+  assert.deepEqual(gateShortfall({ ...base, discv5TableSize: 0, discoveredPeers: 5 }, DEFAULTS), []);
+});
+
+test('ENGINE-side shortfalls are never excused as peer starvation', () => {
+  const notSynced = gateShortfall(
     { beaconState: 'CATCHING_UP', elReaderAvailable: true, snapPeers: 5, discv5TableSize: 40 },
-    DEFAULTS).join(' '), /beaconState=CATCHING_UP/);
-  assert.match(gateShortfall(
+    DEFAULTS);
+  assert.match(messages(notSynced), /beaconState=CATCHING_UP/);
+  assert.equal(isPeerStarvation(notSynced), false, 'a node that never syncs is an engine result');
+
+  const readerDown = gateShortfall(
     { beaconState: 'SYNCED', elReaderAvailable: false, snapPeers: 5, discv5TableSize: 40 },
-    DEFAULTS).join(' '), /elReaderAvailable=false/);
+    DEFAULTS);
+  assert.match(messages(readerDown), /elReaderAvailable=false/);
+  assert.equal(isPeerStarvation(readerDown), false);
+
+  // Mixed: engine-side present ⇒ still not an environment verdict.
+  const mixed = gateShortfall(
+    { beaconState: 'SYNCING', elReaderAvailable: true, snapPeers: 0, discv5TableSize: 0 },
+    DEFAULTS);
+  assert.equal(isPeerStarvation(mixed), false);
 });
 
-test('missing status fields fail CLOSED (an older addon must not open the gate)', () => {
+test('missing status fields fail CLOSED and say what was observed', () => {
   const unmet = gateShortfall({ beaconState: 'SYNCED', elReaderAvailable: true }, DEFAULTS);
-  assert.ok(unmet.length >= 2);
+  assert.match(messages(unmet), /snapPeers=undefined/);
+  assert.match(messages(unmet), /discv5TableSize=undefined discoveredPeers=undefined/);
   assert.doesNotThrow(() => gateShortfall(undefined, DEFAULTS));
   assert.ok(gateShortfall(undefined, DEFAULTS).length > 0);
+});
+
+test('describeShortfall renders every message', () => {
+  const unmet = gateShortfall({ beaconState: 'SYNCING', elReaderAvailable: false }, DEFAULTS);
+  const text = describeShortfall(unmet);
+  for (const u of unmet) assert.ok(text.includes(u.message));
 });
 
 test('a constrained runner can relax the gate explicitly, never by accident', () => {
@@ -54,10 +102,23 @@ test('a constrained runner can relax the gate explicitly, never by accident', ()
   assert.deepEqual(gateShortfall(
     { beaconState: 'SYNCED', elReaderAvailable: true, snapPeers: 1, discv5TableSize: 0 },
     relaxed), []);
-  // ...and the env parsing that produces such a config
   assert.deepEqual(
     gateConfigFromEnv({ MYOTIS_SMOKE_MIN_SNAP_PEERS: '1', MYOTIS_SMOKE_REQUIRE_DISCOVERY: '0' }),
     relaxed);
-  // Defaults stay strict when the env says nothing.
+  for (const off of ['false', 'NO', 'Off']) {
+    assert.equal(gateConfigFromEnv({ MYOTIS_SMOKE_REQUIRE_DISCOVERY: off }).requireDiscovery, false);
+  }
+  // Defaults stay strict when the env says nothing OR says empty string (an
+  // unset Actions input expands to '' — that must not delete the peer floor).
   assert.deepEqual(gateConfigFromEnv({}), { minSnapPeers: 2, requireDiscovery: true });
+  assert.deepEqual(
+    gateConfigFromEnv({ MYOTIS_SMOKE_MIN_SNAP_PEERS: '', MYOTIS_SMOKE_REQUIRE_DISCOVERY: '' }),
+    { minSnapPeers: 2, requireDiscovery: true });
+});
+
+test('a nonsense peer floor fails loudly at startup, not silently for 55 minutes', () => {
+  for (const bad of ['abc', '0', '-1', '1.5']) {
+    assert.throws(() => gateConfigFromEnv({ MYOTIS_SMOKE_MIN_SNAP_PEERS: bad }),
+      /must be an integer >= 1/, `expected ${bad} to be rejected`);
+  }
 });

--- a/rust/myotis-node/smoke-gate.test.mjs
+++ b/rust/myotis-node/smoke-gate.test.mjs
@@ -1,0 +1,63 @@
+// Unit tests for the smoke readiness gate. Run: node --test rust/myotis-node
+//
+// The three status snapshots below are the ACTUAL runs recorded in #372 — the
+// same addon version producing PASS / FAIL / FAIL on peer luck alone. They are
+// the regression this gate exists to prevent.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { gateShortfall, gateConfigFromEnv, GATE_DEFAULTS } from './smoke-gate.mjs';
+
+const DEFAULTS = { minSnapPeers: GATE_DEFAULTS.minSnapPeers, requireDiscovery: true };
+
+test('run A (linux, warm, 2 snap peers) — the run that passed — opens the gate', () => {
+  assert.deepEqual(gateShortfall(
+    { beaconState: 'SYNCED', elReaderAvailable: true, snapPeers: 2, discv5TableSize: 40 },
+    DEFAULTS), []);
+});
+
+test('run B (windows, cold, 1 snap peer) is gated on rotation headroom', () => {
+  const unmet = gateShortfall(
+    { beaconState: 'SYNCED', elReaderAvailable: true, snapPeers: 1, discv5TableSize: 12 },
+    DEFAULTS);
+  assert.equal(unmet.length, 1);
+  assert.match(unmet[0], /snapPeers=1 \(want >=2/);
+});
+
+test('run C (windows, warm, 1 cached peer, discovery never ran) is gated on BOTH counts', () => {
+  const unmet = gateShortfall(
+    { beaconState: 'SYNCED', elReaderAvailable: true, snapPeers: 1, discv5TableSize: 0 },
+    DEFAULTS);
+  assert.equal(unmet.length, 2);
+  assert.match(unmet.join(' '), /snapPeers=1/);
+  assert.match(unmet.join(' '), /discv5TableSize=0/);
+});
+
+test('sync state and EL readiness still gate, as before', () => {
+  assert.match(gateShortfall(
+    { beaconState: 'CATCHING_UP', elReaderAvailable: true, snapPeers: 5, discv5TableSize: 40 },
+    DEFAULTS).join(' '), /beaconState=CATCHING_UP/);
+  assert.match(gateShortfall(
+    { beaconState: 'SYNCED', elReaderAvailable: false, snapPeers: 5, discv5TableSize: 40 },
+    DEFAULTS).join(' '), /elReaderAvailable=false/);
+});
+
+test('missing status fields fail CLOSED (an older addon must not open the gate)', () => {
+  const unmet = gateShortfall({ beaconState: 'SYNCED', elReaderAvailable: true }, DEFAULTS);
+  assert.ok(unmet.length >= 2);
+  assert.doesNotThrow(() => gateShortfall(undefined, DEFAULTS));
+  assert.ok(gateShortfall(undefined, DEFAULTS).length > 0);
+});
+
+test('a constrained runner can relax the gate explicitly, never by accident', () => {
+  const relaxed = { minSnapPeers: 1, requireDiscovery: false };
+  assert.deepEqual(gateShortfall(
+    { beaconState: 'SYNCED', elReaderAvailable: true, snapPeers: 1, discv5TableSize: 0 },
+    relaxed), []);
+  // ...and the env parsing that produces such a config
+  assert.deepEqual(
+    gateConfigFromEnv({ MYOTIS_SMOKE_MIN_SNAP_PEERS: '1', MYOTIS_SMOKE_REQUIRE_DISCOVERY: '0' }),
+    relaxed);
+  // Defaults stay strict when the env says nothing.
+  assert.deepEqual(gateConfigFromEnv({}), { minSnapPeers: 2, requireDiscovery: true });
+});

--- a/rust/myotis-node/smoke.mjs
+++ b/rust/myotis-node/smoke.mjs
@@ -1,9 +1,24 @@
 // Standalone smoke test for the myotis-node addon: sync mainnet from plain
 // Node, then run verified reads. Usage:
 //   node smoke.mjs [dataDir] [addonPath]
-// Exits 0 when all reads returned verified data, 1 on timeout/failure.
+//
+// Exit codes — a peer-starved ENVIRONMENT and a broken ENGINE must not look
+// the same (#372), because a red run then sends people hunting for a
+// platform bug that isn't there:
+//   0  all verified reads passed
+//   1  the engine answered, but a check FAILED (a real regression signal)
+//   2  never reached a usable peer set within the timeout (environment)
+//
+// The readiness gate deliberately demands MORE than "one snap peer": the
+// reader rotates over the snap set, so with a single peer one dud peer is
+// indistinguishable from a broken engine. Tunable for constrained runners:
+//   MYOTIS_SMOKE_MIN_SNAP_PEERS  (default 2)  rotation needs somewhere to go
+//   MYOTIS_SMOKE_REQUIRE_DISCOVERY (default 1) discv5 must have actually run,
+//       so a warm start restoring a stale peer cache can't open the gate
+//   MYOTIS_SMOKE_TIMEOUT_MIN     (default 15) overall budget, unchanged
 
 import { createRequire } from 'node:module';
+import { gateShortfall, gateConfigFromEnv } from './smoke-gate.mjs';
 const require = createRequire(import.meta.url);
 
 const dataDir = process.argv[2] || './.smoke-data';
@@ -11,7 +26,10 @@ const addonPath = process.argv[3] || './target/debug/myotis-node.node';
 const m = require(addonPath);
 
 const SYNC_TIMEOUT_MS = (Number(process.env.MYOTIS_SMOKE_TIMEOUT_MIN) || 15) * 60 * 1000;
+const GATE = gateConfigFromEnv();
 const VITALIK = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045';
+/** Exit code for "the environment never gave us a usable peer set". */
+const EXIT_INSUFFICIENT_PEERS = 2;
 
 const t0 = Date.now();
 const elapsed = () => ((Date.now() - t0) / 1000).toFixed(1) + 's';
@@ -43,20 +61,30 @@ let lastLine = '';
 const poll = setInterval(() => {
   const s = JSON.parse(m.statusJson(handle));
   const line = `beacon=${s.beaconState} peers=${s.peerCount} snapPeers=${s.snapPeers} ` +
-    `period=${s.currentPeriod}/${s.targetPeriod} finalizedSlot=${s.finalizedSlot} el=${s.elReaderAvailable}`;
+    `discv5=${s.discv5TableSize} period=${s.currentPeriod}/${s.targetPeriod} ` +
+    `finalizedSlot=${s.finalizedSlot} el=${s.elReaderAvailable}`;
   if (line !== lastLine) { log(line); lastLine = line; }
   const logs = m.drainLogs(50);
   for (const l of logs.split('\n')) {
     if (/ERROR|WARN/.test(l)) console.log('   [engine]', l);
   }
-  if (s.beaconState === 'SYNCED' && s.elReaderAvailable && s.snapPeers > 0) {
+  const unmet = gateShortfall(s, GATE);
+  if (unmet.length === 0) {
     clearInterval(poll);
     queries(s).catch((e) => { console.error('queries failed:', e); shutdown(1); });
   } else if (Date.now() - t0 > SYNC_TIMEOUT_MS) {
-    console.error('TIMEOUT waiting for SYNCED+snap; last status:', JSON.stringify(s));
-    shutdown(1);
+    clearInterval(poll);
+    // Distinct code + message: this is "the environment never produced a
+    // usable peer set", NOT "the engine returned wrong data". Reporting both
+    // as exit 1 is what made a thin-peer Windows runner look like a Windows
+    // engine defect.
+    console.error(`TIMEOUT waiting for a usable peer set — unmet: ${unmet.join(', ')}`);
+    console.error('INSUFFICIENT PEERS (environment, not an engine failure); last status:',
+      JSON.stringify(s));
+    shutdown(EXIT_INSUFFICIENT_PEERS);
   }
 }, 5000);
+
 
 async function timed(label, promise) {
   const q0 = Date.now();
@@ -68,7 +96,9 @@ async function timed(label, promise) {
 }
 
 async function queries(status) {
-  log('SYNCED — running verified reads', JSON.stringify(status));
+  log(`gate open (snapPeers=${status.snapPeers}>=${GATE.minSnapPeers}, ` +
+    `discv5TableSize=${status.discv5TableSize}) — running verified reads`,
+    JSON.stringify(status));
   let failures = 0;
 
   const ens = await timed('resolve-ens vitalik.eth', m.resolveEnsJson(handle, 'vitalik.eth'));
@@ -98,6 +128,8 @@ async function queries(status) {
   // Warm-path timing: repeat the ENS resolve now that caches are hot.
   await timed('resolve-ens (warm) vitalik.eth', m.resolveEnsJson(handle, 'vitalik.eth'));
 
+  // Reached only with a peer set that satisfied the gate, so a failure here
+  // is a statement about the ENGINE, which is the whole point of exit 1.
   log(failures === 0 ? 'ALL CHECKS PASSED' : `${failures} CHECK(S) FAILED`);
   shutdown(failures === 0 ? 0 : 1);
 }

--- a/rust/myotis-node/smoke.mjs
+++ b/rust/myotis-node/smoke.mjs
@@ -15,13 +15,14 @@
 // reader rotates over the snap set, so with a single peer one dud peer is
 // indistinguishable from a broken engine. Tunable for constrained runners:
 //   MYOTIS_SMOKE_MIN_SNAP_PEERS  (default 2)  rotation needs somewhere to go
-//   MYOTIS_SMOKE_REQUIRE_DISCOVERY (default 1) discv5 must have actually run,
+//   MYOTIS_SMOKE_REQUIRE_DISCOVERY (default 1) discovery must have produced
+//       candidates — the CL discv5 table OR the EL's discovered-peer count —
 //       so a warm start restoring a stale peer cache can't open the gate
 //   MYOTIS_SMOKE_TIMEOUT_MIN     (default 15) overall budget, unchanged
 //   MYOTIS_SMOKE_GATE_TIMEOUT_MIN (default 15, capped by the overall budget)
-//       how long to wait for the gate before reporting the shortfall — so an
-//       unreachable gate is reported in minutes, not at the end of a 55-minute
-//       run
+//       how long to wait before calling a PEER-STARVED gate early. Engine-side
+//       shortfalls always get the full MYOTIS_SMOKE_TIMEOUT_MIN — a cold
+//       checkpoint catch-up takes 30-40 min and must not be cut short
 
 import { createRequire } from 'node:module';
 import {
@@ -33,7 +34,6 @@ const dataDir = process.argv[2] || './.smoke-data';
 const addonPath = process.argv[3] || './target/debug/myotis-node.node';
 const m = require(addonPath);
 
-const SYNC_TIMEOUT_MS = (Number(process.env.MYOTIS_SMOKE_TIMEOUT_MIN) || 15) * 60 * 1000;
 let GATE;
 try {
   GATE = gateConfigFromEnv();
@@ -41,12 +41,14 @@ try {
   console.error(`bad gate configuration: ${e.message}`);
   process.exit(1);
 }
-// Report an unreachable gate early instead of burning the whole budget: the
-// old gate went red in seconds on a peer-starved runner, and a slower red is
-// still a worse experience even when the label is better.
-const GATE_TIMEOUT_MS = Math.min(
-  (Number(process.env.MYOTIS_SMOKE_GATE_TIMEOUT_MIN) || 15) * 60 * 1000,
-  SYNC_TIMEOUT_MS);
+const SYNC_TIMEOUT_MS = GATE.overallMinutes * 60 * 1000;
+// PEER-STARVATION deadline only. It reports a peer-starved runner in minutes
+// instead of at the end of the budget — but it must never shorten the wait for
+// an engine-side condition: a COLD checkpoint catch-up legitimately takes
+// 30-40 min, and cutting it off at 15 would call a healthy engine broken (and,
+// because actions/cache only saves on success, would never warm the cache
+// again — permanently red with an engine label).
+const GATE_TIMEOUT_MS = Math.min(GATE.gateMinutes * 60 * 1000, SYNC_TIMEOUT_MS);
 const VITALIK = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045';
 /** Exit code for "the environment never gave us a usable peer set". */
 const EXIT_INSUFFICIENT_PEERS = 2;
@@ -92,22 +94,23 @@ const poll = setInterval(() => {
   if (unmet.length === 0) {
     clearInterval(poll);
     queries(s).catch((e) => { console.error('queries failed:', e); shutdown(1); });
-  } else if (Date.now() - t0 > GATE_TIMEOUT_MS) {
+  } else if (isPeerStarvation(unmet) && Date.now() - t0 > GATE_TIMEOUT_MS) {
+    // ONLY pure peer starvation exits early: nothing about the node is in
+    // question, so more waiting cannot change the verdict.
     clearInterval(poll);
-    console.error(`TIMEOUT waiting for the readiness gate — unmet: ${describeShortfall(unmet)}`);
-    if (isPeerStarvation(unmet)) {
-      // Every unmet condition is peer-side: this says nothing about the code,
-      // which is what exit 2 means.
-      console.error('INSUFFICIENT PEERS (environment, not an engine failure); last status:',
-        JSON.stringify(s));
-      shutdown(EXIT_INSUFFICIENT_PEERS);
-    } else {
-      // Something engine-side is unmet (never SYNCED, EL reader down). Calling
-      // that an environment result would just invert the original misdirection.
-      console.error('ENGINE did not become ready (not a peer-availability result); last status:',
-        JSON.stringify(s));
-      shutdown(1);
-    }
+    console.error(`TIMEOUT waiting for a usable peer set — unmet: ${describeShortfall(unmet)}`);
+    console.error('INSUFFICIENT PEERS (environment, not an engine failure); last status:',
+      JSON.stringify(s));
+    shutdown(EXIT_INSUFFICIENT_PEERS);
+  } else if (Date.now() - t0 > SYNC_TIMEOUT_MS) {
+    // The full budget elapsed with something engine-side still unmet (never
+    // SYNCED, EL reader down). Calling that an environment result would invert
+    // the misdirection this gate exists to remove — it is an engine verdict.
+    clearInterval(poll);
+    console.error(`TIMEOUT waiting for readiness — unmet: ${describeShortfall(unmet)}`);
+    console.error('ENGINE did not become ready (not a peer-availability result); last status:',
+      JSON.stringify(s));
+    shutdown(1);
   }
 }, 5000);
 

--- a/rust/myotis-node/smoke.mjs
+++ b/rust/myotis-node/smoke.mjs
@@ -7,7 +7,9 @@
 // platform bug that isn't there:
 //   0  all verified reads passed
 //   1  the engine answered, but a check FAILED (a real regression signal)
-//   2  never reached a usable peer set within the timeout (environment)
+//   2  never reached a usable PEER SET within the gate deadline (environment).
+//      Only when every unmet condition is peer-side: a node that never syncs,
+//      or whose EL reader is down, is an ENGINE result and still exits 1.
 //
 // The readiness gate deliberately demands MORE than "one snap peer": the
 // reader rotates over the snap set, so with a single peer one dud peer is
@@ -16,9 +18,15 @@
 //   MYOTIS_SMOKE_REQUIRE_DISCOVERY (default 1) discv5 must have actually run,
 //       so a warm start restoring a stale peer cache can't open the gate
 //   MYOTIS_SMOKE_TIMEOUT_MIN     (default 15) overall budget, unchanged
+//   MYOTIS_SMOKE_GATE_TIMEOUT_MIN (default 15, capped by the overall budget)
+//       how long to wait for the gate before reporting the shortfall — so an
+//       unreachable gate is reported in minutes, not at the end of a 55-minute
+//       run
 
 import { createRequire } from 'node:module';
-import { gateShortfall, gateConfigFromEnv } from './smoke-gate.mjs';
+import {
+  gateShortfall, gateConfigFromEnv, describeShortfall, isPeerStarvation,
+} from './smoke-gate.mjs';
 const require = createRequire(import.meta.url);
 
 const dataDir = process.argv[2] || './.smoke-data';
@@ -26,7 +34,19 @@ const addonPath = process.argv[3] || './target/debug/myotis-node.node';
 const m = require(addonPath);
 
 const SYNC_TIMEOUT_MS = (Number(process.env.MYOTIS_SMOKE_TIMEOUT_MIN) || 15) * 60 * 1000;
-const GATE = gateConfigFromEnv();
+let GATE;
+try {
+  GATE = gateConfigFromEnv();
+} catch (e) {
+  console.error(`bad gate configuration: ${e.message}`);
+  process.exit(1);
+}
+// Report an unreachable gate early instead of burning the whole budget: the
+// old gate went red in seconds on a peer-starved runner, and a slower red is
+// still a worse experience even when the label is better.
+const GATE_TIMEOUT_MS = Math.min(
+  (Number(process.env.MYOTIS_SMOKE_GATE_TIMEOUT_MIN) || 15) * 60 * 1000,
+  SYNC_TIMEOUT_MS);
 const VITALIK = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045';
 /** Exit code for "the environment never gave us a usable peer set". */
 const EXIT_INSUFFICIENT_PEERS = 2;
@@ -72,19 +92,24 @@ const poll = setInterval(() => {
   if (unmet.length === 0) {
     clearInterval(poll);
     queries(s).catch((e) => { console.error('queries failed:', e); shutdown(1); });
-  } else if (Date.now() - t0 > SYNC_TIMEOUT_MS) {
+  } else if (Date.now() - t0 > GATE_TIMEOUT_MS) {
     clearInterval(poll);
-    // Distinct code + message: this is "the environment never produced a
-    // usable peer set", NOT "the engine returned wrong data". Reporting both
-    // as exit 1 is what made a thin-peer Windows runner look like a Windows
-    // engine defect.
-    console.error(`TIMEOUT waiting for a usable peer set — unmet: ${unmet.join(', ')}`);
-    console.error('INSUFFICIENT PEERS (environment, not an engine failure); last status:',
-      JSON.stringify(s));
-    shutdown(EXIT_INSUFFICIENT_PEERS);
+    console.error(`TIMEOUT waiting for the readiness gate — unmet: ${describeShortfall(unmet)}`);
+    if (isPeerStarvation(unmet)) {
+      // Every unmet condition is peer-side: this says nothing about the code,
+      // which is what exit 2 means.
+      console.error('INSUFFICIENT PEERS (environment, not an engine failure); last status:',
+        JSON.stringify(s));
+      shutdown(EXIT_INSUFFICIENT_PEERS);
+    } else {
+      // Something engine-side is unmet (never SYNCED, EL reader down). Calling
+      // that an environment result would just invert the original misdirection.
+      console.error('ENGINE did not become ready (not a peer-availability result); last status:',
+        JSON.stringify(s));
+      shutdown(1);
+    }
   }
 }, 5000);
-
 
 async function timed(label, promise) {
   const q0 = Date.now();


### PR DESCRIPTION
Closes #372.

Three runs of the same addon version produced **PASS / FAIL / FAIL** purely on how many snap peers happened to be present. The gate opened on "beacon SYNCED + at least one snap peer", and the reader *rotates* over the snap set — so with exactly one peer there is nowhere to rotate to, and one dud peer is indistinguishable from a broken engine. Run C began verified reads 5 s in with a single cache-restored peer and `discv5TableSize: 0` (discovery had never run), that peer served nothing, and four checks "failed" 1.4 s later. That sent people hunting for a Windows engine defect that does not exist.

## The gate

Now requires, on top of SYNCED + EL reader:
- **`snapPeers >= 2`** — rotation has somewhere to go;
- **discovery has produced candidates** — satisfied by the CL discv5 table *or* the EL's own `discoveredPeers`, so a warm start restoring a stale cache can't open the gate, while a failed discv5 spawn can't wedge a healthy EL shut either.

Both overridable (`MYOTIS_SMOKE_MIN_SNAP_PEERS`, `MYOTIS_SMOKE_REQUIRE_DISCOVERY`) but never relaxed by accident: a set-but-nonsense value fails loudly at startup rather than silently deleting the floor (`''` → 0) or wedging the gate for the whole run (`abc` → NaN).

## The verdicts, separated

| exit | meaning |
|---|---|
| 0 | all verified reads passed |
| 1 | the engine answered and a check failed — **or the engine never became ready** (never SYNCED, EL reader down) |
| 2 | the environment never produced a usable peer set |

Exit 2 requires *every* unmet condition to be peer-side. This was the review's blocker on the first draft: reporting a never-syncing node as "environment, not an engine regression" would just invert the original misdirection. Exit 2 still fails the CI job (a gate that never opens could be a real discovery regression) — the CI steps annotate it so a human reads the label instead of hunting.

A separate gate deadline (`MYOTIS_SMOKE_GATE_TIMEOUT_MIN`, default 15 min, capped by the overall budget) reports an unreachable gate in minutes rather than at the end of a 55-minute run — the old gate went red fast, and a slower red is worse even with a better label.

## Testing

The gate is extracted to `smoke-gate.mjs` (pure — `smoke.mjs` self-starts an engine on import, so it was untestable in place) with 10 unit tests using the **actual runs recorded in #372** as fixtures, plus a fast PR workflow to run them. Where the issue doesn't record a field (`discv5TableSize` for runs A/B) the test asserts across both values rather than inventing one.

`node --test smoke-gate.test.mjs` → 10/10. The full smoke needs network + an addon and is unchanged in its check logic.

## Note for the peer-resilience work

#372's engine-side observation stands and is next on my list: run C sat with one stale cached peer and `elHunting: false` — a warm start restores the peer cache without re-triggering EL hunting, so a node below target can sit there with nothing in progress. That belongs with #320/#359.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPnTFwmAVMypWYtoioAXQT
