### PR TITLE
Surface verified-read failure reasons end to end

### DIFF
--- a/app-ios/src/iosMain/kotlin/io/myotis/ios/IosRpcBackend.kt
+++ b/app-ios/src/iosMain/kotlin/io/myotis/ios/IosRpcBackend.kt
@@ -331,22 +331,38 @@ class IosRpcBackend(
         return o
     }
 
-    /** Tri-state JSON passthrough: object string | literal "null" | null (can't verify). */
+    /** Tri-state JSON passthrough: object string | literal "null" | null (can't
+     *  verify). A single-key `{"error": ...}` envelope PASSES THROUGH — the
+     *  shared router unwraps it into a -32000 carrying the engine's reason
+     *  (api VerifiedReads contract). Flattening it to null here was the iOS
+     *  hole in the "diagnostics must not depend on the host" guarantee: the
+     *  Rust C ABI already emits exactly this shape (eljson::error_json). */
     private fun triStateJson(json: String): String? {
         val t = json.trim()
         if (t.isEmpty()) return null
         if (t == "null") return t
+        if (isEngineErrorEnvelope(t)) return t
         return if (resultOrNull(t) != null) t else null
     }
 
     /** [triStateJson]'s array twin (eth_getBlockReceipts): array string |
-     *  literal "null" | null. An `{"error"}` envelope (an object) → null. */
+     *  literal "null" | the `{"error"}` envelope (passed through for the
+     *  router to unwrap) | null. */
     private fun triStateArrayJson(json: String): String? {
         val t = json.trim()
         if (t.isEmpty()) return null
         if (t == "null") return t
+        if (isEngineErrorEnvelope(t)) return t
         val e = runCatching { engineJson.parseToJsonElement(t) }.getOrNull() ?: return null
         return if (e is kotlinx.serialization.json.JsonArray) t else null
+    }
+
+    /** The api VerifiedReads error envelope: a single-key `{"error": ...}`
+     *  object — same detection the router's orEngineThrow applies. */
+    private fun isEngineErrorEnvelope(t: String): Boolean {
+        if (!t.startsWith("{\"error\"")) return false
+        val o = runCatching { engineJson.parseToJsonElement(t).jsonObject }.getOrNull() ?: return false
+        return o.size == 1 && o.containsKey("error")
     }
 
     private fun statusOrNull(handle: Long): JsonObject? =

--- a/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/RpcRouter.kt
+++ b/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/RpcRouter.kt
@@ -286,7 +286,19 @@ class RpcRouter(
             // verifiable block: 8x peer returned 0 headers" (the 2026-09-02
             // stale-pool incident, whose generic "no peer / not synced" text
             // sent everyone chasing sync state while the node WAS synced).
+            //
+            // Deliberately no dev-proxy fallback here (unlike a bare-null
+            // decline): the engine ENGAGED verified serving and produced a
+            // diagnosis; forwarding to a proxy would mask exactly the failure
+            // this path exists to surface.
             logger.record(method ?: "request", idStr, "ERROR", elapsedMs(t0), -32000)
+            // A STALE_ANCHOR park must keep its curated, actionable message on
+            // this path too: the Rust engine reports the park through shared
+            // read plumbing ("beacon not synced" via anchored_head), which now
+            // arrives as an envelope — without this probe the operator
+            // guidance would fire only for methods whose failures still cross
+            // as bare nulls (PR review finding).
+            staleAnchorMessage(method ?: "request")?.let { return errorEnvelope(id, -32000, it) }
             return errorEnvelope(id, -32000,
                 "method '${method ?: "request"}' cannot be served verified right now: ${e.reason}")
         }
@@ -383,19 +395,8 @@ class RpcRouter(
                 // the caller acting, once the user decides. Same off-event-loop
                 // discipline as eth_syncing for the (non-blocking, but
                 // FFI-crossing) syncState probe.
-                val be = backend
-                val staleAnchor = be != null && withContext(rpcIoDispatcher) {
-                    be.syncState() == RpcSyncState.STALE_ANCHOR
-                }
-                if (staleAnchor) {
-                    errorEnvelope(id, -32000,
-                        "method '$m' refused: the node's trust anchor is past the " +
-                            "weak-subjectivity bound and syncing is paused awaiting user " +
-                            "consent — raise the bound or accept the risk (Settings / " +
-                            "accept-stale-anchor; details via myotis_beaconStatus)")
-                } else {
-                    errorEnvelope(id, -32000, "method '$m' cannot be served verified right now (no peer / not synced)")
-                }
+                staleAnchorMessage(m)?.let { return errorEnvelope(id, -32000, it) }
+                errorEnvelope(id, -32000, "method '$m' cannot be served verified right now (no peer / not synced)")
             } else {
                 errorEnvelope(id, -32601, "method '$m' is not supported by this permissionless node")
             }
@@ -438,12 +439,34 @@ class RpcRouter(
      *  a reason a wallet/operator needs (mirrors the eth_getLogs contract,
      *  which pioneered the shape for index-coverage errors). */
     private fun String.orEngineThrow(): String {
+        // Fast path: both engines emit the envelope verbatim as {"error":...}
+        // and nothing else starts that way (a block object starts with its own
+        // first field), so a multi-MB full-transactions block is never parsed
+        // twice just to prove it isn't an error.
+        if (!startsWith("{\"error\"")) return this
         val parsed = try { json.parseToJsonElement(this) } catch (_: Exception) { return this }
         val obj = parsed as? JsonObject ?: return this
         if (obj.size != 1) return this
         val err = obj["error"] ?: return this
         val msg = (err as? JsonPrimitive)?.contentOrNull ?: err.toString()
         throw EngineReadUnavailable(msg)
+    }
+
+    /** The curated STALE_ANCHOR refusal for [method], or null when the node
+     *  isn't parked. Shared by the bare-null decline path and the
+     *  [EngineReadUnavailable] path — the park must keep its actionable
+     *  message ("raise the bound or accept the risk") no matter which shape
+     *  the failure crossed the backend boundary in: unlike ordinary
+     *  not-synced it will NOT progress without a human deciding. Same
+     *  off-event-loop discipline as eth_syncing for the FFI-crossing probe. */
+    private suspend fun staleAnchorMessage(method: String): String? {
+        val be = backend ?: return null
+        val parked = withContext(rpcIoDispatcher) { be.syncState() == RpcSyncState.STALE_ANCHOR }
+        if (!parked) return null
+        return "method '$method' refused: the node's trust anchor is past the " +
+            "weak-subjectivity bound and syncing is paused awaiting user " +
+            "consent — raise the bound or accept the risk (Settings / " +
+            "accept-stale-anchor; details via myotis_beaconStatus)"
     }
 
     private suspend fun tryVerified(method: String?, id: JsonElement, root: JsonObject): String? {

--- a/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/RpcRouter.kt
+++ b/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/RpcRouter.kt
@@ -277,7 +277,19 @@ class RpcRouter(
             }
         }
         val t0 = TimeSource.Monotonic.markNow()
-        val verified = tryVerified(method, id, root)
+        val verified = try {
+            tryVerified(method, id, root)
+        } catch (e: EngineReadUnavailable) {
+            // A backend read that failed WITH a reason: the same -32000 class
+            // as the generic decline below, but carrying the engine's actual
+            // diagnosis — e.g. "all 8 snap peer(s) failed to serve a
+            // verifiable block: 8x peer returned 0 headers" (the 2026-09-02
+            // stale-pool incident, whose generic "no peer / not synced" text
+            // sent everyone chasing sync state while the node WAS synced).
+            logger.record(method ?: "request", idStr, "ERROR", elapsedMs(t0), -32000)
+            return errorEnvelope(id, -32000,
+                "method '${method ?: "request"}' cannot be served verified right now: ${e.reason}")
+        }
         if (verified != null) {
             // Label the answer for what it IS. A served override ran over
             // verified state but under the CALLER'S hypothesis, so it is not a
@@ -412,6 +424,28 @@ class RpcRouter(
      * The state-reading handlers (eth_call / eth_getBalance / …) are BLOCKING, so
      * they run on the IO dispatcher to keep the Ktor worker thread free.
      */
+    /** Thrown inside [tryVerified] when a backend JSON read carried an engine
+     *  {"error": ...} envelope; caught at the dispatch site in [handleOne] and
+     *  surfaced as -32000 WITH the engine's reason instead of the generic
+     *  no-peer/not-synced text. */
+    private class EngineReadUnavailable(val reason: String) : RuntimeException(reason)
+
+    /** Unwrap an engine error envelope from a JSON-string read result: a
+     *  single-key `{"error": ...}` object throws [EngineReadUnavailable] (so
+     *  the call sites stay one-liners); every normal result — block object,
+     *  receipt array, the literal "null" — passes through untouched. Engines
+     *  return the envelope instead of a bare null exactly when the failure has
+     *  a reason a wallet/operator needs (mirrors the eth_getLogs contract,
+     *  which pioneered the shape for index-coverage errors). */
+    private fun String.orEngineThrow(): String {
+        val parsed = try { json.parseToJsonElement(this) } catch (_: Exception) { return this }
+        val obj = parsed as? JsonObject ?: return this
+        if (obj.size != 1) return this
+        val err = obj["error"] ?: return this
+        val msg = (err as? JsonPrimitive)?.contentOrNull ?: err.toString()
+        throw EngineReadUnavailable(msg)
+    }
+
     private suspend fun tryVerified(method: String?, id: JsonElement, root: JsonObject): String? {
         val b = backend ?: return null
         return when (method) {
@@ -561,14 +595,14 @@ class RpcRouter(
                 // CAN'T verify (not synced / no peer), which falls through to the strict
                 // error — so we never tell the wallet "pending on a healthy chain" when we
                 // actually couldn't check.
-                val receiptJson = withContext(rpcIoDispatcher) { b.getTransactionReceipt(txHash) } ?: return null
+                val receiptJson = withContext(rpcIoDispatcher) { b.getTransactionReceipt(txHash) }?.orEngineThrow() ?: return null
                 resultEnvelope(id, json.parseToJsonElement(receiptJson)) // "null" → JsonNull result
             }
             "eth_getTransactionByHash" -> {
                 val txHash = (root.params()?.getOrNull(0) as? JsonPrimitive)?.asHexBytes() ?: return null
                 // Object string when found (mined or pending-from-our-cache); "null" for a
                 // verified-unknown tx; Kotlin null (can't verify) → strict error.
-                val txJson = withContext(rpcIoDispatcher) { b.getTransactionByHash(txHash) } ?: return null
+                val txJson = withContext(rpcIoDispatcher) { b.getTransactionByHash(txHash) }?.orEngineThrow() ?: return null
                 resultEnvelope(id, json.parseToJsonElement(txJson))
             }
             "eth_getBlockByNumber" -> {
@@ -584,7 +618,7 @@ class RpcRouter(
                 }
                 // Object string when found; "null" for a future/unknown block; Kotlin null
                 // (can't verify) → fall through to the strict error.
-                val blockJson = withContext(rpcIoDispatcher) { b.getBlockByNumber(block, fullTx) } ?: return null
+                val blockJson = withContext(rpcIoDispatcher) { b.getBlockByNumber(block, fullTx) }?.orEngineThrow() ?: return null
                 resultEnvelope(id, json.parseToJsonElement(blockJson))
             }
             "eth_getBlockByHash" -> {
@@ -599,7 +633,7 @@ class RpcRouter(
                 }
                 // Object string when found; "null" for an unknown/non-canonical hash; Kotlin
                 // null (can't verify) → strict error.
-                val blockJson = withContext(rpcIoDispatcher) { b.getBlockByHash(blockHash, fullTx) } ?: return null
+                val blockJson = withContext(rpcIoDispatcher) { b.getBlockByHash(blockHash, fullTx) }?.orEngineThrow() ?: return null
                 resultEnvelope(id, json.parseToJsonElement(blockJson))
             }
             // ---- compat batch: answers derived from reads already served above ----
@@ -638,50 +672,50 @@ class RpcRouter(
             // null) carries through unchanged.
             "eth_getBlockTransactionCountByNumber" -> {
                 val block = root.params().specShapedBlockTag(0) ?: return null
-                val blockJson = withContext(rpcIoDispatcher) { b.getBlockByNumber(block, false) } ?: return null
+                val blockJson = withContext(rpcIoDispatcher) { b.getBlockByNumber(block, false) }?.orEngineThrow() ?: return null
                 blockArraySizeResult(id, blockJson, "transactions")
             }
             "eth_getBlockTransactionCountByHash" -> {
                 val blockHash = (root.params()?.getOrNull(0))?.asHexBytes()?.takeIf { it.size == 32 } ?: return null
-                val blockJson = withContext(rpcIoDispatcher) { b.getBlockByHash(blockHash, false) } ?: return null
+                val blockJson = withContext(rpcIoDispatcher) { b.getBlockByHash(blockHash, false) }?.orEngineThrow() ?: return null
                 blockArraySizeResult(id, blockJson, "transactions")
             }
             "eth_getTransactionByBlockNumberAndIndex" -> {
                 val p = root.params()
                 val block = p.specShapedBlockTag(0) ?: return null
                 val index = p?.getOrNull(1)?.asQuantityIndex() ?: return null
-                val blockJson = withContext(rpcIoDispatcher) { b.getBlockByNumber(block, true) } ?: return null
+                val blockJson = withContext(rpcIoDispatcher) { b.getBlockByNumber(block, true) }?.orEngineThrow() ?: return null
                 txAtIndexResult(id, blockJson, index)
             }
             "eth_getTransactionByBlockHashAndIndex" -> {
                 val p = root.params()
                 val blockHash = (p?.getOrNull(0))?.asHexBytes()?.takeIf { it.size == 32 } ?: return null
                 val index = p?.getOrNull(1)?.asQuantityIndex() ?: return null
-                val blockJson = withContext(rpcIoDispatcher) { b.getBlockByHash(blockHash, true) } ?: return null
+                val blockJson = withContext(rpcIoDispatcher) { b.getBlockByHash(blockHash, true) }?.orEngineThrow() ?: return null
                 txAtIndexResult(id, blockJson, index)
             }
             "eth_getUncleCountByBlockNumber" -> {
                 val block = root.params().specShapedBlockTag(0) ?: return null
-                val blockJson = withContext(rpcIoDispatcher) { b.getBlockByNumber(block, false) } ?: return null
+                val blockJson = withContext(rpcIoDispatcher) { b.getBlockByNumber(block, false) }?.orEngineThrow() ?: return null
                 blockArraySizeResult(id, blockJson, "uncles")
             }
             "eth_getUncleCountByBlockHash" -> {
                 val blockHash = (root.params()?.getOrNull(0))?.asHexBytes()?.takeIf { it.size == 32 } ?: return null
-                val blockJson = withContext(rpcIoDispatcher) { b.getBlockByHash(blockHash, false) } ?: return null
+                val blockJson = withContext(rpcIoDispatcher) { b.getBlockByHash(blockHash, false) }?.orEngineThrow() ?: return null
                 blockArraySizeResult(id, blockJson, "uncles")
             }
             "eth_getUncleByBlockNumberAndIndex" -> {
                 val p = root.params()
                 val block = p.specShapedBlockTag(0) ?: return null
                 val index = p?.getOrNull(1)?.asQuantityIndex() ?: return null
-                val blockJson = withContext(rpcIoDispatcher) { b.getBlockByNumber(block, false) } ?: return null
+                val blockJson = withContext(rpcIoDispatcher) { b.getBlockByNumber(block, false) }?.orEngineThrow() ?: return null
                 uncleAtIndexResult(id, blockJson, index)
             }
             "eth_getUncleByBlockHashAndIndex" -> {
                 val p = root.params()
                 val blockHash = (p?.getOrNull(0))?.asHexBytes()?.takeIf { it.size == 32 } ?: return null
                 val index = p?.getOrNull(1)?.asQuantityIndex() ?: return null
-                val blockJson = withContext(rpcIoDispatcher) { b.getBlockByHash(blockHash, false) } ?: return null
+                val blockJson = withContext(rpcIoDispatcher) { b.getBlockByHash(blockHash, false) }?.orEngineThrow() ?: return null
                 uncleAtIndexResult(id, blockJson, index)
             }
             "eth_getBlockReceipts" -> {
@@ -706,7 +740,7 @@ class RpcRouter(
                 // Array string when served; "null" for a verified unknown/future
                 // block; Kotlin null (can't verify) → strict error.
                 val receiptsJson =
-                    withContext(rpcIoDispatcher) { b.getBlockReceipts(selector) } ?: return null
+                    withContext(rpcIoDispatcher) { b.getBlockReceipts(selector) }?.orEngineThrow() ?: return null
                 resultEnvelope(id, json.parseToJsonElement(receiptsJson))
             }
             "eth_getLogs" -> {

--- a/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/RpcRouter.kt
+++ b/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/RpcRouter.kt
@@ -824,7 +824,7 @@ class RpcRouter(
                     else -> return null
                 }
                 val historyJson = withContext(rpcIoDispatcher) { b.feeHistory(blockCount, newest, pctArr) }
-                    ?: return null
+                    ?.orEngineThrow() ?: return null
                 resultEnvelope(id, json.parseToJsonElement(historyJson))
             }
             "eth_estimateGas" -> {

--- a/jsonrpc-server/src/jvmTest/kotlin/io/myotis/jsonrpc/RpcRouterTest.kt
+++ b/jsonrpc-server/src/jvmTest/kotlin/io/myotis/jsonrpc/RpcRouterTest.kt
@@ -797,6 +797,34 @@ class RpcRouterTest {
         assertEquals(-32000, errorCode(resp))                    // verified method, can't serve now
     }
 
+    @Test fun getBlockByNumber_engineErrorEnvelope_surfacesMessageAt32000() {
+        // The stale-pool incident (2026-09-02): the engine KNEW the reason and
+        // the wallet saw only "no peer / not synced" while the node was SYNCED.
+        val backend = object : VerifiedReads by FakeBackend() {
+            override fun getBlockByNumber(block: String?, fullTransactions: Boolean): String =
+                """{"error":"all 8 snap peer(s) failed to serve a verifiable block: 8x peer returned 0 headers, expected 1"}"""
+        }
+        val resp = route(backend,
+            """{"jsonrpc":"2.0","id":1,"method":"eth_getBlockByNumber","params":["latest", false]}""")
+        assertTrue(hasError(resp))
+        assertEquals(-32000, errorCode(resp))
+        assertTrue(resp.contains("8x peer returned 0 headers"))
+    }
+
+    @Test fun getBlockByNumber_composite_engineErrorEnvelope_surfacesToo() {
+        // Composites that derive from the block serve (tx count, tx/uncle by
+        // index) must surface the same reason, not embed the envelope as data.
+        val backend = object : VerifiedReads by FakeBackend() {
+            override fun getBlockByNumber(block: String?, fullTransactions: Boolean): String =
+                """{"error":"all 8 snap peer(s) failed to serve a verifiable block: 8x request timed out"}"""
+        }
+        val resp = route(backend,
+            """{"jsonrpc":"2.0","id":1,"method":"eth_getBlockTransactionCountByNumber","params":["latest"]}""")
+        assertTrue(hasError(resp))
+        assertEquals(-32000, errorCode(resp))
+        assertTrue(resp.contains("8x request timed out"))
+    }
+
     @Test fun getLogs_engineErrorEnvelope_surfacesMessageAt32000() {
         val backend = object : VerifiedReads by FakeBackend() {
             override fun getLogs(filterJson: String?): String =

--- a/myotis-api/src/main/java/io/myotis/api/VerifiedReads.java
+++ b/myotis-api/src/main/java/io/myotis/api/VerifiedReads.java
@@ -15,9 +15,10 @@ package io.myotis.api;
  * {@code {"error": "..."}} envelope in place of a bare {@code null} when the
  * failure carries a reason worth surfacing to the caller (the RPC router turns
  * it into a -32000 with that reason; {@code getLogs} pioneered the shape for
- * index-coverage errors). A bare {@code null} stays valid and maps to the
- * generic retryable error. Both engines implement the same convention —
- * diagnostics must not depend on the engine toggle.
+ * index-coverage errors — that method keeps its own, looser envelope contract).
+ * A bare {@code null} stays valid and maps to the generic retryable error.
+ * Both engines — and every host backend, iOS included — implement the same
+ * convention: diagnostics must not depend on the engine toggle or the host.
  *
  * <p>All methods are blocking; call from a worker thread. Block selectors are
  * strings: {@code "latest"}, {@code "pending"}, or a 0x-hex block number.

--- a/myotis-api/src/main/java/io/myotis/api/VerifiedReads.java
+++ b/myotis-api/src/main/java/io/myotis/api/VerifiedReads.java
@@ -11,6 +11,14 @@ package io.myotis.api;
  * literal {@code "null"} (a <em>verified</em> "not found" — e.g. an unknown tx on
  * a synced chain), or {@code null} (no verified answer).
  *
+ * <p>JSON-string read methods may additionally return a single-key
+ * {@code {"error": "..."}} envelope in place of a bare {@code null} when the
+ * failure carries a reason worth surfacing to the caller (the RPC router turns
+ * it into a -32000 with that reason; {@code getLogs} pioneered the shape for
+ * index-coverage errors). A bare {@code null} stays valid and maps to the
+ * generic retryable error. Both engines implement the same convention —
+ * diagnostics must not depend on the engine toggle.
+ *
  * <p>All methods are blocking; call from a worker thread. Block selectors are
  * strings: {@code "latest"}, {@code "pending"}, or a 0x-hex block number.
  */

--- a/myotis-engines/src/main/java/io/myotis/engines/RustVerifiedReads.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustVerifiedReads.java
@@ -146,7 +146,7 @@ final class RustVerifiedReads implements VerifiedReads {
         try {
             return handle.codeVerified(toHex(address));
         } catch (RuntimeException e) {
-            log.debug("[engines] verified code read unavailable: {}", e.getMessage());
+            log.info("[engines] verified code read unavailable: {}", e.getMessage());
             return null;
         }
     }
@@ -161,7 +161,7 @@ final class RustVerifiedReads implements VerifiedReads {
         try {
             return handle.storageAtVerified(toHex(address), toHex(slot32));
         } catch (RuntimeException e) {
-            log.debug("[engines] verified storage read unavailable: {}", e.getMessage());
+            log.info("[engines] verified storage read unavailable: {}", e.getMessage());
             return null;
         }
     }
@@ -198,7 +198,7 @@ final class RustVerifiedReads implements VerifiedReads {
                     block,
                     stateOverridesJson == null ? "" : stateOverridesJson);
         } catch (RuntimeException e) {
-            log.debug("[engines] verified eth_call (overrides) unavailable: {}", e.getMessage());
+            log.info("[engines] verified eth_call (overrides) unavailable: {}", e.getMessage());
             return null;
         }
     }
@@ -219,7 +219,7 @@ final class RustVerifiedReads implements VerifiedReads {
                     valueWei == null ? "" : valueWei,
                     block);
         } catch (RuntimeException e) {
-            log.debug("[engines] verified eth_call unavailable: {}", e.getMessage());
+            log.info("[engines] verified eth_call unavailable: {}", e.getMessage());
             return null;
         }
     }
@@ -242,7 +242,7 @@ final class RustVerifiedReads implements VerifiedReads {
                     : handle.ethCallVerifiedDetailedWithOverrides(
                             fromHex, toHex20, dataHex, value, block, stateOverridesJson);
         } catch (RuntimeException e) {
-            log.debug("[engines] verified eth_call (detailed) unavailable: {}", e.getMessage());
+            log.info("[engines] verified eth_call (detailed) unavailable: {}", e.getMessage());
             return io.myotis.api.CallResult.unavailable(e.getMessage());
         }
     }
@@ -270,8 +270,8 @@ final class RustVerifiedReads implements VerifiedReads {
             // polling), or throws when it can't verify (→ null → strict -32000).
             return handle.transactionReceiptJson(toHex(txHash));
         } catch (RuntimeException e) {
-            log.debug("[engines] verified receipt read unavailable: {}", e.getMessage());
-            return null;
+            log.info("[engines] verified receipt read unavailable: {}", e.getMessage());
+            return errJson(e);
         }
     }
 
@@ -287,9 +287,38 @@ final class RustVerifiedReads implements VerifiedReads {
             // own-sent-tx pending answer yet (needs the sent-tx cache).
             return handle.transactionByHashJson(toHex(txHash));
         } catch (RuntimeException e) {
-            log.debug("[engines] verified tx read unavailable: {}", e.getMessage());
-            return null;
+            log.info("[engines] verified tx read unavailable: {}", e.getMessage());
+            return errJson(e);
         }
+    }
+
+
+    /**
+     * Engine error envelope for the JSON-string read methods: `{"error": ...}`
+     * instead of a bare null, so the router can answer -32000 WITH the
+     * engine's reason (mirrors the eth_getLogs contract). A bare null told a
+     * wallet only "no peer / not synced" — during the 2026-09-02 stale-pool
+     * incident that text pointed at sync state while the node WAS synced and
+     * the real reason ("8x peer returned 0 headers") was swallowed here.
+     */
+    private static String errJson(RuntimeException e) {
+        String m = e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage();
+        StringBuilder b = new StringBuilder(m.length() + 16).append("{\"error\":\"");
+        for (int i = 0; i < m.length(); i++) {
+            char c = m.charAt(i);
+            switch (c) {
+                case '"' -> b.append("\\\"");
+                case '\\' -> b.append("\\\\");
+                case '\n' -> b.append("\\n");
+                case '\r' -> b.append("\\r");
+                case '\t' -> b.append("\\t");
+                default -> {
+                    if (c < 0x20) b.append(String.format("\\u%04x", (int) c));
+                    else b.append(c);
+                }
+            }
+        }
+        return b.append("\"}").toString();
     }
 
     @Override
@@ -301,8 +330,8 @@ final class RustVerifiedReads implements VerifiedReads {
             // block), or throws when it can't verify (→ null → -32000).
             return handle.blockByNumberJson(tag, fullTransactions);
         } catch (RuntimeException e) {
-            log.debug("[engines] verified block read unavailable: {}", e.getMessage());
-            return null;
+            log.info("[engines] verified block read unavailable: {}", e.getMessage());
+            return errJson(e);
         }
     }
 
@@ -315,8 +344,8 @@ final class RustVerifiedReads implements VerifiedReads {
             // verified / reorged away), or throws (→ null → strict -32000).
             return handle.blockByHashJson(toHex(blockHash32), fullTransactions);
         } catch (RuntimeException e) {
-            log.debug("[engines] verified block-by-hash read unavailable: {}", e.getMessage());
-            return null;
+            log.info("[engines] verified block-by-hash read unavailable: {}", e.getMessage());
+            return errJson(e);
         }
     }
 
@@ -343,8 +372,8 @@ final class RustVerifiedReads implements VerifiedReads {
             // block or never-verified hash), or throws (→ null → strict -32000).
             return handle.blockReceiptsJson(sel);
         } catch (RuntimeException e) {
-            log.debug("[engines] verified blockReceipts read unavailable: {}", e.getMessage());
-            return null;
+            log.info("[engines] verified blockReceipts read unavailable: {}", e.getMessage());
+            return errJson(e);
         }
     }
 
@@ -384,7 +413,7 @@ final class RustVerifiedReads implements VerifiedReads {
             // (→ null → strict -32000). No "null" literal case for this method.
             return handle.feeHistoryJson(blockCount, tag, percentilesJson);
         } catch (RuntimeException e) {
-            log.debug("[engines] verified feeHistory unavailable: {}", e.getMessage());
+            log.info("[engines] verified feeHistory unavailable: {}", e.getMessage());
             return null;
         }
     }
@@ -411,7 +440,7 @@ final class RustVerifiedReads implements VerifiedReads {
                     data == null ? "" : toHex(data),
                     valueWei == null ? "" : valueWei);
         } catch (RuntimeException e) {
-            log.debug("[engines] verified estimateGas (detailed) unavailable: {}", e.getMessage());
+            log.info("[engines] verified estimateGas (detailed) unavailable: {}", e.getMessage());
             return io.myotis.api.EstimateResult.unavailable(e.getMessage());
         }
     }
@@ -439,7 +468,7 @@ final class RustVerifiedReads implements VerifiedReads {
             // or a raw unchecked throwable off the native path) as "can't answer
             // verified right now" — the router's tryVerified dispatch is not
             // exception-guarded, so nothing may escape this adapter.
-            log.debug("[engines] verified account read unavailable: {}", e.getMessage());
+            log.info("[engines] verified account read unavailable: {}", e.getMessage());
             return null;
         }
     }

--- a/node-core/src/main/java/io/myotis/node/GatedVerifiedReads.java
+++ b/node-core/src/main/java/io/myotis/node/GatedVerifiedReads.java
@@ -122,27 +122,61 @@ final class GatedVerifiedReads implements VerifiedReads {
 
     @Override
     public String getTransactionReceipt(byte[] txHash) {
-        return guarded(d -> d.getTransactionReceipt(txHash));
+        return guardedJson(d -> d.getTransactionReceipt(txHash));
     }
 
     @Override
     public String getTransactionByHash(byte[] txHash) {
-        return guarded(d -> d.getTransactionByHash(txHash));
+        return guardedJson(d -> d.getTransactionByHash(txHash));
+    }
+
+
+    /**
+     * [guarded] for the JSON-string read methods, with the engine-error
+     * envelope contract the router understands: a read that THROWS with a
+     * message comes back as {"error": ...} instead of propagating (or being
+     * flattened to null), so the router can answer -32000 with the reason.
+     * Same contract as the Rust twin (RustVerifiedReads.errJson) — the two
+     * engines must fail identically or the same wallet sees different
+     * diagnostics depending on the engine toggle.
+     */
+    private String guardedJson(java.util.function.Function<VerifiedReads, String> call) {
+        try {
+            return guarded(call);
+        } catch (RuntimeException e) {
+            String m = e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage();
+            StringBuilder b = new StringBuilder(m.length() + 16).append("{\"error\":\"");
+            for (int i = 0; i < m.length(); i++) {
+                char c = m.charAt(i);
+                switch (c) {
+                    case '"' -> b.append("\\\"");
+                    case '\\' -> b.append("\\\\");
+                    case '\n' -> b.append("\\n");
+                    case '\r' -> b.append("\\r");
+                    case '\t' -> b.append("\\t");
+                    default -> {
+                        if (c < 0x20) b.append(String.format("\\u%04x", (int) c));
+                        else b.append(c);
+                    }
+                }
+            }
+            return b.append("\"}").toString();
+        }
     }
 
     @Override
     public String getBlockByNumber(String block, boolean fullTransactions) {
-        return guarded(d -> d.getBlockByNumber(block, fullTransactions));
+        return guardedJson(d -> d.getBlockByNumber(block, fullTransactions));
     }
 
     @Override
     public String getBlockByHash(byte[] blockHash32, boolean fullTransactions) {
-        return guarded(d -> d.getBlockByHash(blockHash32, fullTransactions));
+        return guardedJson(d -> d.getBlockByHash(blockHash32, fullTransactions));
     }
 
     @Override
     public String getBlockReceipts(String blockSelector) {
-        return guarded(d -> d.getBlockReceipts(blockSelector));
+        return guardedJson(d -> d.getBlockReceipts(blockSelector));
     }
 
     @Override

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -661,6 +661,39 @@ enum BlockFromError {
     Undecodable(String),
 }
 
+/// Compress a whole pool's per-peer failure strings into one diagnosis-grade
+/// line: identical reasons are counted ("6x request timed out"), distinct ones
+/// listed, the output bounded so it stays fit for an error message and a log
+/// ring. The old behavior kept only the LAST peer's error, which hid exactly
+/// the pattern that matters in a whole-pool failure — "all timeouts" (stale
+/// connections) reads very differently from "all window mismatches" (our head
+/// is ahead of the peers').
+fn summarize_peer_failures(failures: &[String]) -> String {
+    const MAX_REASON_CHARS: usize = 120;
+    const MAX_DISTINCT: usize = 4;
+    if failures.is_empty() {
+        return "no failures recorded".to_string();
+    }
+    let mut counts: Vec<(String, usize)> = Vec::new();
+    for f in failures {
+        let short: String = f.chars().take(MAX_REASON_CHARS).collect();
+        match counts.iter_mut().find(|(s, _)| *s == short) {
+            Some((_, n)) => *n += 1,
+            None => counts.push((short, 1)),
+        }
+    }
+    counts.sort_by(|a, b| b.1.cmp(&a.1));
+    let shown = counts.len().min(MAX_DISTINCT);
+    let mut parts: Vec<String> = counts[..shown]
+        .iter()
+        .map(|(s, n)| if *n > 1 { format!("{n}x {s}") } else { s.clone() })
+        .collect();
+    if counts.len() > shown {
+        parts.push(format!("(+{} more distinct reasons)", counts.len() - shown));
+    }
+    parts.join("; ")
+}
+
 /// A verified `eth_feeHistory` result (the Java `rpcFeeHistory` twin). Every
 /// value comes from the beacon-anchored header window; rewards additionally
 /// from bodies verified against `transactionsRoot` and receipts against
@@ -4199,7 +4232,7 @@ impl ElReader {
             return Err("no snap peer available".to_string());
         }
         let total = peers.len();
-        let mut last_err = String::new();
+        let mut failures: Vec<String> = Vec::with_capacity(total);
         for peer in &peers {
             match self.get_block_from(peer, target_num, back, &head_hash, full_transactions).await
             {
@@ -4218,11 +4251,18 @@ impl ElReader {
                 }
                 Err(BlockFromError::Peer(e)) => {
                     self.pool.record_snap_failure(peer.addr()).await;
-                    last_err = e;
+                    failures.push(e);
                 }
             }
         }
-        Err(format!("all {total} snap peer(s) failed to serve a verifiable block: {last_err}"))
+        let summary = summarize_peer_failures(&failures);
+        // WARN, not debug: a whole-pool verified-read failure is the moment an
+        // operator needs the per-peer reasons, and hosts keep info+ only in
+        // their log rings — debug-only reasons made the Android period-1840 /
+        // stale-pool incidents (2026-09-01/02) undiagnosable on-device.
+        tracing::warn!(total, target_num, back, summary = %summary,
+            "verified block fetch failed against every snap peer");
+        Err(format!("all {total} snap peer(s) failed to serve a verifiable block: {summary}"))
     }
 
     /// Fetch + verify one block against a single peer. Fetches the header window
@@ -4821,7 +4861,7 @@ impl ElReader {
             return Err("no snap peer available".to_string());
         }
         let total = peers.len();
-        let mut last_err = String::new();
+        let mut failures: Vec<String> = Vec::with_capacity(total);
         for peer in &peers {
             match self.block_receipts_from(peer, target_num, back, &head_hash).await {
                 Ok(served) => {
@@ -4830,12 +4870,17 @@ impl ElReader {
                 }
                 Err(e) => {
                     self.pool.record_snap_failure(peer.addr()).await;
-                    last_err = e;
+                    failures.push(e);
                 }
             }
         }
+        let summary = summarize_peer_failures(&failures);
+        // Same rationale as get_block_by_number: whole-pool failures must be
+        // diagnosable from an info+ log ring.
+        tracing::warn!(total, target_num, back, summary = %summary,
+            "verified receipts fetch failed against every snap peer");
         Err(format!(
-            "all {total} snap peer(s) failed to serve verifiable block receipts: {last_err}"
+            "all {total} snap peer(s) failed to serve verifiable block receipts: {summary}"
         ))
     }
 

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -5737,6 +5737,54 @@ fn decode_ccip_answer(
 mod tests {
     use super::*;
 
+    /// The whole-pool failure summary: what a stuck wallet's one visible error
+    /// line is built from, so its shape is pinned (2026-09-02 stale-pool
+    /// incident — "8x peer returned 0 headers" was the whole diagnosis).
+    mod failure_summaries {
+        use super::*;
+
+        #[test]
+        fn identical_reasons_collapse_with_a_count() {
+            let f = vec!["peer returned 0 headers, expected 1".to_string(); 8];
+            assert_eq!(
+                summarize_peer_failures(&f),
+                "8x peer returned 0 headers, expected 1"
+            );
+        }
+
+        #[test]
+        fn distinct_reasons_are_listed_most_frequent_first() {
+            let f = vec![
+                "request timed out".to_string(),
+                "peer disconnected".to_string(),
+                "request timed out".to_string(),
+            ];
+            assert_eq!(
+                summarize_peer_failures(&f),
+                "2x request timed out; peer disconnected"
+            );
+        }
+
+        #[test]
+        fn overflow_beyond_the_distinct_cap_is_counted_not_dropped_silently() {
+            let f: Vec<String> = (0..6).map(|i| format!("reason {i}")).collect();
+            let s = summarize_peer_failures(&f);
+            assert!(s.contains("(+2 more distinct reasons)"), "{s}");
+        }
+
+        #[test]
+        fn long_reasons_are_truncated() {
+            let f = vec!["x".repeat(500)];
+            let s = summarize_peer_failures(&f);
+            assert!(s.len() <= 130, "len {}", s.len());
+        }
+
+        #[test]
+        fn empty_input_yields_the_defensive_placeholder() {
+            assert_eq!(summarize_peer_failures(&[]), "no failures recorded");
+        }
+    }
+
     /// Hedging invariants (#320): a silent peer must not hold the read for the
     /// full request timeout, and — the half a naive per-attempt deadline gets
     /// wrong — a slow-but-working peer must still win when the peers after it


### PR DESCRIPTION
## Symptom

A failed ENS/verified query on Android answered only the generic `-32000 "(no peer / not synced)"` — while `myotis_status`/`myotis_beaconStatus` showed a SYNCED node with 8 snap peers. The real reason lived three swallowed layers down and took a live instrument-and-reinstall session to extract. With this PR the same request answers:

```
method 'eth_getBlockByNumber' cannot be served verified right now:
all 8 snap peer(s) failed to serve a verifiable block: 8x peer returned 0 headers, expected 1
```

(That diagnosis — every cached snap peer lagging behind our verified head — is the underlying wedge; its pool-rotation fix is a separate follow-up. This PR is the observability chain, verified end-to-end on the emulator against the live failure.)

## The three layers, un-swallowed

- **Rust reader**: a whole-pool block/receipts failure now aggregates per-peer reasons (`summarize_peer_failures`: identical reasons collapse with counts, frequency-ordered, bounded) instead of keeping only the last peer's error — and WARNs at info, so hosts' log rings show it on-device. Pinned by a new test module.
- **Engine adapters (both engines, same shape)**: the five JSON read methods (block by number/hash, receipt, tx by hash, block receipts) return the single-key `{"error": …}` envelope — the contract `eth_getLogs` pioneered — instead of a swallowed null; adapter swallow-logs raised debug→info. Documented on the API `VerifiedReads` interface; bare null stays valid and generic.
- **Router**: `orEngineThrow()` unwraps the envelope at all 13 consuming sites (composites like tx-count/tx-by-index included) and answers `-32000` **with the engine's reason**. Prefix fast path so a multi-MB block is never parsed twice. Two new router tests pin the direct and composite paths.

## From the internal review

- Its one real catch is fixed: the curated **STALE_ANCHOR** guidance ("raise the bound or accept the risk…") fired only on the bare-null path and would have vanished for exactly these five methods — the probe (`staleAnchorMessage`) is now consulted on both paths.
- **Deliberate**: the envelope path skips the dev proxy fallback (an engine that produced a diagnosis engaged verified serving; proxying would mask it) — commented in code.
- **Noted**: the Java engine's read paths rarely throw (its failures mostly cross as nulls already), so `guardedJson` there is mainly shape-parity plus a robustness net for unexpected exceptions that previously propagated raw; the envelope-collision audit came back clean (block/receipt/tx objects are multi-key, receipts are arrays, `"null"` is JsonNull, unparseable passes through). Follow-up candidates from the review: migrate `eth_getLogs` onto the shared unwrap (message-shape change, deliberately deferred), and a shared escaper in `myotis-api`.

## Verification

- End-to-end on the emulator against the genuine failure state (above).
- Rust `myotis-net` 330 tests green (incl. 5 new); `:jsonrpc-server` (2 new router tests), `:myotis-engines`, `:node-core` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZjDDn6qE9QzhiJHHpKpmx