### PR TITLE
Pin R8 8.13.19: AGP 8.7.3's bundled R8 predates Kotlin 2.2 metadata

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,6 +13,30 @@ import java.util.Properties
 import javax.inject.Inject
 import org.gradle.process.ExecOperations
 
+// R8/D8 override: AGP 8.7.3 bundles R8 8.7.18, which predates Kotlin 2.2 and
+// cannot parse this build's Kotlin 2.2.21 metadata — every Android dex step
+// then warns "An error occurred when parsing kotlin metadata" per Kotlin
+// class, and an R8-minified build ships stale/dropped @Metadata (visible to
+// kotlin-reflect). The remedy while AGP is older than the Kotlin toolchain is
+// pinning a newer R8 on the root buildscript classpath (the R8 project's
+// documented override; the compatible versions come from
+// developer.android.com/studio/build/kotlin-d8-r8-versions): 8.13.19 is that
+// table's version for AGP 8.2.2-8.13 and understands Kotlin 2.2/2.3 metadata.
+// Drop this whole block when AGP itself moves past 8.10 — the bundled R8 then
+// understands Kotlin 2.2 natively.
+buildscript {
+    repositories {
+        google {
+            // Filtered per the convention for special-purpose repos in
+            // settings.gradle.kts: this entry exists only to serve the R8 pin.
+            content { includeGroup("com.android.tools") }
+        }
+    }
+    dependencies {
+        classpath("com.android.tools:r8:8.13.19")
+    }
+}
+
 plugins {
     java
     // Load the Android/Kotlin/Compose plugins once on the root classpath (apply false) so

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,9 +21,11 @@ import org.gradle.process.ExecOperations
 // pinning a newer R8 on the root buildscript classpath (the R8 project's
 // documented override; the compatible versions come from
 // developer.android.com/studio/build/kotlin-d8-r8-versions): 8.13.19 is that
-// table's version for AGP 8.2.2-8.13 and understands Kotlin 2.2/2.3 metadata.
-// Drop this whole block when AGP itself moves past 8.10 — the bundled R8 then
-// understands Kotlin 2.2 natively.
+// table's Kotlin 2.3 row (AGP 8.2.2-8.13, which includes 8.7.3) — a superset
+// of the Kotlin 2.2 row's 8.10.21 (AGP 7.3.1-8.10), so it reads this build's
+// 2.2 metadata and already covers a Kotlin 2.3 bump. Drop this whole block
+// when AGP moves past 8.10 while Kotlin is 2.2 (the bundled R8 then reads 2.2
+// natively); if Kotlin bumps to 2.3 first, the pin is still needed up to AGP 8.13.
 buildscript {
     repositories {
         google {


### PR DESCRIPTION
## Problem

Every Android dex step warned per Kotlin class:

> An error occurred when parsing kotlin metadata. This normally happens when using a newer version of kotlin than the kotlin version released when this version of R8 was created.
> Unexpected error during rewriting of Kotlin metadata for class 'io.myotis.ui.TxScanEvent$Started' …

Cause: AGP 8.7.3 embeds R8/D8 **8.7.18** (inside `builder-8.7.3.jar`), released before Kotlin 2.2 existed, while the build compiles with **Kotlin 2.2.21**. Debug builds only lose the `@Metadata` rewrite; an R8-minified build ships stale or dropped metadata visible to `kotlin-reflect`.

## Fix

Pin `com.android.tools:r8:8.13.19` on the **root** buildscript classpath — the R8 project's documented override for an AGP that lags the Kotlin toolchain. Per Google's [compatibility table](https://developer.android.com/studio/build/kotlin-d8-r8-versions), 8.13.19 is the version for AGP 8.2.2–8.13 (AGP 8.7.3 is in range) and understands Kotlin 2.2/2.3 metadata. The mechanism is classloader precedence: the root buildscript classloader is a parent of the plugin classloaders, so the pinned classes shadow the ones embedded in AGP — which is why the block must live in the root build file, before `plugins {}`. The `google()` entry is content-filtered to `com.android.tools` per the convention for special-purpose repos in `settings.gradle.kts` (R8 is a standalone fat jar with an empty `<dependencies>` POM, so the filter blocks nothing it needs). The block is commented for deletion once AGP moves past 8.10.

## Verification

A/B with a forced `:ui` recompile so a fresh jar feeds the dexing artifact transform (the warnings hide behind the transform cache otherwise):
- without the pin: **197** Kotlin-metadata warnings, `assembleDebug` green
- with the pin: **0** warnings, `assembleDebug` green

An independent no-context review verified the bundled-R8 version claim against the cached AGP artifact, the classloader mechanism, the repo-filter safety, that `FAIL_ON_PROJECT_REPOS` doesn't apply to buildscript repos, and that no module or CI path bypasses the root classpath.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZjDDn6qE9QzhiJHHpKpmx