### PR TITLE
Ungate logIndexStatusJson: the status poll froze the whole UI

### DIFF
--- a/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
@@ -1081,7 +1081,18 @@ final class RustChainHandle implements ChainHandle, NodeStatusReads, io.myotis.a
     /** Log-index status JSON ({"error":...} when the gate is down). */
     @Override
     public String logIndexStatusJson() {
-        return gated(() -> RustEngineNative.nativeLogIndexStatusJson(handle));
+        // NOT gated(): this is a STATUS PROBE the hosts poll every ~2s for the UI
+        // snapshot (Android AndroidNodeBridge.snapshots, desktop DesktopNode). The
+        // gated() wake-and-hold waits up to WAKE_WAIT_CAP_MS for readyForReads() —
+        // which a booting, catching-up, or STALE_ANCHOR-parked chain never
+        // satisfies — so gating here stalled every snapshot emission ~90s per
+        // unready chain and froze the whole UI at its previous state (chains
+        // rendered "stopped" while running; the stale-anchor consent appeared to
+        // do nothing). It also stamped activity + woke paused stacks on every
+        // poll, fighting the idle-pause controller. The native answers with
+        // {"error":...} on its own when the gate is down — exactly the not-ready
+        // shape this method documents — so no readiness hold is needed.
+        return RustEngineNative.nativeLogIndexStatusJson(handle);
     }
 
     /** Import portable log-index snapshots ({"ok":...} / {"error":...}). */

--- a/rust/myotis-engine/src/host.rs
+++ b/rust/myotis-engine/src/host.rs
@@ -2387,8 +2387,13 @@ pub fn log_index_status_json(handle: i64) -> String {
     let Some(engine) = engine() else {
         return eljson::error_json("engine unavailable");
     };
-    let Ok((reader, _, _)) = snapshot_reader(engine, handle) else {
-        return eljson::error_json("node is not running");
+    // Propagate snapshot_reader's reason like the verified-read natives do:
+    // with the host-side wake gate gone from this probe, a paused chain's
+    // status is the first thing a caller sees — "handle is paused" points at
+    // `resume`, where a collapsed "node is not running" pointed at start.
+    let (reader, _, _) = match snapshot_reader(engine, handle) {
+        Ok(snap) => snap,
+        Err(msg) => return eljson::error_json(msg),
     };
     let rate_bps = reader.log_index_rate_bps();
     // Measured against the ANCHORED HEAD, which is what `latest` resolves to


### PR DESCRIPTION
## Symptoms (reported on the Android app)

- After app start, enabled chains render "Node stopped — no data" and appear to never start.
- Accepting the weak-subjectivity (STALE_ANCHOR) risk for Gnosis appears to do nothing — the screen stays parked/paused.

Both are the same bug: the chains were running fine (verified via logcat and by probing the in-app RPC ports); the **UI was frozen**.

## Root cause

The hosts poll `logIndexStatusJson()` per chain every ~2 s for the UI snapshot (`AndroidNodeBridge.snapshots` → `NodeService.logIndexStatusJsonOrNull`; desktop `DesktopNode.kt:302`). On the Rust engine that call was wrapped in `gated()` — the verified-read wake-and-hold whose `awaitWake` blocks up to `WAKE_WAIT_CAP_MS` (90 s) until `readyForReads()` (SYNCED + optimistic head + snap peers). A booting, catching-up, or STALE_ANCHOR-parked chain is RUNNING but never *ready*, so every snapshot emission stalled ~90 s per unready chain, freezing the UI at its previous (or initial empty) state for minutes. Confirmed with a live thread dump: the snapshot worker sat in `WakeGate.await` under `logIndexStatusJson` while both chains ran underneath.

The gate also stamped activity and woke paused stacks on every poll — defeating the idle-pause controller and `dailyCatchUp`'s activity comparison whenever the UI was open.

## Fix

Call the native directly. `logIndexStatusJson` is a status probe, and the native degrades gracefully by design: `log_index_status_json` (rust/myotis-engine/src/host.rs) answers `{"error":"handle is paused"/"handle not started"/…}` — the exact shape the method's Javadoc always documented and every caller already handles (Android catches → null; desktop `runCatching`; the UI parser renders `{"error":…}` as the waiting state). The mutating log-index ops (`setLogIndexConfig`, `importLogIndexFiles`, `exportLogIndex`) stay gated — they genuinely need an awake engine.

This also restores cross-engine parity: the Java engine's `ChainHandle` default is non-blocking, and iOS already calls `RustEngine.logIndexStatusJson` with no gate.

## Verified on-device (emulator, before/after)

- Before: cold start with catching-up mainnet + STALE_ANCHOR-parked gnosis → "Node stopped — no data" for ~4–5 minutes (Start buttons silently no-op on the actually-running stacks).
- After: live Running/CATCHING_UP data 15 s after cold start; the gnosis WS-risk accept is reflected promptly (gnosis now SYNCED, period 3644/3644).
- `:myotis-engines` compile + tests green.

## Caller-visible notes (from the internal review)

- Daemon IPC `logindex-status` on a **manually paused** chain now returns `{"error":"handle is paused"}` instead of waking the chain; the documented backfill polling flow is unaffected (a backfilling chain is RUNNING). An explicitly paused chain needs `resume` first — consistent with the documented error shape.
- With the poll no longer stamping activity, a backfilling chain can now idle-pause under an open Index tab — the idle design taking effect, not a regression; the index persists and resumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZjDDn6qE9QzhiJHHpKpmx
