### PR TITLE
ci: build MyotisKit.xcframework, publish on pre-release (closes the app-ios CI gap)

### DIFF
--- a/.github/workflows/ios-framework.yml
+++ b/.github/workflows/ios-framework.yml
@@ -18,11 +18,27 @@ name: iOS Framework (MyotisKit)
 
 on:
   # Scope push to main + release tags so a branch push that also has an open PR
-  # doesn't build twice (the PR is covered by pull_request below).
+  # doesn't build twice (the PR is covered by pull_request below). Paths gate
+  # both push-to-main and PRs to the inputs that can change MyotisKit — a
+  # docs-only PR shouldn't pay a 10x-billed macOS build. The set is everything
+  # the framework compiles from: rust/ (the C ABI + engine), :app-ios and the
+  # modules it bundles (:ui, :jsonrpc-server), and the Gradle build inputs.
+  # Path filters are ignored for TAG pushes (GitHub behaviour, same as the
+  # sibling ios-xcframework.yml), so releases still fire regardless.
   push:
     branches: [ "main" ]
     tags: [ "v*" ]
+    paths: &fw_paths
+      - 'rust/**'
+      - 'app-ios/**'
+      - 'ui/**'
+      - 'jsonrpc-server/**'
+      - '**/build.gradle.kts'
+      - 'settings.gradle.kts'
+      - 'gradle/libs.versions.toml'
+      - '.github/workflows/ios-framework.yml'
   pull_request:
+    paths: *fw_paths
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -73,26 +89,52 @@ jobs:
       - name: Make gradlew executable
         run: chmod +x gradlew
 
-      # On a tag: the full xcframework (both triples, release) — the published
-      # artifact. Otherwise: the simulator framework only — one cargo triple,
-      # the cheaper safety-net compile that still exercises IosRpcBackend +
-      # cinterop + the C-ABI header. Retry rides out transient repo-resolution.
+      # On a tag: the full xcframework (both triples, RELEASE) — the published
+      # artifact. Otherwise: the DEBUG simulator framework only — one cargo
+      # triple, no whole-program optimization, the fast Kotlin/Native link that
+      # still fully exercises IosRpcBackend + cinterop + the C-ABI header (the
+      # task CLAUDE.md documents as the iOS check). cargo is --release either
+      # way (the cinterop -libraryPath is pinned to target/$triple/release), so
+      # only the KN link mode changes.
+      #
+      # Retry ONLY on resolution-shaped failures: this job's purpose is to
+      # surface a compile break, so a genuine one must fail on the FIRST build,
+      # not after 3 cold macOS runs. Dependency-resolution flakes still retry.
       - name: Build framework
-        id: build
         run: |
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             task=":app-ios:assembleMyotisKitReleaseXCFramework"
           else
-            task=":app-ios:linkReleaseFrameworkIosSimulatorArm64"
+            task=":app-ios:linkDebugFrameworkIosSimulatorArm64"
           fi
-          echo "task=$task"
+          echo "building $task"
           for attempt in 1 2 3; do
-            ./gradlew "$task" --stacktrace && exit 0
-            echo "::warning::framework build attempt $attempt failed; retrying in 25s (transient dependency resolution?)"
-            sleep 25
+            if ./gradlew "$task" --stacktrace 2>&1 | tee /tmp/gradle.log; then
+              exit 0
+            fi
+            if [ "$attempt" -lt 3 ] && grep -qE "Could not resolve|Could not GET|Connection reset|Read timed out|502 |503 |Premature end of Content-Length" /tmp/gradle.log; then
+              echo "::warning::attempt $attempt hit a dependency-resolution flake; retrying in 25s"
+              sleep 25
+              continue
+            fi
+            echo "::error::framework build failed (not a resolution flake — see the log above)"
+            exit 1
           done
-          echo "::error::framework build failed after 3 attempts"
+          echo "::error::framework build failed after 3 resolution retries"
           exit 1
+
+      # A DISABLED :app-ios (the cargo/rustup iOS-target probe came back false)
+      # reports the requested task SKIPPED and exits 0 — so the build step above
+      # can go green having compiled nothing, silently disarming the safety net.
+      # Assert the framework was actually produced. Tag builds are covered by
+      # the `test -d "$xc"` in the packaging step below.
+      - name: Verify the framework was actually linked
+        if: "!startsWith(github.ref, 'refs/tags/v')"
+        run: |
+          set -eu
+          fw="app-ios/build/bin/iosSimulatorArm64/debugFramework/MyotisKit.framework"
+          test -d "$fw"             || { echo "::error::$fw missing — :app-ios was disabled (no cargo/rustup iOS targets on the runner?), so NOTHING was compiled"; exit 1; }
+          echo "linked $fw"
 
       # Zip + checksum the xcframework for upload (the bundle is a directory;
       # it survives artifact round-trips only zipped). ditto is Apple's
@@ -104,7 +146,7 @@ jobs:
           set -eu
           xc="app-ios/build/XCFrameworks/release/MyotisKit.xcframework"
           test -d "$xc" || { echo "::error::missing $xc"; exit 1; }
-          ditto -c -k --keepParent "$xc" MyotisKit.xcframework.zip
+          ditto -c -k --sequesterRsrc --keepParent "$xc" MyotisKit.xcframework.zip
           shasum -a 256 MyotisKit.xcframework.zip | tee MyotisKit.xcframework.zip.sha256
           ls -lh MyotisKit.xcframework.zip
 
@@ -117,6 +159,10 @@ jobs:
             MyotisKit.xcframework.zip
             MyotisKit.xcframework.zip.sha256
           if-no-files-found: error
+          # Artifacts are immutable per run; without this, "Re-run all jobs" on
+          # a tag 409s here and the release job never runs — the button reached
+          # for after the version guard (in this job's needs) fails.
+          overwrite: true
 
   version-guard:
     name: Release version guard
@@ -162,19 +208,46 @@ jobs:
           the Myotis iOS app links, distinct from `MyotisEngine.xcframework` (the raw
           engine C ABI for Swift hosts). Not a signed app.
           SECTION
-          # Same create-or-append race handling as the MyotisEngine and node
-          # workflows publishing to this same release: create with the master
-          # line if absent (tolerating the race), then append THIS section only
-          # if its marker isn't already present (idempotent across reruns), so
-          # neither the master notes nor any sibling's section is clobbered.
-          if ! gh release view "$tag" > /dev/null 2>&1; then
-            gh release create "$tag" --title "Myotis $tag" --prerelease \
-              --notes "Pre-release build of the Myotis wallet apps." || true
+          # Master notes for the case where THIS job creates the release (same
+          # text the android/desktop/node workflows carry) — so a release this
+          # job wins the create race for still documents every sibling's asset.
+          notes=$(mktemp)
+          cat > "$notes" <<'NOTES'
+          Pre-release build of the Myotis wallet apps.
+
+          **Android (`*-android-debug.apk`)** — unsigned *debug* build. Install via
+          "Install unknown apps". Not a signed release build.
+
+          **Desktop macOS (`Myotis-<arch>.dmg`)** — unsigned; download the dmg matching
+          your Mac (arm64 for Apple Silicon, x64 for Intel). First launch:
+          right-click → Open to get past Gatekeeper (not notarized yet).
+
+          **Desktop Linux (`Myotis-<arch>.deb`)** — install with
+          `sudo apt install ./Myotis-<arch>.deb` (x64 for Intel/AMD, arm64 for
+          Raspberry Pi 5 / ARM machines).
+          NOTES
+          printf '\n' >> "$notes"
+          cat "$section" >> "$notes"
+          # Create with the full master body if absent; a sibling may win the
+          # race — on create failure re-check with `view` so a GENUINE failure
+          # still surfaces (matches the node/desktop idiom, not a bare `|| true`).
+          if ! gh release view "$tag" >/dev/null 2>&1; then
+            gh release create "$tag" \
+              --prerelease \
+              --title "Myotis $tag" \
+              --notes-file "$notes" \
+              --target "${GITHUB_SHA}" \
+            || gh release view "$tag" >/dev/null 2>&1
           fi
-          existing=$(gh release view "$tag" --json body --jq .body)
-          if ! grep -q 'MyotisKit.xcframework.zip' <<<"$existing"; then
-            printf '%s\n\n%s\n' "$existing" "$(cat "$section")" > notes.md
-            gh release edit "$tag" --notes-file notes.md
+          # Whether we created it or a sibling did: ensure the MyotisKit section
+          # is present exactly once (idempotent across reruns; appends when a
+          # sibling's notes won the create race). Never clobbers other sections.
+          body=$(mktemp)
+          gh release view "$tag" --json body --jq .body > "$body"
+          if ! grep -q 'MyotisKit.xcframework.zip' "$body"; then
+            printf '\n' >> "$body"
+            cat "$section" >> "$body"
+            gh release edit "$tag" --notes-file "$body"
           fi
           gh release upload "$tag" --clobber \
             MyotisKit.xcframework.zip \

--- a/.github/workflows/ios-framework.yml
+++ b/.github/workflows/ios-framework.yml
@@ -1,0 +1,181 @@
+name: iOS Framework (MyotisKit)
+
+# Builds MyotisKit.xcframework — the Kotlin/Native framework the iOS APP links
+# (:ui's Compose UI + the iOS host seams + IosRpcBackend), via cargo (release
+# static lib for the iOS triples) → cinterop → Kotlin/Native link. No code
+# signing / provisioning: those are only needed for a distributable signed
+# .ipa app, which this is not.
+#
+# DISTINCT from ios-xcframework.yml, which builds MyotisEngine.xcframework —
+# the raw Rust engine C ABI for Swift hosts that embed the engine directly
+# (pure rust/, via build-xcframework.sh). That workflow never compiles the
+# Kotlin :app-ios module, so this is the ONLY automated check that does: a
+# break in IosRpcBackend or a drift in the engine's C ABI header would
+# otherwise sail through green until someone built the app on a Mac (which is
+# why the revert PRs each needed a manual compileKotlinIos* run). The PR/main
+# leg is that safety net; the tag leg publishes the xcframework to the same
+# pre-release the sibling asset workflows populate.
+
+on:
+  # Scope push to main + release tags so a branch push that also has an open PR
+  # doesn't build twice (the PR is covered by pull_request below).
+  push:
+    branches: [ "main" ]
+    tags: [ "v*" ]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    # macos-15 for a recent Xcode toolchain (the Kotlin/Native iOS link needs
+    # Xcode's clang/ld for the target). macos-14's Xcode also links a static
+    # framework, but 15 tracks closer to the dev fleet's Xcode 26.
+    name: Build MyotisKit framework
+    runs-on: macos-15
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Full history: :ui (bundled into the framework) stamps its on-screen
+          # version from the nearest v* tag via `git describe`, which needs
+          # HEAD's history to reach that tag — same reason as the desktop dmg.
+          fetch-depth: 0
+
+      - name: Set up JDK 21 (aarch64)
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          architecture: 'aarch64'
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          # Both iOS triples the framework embeds. The runner is Apple Silicon,
+          # so device (aarch64-apple-ios) and arm64 simulator
+          # (aarch64-apple-ios-sim) are the two the module targets — there is
+          # deliberately no x86_64 simulator (Apple-Silicon-only dev fleet).
+          targets: aarch64-apple-ios, aarch64-apple-ios-sim
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Make gradlew executable
+        run: chmod +x gradlew
+
+      # On a tag: the full xcframework (both triples, release) — the published
+      # artifact. Otherwise: the simulator framework only — one cargo triple,
+      # the cheaper safety-net compile that still exercises IosRpcBackend +
+      # cinterop + the C-ABI header. Retry rides out transient repo-resolution.
+      - name: Build framework
+        id: build
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            task=":app-ios:assembleMyotisKitReleaseXCFramework"
+          else
+            task=":app-ios:linkReleaseFrameworkIosSimulatorArm64"
+          fi
+          echo "task=$task"
+          for attempt in 1 2 3; do
+            ./gradlew "$task" --stacktrace && exit 0
+            echo "::warning::framework build attempt $attempt failed; retrying in 25s (transient dependency resolution?)"
+            sleep 25
+          done
+          echo "::error::framework build failed after 3 attempts"
+          exit 1
+
+      # Zip + checksum the xcframework for upload (the bundle is a directory;
+      # it survives artifact round-trips only zipped). ditto is Apple's
+      # bundle-preserving archiver — matches the sibling MyotisEngine workflow.
+      # Tag builds only — nothing to publish otherwise.
+      - name: Package xcframework
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          set -eu
+          xc="app-ios/build/XCFrameworks/release/MyotisKit.xcframework"
+          test -d "$xc" || { echo "::error::missing $xc"; exit 1; }
+          ditto -c -k --keepParent "$xc" MyotisKit.xcframework.zip
+          shasum -a 256 MyotisKit.xcframework.zip | tee MyotisKit.xcframework.zip.sha256
+          ls -lh MyotisKit.xcframework.zip
+
+      - name: Upload xcframework artifact
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: actions/upload-artifact@v4
+        with:
+          name: myotis-ios-xcframework-${{ github.sha }}
+          path: |
+            MyotisKit.xcframework.zip
+            MyotisKit.xcframework.zip.sha256
+          if-no-files-found: error
+
+  version-guard:
+    name: Release version guard
+    if: startsWith(github.ref, 'refs/tags/v')
+    uses: ./.github/workflows/release-version-guard.yml
+
+  # Attach the xcframework to the GitHub Release for the pushed tag. Runs ONLY
+  # on v* tags, after the build + guard, and reuses the build's artifact. The
+  # desktop/android/node workflows publish to the SAME release for the same
+  # tag; whichever job runs first creates it and the others just upload — the
+  # create step tolerates that race.
+  release:
+    name: Publish xcframework to release
+    needs: [build, version-guard]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download xcframework artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: myotis-ios-xcframework-${{ github.sha }}
+
+      - name: Publish to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # No checkout in this job — gh needs the repo told explicitly or it
+          # dies with "fatal: not a git repository".
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -eu
+          tag="${GITHUB_REF_NAME}"
+          test -f MyotisKit.xcframework.zip \
+            || { echo "::error::missing MyotisKit.xcframework.zip"; exit 1; }
+          section=$(mktemp)
+          cat > "$section" <<'SECTION'
+          **iOS app framework (`MyotisKit.xcframework.zip`)** — the Kotlin/Native
+          framework (device arm64 + simulator arm64) bundling the shared Compose UI
+          and the iOS host seams, embedding the Rust engine over its C ABI. Static —
+          no dyld embed at launch. Drop `MyotisKit.xcframework` into an Xcode project;
+          verify against `MyotisKit.xcframework.zip.sha256`. This is the UI framework
+          the Myotis iOS app links, distinct from `MyotisEngine.xcframework` (the raw
+          engine C ABI for Swift hosts). Not a signed app.
+          SECTION
+          # Same create-or-append race handling as the MyotisEngine and node
+          # workflows publishing to this same release: create with the master
+          # line if absent (tolerating the race), then append THIS section only
+          # if its marker isn't already present (idempotent across reruns), so
+          # neither the master notes nor any sibling's section is clobbered.
+          if ! gh release view "$tag" > /dev/null 2>&1; then
+            gh release create "$tag" --title "Myotis $tag" --prerelease \
+              --notes "Pre-release build of the Myotis wallet apps." || true
+          fi
+          existing=$(gh release view "$tag" --json body --jq .body)
+          if ! grep -q 'MyotisKit.xcframework.zip' <<<"$existing"; then
+            printf '%s\n\n%s\n' "$existing" "$(cat "$section")" > notes.md
+            gh release edit "$tag" --notes-file notes.md
+          fi
+          gh release upload "$tag" --clobber \
+            MyotisKit.xcframework.zip \
+            MyotisKit.xcframework.zip.sha256

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ cd ios-app && xcodebuild -project Myotis.xcodeproj -scheme Myotis \
   -destination 'platform=iOS Simulator,name=<device>' build
 ```
 
-On iOS the app form is a development host more than an integration point: iOS suspends backgrounded apps, so the app's loopback JSON-RPC listener (foreground-only) can't serve a separate wallet app the way the Android and desktop nodes can. The supported iOS integration is **embedding** — a wallet links the `MyotisKit` framework (or the engine's C ABI directly) and runs the node in its own process.
+On iOS the app form is a development host more than an integration point: iOS suspends backgrounded apps, so the app's loopback JSON-RPC listener (foreground-only) can't serve a separate wallet app the way the Android and desktop nodes can. The supported iOS integration is **embedding** — a wallet links the `MyotisKit` framework (or the engine's C ABI directly) and runs the node in its own process. Releases ship a prebuilt **`MyotisKit.xcframework.zip`** (device arm64 + arm64 simulator, `+ .sha256`) so a host can drop it in without a local Kotlin/Native build.
 
 ### Desktop app (GUI)
 

--- a/app-ios/build.gradle.kts
+++ b/app-ios/build.gradle.kts
@@ -7,6 +7,7 @@
 // standard embedAndSignAppleFrameworkForXcode build phase.
 
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
@@ -24,6 +25,13 @@ kotlin {
         "ios_simulator_arm64" to ("aarch64-apple-ios-sim" to "cargoBuildIosSim"),
     )
 
+    // Bundles the per-target frameworks into MyotisKit.xcframework (device +
+    // arm64 simulator) — the single distributable a consumer drops in. The
+    // Xcode app doesn't use it (it links a per-target framework via
+    // embedAndSignAppleFrameworkForXcode); this exists for the CI release
+    // artifact. `assembleMyotisKitReleaseXCFramework` is the produced task.
+    val xcf = XCFramework("MyotisKit")
+
     listOf(iosArm64(), iosSimulatorArm64()).forEach { target: KotlinNativeTarget ->
         val (triple, cargoTask) = rustTargets.getValue(target.konanTarget.name)
         target.compilations.getByName("main").cinterops.create("myotisEngine") {
@@ -38,6 +46,7 @@ kotlin {
             // Static framework: the Rust .a and the Kotlin objects end up in one
             // archive the app links directly — no embed step, no dyld at launch.
             isStatic = true
+            xcf.add(this)
         }
     }
 


### PR DESCRIPTION
Builds **MyotisKit.xcframework** — the Kotlin/Native framework the iOS *app* links (`:ui`'s Compose UI + the iOS host seams + `IosRpcBackend`, embedding the Rust engine over its C ABI) — on CI, and publishes it to the pre-release.

## Why

This framework had **no automated build**. `ios-xcframework.yml` (already in tree) covers only `MyotisEngine.xcframework` — the *raw Rust engine C ABI* for Swift hosts embedding the engine directly — and never compiles the Kotlin `:app-ios` module. So a break in `IosRpcBackend` or a drift in the engine's C-ABI header (`rust/include/myotis_engine.h`) sailed through CI green until someone built the app on a Mac. That's exactly why the two revert PRs (#363/#364) each needed a manual `:app-ios:compileKotlinIosSimulatorArm64` run to catch iOS breakage. This closes that gap.

## What it does (`macos-15`, mirroring desktop-dmg + ios-xcframework)

- **PR / main push:** build the simulator framework only (`linkReleaseFrameworkIosSimulatorArm64`) — one cargo triple, the cheap safety-net compile that still exercises `IosRpcBackend` + cinterop + the C-ABI header. A compile error or ABI drift now fails CI.
- **`v*` tag:** assemble `MyotisKit.xcframework` (device arm64 + simulator arm64, release), zip + sha256 with `ditto`, and publish to the same pre-release the desktop / android / node / MyotisEngine workflows populate — using the sibling `ios-xcframework.yml`'s **marker-guarded create-or-append** notes handling, so no workflow clobbers another's section. ~83 MB zipped.

No code signing / provisioning — the framework is what an integrator consumes; a signed `.ipa` app is a separate, heavier lift.

## Gradle change

`app-ios/build.gradle.kts` gains an `XCFramework` assembly (`assembleMyotisKitReleaseXCFramework`) for the bundled artifact. The Xcode app is unaffected — it still links a per-target framework via `embedAndSignAppleFrameworkForXcode`. The change is pure task registration at configuration time, so it doesn't endanger the `iosFrameworkBuildable` self-disable on cargo-less / non-Mac machines.

## Validation

Built end-to-end **locally on Xcode 26.2**: both release frameworks link (cargo iOS release + cinterop + Kotlin/Native, ~12 min) and `MyotisKit.xcframework` assembles with device + arm64-sim slices. The PR-leg sim task and the tag-leg xcframework task both verified. Independent no-context review addressed — it correctly caught that I'd copied desktop-dmg's create-only notes without its master body; fixed by adopting `ios-xcframework.yml`'s marker-guarded append instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPnTFwmAVMypWYtoioAXQT
