### PR TITLE
docs: point the rotate byzantine-limit deferral at tracking issue #400

### DIFF
--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/rlpx/RLPxConnector.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/rlpx/RLPxConnector.java
@@ -463,7 +463,7 @@ public final class RLPxConnector implements AutoCloseable {
      * holds (junk never verifies); availability of the path is what such a peer
      * controls. Rotating on verification failure would need the trusted roots (or a
      * verify callback) at this layer — deferred with the peer-quality scoring
-     * follow-up (#359 point 3).
+     * follow-up (#400).
      */
     static <T> CompletableFuture<List<T>> rotate(
             String what, int expected,


### PR DESCRIPTION
One-line javadoc follow-up stranded when #387 merged: the `rotate` deferral note referenced "#359 point 3"; the tracking issue for that work now exists (#400, filed at the owner's request re-homing the scoring/verify-rotation follow-up from the closed #355), so point the comment at it. The commit (2efc4372) was pushed to the #387 branch moments after the merge took `16305e65` — cherry-picked here onto main.

Comment-only change; no code. Internal review: trivial by inspection (single javadoc token).

🤖 Generated with [Claude Code](https://claude.com/claude-code)