### PR TITLE
CLAUDE.md: ask about checkpoints and bootnodes before every release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,11 +184,15 @@ ruling, 2026-09-02):
    fetch) age toward the weak-subjectivity bound (13 periods on mainnet, 3 on
    gnosis). A fresh install past the bound parks in `STALE_ANCHOR` until the
    host consents.
-2. **Re-sync the mainnet discv4 bootnodes from go-ethereum?** The list is
-   pinned in `NetworkConfig.MAINNET`, `ElConfig::mainnet()`
-   (`rust/myotis-net/src/el/reader.rs`; its unit test pins the strings and
-   the `myotis-net` live tests read it) and, with pubkeys, `rust/tor-poc`;
-   source of truth is geth's `params/bootnodes.go` `MainnetBootnodes`.
+2. **Re-sync the mainnet discv4 bootnodes from go-ethereum?** Source of
+   truth is geth's `params/bootnodes.go` `MainnetBootnodes`. Pin sites:
+   `NetworkConfig.MAINNET`, `ElConfig::mainnet()`
+   (`rust/myotis-net/src/el/reader.rs`), `rust/tor-poc` (with pubkeys), and
+   any other verbatim copy — do not trust this list, `grep -rn` the tree for
+   one of the current addresses before and after the edit until zero copies
+   of the old ones remain (the `myotis-net` live tests carry their own
+   copies until #414 makes them read `ElConfig::mainnet()` and pins the
+   strings in its unit test).
    Mainnet has no pinned enodes and, in the Rust engine, no EIP-1459 DNS
    fallback (the Java engine has one), so a fresh profile with a stale list
    never seeds EL discovery and never holds a snap peer (#414, 2026-09-02).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,6 +172,29 @@ Do not stop at "pushed" and do not ask whether to open the PR or run the review 
 they are part of the work item. The only time to skip the PR is when the user
 explicitly says not to open one.
 
+## Releases — ask before cutting one
+
+When the user asks for a release (a `v*` tag, a version bump, "cut a release"),
+**ask these two questions first and act only on what they choose** (owner
+ruling, 2026-09-02):
+
+1. **Refresh the trust checkpoints?** The embedded checkpoints (`@checkpoint:*`
+   blocks in `NetworkConfig.java`, mirrored in `rust/myotis-net/src/sync.rs`;
+   `./gradlew refreshCheckpoint -Pnetwork=<net>` writes both engines from one
+   fetch) age toward the weak-subjectivity bound (13 periods on mainnet, 3 on
+   gnosis). A fresh install past the bound parks in `STALE_ANCHOR` until the
+   host consents.
+2. **Re-sync the mainnet discv4 bootnodes from go-ethereum?** The list is
+   pinned in `NetworkConfig.MAINNET`, `ElConfig::mainnet()`
+   (`rust/myotis-net/src/el/reader.rs`; its unit test pins the strings and
+   the `myotis-net` live tests read it) and, with pubkeys, `rust/tor-poc`;
+   source of truth is geth's `params/bootnodes.go` `MainnetBootnodes`.
+   Mainnet has no pinned enodes and, in the Rust engine, no EIP-1459 DNS
+   fallback (the Java engine has one), so a fresh profile with a stale list
+   never seeds EL discovery and never holds a snap peer (#414, 2026-09-02).
+   Warm profiles and the dispatched smoke job hide this because they dial
+   their peer cache directly.
+
 ## Pull requests and code review
 
 These rules are for the **PR author** answering a review. The reviewer's own

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,9 +190,9 @@ ruling, 2026-09-02):
    (`rust/myotis-net/src/el/reader.rs`), `rust/tor-poc` (with pubkeys), and
    any other verbatim copy — do not trust this list, `grep -rn` the tree for
    one of the current addresses before and after the edit until zero copies
-   of the old ones remain (the `myotis-net` live tests carry their own
-   copies until #414 makes them read `ElConfig::mainnet()` and pins the
-   strings in its unit test).
+   of the old ones remain. Since #414 the `myotis-net` live tests read
+   `ElConfig::mainnet()` and `mainnet_config_pins_known_values` pins the
+   four strings, so a partial re-sync fails in the fast lib test.
    Mainnet has no pinned enodes and, in the Rust engine, no EIP-1459 DNS
    fallback (the Java engine has one), so a fresh profile with a stale list
    never seeds EL discovery and never holds a snap peer (#414, 2026-09-02).


### PR DESCRIPTION
## What

Adds a `## Releases — ask before cutting one` section to `CLAUDE.md`, between the Workflow and PR sections. Whenever a release is requested, the assistant must first ask two questions and act only on what the owner chooses:

1. **Refresh the trust checkpoints?** `@checkpoint:*` blocks in `NetworkConfig.java`, mirrored in `rust/myotis-net/src/sync.rs`, written by `./gradlew refreshCheckpoint -Pnetwork=<net>`. They age toward the weak-subjectivity bound (13 periods mainnet, 3 gnosis); a fresh install past it parks in `STALE_ANCHOR`.
2. **Re-sync the mainnet discv4 bootnodes from go-ethereum?** Pinned in `NetworkConfig.MAINNET`, `ElConfig::mainnet()` (unit-test pinned; the live tests read it) and `rust/tor-poc`. With no pinned mainnet enodes and no EIP-1459 fallback in the Rust engine, a stale list leaves a fresh profile with no EL peer at all (#414).

## Why

Owner ruling on 2026-09-02 after the #414 incident: both lists rot silently because warm profiles and the dispatched smoke job start from a peer cache and never exercise the cold path.

## Review

Internal no-context review verified every claim against the tree (marker comments, the Gradle task and its `-Pnetwork` handling, the bound values, the `STALE_ANCHOR` name, the pin sites, the empty mainnet `boot_enodes`, and the smoke gate's discovery check) and asked for two corrections that are in: the DNS-fallback claim is scoped to the Rust engine since the Java engine resolves `enrtree://` for mainnet, and the pin-site list no longer names the live tests, which #414's follow-up derives from `ElConfig::mainnet()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sjcf4jE77EizbQsUneNi6C
