### PR TITLE
Refresh the mainnet static CL peer list from a live census

### DIFF
--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/NetworkConfig.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/NetworkConfig.java
@@ -103,8 +103,10 @@ public record NetworkConfig(
             // an older digest are either stale ENRs or unupgraded nodes — matching
             // them wouldn't help us sync to the current head anyway.
             null,
-            // CL peer multiaddrs: known light-client-serving peers (nimbus, lodestar, lighthouse)
-            // discovered via Lighthouse peer API 2026-03-11
+            // CL peer multiaddrs: known light-client-serving peers. Provenance:
+            // originally discovered via the Lighthouse peer API 2026-03-11,
+            // re-censused via period_census 2026-09-01 (#410), re-verified and
+            // pruned 2026-09-02 (#411 — per-entry evidence in the list comments).
             // NOTE the order: the LITERAL leads and the NAME follows. That looks
             // backwards and is not — see ROOST_PIN_ORDER in the Rust twin. Java
             // walks this list in order and falls through, so a stale literal

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/NetworkConfig.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/NetworkConfig.java
@@ -119,8 +119,9 @@ public record NetworkConfig(
             prependLocal(
                     "/dns4/be833f3590cd0388.dyndns.dappnode.io/tcp/9109/p2p/16Uiu2HAmAj4D6YGK1kvVL2ZtnoCjp3hdz3j6QLCNh6afhSuwYjLC",
             List.of(
-                    // Re-verified 2026-09-02 — census served a 512/512 period-1840
-                    // update (first three) or TCP-alive; TCP-dead entries pruned.
+                    // Re-verified 2026-09-02 — the first two served the census a
+                    // 512/512 period-1840 update, the third served the standalone
+                    // Nimbus light client; the rest TCP-alive. TCP-dead pruned.
                     // Mirror of the Rust MAINNET_STATIC_PEERS: keep the two lists
                     // and their ORDER in step (see the reasoning there).
                     "/ip4/57.129.130.18/tcp/9000/p2p/16Uiu2HAkwmBd7zSRAiBkGar6ghHYfKCKTpGbGL1igrD6mC4W99T9",

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/NetworkConfig.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/NetworkConfig.java
@@ -119,27 +119,21 @@ public record NetworkConfig(
             prependLocal(
                     "/dns4/be833f3590cd0388.dyndns.dappnode.io/tcp/9109/p2p/16Uiu2HAmAj4D6YGK1kvVL2ZtnoCjp3hdz3j6QLCNh6afhSuwYjLC",
             List.of(
-                    // nimbus peers (4 light_client protocols)
-                    "/ip4/176.229.58.1/tcp/9001/p2p/16Uiu2HAmHu1BxzrSWg7sN9JyJenC5unK5ntdk5QFYqQdQyyD7x3a",
-                    "/ip4/81.172.166.237/tcp/9001/p2p/16Uiu2HAmRogw5aqM4ZuVEmZoQvFp25sUnnQ9wpGuWXRLFMmXc88j",
-                    "/ip4/54.157.213.0/tcp/9000/p2p/16Uiu2HAmQz83bNmMaBFCafuxDasiNdPYZF1B4zhgo3DckByU8bo3",
-                    "/ip4/84.229.246.214/tcp/9001/p2p/16Uiu2HAm1UtRynVpuvWUgn3bfNooSUKYSUrbW8oeuBBcwVxbC1c9",
-                    "/ip4/73.205.184.197/tcp/9000/p2p/16Uiu2HAm9CKG1x5rJk6sgEnCh9TKRagNEVVJfjR1jC3ruzPQfwzb",
-                    "/ip4/172.92.13.157/tcp/9000/p2p/16Uiu2HAm7TEx4DP8iVj1RedeDNK59pw9AskGRwV7x9vgexTQi8CM",
-                    "/ip4/77.12.100.127/tcp/9012/p2p/16Uiu2HAmA5VXnNKGu9jmV5yhL3tGy5seiNMnaBMTaV1vBesz84iJ",
+                    // Re-verified 2026-09-02 — census served a 512/512 period-1840
+                    // update (first three) or TCP-alive; TCP-dead entries pruned.
+                    // Mirror of the Rust MAINNET_STATIC_PEERS: keep the two lists
+                    // and their ORDER in step (see the reasoning there).
+                    "/ip4/57.129.130.18/tcp/9000/p2p/16Uiu2HAkwmBd7zSRAiBkGar6ghHYfKCKTpGbGL1igrD6mC4W99T9",
+                    "/ip4/84.112.35.112/tcp/9000/p2p/16Uiu2HAm6YkLaGLMH1Q9caGi4A2WctHPhENumfQMJXVCMVpc7GQY",
+                    "/ip4/91.189.182.90/tcp/9000/p2p/16Uiu2HAmJJUAs17wxW1i4HM5Fce1zYPCvvavxsYorWr4EQVx1Ui8",
                     "/ip4/52.200.203.85/tcp/9000/p2p/16Uiu2HAm6JKuoWTSKP7uTbe1PESUcejo4ffcaADoRMuKmMJQKBeP",
                     "/ip4/82.139.21.242/tcp/9802/p2p/16Uiu2HAm5LSnoe8EdTDhrPEm4M1fnYw34zSo2SYbXLLH4FtfcfnL",
                     "/ip4/217.67.221.74/tcp/9037/p2p/16Uiu2HAmExQubp4XC5KoQwvYxNWJP2M5rpX3VKdtEYgwPnMb5Kn4",
                     "/ip4/135.181.210.123/tcp/9000/p2p/16Uiu2HAmBWXZS9H2ncxgEcVi77GvYtmGUEGpHNyJxsF3Ct25Uidc",
-                    "/ip4/195.201.160.183/tcp/9000/p2p/16Uiu2HAm79xzMY5FNnXGo6xcBRxCzYvMNE7CM6NZytrjXoDB5yRQ",
                     "/ip4/45.10.55.78/tcp/9000/p2p/16Uiu2HAmCpe6iMDvcXFmjLVpJ98u1fqNehpDLS2dmMRgxQ8mgMKu",
                     "/ip4/185.107.68.131/tcp/9000/p2p/16Uiu2HAm3sGDmyV3m4tju3SzekGt2EBSnALQNdn9QebPSiQP5NA2",
                     "/ip4/51.161.218.70/tcp/9000/p2p/16Uiu2HAmE6fJp7ZZVMUFxZGgfxAvfVyX3GDU6Wh88GvWv5U6SriT",
-                    // lodestar peers (4 light_client protocols)
-                    "/ip4/216.105.170.30/tcp/9000/p2p/16Uiu2HAm86YwyECbBiHTo2imwQJ4UXGgR1NLY2W6dPUfEFDony6d",
-                    // lighthouse peers (3 light_client protocols)
-                    "/ip4/54.201.148.177/tcp/9000/p2p/16Uiu2HAmNwEsdBC2phX7qU7camNe9Gs21WyrpV5AZDYyjZBMYjWZ",
-                    "/ip4/16.63.94.117/tcp/9000/p2p/16Uiu2HAmSd7qzG5joNgvEYYcgVvg1y9MiYjpMHMvzRzaWYqXxkCM"
+                    "/ip4/54.201.148.177/tcp/9000/p2p/16Uiu2HAmNwEsdBC2phX7qU7camNe9Gs21WyrpV5AZDYyjZBMYjWZ"
             )),
             "http://localhost:5052",
             1606824023L, // mainnet beacon genesis: 2020-12-01 12:00:23 UTC

--- a/networking/src/test/java/com/jaeckel/ethp2p/networking/NetworkConfigGnosisTest.java
+++ b/networking/src/test/java/com/jaeckel/ethp2p/networking/NetworkConfigGnosisTest.java
@@ -206,7 +206,7 @@ class NetworkConfigGnosisTest {
                         + "16Uiu2HAmAj4D6YGK1kvVL2ZtnoCjp3hdz3j6QLCNh6afhSuwYjLC",
                 cl.get(0),
                 "roost mainnet must be the first CL peer tried");
-        assertEquals(19, cl.size(),
-                "18 discovered peers + roost; pinning must not drop the fallbacks");
+        assertEquals(12, cl.size(),
+                "11 verified peers + roost; pinning must not drop the fallbacks");
     }
 }

--- a/networking/src/test/java/com/jaeckel/ethp2p/networking/NetworkConfigGnosisTest.java
+++ b/networking/src/test/java/com/jaeckel/ethp2p/networking/NetworkConfigGnosisTest.java
@@ -201,12 +201,27 @@ class NetworkConfigGnosisTest {
         // It also matters more here than in Rust: addPeer inserts discovered
         // peers at Math.min(1, size()), so presence-anywhere is a weak claim on
         // this side.
+        // The FULL list, order and addresses — the Rust twin
+        // (mainnet_config_matches_networkconfig_java) pins the same 12 strings,
+        // so an address typo or one-sided IP rotation fails a test on WHICHEVER
+        // side diverges; count + element 0 alone let elements 1-11 drift
+        // machine-unchecked (PR #411 review).
         List<String> cl = NetworkConfig.MAINNET.clPeerMultiaddrs();
-        assertEquals("/dns4/be833f3590cd0388.dyndns.dappnode.io/tcp/9109/p2p/"
-                        + "16Uiu2HAmAj4D6YGK1kvVL2ZtnoCjp3hdz3j6QLCNh6afhSuwYjLC",
-                cl.get(0),
-                "roost mainnet must be the first CL peer tried");
-        assertEquals(12, cl.size(),
-                "11 verified peers + roost; pinning must not drop the fallbacks");
+        assertEquals(List.of(
+                "/dns4/be833f3590cd0388.dyndns.dappnode.io/tcp/9109/p2p/16Uiu2HAmAj4D6YGK1kvVL2ZtnoCjp3hdz3j6QLCNh6afhSuwYjLC",
+                "/ip4/57.129.130.18/tcp/9000/p2p/16Uiu2HAkwmBd7zSRAiBkGar6ghHYfKCKTpGbGL1igrD6mC4W99T9",
+                "/ip4/84.112.35.112/tcp/9000/p2p/16Uiu2HAm6YkLaGLMH1Q9caGi4A2WctHPhENumfQMJXVCMVpc7GQY",
+                "/ip4/91.189.182.90/tcp/9000/p2p/16Uiu2HAmJJUAs17wxW1i4HM5Fce1zYPCvvavxsYorWr4EQVx1Ui8",
+                "/ip4/52.200.203.85/tcp/9000/p2p/16Uiu2HAm6JKuoWTSKP7uTbe1PESUcejo4ffcaADoRMuKmMJQKBeP",
+                "/ip4/82.139.21.242/tcp/9802/p2p/16Uiu2HAm5LSnoe8EdTDhrPEm4M1fnYw34zSo2SYbXLLH4FtfcfnL",
+                "/ip4/217.67.221.74/tcp/9037/p2p/16Uiu2HAmExQubp4XC5KoQwvYxNWJP2M5rpX3VKdtEYgwPnMb5Kn4",
+                "/ip4/135.181.210.123/tcp/9000/p2p/16Uiu2HAmBWXZS9H2ncxgEcVi77GvYtmGUEGpHNyJxsF3Ct25Uidc",
+                "/ip4/45.10.55.78/tcp/9000/p2p/16Uiu2HAmCpe6iMDvcXFmjLVpJ98u1fqNehpDLS2dmMRgxQ8mgMKu",
+                "/ip4/185.107.68.131/tcp/9000/p2p/16Uiu2HAm3sGDmyV3m4tju3SzekGt2EBSnALQNdn9QebPSiQP5NA2",
+                "/ip4/51.161.218.70/tcp/9000/p2p/16Uiu2HAmE6fJp7ZZVMUFxZGgfxAvfVyX3GDU6Wh88GvWv5U6SriT",
+                "/ip4/54.201.148.177/tcp/9000/p2p/16Uiu2HAmNwEsdBC2phX7qU7camNe9Gs21WyrpV5AZDYyjZBMYjWZ"),
+                cl,
+                "same list, order AND addresses as the Rust MAINNET_STATIC_PEERS; "
+                        + "roost mainnet must be the first CL peer tried");
     }
 }

--- a/rust/myotis-net/src/sync.rs
+++ b/rust/myotis-net/src/sync.rs
@@ -544,8 +544,12 @@ const GNOSIS_BOOTSTRAP_ENRS: &[&str] = &[
     "enr:-KG4QM_0UweYmWFjBAaZ1JnMTeUkeGgHWEVp3N2vewhkzNtlRlnObTaz3ki1RP1lNvOvMBh_iOu0-LnEacfdZN8dx4IChGV0aDKQMjfatgYAAGT__________4JpZIJ2NIJpcIRXmtGhiXNlY3AyNTZrMaEDM0NY9iNV9hZMrtkoRrPEKj7tm2TLriwZv-m1ctszvvKDdGNwgiOUg3VkcIIjlA",
 ];
 
-/// Known light-client-serving mainnet peers — the Java `NetworkConfig.MAINNET`
-/// clPeerMultiaddrs list (nimbus/lodestar/lighthouse, discovered 2026-03-11).
+/// Known light-client-serving mainnet peers — mirrored with the Java
+/// `NetworkConfig.MAINNET` clPeerMultiaddrs list (same entries, same order;
+/// both parity tests pin the full strings). Provenance: originally discovered
+/// via the Lighthouse peer API 2026-03-11, re-censused via period_census
+/// 2026-09-01 (#410), re-verified and pruned 2026-09-02 (#411 — per-entry
+/// evidence in the comments below).
 const MAINNET_STATIC_PEERS: &[&str] = &[
     // roost mainnet (rust/roost). FIRST for the same reason as sepolia: a
     // general-purpose beacon node shares one connection semaphore between
@@ -3187,11 +3191,12 @@ mod tests {
         assert_eq!(c.current_fork_digest(), [0x8C, 0x9F, 0x62, 0xFE]);
         assert_eq!(c.accepted_fork_digests(), vec![[0x8C, 0x9F, 0x62, 0xFE]]);
         // The FULL list, order and addresses — same discipline as the sepolia
-        // test below, for the same reason: the Java twin asserts full strings,
-        // and pinning only count + element 0 here (as this test once did) let a
-        // copy-paste divergence between the engines go machine-unchecked. roost
-        // is FIRST — the ordering is the point, not an accident of the list;
-        // the Java twin prepends it with prependLocal().
+        // test below, and the Java twin (NetworkConfigGnosisTest
+        // .mainnetPinsRoostFirst) pins the same 12 strings, so a one-sided edit
+        // fails a test on whichever side diverges; pinning only count +
+        // element 0 (as both tests once did) let elements 1-11 drift
+        // machine-unchecked. roost is FIRST — the ordering is the point, not an
+        // accident of the list; the Java twin prepends it with prependLocal().
         assert_eq!(
             c.static_peers,
             vec![

--- a/rust/myotis-net/src/sync.rs
+++ b/rust/myotis-net/src/sync.rs
@@ -567,8 +567,9 @@ const MAINNET_STATIC_PEERS: &[&str] = &[
     // Re-verified 2026-09-02 (census: updates_by_range(1840,1) answered with a
     // 512/512 update, or TCP-alive at minimum; TCP-dead entries pruned — the
     // roost comment above says why pinning an unreachable address is not free).
-    // The three below served a VERIFIABLE period-1840 update to this census
-    // and are cross-verified against independent clients:
+    // The three below are cross-verified against independent clients (the
+    // first two served this census a 512/512 period-1840 update; the third
+    // was verified via the standalone Nimbus light client):
     //  - 57.129.130.18: Lighthouse v8.2.2; enforces the one_every(10s) updates
     //    quota, so it serves ONE period per ask (single_period_peers handles it);
     //    also served the Java engine's catch-up (periods 1837-1838).
@@ -3185,16 +3186,33 @@ mod tests {
         // The live digest the Java computes (verified against jshell).
         assert_eq!(c.current_fork_digest(), [0x8C, 0x9F, 0x62, 0xFE]);
         assert_eq!(c.accepted_fork_digests(), vec![[0x8C, 0x9F, 0x62, 0xFE]]);
-        // 11 verified peers + roost mainnet, pinned by NAME only.
-        assert_eq!(c.static_peers.len(), 12);
-        // roost is FIRST — the ordering is the point, not an accident of the
-        // list. The Java twin prepends it with prependLocal(); if these two ever
-        // disagree on position, the default engine and the Rust engine pick
-        // different first-choice peers and only one of them is the dedicated one.
+        // The FULL list, order and addresses — same discipline as the sepolia
+        // test below, for the same reason: the Java twin asserts full strings,
+        // and pinning only count + element 0 here (as this test once did) let a
+        // copy-paste divergence between the engines go machine-unchecked. roost
+        // is FIRST — the ordering is the point, not an accident of the list;
+        // the Java twin prepends it with prependLocal().
         assert_eq!(
-            c.static_peers[0],
-            "/dns4/be833f3590cd0388.dyndns.dappnode.io/tcp/9109/p2p/16Uiu2HAmAj4D6YGK1kvVL2ZtnoCjp3hdz3j6QLCNh6afhSuwYjLC"
+            c.static_peers,
+            vec![
+                "/dns4/be833f3590cd0388.dyndns.dappnode.io/tcp/9109/p2p/16Uiu2HAmAj4D6YGK1kvVL2ZtnoCjp3hdz3j6QLCNh6afhSuwYjLC",
+                "/ip4/57.129.130.18/tcp/9000/p2p/16Uiu2HAkwmBd7zSRAiBkGar6ghHYfKCKTpGbGL1igrD6mC4W99T9",
+                "/ip4/84.112.35.112/tcp/9000/p2p/16Uiu2HAm6YkLaGLMH1Q9caGi4A2WctHPhENumfQMJXVCMVpc7GQY",
+                "/ip4/91.189.182.90/tcp/9000/p2p/16Uiu2HAmJJUAs17wxW1i4HM5Fce1zYPCvvavxsYorWr4EQVx1Ui8",
+                "/ip4/52.200.203.85/tcp/9000/p2p/16Uiu2HAm6JKuoWTSKP7uTbe1PESUcejo4ffcaADoRMuKmMJQKBeP",
+                "/ip4/82.139.21.242/tcp/9802/p2p/16Uiu2HAm5LSnoe8EdTDhrPEm4M1fnYw34zSo2SYbXLLH4FtfcfnL",
+                "/ip4/217.67.221.74/tcp/9037/p2p/16Uiu2HAmExQubp4XC5KoQwvYxNWJP2M5rpX3VKdtEYgwPnMb5Kn4",
+                "/ip4/135.181.210.123/tcp/9000/p2p/16Uiu2HAmBWXZS9H2ncxgEcVi77GvYtmGUEGpHNyJxsF3Ct25Uidc",
+                "/ip4/45.10.55.78/tcp/9000/p2p/16Uiu2HAmCpe6iMDvcXFmjLVpJ98u1fqNehpDLS2dmMRgxQ8mgMKu",
+                "/ip4/185.107.68.131/tcp/9000/p2p/16Uiu2HAm3sGDmyV3m4tju3SzekGt2EBSnALQNdn9QebPSiQP5NA2",
+                "/ip4/51.161.218.70/tcp/9000/p2p/16Uiu2HAmE6fJp7ZZVMUFxZGgfxAvfVyX3GDU6Wh88GvWv5U6SriT",
+                "/ip4/54.201.148.177/tcp/9000/p2p/16Uiu2HAmNwEsdBC2phX7qU7camNe9Gs21WyrpV5AZDYyjZBMYjWZ",
+            ],
+            "same list, order AND addresses as the Java NetworkConfig.MAINNET.clPeerMultiaddrs"
         );
+        // A malformed pin would otherwise reach run_sync and surface only as a
+        // "skipping unparseable static peer multiaddr" warn.
+        assert!(c.static_peers.iter().all(|p| parse_static_peer(p).is_some()));
         assert_eq!(c.bootstrap_enrs.len(), 18);
         assert_eq!(c.chain_id, 1);
     }

--- a/rust/myotis-net/src/sync.rs
+++ b/rust/myotis-net/src/sync.rs
@@ -564,24 +564,31 @@ const MAINNET_STATIC_PEERS: &[&str] = &[
     // because it makes no outbound connections — so this line is the thing that
     // breaks if the address moves.
     "/dns4/be833f3590cd0388.dyndns.dappnode.io/tcp/9109/p2p/16Uiu2HAmAj4D6YGK1kvVL2ZtnoCjp3hdz3j6QLCNh6afhSuwYjLC",
-    "/ip4/176.229.58.1/tcp/9001/p2p/16Uiu2HAmHu1BxzrSWg7sN9JyJenC5unK5ntdk5QFYqQdQyyD7x3a",
-    "/ip4/81.172.166.237/tcp/9001/p2p/16Uiu2HAmRogw5aqM4ZuVEmZoQvFp25sUnnQ9wpGuWXRLFMmXc88j",
-    "/ip4/54.157.213.0/tcp/9000/p2p/16Uiu2HAmQz83bNmMaBFCafuxDasiNdPYZF1B4zhgo3DckByU8bo3",
-    "/ip4/84.229.246.214/tcp/9001/p2p/16Uiu2HAm1UtRynVpuvWUgn3bfNooSUKYSUrbW8oeuBBcwVxbC1c9",
-    "/ip4/73.205.184.197/tcp/9000/p2p/16Uiu2HAm9CKG1x5rJk6sgEnCh9TKRagNEVVJfjR1jC3ruzPQfwzb",
-    "/ip4/172.92.13.157/tcp/9000/p2p/16Uiu2HAm7TEx4DP8iVj1RedeDNK59pw9AskGRwV7x9vgexTQi8CM",
-    "/ip4/77.12.100.127/tcp/9012/p2p/16Uiu2HAmA5VXnNKGu9jmV5yhL3tGy5seiNMnaBMTaV1vBesz84iJ",
+    // Re-verified 2026-09-02 (census: updates_by_range(1840,1) answered with a
+    // 512/512 update, or TCP-alive at minimum; TCP-dead entries pruned — the
+    // roost comment above says why pinning an unreachable address is not free).
+    // The three below served a VERIFIABLE period-1840 update to this census
+    // and are cross-verified against independent clients:
+    //  - 57.129.130.18: Lighthouse v8.2.2; enforces the one_every(10s) updates
+    //    quota, so it serves ONE period per ask (single_period_peers handles it);
+    //    also served the Java engine's catch-up (periods 1837-1838).
+    //  - 84.112.35.112: served the Java engine (1836-1837) and this census.
+    //  - 91.189.182.90: Nimbus fleet; served the standalone Nimbus light client
+    //    all five periods 1840-1844 in a single batched response (generous).
+    "/ip4/57.129.130.18/tcp/9000/p2p/16Uiu2HAkwmBd7zSRAiBkGar6ghHYfKCKTpGbGL1igrD6mC4W99T9",
+    "/ip4/84.112.35.112/tcp/9000/p2p/16Uiu2HAm6YkLaGLMH1Q9caGi4A2WctHPhENumfQMJXVCMVpc7GQY",
+    "/ip4/91.189.182.90/tcp/9000/p2p/16Uiu2HAmJJUAs17wxW1i4HM5Fce1zYPCvvavxsYorWr4EQVx1Ui8",
+    // TCP-alive on 2026-09-02 but declining libp2p dials at probe time (busy
+    // public nodes shed light clients first — flaky by construction, kept
+    // because they demonstrably served the period census within hours).
     "/ip4/52.200.203.85/tcp/9000/p2p/16Uiu2HAm6JKuoWTSKP7uTbe1PESUcejo4ffcaADoRMuKmMJQKBeP",
     "/ip4/82.139.21.242/tcp/9802/p2p/16Uiu2HAm5LSnoe8EdTDhrPEm4M1fnYw34zSo2SYbXLLH4FtfcfnL",
     "/ip4/217.67.221.74/tcp/9037/p2p/16Uiu2HAmExQubp4XC5KoQwvYxNWJP2M5rpX3VKdtEYgwPnMb5Kn4",
     "/ip4/135.181.210.123/tcp/9000/p2p/16Uiu2HAmBWXZS9H2ncxgEcVi77GvYtmGUEGpHNyJxsF3Ct25Uidc",
-    "/ip4/195.201.160.183/tcp/9000/p2p/16Uiu2HAm79xzMY5FNnXGo6xcBRxCzYvMNE7CM6NZytrjXoDB5yRQ",
     "/ip4/45.10.55.78/tcp/9000/p2p/16Uiu2HAmCpe6iMDvcXFmjLVpJ98u1fqNehpDLS2dmMRgxQ8mgMKu",
     "/ip4/185.107.68.131/tcp/9000/p2p/16Uiu2HAm3sGDmyV3m4tju3SzekGt2EBSnALQNdn9QebPSiQP5NA2",
     "/ip4/51.161.218.70/tcp/9000/p2p/16Uiu2HAmE6fJp7ZZVMUFxZGgfxAvfVyX3GDU6Wh88GvWv5U6SriT",
-    "/ip4/216.105.170.30/tcp/9000/p2p/16Uiu2HAm86YwyECbBiHTo2imwQJ4UXGgR1NLY2W6dPUfEFDony6d",
     "/ip4/54.201.148.177/tcp/9000/p2p/16Uiu2HAmNwEsdBC2phX7qU7camNe9Gs21WyrpV5AZDYyjZBMYjWZ",
-    "/ip4/16.63.94.117/tcp/9000/p2p/16Uiu2HAmSd7qzG5joNgvEYYcgVvg1y9MiYjpMHMvzRzaWYqXxkCM",
 ];
 
 /// Mainnet CL discv5 bootnodes — the Java `NetworkConfig.MAINNET`
@@ -3178,8 +3185,8 @@ mod tests {
         // The live digest the Java computes (verified against jshell).
         assert_eq!(c.current_fork_digest(), [0x8C, 0x9F, 0x62, 0xFE]);
         assert_eq!(c.accepted_fork_digests(), vec![[0x8C, 0x9F, 0x62, 0xFE]]);
-        // 18 discovered peers + roost mainnet, pinned by NAME only.
-        assert_eq!(c.static_peers.len(), 19);
+        // 11 verified peers + roost mainnet, pinned by NAME only.
+        assert_eq!(c.static_peers.len(), 12);
         // roost is FIRST — the ordering is the point, not an accident of the
         // list. The Java twin prepends it with prependLocal(); if these two ever
         // disagree on position, the default engine and the Rust engine pick


### PR DESCRIPTION
## What

Re-verifies every pinned mainnet CL peer empirically (2026-09-02) and rebuilds the list in **both engines, in lockstep**: 12 entries — roost first (design), three cross-verified servers, eight alive census survivors. The stale checkpoint is deliberately untouched (owner is testing against it).

## How the list was built

- **Census probe** (`period_census`, `MYOTIS_CL_STATIC_PEERS` + `MYOTIS_CL_DISABLE_DISCV5=1`, so only candidates are measured): `updates_by_range(1840, 1)` against all 22 candidates — the 9 legacy pins, the 10 census additions from #410, and 3 new candidates.
- **Raw TCP probes** to separate "dead" from "busy public node declining libp2p at probe time".

Results: 10 entries TCP-dead (7 legacy — dead across two days of probing — plus 3 of the #410 additions that churned within hours), pruned. Eight census entries TCP-alive but declining libp2p right now — flaky by construction (busy nodes shed light clients first), kept as fallbacks since they demonstrably served within hours.

## Added (cross-verified against independent clients)

- `57.129.130.18` — Lighthouse v8.2.2: served this census a 512/512 period-1840 update AND the Java engine's catch-up (periods 1837–1838). One-period-per-ask (its `one_every(10s)` updates quota) — which `single_period_peers` from #410 handles.
- `84.112.35.112` — served the Java engine (1836–1837) and this census.
- `91.189.182.90` — Nimbus fleet: served the standalone Nimbus light client all five periods 1840–1844 in a single batched response.

## Tests

- The mainnet parity test now asserts the **full string list** (order and addresses), matching the sepolia test's discipline — the internal review noted count+element-0 pinning let engine divergence go machine-unchecked — plus the `parse_static_peer` sweep sepolia already had.
- Java `NetworkConfigGnosisTest` roost-first + size 12.
- Rust `myotis-net` 325 green; `:networking` and `:myotis-engines` green.
- Internal no-context review verified engine parity element-by-element (byte-identical), multiaddr syntax, and that no other code references the removed entries (the two remaining hits are parser/quorum test fixtures using the IPs as inert strings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZjDDn6qE9QzhiJHHpKpmx