### PR TITLE
CI: boot the app on a minSdk-29 emulator (Gradle Managed Device)

### DIFF
--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -267,11 +267,50 @@ jobs:
       # cache the system image + AVD to shave those minutes. swiftshader_indirect:
       # the runner has no GPU, so render in software (the documented GMD-on-CI
       # setting).
+      # STEP-level continue-on-error, adjudicated by the next step — not
+      # success-blind: both of this job's first PR runs hit a known AGP/UTP
+      # results-TRANSPORT bug (issuetracker.google.com/issues/335857362) where
+      # the device-side test finishes and its verdict is written to disk, but
+      # UTP's gRPC stream back to Gradle dies ("SEVERE: recordTestResultEvent
+      # ... UNAVAILABLE: io exception" in utp.0.log) and Gradle fails the task
+      # with "Failed to receive the UTP test results" — a false red over a
+      # PASSED run. The verdict file UTP writes is the ground truth either way,
+      # so the next step reads THAT: genuine failures stay red (verdict FAILED,
+      # or no verdict written at all), and the transport bug alone becomes a
+      # loud warning on a green job.
       - name: Run the boot smoke test on the API-29 managed device
+        id: gmd
+        continue-on-error: true
         run: |
           ./gradlew :android-app:api29DebugAndroidTest -PskipRustEngine \
             -Pandroid.testoptions.manageddevices.emulator.gpu=swiftshader_indirect \
             --stacktrace
+
+      - name: Adjudicate the device-side test verdict
+        run: |
+          set -eu
+          mapfile -t protos < <(find android-app/build/outputs/androidTest-results/managedDevice \
+            -name 'test-result.textproto' 2>/dev/null)
+          if [ "${#protos[@]}" -eq 0 ]; then
+            echo "::error::no test-result.textproto was written — the run produced no device-side verdict (infra/build failure; see the gradle step above)"
+            exit 1
+          fi
+          for p in "${protos[@]}"; do
+            if grep -qE 'test_status: (FAILED|ERROR|ABORTED|CANCELLED)' "$p"; then
+              echo "::error::device-side verdict is a failure in $p:"
+              grep -m1 -A12 'error_message' "$p" || true
+              exit 1
+            fi
+          done
+          # An empty or foreign suite must not pass as "our test was fine".
+          grep -q 'NodeBootSmokeTest' "${protos[@]}" \
+            || { echo "::error::NodeBootSmokeTest is missing from the device-side results"; exit 1; }
+          grep -q 'test_status: PASSED' "${protos[@]}" \
+            || { echo "::error::no PASSED verdict recorded"; exit 1; }
+          if [ "${{ steps.gmd.outcome }}" != "success" ]; then
+            echo "::warning title=UTP results transport failed::the gradle task failed only in the UTP results stream (known AGP/UTP gRPC bug, issue 335857362); the device-side verdict is PASSED"
+          fi
+          echo "device-side verdict: PASSED"
 
       # Results + per-test logcat — the boot verdict/diagnostics live here when
       # the test fails. Not on green runs: that bundle is dead weight.

--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -123,10 +123,16 @@ jobs:
       # Retry to ride out transient external-repo resolution blips. NOT --offline:
       # offline turns a single cache miss (e.g. a changed build file) into a hard
       # failure, which is what broke this job before.
-      - name: Build debug APK
+      #
+      # assembleDebugAndroidTest rides along so the boot smoke test's sources
+      # (androidTest) are compiled by a BLOCKING job: AGP wires androidTest into
+      # neither `assemble` nor `check`, and the emulator job below is
+      # continue-on-error — without this, a broken NodeBootSmokeTest.kt could sit
+      # green in CI indefinitely.
+      - name: Build debug APK (+ compile the androidTest APK)
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :android-app:assembleDebug --stacktrace && exit 0
+            ./gradlew :android-app:assembleDebug :android-app:assembleDebugAndroidTest --stacktrace && exit 0
             echo "::warning::APK build attempt $attempt failed; retrying in 25s (transient dependency resolution?)"
             sleep 25
           done
@@ -186,36 +192,53 @@ jobs:
           # fix since it hit exactly that.)
           overwrite: true
 
-  # Boot the actual app on a minSdk (API 29) emulator — the runtime complement to
-  # the static minSdk-29 JDK-API dex gate (scripts/check_apk_min_api.py): the gate
-  # proves every java.*/javax.* reference in the dex resolves at API 29, but it
-  # deliberately skips android.* framework APIs (SDK_INT guards are invisible to a
-  # bytecode scan) and any member api-versions.xml has no entry for — and no scan
-  # proves the app actually BOOTS. This job launches MainActivity and runs
-  # NodeService through a full engine-stack start (networking + consensus init) on
-  # an API-29 AOSP image via the `api29` Gradle Managed Device (NodeBootSmokeTest),
-  # so a startup-path NoClassDefFoundError/NoSuchMethodError fails here instead of
-  # on a user's phone.
+  # Boot the actual app on a minSdk (API 29) emulator. A static bytecode gate
+  # (scripts/check_apk_min_api.py, from the parallel minSdk-29 JDK-API work)
+  # can prove java.*/javax.* references resolve at API 29, but android.*
+  # framework APIs are out of any dex scan's reach (SDK_INT guards are invisible
+  # to it), api-versions.xml has gaps, and no scan proves the app actually
+  # BOOTS. This job launches MainActivity and runs NodeService through a full
+  # engine-stack start (networking + consensus init) on an API-29 AOSP image via
+  # the `api29` Gradle Managed Device (NodeBootSmokeTest), so a startup-path
+  # NoClassDefFoundError/NoSuchMethodError fails here instead of on a user's
+  # phone.
   #
   # -PskipRustEngine: runs on the Java engine. The minSdk-linkage risk this job
-  # hunts lives entirely in the JVM code (the Rust .so has no JDK/ART surface), it
-  # spares this job the whole Android Rust toolchain, and it is exactly the
-  # fallback an APK without the jniLibs uses at runtime.
+  # hunts lives entirely in the JVM code (the Rust .so has no JDK/ART surface),
+  # it spares this job the whole Android Rust toolchain, and it is exactly the
+  # fallback an APK without the jniLibs uses at runtime. Known gap, accepted:
+  # the Rust engine's own on-device load path (JNA/UniFFI) is not exercised by
+  # any boot test yet.
   boot-smoke-api29:
     name: API-29 boot smoke (emulator)
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    # Skip on release tags: nothing consumes this job's result there (release
+    # needs only build + version-guard), and the tagged commit already ran it on
+    # its way through main/PR.
+    if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+    # The in-test deadline only bounds the test body — NOT the system-image
+    # download, AVD creation, or an emulator/adb hang (the failure modes named
+    # below), which would otherwise run to GitHub's 6-hour default on a job
+    # whose failure nothing surfaces.
+    timeout-minutes: 45
     # NON-BLOCKING for now, deliberately: this is the repo's first emulator job,
     # and hosted-runner emulators are notoriously flaky (boot hangs, adb drops)
-    # even with KVM. A red job here stays visible on the PR but neither fails the
-    # workflow nor gates the merge; once it has proven stable for a few weeks,
-    # promote it to blocking by deleting this line.
+    # even with KVM. Job-level continue-on-error semantics: a failure still
+    # shows as a red check on the PR, but the WORKFLOW run passes, so it gates
+    # nothing (do NOT add this job to required checks while this line is here —
+    # a required check blocks merge on red regardless of continue-on-error).
+    # Once it has proven stable for a few weeks, promote it to blocking by
+    # deleting this line. (No retry loop around gradle here, unlike the build
+    # job: a retry would also re-run a genuinely failing boot test into the
+    # job timeout.)
     continue-on-error: true
     steps:
       # Shallow on purpose (no fetch-depth: 0): the build job needs full history
       # for the version stamp; here the stamp is irrelevant, and :ui's version
       # probe degrades to its fallback label instead of failing without it.
+      # (No `chmod +x gradlew` either — the executable bit is committed.)
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -237,33 +260,40 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Make gradlew executable
-        run: chmod +x gradlew
-
       # AGP's managed-device setup downloads the emulator + the API-29 system
       # image (several hundred MB, a couple of minutes) into the runner's
       # preinstalled SDK by itself — no sdkmanager steps needed, licenses are
-      # pre-accepted on the runner image. swiftshader_indirect: the runner has no
-      # GPU, so render in software (the documented GMD-on-CI setting).
+      # pre-accepted on the runner image. Follow-up once the job proves stable:
+      # cache the system image + AVD to shave those minutes. swiftshader_indirect:
+      # the runner has no GPU, so render in software (the documented GMD-on-CI
+      # setting).
       - name: Run the boot smoke test on the API-29 managed device
         run: |
           ./gradlew :android-app:api29DebugAndroidTest -PskipRustEngine \
             -Pandroid.testoptions.manageddevices.emulator.gpu=swiftshader_indirect \
             --stacktrace
 
-      # Results + per-test logcat — the crash stack lives here when the test fails.
+      # Results + per-test logcat — the boot verdict/diagnostics live here when
+      # the test fails. Only on failure: a green run's bundle is dead weight.
+      # if-no-files-found stays on the default `warn`: a failure that produced
+      # no results at all (died before the device) should say so, not vanish.
       - name: Upload managed-device test results
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: api29-boot-smoke-results-${{ github.sha }}
           path: |
             android-app/build/outputs/androidTest-results/managedDevice/
             android-app/build/reports/androidTests/managedDevice/
-          if-no-files-found: ignore
           retention-days: 14
           # Same re-run rationale as the APK artifact above.
           overwrite: true
+
+      # continue-on-error keeps the WORKFLOW green on a failure here; this
+      # annotation makes the red job hard to miss from the run summary too.
+      - name: Surface the failure as an annotation
+        if: failure()
+        run: echo "::warning title=API-29 boot smoke failed::the boot smoke test failed (non-blocking) — see the api29-boot-smoke-results artifact and this job's log"
 
   # Refuse to publish when the pushed tag disagrees with the version in the tree
   # — the asset name below comes from the tag, the versionName inside the apk

--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -274,11 +274,16 @@ jobs:
             --stacktrace
 
       # Results + per-test logcat — the boot verdict/diagnostics live here when
-      # the test fails. Only on failure: a green run's bundle is dead weight.
-      # if-no-files-found stays on the default `warn`: a failure that produced
-      # no results at all (died before the device) should say so, not vanish.
+      # the test fails. Not on green runs: that bundle is dead weight.
+      # `|| cancelled()`: a job that hits timeout-minutes is CANCELLED, not
+      # failed, and failure() alone would skip this exact step on the hang
+      # scenario the timeout exists for — the run most in need of the partial
+      # UTP/emulator logs. (Superseded runs cancelled by concurrency also hit
+      # this; their partial upload is harmless.) if-no-files-found stays on the
+      # default `warn`: a failure that produced no results at all (died before
+      # the device) should say so, not vanish.
       - name: Upload managed-device test results
-        if: failure()
+        if: failure() || cancelled()
         uses: actions/upload-artifact@v4
         with:
           name: api29-boot-smoke-results-${{ github.sha }}
@@ -291,9 +296,10 @@ jobs:
 
       # continue-on-error keeps the WORKFLOW green on a failure here; this
       # annotation makes the red job hard to miss from the run summary too.
+      # `|| cancelled()` for the same timeout-cancellation reason as the upload.
       - name: Surface the failure as an annotation
-        if: failure()
-        run: echo "::warning title=API-29 boot smoke failed::the boot smoke test failed (non-blocking) — see the api29-boot-smoke-results artifact and this job's log"
+        if: failure() || cancelled()
+        run: echo "::warning title=API-29 boot smoke did not pass::the boot smoke test failed, timed out, or was cancelled (non-blocking) — see the api29-boot-smoke-results artifact and this job's log"
 
   # Refuse to publish when the pushed tag disagrees with the version in the tree
   # — the asset name below comes from the tag, the versionName inside the apk

--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -192,9 +192,9 @@ jobs:
           # fix since it hit exactly that.)
           overwrite: true
 
-  # Boot the actual app on a minSdk (API 29) emulator. A static bytecode gate
-  # (scripts/check_apk_min_api.py, from the parallel minSdk-29 JDK-API work)
-  # can prove java.*/javax.* references resolve at API 29, but android.*
+  # Boot the actual app on a minSdk (API 29) emulator. The static bytecode gate
+  # (scripts/check_apk_min_api.py — the build job above runs it) proves
+  # java.*/javax.* references resolve at API 29, but android.*
   # framework APIs are out of any dex scan's reach (SDK_INT guards are invisible
   # to it), api-versions.xml has gaps, and no scan proves the app actually
   # BOOTS. This job launches MainActivity and runs NodeService through a full

--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -186,6 +186,85 @@ jobs:
           # fix since it hit exactly that.)
           overwrite: true
 
+  # Boot the actual app on a minSdk (API 29) emulator — the runtime complement to
+  # the static minSdk-29 JDK-API dex gate (scripts/check_apk_min_api.py): the gate
+  # proves every java.*/javax.* reference in the dex resolves at API 29, but it
+  # deliberately skips android.* framework APIs (SDK_INT guards are invisible to a
+  # bytecode scan) and any member api-versions.xml has no entry for — and no scan
+  # proves the app actually BOOTS. This job launches MainActivity and runs
+  # NodeService through a full engine-stack start (networking + consensus init) on
+  # an API-29 AOSP image via the `api29` Gradle Managed Device (NodeBootSmokeTest),
+  # so a startup-path NoClassDefFoundError/NoSuchMethodError fails here instead of
+  # on a user's phone.
+  #
+  # -PskipRustEngine: runs on the Java engine. The minSdk-linkage risk this job
+  # hunts lives entirely in the JVM code (the Rust .so has no JDK/ART surface), it
+  # spares this job the whole Android Rust toolchain, and it is exactly the
+  # fallback an APK without the jniLibs uses at runtime.
+  boot-smoke-api29:
+    name: API-29 boot smoke (emulator)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    # NON-BLOCKING for now, deliberately: this is the repo's first emulator job,
+    # and hosted-runner emulators are notoriously flaky (boot hangs, adb drops)
+    # even with KVM. A red job here stays visible on the PR but neither fails the
+    # workflow nor gates the merge; once it has proven stable for a few weeks,
+    # promote it to blocking by deleting this line.
+    continue-on-error: true
+    steps:
+      # Shallow on purpose (no fetch-depth: 0): the build job needs full history
+      # for the version stamp; here the stamp is irrelevant, and :ui's version
+      # probe degrades to its fallback label instead of failing without it.
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # The emulator needs hardware virtualization; ubuntu-latest runners expose
+      # /dev/kvm but root-only by default. This is the standard "enable KVM" udev
+      # rule from the android-emulator-runner docs.
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Make gradlew executable
+        run: chmod +x gradlew
+
+      # AGP's managed-device setup downloads the emulator + the API-29 system
+      # image (several hundred MB, a couple of minutes) into the runner's
+      # preinstalled SDK by itself — no sdkmanager steps needed, licenses are
+      # pre-accepted on the runner image. swiftshader_indirect: the runner has no
+      # GPU, so render in software (the documented GMD-on-CI setting).
+      - name: Run the boot smoke test on the API-29 managed device
+        run: |
+          ./gradlew :android-app:api29DebugAndroidTest -PskipRustEngine \
+            -Pandroid.testoptions.manageddevices.emulator.gpu=swiftshader_indirect \
+            --stacktrace
+
+      # Results + per-test logcat — the crash stack lives here when the test fails.
+      - name: Upload managed-device test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: api29-boot-smoke-results-${{ github.sha }}
+          path: |
+            android-app/build/outputs/androidTest-results/managedDevice/
+            android-app/build/reports/androidTests/managedDevice/
+          if-no-files-found: ignore
+          retention-days: 14
+          # Same re-run rationale as the APK artifact above.
+          overwrite: true
+
   # Refuse to publish when the pushed tag disagrees with the version in the tree
   # — the asset name below comes from the tag, the versionName inside the apk
   # comes from project.version. See release-version-guard.yml. Runs in parallel

--- a/android-app/build.gradle.kts
+++ b/android-app/build.gradle.kts
@@ -110,6 +110,7 @@ android {
         versionCode = 8
         versionName = releaseVersion
         buildConfigField("String", "RPC_UPSTREAM", "\"$rpcUpstream\"")
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
     compileOptions {
@@ -151,6 +152,36 @@ android {
     buildTypes {
         release {
             isMinifyEnabled = false
+        }
+    }
+
+    testOptions {
+        // No UI interactions in the smoke test, but system animations still cost
+        // main-thread time on a software-rendered emulator — keep them off.
+        animationsDisabled = true
+        // Gradle Managed Device pinned to minSdk (API 29): the one API level where
+        // "it dexes" is weakest evidence of "it runs" — Android 10/11 never get ART
+        // module updates, so a post-29 java.* reference throws NoSuchMethod/
+        // NoClassDefFoundError with no backport safety net, and android.* framework
+        // APIs are checkable only by executing on the real API level (SDK_INT guards
+        // are invisible to any bytecode scan). NodeBootSmokeTest (androidTest) boots
+        // MainActivity + NodeService on it far enough to run the networking/consensus
+        // init paths. Run with:
+        //   ./gradlew :android-app:api29DebugAndroidTest -PskipRustEngine
+        // (CI does exactly that — see .github/workflows/android-apk.yml; without the
+        // flag the device also gets the Rust engine, which the toolchain gate then
+        // requires). "aosp", not "aosp-atd": the leaner ATD images only exist for
+        // API 30+. x86/x86_64 hosts only — Google never published an API-29 arm64
+        // emulator image, so an Apple-Silicon Mac can't run this device locally;
+        // the CI job on an x86_64 runner is the enforcement point.
+        managedDevices {
+            localDevices {
+                create("api29") {
+                    device = "Pixel 2"
+                    apiLevel = 29
+                    systemImageSource = "aosp"
+                }
+            }
         }
     }
 
@@ -245,6 +276,13 @@ dependencies {
     // emulated Stream interface at minSdk ≤ 33) — earlier 2.1.x left it as a raw
     // API-34 call that crashes on Android 10-13 devices.
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.5")
+
+    // On-device boot smoke test (the api29 managed device above). Test APK only.
+    androidTestImplementation("junit:junit:4.13.2")
+    androidTestImplementation(libs.androidx.test.core)      // ActivityScenario / ApplicationProvider
+    androidTestImplementation(libs.androidx.test.runner)    // AndroidJUnitRunner (testInstrumentationRunner)
+    androidTestImplementation(libs.androidx.test.rules)     // ServiceTestRule
+    androidTestImplementation(libs.androidx.test.ext.junit) // AndroidJUnit4
 
     implementation(project(":core"))
     implementation(project(":networking"))

--- a/android-app/build.gradle.kts
+++ b/android-app/build.gradle.kts
@@ -159,27 +159,35 @@ android {
         // No UI interactions in the smoke test, but system animations still cost
         // main-thread time on a software-rendered emulator — keep them off.
         animationsDisabled = true
-        // Gradle Managed Device pinned to minSdk (API 29): the one API level where
-        // "it dexes" is weakest evidence of "it runs" — Android 10/11 never get ART
-        // module updates, so a post-29 java.* reference throws NoSuchMethod/
-        // NoClassDefFoundError with no backport safety net, and android.* framework
-        // APIs are checkable only by executing on the real API level (SDK_INT guards
-        // are invisible to any bytecode scan). NodeBootSmokeTest (androidTest) boots
-        // MainActivity + NodeService on it far enough to run the networking/consensus
-        // init paths. Run with:
+        // Gradle Managed Device pinned to minSdk (API 29) for NodeBootSmokeTest
+        // (androidTest — its KDoc carries the full why: real-ART boot coverage the
+        // static dex scan cannot give). Run it with
         //   ./gradlew :android-app:api29DebugAndroidTest -PskipRustEngine
-        // (CI does exactly that — see .github/workflows/android-apk.yml; without the
-        // flag the device also gets the Rust engine, which the toolchain gate then
-        // requires). "aosp", not "aosp-atd": the leaner ATD images only exist for
-        // API 30+. x86/x86_64 hosts only — Google never published an API-29 arm64
-        // emulator image, so an Apple-Silicon Mac can't run this device locally;
-        // the CI job on an x86_64 runner is the enforcement point.
+        // (CI adds -Pandroid.testoptions.manageddevices.emulator.gpu=
+        // swiftshader_indirect for its GPU-less runners — see
+        // .github/workflows/android-apk.yml; without -PskipRustEngine the device
+        // also gets the Rust engine, which the toolchain gate then requires).
+        // "aosp", not "aosp-atd": the leaner ATD images only exist for API 30+.
+        // x86_64 hosts only — Google never published an API-29 arm64 emulator
+        // image, so an Apple-Silicon Mac can't run this device locally; the CI
+        // job is the enforcement point.
         managedDevices {
             localDevices {
                 create("api29") {
                     device = "Pixel 2"
                     apiLevel = 29
                     systemImageSource = "aosp"
+                    // REQUIRED, not a preference: the APK always carries native
+                    // libs for exactly arm64-v8a + x86_64 (extractJnaAndroidNatives
+                    // packages libjnidispatch.so even under -PskipRustEngine), and
+                    // an APK with native libs installs only on a device offering a
+                    // matching ABI. Left false, AGP resolves this device to the
+                    // 32-BIT image (verified against AGP 8.7.3: aosp images get
+                    // x86_64 only for apiLevel 26 and 30 — a two-element set, not
+                    // a range — and everything else <= 30 falls through to x86),
+                    // and the install dies with INSTALL_FAILED_NO_MATCHING_ABIS
+                    // before any test runs.
+                    require64Bit = true
                 }
             }
         }
@@ -271,14 +279,14 @@ kotlin {
 // Java. That is what shipped in v0.1.3 and v0.1.4.
 
 dependencies {
-    testImplementation("junit:junit:4.13.2")
+    testImplementation(libs.junit4)
     // 2.1.5 is the first release whose config desugars Stream.toList() (via an
     // emulated Stream interface at minSdk ≤ 33) — earlier 2.1.x left it as a raw
     // API-34 call that crashes on Android 10-13 devices.
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.5")
 
     // On-device boot smoke test (the api29 managed device above). Test APK only.
-    androidTestImplementation("junit:junit:4.13.2")
+    androidTestImplementation(libs.junit4)
     androidTestImplementation(libs.androidx.test.core)      // ActivityScenario / ApplicationProvider
     androidTestImplementation(libs.androidx.test.runner)    // AndroidJUnitRunner (testInstrumentationRunner)
     androidTestImplementation(libs.androidx.test.rules)     // ServiceTestRule

--- a/android-app/src/androidTest/java/com/jaeckel/ethp2p/android/NodeBootSmokeTest.kt
+++ b/android-app/src/androidTest/java/com/jaeckel/ethp2p/android/NodeBootSmokeTest.kt
@@ -28,8 +28,8 @@ import java.util.concurrent.TimeUnit
  * API-29 ART checks they work), `java.*` members the SDK's api-versions.xml has no
  * entry for, and anything that only breaks when class init actually runs (provider
  * lookups, reflective access, native-lib fallbacks). It is the runtime complement to
- * the static minSdk dex gate (scripts/check_apk_min_api.py, from the parallel
- * minSdk-29 JDK-API work).
+ * the static minSdk dex gate (scripts/check_apk_min_api.py, run by the same
+ * workflow's build job).
  *
  * How a startup `NoClassDefFoundError` / `NoSuchMethodError` surfaces here:
  *  - thrown in host/service code or `ENGINE.create()`: the boot worker catches only

--- a/android-app/src/androidTest/java/com/jaeckel/ethp2p/android/NodeBootSmokeTest.kt
+++ b/android-app/src/androidTest/java/com/jaeckel/ethp2p/android/NodeBootSmokeTest.kt
@@ -112,6 +112,10 @@ class NodeBootSmokeTest {
             outcome == null ->
                 "no boot verdict was recorded — the boot worker never finished " +
                     "(service running=${NodeService.isRunning()})"
+            // A failure verdict recorded between the last poll and this re-read:
+            // without this arm it would be misreported as an RPC problem below.
+            outcome != NodeService.BOOT_STARTED ->
+                "boot FAILED between the last poll and this re-read: $outcome"
             snapshot?.rpcServing() != true ->
                 "the stack started but the RPC listener never came up — ChainStack " +
                     "treats that bind as best-effort; look for \"continuing without " +

--- a/android-app/src/androidTest/java/com/jaeckel/ethp2p/android/NodeBootSmokeTest.kt
+++ b/android-app/src/androidTest/java/com/jaeckel/ethp2p/android/NodeBootSmokeTest.kt
@@ -1,0 +1,103 @@
+package com.jaeckel.ethp2p.android
+
+import android.content.Intent
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.rule.ServiceTestRule
+import com.jaeckel.ethp2p.android.log.LogBuffer
+import org.junit.Assert.fail
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * On-device boot smoke test, aimed at the minSdk emulator (the `api29` Gradle managed
+ * device — see the managedDevices block in build.gradle.kts): launch the real
+ * [MainActivity], let its fresh-launch path auto-start [NodeService], and wait until
+ * the primary network's engine stack reports a COMPLETED start.
+ *
+ * The point is runtime linkage, not sync: `ChainStack.start()` synchronously walks the
+ * whole networking + consensus init sequence — EIP-1459 DNS discovery, the RLPx
+ * connector and initial dials, discv4, discv5 + the beacon light client (libp2p, BLS,
+ * SSZ), the Ktor JSON-RPC server, the snap-peer maintainer — so reaching "started"
+ * proves that code actually EXECUTES on this API level. That covers what the static
+ * APK scan (scripts/check_apk_min_api.py) deliberately cannot:
+ *
+ *  - `android.*` framework APIs above minSdk in startup code — out of the dex gate's
+ *    scope, because `SDK_INT` guards are invisible to a bytecode scan (lint's NewApi
+ *    owns the source side; only running on real API-29 ART checks the guards work);
+ *  - `java.*` members the SDK's api-versions.xml has no entry for (the gate must skip
+ *    what it cannot resolve);
+ *  - anything that only breaks when class init actually runs (provider lookups,
+ *    reflective access, native-lib fallbacks).
+ *
+ * A [NoClassDefFoundError] / [NoSuchMethodError] anywhere on the boot path crashes the
+ * app process — NodeService's boot workers catch `Exception`, not `Error` — which
+ * fails this test with the crash stack in the instrumentation report. A boot that dies
+ * with a plain Exception is also caught: the stack never reports started and the
+ * timeout failure below prints the in-app log tail, which includes the boot error.
+ *
+ * The test needs no peers and no internet: "started" means local binds and threads are
+ * up, before any peer answers. It is engine-agnostic — under `-PskipRustEngine` (how
+ * CI runs it) the selector serves the Java engine, exactly the fallback an APK without
+ * the Rust jniLibs uses at runtime.
+ */
+@RunWith(AndroidJUnit4::class)
+class NodeBootSmokeTest {
+
+    @get:Rule
+    val serviceRule = ServiceTestRule()
+
+    @Test
+    fun mainActivityLaunches_andNodeServiceBootsTheEngineStack() {
+        // launch() throws if the activity fails to reach RESUMED — that alone covers
+        // "the app's UI comes up" (Application.onCreate, Compose first render).
+        ActivityScenario.launch(MainActivity::class.java).use {
+            // MainActivity.onCreate has already called startForegroundService (fresh
+            // launch, service not running). Binding does NOT boot anything by itself
+            // (see the BIND_AUTO_CREATE note in MainActivity.onStart) — it only gets
+            // us the instance whose per-network snapshot we can poll.
+            val binder = serviceRule.bindService(
+                Intent(ApplicationProvider.getApplicationContext(), NodeService::class.java)
+            )
+            val service = (binder as NodeService.LocalBinder).service()
+
+            val deadline = System.currentTimeMillis() + BOOT_DEADLINE_MS
+            var last: NodeService.Snapshot? = null
+            while (System.currentTimeMillis() < deadline) {
+                // Polling snapshot() is itself part of the smoke: it runs the engine's
+                // status surfaces (status(), beaconStatus(), the cache-file stats).
+                last = service.snapshot()
+                // "RUNNING + RPC serving" is the start-completed signal: ChainStack
+                // flips its lifecycle to RUNNING on ENTRY to start(), but binds the
+                // RPC listener as the last-but-one init step — so a live listener
+                // means the whole init sequence above it has already executed.
+                if (last != null && last.lifecycle() == "RUNNING" && last.rpcServing()) {
+                    return
+                }
+                Thread.sleep(POLL_INTERVAL_MS)
+            }
+
+            val logTail = LogBuffer.snapshot()
+                .takeLast(LOG_TAIL_LINES)
+                .joinToString("\n") { e -> "${e.level()}/${e.tag()}: ${e.message()}" }
+            fail(
+                "NodeService did not report a fully started stack within " +
+                    "${BOOT_DEADLINE_MS / 1000}s (service running=${NodeService.isRunning()}, " +
+                    "last snapshot=$last).\nRecent app log:\n$logTail"
+            )
+        }
+    }
+
+    private companion object {
+        /** Generous: cold ART + a software-GPU emulator boot the stack in well under a
+         *  minute, but CI runners are slow and the DNS probes may each eat their 10 s
+         *  deadline offline. Well below any outer per-run timeout, so the timeout path
+         *  fails with our diagnostics instead of a bare hang. */
+        const val BOOT_DEADLINE_MS = 300_000L
+        const val POLL_INTERVAL_MS = 500L
+        /** Enough to include the boot banner and any boot failure with its cause chain. */
+        const val LOG_TAIL_LINES = 150
+    }
+}

--- a/android-app/src/androidTest/java/com/jaeckel/ethp2p/android/NodeBootSmokeTest.kt
+++ b/android-app/src/androidTest/java/com/jaeckel/ethp2p/android/NodeBootSmokeTest.kt
@@ -10,44 +10,61 @@ import org.junit.Assert.fail
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.util.concurrent.TimeUnit
 
 /**
  * On-device boot smoke test, aimed at the minSdk emulator (the `api29` Gradle managed
  * device — see the managedDevices block in build.gradle.kts): launch the real
- * [MainActivity], let its fresh-launch path auto-start [NodeService], and wait until
- * the primary network's engine stack reports a COMPLETED start.
+ * [MainActivity], let its fresh-launch path auto-start [NodeService], and wait for the
+ * primary network's boot verdict.
  *
  * The point is runtime linkage, not sync: `ChainStack.start()` synchronously walks the
  * whole networking + consensus init sequence — EIP-1459 DNS discovery, the RLPx
  * connector and initial dials, discv4, discv5 + the beacon light client (libp2p, BLS,
- * SSZ), the Ktor JSON-RPC server, the snap-peer maintainer — so reaching "started"
- * proves that code actually EXECUTES on this API level. That covers what the static
- * APK scan (scripts/check_apk_min_api.py) deliberately cannot:
+ * SSZ), the Ktor JSON-RPC server, the snap-peer maintainer — so a recorded
+ * [NodeService.BOOT_STARTED] proves that code actually EXECUTED on this API level.
+ * That is coverage a static bytecode scan cannot give: `android.*` framework APIs
+ * above minSdk (`SDK_INT` guards are invisible to a dex scan — only running on real
+ * API-29 ART checks they work), `java.*` members the SDK's api-versions.xml has no
+ * entry for, and anything that only breaks when class init actually runs (provider
+ * lookups, reflective access, native-lib fallbacks). It is the runtime complement to
+ * the static minSdk dex gate (scripts/check_apk_min_api.py, from the parallel
+ * minSdk-29 JDK-API work).
  *
- *  - `android.*` framework APIs above minSdk in startup code — out of the dex gate's
- *    scope, because `SDK_INT` guards are invisible to a bytecode scan (lint's NewApi
- *    owns the source side; only running on real API-29 ART checks the guards work);
- *  - `java.*` members the SDK's api-versions.xml has no entry for (the gate must skip
- *    what it cannot resolve);
- *  - anything that only breaks when class init actually runs (provider lookups,
- *    reflective access, native-lib fallbacks).
+ * How a startup `NoClassDefFoundError` / `NoSuchMethodError` surfaces here:
+ *  - thrown in host/service code or `ENGINE.create()`: the boot worker catches only
+ *    `Exception`, so the `Error` crashes the app process and the instrumentation
+ *    report carries the crash stack;
+ *  - thrown inside `ChainStack.start()`: its internal `catch (Throwable)` converts it
+ *    to a `false` return (no crash, stack trace in the log), which [NodeService]
+ *    records as a failed boot outcome — this test then FAILS FAST with the app log's
+ *    error lines instead of burning the whole deadline.
  *
- * A [NoClassDefFoundError] / [NoSuchMethodError] anywhere on the boot path crashes the
- * app process — NodeService's boot workers catch `Exception`, not `Error` — which
- * fails this test with the crash stack in the instrumentation report. A boot that dies
- * with a plain Exception is also caught: the stack never reports started and the
- * timeout failure below prints the in-app log tail, which includes the boot error.
+ * Success additionally requires [NodeService.Snapshot.rpcServing]: ChainStack treats
+ * the JSON-RPC bring-up as best-effort (an init failure there is swallowed with
+ * "continuing without JSON-RPC" and the stack still reports started), so without this
+ * condition a linkage error inside the Ktor/RPC stack would pass silently. On a fresh
+ * emulator nothing else holds the RPC port, so the extra condition adds no flake in
+ * practice.
  *
- * The test needs no peers and no internet: "started" means local binds and threads are
- * up, before any peer answers. It is engine-agnostic — under `-PskipRustEngine` (how
- * CI runs it) the selector serves the Java engine, exactly the fallback an APK without
- * the Rust jniLibs uses at runtime.
+ * Deliberate scope choices:
+ *  - The boot is triggered by MainActivity's fresh-launch auto-start — the real
+ *    cold-launch path. If that auto-start is ever gated (onboarding, a setting), this
+ *    test must start the service itself instead of timing out.
+ *  - Engine-agnostic, but under `-PskipRustEngine` (how CI runs it) the selector
+ *    serves the Java engine — exactly the fallback an APK without the Rust jniLibs
+ *    uses at runtime. The Rust engine's own load path is NOT covered here.
+ *  - Needs no peers and no internet: "started" means local binds and threads are up.
  */
 @RunWith(AndroidJUnit4::class)
 class NodeBootSmokeTest {
 
+    // 60 s, not the rule's 5 s default: the bind callback queues on the main looper
+    // behind NodeService.onCreate/onStartCommand (startForeground, notification
+    // channel, engine class init) on a cold, software-rendered emulator — 5 s there
+    // is a flake that would fail the run before the boot path is exercised at all.
     @get:Rule
-    val serviceRule = ServiceTestRule()
+    val serviceRule: ServiceTestRule = ServiceTestRule.withTimeout(60, TimeUnit.SECONDS)
 
     @Test
     fun mainActivityLaunches_andNodeServiceBootsTheEngineStack() {
@@ -64,40 +81,75 @@ class NodeBootSmokeTest {
             val service = (binder as NodeService.LocalBinder).service()
 
             val deadline = System.currentTimeMillis() + BOOT_DEADLINE_MS
-            var last: NodeService.Snapshot? = null
-            while (System.currentTimeMillis() < deadline) {
-                // Polling snapshot() is itself part of the smoke: it runs the engine's
-                // status surfaces (status(), beaconStatus(), the cache-file stats).
-                last = service.snapshot()
-                // "RUNNING + RPC serving" is the start-completed signal: ChainStack
-                // flips its lifecycle to RUNNING on ENTRY to start(), but binds the
-                // RPC listener as the last-but-one init step — so a live listener
-                // means the whole init sequence above it has already executed.
-                if (last != null && last.lifecycle() == "RUNNING" && last.rpcServing()) {
-                    return
-                }
+            while (true) {
+                if (startedCompletely(service)) return
+                if (System.currentTimeMillis() >= deadline) break
+                // The loop shape guarantees one more check after the final sleep, so
+                // a boot landing right at the deadline can't be misreported.
                 Thread.sleep(POLL_INTERVAL_MS)
             }
-
-            val logTail = LogBuffer.snapshot()
-                .takeLast(LOG_TAIL_LINES)
-                .joinToString("\n") { e -> "${e.level()}/${e.tag()}: ${e.message()}" }
-            fail(
-                "NodeService did not report a fully started stack within " +
-                    "${BOOT_DEADLINE_MS / 1000}s (service running=${NodeService.isRunning()}, " +
-                    "last snapshot=$last).\nRecent app log:\n$logTail"
-            )
+            failTimedOut(service)
         }
     }
 
+    /** One poll: fail the test immediately on a recorded boot failure; true when the
+     *  boot verdict is in AND the (best-effort) RPC listener is live. */
+    private fun startedCompletely(service: NodeService): Boolean {
+        val outcome = NodeService.bootOutcome(NETWORK)
+        // Polling the snapshot is itself part of the smoke: it drives the engine's
+        // status surfaces (status(), beaconStatus(), cache-file stats) on this ART.
+        val snapshot = service.snapshot()
+        if (outcome != null && outcome != NodeService.BOOT_STARTED) {
+            fail("NodeService boot FAILED: $outcome\n${diagnostics(snapshot)}")
+        }
+        return outcome == NodeService.BOOT_STARTED && snapshot?.rpcServing() == true
+    }
+
+    private fun failTimedOut(service: NodeService) {
+        val outcome = NodeService.bootOutcome(NETWORK)
+        val snapshot = service.snapshot()
+        val hint = when {
+            outcome == null ->
+                "no boot verdict was recorded — the boot worker never finished " +
+                    "(service running=${NodeService.isRunning()})"
+            snapshot?.rpcServing() != true ->
+                "the stack started but the RPC listener never came up — ChainStack " +
+                    "treats that bind as best-effort; look for \"continuing without " +
+                    "JSON-RPC\" in the log"
+            // Fully started between the final poll and this diagnostic re-read: a pass.
+            else -> return
+        }
+        fail(
+            "Not fully started after ${BOOT_DEADLINE_MS / 1000}s: $hint\n" +
+                diagnostics(snapshot)
+        )
+    }
+
+    /** Error lines are collected separately from the tail: on the timeout path the
+     *  buffer keeps filling after an early failure (idle ticker, heartbeat), and a
+     *  plain tail would have scrolled the one interesting stack trace away. */
+    private fun diagnostics(snapshot: NodeService.Snapshot?): String {
+        val all = LogBuffer.snapshot()
+        fun fmt(e: LogBuffer.Entry) = "${e.level()}/${e.tag()}: ${e.message()}"
+        val errors = all.filter { it.level() == 'E' }.takeLast(ERROR_LINES)
+        val tail = all.takeLast(TAIL_LINES)
+        return "last snapshot=$snapshot\n" +
+            "--- error log lines (up to $ERROR_LINES) ---\n" +
+            errors.joinToString("\n", transform = ::fmt) +
+            "\n--- log tail (last $TAIL_LINES) ---\n" +
+            tail.joinToString("\n", transform = ::fmt)
+    }
+
     private companion object {
-        /** Generous: cold ART + a software-GPU emulator boot the stack in well under a
-         *  minute, but CI runners are slow and the DNS probes may each eat their 10 s
-         *  deadline offline. Well below any outer per-run timeout, so the timeout path
-         *  fails with our diagnostics instead of a bare hang. */
-        const val BOOT_DEADLINE_MS = 300_000L
-        const val POLL_INTERVAL_MS = 500L
-        /** Enough to include the boot banner and any boot failure with its cause chain. */
-        const val LOG_TAIL_LINES = 150
+        /** The default-enabled network on a fresh install (NodeService.enabledNetworks). */
+        const val NETWORK = "mainnet"
+        /** The boot normally lands well under a minute; 240 s absorbs a slow CI runner
+         *  (each DNS probe may eat its 10 s deadline offline) while staying under the
+         *  job's outer timeout. Boot FAILURES don't wait for this — they fail fast via
+         *  the recorded boot outcome. */
+        const val BOOT_DEADLINE_MS = 240_000L
+        const val POLL_INTERVAL_MS = 2_000L
+        const val ERROR_LINES = 40
+        const val TAIL_LINES = 100
     }
 }

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -95,6 +95,25 @@ public final class NodeService extends Service {
         return RUNNING.get();
     }
 
+    /** {@link #bootOutcome} value for a fully successful boot. */
+    public static final String BOOT_STARTED = "started";
+    /** Terminal verdict of each network's most recent boot attempt: absent while an
+     *  attempt is in flight (or none was made), {@link #BOOT_STARTED} once
+     *  {@code buildAndStart} ran the engine's whole start sequence to completion,
+     *  otherwise a failure description. ChainStack.start() catches {@code Throwable}
+     *  internally (a linkage Error there returns {@code false} instead of crashing the
+     *  process), so without this record a boot failure is observable only as
+     *  "the handle never appears". STATIC like {@link #RUNNING}/{@link #ENGINE}:
+     *  per-network-stack state that outlives service instances. Consumed by the
+     *  API-29 boot smoke test (androidTest); available to the UI as well. */
+    private static final Map<String, String> BOOT_OUTCOMES = new ConcurrentHashMap<>();
+
+    /** The most recent boot attempt's terminal verdict for {@code network} — null
+     *  while no attempt has finished, {@link #BOOT_STARTED}, or a failure summary. */
+    public static String bootOutcome(String network) {
+        return BOOT_OUTCOMES.get(canonicalNetwork(network));
+    }
+
     // ----- Settings (SharedPreferences "ethp2p"), shared by the service + Compose UI -----
     private static final String PREFS_NAME = "ethp2p";
     private static final String K_NETWORK = "network";
@@ -1670,6 +1689,9 @@ public final class NodeService extends Service {
      */
     private void buildAndStart(String netName, long gen) {
         String n = canonicalNetwork(netName);
+        // A new attempt voids the previous verdict; the deliberate-bail paths below
+        // (stop/disable raced the boot) record nothing — absent means "no verdict".
+        BOOT_OUTCOMES.remove(n);
         ChainHandle created = null;
         try {
             int rpcPort = rpcPortFor(this, n);
@@ -1710,6 +1732,7 @@ public final class NodeService extends Service {
                     LogBuffer.i(TAG, "[" + n + "] boot skipped: already hosted by the engine");
                     ChainHandle existing = ENGINE.get(n);
                     if (existing != null) handles.putIfAbsent(n, existing);
+                    BOOT_OUTCOMES.put(n, BOOT_STARTED); // a live stack is a started stack
                     return;
                 }
 
@@ -1785,6 +1808,10 @@ public final class NodeService extends Service {
 
                 if (!handle.start()) {
                     LogBuffer.e(TAG, "[" + n + "] node stack failed to start");
+                    // ChainStack.start() caught the real cause (Throwable, stack
+                    // trace in its log line) and returned false; record the verdict.
+                    BOOT_OUTCOMES.put(n, "engine start() returned false — see the "
+                            + "\"stack failed to start\" log line for the cause");
                     forgetStack(n);
                     try { ENGINE.stop(n); } catch (Throwable ignored) {}
                     return;
@@ -1801,10 +1828,12 @@ public final class NodeService extends Service {
                 // the index install / appender spin-up.
                 pushLogIndexConfig(n, handle);
             }
+            BOOT_OUTCOMES.put(n, BOOT_STARTED);
             updateNotification();
             LogBuffer.i(TAG, "[" + n + "] node stack started (RPC " + rpcPort + ")");
         } catch (Exception e) {
             LogBuffer.e(TAG, "[" + n + "] node boot failed", e);
+            BOOT_OUTCOMES.put(n, unwrap(e));
             // Clean up ONLY this attempt's state, under the lock. The exception released
             // the bootLock, so a racing enable may already have registered a fresh healthy
             // instance — an unconditional forgetStack here would wipe that instance's

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -97,13 +97,18 @@ public final class NodeService extends Service {
 
     /** {@link #bootOutcome} value for a fully successful boot. */
     public static final String BOOT_STARTED = "started";
-    /** Terminal verdict of each network's most recent boot attempt: absent while an
-     *  attempt is in flight (or none was made), {@link #BOOT_STARTED} once
-     *  {@code buildAndStart} ran the engine's whole start sequence to completion,
-     *  otherwise a failure description. ChainStack.start() catches {@code Throwable}
-     *  internally (a linkage Error there returns {@code false} instead of crashing the
-     *  process), so without this record a boot failure is observable only as
-     *  "the handle never appears". STATIC like {@link #RUNNING}/{@link #ENGINE}:
+    /** Terminal verdict of each network's most recent boot attempt:
+     *  {@link #BOOT_STARTED} once {@code buildAndStart} ran the engine's whole start
+     *  sequence to completion, a failure description on a failed attempt, absent while
+     *  the current attempt hasn't recorded one (a deliberately bailed attempt — a
+     *  stop/disable raced the boot — leaves it absent). ChainStack.start() catches
+     *  {@code Throwable} internally (a linkage Error there returns {@code false}
+     *  instead of crashing the process), so without this record a boot failure is
+     *  observable only as "the handle never appears". Verdict lifecycle rides
+     *  {@link #bootLock}: cleared at the top of each attempt's locked boot region and
+     *  written terminally under the same hold, so attempts serialized by the lock
+     *  can't interleave their verdicts (a brief pre-lock window still shows the
+     *  previous attempt's verdict). STATIC like {@link #RUNNING}/{@link #ENGINE}:
      *  per-network-stack state that outlives service instances. Consumed by the
      *  API-29 boot smoke test (androidTest); available to the UI as well. */
     private static final Map<String, String> BOOT_OUTCOMES = new ConcurrentHashMap<>();
@@ -1689,9 +1694,6 @@ public final class NodeService extends Service {
      */
     private void buildAndStart(String netName, long gen) {
         String n = canonicalNetwork(netName);
-        // A new attempt voids the previous verdict; the deliberate-bail paths below
-        // (stop/disable raced the boot) record nothing — absent means "no verdict".
-        BOOT_OUTCOMES.remove(n);
         ChainHandle created = null;
         try {
             int rpcPort = rpcPortFor(this, n);
@@ -1718,6 +1720,11 @@ public final class NodeService extends Service {
             // start() too, since start() blocks and the race window spans it. spawnBoot's worker fires
             // the service-stop check after every bail/return path.
             synchronized (bootLock(n)) {
+                // A new attempt voids the previous verdict — INSIDE the lock, so
+                // verdict transitions serialize with the attempts they describe
+                // (see the BOOT_OUTCOMES javadoc). The bail paths below record
+                // nothing: absent means "no verdict".
+                BOOT_OUTCOMES.remove(n);
                 if (!RUNNING.get() || !isNetworkEnabled(this, n) || stopGen(n) != gen) {
                     LogBuffer.i(TAG, "[" + n + "] stop/disable raced boot; skipping");
                     forgetStack(n);
@@ -1827,13 +1834,12 @@ public final class NodeService extends Service {
                 // the raced-stop guard, so a condemned stack never pays for
                 // the index install / appender spin-up.
                 pushLogIndexConfig(n, handle);
+                BOOT_OUTCOMES.put(n, BOOT_STARTED);
             }
-            BOOT_OUTCOMES.put(n, BOOT_STARTED);
             updateNotification();
             LogBuffer.i(TAG, "[" + n + "] node stack started (RPC " + rpcPort + ")");
         } catch (Exception e) {
             LogBuffer.e(TAG, "[" + n + "] node boot failed", e);
-            BOOT_OUTCOMES.put(n, unwrap(e));
             // Clean up ONLY this attempt's state, under the lock. The exception released
             // the bootLock, so a racing enable may already have registered a fresh healthy
             // instance — an unconditional forgetStack here would wipe that instance's
@@ -1843,6 +1849,17 @@ public final class NodeService extends Service {
             // bookkeeping from this attempt can remain).
             synchronized (bootLock(n)) {
                 ChainHandle current = handles.get(n);
+                // Failure verdict under the lock, and only while this attempt is
+                // still the one the network's state reflects: a racing NEWER attempt
+                // that already registered its own healthy handle owns the verdict —
+                // an unconditional put here would stamp a failure over a live stack.
+                // (current == created also covers the adopted-broken-handle edge:
+                // an "already hosted" adopter that raced this thrower stamped
+                // BOOT_STARTED on the handle we're about to tear down; this write,
+                // ordered after it by the lock, corrects the record.)
+                if (current == created || current == null) {
+                    BOOT_OUTCOMES.put(n, unwrap(e));
+                }
                 if (created != null ? current == created : current == null) {
                     forgetStack(n);
                     if (created != null && ENGINE.get(n) == created) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -152,6 +152,12 @@ androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling
 androidx-compose-material3        = { module = "androidx.compose.material3:material3" }
 # Java-only Worker (no -ktx needed): the daily beacon catch-up job while the node sleeps.
 androidx-work-runtime             = { module = "androidx.work:work-runtime", version = "2.9.1" }
+# Instrumented-test stack for :android-app's minSdk boot smoke test (androidTest
+# only — never in the APK). Versions from the same androidx.test release train.
+androidx-test-core                = { module = "androidx.test:core",       version = "1.6.1" }
+androidx-test-runner              = { module = "androidx.test:runner",     version = "1.6.2" }
+androidx-test-rules               = { module = "androidx.test:rules",      version = "1.6.1" }
+androidx-test-ext-junit           = { module = "androidx.test.ext:junit",  version = "1.2.1" }
 
 # JSON-RPC server (:jsonrpc-server) — all Android-safe (no java.net.http).
 ktor-server-core           = { module = "io.ktor:ktor-server-core",  version.ref = "ktor" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -158,6 +158,10 @@ androidx-test-core                = { module = "androidx.test:core",       versi
 androidx-test-runner              = { module = "androidx.test:runner",     version = "1.6.2" }
 androidx-test-rules               = { module = "androidx.test:rules",      version = "1.6.1" }
 androidx-test-ext-junit           = { module = "androidx.test.ext:junit",  version = "1.2.1" }
+# JUnit 4 for :android-app's local AND instrumented tests (the JVM modules use
+# JUnit 5 via `junit` above; androidx.test is JUnit-4-based). One alias so the
+# two classpaths can't drift onto different JUnit 4 versions.
+junit4                            = { module = "junit:junit",              version = "4.13.2" }
 
 # JSON-RPC server (:jsonrpc-server) — all Android-safe (no java.net.http).
 ktor-server-core           = { module = "io.ktor:ktor-server-core",  version.ref = "ktor" }

--- a/node-core/src/main/java/io/myotis/node/ChainStack.java
+++ b/node-core/src/main/java/io/myotis/node/ChainStack.java
@@ -345,7 +345,10 @@ public final class ChainStack implements io.myotis.api.NodeLifecycle {
             if (!started) { startedAtNs = startRequestNs; started = true; serveStats.reset(); }
             return true;
         } catch (Throwable t) {
-            log.error("[{}] stack failed to start: {}", network.name(), t.toString());
+            // Pass the throwable itself so the full stack + cause chain reach the log
+            // (Android's boot smoke test prints the log tail on failure — a bare
+            // toString() left a linkage Error undiagnosable from CI).
+            log.error("[{}] stack failed to start", network.name(), t);
             shutdown();
             return false;
         }


### PR DESCRIPTION
## What

Nothing in CI actually **boots** the app on the minSdk it claims to support. This adds the runtime half of the minSdk-29 story:

- an **`api29` Gradle Managed Virtual Device** in `:android-app` — Pixel 2, API 29, `aosp` image (the leaner `aosp-atd` images only exist for API 30+), `require64Bit = true` (see below);
- **`NodeBootSmokeTest`** (androidTest): launches the real `MainActivity`, lets its fresh-launch path auto-start `NodeService`, and waits for the network's **boot verdict** — recorded by a small new host-level API, `NodeService.bootOutcome(network)`, only after `ChainStack.start()` has run the *whole* networking/consensus init sequence (EIP-1459 DNS discovery → RLPx connector + initial dials → discv4 → discv5 + beacon LC (libp2p/BLS/SSZ) → JSON-RPC → snap maintainer). Success additionally requires `rpcServing`, because `ChainStack` treats the RPC bring-up as best-effort and swallows init failures there — without that condition a linkage error inside the Ktor/RPC stack would pass silently. A recorded boot *failure* fails the test fast (no deadline burn) with an error-lines log section plus tail;
- a **`boot-smoke-api29` job** in `android-apk.yml`: ubuntu-latest with the standard enable-KVM udev rule, `-PskipRustEngine` (Java engine — no Rust toolchain on this job; exactly the fallback an APK without jniLibs uses), `timeout-minutes: 45`, skipped on `v*` tags, results uploaded only on failure, and a `::warning` annotation so a red run is hard to miss.

## Why this catches what the static gate can't

The static minSdk-29 dex gate (`scripts/check_apk_min_api.py`, landing from the parallel minSdk-29 JDK-API branch — the comments here are phrased to stay accurate whichever merges first) proves `java.*`/`javax.*` references resolve at API 29, but `android.*` framework APIs are deliberately out of its scope (`SDK_INT` guards are invisible to a bytecode scan), `api-versions.xml` has gaps, and no scan proves the app boots. Executing the init paths on real API-29 ART is the complement: a startup `NoClassDefFoundError`/`NoSuchMethodError` in host/`create()` code crashes the process (instrumentation reports the stack); one inside `ChainStack.start()` is caught there (`catch (Throwable)`), surfaces as a failed boot verdict, and fails the test fast — `ChainStack` now logs the throwable itself so the stack trace reaches the log tail.

## Non-blocking, deliberately (for now)

This is the repo's first emulator job and hosted-runner emulators are notoriously flaky, so the job carries `continue-on-error: true` with the semantics spelled out in a comment: a failure **still shows as a red check on the PR**, but the workflow run passes and nothing is gated (don't add the job to required checks while that line exists). Promotion path: delete the line once it has proven stable for a few weeks.

## Notable trap found during review

With `require64Bit` unset, AGP 8.7.3 resolves an api-29 `aosp` device to the **32-bit x86 image** — verified by executing AGP's `computeAbiFromArchitecture` bytecode: the `aosp` → x86_64 special case covers apiLevel **{26, 30}** (a two-element set, not a range), everything else ≤30 falls through to `x86`. Our APK always ships native libs for exactly arm64-v8a + x86_64 (`libjnidispatch.so` is packaged even under `-PskipRustEngine`), so the install would have died with `INSTALL_FAILED_NO_MATCHING_ABIS` before any test ran — invisibly, on a non-blocking job. Hence `require64Bit = true` with a comment carrying the full rationale.

## Internal review

Per the repo workflow, an independent no-context review (8 finder angles + verification passes, incl. AGP/androidx.test bytecode checks and GitHub Actions docs) ran before this PR; all 10 confirmed findings are fixed in the second commit. Highlights beyond the ABI trap: the original crash-detection premise was false (`ChainStack.start()` catches `Throwable` — replaced with the boot-verdict design), the completion proxy was wrong in both directions (replaced), no blocking job compiled the androidTest source (the build job now runs `assembleDebugAndroidTest`), `ServiceTestRule`'s 5 s default bind timeout was a flake source (now 60 s), and the poll loop now guarantees a post-sleep final check. One refuted scare: no UTP/GMD output-idle timeout kills a quiet 5-minute test (AGP sets a 365-day instrument timeout).

## Known gaps / follow-ups (deliberate)

- The **Rust engine's on-device load path** (JNA/UniFFI) is not exercised by any boot test yet — this job runs the Java engine by design.
- System-image/AVD caching and `org.gradle.caching` would cut job time; deferred until the job proves stable (noted in the workflow).
- Local runs need an x86_64 host: Google never published an API-29 arm64 emulator image, so Apple-Silicon Macs can't run this device — CI is the enforcement point.

## Verification

- `:android-app:assembleDebug :android-app:assembleDebugAndroidTest -PskipRustEngine` builds green locally; the test class is in the test APK dex; the instrumentation manifest targets `com.jaeckel.ethp2p.android` with `AndroidJUnitRunner`, minSdk 29.
- Managed-device tasks (`api29DebugAndroidTest`, `api29Setup`) materialize under AGP 8.7.3.
- Workflow YAML parses; `if: failure()` under job-level `continue-on-error`, the 360-min default timeout, `if-no-files-found` default, annotation visibility, and the tag guard were each verified against GitHub's docs.
- The emulator run itself is provable only on CI (see the arm64 note above) — this PR's own run of **API-29 boot smoke (emulator)** is the first real execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)