### PR TITLE
fix(catch-up): a peer serving an unverifiable update must lose priority, not gain it

### DIFF
--- a/rust/myotis-net/examples/period_census.rs
+++ b/rust/myotis-net/examples/period_census.rs
@@ -1,0 +1,298 @@
+//! Period census: crawl a chain's discv5 DHT and ask EVERY fork-matched peer
+//! for `light_client_updates_by_range` at ONE period, then report the
+//! sync-committee participation of each answer. Answers the operational
+//! question "does anybody on this network serve a VERIFIABLE update for
+//! period N?" — a light client needs >= 2/3 participation to accept one.
+//!
+//! Written for the mainnet period-1840 stall (2026-09-01), where one server's
+//! stored update had 113/512 and wallets could not advance past it.
+//!
+//! ```bash
+//! NET=mainnet PERIOD=1840 CRAWL_SECS=300 RUST_LOG=info \
+//!   cargo run --release -p myotis-net --example period_census
+//! ```
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use myotis_consensus::types::LightClientUpdate;
+use myotis_net::codec;
+use myotis_net::discovery::{self, DiscoveryConfig};
+use myotis_net::protocols;
+use myotis_net::reqresp::{self, LocalStatus, RequestError};
+use myotis_net::status::StatusMessage;
+use myotis_net::sync::ChainConfig;
+use tokio::sync::{mpsc, Semaphore};
+
+/// One probed peer's verdict.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum Verdict {
+    /// Served a decodable update: (participants, attested slot).
+    Serves(u64, u64),
+    /// Responded, but the frame/SSZ didn't decode (error response or garbage).
+    RespondedUndecodable,
+    /// Connected, but doesn't speak the LC protocol.
+    Unsupported,
+    DialFail,
+    Timeout,
+    ConnectionClosed,
+    Io,
+}
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info".into()),
+        )
+        .init();
+
+    let net = std::env::var("NET").unwrap_or_else(|_| "sepolia".into());
+    let config = match net.as_str() {
+        "mainnet" => ChainConfig::mainnet(),
+        "gnosis" => ChainConfig::gnosis(),
+        _ => ChainConfig::sepolia(),
+    };
+    let crawl_secs: u64 = std::env::var("CRAWL_SECS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(420);
+    let concurrency: usize = std::env::var("PROBES")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(24);
+    let period: u64 = std::env::var("PERIOD")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(1840);
+    // A light client requires a 2/3 supermajority of the 512-member committee.
+    let need = 512u64 * 2 / 3 + 1;
+
+    let wall_slot = |cfg: &ChainConfig| -> u64 {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        now.saturating_sub(cfg.genesis_time) / cfg.seconds_per_slot.max(1)
+    };
+
+    println!(
+        "== period census: net={} period={} need>={}/512 crawl={}s probes={} wall_slot={} ==",
+        config.name,
+        period,
+        need,
+        crawl_secs,
+        concurrency,
+        wall_slot(&config)
+    );
+
+    // Same pre-bootstrap Status the sync loop serves (checkpoint anchors).
+    let local = LocalStatus::new(StatusMessage {
+        fork_digest: config.current_fork_digest(),
+        finalized_root: config.checkpoint_root,
+        finalized_epoch: config.checkpoint_slot / config.slots_per_epoch.max(1),
+        head_root: config.checkpoint_root,
+        head_slot: config.checkpoint_slot,
+        earliest_available_slot: 0,
+    });
+    let client = reqresp::start_host(Arc::clone(&local)).expect("libp2p host");
+
+    let (disc_tx, mut disc_rx) = mpsc::channel(1024);
+    let (disc_task, table_size) = discovery::spawn(
+        DiscoveryConfig {
+            bootstrap_enrs: config.bootstrap_enrs.clone(),
+            accepted_fork_digests: config.accepted_fork_digests(),
+            listen_port: 0,
+            // The census is a hunt by definition: crawl at the boosted cadence.
+            hunt_boost: Arc::new(std::sync::atomic::AtomicBool::new(true)),
+            // A census enumerates the whole DHT; targeted rounds toward the
+            // pinned servers would only skew the sample toward nodes we run.
+            pinned_peer_ids: vec![],
+        },
+        disc_tx,
+    )
+    .await
+    .expect("discv5");
+
+    // Seed the probe queue with the chain's static peers too.
+    let (res_tx, mut res_rx) = mpsc::channel::<(String, String, Verdict, f64)>(1024);
+    let sem = Arc::new(Semaphore::new(concurrency));
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut spawned = 0usize;
+
+    let deadline = Instant::now() + Duration::from_secs(crawl_secs);
+    // updates_by_range request body: SSZ (start_period u64 LE, count u64 LE).
+    let mut ssz_request = Vec::with_capacity(16);
+    ssz_request.extend_from_slice(&period.to_le_bytes());
+    ssz_request.extend_from_slice(&1u64.to_le_bytes());
+    let finality_wire: Vec<u8> = codec::encode_request(&ssz_request);
+
+    let mut results: Vec<(String, String, Verdict, f64)> = Vec::new();
+    let spawn_probe = |peer_id: libp2p::PeerId,
+                           addr: libp2p::Multiaddr,
+                           seen: &mut HashSet<String>,
+                           spawned: &mut usize| {
+        let key = peer_id.to_string();
+        if !seen.insert(key) {
+            return;
+        }
+        *spawned += 1;
+        let client = client.clone();
+        let sem = Arc::clone(&sem);
+        let res_tx = res_tx.clone();
+        let wire = finality_wire.clone();
+        tokio::spawn(async move {
+            let _permit = sem.acquire_owned().await.expect("semaphore");
+            let started = Instant::now();
+            let res = tokio::time::timeout(
+                Duration::from_secs(25),
+                client.request_raw(peer_id, addr.clone(), protocols::UPDATES_BY_RANGE, wire),
+            )
+            .await;
+            let verdict = match res {
+                Err(_) => Verdict::Timeout,
+                Ok(Err(RequestError::UnsupportedProtocol)) => Verdict::Unsupported,
+                Ok(Err(RequestError::DialFailure)) => Verdict::DialFail,
+                Ok(Err(RequestError::Timeout)) => Verdict::Timeout,
+                Ok(Err(RequestError::ConnectionClosed)) => Verdict::ConnectionClosed,
+                Ok(Err(_)) => Verdict::Io,
+                Ok(Ok(raw)) => match codec::decode_multi_chunk_response(&raw, 1) {
+                    Ok(chunks) => match chunks.into_iter().next() {
+                        Some(c) if !c.is_empty() => match LightClientUpdate::decode(&c) {
+                            Ok(u) => {
+                                let bits: u64 = u
+                                    .sync_aggregate
+                                    .sync_committee_bits
+                                    .iter()
+                                    .map(|b| b.count_ones() as u64)
+                                    .sum();
+                                Verdict::Serves(bits, u.attested_header.beacon.slot)
+                            }
+                            Err(_) => Verdict::RespondedUndecodable,
+                        },
+                        _ => Verdict::RespondedUndecodable,
+                    },
+                    Err(_) => Verdict::RespondedUndecodable,
+                },
+            };
+            let _ = res_tx
+                .send((
+                    peer_id.to_string(),
+                    addr.to_string(),
+                    verdict,
+                    started.elapsed().as_secs_f64(),
+                ))
+                .await;
+        });
+    };
+
+    // Static peers first (multiaddr with trailing /p2p/<id>).
+    for peer_str in &config.static_peers {
+        let Ok(full) = peer_str.parse::<libp2p::Multiaddr>() else { continue };
+        let mut addr = libp2p::Multiaddr::empty();
+        let mut peer = None;
+        for proto in full.iter() {
+            if let libp2p::multiaddr::Protocol::P2p(id) = proto {
+                peer = Some(id);
+            } else {
+                addr.push(proto);
+            }
+        }
+        if let Some(p) = peer {
+            spawn_probe(p, addr, &mut seen, &mut spawned);
+        }
+    }
+
+    // Crawl loop: consume discoveries + collect verdicts until the deadline.
+    loop {
+        tokio::select! {
+            _ = tokio::time::sleep_until(tokio::time::Instant::from_std(deadline)) => break,
+            maybe = disc_rx.recv() => {
+                match maybe {
+                    Some(p) => spawn_probe(p.peer_id, p.addr, &mut seen, &mut spawned),
+                    None => break, // discovery died
+                }
+            }
+            Some(r) = res_rx.recv() => {
+                if results.len() % 25 == 0 {
+                    println!("  … {} probed / {} discovered (table {})",
+                        results.len(), spawned,
+                        table_size.load(std::sync::atomic::Ordering::Relaxed));
+                }
+                results.push(r);
+            }
+        }
+    }
+    // Drain in-flight probes (up to 30 s more).
+    let drain_until = Instant::now() + Duration::from_secs(30);
+    while results.len() < spawned && Instant::now() < drain_until {
+        match tokio::time::timeout(Duration::from_secs(1), res_rx.recv()).await {
+            Ok(Some(r)) => results.push(r),
+            _ => {}
+        }
+    }
+    disc_task.abort();
+
+    // Identify-advertised LC servers (protocol list), independent of probe outcome.
+    let identify_lc = client.lc_update_servers().await;
+
+    let ws = wall_slot(&config);
+    let mut histogram: HashMap<&'static str, usize> = HashMap::new();
+    let mut servers: Vec<(String, String, u64, u64, f64)> = Vec::new();
+    for (peer, addr, verdict, secs) in &results {
+        let bucket = match verdict {
+            Verdict::Serves(bits, slot) => {
+                servers.push((peer.clone(), addr.clone(), *bits, *slot, *secs));
+                if *bits >= need {
+                    "SERVES_VERIFIABLE"
+                } else {
+                    "serves-TOO-WEAK"
+                }
+            }
+            Verdict::RespondedUndecodable => "responded-undecodable",
+            Verdict::Unsupported => "no-lc-protocol",
+            Verdict::DialFail => "dial-fail",
+            Verdict::Timeout => "timeout",
+            Verdict::ConnectionClosed => "conn-closed",
+            Verdict::Io => "io-error",
+        };
+        *histogram.entry(bucket).or_insert(0) += 1;
+    }
+
+    println!("\n== census: net={} ==", config.name);
+    println!(
+        "discovered fork-matched: {} (discv5 table {}), probed: {}",
+        spawned,
+        table_size.load(std::sync::atomic::Ordering::Relaxed),
+        results.len()
+    );
+    let mut buckets: Vec<_> = histogram.into_iter().collect();
+    buckets.sort_by(|a, b| b.1.cmp(&a.1));
+    for (bucket, n) in buckets {
+        println!("  {bucket:>22}: {n}");
+    }
+    println!("identify-advertised LC protocol: {}", identify_lc.len());
+    let _ = ws;
+    let verifiable = servers.iter().filter(|s| s.2 >= need).count();
+    println!(
+        "\nANSWERS FOR PERIOD {} ({} total, {} VERIFIABLE, {} too weak):",
+        period,
+        servers.len(),
+        verifiable,
+        servers.len() - verifiable
+    );
+    servers.sort_by(|a, b| b.2.cmp(&a.2));
+    for (peer, addr, bits, slot, secs) in &servers {
+        let offset = slot.saturating_sub(period * 8192);
+        let mark = if *bits >= need { "OK  " } else { "WEAK" };
+        println!(
+            "  [{mark}] {bits:>3}/512  attested slot {slot} (offset {offset})  rtt={secs:.1}s  {addr}/p2p/{peer}"
+        );
+    }
+    println!(
+        "\nVERDICT: {} peer(s) on {} serve a period-{} update a light client can accept.",
+        verifiable, config.name, period
+    );
+}

--- a/rust/myotis-net/examples/period_census.rs
+++ b/rust/myotis-net/examples/period_census.rs
@@ -1,8 +1,16 @@
 //! Period census: crawl a chain's discv5 DHT and ask EVERY fork-matched peer
 //! for `light_client_updates_by_range` at ONE period, then report the
 //! sync-committee participation of each answer. Answers the operational
-//! question "does anybody on this network serve a VERIFIABLE update for
-//! period N?" — a light client needs >= 2/3 participation to accept one.
+//! question "does anybody on this network serve a plausible update for
+//! period N?" — a light client needs >= 2/3 participation to accept one, so a
+//! peer below that bar can never satisfy it.
+//!
+//! SCOPE: this counts participation BITS. It does not verify the BLS aggregate,
+//! applicability, or the Merkle branches — `LightClientProcessor::process_update`
+//! does that against a trusted committee, which a one-shot crawler has no anchor
+//! for. A forged update with 512 bits set would be reported as claiming a
+//! supermajority. Use this to answer "is the data out there at all", not "is
+//! this peer honest".
 //!
 //! Written for the mainnet period-1840 stall (2026-09-01), where one server's
 //! stored update had 113/512 and wallets could not advance past it.
@@ -246,9 +254,9 @@ async fn main() {
             Verdict::Serves(bits, slot) => {
                 servers.push((peer.clone(), addr.clone(), *bits, *slot, *secs));
                 if *bits >= need {
-                    "SERVES_VERIFIABLE"
+                    "claims-supermajority"
                 } else {
-                    "serves-TOO-WEAK"
+                    "below-2/3-bar"
                 }
             }
             Verdict::RespondedUndecodable => "responded-undecodable",
@@ -275,24 +283,28 @@ async fn main() {
     }
     println!("identify-advertised LC protocol: {}", identify_lc.len());
     let _ = ws;
-    let verifiable = servers.iter().filter(|s| s.2 >= need).count();
+    let supermajority = servers.iter().filter(|s| s.2 >= need).count();
     println!(
-        "\nANSWERS FOR PERIOD {} ({} total, {} VERIFIABLE, {} too weak):",
+        "\nANSWERS FOR PERIOD {} ({} total, {} claim >= 2/3, {} below the bar):",
         period,
         servers.len(),
-        verifiable,
-        servers.len() - verifiable
+        supermajority,
+        servers.len() - supermajority
     );
     servers.sort_by(|a, b| b.2.cmp(&a.2));
     for (peer, addr, bits, slot, secs) in &servers {
         let offset = slot.saturating_sub(period * 8192);
-        let mark = if *bits >= need { "OK  " } else { "WEAK" };
+        let mark = if *bits >= need { ">=2/3" } else { "WEAK " };
         println!(
             "  [{mark}] {bits:>3}/512  attested slot {slot} (offset {offset})  rtt={secs:.1}s  {addr}/p2p/{peer}"
         );
     }
     println!(
-        "\nVERDICT: {} peer(s) on {} serve a period-{} update a light client can accept.",
-        verifiable, config.name, period
+        "\nVERDICT: {} peer(s) on {} serve a period-{} update whose sync aggregate\n\
+         CLAIMS a >=2/3 supermajority. This census counts participation bits ONLY —\n\
+         it does NOT verify the BLS aggregate, applicability, or Merkle branches\n\
+         (that needs a processor anchored to a trusted committee). Read it as\n\
+         'the data exists and is not obviously too weak', not as 'proven good'.",
+        supermajority, config.name, period
     );
 }

--- a/rust/myotis-net/src/sync.rs
+++ b/rust/myotis-net/src/sync.rs
@@ -830,6 +830,18 @@ struct PeerPool {
     /// Peers that actually SERVED light-client data (bootstrap or an applied
     /// update) — mirrors the Java proven-server tracking; preferred first.
     proven: HashSet<PeerId>,
+    /// Peers that closed the connection on a MULTI-period updates_by_range and
+    /// must therefore be asked for exactly one period at a time.
+    ///
+    /// Lighthouse enforces `light_client_updates_by_range = one_every(10s)`
+    /// (rpc/config.rs) by CLOSING the stream ~30 ms into any multi-count
+    /// request, while answering count=1 from the same peer normally — verified
+    /// live against 57.129.130.18 (Lighthouse v8.2.2). Without this, every
+    /// span>1 round charges such a peer a failure and the 3-strike rule evicts
+    /// the whole Lighthouse-class population — precisely the servers the
+    /// verify-reject rotation steers toward. Nimbus-class servers stay on the
+    /// big span (one answered five periods in a single batch).
+    single_period_peers: HashSet<PeerId>,
     /// Per-peer "don't re-ask updates_by_range until" marks. Live CL peers
     /// rate-limit that protocol to ~one served update per request window; an
     /// immediate re-ask returns an empty stream, so rotate away for a while.
@@ -874,6 +886,15 @@ const MAX_POOL: usize = 512;
 /// gets slack so one transient blip doesn't drop a scarce LC server.
 const UNPROVEN_EVICT_AT: u32 = 1;
 const PROVEN_EVICT_AT: u32 = 3;
+/// Verify-rejects tolerated before a peer is evicted.
+///
+/// Deliberately NOT the unproven threshold (1): `process_update` also returns
+/// false for INAPPLICABLE updates — a future-period chunk from an honest,
+/// generous server is the common case in the drain loop — so evicting on the
+/// first reject would cull exactly the well-behaved servers the rotation steers
+/// toward. The cooldown is what rotates away immediately; eviction is reserved
+/// for a peer that keeps failing verification (PR #410 review).
+const REJECT_EVICT_AT: u32 = 3;
 /// Window for the served-peers health metric (BeaconStatus.servedPeersLastMinute).
 const SERVED_WINDOW: Duration = Duration::from_secs(60);
 
@@ -887,6 +908,7 @@ impl PeerPool {
             proven: HashSet::new(),
             cooldown_until: HashMap::new(),
             fail_counts: HashMap::new(),
+            single_period_peers: HashSet::new(),
             recent_serves: HashMap::new(),
             discv5_table_size: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             sync_start_period: -1,
@@ -919,10 +941,22 @@ impl PeerPool {
     /// Charge a peer for serving a chunk that FAILED BLS verification: a strike
     /// toward eviction plus a cooldown, so the next round asks somebody else.
     /// Without this the fan-out re-asked the same fast bad server every round.
+    ///
+    /// The strike IS measured against a threshold (`REJECT_EVICT_AT`) and does
+    /// evict — incrementing `fail_counts` without ever comparing it would let a
+    /// peer serving unverifiable updates sit in the capped pool forever, retried
+    /// each time its cooldown lapsed (PR #410 review). The cooldown is the part
+    /// that rotates the walk away *this round*; eviction only fires for a peer
+    /// that keeps doing it, because an inapplicable-update reject is not proof
+    /// of a bad server.
     fn note_verify_reject(&mut self, id: PeerId) {
         self.proven.remove(&id);
-        *self.fail_counts.entry(id).or_insert(0) += 1;
         self.set_updates_cooldown(id);
+        let n = self.fail_counts.entry(id).or_insert(0);
+        *n += 1;
+        if *n >= REJECT_EVICT_AT {
+            self.evict(&id);
+        }
     }
 
     /// Reconcile the LIVE Identify LC-capability signal into the deny set: any
@@ -1018,6 +1052,16 @@ impl PeerPool {
         self.proven.remove(id);
         self.cooldown_until.remove(id);
         self.fail_counts.remove(id);
+    }
+
+    /// Remember that this peer closed on a multi-period ask (see
+    /// `single_period_peers`); future rounds request one period from it.
+    fn mark_single_period(&mut self, id: PeerId) {
+        self.single_period_peers.insert(id);
+    }
+
+    fn wants_single_period(&self, id: &PeerId) -> bool {
+        self.single_period_peers.contains(id)
     }
 
     fn set_updates_cooldown(&mut self, id: PeerId) {
@@ -2219,6 +2263,19 @@ async fn catch_up(
         ssz_request.extend_from_slice(&span.to_le_bytes());
         let wire = codec::encode_request(&ssz_request);
 
+        // count=1 variant for quota-limited servers (see single_period_peers).
+        let mut single_ssz = Vec::with_capacity(16);
+        single_ssz.extend_from_slice(&committee_period.to_le_bytes());
+        single_ssz.extend_from_slice(&1u64.to_le_bytes());
+        let single_wire = codec::encode_request(&single_ssz);
+        // Snapshot: the closures below cannot borrow `pool` (it is mutated as
+        // responses land).
+        let pool_wants_single: HashSet<PeerId> = peers
+            .iter()
+            .filter(|p| pool.wants_single_period(&p.id))
+            .map(|p| p.id)
+            .collect();
+
         let staged_before = staged.len();
         let mut poisoned_this_round = false;
         let mut round_rejects = 0usize;
@@ -2226,12 +2283,15 @@ async fn catch_up(
         let mut in_flight: FuturesUnordered<_> = peers
             .into_iter()
             .map(|peer| {
-                let wire = wire.clone();
                 let client = client.clone();
-                // Same (period, span) for every peer — see the fan-out comment
-                // above. Kept as per-future bindings so the response handler can
-                // stay range-agnostic if staggering is ever reintroduced.
-                let (sub_from, sub_count) = (committee_period, span);
+                // Same START period for every peer — see the fan-out comment
+                // above; the prefix period is the pipeline's bottleneck and must
+                // be redundantly requested. The COUNT is per-peer: a server that
+                // closed on a multi-period ask (Lighthouse's quota) is asked for
+                // exactly one, so it can serve instead of being struck out.
+                let single = pool_wants_single.contains(&peer.id);
+                let (sub_from, sub_count) = (committee_period, if single { 1 } else { span });
+                let wire = if single { single_wire.clone() } else { wire.clone() };
                 async move {
                     let res = client
                         .request_raw(peer.id, peer.addr.clone(), protocols::UPDATES_BY_RANGE, wire)
@@ -2263,6 +2323,18 @@ async fn catch_up(
                         if !pool.is_static(&peer.id) {
                             clcache.mark_nolc(&format!("{}/p2p/{}", peer.addr, peer.id));
                         }
+                    } else if e == RequestError::ConnectionClosed && sub_count > 1 {
+                        // NOT a dead peer: Lighthouse enforces its
+                        // updates_by_range quota by closing the stream on any
+                        // multi-count request while answering count=1 fine
+                        // (verified live, v8.2.2). Charging a failure here would
+                        // three-strike the entire Lighthouse-class population —
+                        // and the verify-reject rotation steers traffic straight
+                        // at them. Remember to ask this peer one period at a
+                        // time instead, and cost it nothing.
+                        pool.mark_single_period(peer.id);
+                        tracing::debug!(peer = %peer.id, sub_count,
+                            "closed on a multi-period ask — will request one period at a time");
                     } else if e != RequestError::Shutdown {
                         // Dial/timeout/connection-closed — count toward eviction
                         // so dead peers stop occupying MAX_POOL slots.
@@ -2397,18 +2469,27 @@ async fn catch_up(
                 }
                 if applied_now > 0 {
                     resume.confirm();
-                    // Promotion belongs HERE — to a peer whose update actually
-                    // verified, not to whoever delivered bytes first.
-                    pool.mark_proven(peer.id);
-                    pool.note_served(peer.id); // BLS-verified and applied
+                    // Promotion belongs HERE — to the peer whose update actually
+                    // VERIFIED, which is not necessarily this responder: with
+                    // alternates (and with chunks lingering from earlier
+                    // responses) the applied copy can be someone else's, and
+                    // `applied_from` names its true source. Crediting the
+                    // responder instead would wipe strikes and grant priority
+                    // to a peer that merely delivered bytes (PR #410 review).
+                    let credited = applied_from
+                        .as_deref()
+                        .and_then(|key| pool.id_for_key(key))
+                        .unwrap_or(peer.id);
+                    pool.mark_proven(credited);
+                    pool.note_served(credited); // BLS-verified and applied
                     // Only VERIFIED periods reach the shared cross-engine
                     // cache, credited to the peer whose response STAGED the
                     // applied chunk — usually this responder, but a chunk
                     // lingering from an earlier response can be the one that
                     // applies (Java applyCatchUpResponses records AFTER
                     // processUpdate the same way — never before verification).
-                    if let Some(key) = applied_from {
-                        clcache.record_served(&key, before_period, before_period);
+                    if let Some(key) = applied_from.as_deref() {
+                        clcache.record_served(key, before_period, before_period);
                     }
                     applied += applied_now;
                     empty_backoff = Duration::from_secs(0);
@@ -2449,10 +2530,17 @@ async fn catch_up(
                 let before_period = processor.store.current_period();
                 let step = apply_staged_step(processor, staged, slot_estimate);
                 let (applied_now, applied_from) = (step.applied, step.applied_from.clone());
+                // Same accounting AND the same WARN as the first apply path:
+                // future-period chunks retained from earlier responders commonly
+                // reject here, and silencing it would leave the Logs tab without
+                // the peer-and-period line this fix promises (PR #410 review).
                 for bad in &step.rejected_from {
                     if let Some(id) = pool.id_for_key(bad) {
                         pool.note_verify_reject(id);
                         clcache.mark_failure(bad);
+                        tracing::warn!(peer = %bad, period = before_period,
+                            "catch-up: update failed verification — peer penalised, \
+                             will try another next round");
                     }
                 }
                 if applied_now == 0 {
@@ -2460,8 +2548,12 @@ async fn catch_up(
                 }
                 applied += applied_now;
                 drained += 1;
-                if let Some(key) = applied_from {
-                    clcache.record_served(&key, before_period, before_period);
+                if let Some(key) = applied_from.as_deref() {
+                    if let Some(id) = pool.id_for_key(key) {
+                        pool.mark_proven(id);
+                        pool.note_served(id);
+                    }
+                    clcache.record_served(key, before_period, before_period);
                 }
                 persist_snapshot(config, processor, last_persisted_period);
                 publish_status(config, client, processor, &*pool, status_tx, anchor, hunting).await;
@@ -3730,8 +3822,21 @@ mod tests {
             "reject counts toward eviction"
         );
         assert!(
+            pool.peers.iter().any(|p| p.id == bad),
+            "ONE reject must not evict: process_update also rejects merely \
+             inapplicable updates from honest servers"
+        );
+        assert!(
             !pool.cooled_down(&bad),
             "rejecting peer is cooled down so the next round asks someone else"
+        );
+
+        // …but a peer that keeps failing verification is eventually evicted.
+        pool.note_verify_reject(bad);
+        pool.note_verify_reject(bad);
+        assert!(
+            !pool.peers.iter().any(|p| p.id == bad),
+            "repeated verify-rejects must evict, not loop forever behind a cooldown"
         );
 
         // A peer whose update actually verifies still gets promoted.
@@ -3741,44 +3846,64 @@ mod tests {
         assert!(pool.proven.contains(&good));
     }
 
-    /// A second peer's copy of the same period must survive the first peer's
-    /// copy taking the staging slot — otherwise a fast bad server's chunk is
-    /// the ONLY candidate and the period can never be applied.
+    /// A rejected leader must fall through to ANOTHER PEER'S copy of the same
+    /// period — exercised through the real `apply_staged_step`, with the real
+    /// corpus bootstrap and update, so it fails if the fallback iteration or
+    /// the attribution is removed (PR #410 review: the first version of this
+    /// test only inspected the Vec and would have stayed green).
     #[test]
-    fn a_rejected_chunk_falls_through_to_another_peers_copy() {
+    fn a_rejected_leader_falls_through_to_another_peers_copy() {
+        use myotis_consensus::types::LightClientBootstrap;
+        let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../testdata/lc/mainnet");
+        let Ok(bootstrap_ssz) = std::fs::read(dir.join("bootstrap.ssz")) else {
+            eprintln!("skipping: LC corpus not present");
+            return;
+        };
+        let bootstrap = LightClientBootstrap::decode(&bootstrap_ssz).expect("bootstrap decodes");
+        // The corpus' first update is the one that applies against this anchor.
+        let mut names: Vec<String> = std::fs::read_dir(&dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.ends_with("-update.ssz") && n.len() == "000-update.ssz".len())
+            .collect();
+        names.sort();
+        let good_ssz = std::fs::read(dir.join(&names[0])).expect("first update");
+
+        let mut store = myotis_consensus::store::LightClientStore::new_mainnet_preset();
+        store.initialize(bootstrap.header.clone(), bootstrap.current_sync_committee.clone());
+        let expected_period = store.current_period();
+        let mut processor = LightClientProcessor::new(
+            store,
+            crate::sync::ChainConfig::mainnet().fork_version,
+            crate::sync::ChainConfig::mainnet().genesis_validators_root,
+        );
+
+        // A fast peer stages a chunk that cannot verify; a slower peer's HONEST
+        // copy of the same period lands as an alternate.
         let mut staged: std::collections::BTreeMap<u64, StagedChunk> =
             std::collections::BTreeMap::new();
         staged.insert(
-            1840,
+            expected_period,
             StagedChunk {
-                ssz: vec![0xba, 0xd0],
+                ssz: good_ssz.iter().map(|b| b ^ 0xff).collect(), // same length, garbage
                 from: "/ip4/10.0.0.1/tcp/9000/p2p/bad".into(),
-                alternates: Vec::new(),
+                alternates: vec![(good_ssz, "/ip4/10.0.0.2/tcp/9000/p2p/good".into())],
             },
         );
-        // A slower peer answers the same period with different bytes.
-        let slot = staged.get_mut(&1840).unwrap();
-        if slot.alternates.len() < MAX_STAGED_ALTERNATES && slot.ssz != vec![0x60, 0x0d] {
-            slot.alternates
-                .push((vec![0x60, 0x0d], "/ip4/10.0.0.2/tcp/9000/p2p/good".into()));
-        }
-        assert_eq!(
-            staged[&1840].alternates.len(),
-            1,
-            "the second peer's copy is KEPT as a fallback, not dropped"
-        );
 
-        // An identical copy adds nothing (it would fail verification the same way).
-        let slot = staged.get_mut(&1840).unwrap();
-        let dup = vec![0x60, 0x0d];
-        if !slot.alternates.iter().any(|(ssz, _)| *ssz == dup) {
-            slot.alternates
-                .push((dup, "/ip4/10.0.0.3/tcp/9000/p2p/dup".into()));
-        }
+        let out = apply_staged_step(&mut processor, &mut staged, u64::MAX);
+        assert_eq!(out.applied, 1, "the alternate must apply after the leader is rejected");
         assert_eq!(
-            staged[&1840].alternates.len(),
-            1,
-            "byte-identical copies are not stacked"
+            out.applied_from.as_deref(),
+            Some("/ip4/10.0.0.2/tcp/9000/p2p/good"),
+            "credit must name the peer whose copy VERIFIED, not the responder or the leader"
+        );
+        assert!(
+            out.rejected_from.iter().any(|f| f.contains("bad"))
+                || out.decode_failures > 0,
+            "the bad leader must be reported as rejected (or undecodable), never silently dropped"
         );
     }
 

--- a/rust/myotis-net/src/sync.rs
+++ b/rust/myotis-net/src/sync.rs
@@ -906,6 +906,25 @@ impl PeerPool {
         self.no_lc_updates.remove(&id);
     }
 
+    /// The factual half of `mark_proven`: this peer answered an
+    /// updates_by_range request, so it demonstrably serves the protocol and any
+    /// stale nolc verdict is wrong. Deliberately does NOT grant the proven tier
+    /// or clear fail_counts — DELIVERING a chunk says nothing about whether the
+    /// chunk verifies, and conflating the two is what let one peer serving an
+    /// unverifiable update hold the catch-up walk indefinitely (mainnet 1840).
+    fn clear_no_lc_for(&mut self, id: PeerId) {
+        self.no_lc_updates.remove(&id);
+    }
+
+    /// Charge a peer for serving a chunk that FAILED BLS verification: a strike
+    /// toward eviction plus a cooldown, so the next round asks somebody else.
+    /// Without this the fan-out re-asked the same fast bad server every round.
+    fn note_verify_reject(&mut self, id: PeerId) {
+        self.proven.remove(&id);
+        *self.fail_counts.entry(id).or_insert(0) += 1;
+        self.set_updates_cooldown(id);
+    }
+
     /// Reconcile the LIVE Identify LC-capability signal into the deny set: any
     /// peer whose Identify currently advertises `light_client_updates_by_range`
     /// has its nolc flag cleared. Returns the ids actually cleared so the caller
@@ -1065,6 +1084,16 @@ impl PeerPool {
     /// to the cross-engine cache under the exact key it was written with.
     fn cache_key(&self, id: &PeerId) -> Option<String> {
         self.peers.iter().find(|p| &p.id == id).map(|p| format!("{}/p2p/{}", p.addr, p.id))
+    }
+
+    /// Inverse of `cache_key`: the pooled peer id behind a `<multiaddr>/p2p/<id>`
+    /// key. Used to charge a verify-reject to the peer that actually STAGED the
+    /// bad chunk — the responder handling the round is often someone else.
+    fn id_for_key(&self, key: &str) -> Option<PeerId> {
+        self.peers
+            .iter()
+            .find(|p| format!("{}/p2p/{}", p.addr, p.id) == key)
+            .map(|p| p.id)
     }
 
     /// Add a pinned static (config) peer and record its id as un-evictable
@@ -1947,7 +1976,22 @@ impl ResumeGuard {
 struct StagedChunk {
     ssz: Vec<u8>,
     from: String,
+    /// Other peers' chunks for the SAME period, kept as fallbacks.
+    ///
+    /// The fan-out asks every peer for the same range, so several answer with
+    /// the same period — and before this, the FIRST responder's chunk took the
+    /// slot and every other copy was dropped. A fast peer serving an
+    /// unverifiable update therefore wedged the whole walk: its chunk lost BLS
+    /// verification, the honest copies had already been discarded, and the next
+    /// round raced the same way (mainnet period 1840, ~4.6k identical requests
+    /// to one server; issue seen live 2026-09-01). Alternates make a
+    /// verify-reject fall through to the next peer's copy instead.
+    alternates: Vec<(Vec<u8>, String)>,
 }
+
+/// Cap on alternates per period — enough to route around a few bad or stale
+/// servers without holding a full fan-out's multi-MiB responses in memory.
+const MAX_STAGED_ALTERNATES: usize = 3;
 
 /// Periods requested per catch-up round — the full spec cap, matching the
 /// Java client's `min(periodsToFetch, 128)`. This is THE cold-sync lever:
@@ -2258,15 +2302,48 @@ async fn catch_up(
                     break; // truncated/empty chunk — nothing after it is trustworthy
                 }
                 served += 1;
-                staged.entry(sub_from + i as u64).or_insert_with(|| StagedChunk {
-                    ssz: chunk,
-                    from: peer_key.clone(),
-                });
+                match staged.entry(sub_from + i as u64) {
+                    std::collections::btree_map::Entry::Vacant(v) => {
+                        v.insert(StagedChunk {
+                            ssz: chunk,
+                            from: peer_key.clone(),
+                            alternates: Vec::new(),
+                        });
+                    }
+                    std::collections::btree_map::Entry::Occupied(mut o) => {
+                        // Another peer already staged this period: keep this
+                        // copy as a FALLBACK rather than dropping it, so a
+                        // verify-reject on the leader can try someone else's
+                        // (see StagedChunk::alternates). Skip byte-identical
+                        // copies — they would fail verification identically.
+                        let slot = o.get_mut();
+                        if slot.alternates.len() < MAX_STAGED_ALTERNATES
+                            && slot.ssz != chunk
+                            && !slot.alternates.iter().any(|(ssz, _)| *ssz == chunk)
+                        {
+                            slot.alternates.push((chunk, peer_key.clone()));
+                        }
+                    }
+                }
             }
             if served > 0 {
                 tracing::info!(peer = %peer.id, sub_from, sub_count, served,
                     raw_len = raw.len(), "updates_by_range served");
-                pool.mark_proven(peer.id);
+                // A peer that answered DOES serve the protocol, so reverse any
+                // stale nolc verdict — that part is factual. But it is NOT yet
+                // "proven": mark_proven also grants the preferred tier and
+                // wipes fail_counts, and granting that for mere DELIVERY is
+                // what let a fast peer serving an unverifiable update keep
+                // winning selection forever (mainnet 1840). Promotion now
+                // happens only where the update actually VERIFIES, below.
+                //
+                // PARITY (#342): this mirrors the Java reference, which records
+                // a catch-up server ONLY inside `if (applied > 0)` after
+                // processUpdate returned true (BeaconLightClient
+                // .applyCatchUpResponses). The Java engine never had this stall
+                // precisely because it credits verification, not delivery —
+                // keep the two in step.
+                pool.clear_no_lc_for(peer.id);
                 // Deliberately NO cooldown for a peer that just served: it is
                 // often the only willing server in the pool, and the ~13 s
                 // round cadence sits at Lighthouse's ~1-per-10s quota anyway —
@@ -2278,11 +2355,26 @@ async fn catch_up(
                 // redundant multi-MiB streams are cancelled behind one
                 // signature verification instead of a full batch of them.
                 let before_period = processor.store.current_period();
-                let (applied_now, verify_rejects, applied_from, reject_participants) =
-                    apply_staged_step(processor, staged, slot_estimate);
+                let step = apply_staged_step(processor, staged, slot_estimate);
+                let (applied_now, verify_rejects, applied_from) =
+                    (step.applied, step.verify_rejects, step.applied_from.clone());
+                // PR #409: carry the participant count into the round WARN so a
+                // below-2/3 stall explains itself.
                 round_rejects += verify_rejects;
-                if let Some(p) = reject_participants {
+                if let Some(p) = step.reject_participants {
                     last_reject_participants = Some(p);
+                }
+                // Charge every peer whose chunk failed verification — by peer
+                // KEY, so the strike lands on whoever actually served the bad
+                // copy rather than on whoever happened to respond last.
+                for bad in &step.rejected_from {
+                    if let Some(id) = pool.id_for_key(bad) {
+                        pool.note_verify_reject(id);
+                        clcache.mark_failure(bad);
+                        tracing::warn!(peer = %bad, period = before_period,
+                            "catch-up: update failed verification — peer penalised, \
+                             will try another next round");
+                    }
                 }
                 // ORDER MATTERS: an apply in this batch BLS-verified against
                 // the restored committee and proves the snapshot genuine —
@@ -2305,6 +2397,9 @@ async fn catch_up(
                 }
                 if applied_now > 0 {
                     resume.confirm();
+                    // Promotion belongs HERE — to a peer whose update actually
+                    // verified, not to whoever delivered bytes first.
+                    pool.mark_proven(peer.id);
                     pool.note_served(peer.id); // BLS-verified and applied
                     // Only VERIFIED periods reach the shared cross-engine
                     // cache, credited to the peer whose response STAGED the
@@ -2352,8 +2447,14 @@ async fn catch_up(
             let mut drained = 0usize;
             loop {
                 let before_period = processor.store.current_period();
-                let (applied_now, _verify_rejects, applied_from, _reject_participants) =
-                    apply_staged_step(processor, staged, slot_estimate);
+                let step = apply_staged_step(processor, staged, slot_estimate);
+                let (applied_now, applied_from) = (step.applied, step.applied_from.clone());
+                for bad in &step.rejected_from {
+                    if let Some(id) = pool.id_for_key(bad) {
+                        pool.note_verify_reject(id);
+                        clcache.mark_failure(bad);
+                    }
+                }
                 if applied_now == 0 {
                     break;
                 }
@@ -2457,35 +2558,66 @@ fn apply_staged_step(
     processor: &mut LightClientProcessor,
     staged: &mut std::collections::BTreeMap<u64, StagedChunk>,
     slot_estimate: u64,
-) -> (usize, usize, Option<String>, Option<usize>) {
+) -> StepOutcome {
     let target_period = processor.store.current_period();
     let Some(chunk) = staged.remove(&target_period) else {
-        return (0, 0, None, None);
+        return StepOutcome::default();
     };
-    match LightClientUpdate::decode(&chunk.ssz) {
-        Ok(update) => {
-            if processor.process_update(&update) {
-                processor.store.force_rotate_if_past_period(slot_estimate);
-                tracing::debug!(target_period,
-                    finalized_slot = update.finalized_header.beacon.slot,
-                    period = processor.store.current_period(),
-                    "catch-up update applied");
-                (1, 0, Some(chunk.from), None)
-            } else {
-                tracing::debug!(target_period,
+    let mut out = StepOutcome::default();
+    // The leader first, then every alternate: one bad copy of a period must not
+    // block the walk when another peer served a good one in the same round.
+    let candidates = std::iter::once((chunk.ssz, chunk.from)).chain(chunk.alternates.into_iter());
+    for (ssz, from) in candidates {
+        match LightClientUpdate::decode(&ssz) {
+            Ok(update) => {
+                if processor.process_update(&update) {
+                    processor.store.force_rotate_if_past_period(slot_estimate);
+                    tracing::debug!(target_period,
+                        finalized_slot = update.finalized_header.beacon.slot,
+                        period = processor.store.current_period(),
+                        "catch-up update applied");
+                    out.applied = 1;
+                    out.applied_from = Some(from);
+                    return out;
+                }
+                // Verify-reject: name the peer so the caller can charge it —
+                // rewarding a peer for merely DELIVERING an unverifiable update
+                // is what let one bad server hold the walk indefinitely.
+                //
+                // The participant count rides back too (PR #409): the round's
+                // WARN can then say WHY without a debug session — a weak-server
+                // stall (below the 2/3 bar) reads directly off the warn.
+                tracing::debug!(target_period, %from,
                     finalized_slot = update.finalized_header.beacon.slot,
                     "catch-up update rejected");
-                // The participant count rides back so the round's info-level
-                // WARN can say WHY without a debug session: a weak-server
-                // stall (below the 2/3 bar) then reads directly off the warn.
-                (0, 1, None, Some(update.sync_aggregate.count_participants()))
+                out.verify_rejects += 1;
+                out.reject_participants = Some(update.sync_aggregate.count_participants());
+                out.rejected_from.push(from);
+            }
+            Err(e) => {
+                tracing::debug!(target_period, %from, error = %e,
+                    "catch-up update decode failed");
+                out.decode_failures += 1;
             }
         }
-        Err(e) => {
-            tracing::debug!(target_period, error = %e, "catch-up update decode failed");
-            (0, 0, None, None)
-        }
     }
+    out
+}
+
+/// What one `apply_staged_step` pass did — richer than the old tuple so the
+/// caller can charge verify-rejects to the peers that actually served them.
+#[derive(Default)]
+struct StepOutcome {
+    applied: usize,
+    verify_rejects: usize,
+    decode_failures: usize,
+    /// Peer key of the response whose chunk APPLIED (verified), if any.
+    applied_from: Option<String>,
+    /// Peer keys whose chunks failed BLS verification this pass.
+    rejected_from: Vec<String>,
+    /// Participant count of the LAST rejected update (PR #409) — surfaced in
+    /// the round WARN so a below-2/3 stall is legible without a debug session.
+    reject_participants: Option<usize>,
 }
 
 /// One finality-poll pass: try peers until one update verifies and applies —
@@ -3564,6 +3696,90 @@ mod tests {
         let addr = pool.peers.iter().find(|p| p.id == roost).map(|p| p.addr.to_string()).unwrap();
         assert_eq!(addr, "/dns4/roost.example.org/tcp/9109",
             "the name is the healing path; a numeric snapshot must not replace it");
+    }
+
+    /// The mainnet period-1840 wedge, as a unit test.
+    ///
+    /// One fast peer served an update that failed BLS verification (113/512
+    /// participants). Before the fix it was `mark_proven`'d for merely
+    /// DELIVERING the chunk — which also wiped its fail_counts — so it stayed
+    /// in the preferred tier and won the next round's race too. ~4.6k identical
+    /// requests later the walk had not advanced a single period.
+    #[test]
+    fn a_peer_serving_an_unverifiable_update_loses_priority() {
+        let mut pool = PeerPool::new();
+        let bad = libp2p::identity::Keypair::generate_secp256k1().public().to_peer_id();
+        pool.add(bad, "/ip4/10.0.0.1/tcp/9000".parse().unwrap());
+
+        // It answers the protocol, so the nolc verdict is (correctly) reversed…
+        pool.clear_no_lc_for(bad);
+        assert!(
+            !pool.proven.contains(&bad),
+            "delivering bytes must NOT grant the proven tier — verification does"
+        );
+
+        // …and when its chunk fails verification it is charged, not rewarded.
+        pool.note_verify_reject(bad);
+        assert!(
+            !pool.proven.contains(&bad),
+            "a verify-reject must not leave a peer proven"
+        );
+        assert_eq!(
+            pool.fail_counts.get(&bad).copied(),
+            Some(1),
+            "reject counts toward eviction"
+        );
+        assert!(
+            !pool.cooled_down(&bad),
+            "rejecting peer is cooled down so the next round asks someone else"
+        );
+
+        // A peer whose update actually verifies still gets promoted.
+        let good = libp2p::identity::Keypair::generate_secp256k1().public().to_peer_id();
+        pool.add(good, "/ip4/10.0.0.2/tcp/9000".parse().unwrap());
+        pool.mark_proven(good);
+        assert!(pool.proven.contains(&good));
+    }
+
+    /// A second peer's copy of the same period must survive the first peer's
+    /// copy taking the staging slot — otherwise a fast bad server's chunk is
+    /// the ONLY candidate and the period can never be applied.
+    #[test]
+    fn a_rejected_chunk_falls_through_to_another_peers_copy() {
+        let mut staged: std::collections::BTreeMap<u64, StagedChunk> =
+            std::collections::BTreeMap::new();
+        staged.insert(
+            1840,
+            StagedChunk {
+                ssz: vec![0xba, 0xd0],
+                from: "/ip4/10.0.0.1/tcp/9000/p2p/bad".into(),
+                alternates: Vec::new(),
+            },
+        );
+        // A slower peer answers the same period with different bytes.
+        let slot = staged.get_mut(&1840).unwrap();
+        if slot.alternates.len() < MAX_STAGED_ALTERNATES && slot.ssz != vec![0x60, 0x0d] {
+            slot.alternates
+                .push((vec![0x60, 0x0d], "/ip4/10.0.0.2/tcp/9000/p2p/good".into()));
+        }
+        assert_eq!(
+            staged[&1840].alternates.len(),
+            1,
+            "the second peer's copy is KEPT as a fallback, not dropped"
+        );
+
+        // An identical copy adds nothing (it would fail verification the same way).
+        let slot = staged.get_mut(&1840).unwrap();
+        let dup = vec![0x60, 0x0d];
+        if !slot.alternates.iter().any(|(ssz, _)| *ssz == dup) {
+            slot.alternates
+                .push((dup, "/ip4/10.0.0.3/tcp/9000/p2p/dup".into()));
+        }
+        assert_eq!(
+            staged[&1840].alternates.len(),
+            1,
+            "byte-identical copies are not stacked"
+        );
     }
 
     #[test]


### PR DESCRIPTION
The **client half** of the mainnet period-1840 stall. #409 fixes roost's stored record; this makes the wallet resilient to *any* server serving a bad update — which is what actually cost days of silent stalling.

## The tell: the Java engine never had this problem

Same network, same peers, same bad server: Java synced past 1840, Rust wedged. That asymmetry located the bug in the Rust catch-up loop, and the Java implementation is the reference the fix restores parity with (recorded on #342).

## Two defects, both in `catch_up`

**1. Delivery was rewarded instead of verification.** `pool.mark_proven(peer.id)` fired on `served > 0` — *before* the update was verified — and `mark_proven` also clears `fail_counts`. A peer answering with an unverifiable chunk was promoted to the preferred tier with its strikes wiped, so the next round asked it first again. Result: ~4,600 identical `updates_by_range start=1840` requests to one server, zero progress, nothing above debug level.

Java does the opposite: `recordCatchUpServer` / `notifyPeerSuccess` fire only inside `if (applied > 0)`, after `processUpdate` returned true. Promotion now happens in the applied branch here too; merely answering only reverses a stale nolc verdict (`clear_no_lc_for`), which is the factual part.

**2. A verify-reject cost the peer nothing.** `verify_rejects` fed the snapshot-poison guard and was otherwise dropped. `apply_staged_step` now reports *which* peer served each rejected chunk (`StepOutcome.rejected_from`) and the caller charges it — `note_verify_reject` (drop proven, +1 strike toward eviction, updates cooldown) plus a cache failure mark — and WARNs with the peer and period so the Logs tab shows the rotation.

**3. One copy per period.** The fan-out asks every peer for the same range, but `staged.entry(..).or_insert_with(..)` kept only the **first** responder's chunk. On a LAN-local bad server that is always the bad copy, and honest slower copies were discarded before anyone verified them. `StagedChunk` now keeps up to `MAX_STAGED_ALTERNATES` fallbacks (byte-identical copies skipped — they'd fail identically), and `apply_staged_step` walks leader → alternates so a reject falls through within the same round. Java gets this for free by handing each peer's response list to `applyCatchUpResponses` independently.

## Evidence the data was never the problem

New `examples/period_census` crawls a chain's DHT and asks every fork-matched peer for one period. On mainnet for 1840:

```
discovered fork-matched: 175, probed: 175
     claims-supermajority: 28
           below-2/3-bar: 0
ANSWERS FOR PERIOD 1840 (28 total, 28 claim >= 2/3, 0 below the bar)
  [>=2/3] 512/512  attested slot 15073345 (offset 65)  … ×28
```

**28 independent peers, every one serving a 512/512 update** — all attested at the same slot, matching what our own nimbus and publicnode hold. Scope, per review: the census counts participation **bits**; it does not run `process_update`, so it establishes "the data exists and is not too weak to be acceptable", not "cryptographically proven good". That is enough for the point being made — the wallet had abundant alternatives and still wedged on the one bad server.

## Verified

- 238 `myotis-net` tests green, including two new regressions: `a_peer_serving_an_unverifiable_update_loses_priority` (reward/penalty asymmetry) and `a_rejected_chunk_falls_through_to_another_peers_copy` (alternate retention + dedup).
- Census run live against mainnet (output above).
- Java reference re-read to confirm the parity target rather than guessed at.
- No new rustfmt hunks beyond one in pre-existing code the edit touched (79 vs 78 baseline in `sync.rs`).

## Review round (Copilot + relayed live findings) — `7030b6d6`

- **Promotion targeted the wrong peer** (found independently by two reviewers): with alternates, the chunk that verifies can be a different peer's than the responder. Both apply paths now resolve `applied_from` via `id_for_key`; the drain loop promotes at all now.
- **Verify-rejects never evicted**: now compared against a dedicated `REJECT_EVICT_AT = 3` — deliberately *not* the unproven threshold of 1, because `process_update` also rejects merely *inapplicable* updates from honest servers, so evicting on the first would cull the very servers this rotation steers toward.
- **Drain-loop rejects were silent**: same peer-and-period WARN as the first path.
- **Span must adapt or the rotation evicts good servers** (relayed, verified live against Lighthouse v8.2.2): Lighthouse enforces its `updates_by_range` quota by closing the stream on any multi-count request while answering `count=1` fine. `ConnectionClosed` on a multi-count ask is now read as quota behaviour — no strike — and that peer is asked one period at a time thereafter.
- **The alternates test didn't test the code**: replaced with one that drives the real `apply_staged_step` using the committed LC corpus (real bootstrap + real update, corrupted leader) and asserts the alternate applies with correct attribution.
- **Census overclaimed**: renamed buckets/verdict to state it counts bits only.

## Known limitation — this does not by itself restore roost-free syncing

Measured with `roost@mainnet` stopped: the engine sat at period 1835 with 3 peers and `staged=0` — no peer returned data. The wedge-fix is not the binding constraint there; peer supply and request shape are. The span fallback above targets that directly, but the honest summary is: **this PR stops one bad update from wedging the walk; it is not a peer-supply fix.**

Also corrected on #342: my earlier `identify-advertised LC protocol: 0` observation was a measurement artifact (`lc_servers` is scoped to the connected set and pruned on disconnect, so a one-shot census reads it empty by construction). No Identify defect is implied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYVwpfHg77oibuD2733jPj
