### PR TITLE
Map the Rust engine's finalized execution block into beaconStatus

### DIFF
--- a/app-ios/src/iosMain/kotlin/io/myotis/ios/IosRpcStatusSource.kt
+++ b/app-ios/src/iosMain/kotlin/io/myotis/ios/IosRpcStatusSource.kt
@@ -86,11 +86,13 @@ class IosRpcStatusSource(
                 put("finalizedPeriod", o.engineLong("finalizedSlot") / 8192L)
                 put("syncCommitteePeriod", currentPeriod)
                 put("wallClockPeriod", targetPeriod)
-                // The Rust engine doesn't expose the EL anchor / state-root cache
-                // introspection over the FFI (JNI parity: RustChainHandle reports
-                // the same empties).
+                // The finalized payload's block from the beacon anchor — the same
+                // status-JSON field RustChainHandle maps (missing key → 0; never
+                // the optimistic head). The exec state root / state-root cache
+                // introspection stay unexposed over the FFI (JNI parity: the JVM
+                // adapter reports the same empties).
                 put("executionStateRoot", JsonNull)
-                put("executionBlockNumber", 0)
+                put("executionBlockNumber", o.engineLong("finalizedBlockNumber"))
                 put("knownStateRoots", 0)
                 put("fillThreshold", 0)
             }

--- a/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
@@ -600,9 +600,9 @@ final class RustChainHandle implements ChainHandle, NodeStatusReads, io.myotis.a
                                             // slot (SLOTS_PER_SYNC_COMMITTEE_PERIOD),
                                             // consistent with StatusSnapshot — not the
                                             // committee's currentPeriod.
-                null,                  // executionStateRootHex (EL)
-                null,                  // executionBlockHashHex (EL)
-                0L,                    // executionBlockNumber
+                null,                  // executionStateRootHex (not in the status JSON)
+                null,                  // executionBlockHashHex (not in the status JSON)
+                s.finalizedBlockNumber(),  // executionBlockNumber (== finalized payload's block)
                 0,                     // knownStateRoots
                 0,                     // fillThreshold
                 s.wsBoundPeriods(),

--- a/myotis-engines/src/test/java/io/myotis/engines/RustStatusJsonTest.java
+++ b/myotis-engines/src/test/java/io/myotis/engines/RustStatusJsonTest.java
@@ -241,10 +241,12 @@ class RustStatusJsonTest {
         assertEquals(14560032L, bs.optimisticSlot());
         assertEquals(5, bs.connectedPeers());
         assertEquals(5L, bs.lightClientPeers());
-        // EL fields empty on the CL-only engine.
+        // The finalized payload's block flows from the beacon anchor (same status-JSON
+        // field statusSnapshot() maps); the exec state root / block hash are not in
+        // the status JSON, so they stay null on this surface.
         assertNull(bs.executionStateRootHex());
         assertNull(bs.executionBlockHashHex());
-        assertEquals(0L, bs.executionBlockNumber());
+        assertEquals(20999000L, bs.executionBlockNumber());
     }
 
     /** The weak-subjectivity park: STALE_ANCHOR maps through BOTH surfaces with the
@@ -301,6 +303,8 @@ class RustStatusJsonTest {
         assertEquals(1777L, s.wallClockPeriod());
         BeaconStatus bs = RustChainHandle.beaconStatusFromJson("mainnet", OLD_SHAPE_CATCHING_UP_JSON);
         assertEquals(1777L, bs.targetPeriod());
+        // No finalizedBlockNumber key in the old shape → 0, never a throw.
+        assertEquals(0L, bs.executionBlockNumber());
     }
 
     @Test


### PR DESCRIPTION
Fixes #394.

## Problem

Under the Rust engine (the default via `myotis.engine=auto`), `beacon-status` / `myotis_beaconStatus` always reported `executionBlockNumber: 0` — even when `state` was `SYNCED`. The native status JSON has carried the finalized payload's block number all along (`finalizedBlockNumber` == `executionBlockNumber`, from the beacon anchor, `rust/myotis-engine/src/host.rs`), and `statusSnapshot()` maps it — but both beacon-status adapters substituted a constant 0 left over from the CL-only era:

- `RustChainHandle.beaconStatus()` (JVM hosts: daemon, desktop, Android) hard-coded `0L`.
- `IosRpcStatusSource.beaconStatusJson()` (iOS C-ABI host) independently hard-coded `0`.

That left fail-closed consumers no way to read the verified finalized execution height; `eth_blockNumber` is defined as the optimistic head, so it is not a substitute.

## Change

- `RustChainHandle.beaconStatus()` forwards `ParsedStatus.finalizedBlockNumber` (already parsed at `RustChainHandle.java:443`; the same field `statusSnapshot()` maps) instead of `0L`.
- `IosRpcStatusSource.beaconStatusJson()` forwards `o.engineLong("finalizedBlockNumber")` from the same shared `host::status_json` shape.
- Missing-key tolerance unchanged on both sides: an older `.so` without the key still parses as 0 (`getLong(…, 0L)` / `engineLong` default), never the optimistic head.
- `RustStatusJsonTest.beaconStatusMapping()` now pins the non-zero value from the synthetic catching-up fixture (`20999000`), and the old-shape test additionally pins the missing-key → 0 fallback.

The exec state root / block hash stay `null` and `knownStateRoots`/`fillThreshold` stay 0 on this surface — those are genuinely not exported in the Rust status JSON; exporting them is a separate change.

## Validation

- `./gradlew :myotis-engines:test` — green (the parse/mapping golden tests need no native library; the live-JNI test self-skips).
- The iOS change is the one-line Kotlin mirror of the JVM mapping; it cannot be compiled on this Linux container (Apple targets need macOS), so it rides the repo's CI like any other `app-ios` change.
- Internal code review found no correctness issues in the changed lines. Three adjacent, out-of-scope observations it surfaced, recorded here rather than widening the diff (the issue asks for the response shape to otherwise stay unchanged):
  - `IosRpcStatusSource.beaconStatusJson` has no `STALE_ANCHOR` branch and omits `wsBoundPeriods`, both pre-existing parity gaps vs. the pinned JVM `StatusJson` shape.
  - On an idle-paused handle the native status freezes CL fields but zeroes the EL counts, so `executionBlockNumber` now visibly drops to 0 during sleep next to a frozen `finalizedSlot` — same behavior `statusSnapshot()` already has; a proper fix would freeze the EL block numbers with the beacon fields Rust-side.

## Note

The independently opened fork PR #395 addresses the same issue with a functionally identical mapping change; per this repo's policy fork PRs are owner-reviewed manually. Merging either makes the other redundant — this one is validated by the local test run above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018xRWHPLPpYuzgHuRML6y5J

---
_Generated by [Claude Code](https://claude.ai/code/session_018xRWHPLPpYuzgHuRML6y5J)_