### PR TITLE
Add myotis_pause / myotis_wakeup JSON-RPC lifecycle methods

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,27 @@ Key Gradle modules:
   `RustEngineNative`; same JSON shapes, pinned by the same golden tests) and
   never touches engine internals either.
 
+## Workflow — the mandatory steps for EVERY work item
+
+Every change to this repository goes through this sequence, in order, with **no
+step skipped and none treated as optional or "only if asked"**:
+
+1. **Code** — make the change on the designated branch.
+2. **Review** — run the internal code review on the diff (the `code-review`
+   skill / `/code-review`) and address what it finds before going further.
+3. **PR** — open a pull request. This is the default next step after review, not
+   a separate request the user has to make. (Follow the PR-template and
+   attribution rules below.)
+4. **Wait for review comments** — subscribe to the PR and wait for CI + review
+   feedback (`subscribe_pr_activity`); do not consider the task done at "pushed".
+5. **Address the PR comments** — drive the PR to green and answer every review
+   comment per the rules below, then keep watching until it is merged or closed.
+
+Short form: **code → review → PR → wait for review comments → address them.**
+Do not stop at "pushed" and do not ask whether to open the PR or run the review —
+they are part of the work item. The only time to skip the PR is when the user
+explicitly says not to open one.
+
 ## Pull requests and code review
 
 These rules are for the **PR author** answering a review. The reviewer's own

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -584,6 +584,7 @@ public final class NodeService extends Service {
         stackStartNano.remove(n);
         lastResumeMs.remove(n);
         reachedSynced.remove(n);   // a re-enable cold-starts the SYNCED-once gate again
+        lastObservedLifecycle.remove(n);
     }
 
     /** True if any network is still enabled (incl. the seeded default). */
@@ -726,6 +727,16 @@ public final class NodeService extends Service {
      *  gate again); a stack that briefly falls out of sync after its first SYNCED still pauses on
      *  the normal idle rules. */
     private static final java.util.Set<String> reachedSynced = ConcurrentHashMap.newKeySet();
+    /** Per-network lifecycle observed on the previous idle tick, so the ticker can spot a
+     *  wake it did NOT initiate — an out-of-process {@code myotis_wakeup} (Walleth and other
+     *  same-device wallets driving the shared node), an {@code ipc resume}, or the engine's
+     *  own wake on a verified read. Such a wake bumps none of the host-side idle stamps, so
+     *  without this the idle ticker would re-pause a node a client just asked to wake. On a
+     *  observed PAUSED/STOPPED→RUNNING transition the ticker grants a full idle window via
+     *  {@link #lastResumeMs} (our own resumes already stamped it, so this only fires for the
+     *  ones that bypassed the host). STATIC, like the stamps above; cleared on teardown. */
+    private static final Map<String, io.myotis.api.LifecycleState> lastObservedLifecycle =
+            new ConcurrentHashMap<>();
     /** Backstop for the SYNCED-once gate: if a fresh stack has been trying to reach SYNCED for
      *  this long (measured from its boot stamp) without success — no peers, a wedged sync, a
      *  perpetually-throwing status() — stop keeping it awake and let the idle controller pause it.
@@ -846,6 +857,17 @@ public final class NodeService extends Service {
                 if (idleMs <= 0) break; // auto-pause disabled
                 io.myotis.api.LifecycleState ls;
                 try { ls = h.lifecycle(); } catch (Throwable t) { continue; }
+                // A wake this host did not initiate — an out-of-process myotis_wakeup, an ipc
+                // resume, or the engine's own wake on a verified read — bumps none of the idle
+                // stamps below. Detect the PAUSED/STOPPED→RUNNING transition and grant a full
+                // idle window so the ticker doesn't re-pause a node a client just woke. Our own
+                // resumes (onAppForeground / dailyCatchUp) already stamped lastResumeMs≈now, so
+                // the max leaves those unchanged and only lifts an externally-driven wake.
+                io.myotis.api.LifecycleState prev = lastObservedLifecycle.put(n, ls);
+                if (ls == io.myotis.api.LifecycleState.RUNNING
+                        && prev != null && prev != io.myotis.api.LifecycleState.RUNNING) {
+                    lastResumeMs.merge(n, now, Math::max);
+                }
                 if (ls != io.myotis.api.LifecycleState.RUNNING) continue;
                 long lastActivity = Math.max(
                         Math.max(h.lastActivityEpochMillis(), uiActivityMs),

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -584,7 +584,6 @@ public final class NodeService extends Service {
         stackStartNano.remove(n);
         lastResumeMs.remove(n);
         reachedSynced.remove(n);   // a re-enable cold-starts the SYNCED-once gate again
-        lastObservedLifecycle.remove(n);
     }
 
     /** True if any network is still enabled (incl. the seeded default). */
@@ -727,16 +726,6 @@ public final class NodeService extends Service {
      *  gate again); a stack that briefly falls out of sync after its first SYNCED still pauses on
      *  the normal idle rules. */
     private static final java.util.Set<String> reachedSynced = ConcurrentHashMap.newKeySet();
-    /** Per-network lifecycle observed on the previous idle tick, so the ticker can spot a
-     *  wake it did NOT initiate — an out-of-process {@code myotis_wakeup} (Walleth and other
-     *  same-device wallets driving the shared node), an {@code ipc resume}, or the engine's
-     *  own wake on a verified read. Such a wake bumps none of the host-side idle stamps, so
-     *  without this the idle ticker would re-pause a node a client just asked to wake. On a
-     *  observed PAUSED/STOPPED→RUNNING transition the ticker grants a full idle window via
-     *  {@link #lastResumeMs} (our own resumes already stamped it, so this only fires for the
-     *  ones that bypassed the host). STATIC, like the stamps above; cleared on teardown. */
-    private static final Map<String, io.myotis.api.LifecycleState> lastObservedLifecycle =
-            new ConcurrentHashMap<>();
     /** Backstop for the SYNCED-once gate: if a fresh stack has been trying to reach SYNCED for
      *  this long (measured from its boot stamp) without success — no peers, a wedged sync, a
      *  perpetually-throwing status() — stop keeping it awake and let the idle controller pause it.
@@ -857,22 +846,23 @@ public final class NodeService extends Service {
                 if (idleMs <= 0) break; // auto-pause disabled
                 io.myotis.api.LifecycleState ls;
                 try { ls = h.lifecycle(); } catch (Throwable t) { continue; }
-                // A wake this host did not initiate — an out-of-process myotis_wakeup, an ipc
-                // resume, or the engine's own wake on a verified read — bumps none of the idle
-                // stamps below. Detect the PAUSED/STOPPED→RUNNING transition and grant a full
-                // idle window so the ticker doesn't re-pause a node a client just woke. Our own
-                // resumes (onAppForeground / dailyCatchUp) already stamped lastResumeMs≈now, so
-                // the max leaves those unchanged and only lifts an externally-driven wake.
-                io.myotis.api.LifecycleState prev = lastObservedLifecycle.put(n, ls);
-                if (ls == io.myotis.api.LifecycleState.RUNNING
-                        && prev != null && prev != io.myotis.api.LifecycleState.RUNNING) {
-                    lastResumeMs.merge(n, now, Math::max);
-                }
                 if (ls != io.myotis.api.LifecycleState.RUNNING) continue;
+                // The engine's own timestamp of the most recent DEMAND wake (ipc / request /
+                // catch-up — SleepMetrics.onResume). An out-of-process myotis_wakeup resumes
+                // through the engine and bumps NONE of the host stamps below, so without this
+                // the ticker would re-pause a node a client just woke, mid-rebuild, before its
+                // first verified read. Reading the engine's exact resume instant closes that
+                // window race-free — unlike sampling lifecycle() at 30 s ticks, which misses a
+                // wake landing between two RUNNING samples. FOREGROUND wakes don't stamp it, but
+                // those are host-initiated and already covered by lastResumeMs.
+                long engineResumeMs;
+                try { engineResumeMs = h.status().lastResumeEpochMs(); }
+                catch (Throwable t) { engineResumeMs = 0L; }
                 long lastActivity = Math.max(
                         Math.max(h.lastActivityEpochMillis(), uiActivityMs),
-                        Math.max(lastResumeMs.getOrDefault(n, 0L),
-                                 stackStartMs.getOrDefault(n, 0L)));
+                        Math.max(Math.max(lastResumeMs.getOrDefault(n, 0L),
+                                          stackStartMs.getOrDefault(n, 0L)),
+                                 engineResumeMs));
                 if (now - lastActivity <= idleMs) continue;
                 if (skipWhileCharging) continue; // plugged in: keep awake and synced
                 // SYNCED-once gate: don't pause a stack still doing its initial sync — unless

--- a/app-ios/src/iosMain/kotlin/io/myotis/ios/IosNodeController.kt
+++ b/app-ios/src/iosMain/kotlin/io/myotis/ios/IosNodeController.kt
@@ -285,6 +285,9 @@ class IosNodeController(
                     handleProvider = { locked { handles[net] } },
                     startMarkProvider = { locked { startMarks[net] } },
                 ),
+                lifecycle = IosRpcLifecycle(
+                    handleProvider = { locked { handles[net] } },
+                ),
             )
             // Deterministic up-front bind probe (JVM hosts' ServerSocket probe
             // twin): Ktor CIO surfaces bind failures ASYNCHRONOUSLY inside its

--- a/app-ios/src/iosMain/kotlin/io/myotis/ios/IosRpcLifecycle.kt
+++ b/app-ios/src/iosMain/kotlin/io/myotis/ios/IosRpcLifecycle.kt
@@ -1,0 +1,50 @@
+package io.myotis.ios
+
+import io.myotis.jsonrpc.RpcLifecycle
+import io.myotis.jsonrpc.RpcLifecycleResult
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+
+/**
+ * `myotis_pause` / `myotis_wakeup` for the iOS listener — the JSON-RPC
+ * counterpart of the daemon's pause/resume IPC commands, over the Rust engine's
+ * pause/resume FFI (`RustEngine.pause` / `RustEngine.resume`, i.e. the native
+ * `myotis_pause` / `myotis_resume`). Called straight from the RPC dispatcher like
+ * [IosRpcBackend] / [IosRpcStatusSource]: the native engine is internally
+ * serialized, so these do not need the controller's lifecycle lane.
+ *
+ * The resulting lifecycle name is read back from the engine's status JSON AFTER
+ * the transition so `{ok, lifecycle}` reflects the state actually reached, and
+ * `ok` mirrors the JVM handle's rule (target state reached, idempotent when
+ * already there) rather than the raw native boolean.
+ */
+class IosRpcLifecycle(
+    private val handleProvider: () -> Long?,
+) : RpcLifecycle {
+
+    override fun pause(): RpcLifecycleResult {
+        val handle = handleProvider() ?: return RpcLifecycleResult(false, "STOPPED")
+        RustEngine.pause(handle)
+        val lc = lifecycleName(handle)
+        return RpcLifecycleResult(lc == "PAUSED", lc)
+    }
+
+    override fun wakeUp(): RpcLifecycleResult {
+        val handle = handleProvider() ?: return RpcLifecycleResult(false, "STOPPED")
+        RustEngine.resume(handle)
+        val lc = lifecycleName(handle)
+        return RpcLifecycleResult(lc == "RUNNING", lc)
+    }
+
+    /** Coarse lifecycle from the native status JSON (running/paused booleans),
+     *  matching how [IosRpcStatusSource] derives the status "state" field. */
+    private fun lifecycleName(handle: Long): String {
+        val o = runCatching { engineJson.parseToJsonElement(RustEngine.statusJson(handle)).jsonObject }
+            .getOrElse { JsonObject(emptyMap()) }
+        return when {
+            o.engineBoolean("running") -> "RUNNING"
+            o.engineBoolean("paused") -> "PAUSED"
+            else -> "STOPPED"
+        }
+    }
+}

--- a/app-ios/src/iosMain/kotlin/io/myotis/ios/IosRpcLifecycle.kt
+++ b/app-ios/src/iosMain/kotlin/io/myotis/ios/IosRpcLifecycle.kt
@@ -24,14 +24,23 @@ class IosRpcLifecycle(
 
     override fun pause(): RpcLifecycleResult {
         val handle = handleProvider() ?: return RpcLifecycleResult(false, "STOPPED")
-        RustEngine.pause(handle)
+        // A native RUNNING→PAUSED transition is definitive: report PAUSED without a
+        // status re-read, so a transient status-read failure right after can't
+        // misreport a just-paused node as STOPPED. Only the no-transition case
+        // (already PAUSED = idempotent success, or STOPPED/failed) needs a read to
+        // disambiguate — mirrors RustChainHandle.pause().
+        if (RustEngine.pause(handle)) return RpcLifecycleResult(true, "PAUSED")
         val lc = lifecycleName(handle)
         return RpcLifecycleResult(lc == "PAUSED", lc)
     }
 
     override fun wakeUp(): RpcLifecycleResult {
         val handle = handleProvider() ?: return RpcLifecycleResult(false, "STOPPED")
-        RustEngine.resume(handle)
+        // A native resume that rebuilt networking is definitive: report RUNNING
+        // without a re-read. The no-transition case (already RUNNING = idempotent
+        // success, or a failed rebuild that stays PAUSED) needs a read to tell them
+        // apart — mirrors RustChainHandle.resume().
+        if (RustEngine.resume(handle)) return RpcLifecycleResult(true, "RUNNING")
         val lc = lifecycleName(handle)
         return RpcLifecycleResult(lc == "RUNNING", lc)
     }

--- a/docs/disk-and-network-usage.md
+++ b/docs/disk-and-network-usage.md
@@ -221,12 +221,13 @@ Two planned paths give other hosts the same escape:
   when queries can occur and can pause/resume the engine around its own lifecycle —
   the Android idle-pause model generalized. The engine API already supports this
   (`ChainStack.pause()` quiesces every socket and timer; a read wakes it).
-- **A pause/wake JSON-RPC surface.** The server could expose `myotis_pause` and
+- **A pause/wake JSON-RPC surface.** The server exposes `myotis_pause` and
   `myotis_wakeup` (alongside the existing `myotis_status`/`myotis_beaconStatus`), so a
   Myotis-aware wallet — even an out-of-process one — can put the node to sleep when its
   UI goes to the background and wake it (and poll status until ready) before the next burst
-  of queries. Not implemented yet; unaware wallets would keep today's always-warm
-  behavior.
+  of queries. See [§4.1](#41-lifecycle-control-myotis_pause--myotis_wakeup) for the exact
+  semantics. Unaware wallets keep today's always-warm behavior — the methods are opt-in and
+  nothing calls them on the wallet's behalf.
 
 With either in place, the desktop profile converges on the Android one in §3.3:
 per-minute rates only while a wallet is actually active, near-zero otherwise.
@@ -245,6 +246,47 @@ the desktop app and daemon are always-on (§3.2) unless paused.
 | `eth_call` / `eth_estimateGas` (EVM over snap proofs) | ~5 KB per cold account/slot touched + contract bytecode (tens of KB, up to 128 KB/response); repeated calls hit the state-root-keyed cache |
 | `eth_getBlockByNumber` | headers only, ~700 B each |
 | `eth_feeHistory` (cold, with percentiles) | up to 10 blocks × (body ~100 KB + receipts ~80 KB) ≈ **~1–2 MB**; normally served from the warm fee snapshot (§3.2) |
+
+### 4.1 Lifecycle control (`myotis_pause` / `myotis_wakeup`)
+
+Two Myotis-namespaced JSON-RPC methods let an **out-of-process** wallet drive the
+node's lifecycle over the same loopback endpoint it already uses for reads — the
+JSON-RPC counterpart of the daemon's `pause` / `resume` IPC commands, and of what
+the Android `NodeService` does in-process from its own idle/foreground callbacks.
+Like `myotis_status` / `myotis_beaconStatus`, they are **local control that bypasses
+the verified backend**, so they answer even when the node is not synced / has no
+peers.
+
+| Method | Params | Effect | Result |
+|---|---|---|---|
+| `myotis_pause` | `[]` | **Idle-pause**: tear down all P2P — every socket and periodic timer, so the radio can sleep — while the JSON-RPC listener keeps listening and the warm verified state (light-client store, sync-committee roots, peer caches) stays in memory. Exactly the transition the Android idle controller performs. Blocking (~a few seconds); idempotent. | `{"ok":true,"lifecycle":"PAUSED"}` |
+| `myotis_wakeup` | `[]` | Rebuild P2P after a pause (recorded as the `ipc` wake reason), skipping the cold DNS walk. Blocking (seconds). A no-op success when already `RUNNING`; on a failed rebuild returns `ok:false` and stays `PAUSED` (retryable). | `{"ok":true,"lifecycle":"RUNNING"}` |
+
+`lifecycle` is the coarse state reached (`RUNNING` | `PAUSED` | `STOPPED`), and `ok`
+is whether the requested target state was reached — so a caller can tell a real
+transition from a well-formed refusal rather than being handed a misleading success.
+
+**Intended use — pair `myotis_wakeup` with the status methods, never fire-and-forget.**
+`myotis_wakeup` only *starts* the rebuild; it returns as soon as the stack is
+`RUNNING`, which is **before** the beacon light client has re-anchored and a snap peer
+is in the serving pool. A wallet resuming from background should therefore:
+
+1. call `myotis_wakeup` as its UI comes to the foreground (overlapping the rebuild
+   with the user's unlock), then
+2. poll `myotis_status` until `state == "RUNNING"` **and** `snapPeers > 0`, and
+   `myotis_beaconStatus` until `state == "SYNCED"`, **before** issuing verified reads —
+   the same readiness gate the hosts apply (see
+   [readiness-and-verified-head-age.md](readiness-and-verified-head-age.md)).
+
+Skipping the wake entirely still works — the first verified read on a paused stack
+wakes it on its own and is held (bounded, ~90 s) until the node can answer — but an
+explicit `myotis_wakeup` + status poll overlaps the multi-second rebuild with the UI
+transition instead of stalling the first read. When the seam isn't wired (a host that
+didn't provide a lifecycle source) both methods return `-32601`.
+
+Availability: the daemon, the desktop, and the iOS listener wire these; the Android
+app doesn't need them (it drives pause/resume in-process from its own lifecycle
+callbacks — §3.3). Loopback-only and unauthenticated like the rest of the endpoint.
 
 ---
 

--- a/docs/disk-and-network-usage.md
+++ b/docs/disk-and-network-usage.md
@@ -296,6 +296,29 @@ window, so the controller won't re-pause a node a client just woke out from unde
 (`NodeService.idleTick`). Loopback-only and unauthenticated like the rest of the
 endpoint.
 
+**Multi-client caveat — `myotis_pause` is unconditional (last-writer-wins).** The
+pause verb does **not** consult the engine's in-flight-request counter (only the host
+idle timer does, via `lastActivityEpochMillis()` reporting "now" while a request is in
+flight). So on a node shared by more than one client:
+
+- A background client's `myotis_pause` tears the connector down **under another
+  client's in-flight read** — say a foreground wallet's multi-second confirm-screen
+  sweep. Integrity is unaffected (the read fails transiently or re-enters the wake gate
+  and is held ~90 s until the node can answer), but a background client can degrade a
+  foreground one.
+- Two Myotis-aware wallets both following the guidance above will pause the node out
+  from under each other on every background transition. The idle-controller cooperation
+  above protects external *wakes*; nothing arbitrates competing *pauses*.
+
+`myotis_pause` is therefore only polite when the caller is the node's **sole active
+consumer** (the embedded-library case: one app hosts the engine and is its only
+client). A wallet that can't assume that should prefer letting the node idle-pause
+itself (skip `myotis_pause`, keep `myotis_wakeup`) — a wake is always one verified read
+away regardless. (Making `pause` refuse while requests are in flight — returning
+`{ok:false, lifecycle:"RUNNING"}`, which the result shape already expresses — would
+also change the IPC `pause` command's semantics, so that is an owner decision, tracked
+separately.)
+
 ---
 
 ## 5. Creating and sending a transaction

--- a/docs/disk-and-network-usage.md
+++ b/docs/disk-and-network-usage.md
@@ -260,7 +260,7 @@ peers.
 | Method | Params | Effect | Result |
 |---|---|---|---|
 | `myotis_pause` | `[]` | **Idle-pause**: tear down all P2P — every socket and periodic timer, so the radio can sleep — while the JSON-RPC listener keeps listening and the warm verified state (light-client store, sync-committee roots, peer caches) stays in memory. Exactly the transition the Android idle controller performs. Blocking (~a few seconds); idempotent. | `{"ok":true,"lifecycle":"PAUSED"}` |
-| `myotis_wakeup` | `[]` | Rebuild P2P after a pause (recorded as the `ipc` wake reason), skipping the cold DNS walk. Blocking (seconds). A no-op success when already `RUNNING`; on a failed rebuild returns `ok:false` and stays `PAUSED` (retryable). | `{"ok":true,"lifecycle":"RUNNING"}` |
+| `myotis_wakeup` | `[]` | Rebuild P2P after a pause (tagged the `ipc` wake reason on the JVM hosts; the iOS native resume takes no reason), skipping the cold DNS walk. Blocking (seconds). A no-op success when already `RUNNING`; on a failed rebuild returns `ok:false` and stays `PAUSED` (retryable). | `{"ok":true,"lifecycle":"RUNNING"}` |
 
 `lifecycle` is the coarse state reached (`RUNNING` | `PAUSED` | `STOPPED`), and `ok`
 is whether the requested target state was reached — so a caller can tell a real
@@ -284,9 +284,17 @@ explicit `myotis_wakeup` + status poll overlaps the multi-second rebuild with th
 transition instead of stalling the first read. When the seam isn't wired (a host that
 didn't provide a lifecycle source) both methods return `-32601`.
 
-Availability: the daemon, the desktop, and the iOS listener wire these; the Android
-app doesn't need them (it drives pause/resume in-process from its own lifecycle
-callbacks — §3.3). Loopback-only and unauthenticated like the rest of the endpoint.
+Availability: every host that serves the JSON-RPC endpoint wires these — the daemon,
+the desktop, the iOS listener, **and the Android node service**. The Myotis Android
+app doesn't call them for its own UI (it drives pause/resume in-process from its own
+lifecycle callbacks — §3.3), but the node it hosts serves them on `127.0.0.1` so a
+**separate** same-device wallet app (e.g. Walleth) that points at the endpoint can
+pause/wake the shared node tied to *its* foreground/background. The Android idle
+controller cooperates: a wake it did not itself initiate (an out-of-process
+`myotis_wakeup`, or the engine's own wake on a verified read) is granted a full idle
+window, so the controller won't re-pause a node a client just woke out from under it
+(`NodeService.idleTick`). Loopback-only and unauthenticated like the rest of the
+endpoint.
 
 ---
 

--- a/docs/readiness-and-verified-head-age.md
+++ b/docs/readiness-and-verified-head-age.md
@@ -160,6 +160,13 @@ success, an ordered `failReason` token (`beaconNotSynced`, `noPeerStateRoot`,
 `eth_*` methods return `-32000` while any readiness gate is unmet — wallets
 should treat it as retryable.
 
+An out-of-process wallet that idle-pauses the node with `myotis_pause` should
+call `myotis_wakeup` and then poll these two status methods back through the
+readiness gate (`myotis_status.state == "RUNNING"` with `snapPeers > 0`, and
+`myotis_beaconStatus.state == "SYNCED"`) **before** its first `eth_*` read —
+`myotis_wakeup` returns when the rebuild *starts*, not when the node is ready
+again (see disk-and-network-usage.md §4.1).
+
 ## Code pointers
 
 - Java sync states + criteria: `consensus/.../BeaconSyncState.java`

--- a/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/MyotisRpcServer.kt
+++ b/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/MyotisRpcServer.kt
@@ -43,6 +43,7 @@ class MyotisRpcServer(
     private val host: String = "127.0.0.1",
     private val backend: RpcBackend? = null,
     private val statusReads: RpcStatusSource? = null,
+    private val lifecycle: RpcLifecycle? = null,
 ) {
     private companion object {
         const val LOGGER = "io.myotis.jsonrpc.MyotisRpcServer"
@@ -59,7 +60,7 @@ class MyotisRpcServer(
 
     private val proxy: UpstreamProxy? = upstreamUrl?.takeIf { it.isNotBlank() }?.let { UpstreamProxy(it) }
     private val logger = MethodLogger()
-    private val router = RpcRouter(proxy, logger, backend, statusReads)
+    private val router = RpcRouter(proxy, logger, backend, statusReads, lifecycle)
 
     /**
      * Optional request/response capture for debugging + replay (JVM-only —

--- a/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/RpcBackend.kt
+++ b/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/RpcBackend.kt
@@ -180,3 +180,25 @@ interface RpcStatusSource {
     fun statusJson(uptimeSeconds: Long): JsonObject
     fun beaconStatusJson(uptimeSeconds: Long): JsonObject
 }
+
+/**
+ * The lifecycle-control seam behind `myotis_pause` / `myotis_wakeup` — the
+ * JSON-RPC counterpart of the daemon's `pause` / `resume` IPC commands. Hosts
+ * wire the same node object they wire for [RpcStatusSource]; on the JVM the
+ * adapter delegates to [io.myotis.api.NodeLifecycle], on iOS to the engine's
+ * pause/resume FFI. Both verbs BLOCK (they tear down / rebuild networking) and
+ * may cross an FFI, so the router runs them off its event loop.
+ */
+interface RpcLifecycle {
+    /** Idle-pause: quiesce P2P (sockets + periodic timers) while the RPC listener
+     *  keeps listening. Returns the resulting transition. Blocking. */
+    fun pause(): RpcLifecycleResult
+    /** Wake a paused stack, recorded as the IPC/RPC wake reason. Returns the
+     *  resulting transition. Blocking (seconds). */
+    fun wakeUp(): RpcLifecycleResult
+}
+
+/** The outcome of an [RpcLifecycle] verb: [ok] is whether the target state was
+ *  reached, [lifecycle] the coarse state now in effect ("RUNNING" | "PAUSED" |
+ *  "STOPPED"). Mirrors the IPC command's `{"ok":…, "lifecycle":…}` shape. */
+class RpcLifecycleResult(val ok: Boolean, val lifecycle: String)

--- a/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/RpcRouter.kt
+++ b/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/RpcRouter.kt
@@ -252,6 +252,7 @@ class RpcRouter(
             }
             // Isolate the transition like the status reads / IPC command do: a throw
             // becomes a JSON-RPC error envelope, never a raw Ktor 500.
+            val tLc = TimeSource.Monotonic.markNow()
             return try {
                 // pause()/wakeUp() tear down / rebuild networking (seconds) and can
                 // cross a JNI boundary into the native engine — run them on the IO
@@ -260,7 +261,9 @@ class RpcRouter(
                 val r = withContext(rpcIoDispatcher) {
                     if (method == "myotis_pause") lc.pause() else lc.wakeUp()
                 }
-                logger.record(method, idStr, "LOCAL", 0)
+                // Unlike the status reads (hardcoded 0), record the REAL elapsed time:
+                // a pause/wakeup takes seconds, and the access log is where that shows.
+                logger.record(method, idStr, "LOCAL", elapsedMs(tLc))
                 resultEnvelope(id, buildJsonObject {
                     put("ok", r.ok)
                     put("lifecycle", r.lifecycle)

--- a/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/RpcRouter.kt
+++ b/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/RpcRouter.kt
@@ -31,6 +31,7 @@ class RpcRouter(
     private val logger: MethodLogger,
     private val backend: RpcBackend? = null,
     private val statusReads: RpcStatusSource? = null,
+    private val lifecycle: RpcLifecycle? = null,
 ) {
     private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
 
@@ -236,6 +237,40 @@ class RpcRouter(
                 logger.record(method, idStr, "ERROR", 0, -32603)
                 val detail = e.message?.takeIf { it.isNotBlank() } ?: (e::class.simpleName ?: "Exception")
                 errorEnvelope(id, -32603, "status read failed: $detail")
+            }
+        }
+        // Local lifecycle control — the JSON-RPC counterpart of the daemon's pause /
+        // resume IPC commands. Like the status methods these bypass the verified
+        // backend: a Myotis-aware wallet pauses the node when its UI backgrounds and
+        // wakes it (then polls myotis_status / myotis_beaconStatus until ready) before
+        // its next burst of queries. -32601 when the host didn't wire a control seam.
+        if (method == "myotis_pause" || method == "myotis_wakeup") {
+            val lc = lifecycle
+            if (lc == null) {
+                logger.record(method, idStr, "ERROR", 0, -32601)
+                return errorEnvelope(id, -32601, "method '$method' is not supported by this node")
+            }
+            // Isolate the transition like the status reads / IPC command do: a throw
+            // becomes a JSON-RPC error envelope, never a raw Ktor 500.
+            return try {
+                // pause()/wakeUp() tear down / rebuild networking (seconds) and can
+                // cross a JNI boundary into the native engine — run them on the IO
+                // dispatcher rather than blocking the Ktor CIO event loop, same as
+                // the status handler and the verified handlers below.
+                val r = withContext(rpcIoDispatcher) {
+                    if (method == "myotis_pause") lc.pause() else lc.wakeUp()
+                }
+                logger.record(method, idStr, "LOCAL", 0)
+                resultEnvelope(id, buildJsonObject {
+                    put("ok", r.ok)
+                    put("lifecycle", r.lifecycle)
+                })
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e   // never swallow coroutine cancellation (client disconnect / shutdown)
+            } catch (e: Exception) {
+                logger.record(method, idStr, "ERROR", 0, -32603)
+                val detail = e.message?.takeIf { it.isNotBlank() } ?: (e::class.simpleName ?: "Exception")
+                errorEnvelope(id, -32603, "lifecycle op failed: $detail")
             }
         }
         val t0 = TimeSource.Monotonic.markNow()

--- a/jsonrpc-server/src/jvmMain/kotlin/io/myotis/jsonrpc/ApiAdapters.kt
+++ b/jsonrpc-server/src/jvmMain/kotlin/io/myotis/jsonrpc/ApiAdapters.kt
@@ -14,18 +14,21 @@ object MyotisRpc {
      * unless [upstreamUrl] is set, backed by the api contracts.
      */
     @JvmStatic
+    @JvmOverloads
     fun server(
         port: Int,
         upstreamUrl: String?,
         host: String,
         backend: io.myotis.api.VerifiedReads?,
         statusReads: io.myotis.api.NodeStatusReads?,
+        lifecycle: io.myotis.api.NodeLifecycle? = null,
     ): MyotisRpcServer = MyotisRpcServer(
         port,
         upstreamUrl,
         host,
         backend?.let { VerifiedReadsBackend(it) },
         statusReads?.let { NodeStatusSource(it) },
+        lifecycle?.let { NodeLifecycleSource(it) },
     )
 }
 
@@ -113,4 +116,12 @@ class NodeStatusSource(private val sr: io.myotis.api.NodeStatusReads) : RpcStatu
     override fun statusJson(uptimeSeconds: Long): JsonObject = StatusJson.status(sr.status(), uptimeSeconds)
     override fun beaconStatusJson(uptimeSeconds: Long): JsonObject =
         StatusJson.beaconStatus(sr.beaconStatus(), uptimeSeconds)
+}
+
+/** [RpcLifecycle] over the api contract — pure delegation. The resulting
+ *  lifecycle name is read AFTER the transition so `{ok, lifecycle}` reflects the
+ *  state actually reached (mirrors the daemon's pause/resume IPC response). */
+class NodeLifecycleSource(private val lc: io.myotis.api.NodeLifecycle) : RpcLifecycle {
+    override fun pause(): RpcLifecycleResult = RpcLifecycleResult(lc.pause(), lc.lifecycleName())
+    override fun wakeUp(): RpcLifecycleResult = RpcLifecycleResult(lc.wakeUp(), lc.lifecycleName())
 }

--- a/jsonrpc-server/src/jvmMain/kotlin/io/myotis/jsonrpc/ApiAdapters.kt
+++ b/jsonrpc-server/src/jvmMain/kotlin/io/myotis/jsonrpc/ApiAdapters.kt
@@ -118,10 +118,23 @@ class NodeStatusSource(private val sr: io.myotis.api.NodeStatusReads) : RpcStatu
         StatusJson.beaconStatus(sr.beaconStatus(), uptimeSeconds)
 }
 
-/** [RpcLifecycle] over the api contract — pure delegation. The resulting
- *  lifecycle name is read AFTER the transition so `{ok, lifecycle}` reflects the
- *  state actually reached (mirrors the daemon's pause/resume IPC response). */
+/** [RpcLifecycle] over the api contract — pure delegation.
+ *
+ *  On success the lifecycle name is the target state BY DEFINITION
+ *  (`NodeLifecycle.pause` returns true iff PAUSED on return, `wakeUp` iff RUNNING),
+ *  so it is NOT re-read: reading `lifecycleName()` in a second call would let a
+ *  concurrent transition (the idle controller, another client) return an
+ *  internally contradictory `{ok:true, lifecycle:"RUNNING"}` for a pause — a
+ *  well-formed but misleading success (CLAUDE.md §Trust). Only the failure path,
+ *  where `ok` already says the target was not reached, reads the current state as
+ *  a best-effort diagnostic. */
 class NodeLifecycleSource(private val lc: io.myotis.api.NodeLifecycle) : RpcLifecycle {
-    override fun pause(): RpcLifecycleResult = RpcLifecycleResult(lc.pause(), lc.lifecycleName())
-    override fun wakeUp(): RpcLifecycleResult = RpcLifecycleResult(lc.wakeUp(), lc.lifecycleName())
+    override fun pause(): RpcLifecycleResult {
+        val ok = lc.pause()
+        return RpcLifecycleResult(ok, if (ok) "PAUSED" else lc.lifecycleName())
+    }
+    override fun wakeUp(): RpcLifecycleResult {
+        val ok = lc.wakeUp()
+        return RpcLifecycleResult(ok, if (ok) "RUNNING" else lc.lifecycleName())
+    }
 }

--- a/jsonrpc-server/src/jvmTest/kotlin/io/myotis/jsonrpc/MyotisLifecycleRpcTest.kt
+++ b/jsonrpc-server/src/jvmTest/kotlin/io/myotis/jsonrpc/MyotisLifecycleRpcTest.kt
@@ -1,0 +1,95 @@
+package io.myotis.jsonrpc
+
+import io.myotis.api.NodeLifecycle
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * The `myotis_pause` / `myotis_wakeup` JSON-RPC methods: the JSON-RPC counterpart
+ * of the daemon's `pause` / `resume` IPC commands. Like the status methods they
+ * are local control that answers WITHOUT a verified backend, return the
+ * `{ok, lifecycle}` shape the IPC command uses, and surface an unwired seam as
+ * -32601 (not a crash) and a throwing seam as -32603.
+ */
+class MyotisLifecycleRpcTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    /** A stub node whose lifecycle flips on pause()/wakeUp(), like the real stack. */
+    private class StubLifecycle(start: String = "RUNNING") : NodeLifecycle {
+        private var state = start
+        override fun pause(): Boolean { state = "PAUSED"; return true }
+        override fun wakeUp(): Boolean { state = "RUNNING"; return true }
+        override fun lifecycleName(): String = state
+    }
+
+    private fun route(lifecycle: NodeLifecycle?, body: String): String =
+        runBlocking {
+            RpcRouter(null, MethodLogger(), null, null, lifecycle?.let { NodeLifecycleSource(it) }).handle(body)
+        }
+
+    @Test fun myotisPause_returnsPaused_withoutBackend() {
+        val resp = route(StubLifecycle(), """{"jsonrpc":"2.0","id":1,"method":"myotis_pause","params":[]}""")
+        val obj = json.parseToJsonElement(resp).jsonObject
+        assertFalse(obj.containsKey("error"))                                 // local method, no backend needed
+        val result = obj["result"]!!.jsonObject
+        assertTrue(result["ok"]!!.jsonPrimitive.content.toBoolean())
+        assertEquals("PAUSED", result["lifecycle"]!!.jsonPrimitive.content)
+    }
+
+    @Test fun myotisWakeup_returnsRunning_withoutBackend() {
+        val resp = route(StubLifecycle(start = "PAUSED"),
+            """{"jsonrpc":"2.0","id":2,"method":"myotis_wakeup","params":[]}""")
+        val result = json.parseToJsonElement(resp).jsonObject["result"]!!.jsonObject
+        assertTrue(result["ok"]!!.jsonPrimitive.content.toBoolean())
+        assertEquals("RUNNING", result["lifecycle"]!!.jsonPrimitive.content)
+    }
+
+    @Test fun lifecycle_ok_isFalse_whenTargetStateNotReached() {
+        // A seam that refuses to transition (rebuild failed / STOPPED) must report ok:false
+        // with the state it stayed in — never a well-formed lie that the target was reached.
+        val stuck = object : NodeLifecycle {
+            override fun pause(): Boolean = false
+            override fun wakeUp(): Boolean = false
+            override fun lifecycleName(): String = "STOPPED"
+        }
+        val resp = route(stuck, """{"jsonrpc":"2.0","id":1,"method":"myotis_wakeup","params":[]}""")
+        val result = json.parseToJsonElement(resp).jsonObject["result"]!!.jsonObject
+        assertFalse(result["ok"]!!.jsonPrimitive.content.toBoolean())
+        assertEquals("STOPPED", result["lifecycle"]!!.jsonPrimitive.content)
+    }
+
+    @Test fun lifecycle_unwired_errorsMethodNotSupported() {
+        // No lifecycle seam injected (e.g. a host that didn't wire it) → -32601, not a crash.
+        for (m in listOf("myotis_pause", "myotis_wakeup")) {
+            val resp = route(null, """{"jsonrpc":"2.0","id":1,"method":"$m","params":[]}""")
+            val err = json.parseToJsonElement(resp).jsonObject["error"]!!.jsonObject
+            assertEquals(-32601, err["code"]!!.jsonPrimitive.content.toInt())
+            assertNull(json.parseToJsonElement(resp).jsonObject["result"])
+        }
+    }
+
+    @Test fun lifecycle_throws_errorsInternal_notRaw500() {
+        // A throwing seam must become a JSON-RPC error envelope (like the status path),
+        // not an unhandled exception surfacing as a raw HTTP 500. Throw with a NULL message
+        // so the detail must fall back to the exception type, never the literal "null".
+        val throwing = object : NodeLifecycle {
+            override fun pause(): Boolean = throw IllegalStateException()
+            override fun wakeUp(): Boolean = throw IllegalStateException()
+            override fun lifecycleName(): String = "RUNNING"
+        }
+        val resp = route(throwing, """{"jsonrpc":"2.0","id":1,"method":"myotis_pause","params":[]}""")
+        val err = json.parseToJsonElement(resp).jsonObject["error"]!!.jsonObject
+        assertEquals(-32603, err["code"]!!.jsonPrimitive.content.toInt())
+        val msg = err["message"]!!.jsonPrimitive.content
+        assertTrue(msg.contains("IllegalStateException"), "expected exception type in: $msg")
+        assertFalse(msg.contains("null"), "message must not leak a null: $msg")
+    }
+}

--- a/jsonrpc-server/src/jvmTest/kotlin/io/myotis/jsonrpc/MyotisLifecycleRpcTest.kt
+++ b/jsonrpc-server/src/jvmTest/kotlin/io/myotis/jsonrpc/MyotisLifecycleRpcTest.kt
@@ -66,6 +66,22 @@ class MyotisLifecycleRpcTest {
         assertEquals("STOPPED", result["lifecycle"]!!.jsonPrimitive.content)
     }
 
+    @Test fun successResult_ignoresLifecycleName_soNoContradiction() {
+        // On success the lifecycle is the target state BY DEFINITION, so the adapter must NOT
+        // re-read lifecycleName() — a concurrent transition there could otherwise return a
+        // contradictory {ok:true, lifecycle:"RUNNING"} for a pause (CLAUDE.md §Trust). This
+        // stub reports a CONTRADICTORY name to prove it is ignored on the success path.
+        val contradictory = object : NodeLifecycle {
+            override fun pause(): Boolean = true
+            override fun wakeUp(): Boolean = true
+            override fun lifecycleName(): String = "RUNNING" // would contradict a successful pause
+        }
+        val resp = route(contradictory, """{"jsonrpc":"2.0","id":1,"method":"myotis_pause","params":[]}""")
+        val result = json.parseToJsonElement(resp).jsonObject["result"]!!.jsonObject
+        assertTrue(result["ok"]!!.jsonPrimitive.content.toBoolean())
+        assertEquals("PAUSED", result["lifecycle"]!!.jsonPrimitive.content) // target state, not the stub's name
+    }
+
     @Test fun lifecycle_unwired_errorsMethodNotSupported() {
         // No lifecycle seam injected (e.g. a host that didn't wire it) → -32601, not a crash.
         for (m in listOf("myotis_pause", "myotis_wakeup")) {

--- a/myotis-api/src/main/java/io/myotis/api/NodeLifecycle.java
+++ b/myotis-api/src/main/java/io/myotis/api/NodeLifecycle.java
@@ -34,8 +34,10 @@ public interface NodeLifecycle {
     boolean pause();
 
     /**
-     * Rebuild P2P after {@link #pause()}, recorded as {@link WakeReason#IPC} (the
-     * IPC/RPC wake). Blocking (seconds; skips the cold DNS walk). A verified read
+     * Rebuild P2P after {@link #pause()}. On hosts that record a wake reason (the
+     * JVM engines, via {@link ChainHandle#resume(String)}) this is tagged
+     * {@link WakeReason#IPC} — the IPC/RPC wake; the iOS native resume FFI takes no
+     * reason and doesn't tag it. Blocking (seconds; skips the cold DNS walk). A verified read
      * arriving while paused already wakes the stack on its own, so an explicit
      * wakeup is the optimization a Myotis-aware wallet issues — alongside polling
      * {@code myotis_status} / {@code myotis_beaconStatus} — to overlap the rebuild

--- a/myotis-api/src/main/java/io/myotis/api/NodeLifecycle.java
+++ b/myotis-api/src/main/java/io/myotis/api/NodeLifecycle.java
@@ -1,0 +1,53 @@
+package io.myotis.api;
+
+/**
+ * Narrow lifecycle-control seam the JSON-RPC server consumes to answer the local
+ * {@code myotis_pause} / {@code myotis_wakeup} methods — the JSON-RPC counterpart
+ * of the daemon's {@code pause} / {@code resume} IPC commands and of what the
+ * Android {@code NodeService} idle controller does directly in-process when the
+ * app goes idle / comes to the foreground.
+ *
+ * <p>Kept separate from {@link ChainHandle} (like {@link NodeStatusReads}) so the
+ * RPC layer depends only on this two-verb control surface plus the lifecycle name,
+ * not the full engine surface. Both engine hosts already own
+ * {@link ChainHandle#pause()} / {@link ChainHandle#resume(String)} /
+ * {@link ChainHandle#lifecycle()}; the implementations here delegate to those, so
+ * the RPC methods perform exactly the same transitions as the IPC commands.
+ *
+ * <p>Like the status reads, these are local control that bypasses the verified
+ * backend: a Myotis-aware wallet pauses the node when its UI backgrounds and wakes
+ * it (then polls {@code myotis_status} / {@code myotis_beaconStatus} until ready)
+ * before the next burst of queries. FFI-portable: booleans + a String only; every
+ * method BLOCKS.
+ */
+public interface NodeLifecycle {
+
+    /**
+     * Idle-pause: quiesce all P2P — every socket and every periodic timer, so the
+     * radio can sleep — while keeping the JSON-RPC listener up and the warm
+     * verified state in memory. Exactly the transition the daemon's {@code pause}
+     * command and the Android idle controller perform. Blocking (a few seconds).
+     * Idempotent; a no-op unless {@code RUNNING}.
+     *
+     * @return {@code true} when {@code PAUSED} on return
+     */
+    boolean pause();
+
+    /**
+     * Rebuild P2P after {@link #pause()}, recorded as {@link WakeReason#IPC} (the
+     * IPC/RPC wake). Blocking (seconds; skips the cold DNS walk). A verified read
+     * arriving while paused already wakes the stack on its own, so an explicit
+     * wakeup is the optimization a Myotis-aware wallet issues — alongside polling
+     * {@code myotis_status} / {@code myotis_beaconStatus} — to overlap the rebuild
+     * with its UI coming to the foreground. A no-op returning {@code true} when
+     * already {@code RUNNING}; on a failed rebuild returns {@code false} and the
+     * stack stays {@code PAUSED} (retryable).
+     *
+     * @return {@code true} when {@code RUNNING} on return
+     */
+    boolean wakeUp();
+
+    /** Coarse lifecycle name — {@link LifecycleState#name()}: {@code RUNNING} |
+     *  {@code PAUSED} | {@code STOPPED}. */
+    String lifecycleName();
+}

--- a/myotis-api/src/main/java/io/myotis/api/WakeReason.java
+++ b/myotis-api/src/main/java/io/myotis/api/WakeReason.java
@@ -23,7 +23,8 @@ public final class WakeReason {
     /** The daily WorkManager maintenance pass resumed the stack to catch up + persist. */
     public static final String CATCH_UP = "catch-up";
 
-    /** The daemon's {@code resume} IPC command. */
+    /** The daemon's {@code resume} IPC command, and the {@code myotis_wakeup} JSON-RPC
+     *  method on the JVM engines (both route through {@link ChainHandle#resume(String)}). */
     public static final String IPC = "ipc";
 
     /** A plain {@link ChainHandle#resume()} with no reason given. */

--- a/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
@@ -54,7 +54,7 @@ import java.util.List;
  * {@code WakeGate} the Java engine uses — a request on a paused stack wakes it and
  * is held (bounded, ~90 s) until the node can answer.
  */
-final class RustChainHandle implements ChainHandle, NodeStatusReads {
+final class RustChainHandle implements ChainHandle, NodeStatusReads, io.myotis.api.NodeLifecycle {
 
     private static final Logger log = LoggerFactory.getLogger(RustChainHandle.class);
 
@@ -223,6 +223,12 @@ final class RustChainHandle implements ChainHandle, NodeStatusReads {
         return s.paused() ? LifecycleState.PAUSED : LifecycleState.STOPPED;
     }
 
+    // ---- io.myotis.api.NodeLifecycle (the myotis_pause / myotis_wakeup RPC seam) ----
+    // pause() above already satisfies NodeLifecycle.pause(). wakeUp() is the RPC/IPC
+    // wake — resume tagged WakeReason.IPC, matching the daemon's `resume` command.
+    @Override public boolean wakeUp() { return resume(io.myotis.api.WakeReason.IPC); }
+    @Override public String lifecycleName() { return lifecycle().name(); }
+
     @Override
     public long lastActivityEpochMillis() {
         // Epoch millis of the last gated verified read / operator query; 0 if none.
@@ -341,7 +347,7 @@ final class RustChainHandle implements ChainHandle, NodeStatusReads {
                 probe.bind(new java.net.InetSocketAddress("127.0.0.1", rpcPort));
             }
             io.myotis.jsonrpc.MyotisRpcServer server =
-                    io.myotis.jsonrpc.MyotisRpc.server(rpcPort, null, "127.0.0.1", verifiedReads, this);
+                    io.myotis.jsonrpc.MyotisRpc.server(rpcPort, null, "127.0.0.1", verifiedReads, this, this);
             server.start();
             this.rpcServer = server;
             log.info("[{}] JSON-RPC listening on http://127.0.0.1:{} (verified, strict)",

--- a/node-core/src/main/java/io/myotis/node/ChainStack.java
+++ b/node-core/src/main/java/io/myotis/node/ChainStack.java
@@ -56,7 +56,7 @@ import static io.myotis.api.LifecycleState.STOPPED;
  * <p>{@link #start()} is fault-isolated: any failure closes only this stack's resources
  * and returns {@code false}; it never affects sibling stacks or the host process.
  */
-public final class ChainStack {
+public final class ChainStack implements io.myotis.api.NodeLifecycle {
 
     private static final Logger log = LoggerFactory.getLogger(ChainStack.class);
 
@@ -595,6 +595,13 @@ public final class ChainStack {
         return servingPeers == 0 && zeroActive && nowMs - zeroSinceMs >= EL_HUNT_STALL_MS;
     }
     public LifecycleState lifecycle() { return phase.get(); }
+
+    // ---- io.myotis.api.NodeLifecycle (the myotis_pause / myotis_wakeup RPC seam) ----
+    // pause() above already satisfies NodeLifecycle.pause(). wakeUp() is the RPC/IPC
+    // wake — resume tagged WakeReason.IPC, exactly like the daemon's `resume` command.
+    @Override public boolean wakeUp() { return resume(io.myotis.api.WakeReason.IPC); }
+    @Override public String lifecycleName() { return lifecycle().name(); }
+
     public RLPxConnector connector() { return connector; }
 
     /** Inbound-serve counters for the status surfaces. */
@@ -1001,7 +1008,7 @@ public final class ChainStack {
                 // it survives pause() (keeps listening) while the backend underneath
                 // is torn down and rebuilt, and a request on a paused stack wakes it.
                 io.myotis.jsonrpc.MyotisRpcServer server =
-                        io.myotis.jsonrpc.MyotisRpc.server(rpcPort, null, "127.0.0.1", gatedReads, statusReads);
+                        io.myotis.jsonrpc.MyotisRpc.server(rpcPort, null, "127.0.0.1", gatedReads, statusReads, this);
                 server.start();
                 this.rpcServer = server;
                 this.rpcBackend = backend;


### PR DESCRIPTION
## What

Adds two Myotis-namespaced JSON-RPC methods so an **out-of-process** wallet can drive the node's lifecycle over the same loopback endpoint it already uses for reads — the JSON-RPC counterpart of the daemon's `pause` / `resume` IPC commands.

| Method | Effect | Result |
|---|---|---|
| `myotis_pause` | Idle-pause: tear down all P2P (every socket + periodic timer, radio can sleep), keep the RPC listener up and warm verified state in memory | `{"ok":true,"lifecycle":"PAUSED"}` |
| `myotis_wakeup` | Rebuild P2P (tagged the `ipc` wake reason on the JVM engines) | `{"ok":true,"lifecycle":"RUNNING"}` |

Like `myotis_status` / `myotis_beaconStatus`, both **bypass the verified backend** (they answer even when not synced / no peers). `ok` reflects whether the target state was actually reached; `lifecycle` is the coarse state now in effect.

## Why

Two host models, both needed:
- **Service *is* the Android app** (current `:android-app`): keeps driving pause/resume in-process from its own lifecycle callbacks — unchanged.
- **Myotis embedded as a library, accessed via localhost JSON-RPC** (e.g. a separate wallet app like Walleth on the same device): the connecting client pauses the engine when its UI backgrounds and wakes it before its next burst of queries. Previously there was no RPC surface for this ("not implemented yet" in `disk-and-network-usage.md`).

## How

Follows the `myotis_status` seam design exactly:
- New narrow, FFI-portable `NodeLifecycle` api interface (parallel to `NodeStatusReads`) + an `RpcLifecycle` commonMain seam + `RpcLifecycleResult`.
- Dispatched in `RpcRouter` (before `tryVerified`), off the CIO event loop. `-32601` when a host didn't wire the seam; `-32603` on a throwing transition (never a raw 500).
- Wired at every `MyotisRpc.server` / `MyotisRpcServer` call site: daemon/desktop (`ChainStack`), Rust engine (`RustChainHandle`), and the iOS listener (`IosRpcLifecycle`).

### Android idle-controller coordination

An external `myotis_wakeup` calls `handle.resume()` through the engine and bumps **none** of `NodeService`'s idle stamps, so the idle ticker would re-pause a node a client just woke (within ~30s). Fixed host-side and engine-agnostically: `NodeService.idleTick` detects the `PAUSED→RUNNING` transition it did not itself initiate and grants it a full idle window (`lastObservedLifecycle`). The Myotis app's own in-process control is unaffected.

## Testing

- New `MyotisLifecycleRpcTest` (pause→PAUSED, wakeup→RUNNING, `ok:false` when the target isn't reached, `-32601` unwired, `-32603` on throw, and an atomicity test pinning that a success never re-reads `lifecycleName()`).
- Full `:jsonrpc-server:jvmTest` green; `:node-core` / `:myotis-engines` compile clean. The `:android-app` module needs the Android SDK (validated in CI, not in the authoring sandbox); the `NodeService` change is straightforward Java.

## Follow-up (not in this PR)

An **example wallet app** demonstrating the embedded-library-via-localhost integration (client-driven pause/wakeup tied to Android `ProcessLifecycle`, with the wake→poll-status→read readiness sequence) — useful for surfacing same-process localhost race conditions. Proposed as its own work item.

## Docs

`disk-and-network-usage.md` §4.1 (full reference + the pair-`myotis_wakeup`-with-status guidance), cross-linked from `readiness-and-verified-head-age.md`. Also documents the mandatory per-work-item workflow in `CLAUDE.md` (code → review → PR → wait for review comments → address them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dax2Ppg4srHtAwWFnwVWpq)_