### PR TITLE
Re-sync the mainnet discv4 bootnodes with go-ethereum

### DIFF
--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/NetworkConfig.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/NetworkConfig.java
@@ -79,11 +79,16 @@ public record NetworkConfig(
             Bytes32.fromHexString("d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"), // genesis (honest)
             new byte[]{(byte) 0x07, (byte) 0xc9, (byte) 0x46, (byte) 0x2e}, // post-BPO2 (Fusaka)
             0L,
+            // discv4 bootnodes = go-ethereum params/bootnodes.go MainnetBootnodes
+            // (labels are geth's), re-synced 2026-09-02: two stale entries replaced
+            // by the Hetzner pair. Keep in lockstep with the Rust twin
+            // (rust/myotis-net/src/el/reader.rs, ElConfig::mainnet), which
+            // documents the incident.
             List.of(
-                    new InetSocketAddress("18.138.108.67", 30303),
-                    new InetSocketAddress("3.209.45.79", 30303),
-                    new InetSocketAddress("18.188.214.86", 30303),
-                    new InetSocketAddress("3.219.208.172", 30303)
+                    new InetSocketAddress("18.138.108.67", 30303), // bootnode-aws-ap-southeast-1-001
+                    new InetSocketAddress("3.209.45.79", 30303),   // bootnode-aws-us-east-1-001
+                    new InetSocketAddress("65.108.70.101", 30303), // bootnode-hetzner-hel
+                    new InetSocketAddress("157.90.35.166", 30303)  // bootnode-hetzner-fsn
             ),
             // genesis_validators_root (mainnet)
             Bytes.fromHexString("4b363db94e286120d76eb905340fdd4e54bfe9f06bf33ff6cf5ad27f511bfe95").toArrayUnsafe(),

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -6145,7 +6145,20 @@ mod tests {
             c.genesis_hash,
             hex32("d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3")
         );
-        assert_eq!(c.bootnodes.len(), 4, "all four mainnet bootnodes must parse");
+        // The four discv4 seeds, pinned as strings: this const is the anchor
+        // the live tests build from and the Java NetworkConfig.MAINNET mirrors,
+        // so a partial re-sync fails here in a fast lib test.
+        let bootnodes: Vec<String> = c.bootnodes.iter().map(|a| a.to_string()).collect();
+        assert_eq!(
+            bootnodes,
+            [
+                "18.138.108.67:30303",
+                "3.209.45.79:30303",
+                "65.108.70.101:30303",
+                "157.90.35.166:30303",
+            ],
+            "mainnet discv4 bootnodes = go-ethereum MainnetBootnodes (see ElConfig::mainnet)"
+        );
     }
 
     #[test]

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -120,11 +120,21 @@ impl ElConfig {
     /// pinned hash the Java engine also carries; a hard fork would need a bump
     /// here (tracked as the EL-A7 fork-id item).
     pub fn mainnet() -> ElConfig {
+        // discv4 bootnodes = go-ethereum `params/bootnodes.go` MainnetBootnodes
+        // (labels are geth's), re-synced 2026-09-02. The previous list carried
+        // two addresses that are not in geth's current list (18.188.214.86,
+        // 3.219.208.172); observed from one vantage point that day, none of the
+        // old four answered a ping while both Hetzner entries did. With no
+        // pinned mainnet enodes and no EIP-1459 DNS fallback, an embedder's
+        // fresh profile (no EL peer cache) then never seeds discovery and never
+        // holds a snap peer. Mirror any change into the Java
+        // `NetworkConfig.MAINNET`, the live tests under `tests/` (they pin this
+        // list verbatim) and `rust/tor-poc/src/main.rs` (carries the pubkeys).
         const MAINNET_BOOTNODES: &[&str] = &[
-            "18.138.108.67:30303",
-            "3.209.45.79:30303",
-            "18.188.214.86:30303",
-            "3.219.208.172:30303",
+            "18.138.108.67:30303", // bootnode-aws-ap-southeast-1-001
+            "3.209.45.79:30303",   // bootnode-aws-us-east-1-001
+            "65.108.70.101:30303", // bootnode-hetzner-hel
+            "157.90.35.166:30303", // bootnode-hetzner-fsn
         ];
         ElConfig {
             network_id: 1,

--- a/rust/myotis-net/tests/live_discv4.rs
+++ b/rust/myotis-net/tests/live_discv4.rs
@@ -19,8 +19,8 @@ use myotis_net::el::discv4::{Discv4Config, Discv4Service};
 const MAINNET_BOOTNODES: &[&str] = &[
     "18.138.108.67:30303",
     "3.209.45.79:30303",
-    "18.188.214.86:30303",
-    "3.219.208.172:30303",
+    "65.108.70.101:30303",
+    "157.90.35.166:30303",
 ];
 
 #[tokio::test(flavor = "multi_thread")]

--- a/rust/myotis-net/tests/live_discv4.rs
+++ b/rust/myotis-net/tests/live_discv4.rs
@@ -14,14 +14,7 @@ use std::time::Duration;
 use myotis_core::keccak::keccak256;
 use myotis_core::nodekey::NodeKey;
 use myotis_net::el::discv4::{Discv4Config, Discv4Service};
-
-/// Mainnet discv4 bootnodes (ip:port), mirroring `NetworkConfig.MAINNET`.
-const MAINNET_BOOTNODES: &[&str] = &[
-    "18.138.108.67:30303",
-    "3.209.45.79:30303",
-    "65.108.70.101:30303",
-    "157.90.35.166:30303",
-];
+use myotis_net::el::reader::ElConfig;
 
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "live network test: pings mainnet discv4 bootnodes over UDP"]
@@ -34,10 +27,9 @@ async fn bonds_and_discovers_on_live_mainnet() {
         .try_init();
 
     let key = Arc::new(NodeKey::from_secret_bytes(&keccak256(b"myotis-live-discv4")).unwrap());
-    let bootnodes: Vec<SocketAddr> = MAINNET_BOOTNODES
-        .iter()
-        .map(|s| s.parse().expect("valid bootnode addr"))
-        .collect();
+    // Seed list = the engine config (one source of truth, pinned by
+    // `mainnet_config_pins_known_values`).
+    let bootnodes: Vec<SocketAddr> = ElConfig::mainnet().bootnodes;
 
     let (tx, mut rx) = tokio::sync::mpsc::channel(256);
     let service = Discv4Service::start(

--- a/rust/myotis-net/tests/live_eth.rs
+++ b/rust/myotis-net/tests/live_eth.rs
@@ -28,13 +28,7 @@ use myotis_core::nodekey::NodeKey;
 use myotis_net::el::discv4::{Discv4Config, Discv4Service, TableEntry};
 use myotis_net::el::eth::session::{EthConfig, EthSession};
 use myotis_net::el::rlpx::transport::RlpxConnection;
-
-const MAINNET_BOOTNODES: &[&str] = &[
-    "18.138.108.67:30303",
-    "3.209.45.79:30303",
-    "65.108.70.101:30303",
-    "157.90.35.166:30303",
-];
+use myotis_net::el::reader::ElConfig;
 
 /// Mainnet chain constants (mirror `NetworkConfig.MAINNET`).
 const MAINNET_GENESIS: &str = "d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3";
@@ -52,7 +46,7 @@ async fn fetches_and_verifies_headers_on_live_mainnet() {
         .try_init();
 
     let key = Arc::new(NodeKey::from_secret_bytes(&keccak256(b"myotis-live-eth")).unwrap());
-    let bootnodes: Vec<SocketAddr> = MAINNET_BOOTNODES.iter().map(|s| s.parse().unwrap()).collect();
+    let bootnodes: Vec<SocketAddr> = ElConfig::mainnet().bootnodes; // one source of truth
     let genesis = hex32(MAINNET_GENESIS);
 
     let (tx, mut rx) = tokio::sync::mpsc::channel::<TableEntry>(256);

--- a/rust/myotis-net/tests/live_eth.rs
+++ b/rust/myotis-net/tests/live_eth.rs
@@ -32,8 +32,8 @@ use myotis_net::el::rlpx::transport::RlpxConnection;
 const MAINNET_BOOTNODES: &[&str] = &[
     "18.138.108.67:30303",
     "3.209.45.79:30303",
-    "18.188.214.86:30303",
-    "3.219.208.172:30303",
+    "65.108.70.101:30303",
+    "157.90.35.166:30303",
 ];
 
 /// Mainnet chain constants (mirror `NetworkConfig.MAINNET`).

--- a/rust/myotis-net/tests/live_managed_peer.rs
+++ b/rust/myotis-net/tests/live_managed_peer.rs
@@ -24,13 +24,8 @@ use myotis_net::el::eth::session::{EthConfig, EthSession};
 use myotis_net::el::peer::ManagedPeer;
 use myotis_net::el::rlpx::transport::RlpxConnection;
 use myotis_net::el::snap::fetch::AccountOutcome;
+use myotis_net::el::reader::ElConfig;
 
-const MAINNET_BOOTNODES: &[&str] = &[
-    "18.138.108.67:30303",
-    "3.209.45.79:30303",
-    "65.108.70.101:30303",
-    "157.90.35.166:30303",
-];
 const MAINNET_GENESIS: &str = "d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3";
 const MAINNET_FORK_ID: [u8; 4] = [0x07, 0xc9, 0x46, 0x2e];
 const PROBE_ADDRESS_HEX: &str = "d8da6bf26964af9d7eed9e03e53415d37aa96045";
@@ -46,7 +41,7 @@ async fn managed_peer_survives_idle_and_serves_twice() {
         .try_init();
 
     let key = Arc::new(NodeKey::from_secret_bytes(&keccak256(b"myotis-live-managed")).unwrap());
-    let bootnodes: Vec<SocketAddr> = MAINNET_BOOTNODES.iter().map(|s| s.parse().unwrap()).collect();
+    let bootnodes: Vec<SocketAddr> = ElConfig::mainnet().bootnodes; // one source of truth
     let genesis = hex32(MAINNET_GENESIS);
 
     let (tx, mut rx) = tokio::sync::mpsc::channel::<TableEntry>(256);

--- a/rust/myotis-net/tests/live_managed_peer.rs
+++ b/rust/myotis-net/tests/live_managed_peer.rs
@@ -28,8 +28,8 @@ use myotis_net::el::snap::fetch::AccountOutcome;
 const MAINNET_BOOTNODES: &[&str] = &[
     "18.138.108.67:30303",
     "3.209.45.79:30303",
-    "18.188.214.86:30303",
-    "3.219.208.172:30303",
+    "65.108.70.101:30303",
+    "157.90.35.166:30303",
 ];
 const MAINNET_GENESIS: &str = "d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3";
 const MAINNET_FORK_ID: [u8; 4] = [0x07, 0xc9, 0x46, 0x2e];

--- a/rust/myotis-net/tests/live_pool.rs
+++ b/rust/myotis-net/tests/live_pool.rs
@@ -28,8 +28,8 @@ use myotis_net::el::snap::fetch::AccountOutcome;
 const MAINNET_BOOTNODES: &[&str] = &[
     "18.138.108.67:30303",
     "3.209.45.79:30303",
-    "18.188.214.86:30303",
-    "3.219.208.172:30303",
+    "65.108.70.101:30303",
+    "157.90.35.166:30303",
 ];
 const MAINNET_GENESIS: &str = "d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3";
 const MAINNET_FORK_ID: [u8; 4] = [0x07, 0xc9, 0x46, 0x2e];

--- a/rust/myotis-net/tests/live_pool.rs
+++ b/rust/myotis-net/tests/live_pool.rs
@@ -24,13 +24,8 @@ use myotis_net::el::discv4::{Discv4Config, Discv4Service, TableEntry};
 use myotis_net::el::eth::session::EthConfig;
 use myotis_net::el::pool::{PeerPool, PoolConfig};
 use myotis_net::el::snap::fetch::AccountOutcome;
+use myotis_net::el::reader::ElConfig;
 
-const MAINNET_BOOTNODES: &[&str] = &[
-    "18.138.108.67:30303",
-    "3.209.45.79:30303",
-    "65.108.70.101:30303",
-    "157.90.35.166:30303",
-];
 const MAINNET_GENESIS: &str = "d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3";
 const MAINNET_FORK_ID: [u8; 4] = [0x07, 0xc9, 0x46, 0x2e];
 const PROBE_ADDRESS_HEX: &str = "d8da6bf26964af9d7eed9e03e53415d37aa96045";
@@ -46,7 +41,7 @@ async fn pool_dials_from_discovery_and_serves_a_verified_account() {
         .try_init();
 
     let key = Arc::new(NodeKey::from_secret_bytes(&keccak256(b"myotis-live-pool")).unwrap());
-    let bootnodes: Vec<SocketAddr> = MAINNET_BOOTNODES.iter().map(|s| s.parse().unwrap()).collect();
+    let bootnodes: Vec<SocketAddr> = ElConfig::mainnet().bootnodes; // one source of truth
     let genesis = hex32(MAINNET_GENESIS);
 
     let (tx, rx) = tokio::sync::mpsc::channel::<TableEntry>(256);

--- a/rust/myotis-net/tests/live_rlpx.rs
+++ b/rust/myotis-net/tests/live_rlpx.rs
@@ -20,8 +20,8 @@ use myotis_net::el::rlpx::transport::{decode_hello, encode_hello, RlpxConnection
 const MAINNET_BOOTNODES: &[&str] = &[
     "18.138.108.67:30303",
     "3.209.45.79:30303",
-    "18.188.214.86:30303",
-    "3.219.208.172:30303",
+    "65.108.70.101:30303",
+    "157.90.35.166:30303",
 ];
 
 #[tokio::test(flavor = "multi_thread")]

--- a/rust/myotis-net/tests/live_rlpx.rs
+++ b/rust/myotis-net/tests/live_rlpx.rs
@@ -16,13 +16,7 @@ use myotis_core::keccak::keccak256;
 use myotis_core::nodekey::NodeKey;
 use myotis_net::el::discv4::{Discv4Config, Discv4Service, TableEntry};
 use myotis_net::el::rlpx::transport::{decode_hello, encode_hello, RlpxConnection, P2P_HELLO};
-
-const MAINNET_BOOTNODES: &[&str] = &[
-    "18.138.108.67:30303",
-    "3.209.45.79:30303",
-    "65.108.70.101:30303",
-    "157.90.35.166:30303",
-];
+use myotis_net::el::reader::ElConfig;
 
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "live network test: discovers a mainnet peer and RLPx-dials it to FRAMED"]
@@ -35,7 +29,7 @@ async fn dials_a_mainnet_peer_to_framed() {
         .try_init();
 
     let key = Arc::new(NodeKey::from_secret_bytes(&keccak256(b"myotis-live-rlpx")).unwrap());
-    let bootnodes: Vec<SocketAddr> = MAINNET_BOOTNODES.iter().map(|s| s.parse().unwrap()).collect();
+    let bootnodes: Vec<SocketAddr> = ElConfig::mainnet().bootnodes; // one source of truth
 
     let (tx, mut rx) = tokio::sync::mpsc::channel::<TableEntry>(256);
     let discovery = Discv4Service::start(

--- a/rust/myotis-net/tests/live_snap.rs
+++ b/rust/myotis-net/tests/live_snap.rs
@@ -24,13 +24,8 @@ use myotis_net::el::discv4::{Discv4Config, Discv4Service, TableEntry};
 use myotis_net::el::eth::session::{EthConfig, EthSession};
 use myotis_net::el::rlpx::transport::RlpxConnection;
 use myotis_net::el::snap::fetch::AccountOutcome;
+use myotis_net::el::reader::ElConfig;
 
-const MAINNET_BOOTNODES: &[&str] = &[
-    "18.138.108.67:30303",
-    "3.209.45.79:30303",
-    "65.108.70.101:30303",
-    "157.90.35.166:30303",
-];
 const MAINNET_GENESIS: &str = "d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3";
 const MAINNET_FORK_ID: [u8; 4] = [0x07, 0xc9, 0x46, 0x2e];
 // A well-known mainnet address with state (the "vitalik.eth" address).
@@ -47,7 +42,7 @@ async fn fetches_a_verified_account_on_live_mainnet() {
         .try_init();
 
     let key = Arc::new(NodeKey::from_secret_bytes(&keccak256(b"myotis-live-snap")).unwrap());
-    let bootnodes: Vec<SocketAddr> = MAINNET_BOOTNODES.iter().map(|s| s.parse().unwrap()).collect();
+    let bootnodes: Vec<SocketAddr> = ElConfig::mainnet().bootnodes; // one source of truth
     let genesis = hex32(MAINNET_GENESIS);
 
     let (tx, mut rx) = tokio::sync::mpsc::channel::<TableEntry>(256);

--- a/rust/myotis-net/tests/live_snap.rs
+++ b/rust/myotis-net/tests/live_snap.rs
@@ -28,8 +28,8 @@ use myotis_net::el::snap::fetch::AccountOutcome;
 const MAINNET_BOOTNODES: &[&str] = &[
     "18.138.108.67:30303",
     "3.209.45.79:30303",
-    "18.188.214.86:30303",
-    "3.219.208.172:30303",
+    "65.108.70.101:30303",
+    "157.90.35.166:30303",
 ];
 const MAINNET_GENESIS: &str = "d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3";
 const MAINNET_FORK_ID: [u8; 4] = [0x07, 0xc9, 0x46, 0x2e];


### PR DESCRIPTION
## What

Replaces the two mainnet discv4 bootnode addresses that are no longer in go-ethereum's `params/bootnodes.go` (`18.188.214.86`, `3.219.208.172`) with geth's current Hetzner pair (`65.108.70.101`, `157.90.35.166`), in **both engines in lockstep** (Rust `ElConfig::mainnet`, Java `NetworkConfig.MAINNET`) and in the six `myotis-net` live tests that pin the list verbatim. `rust/tor-poc` already carried the current four with pubkeys. Labels on the entries are geth's own.

## Why

A fresh Freedom desktop profile (no EL peer cache) could never reach a mainnet snap peer with either the v0.1.7 release addon or a build from `main`:

- Beacon side fine: resumed from the snapshot, `SYNCED` at period 1846/1846 within 10 s, finality updates flowing.
- EL side dead: `discoveredPeers=0`, `attemptedDials=0`, `snapPeers=0` for the entire run; `elHunting` after the 60 s stall window. With `myotis_net::el::discv4=debug`, the routing table stayed at `table=0` on every refresh — no pong from any of the four old bootnodes.
- Same host, same minute, Gnosis: pongs within a second, 27 discovered and 2 snap peers at 10 s. So UDP and the discv4 code are fine; the mainnet seed list is the problem.
- With this list on the identical mainnet snapshot: pongs from both Hetzner entries immediately, `snapPeers=2` at 10 s, 55 discovered at 80 s. Freedom then logged `mainnet ready — verified reads available` 10.7 s after start and wrote `peers.cache`.

Mainnet has no pinned enodes and the Rust engine has no EIP-1459 DNS fallback, so bootnodes are the only cold-start seed. Warm profiles and the CI smoke test dial cached peers directly, which is why nothing caught it. None of today's other commits touch EL discovery; the list has been unchanged since the reader landed on 2026-07-07.

The two AWS entries are kept because geth still publishes them, even though they were silent from this vantage point that day.

## Tests

- `cargo test -p myotis-net --lib`: 330 passed (includes `mainnet_config_pins_known_values`).
- `cargo test -p myotis-net --no-run`: all live test targets compile.
- `./gradlew :networking:compileJava :networking:test --tests '*NetworkConfig*'`: 19 tests green.
- `git diff --check` clean.
- Internal no-context review: confirmed no remaining copies of the old addresses anywhere in the tree (Rust, Java, Kotlin, Swift, docs, CI), no test or golden file asserts the old list or its order, and asked for the softer wording now in the comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sjcf4jE77EizbQsUneNi6C
