### PR TITLE
rpc: widen block-by-number lookback 256 → 512 for Swarm round reads

### DIFF
--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -87,11 +87,6 @@ public final class NodeService extends Service {
     // that discovery signal without serving unverified data. Flip to false only for
     // local debugging against an injected upstream.
     private static final boolean STRICT_NO_PROXY = true;
-    // Max blocks below the verified head we'll fetch+verify headers for to answer
-    // eth_getBlockByNumber by number. "latest" is 1 header; older numbers cost a header
-    // range, so bound it (MetaMask asks for "latest" for the fee market anyway).
-    private static final int BLOCK_LOOKBACK_MAX = 256;
-
     // Static so MainActivity can reflect the correct button state after a
     // configuration change — the activity instance is recreated, but the
     // service process (and this flag) outlive it.

--- a/myotis-engines/src/test/java/io/myotis/engines/RustVerifiedReadJsonTest.java
+++ b/myotis-engines/src/test/java/io/myotis/engines/RustVerifiedReadJsonTest.java
@@ -581,7 +581,7 @@ class RustVerifiedReadJsonTest {
     @Test
     void feeHistoryErrorObjectBecomesEngineException() {
         assertThrows(EngineException.class, () -> RustChainHandle.feeHistoryJsonOrThrow(
-                "{\"error\":\"oldest block 20 is beyond the 256-block verify window\"}"));
+                "{\"error\":\"oldest block 20 is beyond the 512-block verify window\"}"));
     }
 
     @Test

--- a/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
+++ b/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
@@ -77,7 +77,13 @@ public final class VerifiedRpcBackend implements io.myotis.api.VerifiedReads,
     // Max blocks below the verified head we'll fetch+verify headers for to answer
     // eth_getBlockByNumber by number. "latest" is 1 header; older numbers cost a header
     // range, so bound it (MetaMask asks for "latest" for the fee market anyway).
-    private static final int BLOCK_LOOKBACK_MAX = 256;
+    // 512, not 256: Swarm's bee reads the previous redistribution round's start
+    // header for its sample cutoff — up to 2×152−1 = 303 blocks behind head, plus
+    // whatever skew bee's cached block number has against our anchored head at
+    // serve time. 256 made that call fail for the tail of every round; 512 covers
+    // it with margin and stays one modest header-range fetch (~300 KB).
+    // Mirrored by the Rust engine's BLOCK_LOOKBACK_MAX (el/reader.rs) — keep in sync.
+    private static final int BLOCK_LOOKBACK_MAX = 512;
 
     private static final long ENS_TIMEOUT_SEC = 60;
 

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -5862,6 +5862,53 @@ mod tests {
         }
     }
 
+    /// The Java engine's `VerifiedRpcBackend.BLOCK_LOOKBACK_MAX` and this
+    /// file's [`BLOCK_LOOKBACK_MAX`] are two copies of one serving policy:
+    /// the engines must answer the same pinned block request identically, so
+    /// a lone bump on either side would open a window of pins the two answer
+    /// differently. Same shape as `sync.rs`'s `java_and_rust_checkpoints_agree`:
+    /// parse the Java source and compare, skipping only outside a repo checkout
+    /// (a vendored crate has no Java engine to disagree with).
+    #[test]
+    fn java_and_rust_block_lookback_agree() {
+        let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+        let java =
+            repo_root.join("rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java");
+        let src = match std::fs::read_to_string(&java) {
+            Ok(s) => s,
+            Err(e) => {
+                // Inside a checkout an unreadable path means the Java file MOVED —
+                // skipping there would silently disarm this guard forever.
+                if repo_root.join("settings.gradle.kts").exists() {
+                    panic!(
+                        "this is a repo checkout (settings.gradle.kts present) but {} is \
+                         unreadable ({e}) — VerifiedRpcBackend.java moved; update this \
+                         test's path",
+                        java.display()
+                    );
+                }
+                eprintln!("skipping: not a repo checkout ({} unreadable: {e})", java.display());
+                return;
+            }
+        };
+        let needle = "BLOCK_LOOKBACK_MAX = ";
+        let at = src
+            .find(needle)
+            .expect("no `BLOCK_LOOKBACK_MAX = ` assignment in VerifiedRpcBackend.java");
+        let digits: String = src[at + needle.len()..]
+            .chars()
+            .take_while(|c| c.is_ascii_digit())
+            .collect();
+        let java_value: u64 = digits.parse().unwrap_or_else(|_| {
+            panic!("unparseable BLOCK_LOOKBACK_MAX in VerifiedRpcBackend.java: {digits:?}")
+        });
+        assert_eq!(
+            java_value, BLOCK_LOOKBACK_MAX,
+            "Java VerifiedRpcBackend.BLOCK_LOOKBACK_MAX ({java_value}) and Rust \
+             BLOCK_LOOKBACK_MAX ({BLOCK_LOOKBACK_MAX}) have drifted — bump both together"
+        );
+    }
+
     struct ScriptedCaller(Vec<([u8; 20], Vec<u8>)>);
     impl myotis_evm::EthCaller for ScriptedCaller {
         fn eth_call(

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -303,7 +303,14 @@ pub struct VerifiedBlock {
 /// How far below the beacon head a block pin may be and still verify cheaply
 /// (mirrors the Java `VerifiedRpcBackend.BLOCK_LOOKBACK_MAX`): the header window
 /// [target..head] is fetched in one request, so this bounds its size.
-const BLOCK_LOOKBACK_MAX: u64 = 256;
+///
+/// 512, not 256: Swarm's bee reads the previous redistribution round's start
+/// header for its sample cutoff — up to 2×152−1 = 303 blocks behind head, plus
+/// whatever skew bee's cached block number has against our anchored head at
+/// serve time. 256 made that call fail for the tail of every round; 512 covers
+/// it with margin and keeps the window one ~300 KB fetch, still within the eth
+/// response soft limit.
+const BLOCK_LOOKBACK_MAX: u64 = 512;
 
 /// First-ever receipt scan for a tx hash looks back this many blocks below the
 /// head (the Java `RECEIPT_INITIAL_LOOKBACK_BLOCKS`); the per-tx cursor then
@@ -4237,7 +4244,7 @@ impl ElReader {
         full_transactions: bool,
     ) -> Result<VerifiedBlock, BlockFromError> {
         // The contiguous forward window [target .. head] (back + 1 headers), in one
-        // request. back < BLOCK_LOOKBACK_MAX (256) bounds this to ~150 KB, within the
+        // request. back < BLOCK_LOOKBACK_MAX (512) bounds this to ~300 KB, within the
         // eth response soft limit; a peer that caps its response below back+1 fails
         // the anchored-window length check and is skipped (fails closed — the caller
         // tries the next peer), so deep pins carry a slightly higher liveness risk


### PR DESCRIPTION
## Why

Swarm's bee full node derives its redistribution sample cutoff from the previous round's start header: `eth_getBlockByNumber` at a height 152–303 blocks behind head (`getPreviousRoundTime`, `pkg/storageincentives/agent.go`), plus whatever skew bee's cached block number carries against our anchored head at serve time.

The 256-block lookback refuses the tail of that range — probed live against a synced Gnosis daemon: `head−240` serves, `head−256` refuses. Bee's commit-phase calls land at distance 152–189 (fine), but a node sampling late in a round, or catching up after a stall, crosses the edge and the round fails.

512 = the 303-block worst case + margin, as a generic power of two rather than Swarm's `2×152` (a foreign protocol constant this client shouldn't encode). Anything needing more than 512 (deep history) is a different design — a sparse verified-hash ladder — deliberately out of scope here.

## What

- `VerifiedRpcBackend.BLOCK_LOOKBACK_MAX` (Java) 256 → 512
- `el/reader.rs BLOCK_LOOKBACK_MAX` (Rust mirror) 256 → 512, stale `~150 KB` window-size comment updated to `~300 KB`
- Review findings: deleted `NodeService`'s unreferenced third copy of the constant (stale 256 mirror); refreshed a test fixture quoting the old `256-block` engine error string

## Cost

The anchored header window stays a single `GetBlockHeaders` fetch: worst case 512 headers ≈ 300 KB, within the eth response soft limit (geth-family serve caps: 1024 headers / ~2 MiB) and this repo's own `MAX_SERVED_HEADERS = 1024`. Only deep-pin requests pay it; `latest` remains 1 header.

## Verification

- `:rpc-backend:test`, `cargo test -p myotis-net --lib window` (9 tests), `RustVerifiedReadJsonTest`, `:android-app:compileDebugJavaWithJavac` — all green
- Live probe on a synced Gnosis daemon pinned the old edge (−240 ok / −256 refused) before the change
- Independent no-context review of the diff; its two findings are the second commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFBXMzaidyXqKr1LovAZ5v