### PR TITLE
perf(logindex): bound the checkpoint WRITE RATE, not its interval

### DIFF
--- a/docs/eth-getlogs-design.md
+++ b/docs/eth-getlogs-design.md
@@ -79,6 +79,82 @@ streaming serialization + delta checkpoints) before slice 4 backfills
 mainnet on mobile hosts. Full-rewrite checkpoints across a long backfill are
 also O(n²) write amplification; the segmented store fixes both.
 
+**Checkpoint cadence (size-aware).** Until the segmented store lands, every
+checkpoint rewrites the whole file, so a fixed interval makes the write RATE
+grow with the index. Measured on the Gnosis Bee backfill: with a flat 10 s
+cadence and an index that reached 238 MB, the daemon wrote **366 GB over a
+6 h 22 m walk** (~15 MiB/s averaged; ~17.8 MiB/s sustained over the sampled
+window). At that size the 10 s interval is not even the binding constraint —
+one 238 MB write takes longer than 10 s, so the next checkpoint was due the
+moment the previous finished and the process wrote essentially continuously,
+at whatever the disk would take. On a phone that is flash wear, not just
+noise.
+
+What is bounded is therefore the sustained write rate, not the interval:
+`persist_interval(last_snapshot_bytes) = ceil(bytes / 1 MiB/s)` clamped to
+`[10 s, 600 s]` (rounded *up* — rounding down puts every non-multiple size
+over budget). The lower clamp keeps a small or freshly-started index
+checkpointing briskly, since when the file is small lost progress is the only
+cost that matters; the upper clamp bounds how much of a walk a crash re-does
+once the budget is unachievable anyway. The same index (238 MB = 227 MiB):
+~227 s between checkpoints, ~22 GiB per walk instead of 366 GB.
+
+Every *periodic* checkpoint path shares this throttle — walker, head bridge,
+tail, and the appender's 64-block checkpoint. The appender's block counter is
+not on its own a bound on the write rate: catching up after a gap applies 16
+blocks per 6 s tick, so 64 blocks arrive every ~24 s whatever the index
+weighs. The counter says *there is work to record*; the throttle says *when*,
+and is not cleared when it defers (that would drop the checkpoint rather than
+delay it). Two once-per-event writes are deliberately exempt: `ElReader::stop`
+(the last write before the index goes away) and a head bridge's FINAL slice.
+The bridge still *consults* the throttle so that write stamps the clock —
+short-circuiting past it would let a phone that wakes repeatedly from sleep
+complete a bridge, write off-budget, and leave the next tick free to
+checkpoint again immediately behind it.
+
+A failed checkpoint is logged, not swallowed. It stays best-effort — the
+previous snapshot is what a crash finds, which is safe — but a *permanently*
+failing one (`ENOSPC` being the realistic cause) now costs up to 600 s of walk
+per crash rather than 10 s, so it must not be invisible.
+
+This bounds the constant — the O(n²) asymptotics still need the segmented
+store above.
+
+**Serialize under the lock, fsync outside it.** A checkpoint reads the whole
+store, so serialization has to hold the index mutex; the write and the `fsync`
+must not. On a multi-hundred-MB index the fsync dominates the checkpoint by
+orders of magnitude, and holding the mutex across it stalls the appender, the
+backfill walker and every `getLogs` query for the whole duration. This applies
+to the PERIODIC checkpoint; the config push, the export and the import merge
+still serialize and fsync under the index lock, which is fine because they run
+once per user action, not on a clock.
+
+Dropping the index lock before the write means it can no longer be what keeps
+two checkpoints apart, and it was: every writer used to hold it across the
+whole create→write→fsync→rename. Two mechanisms replace it.
+
+- `write_atomic` (`logindex.rs`) names its temp file with a per-**call**
+  counter, not just the pid (`next_tmp_path`). Two writers aiming at one path
+  would otherwise share a temp file: the loser's `File::create` truncates the
+  winner's mid-write, or the winner renames the shared temp out from under the
+  loser, whose still-open fd then writes into the LIVE `.db` that readers are
+  reading. It removes the temp on failure of either the write or the rename —
+  the likely trigger is `ENOSPC`, and after a successful write the leftover is
+  a *full-size* snapshot, which is exactly what keeps a disk full — and fsyncs
+  the parent directory so the rename itself is durable. This is the log
+  index's primitive, not a repo-wide one — `sync.rs` and roost keep their own.
+- `ElReader::log_index_write` is a dedicated mutex held across
+  serialize→rename by every site that writes an index `.db` (the periodic
+  checkpoint, the config-push checkpoint, the export and the import merge).
+  Without it the rename order need not match the serialize order, and an older
+  snapshot can silently land on top of a newer one — or an export, which
+  strips display names, can land on the canonical file. **Lock order: acquired
+  before `log_index`, never after.** The periodic checkpoint takes it with
+  `try_lock` and skips on contention: an import merges GBs under it, the
+  checkpoint is best-effort, and whoever holds it is writing a newer snapshot
+  anyway. A skip un-stamps the clock so the next tick retries rather than
+  waiting out a whole interval.
+
 ### 2. Head-follow appender (forward, cheap, always-on while enabled)
 
 A tokio task owned by `ElReader` (so `ElReader::stop`/pause aborts it —

--- a/docs/eth-getlogs-design.md
+++ b/docs/eth-getlogs-design.md
@@ -107,10 +107,32 @@ weighs. The counter says *there is work to record*; the throttle says *when*,
 and is not cleared when it defers (that would drop the checkpoint rather than
 delay it). Two once-per-event writes are deliberately exempt: `ElReader::stop`
 (the last write before the index goes away) and a head bridge's FINAL slice.
-The bridge still *consults* the throttle so that write stamps the clock —
-short-circuiting past it would let a phone that wakes repeatedly from sleep
-complete a bridge, write off-budget, and leave the next tick free to
-checkpoint again immediately behind it.
+
+The clock those intervals are measured from (`PersistClock`) obeys one rule:
+**only a write ends an interval, and the decision to write is taken where the
+write happens.** `PersistClock::is_due` is a pure read — asking never consumes
+anything — and `persist_log_index` consults it *under the checkpoint lock*,
+not the caller before calling. Both halves are load-bearing. A predicate that
+stamped would charge a full interval (up to 600 s of re-walked work on a crash)
+to a checkpoint that may never be written, since a writer skips when another
+holds the lock; and a decision taken outside the lock is not a claim — two
+writers genuinely race here (the backfill step runs outside `log_index_drive`,
+and a host thread can drive the tail on the `getLogs` path), so a "yes" read
+before the other's write would be honoured after it, rewriting the whole file
+back to back.
+
+Everything that makes the file current starts an interval, so an off-budget
+write can never be followed seconds later by a throttled one measuring from a
+stale stamp — a phone waking repeatedly from sleep completing a bridge, or an
+import that just wrote a multi-GB merge and would otherwise see the very next
+appender tick rewrite it. That covers the throttled checkpoints, the two
+exempt ones, the wholesale replacements (config push, import merge — which
+stamp only if the write actually landed), and, distinctly, *adoption*: loading
+a snapshot writes nothing but the file already describes the index installed
+from it. Adoption credits all but the 10 s floor of the interval, so a launch
+does not rewrite hundreds of MB byte-identical but for the header, while a
+session shorter than the interval — routine on Android, where the platform
+restarts the process — still banks its progress once.
 
 A failed checkpoint is logged, not swallowed. It stays best-effort — the
 previous snapshot is what a crash finds, which is safe — but a *permanently*

--- a/rust/myotis-net/src/el/logindex.rs
+++ b/rust/myotis-net/src/el/logindex.rs
@@ -573,6 +573,63 @@ impl LogIndex {
 // yields None and the caller re-indexes. Never correctness-critical.
 // ---------------------------------------------------------------------------
 
+/// The scratch path one [`write_atomic`] call writes through before renaming
+/// it into place. Distinct for every CALL, not merely every process: two
+/// writers in one process aiming at the same `path` would otherwise share a
+/// temp file, and the loser's `File::create` truncates the winner's mid-write —
+/// or worse, the winner renames the shared temp out from under the loser, whose
+/// still-open fd then keeps writing into the LIVE `.db` that readers are
+/// reading. That was invisible while every caller happened to hold the index
+/// mutex across the whole write; it stops being invisible the moment one of
+/// them doesn't. Separate from `write_atomic` so the distinctness can be
+/// asserted directly instead of only being raced for.
+fn next_tmp_path(path: &Path) -> PathBuf {
+    static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    path.with_extension(format!("tmp.{}.{seq}", std::process::id()))
+}
+
+/// Write `bytes` to `path` atomically: private temp file, fsync, rename, then
+/// fsync the parent directory so the rename itself survives a power loss.
+/// The one place the log-index snapshot pattern lives, so every writer of an
+/// index `.db` gets the same durability, and so a caller can serialize under
+/// whatever lock owns the index and then do the slow part — the fsync —
+/// without holding it. (Other snapshot writers in the tree — `sync.rs`, roost
+/// — keep their own; this is not a repo-wide primitive.)
+///
+/// The temp name comes from [`next_tmp_path`] — see there for why a per-call
+/// counter, and not just the pid, is what makes two concurrent writers safe.
+pub fn write_atomic(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let tmp = next_tmp_path(path);
+    let write = || -> std::io::Result<()> {
+        let mut f = std::fs::File::create(&tmp)?;
+        f.write_all(bytes)?;
+        f.sync_all()
+    };
+    if let Err(e) = write() {
+        // A partial temp is dead weight at full snapshot size, and the likely
+        // trigger is ENOSPC — leaving it behind is what keeps the disk full.
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e);
+    }
+    if let Err(e) = std::fs::rename(&tmp, path) {
+        // Same reasoning, and here the temp is FULL size: a failed rename
+        // (EACCES, EROFS, a dataDir symlinked across filesystems) would
+        // otherwise leave a whole snapshot behind on every attempt.
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e);
+    }
+    // Best-effort: a rename is not durable until the directory entry is. If
+    // this fails the old checkpoint is still what a crash would find, which is
+    // the same safe degradation as no checkpoint at all.
+    if let Some(dir) = path.parent() {
+        if let Ok(d) = std::fs::File::open(dir) {
+            let _ = d.sync_all();
+        }
+    }
+    Ok(())
+}
+
 const MAGIC: &[u8; 4] = b"MLIX";
 /// v1: config-keyed blob (fingerprint only — unreadable without the exact
 ///     watch-list that produced it; still LOADED for upgrade, never written).
@@ -657,13 +714,7 @@ impl LogIndex {
 
     /// [`Self::persist`] with the same clamp as [`Self::serialize_clamped`].
     pub fn persist_clamped(&self, tag: &ChainTag, path: &Path, max_block: u64) -> std::io::Result<()> {
-        let tmp: PathBuf = path.with_extension(format!("tmp.{}", std::process::id()));
-        {
-            let mut f = std::fs::File::create(&tmp)?;
-            f.write_all(&self.serialize_clamped(tag, max_block))?;
-            f.sync_all()?;
-        }
-        std::fs::rename(&tmp, path)
+        write_atomic(path, &self.serialize_clamped(tag, max_block))
     }
 
     pub fn serialize(&self, tag: &ChainTag) -> Vec<u8> {
@@ -684,13 +735,7 @@ impl LogIndex {
         path: &Path,
         clamp: Option<u64>,
     ) -> std::io::Result<()> {
-        let tmp: PathBuf = path.with_extension(format!("tmp.{}", std::process::id()));
-        {
-            let mut f = std::fs::File::create(&tmp)?;
-            f.write_all(&self.serialize_impl(tag, clamp, true))?;
-            f.sync_all()?;
-        }
-        std::fs::rename(&tmp, path)
+        write_atomic(path, &self.serialize_impl(tag, clamp, true))
     }
 
     fn serialize_with_clamp(&self, tag: &ChainTag, clamp: Option<u64>) -> Vec<u8> {
@@ -895,17 +940,11 @@ impl LogIndex {
         header[..4] == *MAGIC && u32::from_le_bytes([header[4], header[5], header[6], header[7]]) == VERSION_LEGACY
     }
 
-    /// Atomic best-effort persist: temp file (pid-suffixed) + rename, the
-    /// `persist_snapshot` pattern. A failed write costs a re-index on the
-    /// affected range, never correctness.
+    /// Atomic best-effort persist: temp file (named per CALL — see
+    /// `next_tmp_path`) + rename, the `persist_snapshot` pattern. A failed
+    /// write costs a re-index on the affected range, never correctness.
     pub fn persist(&self, tag: &ChainTag, path: &Path) -> std::io::Result<()> {
-        let tmp: PathBuf = path.with_extension(format!("tmp.{}", std::process::id()));
-        {
-            let mut f = std::fs::File::create(&tmp)?;
-            f.write_all(&self.serialize(tag))?;
-            f.sync_all()?;
-        }
-        std::fs::rename(&tmp, path)
+        write_atomic(path, &self.serialize(tag))
     }
 
     /// Load a persisted index for `config`; None on absence or any mismatch.
@@ -1430,6 +1469,103 @@ mod tests {
         // Nothing above the clamp → byte-identical to a plain serialize.
         assert_eq!(ix.serialize_clamped(&tag(), 14), ix.serialize(&tag()));
         let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn two_writes_to_one_path_never_share_a_scratch_file() {
+        // THE invariant that keeps two concurrent checkpoints apart, asserted
+        // directly rather than raced for: `concurrent_writers_never_leave_a_
+        // spliced_file` below exercises the same property, but only detects a
+        // violation when the threads happen to interleave inside the write
+        // window, so it cannot be the only guard. Here a regression to a
+        // per-process name fails every run, on any scheduler.
+        let path = std::path::Path::new("/tmp/whatever/index.db");
+        let names: std::collections::HashSet<_> = (0..64).map(|_| next_tmp_path(path)).collect();
+        assert_eq!(names.len(), 64, "two calls chose the same temp path");
+        // Still per-process, still beside the target, still not the target.
+        for n in &names {
+            assert_eq!(
+                n.parent(),
+                path.parent(),
+                "temp must be renameable onto path"
+            );
+            assert_ne!(n, path, "temp must not BE the target");
+            assert!(
+                n.to_string_lossy()
+                    .contains(&format!(".tmp.{}.", std::process::id())),
+                "temp must stay identifiable as this process's: {n:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn concurrent_writers_never_leave_a_spliced_file() {
+        // The checkpoint write no longer happens under the index lock, so the
+        // temp path is what keeps two writers apart. With a per-PROCESS temp
+        // name they share one file: the second `File::create` truncates the
+        // first mid-write and the reader gets a splice of both — which, on a
+        // real index, means a checksum failure and a full re-walk of months of
+        // backfill. Distinct payload bytes make a splice detectable.
+        let dir = std::env::temp_dir().join(format!("logindex-atomic-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("racing.db");
+        const LEN: usize = 1 << 20; // big enough that the writes genuinely overlap
+        const WRITERS: u8 = 8;
+        let done = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        // A reader running throughout: `path` must NEVER be observable in a
+        // partial state. That is what the rename buys, and it is the property
+        // a caller relies on when it reloads a checkpoint after a crash.
+        let watcher = {
+            let (path, done) = (path.clone(), done.clone());
+            std::thread::spawn(move || {
+                let mut torn = None;
+                while !done.load(std::sync::atomic::Ordering::Relaxed) {
+                    if let Ok(got) = std::fs::read(&path) {
+                        if got.len() != LEN || got.iter().any(|b| *b != got[0]) {
+                            torn = Some(got.len());
+                            break;
+                        }
+                    }
+                }
+                torn
+            })
+        };
+        let writers: Vec<std::thread::JoinHandle<()>> = (1..=WRITERS)
+            .map(|k| {
+                let path = path.clone();
+                std::thread::spawn(move || {
+                    for _ in 0..3 {
+                        write_atomic(&path, &vec![k; LEN]).unwrap();
+                    }
+                })
+            })
+            .collect();
+        for w in writers {
+            w.join().unwrap();
+        }
+        done.store(true, std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(
+            watcher.join().unwrap(),
+            None,
+            "a reader saw a partial file: the swap is not atomic"
+        );
+        // Whatever landed must be exactly ONE writer's payload, whole.
+        let got = std::fs::read(&path).unwrap();
+        assert_eq!(got.len(), LEN, "file is not one writer's payload");
+        let first = got[0];
+        assert!(
+            (1..=WRITERS).contains(&first),
+            "byte from no writer: {first}"
+        );
+        assert!(got.iter().all(|b| *b == first), "spliced payloads");
+        // And no temp files are left behind on the success path.
+        let leftovers: Vec<_> = std::fs::read_dir(&dir)
+            .unwrap()
+            .filter_map(|e| e.ok().map(|e| e.file_name()))
+            .filter(|n| n.to_string_lossy().contains(".tmp."))
+            .collect();
+        assert!(leftovers.is_empty(), "leaked temp files: {leftovers:?}");
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -614,8 +614,21 @@ pub struct ElReader {
     /// stop, never under a network await.
     log_index: std::sync::Mutex<Option<crate::el::logindex::LogIndex>>,
     /// Last backfill checkpoint write — throttles the full-index persist
-    /// (see the step's PERSIST_MIN_INTERVAL).
+    /// (see [`persist_interval`]).
     log_index_last_persist: std::sync::Mutex<Option<std::time::Instant>>,
+    /// Bytes the last checkpoint wrote, i.e. what the next one will cost.
+    /// Drives the size-aware cadence — see [`persist_interval`].
+    log_index_last_persist_bytes: std::sync::atomic::AtomicU64,
+    /// Serializes CHECKPOINT WRITES to `log_index_path` against each other,
+    /// spanning serialize→rename. `log_index` used to do this by accident:
+    /// every writer held it across the whole write. Now that the fsync happens
+    /// outside it, something has to keep two checkpoints from interleaving —
+    /// otherwise the bytes that land last are not necessarily the newest, and
+    /// an older snapshot silently renames over a newer one.
+    ///
+    /// LOCK ORDER: acquired BEFORE `log_index`, never after. Every site that
+    /// writes the canonical `.db` takes it at the top of the function.
+    log_index_write: std::sync::Mutex<()>,
     /// Adaptive chunk-pipeline depth signal: true after an untruncated batch
     /// (pipelining pays), false after a budget-truncated one (prefetch would
     /// waste the serving link). See log_index_backfill_batch.
@@ -788,6 +801,8 @@ impl ElReader {
             log_index_bridge: std::sync::Mutex::new(None),
             log_index_tail: std::sync::Mutex::new(Vec::new()),
             log_index_last_persist: std::sync::Mutex::new(None),
+            log_index_last_persist_bytes: std::sync::atomic::AtomicU64::new(0),
+            log_index_write: std::sync::Mutex::new(()),
             log_index_pipeline_full: std::sync::atomic::AtomicBool::new(true),
             log_index_path: cfg.log_index_path,
             log_index_task: std::sync::Mutex::new(None),
@@ -822,6 +837,12 @@ impl ElReader {
             }
         };
         let tag = self.chain_tag();
+        // This path checkpoints the outgoing index below; take the checkpoint
+        // lock BEFORE the index lock so it can never race (or invert) with a
+        // periodic checkpoint. See `log_index_write` for the ordering rule.
+        let Ok(_writing) = self.log_index_write.lock() else {
+            return false;
+        };
         let Ok(mut slot) = self.log_index.lock() else {
             return false;
         };
@@ -856,6 +877,7 @@ impl ElReader {
                 } else {
                     ix.persist_clamped(&tag, p, finalized_now)
                 };
+                self.note_checkpoint_size(p);
             }
             let effective = config.union_with(&ix.config().watch);
             let old = slot.take().expect("checked Some above");
@@ -1029,6 +1051,15 @@ impl ElReader {
     pub fn export_log_index(&self, path: &std::path::Path) -> Result<(), String> {
         let tag = self.chain_tag();
         let finalized = self.finalized_block_number();
+        // Nothing stops a caller aiming an export at our own checkpoint path,
+        // and an export STRIPS display names. While the periodic checkpoint
+        // held the index lock across its whole write these two were mutually
+        // exclusive by accident; now that it doesn't, take the checkpoint lock
+        // explicitly — BEFORE the index lock, per `log_index_write` — so the
+        // two writers stay totally ordered instead of renaming over each other.
+        let Ok(_writing) = self.log_index_write.lock() else {
+            return Err("log index unavailable".to_string());
+        };
         match self.log_index.lock() {
             Ok(slot) => match slot.as_ref() {
                 Some(ix) => ix
@@ -1078,6 +1109,14 @@ impl ElReader {
         if sources.is_empty() {
             return Err("no files given".to_string());
         }
+        // Held for the whole checkpoint→read→merge→write sequence, BEFORE the
+        // index lock (see `log_index_write`). Without it a periodic checkpoint
+        // can land between the checkpoint below and the merged write, and the
+        // merge would silently drop whatever it recorded — or rename over the
+        // merged result afterwards, discarding the import from disk entirely.
+        let Ok(_writing) = self.log_index_write.lock() else {
+            return Err("log index unavailable".to_string());
+        };
         // Checkpoint the live index (finality-clamped, v2) and merge THROUGH
         // THE FILE rather than cloning the live store: the store is fully
         // resident and can be GBs — a clone would double it under the lock.
@@ -1150,6 +1189,7 @@ impl ElReader {
         merged
             .persist(&tag, &own_path)
             .map_err(|e| format!("could not write {}: {e}", own_path.display()))?;
+        self.note_checkpoint_size(&own_path);
         match self.log_index.lock() {
             Ok(mut slot) => {
                 // Bridge/tail/rate describe the OLD coverage shape. Cleared
@@ -1325,7 +1365,7 @@ impl ElReader {
     async fn log_index_append_tick(&self, since_persist: &mut u32, ticks: u64) {
         // Checkpoint due from a PREVIOUS tick first: batches that end early
         // (peer failure mid-catch-up) must not defer persistence forever.
-        if *since_persist >= 64 {
+        if *since_persist >= 64 && self.log_index_persist_due() {
             self.persist_log_index(self.finalized_block_number());
             *since_persist = 0;
         }
@@ -1407,8 +1447,16 @@ impl ElReader {
             }
             *since_persist += 1;
         }
-        // Checkpoint roughly every 64 appended blocks (best-effort).
-        if *since_persist >= 64 {
+        // Checkpoint roughly every 64 appended blocks (best-effort) — but on
+        // the SAME size-aware throttle as the walker and the bridge. The block
+        // count alone is not a bound on the write rate: catching up after a
+        // gap applies 16 blocks per 6 s tick, so 64 blocks arrive every ~24 s
+        // whatever the index weighs — a full rewrite of a 238 MB file at
+        // ~10 MiB/s, which is the exact pathology `persist_interval` exists to
+        // stop. The counter is NOT reset when the throttle defers: it is the
+        // "there is work to record" flag, and clearing it would drop the
+        // checkpoint instead of delaying it.
+        if *since_persist >= 64 && self.log_index_persist_due() {
             self.persist_log_index(self.finalized_block_number());
             *since_persist = 0;
         }
@@ -1752,20 +1800,76 @@ impl ElReader {
     /// blocks, nothing would ever rewind them (they would look immutable
     /// while possibly being orphaned).
     fn persist_log_index(&self, finalized: u64) {
-        if let (Some(path), Ok(slot)) = (self.log_index_path.as_deref(), self.log_index.lock()) {
-            if let Some(ix) = slot.as_ref() {
-                let tag = self.chain_tag();
-                if finalized == 0 {
-                    // No beacon anchor yet. There is no optimistic coverage to
-                    // clamp either (the tail only runs below a real finality),
-                    // and clamping AT ZERO would rewind the whole index and
-                    // rename an empty file over a good checkpoint — losing, on
-                    // a phone, months of backfill. Write it as it stands.
-                    let _ = ix.persist(&tag, path);
-                } else {
-                    let _ = ix.persist_clamped(&tag, path, finalized);
-                }
+        let Some(path) = self.log_index_path.as_deref() else {
+            return;
+        };
+        // Held across serialize→rename so checkpoints are totally ordered:
+        // the bytes that land last are the newest. Taken BEFORE the index
+        // lock — see `log_index_write`.
+        //
+        // TRY-lock, because the other holders are slow and this one is
+        // best-effort: an import merges GBs under it, and blocking here would
+        // stall the appender tick and every getLogs that needs a head advance
+        // for the whole merge — the exact stall this change exists to remove,
+        // moved rather than fixed. Skipping instead costs nothing: the writer
+        // holding the lock is writing a NEWER snapshot than this one would.
+        let Ok(_writing) = self.log_index_write.try_lock() else {
+            // Un-stamp so the next tick retries promptly. `log_index_persist_due`
+            // stamps when it says yes, so without this a skipped checkpoint
+            // would silently cost a full interval.
+            if let Ok(mut t) = self.log_index_last_persist.lock() {
+                *t = None;
             }
+            return;
+        };
+        // Serialize under the index lock — it reads the whole store — but do
+        // the write and the FSYNC outside it. On a multi-hundred-MB index the
+        // fsync dominates the checkpoint by orders of magnitude, and holding
+        // the index mutex across it stalls the appender, the backfill walker
+        // and every getLogs query for the whole duration.
+        let bytes = {
+            let Ok(slot) = self.log_index.lock() else {
+                return;
+            };
+            let Some(ix) = slot.as_ref() else {
+                return;
+            };
+            checkpoint_bytes(ix, &self.chain_tag(), finalized)
+        };
+        // Feeds the size-aware cadence: what the NEXT checkpoint will cost is
+        // what this one cost. Recorded whether or not the write succeeded — a
+        // failed write is still a write attempt, and its cost is the same.
+        self.log_index_last_persist_bytes
+            .store(bytes.len() as u64, std::sync::atomic::Ordering::Relaxed);
+        // Best-effort, but not SILENT. A checkpoint that fails every time —
+        // ENOSPC is the likely cause, and the one this size-aware cadence
+        // makes rarer but not impossible — now costs up to PERSIST_MAX_INTERVAL
+        // of walk per crash instead of ten seconds, and would otherwise leave
+        // no trace of why. Same reasoning as the tail: a silently broken
+        // checkpoint is the wrong failure shape.
+        if let Err(e) = crate::el::logindex::write_atomic(path, &bytes) {
+            tracing::warn!(
+                error = %e,
+                bytes = bytes.len(),
+                path = %path.display(),
+                "log index checkpoint failed; a crash now costs the walk since the last good one"
+            );
+        }
+    }
+
+    /// Feed the size-aware cadence from a checkpoint this type did not
+    /// serialize itself. The config push and the import merge write through
+    /// `LogIndex::persist`, which serializes internally, so there is no byte
+    /// count to record — and both REPLACE the index wholesale. Without this,
+    /// a push that swaps a 238 MB index for a fresh empty one would leave the
+    /// new walk's first window checkpointing every ~238 s, and the first
+    /// checkpoint after importing a multi-GB snapshot would fire at the small
+    /// index's interval. Self-corrects after one write either way; this makes
+    /// it not happen at all.
+    fn note_checkpoint_size(&self, path: &std::path::Path) {
+        if let Ok(m) = std::fs::metadata(path) {
+            self.log_index_last_persist_bytes
+                .store(m.len(), std::sync::atomic::Ordering::Relaxed);
         }
     }
 
@@ -1790,13 +1894,17 @@ impl ElReader {
     }
 
     /// True when a full-index checkpoint is due (and claims the slot). The
-    /// persist is a whole-file rewrite under the index lock, so both the
-    /// backfill and the bridge share this throttle.
+    /// persist is a whole-file rewrite, so both the backfill and the bridge
+    /// share this throttle — and the interval SCALES WITH THE FILE, see
+    /// [`persist_interval`].
     fn log_index_persist_due(&self) -> bool {
-        const PERSIST_MIN_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10);
+        let last_bytes = self
+            .log_index_last_persist_bytes
+            .load(std::sync::atomic::Ordering::Relaxed);
         self.log_index_last_persist.lock().is_ok_and(|mut t| {
-            if t.is_none_or(|prev| prev.elapsed() >= PERSIST_MIN_INTERVAL) {
-                *t = Some(std::time::Instant::now());
+            let now = std::time::Instant::now();
+            if persist_due(*t, now, last_bytes) {
+                *t = Some(now);
                 true
             } else {
                 false
@@ -2143,8 +2251,19 @@ impl ElReader {
             // Checkpoint on the same throttle the backfill uses — the persist
             // is a full-index rewrite, and bridging can apply thousands of
             // blocks per tick. Always checkpoint the final slice.
-            if applied_this_tick > 0 && (done || self.log_index_persist_due()) {
-                self.persist_log_index(self.finalized_block_number());
+            //
+            // The throttle is consulted even when `done` forces the write, so
+            // the clock is STAMPED either way. Short-circuiting past it (`done
+            // || due`) let a completing bridge write off-budget AND leave the
+            // clock unstamped, so the next tick's throttled checkpoint could
+            // fire immediately behind it — two full rewrites back to back,
+            // which on a phone waking repeatedly from sleep is the write
+            // amplification this change removes, reintroduced.
+            if applied_this_tick > 0 {
+                let due = self.log_index_persist_due();
+                if done || due {
+                    self.persist_log_index(self.finalized_block_number());
+                }
             }
             if done {
                 tracing::info!(to = anchor_n, "log index head bridge complete; head-follow resumes");
@@ -2272,10 +2391,10 @@ impl ElReader {
             tokio::task::yield_now().await;
         }
         // Checkpoint at most once per throttle window of progressing steps
-        // (not per batch, not even per step) — see log_index_persist_due; a
-        // crash now costs at most ~10s of batches.
-        let persist_due = any_progress && self.log_index_persist_due();
-        if persist_due {
+        // (not per batch, not even per step) — see log_index_persist_due. The
+        // window SCALES WITH THE FILE (10s..600s, see persist_interval), so a
+        // crash costs whatever the walker produced during one window.
+        if any_progress && self.log_index_persist_due() {
             self.persist_log_index(self.finalized_block_number());
         }
         // Rolling throughput for the status ETA, measured against WALL CLOCK
@@ -5510,6 +5629,78 @@ fn should_apply(n: u64, stop_below: Option<u64>) -> bool {
     !stop_below.is_some_and(|stop| n <= stop)
 }
 
+/// Sustained bytes/sec the log-index checkpoints are allowed to write.
+const PERSIST_WRITE_BUDGET_BPS: u64 = 1 << 20; // 1 MiB/s
+/// Never checkpoint more often than this, however small the index.
+const PERSIST_MIN_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10);
+/// Never go longer than this between checkpoints, however large. Past this
+/// point the budget is already blown and the only thing left to protect is how
+/// much of the walk a crash would cost.
+const PERSIST_MAX_INTERVAL: std::time::Duration = std::time::Duration::from_secs(600);
+
+/// How long to wait between full-index checkpoints, given what the last one
+/// cost to write.
+///
+/// The store is a FULL-REWRITE format: a checkpoint costs its entire size in
+/// bytes written, every time. A FIXED interval therefore makes the write RATE
+/// grow without bound as the index does, which is the wrong quantity to hold
+/// constant. Measured on the Gnosis backfill: a 238 MB index on a flat 10 s
+/// cadence wrote 366 GB across one 6h22m run — a measured 17.8 MiB/s sustained
+/// over the sampled window — for an index that ended at 238 MB. (The flat 10 s
+/// interval is not even the binding constraint at that size: a 238 MB write
+/// takes longer than 10 s, so the next checkpoint was due the moment the
+/// previous one finished and the daemon wrote essentially continuously, at
+/// whatever the disk would take.) On a phone that is not merely I/O, it is
+/// flash wear, and it is why this is worth a policy rather than a constant.
+///
+/// So scale the interval with the size and let the RATE be what stays bounded.
+/// The trade is self-balancing: a longer interval costs a crash more re-walked
+/// blocks, but the amount re-walked is exactly what the walker produced during
+/// one interval — the same work the checkpoint would have been recording.
+///
+/// This bounds the constant. The asymptotics — O(n²) total bytes across a walk
+/// that grows the index linearly — are inherent to full-rewrite checkpoints and
+/// are fixed by the segmented/delta store already recorded as required before
+/// mainnet-scale mobile backfill (docs/eth-getlogs-design.md §Store).
+fn persist_interval(last_bytes: u64) -> std::time::Duration {
+    // div_ceil, not truncating division: rounding the interval DOWN puts the
+    // sustained rate over the budget for every size that isn't a whole
+    // multiple of it (11.5 MiB → 11 s → ~4.5% over). Rounding up is the side
+    // that keeps the invariant the budget names.
+    std::time::Duration::from_secs(last_bytes.div_ceil(PERSIST_WRITE_BUDGET_BPS))
+        .clamp(PERSIST_MIN_INTERVAL, PERSIST_MAX_INTERVAL)
+}
+
+/// Whether a checkpoint is due, given when the last one ran and what it cost.
+/// Split out from [`ElReader::log_index_persist_due`] so the decision — not
+/// just the interval it consults — is testable without a live reader.
+fn persist_due(prev: Option<std::time::Instant>, now: std::time::Instant, last_bytes: u64) -> bool {
+    prev.is_none_or(|p| now.saturating_duration_since(p) >= persist_interval(last_bytes))
+}
+
+/// The bytes one checkpoint of `ix` should contain at the given finality.
+///
+/// Split out so BOTH branches are testable: the choice is trust-relevant, and
+/// getting it wrong is invisible from the outside — a checkpoint that skipped
+/// the clamp claims coverage the next run cannot re-verify, and one that
+/// clamped at zero finality would rename an empty file over a good snapshot.
+fn checkpoint_bytes(
+    ix: &crate::el::logindex::LogIndex,
+    tag: &crate::el::logindex::ChainTag,
+    finalized: u64,
+) -> Vec<u8> {
+    if finalized == 0 {
+        // No beacon anchor yet. There is no optimistic coverage to clamp
+        // either (the tail only runs below a real finality), and clamping AT
+        // ZERO would rewind the whole index and rename an empty file over a
+        // good checkpoint — losing, on a phone, months of backfill. Write it
+        // as it stands.
+        ix.serialize(tag)
+    } else {
+        ix.serialize_clamped(tag, finalized)
+    }
+}
+
 #[cfg(test)]
 mod tail_reorg_tests {
     use super::{tail_fork_point, tail_vouches_for, tail_window_floor};
@@ -5744,3 +5935,210 @@ mod backfill_truncation_tests {
     }
 }
 
+#[cfg(test)]
+mod persist_cadence_tests {
+    use super::{
+        checkpoint_bytes, persist_due, persist_interval, PERSIST_MAX_INTERVAL,
+        PERSIST_MIN_INTERVAL, PERSIST_WRITE_BUDGET_BPS,
+    };
+    use std::time::Duration;
+
+    const MIB: u64 = 1 << 20;
+
+    /// Bytes/sec a walk sustains if it checkpoints `bytes` every
+    /// `persist_interval(bytes)`.
+    fn sustained_bps(bytes: u64) -> u64 {
+        bytes / persist_interval(bytes).as_secs()
+    }
+
+    /// The literal schedule, written out rather than expressed in terms of the
+    /// constants under test — otherwise every assertion below would hold for
+    /// any value of them and the numbers would be unpinned.
+    #[test]
+    fn the_schedule_is_exactly_this() {
+        assert_eq!(persist_interval(0), Duration::from_secs(10));
+        assert_eq!(persist_interval(1), Duration::from_secs(10));
+        assert_eq!(persist_interval(10 * MIB), Duration::from_secs(10));
+        // Just past the floor the interval must start tracking the size — and
+        // must round UP, or the sustained rate exceeds the budget for every
+        // size that is not a whole multiple of it.
+        assert_eq!(persist_interval(10 * MIB + 1), Duration::from_secs(11));
+        assert_eq!(persist_interval(11 * MIB), Duration::from_secs(11));
+        assert_eq!(persist_interval(238 * MIB), Duration::from_secs(238));
+        assert_eq!(persist_interval(600 * MIB), Duration::from_secs(600));
+        // ...and stops tracking it at the cap.
+        assert_eq!(persist_interval(600 * MIB + 1), Duration::from_secs(600));
+        assert_eq!(persist_interval(u64::MAX), Duration::from_secs(600));
+    }
+
+    #[test]
+    fn the_write_rate_is_what_stays_bounded_not_the_interval() {
+        // THE regression this exists for: on the measured 238 MB Gnosis index a
+        // flat 10 s cadence meant a full rewrite every 10 s — 366 GB over one
+        // 6h22m backfill. Assert against the OLD policy directly, so this fails
+        // if the old behaviour ever comes back.
+        const MEASURED: u64 = 238 * MIB;
+        let flat_10s = MEASURED / 10;
+        assert!(
+            flat_10s > 20 * MIB,
+            "the pathology being fixed no longer reproduces: {flat_10s} B/s"
+        );
+        // Every size where the budget is achievable at all (i.e. up to the cap)
+        // holds the RATE, not the interval, constant. Deliberately includes
+        // non-multiples of the budget, where truncating division would break it.
+        let cap = PERSIST_WRITE_BUDGET_BPS * PERSIST_MAX_INTERVAL.as_secs();
+        for bytes in [
+            1,
+            MIB,
+            8 * MIB + 3,
+            11 * MIB + 512 * 1024,
+            64 * MIB,
+            MEASURED,
+            cap,
+        ] {
+            assert!(bytes <= cap, "test input above the cap says nothing");
+            assert!(
+                sustained_bps(bytes) <= PERSIST_WRITE_BUDGET_BPS,
+                "{bytes} B index sustains {} B/s, over budget",
+                sustained_bps(bytes)
+            );
+        }
+        // Above the cap the budget is knowingly abandoned — the point of the
+        // cap is that a crash cannot cost the whole walk.
+        assert!(sustained_bps(cap * 4) > PERSIST_WRITE_BUDGET_BPS);
+    }
+
+    #[test]
+    fn a_small_index_still_checkpoints_briskly() {
+        // The budget must not make a fresh or tiny index checkpoint rarely —
+        // early in a walk the file is small and losing progress is the only
+        // cost that matters. 10 s, not "whatever PERSIST_MIN_INTERVAL says".
+        assert_eq!(PERSIST_MIN_INTERVAL, Duration::from_secs(10));
+        for bytes in [0, 1, 4096, 5 * MIB] {
+            assert_eq!(persist_interval(bytes), Duration::from_secs(10));
+        }
+    }
+
+    #[test]
+    fn a_huge_index_is_capped_so_a_crash_cannot_cost_the_whole_walk() {
+        assert_eq!(PERSIST_MAX_INTERVAL, Duration::from_secs(600));
+        // The cap must bite strictly ABOVE the largest size the budget can
+        // still serve, and never below it.
+        assert_eq!(persist_interval(599 * MIB), Duration::from_secs(599));
+        assert_eq!(persist_interval(1024 * MIB), Duration::from_secs(600));
+        assert_eq!(persist_interval(u64::MAX), Duration::from_secs(600));
+    }
+
+    #[test]
+    fn the_interval_is_monotone_in_size() {
+        // A bigger file may never checkpoint MORE often than a smaller one —
+        // otherwise growth could speed the cadence up and the rate would run
+        // away. Walks well past the cap so the plateau is covered too.
+        let mut prev = persist_interval(0);
+        for step in 0..1600u64 {
+            let cur = persist_interval(step * MIB / 2);
+            assert!(cur >= prev, "interval shrank at {step} half-MB");
+            prev = cur;
+        }
+        assert_eq!(prev, PERSIST_MAX_INTERVAL, "never reached the plateau");
+    }
+
+    #[test]
+    fn the_decision_consults_the_size_not_a_fixed_window() {
+        // Pins the WIRING, not just the policy: a checkpoint is due when the
+        // size-aware interval has elapsed. Reverting the consumer to a fixed
+        // 10 s window (the bug) makes the 238 MB case fire at 60 s.
+        let now = std::time::Instant::now();
+        let ago = |s: u64| now.checked_sub(Duration::from_secs(s));
+        assert!(persist_due(None, now, 238 * MIB), "first ever must fire");
+        assert!(
+            !persist_due(ago(60), now, 238 * MIB),
+            "fired on a fixed window"
+        );
+        assert!(!persist_due(ago(237), now, 238 * MIB));
+        assert!(persist_due(ago(238), now, 238 * MIB));
+        // ...and the same clock on a small index still fires briskly, so this
+        // is genuinely reading the size and not just a longer constant.
+        assert!(persist_due(ago(10), now, 1024));
+        assert!(!persist_due(ago(9), now, 1024));
+    }
+
+    #[test]
+    fn a_checkpoint_clamps_at_finality_but_never_at_a_missing_anchor() {
+        use crate::el::logindex::{ChainTag, LogIndex, LogIndexConfig, StoredLog, WatchEntry};
+        let tag = ChainTag {
+            network_id: 1,
+            genesis_hash: [0xd4; 32],
+        };
+        let cfg = LogIndexConfig {
+            enabled: true,
+            max_speed: false,
+            watch: vec![WatchEntry {
+                address: [1u8; 20],
+                from_block: 0,
+                topic0s: vec![],
+                name: String::new(),
+            }],
+        };
+        let mut ix = LogIndex::new(cfg.clone()).unwrap();
+        for b in 10u64..=14 {
+            ix.append_block(
+                b,
+                [b as u8; 32],
+                vec![StoredLog {
+                    block_number: b,
+                    block_hash: [b as u8; 32],
+                    tx_hash: [0xcc; 32],
+                    tx_index: 0,
+                    log_index: 0,
+                    address: [1u8; 20],
+                    topics: vec![],
+                    data: vec![],
+                }],
+            )
+            .unwrap();
+        }
+        // Finality at 12: 13-14 are optimistic. They are verifiable only
+        // against THIS run's in-memory tail record, so a checkpoint carrying
+        // them would leave the next run holding coverage it can never
+        // re-check — and once finality passes them nothing would rewind them.
+        let clamp = std::env::temp_dir().join(format!("ckpt-clamp-{}.db", std::process::id()));
+        crate::el::logindex::write_atomic(&clamp, &checkpoint_bytes(&ix, &tag, 12)).unwrap();
+        let clamped = LogIndex::load(&cfg, &tag, &clamp).unwrap();
+        assert_eq!(
+            clamped.coverage_of(&[1u8; 20]).unwrap().span,
+            Some((10, 12))
+        );
+        let _ = std::fs::remove_file(&clamp);
+        // Zero finality means NO anchor, not "finality is at block zero":
+        // clamping there would rewind everything and rename an empty file over
+        // a good checkpoint. Write it as it stands instead — which does record
+        // 13-14 unclamped, so the first half's rule is not universal. What
+        // makes that safe is that finality never REGRESSES to zero:
+        // `AnchorState::execution_state_root` is set once and never cleared,
+        // and the tail tick returns early while it is unset, so the only run
+        // that can write this file is one that has not yet had an anchor at
+        // all — and it appended those blocks under its own tail record.
+        let nofin = std::env::temp_dir().join(format!("ckpt-nofin-{}.db", std::process::id()));
+        crate::el::logindex::write_atomic(&nofin, &checkpoint_bytes(&ix, &tag, 0)).unwrap();
+        let unclamped = LogIndex::load(&cfg, &tag, &nofin).unwrap();
+        assert_eq!(
+            unclamped.coverage_of(&[1u8; 20]).unwrap().span,
+            Some((10, 14))
+        );
+        let _ = std::fs::remove_file(&nofin);
+    }
+
+    #[test]
+    fn a_zero_size_gets_the_floor_not_a_zero_interval() {
+        // A lost recorded size reads back as 0. That must degrade to the FLOOR
+        // — the old cadence, which was merely wasteful — and never to a zero
+        // interval, which is an unthrottled write loop. (What it cannot catch
+        // is the loss itself; every writer stores the size at its own write,
+        // `persist_log_index` inline and the config/import paths through
+        // `note_checkpoint_size`.)
+        assert_eq!(persist_interval(0), PERSIST_MIN_INTERVAL);
+        assert!(persist_interval(0) > Duration::ZERO);
+        assert_ne!(persist_interval(238 * MIB), persist_interval(0));
+    }
+}

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -825,6 +825,12 @@ impl ElReader {
     /// frontiers at different heights would wedge the appender.
     /// Returns false (and installs nothing) for an invalid config
     /// (duplicate watch addresses).
+    ///
+    /// BLOCKS while another writer holds the checkpoint lock — an import
+    /// merging GBs is the worst case, and it is unbounded from here. That
+    /// covers even the fast path that writes nothing, because the branch
+    /// decision needs the index lock and taking the checkpoint lock after it
+    /// would invert the order. Hosts should not call this on a UI thread.
     pub fn set_log_index_config(&self, config: crate::el::logindex::LogIndexConfig) -> bool {
         let finalized_now = self.finalized_block_number();
         // A SUCCESSFUL config apply invalidates the rate anchor: a pacing
@@ -877,7 +883,6 @@ impl ElReader {
                 } else {
                     ix.persist_clamped(&tag, p, finalized_now)
                 };
-                self.note_checkpoint_size(p);
             }
             let effective = config.union_with(&ix.config().watch);
             let old = slot.take().expect("checked Some above");
@@ -923,7 +928,21 @@ impl ElReader {
                     }
                 }
             };
+            // Size the cadence off the index that is now INSTALLED, not the
+            // one just checkpointed. Two branches above replace the old index
+            // with an EMPTY one (a failed merge, a topic conflict), and
+            // leaving the outgoing 238 MB recorded there would make the first
+            // window of a walk that restarted from scratch checkpoint every
+            // ~238 s — backwards, since a small index is exactly when
+            // progress is cheapest to protect.
+            let installed_is_empty = fresh.log_count() == 0;
             *slot = Some(fresh);
+            if installed_is_empty {
+                self.log_index_last_persist_bytes
+                    .store(0, std::sync::atomic::Ordering::Relaxed);
+            } else if let Some(p) = self.log_index_path.as_deref() {
+                self.note_checkpoint_size(p);
+            }
             reset_rate();
             return true;
         }
@@ -992,7 +1011,21 @@ impl ElReader {
                 }
             }
         };
+        let installed_is_empty = ix.log_count() == 0;
         *slot = Some(ix);
+        // Boot path: seed the cadence from the snapshot on disk, so the FIRST
+        // checkpoint of a restarted daemon is already sized. Otherwise the
+        // counter is still 0, `persist_interval` returns the 10 s floor, and a
+        // process holding a 238 MB snapshot writes all of it once before the
+        // cadence corrects itself. One write per launch is nothing across a
+        // walk — but on Android the platform restarts the process routinely,
+        // so there the duty cycle is set by how often the user backgrounds the
+        // app, which is the same flash-wear shape this change exists to fix.
+        if !installed_is_empty {
+            if let Some(p) = self.log_index_path.as_deref() {
+                self.note_checkpoint_size(p);
+            }
+        }
         reset_rate();
         true
     }
@@ -1033,6 +1066,11 @@ impl ElReader {
             ix.set_enabled(true);
             *slot = Some(ix);
         }
+        // Same reason as the boot path in `set_log_index_config`: this
+        // installs an index straight off disk, so the first checkpoint would
+        // otherwise fire at the 10 s floor and rewrite the whole file before
+        // the cadence learned what it weighs.
+        self.note_checkpoint_size(path);
         tracing::info!(path = %path.display(), "activated log-index snapshot from disk");
         self.ensure_log_index_appender(rt);
     }
@@ -1048,6 +1086,9 @@ impl ElReader {
     /// generator daemon must not bake its own resolutions into a file whose
     /// importers would then never re-resolve (`set_name` fills only empty
     /// names).
+    ///
+    /// BLOCKS while another writer holds the checkpoint lock (an import
+    /// merging GBs is the worst case) — not a UI-thread call.
     pub fn export_log_index(&self, path: &std::path::Path) -> Result<(), String> {
         let tag = self.chain_tag();
         let finalized = self.finalized_block_number();
@@ -1365,8 +1406,10 @@ impl ElReader {
     async fn log_index_append_tick(&self, since_persist: &mut u32, ticks: u64) {
         // Checkpoint due from a PREVIOUS tick first: batches that end early
         // (peer failure mid-catch-up) must not defer persistence forever.
-        if *since_persist >= 64 && self.log_index_persist_due() {
-            self.persist_log_index(self.finalized_block_number());
+        if *since_persist >= 64
+            && self.log_index_persist_due()
+            && self.persist_log_index(self.finalized_block_number())
+        {
             *since_persist = 0;
         }
         let enabled = self.with_log_index(|ix| ix.config().enabled).unwrap_or(false);
@@ -1453,11 +1496,18 @@ impl ElReader {
         // gap applies 16 blocks per 6 s tick, so 64 blocks arrive every ~24 s
         // whatever the index weighs — a full rewrite of a 238 MB file at
         // ~10 MiB/s, which is the exact pathology `persist_interval` exists to
-        // stop. The counter is NOT reset when the throttle defers: it is the
-        // "there is work to record" flag, and clearing it would drop the
-        // checkpoint instead of delaying it.
-        if *since_persist >= 64 && self.log_index_persist_due() {
-            self.persist_log_index(self.finalized_block_number());
+        // stop. The counter is NOT reset unless a checkpoint actually LANDED:
+        // it is the "there is work to record" flag, and both ways a checkpoint
+        // can be dropped — the throttle deferring it, and `persist_log_index`
+        // skipping on write-lock contention — must delay it, not discard it.
+        // A discarded one waits for the next 64 blocks, which on a node that
+        // is purely head-following (backfill done, so no walker or tail
+        // checkpoint to cover for it) is ~13 minutes at 12 s blocks, not the
+        // ~24 s of catch-up this comment reasons about.
+        if *since_persist >= 64
+            && self.log_index_persist_due()
+            && self.persist_log_index(self.finalized_block_number())
+        {
             *since_persist = 0;
         }
     }
@@ -1799,9 +1849,20 @@ impl ElReader {
     /// coverage it can never re-check — and once finality moves past those
     /// blocks, nothing would ever rewind them (they would look immutable
     /// while possibly being orphaned).
-    fn persist_log_index(&self, finalized: u64) {
+    ///
+    /// Returns whether a checkpoint was actually WRITTEN. Callers use it to
+    /// decide whether their "there is work to record" flag may be cleared —
+    /// clearing it for a checkpoint that never happened drops the work rather
+    /// than deferring it.
+    ///
+    /// Owns the write clock in both directions: a successful write stamps it,
+    /// a skipped one un-stamps it. That is what makes "a full-size write
+    /// resets the interval" true no matter which path forced the write —
+    /// including the ones that write unthrottled — instead of each call site
+    /// having to remember to stamp.
+    fn persist_log_index(&self, finalized: u64) -> bool {
         let Some(path) = self.log_index_path.as_deref() else {
-            return;
+            return false;
         };
         // Held across serialize→rename so checkpoints are totally ordered:
         // the bytes that land last are the newest. Taken BEFORE the index
@@ -1817,10 +1878,8 @@ impl ElReader {
             // Un-stamp so the next tick retries promptly. `log_index_persist_due`
             // stamps when it says yes, so without this a skipped checkpoint
             // would silently cost a full interval.
-            if let Ok(mut t) = self.log_index_last_persist.lock() {
-                *t = None;
-            }
-            return;
+            self.stamp_persist_clock(None);
+            return false;
         };
         // Serialize under the index lock — it reads the whole store — but do
         // the write and the FSYNC outside it. On a multi-hundred-MB index the
@@ -1829,10 +1888,10 @@ impl ElReader {
         // and every getLogs query for the whole duration.
         let bytes = {
             let Ok(slot) = self.log_index.lock() else {
-                return;
+                return false;
             };
             let Some(ix) = slot.as_ref() else {
-                return;
+                return false;
             };
             checkpoint_bytes(ix, &self.chain_tag(), finalized)
         };
@@ -1854,6 +1913,28 @@ impl ElReader {
                 path = %path.display(),
                 "log index checkpoint failed; a crash now costs the walk since the last good one"
             );
+            // The clock is deliberately LEFT as the throttle set it. A failed
+            // write still cost a full serialize and a full write attempt, so
+            // un-stamping here would turn a persistent failure (ENOSPC) into a
+            // retry every tick — 238 MB serialized and pushed at the disk
+            // every 6 s, which is worse than the pathology being fixed. It
+            // retries on the ordinary cadence instead.
+            return false;
+        }
+        // The bytes are on disk — start the next interval HERE, whatever made
+        // this write happen. The unthrottled writers (a completing head
+        // bridge, `stop`) go through this same line, so one of them can no
+        // longer be followed immediately by a throttled checkpoint that is
+        // measuring from a stale stamp.
+        self.stamp_persist_clock(Some(std::time::Instant::now()));
+        true
+    }
+
+    /// Set the "last checkpoint landed at" clock. `None` means *no interval is
+    /// running* — the next `log_index_persist_due` fires immediately.
+    fn stamp_persist_clock(&self, at: Option<std::time::Instant>) {
+        if let Ok(mut t) = self.log_index_last_persist.lock() {
+            *t = at;
         }
     }
 
@@ -2252,18 +2333,15 @@ impl ElReader {
             // is a full-index rewrite, and bridging can apply thousands of
             // blocks per tick. Always checkpoint the final slice.
             //
-            // The throttle is consulted even when `done` forces the write, so
-            // the clock is STAMPED either way. Short-circuiting past it (`done
-            // || due`) let a completing bridge write off-budget AND leave the
-            // clock unstamped, so the next tick's throttled checkpoint could
-            // fire immediately behind it — two full rewrites back to back,
-            // which on a phone waking repeatedly from sleep is the write
-            // amplification this change removes, reintroduced.
-            if applied_this_tick > 0 {
-                let due = self.log_index_persist_due();
-                if done || due {
-                    self.persist_log_index(self.finalized_block_number());
-                }
+            // The final slice writes off-budget, but `persist_log_index`
+            // stamps the clock on every successful write, so the next
+            // throttled checkpoint measures its interval from THIS write. It
+            // used to measure from the last throttled one, which let a bridge
+            // completing late in an interval be followed seconds later by a
+            // second full rewrite — the write amplification this change
+            // removes, back again on exactly the phone-waking-from-sleep path.
+            if applied_this_tick > 0 && (done || self.log_index_persist_due()) {
+                self.persist_log_index(self.finalized_block_number());
             }
             if done {
                 tracing::info!(to = anchor_n, "log index head bridge complete; head-follow resumes");
@@ -6048,19 +6126,28 @@ mod persist_cadence_tests {
         // Pins the WIRING, not just the policy: a checkpoint is due when the
         // size-aware interval has elapsed. Reverting the consumer to a fixed
         // 10 s window (the bug) makes the 238 MB case fire at 60 s.
-        let now = std::time::Instant::now();
-        let ago = |s: u64| now.checked_sub(Duration::from_secs(s));
-        assert!(persist_due(None, now, 238 * MIB), "first ever must fire");
+        //
+        // Moves the OBSERVATION time forward rather than the stamp backward:
+        // `Instant::checked_sub` returns None below the epoch (boot, on
+        // CLOCK_MONOTONIC), and on a host whose uptime is under 238 s — a
+        // freshly started CI container is the realistic case — every `ago(..)`
+        // would collapse to None, which `persist_due` answers `true` to by its
+        // first rule. The negative assertions would then fail and the positive
+        // ones would pass for the wrong reason. `Instant + Duration` has no
+        // such edge.
+        let base = std::time::Instant::now();
+        let after = |s: u64| base + Duration::from_secs(s);
+        assert!(persist_due(None, base, 238 * MIB), "first ever must fire");
         assert!(
-            !persist_due(ago(60), now, 238 * MIB),
+            !persist_due(Some(base), after(60), 238 * MIB),
             "fired on a fixed window"
         );
-        assert!(!persist_due(ago(237), now, 238 * MIB));
-        assert!(persist_due(ago(238), now, 238 * MIB));
+        assert!(!persist_due(Some(base), after(237), 238 * MIB));
+        assert!(persist_due(Some(base), after(238), 238 * MIB));
         // ...and the same clock on a small index still fires briskly, so this
         // is genuinely reading the size and not just a longer constant.
-        assert!(persist_due(ago(10), now, 1024));
-        assert!(!persist_due(ago(9), now, 1024));
+        assert!(persist_due(Some(base), after(10), 1024));
+        assert!(!persist_due(Some(base), after(9), 1024));
     }
 
     #[test]

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -613,12 +613,9 @@ pub struct ElReader {
     /// queries are in-memory work; persistence happens on checkpoints and
     /// stop, never under a network await.
     log_index: std::sync::Mutex<Option<crate::el::logindex::LogIndex>>,
-    /// Last backfill checkpoint write — throttles the full-index persist
-    /// (see [`persist_interval`]).
-    log_index_last_persist: std::sync::Mutex<Option<std::time::Instant>>,
-    /// Bytes the last checkpoint wrote, i.e. what the next one will cost.
-    /// Drives the size-aware cadence — see [`persist_interval`].
-    log_index_last_persist_bytes: std::sync::atomic::AtomicU64,
+    /// Throttles the full-index checkpoint: when the file on disk last became
+    /// current, and what it weighed. See [`PersistClock`].
+    log_index_persist: PersistClock,
     /// Serializes CHECKPOINT WRITES to `log_index_path` against each other,
     /// spanning serialize→rename. `log_index` used to do this by accident:
     /// every writer held it across the whole write. Now that the fsync happens
@@ -800,8 +797,7 @@ impl ElReader {
             log_index_rate: std::sync::Mutex::new(None),
             log_index_bridge: std::sync::Mutex::new(None),
             log_index_tail: std::sync::Mutex::new(Vec::new()),
-            log_index_last_persist: std::sync::Mutex::new(None),
-            log_index_last_persist_bytes: std::sync::atomic::AtomicU64::new(0),
+            log_index_persist: PersistClock::new(),
             log_index_write: std::sync::Mutex::new(()),
             log_index_pipeline_full: std::sync::atomic::AtomicBool::new(true),
             log_index_path: cfg.log_index_path,
@@ -873,17 +869,34 @@ impl ElReader {
             if let Ok(mut t) = self.log_index_tail.lock() {
                 t.clear();
             }
-            if let Some(p) = self.log_index_path.as_deref() {
+            // Whether the file on disk now holds this checkpoint. Best-effort
+            // like the periodic ones, but NOT silent, and not assumed: the
+            // clock below may only start an interval for a write that landed
+            // — crediting a failed one would leave the incoming index's
+            // progress unprotected for a whole interval while the file on
+            // disk is stale or missing.
+            let checkpointed = match self.log_index_path.as_deref() {
                 // Clamped like every other checkpoint: optimistic coverage is
                 // only verifiable against this run's tail record. A zero
                 // finality means no anchor (so nothing optimistic exists) —
                 // clamping there would erase the file.
-                let _ = if finalized_now == 0 {
-                    ix.persist(&tag, p)
-                } else {
-                    ix.persist_clamped(&tag, p, finalized_now)
-                };
-            }
+                Some(p) => {
+                    let r = if finalized_now == 0 {
+                        ix.persist(&tag, p)
+                    } else {
+                        ix.persist_clamped(&tag, p, finalized_now)
+                    };
+                    if let Err(e) = &r {
+                        tracing::warn!(
+                            error = %e,
+                            path = %p.display(),
+                            "could not checkpoint the outgoing log index before replacing it"
+                        );
+                    }
+                    r.is_ok()
+                }
+                None => false,
+            };
             let effective = config.union_with(&ix.config().watch);
             let old = slot.take().expect("checked Some above");
             let fresh = match effective {
@@ -928,20 +941,28 @@ impl ElReader {
                     }
                 }
             };
-            // Size the cadence off the index that is now INSTALLED, not the
-            // one just checkpointed. Two branches above replace the old index
-            // with an EMPTY one (a failed merge, a topic conflict), and
-            // leaving the outgoing 238 MB recorded there would make the first
-            // window of a walk that restarted from scratch checkpoint every
-            // ~238 s — backwards, since a small index is exactly when
-            // progress is cheapest to protect.
             let installed_is_empty = fresh.log_count() == 0;
             *slot = Some(fresh);
-            if installed_is_empty {
-                self.log_index_last_persist_bytes
-                    .store(0, std::sync::atomic::Ordering::Relaxed);
-            } else if let Some(p) = self.log_index_path.as_deref() {
-                self.note_checkpoint_size(p);
+            // The checkpoint above put a full-size file on disk, so it starts
+            // an interval — without one the next appender tick would rewrite
+            // it immediately. Only if it actually landed, though.
+            if checkpointed {
+                if installed_is_empty {
+                    // Size the cadence off the index that is now INSTALLED,
+                    // not off the 238 MB just written. Two branches above
+                    // replace the old index with an EMPTY one (a failed merge,
+                    // a topic conflict), and recording the outgoing size would
+                    // make the first window of a walk that restarted from
+                    // scratch checkpoint every ~238 s — backwards, since a
+                    // small index is exactly when progress is cheapest to
+                    // protect. Zero reads back as the FLOOR, so the interval
+                    // this stamp starts is 10 s; that is the point, not an
+                    // oversight to "fix" into the outgoing file's size.
+                    self.log_index_persist
+                        .wrote(std::time::Instant::now(), Some(0));
+                } else if let Some(p) = self.log_index_path.as_deref() {
+                    self.note_checkpoint_written(p);
+                }
             }
             reset_rate();
             return true;
@@ -1013,17 +1034,19 @@ impl ElReader {
         };
         let installed_is_empty = ix.log_count() == 0;
         *slot = Some(ix);
-        // Boot path: seed the cadence from the snapshot on disk, so the FIRST
-        // checkpoint of a restarted daemon is already sized. Otherwise the
-        // counter is still 0, `persist_interval` returns the 10 s floor, and a
-        // process holding a 238 MB snapshot writes all of it once before the
-        // cadence corrects itself. One write per launch is nothing across a
-        // walk — but on Android the platform restarts the process routinely,
-        // so there the duty cycle is set by how often the user backgrounds the
-        // app, which is the same flash-wear shape this change exists to fix.
+        // Boot path: ADOPT the snapshot on disk — it already describes the
+        // index just installed from it, so the first checkpoint of a restarted
+        // daemon is sized, and does not rewrite hundreds of MB byte-identical
+        // but for the header within a tick of launching. See
+        // [`PersistClock::adopted`] for why it still checkpoints at the floor
+        // rather than a full interval later.
+        //
+        // Only when the installed index came off that file: an EMPTY one means
+        // nothing on disk describes it (no snapshot, or one discarded as
+        // foreign/conflicting), so its first coverage must checkpoint promptly.
         if !installed_is_empty {
             if let Some(p) = self.log_index_path.as_deref() {
-                self.note_checkpoint_size(p);
+                self.note_checkpoint_adopted(p);
             }
         }
         reset_rate();
@@ -1066,11 +1089,11 @@ impl ElReader {
             ix.set_enabled(true);
             *slot = Some(ix);
         }
-        // Same reason as the boot path in `set_log_index_config`: this
-        // installs an index straight off disk, so the first checkpoint would
-        // otherwise fire at the 10 s floor and rewrite the whole file before
-        // the cadence learned what it weighs.
-        self.note_checkpoint_size(path);
+        // Same reason as the boot path in `set_log_index_config`: this installs
+        // an index straight off disk, so without adopting it the first
+        // checkpoint would rewrite the whole file before the cadence learned
+        // what it weighs.
+        self.note_checkpoint_adopted(path);
         tracing::info!(path = %path.display(), "activated log-index snapshot from disk");
         self.ensure_log_index_appender(rt);
     }
@@ -1128,6 +1151,10 @@ impl ElReader {
     ///
     /// Importing enables the index (it is the opt-in, explicitly) and leaves
     /// the pacing bit as it was.
+    ///
+    /// BLOCKS for the whole checkpoint→merge→write sequence — GBs, on the
+    /// checkpoint lock and then the index lock — so it is not a UI-thread
+    /// call, and neither an export nor a config push can proceed during it.
     pub fn import_log_index(&self, paths: &[std::path::PathBuf]) -> Result<(), String> {
         let Some(own_path) = self.log_index_path.clone() else {
             return Err("this node runs without a log-index path (no data dir)".to_string());
@@ -1230,7 +1257,7 @@ impl ElReader {
         merged
             .persist(&tag, &own_path)
             .map_err(|e| format!("could not write {}: {e}", own_path.display()))?;
-        self.note_checkpoint_size(&own_path);
+        self.note_checkpoint_written(&own_path);
         match self.log_index.lock() {
             Ok(mut slot) => {
                 // Bridge/tail/rate describe the OLD coverage shape. Cleared
@@ -1406,10 +1433,7 @@ impl ElReader {
     async fn log_index_append_tick(&self, since_persist: &mut u32, ticks: u64) {
         // Checkpoint due from a PREVIOUS tick first: batches that end early
         // (peer failure mid-catch-up) must not defer persistence forever.
-        if *since_persist >= 64
-            && self.log_index_persist_due()
-            && self.persist_log_index(self.finalized_block_number())
-        {
+        if *since_persist >= 64 && self.persist_log_index(self.finalized_block_number(), true) {
             *since_persist = 0;
         }
         let enabled = self.with_log_index(|ix| ix.config().enabled).unwrap_or(false);
@@ -1488,7 +1512,7 @@ impl ElReader {
             if !appended {
                 return;
             }
-            *since_persist += 1;
+            *since_persist = since_persist.saturating_add(1);
         }
         // Checkpoint roughly every 64 appended blocks (best-effort) — but on
         // the SAME size-aware throttle as the walker and the bridge. The block
@@ -1500,14 +1524,13 @@ impl ElReader {
         // it is the "there is work to record" flag, and both ways a checkpoint
         // can be dropped — the throttle deferring it, and `persist_log_index`
         // skipping on write-lock contention — must delay it, not discard it.
-        // A discarded one waits for the next 64 blocks, which on a node that
-        // is purely head-following (backfill done, so no walker or tail
-        // checkpoint to cover for it) is ~13 minutes at 12 s blocks, not the
-        // ~24 s of catch-up this comment reasons about.
-        if *since_persist >= 64
-            && self.log_index_persist_due()
-            && self.persist_log_index(self.finalized_block_number())
-        {
+        // A discarded one waits for the next 64 blocks — ~24 s while catching
+        // up, but as long as ~13 minutes at 12 s blocks once the append edge
+        // is at the head and each tick applies one block. (The tail tick
+        // checkpoints on the same throttle, so a head-following node is
+        // covered in practice; the counter still must not be cleared for a
+        // write that did not happen.)
+        if *since_persist >= 64 && self.persist_log_index(self.finalized_block_number(), true) {
             *since_persist = 0;
         }
     }
@@ -1824,9 +1847,7 @@ impl ElReader {
         }
         if appended > 0 {
             tracing::debug!(appended, head_n, "log index tail advanced");
-            if self.log_index_persist_due() {
-                self.persist_log_index(finalized);
-            }
+            self.persist_log_index(finalized, true);
         }
     }
 
@@ -1855,12 +1876,26 @@ impl ElReader {
     /// clearing it for a checkpoint that never happened drops the work rather
     /// than deferring it.
     ///
-    /// Owns the write clock in both directions: a successful write stamps it,
-    /// a skipped one un-stamps it. That is what makes "a full-size write
-    /// resets the interval" true no matter which path forced the write —
-    /// including the ones that write unthrottled — instead of each call site
-    /// having to remember to stamp.
-    fn persist_log_index(&self, finalized: u64) -> bool {
+    /// OWNS THE THROTTLE, decision and write together: with
+    /// `respect_throttle`, [`PersistClock::is_due`] is consulted HERE, under
+    /// the checkpoint lock, never by the caller. Two writers genuinely race —
+    /// the backfill step runs outside `log_index_drive`, and a host thread can
+    /// drive the tail on the getLogs path — and a caller that asked "is it
+    /// due?" before the other one wrote would get its "yes" honoured after,
+    /// rewriting the whole file back to back. The lock is what makes the
+    /// decision and the write it authorizes inseparable; a pure read outside
+    /// it is not a claim.
+    ///
+    /// Pass `false` for the two once-per-event writes that are exempt by
+    /// design (`stop`, a head bridge's FINAL slice).
+    ///
+    /// The clock advances on the two outcomes that actually cost a write — a
+    /// successful checkpoint and a failed one — and on nothing else, so "a
+    /// full-size write resets the interval" holds whichever path forced it.
+    /// The paths that replace the file wholesale (config push, import merge)
+    /// and the ones that adopt a file already on disk stamp the same clock via
+    /// [`Self::note_checkpoint_written`] / [`Self::note_checkpoint_adopted`].
+    fn persist_log_index(&self, finalized: u64, respect_throttle: bool) -> bool {
         let Some(path) = self.log_index_path.as_deref() else {
             return false;
         };
@@ -1875,12 +1910,20 @@ impl ElReader {
         // moved rather than fixed. Skipping instead costs nothing: the writer
         // holding the lock is writing a NEWER snapshot than this one would.
         let Ok(_writing) = self.log_index_write.try_lock() else {
-            // Un-stamp so the next tick retries promptly. `log_index_persist_due`
-            // stamps when it says yes, so without this a skipped checkpoint
-            // would silently cost a full interval.
-            self.stamp_persist_clock(None);
+            // Clock deliberately UNTOUCHED: nothing was written, so no interval
+            // started, so the next tick is due again immediately. Writing to it
+            // here — in either direction — is the bug: stamping would charge a
+            // full interval for a checkpoint that never happened, and clearing
+            // would race the holder that is stamping it as we look (it may be
+            // finishing its write right now), discarding a fresh interval and
+            // forcing the duplicate full rewrite this whole change removes.
             return false;
         };
+        // The throttle, consulted under the lock — see this function's doc.
+        // Before any serialize: a deferred checkpoint must cost nothing.
+        if respect_throttle && !self.log_index_persist.is_due() {
+            return false;
+        }
         // Serialize under the index lock — it reads the whole store — but do
         // the write and the FSYNC outside it. On a multi-hundred-MB index the
         // fsync dominates the checkpoint by orders of magnitude, and holding
@@ -1895,11 +1938,6 @@ impl ElReader {
             };
             checkpoint_bytes(ix, &self.chain_tag(), finalized)
         };
-        // Feeds the size-aware cadence: what the NEXT checkpoint will cost is
-        // what this one cost. Recorded whether or not the write succeeded — a
-        // failed write is still a write attempt, and its cost is the same.
-        self.log_index_last_persist_bytes
-            .store(bytes.len() as u64, std::sync::atomic::Ordering::Relaxed);
         // Best-effort, but not SILENT. A checkpoint that fails every time —
         // ENOSPC is the likely cause, and the one this size-aware cadence
         // makes rarer but not impossible — now costs up to PERSIST_MAX_INTERVAL
@@ -1913,45 +1951,52 @@ impl ElReader {
                 path = %path.display(),
                 "log index checkpoint failed; a crash now costs the walk since the last good one"
             );
-            // The clock is deliberately LEFT as the throttle set it. A failed
-            // write still cost a full serialize and a full write attempt, so
-            // un-stamping here would turn a persistent failure (ENOSPC) into a
+            // Both halves of the clock advance on failure too: the serialize
+            // and the write attempt cost the same as a successful one, and
+            // leaving it alone would turn a persistent failure (ENOSPC) into a
             // retry every tick — 238 MB serialized and pushed at the disk
             // every 6 s, which is worse than the pathology being fixed. It
             // retries on the ordinary cadence instead.
+            self.log_index_persist
+                .wrote(std::time::Instant::now(), Some(bytes.len() as u64));
             return false;
         }
         // The bytes are on disk — start the next interval HERE, whatever made
-        // this write happen. The unthrottled writers (a completing head
-        // bridge, `stop`) go through this same line, so one of them can no
-        // longer be followed immediately by a throttled checkpoint that is
-        // measuring from a stale stamp.
-        self.stamp_persist_clock(Some(std::time::Instant::now()));
+        // this write happen, and size it by what this one cost. The
+        // unthrottled writers (a completing head bridge, `stop`) go through
+        // this same line, so one of them can no longer be followed immediately
+        // by a throttled checkpoint that is measuring from a stale stamp.
+        self.log_index_persist
+            .wrote(std::time::Instant::now(), Some(bytes.len() as u64));
         true
     }
 
-    /// Set the "last checkpoint landed at" clock. `None` means *no interval is
-    /// running* — the next `log_index_persist_due` fires immediately.
-    fn stamp_persist_clock(&self, at: Option<std::time::Instant>) {
-        if let Ok(mut t) = self.log_index_last_persist.lock() {
-            *t = at;
-        }
+    /// A full-size file was just WRITTEN to `path` by a path that does not go
+    /// through [`Self::persist_log_index`] — the config push and the import
+    /// merge, which write through `LogIndex::persist` (it serializes
+    /// internally, so the size has to be read back off the file).
+    ///
+    /// Both halves matter. Without the size, the first checkpoint after
+    /// importing a multi-GB snapshot would fire at the small index's interval.
+    /// Without the stamp, the write just done would not start an interval, so
+    /// the very next appender tick would rewrite the same multi-GB file — the
+    /// "two full rewrites back to back" this throttle exists to stop, on the
+    /// path where the file is largest.
+    ///
+    /// Only call this for a write that LANDED: crediting a failed one leaves
+    /// the installed index unprotected for a whole interval while the file on
+    /// disk is stale or missing.
+    fn note_checkpoint_written(&self, path: &std::path::Path) {
+        self.log_index_persist
+            .wrote(std::time::Instant::now(), file_len(path));
     }
 
-    /// Feed the size-aware cadence from a checkpoint this type did not
-    /// serialize itself. The config push and the import merge write through
-    /// `LogIndex::persist`, which serializes internally, so there is no byte
-    /// count to record — and both REPLACE the index wholesale. Without this,
-    /// a push that swaps a 238 MB index for a fresh empty one would leave the
-    /// new walk's first window checkpointing every ~238 s, and the first
-    /// checkpoint after importing a multi-GB snapshot would fire at the small
-    /// index's interval. Self-corrects after one write either way; this makes
-    /// it not happen at all.
-    fn note_checkpoint_size(&self, path: &std::path::Path) {
-        if let Ok(m) = std::fs::metadata(path) {
-            self.log_index_last_persist_bytes
-                .store(m.len(), std::sync::atomic::Ordering::Relaxed);
-        }
+    /// An index was installed straight off the file at `path`, which therefore
+    /// already describes it — nothing was written. See
+    /// [`PersistClock::adopted`].
+    fn note_checkpoint_adopted(&self, path: &std::path::Path) {
+        self.log_index_persist
+            .adopted(std::time::Instant::now(), file_len(path));
     }
 
     /// The chain identity stamped into (and demanded of) every log-index
@@ -1972,25 +2017,6 @@ impl ElReader {
         self.with_log_index(|ix| ix.append_edge())
             .flatten()
             .map(|edge| edge.saturating_sub(1))
-    }
-
-    /// True when a full-index checkpoint is due (and claims the slot). The
-    /// persist is a whole-file rewrite, so both the backfill and the bridge
-    /// share this throttle — and the interval SCALES WITH THE FILE, see
-    /// [`persist_interval`].
-    fn log_index_persist_due(&self) -> bool {
-        let last_bytes = self
-            .log_index_last_persist_bytes
-            .load(std::sync::atomic::Ordering::Relaxed);
-        self.log_index_last_persist.lock().is_ok_and(|mut t| {
-            let now = std::time::Instant::now();
-            if persist_due(*t, now, last_bytes) {
-                *t = Some(now);
-                true
-            } else {
-                false
-            }
-        })
     }
 
     /// Drop any in-progress bridge plan (the gap closed, or the premises it
@@ -2331,17 +2357,19 @@ impl ElReader {
             let done = plan.applied >= total;
             // Checkpoint on the same throttle the backfill uses — the persist
             // is a full-index rewrite, and bridging can apply thousands of
-            // blocks per tick. Always checkpoint the final slice.
+            // blocks per tick. The FINAL slice always writes (`!done` waives
+            // the throttle): head-follow resumes after it, and the plan is
+            // dropped, so nothing else would record it.
             //
-            // The final slice writes off-budget, but `persist_log_index`
-            // stamps the clock on every successful write, so the next
-            // throttled checkpoint measures its interval from THIS write. It
-            // used to measure from the last throttled one, which let a bridge
-            // completing late in an interval be followed seconds later by a
-            // second full rewrite — the write amplification this change
-            // removes, back again on exactly the phone-waking-from-sleep path.
-            if applied_this_tick > 0 && (done || self.log_index_persist_due()) {
-                self.persist_log_index(self.finalized_block_number());
+            // That write is off-budget, but it stamps the clock like every
+            // other, so the next throttled checkpoint measures its interval
+            // from THIS write. It used to measure from the last throttled one,
+            // which let a bridge completing late in an interval be followed
+            // seconds later by a second full rewrite — the write amplification
+            // this change removes, back again on exactly the
+            // phone-waking-from-sleep path.
+            if applied_this_tick > 0 {
+                self.persist_log_index(self.finalized_block_number(), !done);
             }
             if done {
                 tracing::info!(to = anchor_n, "log index head bridge complete; head-follow resumes");
@@ -2469,11 +2497,12 @@ impl ElReader {
             tokio::task::yield_now().await;
         }
         // Checkpoint at most once per throttle window of progressing steps
-        // (not per batch, not even per step) — see log_index_persist_due. The
-        // window SCALES WITH THE FILE (10s..600s, see persist_interval), so a
-        // crash costs whatever the walker produced during one window.
-        if any_progress && self.log_index_persist_due() {
-            self.persist_log_index(self.finalized_block_number());
+        // (not per batch, not even per step) — `persist_log_index` applies the
+        // throttle itself. The window SCALES WITH THE FILE (10s..600s, see
+        // persist_interval), so a crash costs whatever the walker produced
+        // during one window.
+        if any_progress {
+            self.persist_log_index(self.finalized_block_number(), true);
         }
         // Rolling throughput for the status ETA, measured against WALL CLOCK
         // between progress observations (the anchor persists across idle
@@ -4765,7 +4794,10 @@ impl ElReader {
         }
         // Best-effort index checkpoint before teardown: a failed write only
         // costs a re-index of the uncheckpointed tail, never correctness.
-        self.persist_log_index(self.finalized_block_number());
+        // OFF-BUDGET (`respect_throttle = false`) — it is the last write
+        // before the index goes away, and on Android a graceful teardown is
+        // what banks a session whose interval had not elapsed.
+        self.persist_log_index(self.finalized_block_number(), false);
         self.pool.stop().await;
         self.discovery.stop().await;
     }
@@ -5749,11 +5781,108 @@ fn persist_interval(last_bytes: u64) -> std::time::Duration {
         .clamp(PERSIST_MIN_INTERVAL, PERSIST_MAX_INTERVAL)
 }
 
+/// A file's size, or None if it cannot be stated. Never a guess: a missing
+/// size must leave the last known one standing, not reset the cadence to the
+/// floor and un-throttle the next write.
+fn file_len(path: &std::path::Path) -> Option<u64> {
+    std::fs::metadata(path).ok().map(|m| m.len())
+}
+
 /// Whether a checkpoint is due, given when the last one ran and what it cost.
-/// Split out from [`ElReader::log_index_persist_due`] so the decision — not
-/// just the interval it consults — is testable without a live reader.
+/// Split out from [`PersistClock`] so the decision — not just the interval it
+/// consults — is testable without a live reader.
 fn persist_due(prev: Option<std::time::Instant>, now: std::time::Instant, last_bytes: u64) -> bool {
     prev.is_none_or(|p| now.saturating_duration_since(p) >= persist_interval(last_bytes))
+}
+
+/// When the log-index file on disk last became a current checkpoint, and what
+/// it weighed then — the whole state the size-aware throttle runs on.
+///
+/// A checkpoint is a WHOLE-FILE rewrite, so the two live together: the cost of
+/// the next write is what the last one cost, and the interval it earns scales
+/// with it (see [`persist_interval`]).
+///
+/// The one rule: **only a write ends an interval.** [`Self::is_due`] is a pure
+/// read — asking does not consume anything — because the caller may not get to
+/// write (another writer holds the checkpoint lock), and charging a
+/// checkpoint that never happened a full interval throws away up to
+/// [`PERSIST_MAX_INTERVAL`] of walk on a crash. There is no way to un-stamp:
+/// `None` means *nothing has been written or adopted this process*, and once
+/// that stops being true it never becomes true again.
+#[derive(Debug)]
+struct PersistClock {
+    last: std::sync::Mutex<Option<std::time::Instant>>,
+    bytes: std::sync::atomic::AtomicU64,
+}
+
+impl PersistClock {
+    fn new() -> Self {
+        Self {
+            last: std::sync::Mutex::new(None),
+            bytes: std::sync::atomic::AtomicU64::new(0),
+        }
+    }
+
+    /// True when a checkpoint is due. PURE — see the type doc. A node with no
+    /// index path never stamps, so this stays permanently true there; the
+    /// writer's own early return, not the clock, is what stops it.
+    fn is_due(&self) -> bool {
+        self.is_due_at(std::time::Instant::now())
+    }
+
+    fn is_due_at(&self, now: std::time::Instant) -> bool {
+        let bytes = self.bytes.load(std::sync::atomic::Ordering::Relaxed);
+        self.last.lock().is_ok_and(|t| persist_due(*t, now, bytes))
+    }
+
+    /// A checkpoint of `bytes` landed at `at` (or cost what one costs —
+    /// a failed write has already paid the serialize and the write attempt,
+    /// so it starts an interval too; otherwise a persistent `ENOSPC` retries
+    /// every tick). `None` bytes means the size could not be read — keep the
+    /// last known one rather than forfeit the interval this write earned.
+    fn wrote(&self, at: std::time::Instant, bytes: Option<u64>) {
+        self.note_bytes(bytes);
+        self.stamp(at);
+    }
+
+    /// A file already on disk describes the index just installed from it — no
+    /// write happened, and none is needed to make the file current.
+    ///
+    /// Credits the interval all but [`PERSIST_MIN_INTERVAL`] of its length:
+    /// the first checkpoint of the session lands at the FLOOR rather than a
+    /// size-derived 238–600 s. Both halves matter on the platform that drove
+    /// this — Android restarts the process routinely. Without the credit a
+    /// session shorter than the interval would bank nothing at all (and a
+    /// device whose sessions are consistently short would never advance the
+    /// file); without the stamp the first tick would rewrite hundreds of MB
+    /// byte-identical but for the header, every launch, which is the flash
+    /// wear this throttle exists to stop.
+    fn adopted(&self, at: std::time::Instant, bytes: Option<u64>) {
+        self.note_bytes(bytes);
+        let credit = persist_interval(self.bytes.load(std::sync::atomic::Ordering::Relaxed))
+            .saturating_sub(PERSIST_MIN_INTERVAL);
+        // `checked_sub` returns None below the monotonic epoch — on a host
+        // whose uptime is under one interval. Falling back to `at` merely
+        // grants the full interval, which is the pre-credit behaviour.
+        self.stamp(at.checked_sub(credit).unwrap_or(at));
+    }
+
+    /// Size the NEXT interval without touching the clock: for the index that
+    /// was just installed, not the file that was just written. A push that
+    /// swaps a 238 MB index for a fresh empty one must not leave the new
+    /// walk's first window checkpointing every ~238 s — a small index is
+    /// exactly when progress is cheapest to protect.
+    fn note_bytes(&self, bytes: Option<u64>) {
+        if let Some(b) = bytes {
+            self.bytes.store(b, std::sync::atomic::Ordering::Relaxed);
+        }
+    }
+
+    fn stamp(&self, at: std::time::Instant) {
+        if let Ok(mut t) = self.last.lock() {
+            *t = Some(at);
+        }
+    }
 }
 
 /// The bytes one checkpoint of `ix` should contain at the given finality.
@@ -6016,7 +6145,7 @@ mod backfill_truncation_tests {
 #[cfg(test)]
 mod persist_cadence_tests {
     use super::{
-        checkpoint_bytes, persist_due, persist_interval, PERSIST_MAX_INTERVAL,
+        checkpoint_bytes, persist_due, persist_interval, PersistClock, PERSIST_MAX_INTERVAL,
         PERSIST_MIN_INTERVAL, PERSIST_WRITE_BUDGET_BPS,
     };
     use std::time::Duration;
@@ -6222,10 +6351,81 @@ mod persist_cadence_tests {
         // — the old cadence, which was merely wasteful — and never to a zero
         // interval, which is an unthrottled write loop. (What it cannot catch
         // is the loss itself; every writer stores the size at its own write,
-        // `persist_log_index` inline and the config/import paths through
-        // `note_checkpoint_size`.)
+        // `persist_log_index` inline and the config/import/load paths through
+        // `note_checkpoint_on_disk`.)
         assert_eq!(persist_interval(0), PERSIST_MIN_INTERVAL);
         assert!(persist_interval(0) > Duration::ZERO);
         assert_ne!(persist_interval(238 * MIB), persist_interval(0));
+    }
+
+    // Below: the CLOCK, not just the policy. Same forward-time discipline as
+    // `the_decision_consults_the_size_not_a_fixed_window` — never `ago(..)`.
+
+    #[test]
+    fn asking_whether_a_checkpoint_is_due_does_not_consume_the_interval() {
+        // THE regression this guards: while the predicate stamped the clock,
+        // one decider's "yes" made the other's "no" — which reads like mutual
+        // exclusion but is not (the two are not synchronized), and charged a
+        // full interval to a checkpoint that may never be written at all.
+        // Both deciders must see "due"; `persist_log_index` settles which one
+        // writes, under the checkpoint lock.
+        let clock = PersistClock::new();
+        clock.note_bytes(Some(238 * MIB));
+        assert!(clock.is_due(), "a never-written index must checkpoint now");
+        assert!(clock.is_due(), "asking consumed the interval");
+        assert!(clock.is_due());
+    }
+
+    #[test]
+    fn only_a_write_ends_an_interval() {
+        let base = std::time::Instant::now();
+        let clock = PersistClock::new();
+        assert!(clock.is_due_at(base));
+        clock.wrote(base, Some(238 * MIB));
+        assert!(!clock.is_due_at(base + Duration::from_secs(237)));
+        assert!(clock.is_due_at(base + Duration::from_secs(238)));
+        // The size travels with the write, so the NEXT interval is sized by
+        // what the last checkpoint actually cost — not by whatever was last
+        // asked about.
+        clock.wrote(base + Duration::from_secs(238), Some(1024));
+        assert!(clock.is_due_at(base + Duration::from_secs(248)));
+    }
+
+    #[test]
+    fn adopting_a_file_still_leaves_one_cheap_checkpoint_in_the_session() {
+        // A load is not a write: the file is already current, so it starts an
+        // interval — but crediting the WHOLE interval means an Android session
+        // shorter than 238 s banks nothing, and a device whose sessions are
+        // consistently short never advances the file at all. Adoption credits
+        // all but the floor, so the first checkpoint lands at 10 s.
+        let base = std::time::Instant::now();
+        let clock = PersistClock::new();
+        clock.adopted(base, Some(238 * MIB));
+        assert!(
+            !clock.is_due_at(base + Duration::from_secs(9)),
+            "adoption must still suppress the immediate byte-identical rewrite"
+        );
+        assert!(
+            clock.is_due_at(base + PERSIST_MIN_INTERVAL),
+            "a whole interval was credited; a short session banks nothing"
+        );
+        // ...and the size is adopted too, so the checkpoint that follows is
+        // paced by the real file, not by the floor.
+        clock.wrote(base + PERSIST_MIN_INTERVAL, Some(238 * MIB));
+        assert!(!clock.is_due_at(base + PERSIST_MIN_INTERVAL + Duration::from_secs(237)));
+    }
+
+    #[test]
+    fn a_size_that_cannot_be_read_keeps_the_last_one() {
+        // `file_len` returns None when the file is gone or unstattable. That
+        // must not reset the cadence to the floor — the next write still costs
+        // what the last one cost, and pacing it at 10 s is the unthrottled
+        // rewrite loop this whole change removes.
+        let base = std::time::Instant::now();
+        let clock = PersistClock::new();
+        clock.wrote(base, Some(238 * MIB));
+        clock.wrote(base + Duration::from_secs(238), None);
+        assert!(!clock.is_due_at(base + Duration::from_secs(238 + 237)));
+        assert!(clock.is_due_at(base + Duration::from_secs(238 + 238)));
     }
 }


### PR DESCRIPTION
## The problem

The log index checkpoints by rewriting the **whole file**, on a fixed 10 s cadence, **while holding the index mutex**. So the write rate grows with the index.

Measured on the Gnosis Bee backfill: an index that reached **238 MB** had the daemon write **366 GB over a 6 h 22 m walk** (~15 MiB/s averaged). At that size 10 s is not even the binding constraint — one write takes longer than the interval, so the next checkpoint was due the moment the previous one finished and the process wrote essentially continuously. On a phone that is flash wear, and it is exactly the wrong shape for the wallet's primary target.

## What changes

**1. Bound the write RATE, not the interval.**
`persist_interval(last_snapshot_bytes) = ceil(bytes / 1 MiB/s)`, clamped to `[10 s, 600 s]`. Rounded *up* — rounding down puts every non-multiple size over budget. The floor keeps a small or freshly-started index checkpointing briskly (when the file is cheap, lost progress is the only cost that matters); the ceiling bounds how much walk a crash re-does once the budget is unachievable anyway. Same index: ~227 s between checkpoints, **~22 GiB per walk instead of 366 GB**.

Every *periodic* path shares the throttle — walker, head bridge, tail, and the appender's 64-block checkpoint. That block counter is not itself a rate bound: catching up after a gap applies 16 blocks per 6 s tick, so 64 blocks arrive every ~24 s whatever the index weighs. The counter says *there is work to record*, the throttle says *when* — and it is deliberately not cleared when it defers (that would drop the checkpoint rather than delay it).

Two once-per-event writes are exempt: `ElReader::stop` and a head bridge's final slice. The bridge still *consults* the throttle so that write stamps the clock — short-circuiting past it would let a phone waking repeatedly from sleep complete a bridge, write off-budget, and leave the next tick free to checkpoint again right behind it.

**2. Serialize under the lock, fsync outside it.**
On a multi-hundred-MB index the fsync dominates the checkpoint by orders of magnitude, and holding the index mutex across it stalls the appender, the backfill walker and every `getLogs` query for the whole duration.

**3. Replace what the index lock was accidentally providing.**
It was also what kept two checkpoints apart — every writer held it across the whole create→write→fsync→rename. Dropping it needs two mechanisms, not one:

- `write_atomic` names its temp file per **call** (`next_tmp_path`), not per process. Two writers aiming at one path would otherwise share a temp: the loser's `File::create` truncates the winner's write, or the winner renames the shared temp out from under the loser — whose still-open fd then writes into the **live `.db` readers are reading**. It also now removes the temp when the *rename* fails, not only the write (after a successful write that leftover is a full-size snapshot, which is what keeps a disk full).
- `ElReader::log_index_write`, a dedicated mutex spanning serialize→rename at every site that writes an index `.db` (periodic checkpoint, config push, export, import merge). **Lock order: before `log_index`, never after.** The periodic path `try_lock`s and skips on contention — an import merges GBs under it, the checkpoint is best-effort, and whoever holds the lock is writing a newer snapshot anyway — un-stamping the clock so the next tick retries rather than waiting out a full interval.

**4. A failed checkpoint is logged.** Still best-effort (the previous snapshot is what a crash finds), but a permanently failing one — `ENOSPC` — now costs up to 600 s of walk per crash instead of 10 s, so it must not be invisible.

## Correctness

No trust or verification surface moves. `checkpoint_bytes` keeps the existing rule that a checkpoint is clamped at finality, so nothing optimistic — verifiable only against *this* run's in-memory tail record — is ever written for a later run to inherit. The `finalized == 0` case stays unclamped because zero means *no anchor*, not *finality at block zero*; clamping there would rename an empty file over a good checkpoint. That is safe because finality never regresses to zero (`AnchorState::execution_state_root` is set once and never cleared, and the tail tick returns early while it is unset) — the test now says so rather than leaving it to be re-derived.

## Verification

- `cargo test -p myotis-net`: 270 pass. `cargo build --release -p myotis-net` clean. `cargo clippy --all-targets`: no new warnings from these files (the pre-existing `never_loop` error in `el/eth/session.rs` and the ~200 rustfmt diffs in these two files are on `main` untouched — this crate is not fmt-enforced, but every line this PR adds is rustfmt-clean).
- Reviewed by two independent subagents with no implementation knowledge, then a third on the final diff. Their findings are what produced the `try_lock`, the export lock, the bridge throttle fix, `note_checkpoint_size`, the failure log, the rename-failure cleanup, and the deterministic temp-name test.
- **Mutation-tested.** Caught: dropping the clamp; truncating division instead of `div_ceil`; budget ×10 and ÷10; both interval bounds; *deleting the fix* (back to a hardcoded 10 s); dropping the finality clamp; a per-process temp name; writing in place with no temp/rename. The race-sensitive ones were run 3× each, since one green run of a concurrency test means nothing.

## Known gaps, stated plainly

- **`f.sync_all()` is not covered by a test.** Deleting it leaves every unit test green — proving durability needs a power-loss harness, which does not exist here.
- **The bridge-throttle wiring and the `try_lock` skip are not unit-tested.** Both are inside an async method holding real locks; the pure policy underneath (`persist_due`, `persist_interval`, `checkpoint_bytes`) is tested against literals, but the call-site wiring is verified by reading, not by a test.
- **`concurrent_writers_never_leave_a_spliced_file` is a probabilistic detector** (~70% on the pre-fix code, measured over 26 runs of a standalone harness). It stays because the failure it catches is real and nasty, but the actual invariant — two calls never choose one scratch path — is now pinned deterministically by `two_writes_to_one_path_never_share_a_scratch_file`, which fails on every run against a per-process name.
- This bounds the **constant**. Full-rewrite checkpoints are still O(n²) across a long walk; the segmented store already described in `docs/eth-getlogs-design.md` is what fixes the asymptotics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)