### PR TITLE
build: content-filter every third-party Maven repo, dedupe JitPack

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -102,6 +102,9 @@ jvm-libp2p          = { module = "io.libp2p:jvm-libp2p",                   versi
 # (replaces the old hand-JNI). :android-app additionally pins the @aar variant so
 # the packaged natives come from JNA's Android artifact.
 jna                 = { module = "net.java.dev.jna:jna",                   version.ref = "jna" }
+# JitPack-served coordinates (this and kethereum below): the group must be
+# allowed by the JitPack content filter in settings.gradle.kts — a cold
+# resolve's "Could not find" error will not mention that filter.
 trueblocks-kotlin   = { module = "com.github.biafra23:trueblocks-kotlin", version.ref = "trueblocks-kotlin" }
 # trueblocks-kotlin's own dependency, made explicit so :tx-history can call
 # Bloom.isMemberBytes(Address) at compile time (the JitPack POM exposes kethereum

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,8 +5,15 @@ pluginManagement {
         gradlePluginPortal()
         mavenCentral()
         google()
-        // Compose Multiplatform Gradle plugin (org.jetbrains.compose).
-        maven { url = uri("https://maven.pkg.jetbrains.space/public/p/compose/dev") }
+        // Compose Multiplatform Gradle plugin dev builds (org.jetbrains.compose).
+        // Never probed while the stable plugin resolves from the Plugin Portal;
+        // filtered so the escape hatch cannot serve arbitrary other plugin ids.
+        maven {
+            url = uri("https://maven.pkg.jetbrains.space/public/p/compose/dev")
+            content {
+                includeGroupAndSubgroups("org.jetbrains.compose")
+            }
+        }
     }
 }
 
@@ -15,25 +22,67 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        maven { url = uri("https://jitpack.io") }
-        maven {
-            name = "ConsenSys"
-            url = uri("https://artifacts.consensys.net/public/maven/maven/")
-        }
-        maven {
-            name = "Cloudsmith-libp2p"
-            url = uri("https://dl.cloudsmith.io/public/libp2p/jvm-libp2p/maven/")
-        }
+        // JitPack builds arbitrary GitHub repos on demand, so an unfiltered
+        // entry lets resolution ask it for ANY group — a dependency-confusion
+        // surface. Serve only the groups it actually provides, established
+        // empirically from a cold-cache full resolve (re-establish the same
+        // way: isolated GRADLE_USER_HOME + --info, which names the serving
+        // repo per artifact). Adding a JitPack dependency? Its group must be
+        // included below — a cold resolve's "Could not find" error will NOT
+        // mention this filter, the repo is simply absent from the searched
+        // locations. Other com.github.* groups in the graph (ben-manes.caffeine,
+        // luben, jnr, …) are Maven-Central-hosted and must NOT route through
+        // here.
         maven {
             name = "JitPack"
             url = uri("https://jitpack.io")
+            content {
+                // biafra23 forks: trueblocks-kotlin (gradle/libs.versions.toml),
+                // the besu fork under the com.github.biafra23.besu subgroup
+                // (android-app substitutions), and — once #397 lands — the
+                // discovery fork.
+                includeGroupAndSubgroups("com.github.biafra23")
+                // kethereum + khex: bare group (khex root) plus the
+                // .kethereum / .khex subgroups.
+                includeGroupAndSubgroups("com.github.komputing")
+                // java-multibase, a jvm-libp2p transitive.
+                includeGroup("com.github.multiformats")
+            }
         }
-        // Hyperledger Besu publishes release artifacts (incl. the standalone
-        // `evm` module) here. Maven Central mirrors are inconsistent across
-        // versions, so we pin the source.
+        // Still needed for two tech.pegasys artifacts Maven Central does not
+        // serve: noise-java 22.1.0 (jvm-libp2p transitive; no other declared
+        // repo has it — it alone keeps this repo alive) and jblst 0.3.15
+        // (:consensus BLS benchmark; Central carries only 0.3.17+, so a bump
+        // may move jblst to Central — noise-java still pins the repo).
+        // io.consensys.protocols:discovery moved to Maven Central and is gone
+        // from here.
+        maven {
+            name = "ConsenSys"
+            url = uri("https://artifacts.consensys.net/public/maven/maven/")
+            content {
+                includeGroup("tech.pegasys")
+            }
+        }
+        // jvm-libp2p's own repo. Filtered: unfiltered, this entry was probed
+        // for — and, declared first, could shadow — the org.hyperledger.besu
+        // artifacts served by the Hyperledger repo below.
+        maven {
+            name = "Cloudsmith-libp2p"
+            url = uri("https://dl.cloudsmith.io/public/libp2p/jvm-libp2p/maven/")
+            content {
+                includeGroup("io.libp2p")
+            }
+        }
+        // Besu's release repo. The pinned Besu artifacts (besu-evm,
+        // besu-datatypes, the org.hyperledger.besu.internal modules) are not
+        // on Maven Central at all — this repo is their only source (Central
+        // is probed first and 404s them).
         maven {
             name = "Hyperledger"
             url = uri("https://hyperledger.jfrog.io/artifactory/besu-maven")
+            content {
+                includeGroupAndSubgroups("org.hyperledger.besu")
+            }
         }
     }
 }


### PR DESCRIPTION
Follow-up to the internal review of the discv5-fork work (now [#397](https://github.com/biafra23/myotis/pull/397)), which flagged three `dependencyResolutionManagement` issues and deferred them to keep that PR focused: `jitpack.io` declared **twice** (unnamed entry probed 3rd, named `JitPack` 6th), **no content filtering anywhere** (JitPack builds arbitrary GitHub repos on demand — a dependency-confusion surface for a wallet), and a ConsenSys artifactory believed to be dead weight.

## What the cold-cache resolves showed

Method: fully cold resolves (isolated `GRADLE_USER_HOME`, `--no-daemon`, `--info`) of `:android-app:assembleDebug :app:compileJava :app-desktop:compileKotlin testClasses` plus a lenient sweep that resolves **all 728 resolvable configurations of all 16 modules** (test/runtime classpaths included), with every artifact attributed to its serving repository from the `Downloading …` / `Found locally available resource with matching checksum: […]` log lines. One baseline run against `main`, then verification runs against the change; **the artifact→repository attribution is byte-identical across all runs** (~880 modules: mavenCentral 559, google 304, Hyperledger 13, JitPack 12, ConsenSys 2, Cloudsmith 1).

Baseline findings:

- **The unfiltered JitPack entry was probed ~640× for groups that must never resolve from it** — 498 requests for `org.hyperledger.besu`, 134 for `org.hyperledger.besu.internal`, plus `tech.pegasys` and `io.libp2p`. Wasted cold-resolve round trips and exactly the confusion surface the review feared (the `ci.yml` retry loop exists partly for JitPack blips).
- **JitPack legitimately serves 12 modules in 3 group families**: `com.github.biafra23` (trueblocks-kotlin) + `.besu` subgroup (the fork substitutions), `com.github.komputing` (+ `.kethereum`/`.khex`), `com.github.multiformats` (java-multibase, a jvm-libp2p transitive).
- **The ConsenSys artifactory is *not* removable — the review's premise was wrong.** `io.consensys.protocols:discovery` did move to Maven Central (200 there, 404 on the artifactory), but the artifactory still **uniquely** serves `tech.pegasys:noise-java:22.1.0` (jvm-libp2p transitive; on no other declared repo) and `tech.pegasys:jblst:0.3.15` (`:consensus` `testImplementation`; Central starts at 0.3.17). noise-java is the artifact that permanently pins the repo.
- **Cloudsmith shadowing was real**: the baseline log shows 12 `Resource missing` probes asking dl.cloudsmith.io for `org/hyperledger/besu/**` *before* the Hyperledger repo serves them — Besu 26.4.0 artifacts are not on Central at all, and Cloudsmith is declared first, so a poisoned publish there would have won by declaration order.

## The change

Every third-party repository is now restricted to exactly the groups it empirically serves:

- **JitPack**: deduped into the single named entry at the first entry's position (probe order for its groups unchanged) with `includeGroupAndSubgroups("com.github.biafra23")` (also covers the `com.github.biafra23:discovery` coordinate #397 introduces — that PR needs no settings change), `includeGroupAndSubgroups("com.github.komputing")`, `includeGroup("com.github.multiformats")`.
- **ConsenSys** → `includeGroup("tech.pegasys")`, with a comment recording what actually still pins the repo (noise-java, not jblst).
- **Cloudsmith-libp2p** → `includeGroup("io.libp2p")`; **Hyperledger** → `includeGroupAndSubgroups("org.hyperledger.besu")` (covers `.internal`), closing the shadowing above and the silent fall-through for JitPack groups on a JitPack 404 — a miss now fails loudly with "Could not find" instead of walking to an unrelated repo.
- **pluginManagement's compose-dev repo** → `includeGroupAndSubgroups("org.jetbrains.compose")`. It served zero artifacts in every run (the stable compose plugin comes from the Plugin Portal); the filter constrains the dormant dev-version escape hatch, verified to still cover a dev plugin + its classpath.
- Breadcrumbs: the catalog's JitPack coordinates now point at the filter, because a filtered-out repo **vanishes** from Gradle's "Could not find … Searched in the following locations" error (reproduced empirically on this repo's Gradle 8.12 wrapper — nothing in the error hints at a content filter).
- Other `com.github.*` groups in the graph (ben-manes.caffeine, luben, jnr, openjson, zafarkhaja, spullara, …) are Maven-Central-hosted, keep resolving from Central, and are now never offered to JitPack.

**Deliberately NOT `exclusiveContent`**: with every repo filtered, a JitPack miss already fails loudly (same guarantee against later repos), while Central-first stays intact — the right preference, since Central's `com.github.*` namespace is closed to new registration (grandfathered groups only, so pre-emption isn't attacker-reachable) and the artifactory-to-Central migration of `discovery` shows sources do move and Central-first absorbs it. `exclusiveContent` on ConsenSys would also pin jblst away from Central needlessly.

## Verification

Final fully cold resolve + full-configuration sweep against the complete filter set: build and sweep green, artifact→repository attribution byte-identical to baseline, JitPack contacted **only** for its three group families (32 probes, down from ~672), **zero** Cloudsmith probes for Besu coordinates, zero probes to the compose-dev repo. An independent no-context review round (10 finder angles + adversarial verifiers + gap sweep) ran on the diff; its findings produced the Cloudsmith/Hyperledger/compose-dev filters and comment corrections in this PR, and everything below.

## Owner decisions / follow-ups (not in this PR)

1. **`com.github.biafra23:trueblocks-kotlin:main-SNAPSHOT` should be re-pinned to a tag or commit hash** (JitPack supports commit-hash versions). This is the prerequisite for any checksum story: Gradle dependency verification **does not verify changing modules at all** ("Gradle will not verify changing dependencies (in particular SNAPSHOT dependencies)…"), so as pinned today, `verification-metadata.xml` would be inert for the one dependency that most needs it — a moving branch build through an on-demand build service.
2. **Checksum pinning (`gradle/verification-metadata.xml`) after (1)**: converts silent JitPack-rebuild substitution into hard failure — right direction for a wallet, but verification is global once enabled (no per-repository scoping; ~880 modules + plugins, with broad `<trusted-artifacts>` wildcards needed to scope effort to the JitPack set), and the `--write-verification-metadata` bootstrap misses execution-time resolves (e.g. AGP's lint classpath) unless those tasks run. Real maintenance commitment — owner's call. Mitigating context: JitPack now freezes public release artifacts 7 days after publish (operational promise, not cryptography), and #397 already verified the served discovery jar byte-for-byte. Draft #76 (submodules + composite builds) would moot JitPack entirely.
3. **`google()` could be filtered too** (`androidx\..*` / `com\.android.*` / `com\.google\..*`): would cut one wasted dl.google.com probe for every Central-served module (~hundreds per cold resolve). The regex form was probe-verified to cover even AGP's *execution-time* lint resolution (`com.android.tools.lint` 31.13.2 graph). Left out: pure cold-cache efficiency on a trusted, first-position repo, and a future google-only group outside the regexes (e.g. cronet) would 404 confusingly until the filter is extended. Happy to do as a follow-up.
4. A stale comment in `android-app/build.gradle.kts` (claims the Besu fork sits at 24.12.2 and that besu-datatypes comes from Central — Central has never hosted it) is spun off separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
