### PR TITLE
hedged_race: drop the dead start_another flag

### DIFF
--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -570,16 +570,17 @@ where
         last_err: String::new(),
     };
     // ONE push site: two `async move` blocks are distinct anonymous types and
-    // could not share a FuturesUnordered without boxing every attempt.
-    let mut start_another = true;
+    // could not share a FuturesUnordered without boxing every attempt. Pushed
+    // whenever there is capacity: every select arm below that continues the
+    // loop — failed attempt, non-verdict answer, hedge timer — is a
+    // "start another" trigger, so no flag needs to gate this.
     loop {
-        if start_another && next < total && in_flight.len() < MAX_HEDGED_ATTEMPTS {
+        if next < total && in_flight.len() < MAX_HEDGED_ATTEMPTS {
             let idx = next;
             let fut = make(peers[idx].clone());
             in_flight.push(async move { (idx, fut.await) });
             next += 1;
         }
-        start_another = false;
         if in_flight.is_empty() {
             break;
         }
@@ -595,19 +596,15 @@ where
                     // a different peer can still verify.
                     out.missed.push(idx);
                     out.fallback.get_or_insert(value);
-                    start_another = true;
                 }
                 Err(e) => {
                     out.missed.push(idx);
                     out.last_err = e;
-                    start_another = true;
                 }
             },
-            // Nobody answered in time and a candidate remains: start it
-            // ALONGSIDE the ones running, never instead of them.
-            _ = hedge, if next < total && in_flight.len() < MAX_HEDGED_ATTEMPTS => {
-                start_another = true;
-            }
+            // Nobody answered in time and a candidate remains: wake the loop,
+            // which starts it ALONGSIDE the ones running, never instead of them.
+            _ = hedge, if next < total && in_flight.len() < MAX_HEDGED_ATTEMPTS => {}
             else => break,
         }
     }


### PR DESCRIPTION
## Problem

Every Gradle build printed rustc's `unused_assignments` warning for `start_another = false` in `hedged_race` (`rust/myotis-net/src/el/reader.rs:582`) — once per compile of `myotis-net`, so it appeared repeatedly (host build, each Android target, test builds) and looked like one warning per module.

## Analysis

The flag was semantically inert. Tracing every path of the loop: the accepted-answer arm returns, and every `select!` arm that continues the loop — failed attempt, non-verdict answer, hedge timer — set `start_another = true` before the next loop-top evaluation. So the `false` assignment was never observable and the flag never gated the push.

## Fix

Remove the flag; push whenever there is capacity at the single push site. Behavior-identical — the hedging policy in the doc comment (first attempt immediately, one more per `HEDGE_DELAY` without an answer, `MAX_HEDGED_ATTEMPTS` cap, immediate replacement on failure/non-verdict) is unchanged, and the pacing still comes from the select blocking on the fresh `HEDGE_DELAY` sleep. The push-site comment now states why no flag is needed.

## Verification

- `cargo check -p myotis-net`: zero warnings.
- All 7 `hedged_reads` unit tests pass unchanged, including the paused-clock pacing test (`a_silent_peer_does_not_hold_the_read`, exact `HEDGE_DELAY + 50ms`) and the cap test (`concurrency_is_capped_including_the_refill_path`) — whose own comment already described the loop-top capacity check, not the flag, as what holds the cap.
- Full `myotis-net` suite: 323 tests pass.
- An independent no-context review traced every control path of the old loop and confirmed there is no state where the old code skipped a push the new code performs, or vice versa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZjDDn6qE9QzhiJHHpKpmx