### PR TITLE
roost: refresh provisional LC updates; surface catch-up verify-rejects

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4096,6 +4096,7 @@ version = "0.1.7"
 dependencies = [
  "myotis-bls",
  "sha2",
+ "tracing",
 ]
 
 [[package]]

--- a/rust/myotis-consensus/Cargo.toml
+++ b/rust/myotis-consensus/Cargo.toml
@@ -11,3 +11,6 @@ myotis-bls = { path = "../myotis-bls", default-features = false }
 # SSZ merkleization is SHA-256 only; the containers themselves are hand-decoded
 # (fork-polymorphic layouts — see src/ssz.rs for why not ssz_derive).
 sha2 = "0.10"
+# Diagnostics only (debug-level rejection reasons in store.rs): the tracing
+# facade is I/O-free and wasm-safe, so the sans-I/O canary is unaffected.
+tracing = "=0.1.44"

--- a/rust/myotis-consensus/src/store.rs
+++ b/rust/myotis-consensus/src/store.rs
@@ -198,6 +198,7 @@ impl LightClientProcessor {
 
     pub fn process_update(&mut self, update: &LightClientUpdate) -> bool {
         let Some(committee) = self.store.current_sync_committee() else {
+            tracing::debug!("update rejected: store has no current sync committee");
             return false;
         };
 
@@ -212,6 +213,10 @@ impl LightClientProcessor {
             sig_period == store_period
         };
         if !applicable {
+            tracing::debug!(store_period, sig_period, have_next,
+                signature_slot = update.signature_slot,
+                attested_slot = update.attested_header.beacon.slot,
+                "update rejected: not applicable to the store's period");
             return false;
         }
 
@@ -222,6 +227,11 @@ impl LightClientProcessor {
             &self.fork_version,
             &self.genesis_validators_root,
         ) {
+            tracing::debug!(store_period, sig_period,
+                signature_slot = update.signature_slot,
+                attested_slot = update.attested_header.beacon.slot,
+                participants = update.sync_aggregate.count_participants(),
+                "update rejected: sync-aggregate BLS verification failed");
             return false;
         }
 
@@ -234,12 +244,20 @@ impl LightClientProcessor {
             spec::finalized_root_gindex(depth),
             &update.attested_header.beacon.state_root,
         ) {
+            tracing::debug!(depth,
+                finalized_slot = update.finalized_header.beacon.slot,
+                attested_slot = update.attested_header.beacon.slot,
+                "update rejected: finality branch does not verify");
             return false;
         }
 
         if !Self::verify_execution_branch(&update.attested_header)
             || !Self::verify_execution_branch(&update.finalized_header)
         {
+            tracing::debug!(
+                attested_slot = update.attested_header.beacon.slot,
+                finalized_slot = update.finalized_header.beacon.slot,
+                "update rejected: execution branch does not verify");
             return false;
         }
 
@@ -253,6 +271,9 @@ impl LightClientProcessor {
                 spec::next_sync_committee_gindex(depth),
                 &update.attested_header.beacon.state_root,
             ) {
+                tracing::debug!(depth,
+                    attested_slot = update.attested_header.beacon.slot,
+                    "update rejected: next-sync-committee branch does not verify");
                 return false;
             }
             self.store

--- a/rust/myotis-net/src/sync.rs
+++ b/rust/myotis-net/src/sync.rs
@@ -2178,6 +2178,7 @@ async fn catch_up(
         let staged_before = staged.len();
         let mut poisoned_this_round = false;
         let mut round_rejects = 0usize;
+        let mut last_reject_participants: Option<usize> = None;
         let mut in_flight: FuturesUnordered<_> = peers
             .into_iter()
             .map(|peer| {
@@ -2277,9 +2278,12 @@ async fn catch_up(
                 // redundant multi-MiB streams are cancelled behind one
                 // signature verification instead of a full batch of them.
                 let before_period = processor.store.current_period();
-                let (applied_now, verify_rejects, applied_from) =
+                let (applied_now, verify_rejects, applied_from, reject_participants) =
                     apply_staged_step(processor, staged, slot_estimate);
                 round_rejects += verify_rejects;
+                if let Some(p) = reject_participants {
+                    last_reject_participants = Some(p);
+                }
                 // ORDER MATTERS: an apply in this batch BLS-verified against
                 // the restored committee and proves the snapshot genuine —
                 // confirm() must win over poison accounting (a reject in the
@@ -2348,7 +2352,7 @@ async fn catch_up(
             let mut drained = 0usize;
             loop {
                 let before_period = processor.store.current_period();
-                let (applied_now, _verify_rejects, applied_from) =
+                let (applied_now, _verify_rejects, applied_from, _reject_participants) =
                     apply_staged_step(processor, staged, slot_estimate);
                 if applied_now == 0 {
                     break;
@@ -2400,8 +2404,9 @@ async fn catch_up(
                 // store or the period's data.)
                 tracing::warn!(period = processor.store.current_period(),
                     rejects = round_rejects, idle_rounds,
+                    participants = ?last_reject_participants,
                     "catch-up: staged update for the target period failed verification — \
-                     the serving peer may hold a weak-participation update for it");
+                     below-2/3 participants means the serving peer holds a weak update");
             }
             if idle_rounds >= CATCHUP_MAX_IDLE_ROUNDS {
                 tracing::warn!(period = processor.store.current_period(), idle_rounds,
@@ -2437,9 +2442,12 @@ async fn catch_up(
 /// (`force_rotate_if_past_period` on the recorded wall-clock estimate — Java
 /// `applyCatchUpResponses`). A chunk that fails decode/verify is dropped from
 /// the buffer so the next round refetches that period from a different peer.
-/// Returns `(applied, verify_rejects, applied_from)` — applied and
-/// verify_rejects are each 0 or 1, and applied_from is the shared-cache key
-/// of the peer whose response staged the applied chunk (None unless applied).
+/// Returns `(applied, verify_rejects, applied_from, reject_participants)` —
+/// applied and verify_rejects are each 0 or 1, applied_from is the
+/// shared-cache key of the peer whose response staged the applied chunk (None
+/// unless applied), and reject_participants is the rejected update's
+/// sync-aggregate participant count (None unless a verify-reject), carried so
+/// the round's WARN can name a weak-server stall at info level.
 /// verify_rejects counts ONLY an update that decoded fine but failed
 /// BLS/Merkle verification (`process_update` → false): that is the resume
 /// guard's poison signal, since a corrupt restored committee rejects every
@@ -2449,10 +2457,10 @@ fn apply_staged_step(
     processor: &mut LightClientProcessor,
     staged: &mut std::collections::BTreeMap<u64, StagedChunk>,
     slot_estimate: u64,
-) -> (usize, usize, Option<String>) {
+) -> (usize, usize, Option<String>, Option<usize>) {
     let target_period = processor.store.current_period();
     let Some(chunk) = staged.remove(&target_period) else {
-        return (0, 0, None);
+        return (0, 0, None, None);
     };
     match LightClientUpdate::decode(&chunk.ssz) {
         Ok(update) => {
@@ -2462,17 +2470,20 @@ fn apply_staged_step(
                     finalized_slot = update.finalized_header.beacon.slot,
                     period = processor.store.current_period(),
                     "catch-up update applied");
-                (1, 0, Some(chunk.from))
+                (1, 0, Some(chunk.from), None)
             } else {
                 tracing::debug!(target_period,
                     finalized_slot = update.finalized_header.beacon.slot,
                     "catch-up update rejected");
-                (0, 1, None)
+                // The participant count rides back so the round's info-level
+                // WARN can say WHY without a debug session: a weak-server
+                // stall (below the 2/3 bar) then reads directly off the warn.
+                (0, 1, None, Some(update.sync_aggregate.count_participants()))
             }
         }
         Err(e) => {
             tracing::debug!(target_period, error = %e, "catch-up update decode failed");
-            (0, 0, None)
+            (0, 0, None, None)
         }
     }
 }

--- a/rust/myotis-net/src/sync.rs
+++ b/rust/myotis-net/src/sync.rs
@@ -2389,11 +2389,15 @@ async fn catch_up(
             if round_rejects > 0 {
                 // Loud on purpose (hosts keep info+ only in their log rings): a
                 // round whose staged update for the target period keeps failing
-                // verification is how a serving peer holding a weak or foreign
-                // update stalls catch-up INDEFINITELY — exactly this shape hid
-                // a server-side weak-participation update (113/512 signers at
+                // verification is how a serving peer holding a weak update
+                // stalls catch-up INDEFINITELY — exactly this shape hid a
+                // server-side weak-participation update (113/512 signers at
                 // mainnet period 1840) behind debug-only logs for days. The
                 // per-check reason logs at debug in myotis_consensus::store.
+                // (Counts verify-rejects only; a chunk that fails DECODE stays
+                // debug — apply_staged_step reports it as neither applied nor
+                // rejected, because malformed frames say nothing about our
+                // store or the period's data.)
                 tracing::warn!(period = processor.store.current_period(),
                     rejects = round_rejects, idle_rounds,
                     "catch-up: staged update for the target period failed verification — \

--- a/rust/myotis-net/src/sync.rs
+++ b/rust/myotis-net/src/sync.rs
@@ -2177,6 +2177,7 @@ async fn catch_up(
 
         let staged_before = staged.len();
         let mut poisoned_this_round = false;
+        let mut round_rejects = 0usize;
         let mut in_flight: FuturesUnordered<_> = peers
             .into_iter()
             .map(|peer| {
@@ -2278,6 +2279,7 @@ async fn catch_up(
                 let before_period = processor.store.current_period();
                 let (applied_now, verify_rejects, applied_from) =
                     apply_staged_step(processor, staged, slot_estimate);
+                round_rejects += verify_rejects;
                 // ORDER MATTERS: an apply in this batch BLS-verified against
                 // the restored committee and proves the snapshot genuine —
                 // confirm() must win over poison accounting (a reject in the
@@ -2384,6 +2386,19 @@ async fn catch_up(
             empty_backoff = Duration::from_secs(0);
         } else {
             idle_rounds += 1;
+            if round_rejects > 0 {
+                // Loud on purpose (hosts keep info+ only in their log rings): a
+                // round whose staged update for the target period keeps failing
+                // verification is how a serving peer holding a weak or foreign
+                // update stalls catch-up INDEFINITELY — exactly this shape hid
+                // a server-side weak-participation update (113/512 signers at
+                // mainnet period 1840) behind debug-only logs for days. The
+                // per-check reason logs at debug in myotis_consensus::store.
+                tracing::warn!(period = processor.store.current_period(),
+                    rejects = round_rejects, idle_rounds,
+                    "catch-up: staged update for the target period failed verification — \
+                     the serving peer may hold a weak-participation update for it");
+            }
             if idle_rounds >= CATCHUP_MAX_IDLE_ROUNDS {
                 tracing::warn!(period = processor.store.current_period(), idle_rounds,
                     "catch-up made no progress — returning to the poll loop");

--- a/rust/roost/Cargo.lock
+++ b/rust/roost/Cargo.lock
@@ -3099,6 +3099,7 @@ version = "0.1.7"
 dependencies = [
  "myotis-bls",
  "sha2",
+ "tracing",
 ]
 
 [[package]]
@@ -4253,6 +4254,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "hex",
+ "myotis-consensus",
  "myotis-net",
  "reqwest",
  "serde_json",

--- a/rust/roost/Cargo.toml
+++ b/rust/roost/Cargo.toml
@@ -36,6 +36,10 @@ path = "src/main.rs"
 # `decode_multi_chunk_response` / `protocols`. The whole point is to serve bytes
 # our own wallets are already proven against.
 myotis-net = { path = "../myotis-net" }
+# Decode LightClientUpdate at ingest to judge sync-aggregate participation:
+# an update captured while its period is in progress can carry a fraction of
+# the committee, and a wallet refuses < 2/3 — see the ingest fill loop.
+myotis-consensus = { path = "../myotis-consensus" }
 
 # An async HTTP client is a genuine gap in the Rust workspace (it has only
 # serde_json today). rustls rather than native-tls: this is a Linux daemon, and

--- a/rust/roost/src/main.rs
+++ b/rust/roost/src/main.rs
@@ -409,9 +409,14 @@ async fn ingest(rest_base: &str, archive_path: &Path) -> Result<()> {
     let mut newest_digest = None;
     for period in floor..=head_period {
         let stored = participation.get(&period).copied();
-        let weak = stored.is_some_and(|p| {
-            p * 3 < myotis_consensus::spec::SYNC_COMMITTEE_SIZE * 2
-        });
+        // An UNDECODABLE stored record (stored=None while the period is held)
+        // is provisional too: it serves nobody a build with this decoder can
+        // serve, and freezing it would be the same stall class this loop
+        // exists to prevent — a decodable fresh update is a strict upgrade.
+        let weak = store.has_period(period)
+            && stored.is_none_or(|p| {
+                p * 3 < myotis_consensus::spec::SYNC_COMMITTEE_SIZE * 2
+            });
         if store.has_period(period) && !weak && period != head_period {
             continue;
         }
@@ -422,10 +427,13 @@ async fn ingest(rest_base: &str, archive_path: &Path) -> Result<()> {
             continue;
         }
         let mut stored_now = 0usize;
+        let was_held = store.has_period(period);
         for c in &chunks {
-            if store.has_period(period) {
-                let fresh = participation_of(&c.ssz);
-                match (stored, fresh) {
+            if was_held {
+                match (stored, participation_of(&c.ssz)) {
+                    // A fresh update this build cannot decode can't be judged —
+                    // keep what we have rather than churn blindly.
+                    (_, None) => continue,
                     (Some(old), Some(new)) if new <= old => {
                         println!(
                             "  period {period}: upstream no better \
@@ -439,10 +447,12 @@ async fn ingest(rest_base: &str, archive_path: &Path) -> Result<()> {
                              ({old} -> {new} participants)"
                         );
                     }
-                    // An undecodable side (foreign fork shape for this build's
-                    // decoder) can't be compared — keep what we have rather
-                    // than churn on a judgement we cannot make.
-                    _ => continue,
+                    (None, Some(new)) => {
+                        println!(
+                            "  period {period}: replacing an undecodable stored \
+                             update ({new} participants)"
+                        );
+                    }
                 }
             }
             archive.append(period, c.fork_digest, &c.ssz)?;
@@ -450,12 +460,12 @@ async fn ingest(rest_base: &str, archive_path: &Path) -> Result<()> {
             fetched += 1;
             stored_now += 1;
         }
-        if stored_now > 0 && stored.is_none() {
+        if stored_now > 0 && !was_held {
             println!("  period {period}: stored {stored_now} chunk(s)");
         }
     }
     archive.flush()?;
-    println!("  fetched   {fetched} new period(s)");
+    println!("  fetched   {fetched} update(s) (new or replaced)");
 
     // The newest period's digest, used as the interim context bytes for the
     // single-object endpoints below.

--- a/rust/roost/src/main.rs
+++ b/rust/roost/src/main.rs
@@ -450,11 +450,21 @@ async fn ingest(rest_base: &str, archive_path: &Path) -> Result<()> {
             if held {
                 let fresh = participation_of(&c.ssz);
                 if !should_replace(stored, fresh) {
-                    if let (Some(old), Some(new)) = (stored, fresh) {
-                        println!(
+                    match (stored, fresh) {
+                        (Some(old), Some(new)) => println!(
                             "  period {period}: upstream no better \
                              ({new} <= {old} participants), keeping"
-                        );
+                        ),
+                        // stdout is the operator's whole interface — a
+                        // provisional period whose upstream answer doesn't
+                        // decode must say so, not stay silent run after run.
+                        (_, None) => println!(
+                            "  period {period}: upstream answer undecodable by \
+                             this build — keeping the held record"
+                        ),
+                        (None, Some(_)) => unreachable!(
+                            "should_replace is true for decodable-over-undecodable"
+                        ),
                     }
                     continue;
                 }
@@ -555,7 +565,7 @@ async fn ingest(rest_base: &str, archive_path: &Path) -> Result<()> {
 /// Sync-aggregate participant count of an SSZ-encoded `LightClientUpdate`, or
 /// `None` when it does not decode with this build's (fork-polymorphic) decoder.
 /// Used by ingest to judge whether a stored update is provisional.
-fn participation_of(ssz: &[u8]) -> Option<usize> {
+pub(crate) fn participation_of(ssz: &[u8]) -> Option<usize> {
     myotis_consensus::types::LightClientUpdate::decode(ssz)
         .ok()
         .map(|u| u.sync_aggregate.count_participants())
@@ -563,7 +573,7 @@ fn participation_of(ssz: &[u8]) -> Option<usize> {
 
 /// Below the light-client supermajority bar — a wallet REFUSES such an update,
 /// so serving one stalls every catch-up through its period.
-fn below_supermajority(participants: usize) -> bool {
+pub(crate) fn below_supermajority(participants: usize) -> bool {
     participants * 3 < myotis_consensus::spec::SYNC_COMMITTEE_SIZE * 2
 }
 
@@ -573,7 +583,7 @@ fn below_supermajority(participants: usize) -> bool {
 /// the supermajority; or stored undecodable by this build (`stored == None`
 /// while held — a record nobody with this decoder can use). Pure — every
 /// promised ingest property is pinned by the table tests below.
-fn needs_refetch(held: bool, stored: Option<usize>, in_progress: bool) -> bool {
+pub(crate) fn needs_refetch(held: bool, stored: Option<usize>, in_progress: bool) -> bool {
     !held || in_progress || stored.is_none_or(below_supermajority)
 }
 
@@ -582,7 +592,7 @@ fn needs_refetch(held: bool, stored: Option<usize>, in_progress: bool) -> bool {
 /// chunk never replaces anything (it cannot be judged). Strictly-better-only
 /// is what makes repeated ingests idempotent — equal copies are never
 /// re-appended. Pure — pinned by the table tests below.
-fn should_replace(stored: Option<usize>, fresh: Option<usize>) -> bool {
+pub(crate) fn should_replace(stored: Option<usize>, fresh: Option<usize>) -> bool {
     match (stored, fresh) {
         (_, None) => false,
         (None, Some(_)) => true,

--- a/rust/roost/src/main.rs
+++ b/rust/roost/src/main.rs
@@ -362,8 +362,11 @@ async fn ingest(rest_base: &str, archive_path: &Path) -> Result<()> {
     let store = LcStore::new();
     let mut participation: std::collections::BTreeMap<u64, usize> =
         std::collections::BTreeMap::new();
+    let mut held_periods: std::collections::BTreeSet<u64> =
+        std::collections::BTreeSet::new();
     for (period, rec) in &records {
         store.insert_update(*period, rec.fork_digest, &rec.ssz);
+        held_periods.insert(*period);
         match participation_of(&rec.ssz) {
             Some(p) => {
                 participation.insert(*period, p);
@@ -407,17 +410,33 @@ async fn ingest(rest_base: &str, archive_path: &Path) -> Result<()> {
     // supersede on this run and on every later start.
     let mut fetched = 0usize;
     let mut newest_digest = None;
+    // Below the upstream window nothing can be refetched from this node — and
+    // below-floor periods are exactly roost's unique serving value — so a weak
+    // or undecodable record there is an UNHEALABLE stall for every wallet that
+    // walks it. Nothing to fix automatically; say it loudly instead of the
+    // silence that hid period 1840 (restore from a back-archive or a node with
+    // deeper light-client retention).
+    for (&period, &p) in participation.range(..floor) {
+        if below_supermajority(p) {
+            println!(
+                "  period {period}: WEAK ({p} participants) and below the \
+                 upstream window — unhealable from this node"
+            );
+        }
+    }
+    for &period in held_periods.range(..floor) {
+        if !participation.contains_key(&period) {
+            println!(
+                "  period {period}: UNDECODABLE and below the upstream window — \
+                 unhealable from this node"
+            );
+        }
+    }
+
     for period in floor..=head_period {
+        let held = store.has_period(period);
         let stored = participation.get(&period).copied();
-        // An UNDECODABLE stored record (stored=None while the period is held)
-        // is provisional too: it serves nobody a build with this decoder can
-        // serve, and freezing it would be the same stall class this loop
-        // exists to prevent — a decodable fresh update is a strict upgrade.
-        let weak = store.has_period(period)
-            && stored.is_none_or(|p| {
-                p * 3 < myotis_consensus::spec::SYNC_COMMITTEE_SIZE * 2
-            });
-        if store.has_period(period) && !weak && period != head_period {
+        if !needs_refetch(held, stored, period == head_period) {
             continue;
         }
         let resp = client.updates(period, 1).await?;
@@ -427,32 +446,28 @@ async fn ingest(rest_base: &str, archive_path: &Path) -> Result<()> {
             continue;
         }
         let mut stored_now = 0usize;
-        let was_held = store.has_period(period);
         for c in &chunks {
-            if was_held {
-                match (stored, participation_of(&c.ssz)) {
-                    // A fresh update this build cannot decode can't be judged —
-                    // keep what we have rather than churn blindly.
-                    (_, None) => continue,
-                    (Some(old), Some(new)) if new <= old => {
+            if held {
+                let fresh = participation_of(&c.ssz);
+                if !should_replace(stored, fresh) {
+                    if let (Some(old), Some(new)) = (stored, fresh) {
                         println!(
                             "  period {period}: upstream no better \
                              ({new} <= {old} participants), keeping"
                         );
-                        continue;
                     }
-                    (Some(old), Some(new)) => {
-                        println!(
-                            "  period {period}: replacing a provisional update \
-                             ({old} -> {new} participants)"
-                        );
-                    }
-                    (None, Some(new)) => {
-                        println!(
-                            "  period {period}: replacing an undecodable stored \
-                             update ({new} participants)"
-                        );
-                    }
+                    continue;
+                }
+                match (stored, fresh) {
+                    (Some(old), Some(new)) => println!(
+                        "  period {period}: replacing a provisional update \
+                         ({old} -> {new} participants)"
+                    ),
+                    (None, Some(new)) => println!(
+                        "  period {period}: replacing an undecodable stored \
+                         update ({new} participants)"
+                    ),
+                    (_, None) => unreachable!("should_replace is false for an undecodable fresh chunk"),
                 }
             }
             archive.append(period, c.fork_digest, &c.ssz)?;
@@ -460,7 +475,7 @@ async fn ingest(rest_base: &str, archive_path: &Path) -> Result<()> {
             fetched += 1;
             stored_now += 1;
         }
-        if stored_now > 0 && !was_held {
+        if stored_now > 0 && !held {
             println!("  period {period}: stored {stored_now} chunk(s)");
         }
     }
@@ -544,6 +559,35 @@ fn participation_of(ssz: &[u8]) -> Option<usize> {
     myotis_consensus::types::LightClientUpdate::decode(ssz)
         .ok()
         .map(|u| u.sync_aggregate.count_participants())
+}
+
+/// Below the light-client supermajority bar — a wallet REFUSES such an update,
+/// so serving one stalls every catch-up through its period.
+fn below_supermajority(participants: usize) -> bool {
+    participants * 3 < myotis_consensus::spec::SYNC_COMMITTEE_SIZE * 2
+}
+
+/// Whether ingest must refetch a period from upstream instead of freezing what
+/// it holds: not held at all; still in progress (upstream's by-range answer is
+/// its best update SEEN SO FAR, improving as the period ages); stored below
+/// the supermajority; or stored undecodable by this build (`stored == None`
+/// while held — a record nobody with this decoder can use). Pure — every
+/// promised ingest property is pinned by the table tests below.
+fn needs_refetch(held: bool, stored: Option<usize>, in_progress: bool) -> bool {
+    !held || in_progress || stored.is_none_or(below_supermajority)
+}
+
+/// Whether a fresh chunk replaces a held record: strictly more participants;
+/// a decodable update beats an undecodable stored one; an undecodable fresh
+/// chunk never replaces anything (it cannot be judged). Strictly-better-only
+/// is what makes repeated ingests idempotent — equal copies are never
+/// re-appended. Pure — pinned by the table tests below.
+fn should_replace(stored: Option<usize>, fresh: Option<usize>) -> bool {
+    match (stored, fresh) {
+        (_, None) => false,
+        (None, Some(_)) => true,
+        (Some(old), Some(new)) => new > old,
+    }
 }
 
 /// Serve from the store exactly as the libp2p responder will, and decode the
@@ -768,4 +812,74 @@ async fn find_window_floor(client: &NimbusRest, head_period: u64) -> Result<Opti
         }
     }
     Ok(Some(lo))
+}
+
+#[cfg(test)]
+mod ingest_decision_tests {
+    use super::{below_supermajority, needs_refetch, participation_of, should_replace};
+
+    // 2/3 of 512 = 341.33…, so 342 participants is the lowest acceptable count.
+    #[test]
+    fn supermajority_bar_sits_at_two_thirds_of_512() {
+        assert!(below_supermajority(0));
+        assert!(below_supermajority(113)); // the frozen period-1840 record
+        assert!(below_supermajority(341));
+        assert!(!below_supermajority(342));
+        assert!(!below_supermajority(512));
+    }
+
+    #[test]
+    fn missing_periods_are_always_fetched() {
+        assert!(needs_refetch(false, None, false));
+        assert!(needs_refetch(false, None, true));
+    }
+
+    #[test]
+    fn the_in_progress_period_is_always_provisional() {
+        assert!(needs_refetch(true, Some(512), true));
+    }
+
+    #[test]
+    fn a_weak_stored_update_is_provisional() {
+        assert!(needs_refetch(true, Some(113), false));
+        assert!(needs_refetch(true, Some(341), false));
+    }
+
+    #[test]
+    fn an_undecodable_stored_update_is_provisional() {
+        assert!(needs_refetch(true, None, false));
+    }
+
+    #[test]
+    fn a_strong_complete_period_is_frozen() {
+        assert!(!needs_refetch(true, Some(342), false));
+        assert!(!needs_refetch(true, Some(512), false));
+    }
+
+    #[test]
+    fn replacement_is_strictly_better_only() {
+        assert!(should_replace(Some(113), Some(114)));
+        assert!(should_replace(Some(113), Some(512)));
+        assert!(!should_replace(Some(113), Some(113))); // idempotent re-ingest
+        assert!(!should_replace(Some(512), Some(342)));
+    }
+
+    #[test]
+    fn a_decodable_update_beats_an_undecodable_stored_one() {
+        assert!(should_replace(None, Some(1)));
+        assert!(should_replace(None, Some(512)));
+    }
+
+    #[test]
+    fn an_undecodable_fresh_chunk_never_replaces_anything() {
+        assert!(!should_replace(Some(113), None));
+        assert!(!should_replace(None, None));
+    }
+
+    #[test]
+    fn participation_of_rejects_undecodable_bytes() {
+        assert_eq!(participation_of(&[]), None);
+        assert_eq!(participation_of(&[0u8; 64]), None);
+        assert_eq!(participation_of(b"not an ssz light client update"), None);
+    }
 }

--- a/rust/roost/src/main.rs
+++ b/rust/roost/src/main.rs
@@ -356,9 +356,22 @@ async fn ingest(rest_base: &str, archive_path: &Path) -> Result<()> {
 
     // Memory is an accelerator in front of the archive, so the store is rebuilt
     // from it on every start. Re-encoding 1327 periods is milliseconds.
+    // Participation is decoded alongside: the fill loop below uses it to decide
+    // whether a stored update is provisional. Last record per period wins, the
+    // same last-wins rule insert_update applies.
     let store = LcStore::new();
+    let mut participation: std::collections::BTreeMap<u64, usize> =
+        std::collections::BTreeMap::new();
     for (period, rec) in &records {
         store.insert_update(*period, rec.fork_digest, &rec.ssz);
+        match participation_of(&rec.ssz) {
+            Some(p) => {
+                participation.insert(*period, p);
+            }
+            None => {
+                participation.remove(period);
+            }
+        }
     }
 
     let (head_slot, syncing) = client.syncing().await?;
@@ -379,10 +392,27 @@ async fn ingest(rest_base: &str, archive_path: &Path) -> Result<()> {
     println!("  window    periods {floor}..={head_period}");
 
     println!("\n== fill ==");
+    // A stored update is PROVISIONAL — refetched, not frozen — when its
+    // sync-aggregate participation is below the light-client supermajority
+    // (participants*3 < SYNC_COMMITTEE_SIZE*2) or its period is still in
+    // progress. Upstream's by-range answer is its best update SEEN SO FAR, so
+    // an ingest that runs early in a period can capture the period's first
+    // slots' update carrying a fraction of the committee (observed: 113/512 at
+    // mainnet period 1840, attested at the period's slot 0) — and a wallet
+    // REFUSES < 2/3, so a frozen weak update stalls every catch-up through
+    // that period, silently, forever. `has_period` used to be that freezer.
+    // Replacement is strictly-better-only (more participants), so a repeated
+    // ingest never grows the archive with equal copies; the append-only
+    // archive + last-wins insert_update/rebuild make the better record
+    // supersede on this run and on every later start.
     let mut fetched = 0usize;
     let mut newest_digest = None;
     for period in floor..=head_period {
-        if store.has_period(period) {
+        let stored = participation.get(&period).copied();
+        let weak = stored.is_some_and(|p| {
+            p * 3 < myotis_consensus::spec::SYNC_COMMITTEE_SIZE * 2
+        });
+        if store.has_period(period) && !weak && period != head_period {
             continue;
         }
         let resp = client.updates(period, 1).await?;
@@ -391,12 +421,38 @@ async fn ingest(rest_base: &str, archive_path: &Path) -> Result<()> {
             println!("  period {period}: upstream returned no data, skipping");
             continue;
         }
+        let mut stored_now = 0usize;
         for c in &chunks {
+            if store.has_period(period) {
+                let fresh = participation_of(&c.ssz);
+                match (stored, fresh) {
+                    (Some(old), Some(new)) if new <= old => {
+                        println!(
+                            "  period {period}: upstream no better \
+                             ({new} <= {old} participants), keeping"
+                        );
+                        continue;
+                    }
+                    (Some(old), Some(new)) => {
+                        println!(
+                            "  period {period}: replacing a provisional update \
+                             ({old} -> {new} participants)"
+                        );
+                    }
+                    // An undecodable side (foreign fork shape for this build's
+                    // decoder) can't be compared — keep what we have rather
+                    // than churn on a judgement we cannot make.
+                    _ => continue,
+                }
+            }
             archive.append(period, c.fork_digest, &c.ssz)?;
             store.insert_update(period, c.fork_digest, &c.ssz);
             fetched += 1;
+            stored_now += 1;
         }
-        println!("  period {period}: stored {} chunk(s)", chunks.len());
+        if stored_now > 0 && stored.is_none() {
+            println!("  period {period}: stored {stored_now} chunk(s)");
+        }
     }
     archive.flush()?;
     println!("  fetched   {fetched} new period(s)");
@@ -469,6 +525,15 @@ async fn ingest(rest_base: &str, archive_path: &Path) -> Result<()> {
 
     serving_self_check(&store, &c, bootstrap_root)?;
     Ok(())
+}
+
+/// Sync-aggregate participant count of an SSZ-encoded `LightClientUpdate`, or
+/// `None` when it does not decode with this build's (fork-polymorphic) decoder.
+/// Used by ingest to judge whether a stored update is provisional.
+fn participation_of(ssz: &[u8]) -> Option<usize> {
+    myotis_consensus::types::LightClientUpdate::decode(ssz)
+        .ok()
+        .map(|u| u.sync_aggregate.count_participants())
 }
 
 /// Serve from the store exactly as the libp2p responder will, and decode the

--- a/rust/roost/src/serve.rs
+++ b/rust/roost/src/serve.rs
@@ -320,7 +320,19 @@ async fn resolve_fork_digest(
     archived
 }
 
-/// Fill every period the upstream still serves that we do not already hold.
+/// Fill every period the upstream still serves that we do not already hold —
+/// and REFRESH every held period whose record is provisional: below the
+/// light-client supermajority or undecodable by this build. An update captured
+/// while its period was in progress can carry a fraction of the committee
+/// (observed: 113/512 at mainnet period 1840, frozen by the old
+/// `has_period`-skip, stalling every wallet's catch-up), and this daemon's
+/// slot ticker captures a new period within minutes of rollover — so without
+/// the refresh rule the daemon re-earns that freeze on every rollover no
+/// matter what the CLI ingest does. Unlike the CLI ingest, the daemon does NOT
+/// always refetch the in-progress period: it refreshes only while the record
+/// is below the bar, so each period costs a handful of strictly-improving
+/// appends and goes quiet once wallets can use it (the shared
+/// `needs_refetch`/`should_replace` rules in main.rs, `in_progress = false`).
 async fn fill_periods(
     client: &NimbusRest,
     store: &LcStore,
@@ -330,7 +342,16 @@ async fn fill_periods(
 ) -> Result<usize> {
     let mut fetched = 0;
     for period in floor..=head_period {
-        if store.has_period(period) {
+        let held = store.has_period(period);
+        let stored = if held {
+            store
+                .update_ssz(period)
+                .as_deref()
+                .and_then(crate::participation_of)
+        } else {
+            None
+        };
+        if !crate::needs_refetch(held, stored, false) {
             continue;
         }
         // One flaky request out of ~1300 must not abort a whole backfill; the
@@ -350,6 +371,16 @@ async fn fill_periods(
             }
         };
         for c in &chunks {
+            if held {
+                let fresh = crate::participation_of(&c.ssz);
+                if !crate::should_replace(stored, fresh) {
+                    tracing::debug!(period, ?stored, ?fresh,
+                        "provisional record kept — upstream no better");
+                    continue;
+                }
+                tracing::info!(period, ?stored, ?fresh,
+                    "replacing a provisional update");
+            }
             archive.append(period, c.fork_digest, &c.ssz)?;
             store.insert_update(period, c.fork_digest, &c.ssz);
             fetched += 1;
@@ -848,14 +879,16 @@ pub async fn serve(
                 }
 
                 // A new period turns over every ~27 hours; checking each slot is
-                // free next to the HTTP calls above.
+                // free next to the HTTP calls above. No has_period guard:
+                // fill_periods itself decides — it also REFRESHES a held record
+                // that is still below the supermajority bar (the guard was what
+                // froze a 113/512 capture at mainnet period 1840), and it makes
+                // zero upstream calls once the record clears the bar.
                 let p = params.period_of_slot(head_slot);
-                if !store.has_period(p) {
-                    match fill_periods(&client, &store, &mut archive, p, p).await {
-                        Ok(n) if n > 0 => tracing::info!(period = p, "archived a new period"),
-                        Ok(_) => {}
-                        Err(e) => tracing::warn!(error = %e, "filling the new period failed"),
-                    }
+                match fill_periods(&client, &store, &mut archive, p, p).await {
+                    Ok(n) if n > 0 => tracing::info!(period = p, "archived a new period"),
+                    Ok(_) => {}
+                    Err(e) => tracing::warn!(error = %e, "filling the new period failed"),
                 }
             }
         }

--- a/rust/roost/src/store.rs
+++ b/rust/roost/src/store.rs
@@ -36,7 +36,7 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
 use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
-use myotis_net::codec::encode_success_response;
+use myotis_net::codec::{decode_multi_chunk_response, encode_success_response};
 
 use crate::rest::MAX_REQUEST_LIGHT_CLIENT_UPDATES;
 
@@ -145,6 +145,18 @@ impl LcStore {
     /// Encode once, at ingest. `fork_digest` is the digest the source framed,
     /// re-emitted verbatim — not derived from a fork name, which since EIP-7892
     /// would not determine it.
+    /// Raw SSZ of the held update for `period` (wire framing stripped), for the
+    /// ingest-refresh decision — see `fill_periods` / the CLI ingest fill loop.
+    /// `None` when the period is not held (or, defensively, when our own wire
+    /// encoding fails to round-trip).
+    pub fn update_ssz(&self, period: u64) -> Option<Vec<u8>> {
+        let wire = self.read().updates.get(&period).cloned()?;
+        decode_multi_chunk_response(&wire, 1)
+            .ok()?
+            .into_iter()
+            .next()
+    }
+
     pub fn insert_update(&self, period: u64, fork_digest: [u8; 4], ssz: &[u8]) {
         let wire: Arc<[u8]> = encode_success_response(ssz, Some(fork_digest)).into();
         let mut inner = self.write();


### PR DESCRIPTION
## Symptom

Mainnet LC sync hangs at period 1840 on every wallet (Android emulator, and reproduced on the host with `live_mainnet`): the catch-up loop requests `updates_by_range from_period=1840` forever, the dedicated roost node answers every time, nothing applies, no error anywhere above debug level.

## Root cause (server side, with the full evidence chain)

- The wallet finds and uses roost fine. Reproduced with the `live_mainnet` test: periods **1835–1839 decode, BLS-verify, and apply**; period **1840 is rejected** with `sync-aggregate BLS verification failed … participants=113` — 113/512 is below the ⅔ supermajority (342) a light client requires, and refusing it is correct (113 signers prove nothing).
- roost's stored update for 1840 is attested at the period's **first slot** (15073280) — the moment participation dips during committee rotation. Upstream's actual best update for 1840 (verified live against publicnode) has **512/512**, attested at slot 65.
- roost's ingest fill loop ran `floor..=head_period` — including the **in-progress** period — and `if store.has_period(period) { continue; }` froze whatever it first stored. An ingest run shortly after period 1840 began captured upstream's provisional best-so-far and froze it; every wallet catching up through 1840 has stalled silently since.

## Fixes

**roost ingest (the heal + the prevention):** a stored update is now *provisional* — refetched rather than frozen — when its participation is below ⅔, when it doesn't decode with this build's decoder, or when its period is still in progress. Replacement is strictly-better-only (more participants; a decodable update beats an undecodable one; a fresh undecodable update never replaces anything), so repeated ingests are idempotent and never grow the archive with equal copies. Append-only archive + last-wins `insert_update`/rebuild make the better record supersede on this run and on every later start. **Re-running `ingest` against the existing archive replaces the weak 1840 record** — no archive surgery needed.

**myotis-consensus (the missing diagnosis):** `process_update`'s five silent `return false` sites each log a debug reason now (applicability periods, participant count, which Merkle branch failed). This stall took a live thread-dump-and-instrument session to find; the next one is a debug filter away. `tracing` facade only — the wasm32 sans-I/O canary passes (verified locally with the rustup target + Homebrew clang).

**myotis-net (host-visible symptom):** an idle catch-up round that had verify-rejects now WARNs with the target period, so the Android/desktop Logs tab shows the stall's nature instead of a bare "no progress". Verify-rejects only; decode failures deliberately stay debug (malformed frames say nothing about our store).

The Java engine needs no twin: it already logs the participation rejection at INFO and the server-side roost fix heals both engines at the source (confirmed by the internal review).

## Verification

- `live_mainnet` against the live roost reproduces the stall and pinpoints the reason with the new logs.
- Upstream comparison: publicnode's period-1840 update = 512/512 participants vs roost's stored 113/512.
- roost tests (81), myotis-consensus (13), myotis-net (323+) all green; wasm canary green.
- Internal no-context review traced the full fill-loop state machine; its one risk finding (undecodable stored records frozen the same way) is fixed in the second commit.

## Operator note (after merge)

Rebuild roost on the dappnode and re-run `ingest`: it will print `period 1840: replacing a provisional update (113 -> 512 participants)` and mainnet wallets unstick immediately — no wallet update required (the client-side changes here are observability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZjDDn6qE9QzhiJHHpKpmx