### PR TITLE
Tip-tolerant latest reads: bounded retry when peers trail the anchored head

### DIFF
--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -322,6 +322,36 @@ pub struct VerifiedBlock {
 /// response soft limit.
 const BLOCK_LOOKBACK_MAX: u64 = 512;
 
+/// Tip-lag tolerance for a `latest` block/receipt read. The anchored head is
+/// the beacon OPTIMISTIC head, which can momentarily run 1-2 blocks ahead of
+/// what EL peers have imported — they then honestly answer "0 headers" for a
+/// block that, for them, does not exist yet (verified live 2026-09-02: `head`
+/// missed while `head-100` served, gap closing within seconds). The header
+/// window can only be verified up to the anchored head hash, so we cannot
+/// serve an older block instead — but the lag is transient, so a bounded
+/// retry (re-reading the advancing anchor and the current pool each time)
+/// rides it out. Scoped to `latest`: a pinned number returning "0 headers"
+/// is a peer that pruned it, not tip lag. ~3 × 400 ms adds latency ONLY on
+/// the failing path, and only when EVERY peer is merely behind the head (a
+/// mixed/transport failure fails fast — retrying it just burns a second).
+const TIP_LAG_RETRIES: usize = 3;
+const TIP_LAG_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(400);
+
+/// True when every per-peer failure is a "behind the anchored head" shape
+/// (short/empty header window, or a window head that isn't yet the anchored
+/// head) — the exact signature of the optimistic-head-vs-imported-tip race,
+/// distinct from a transport failure (timeout/disconnect) or a genuine proof
+/// error. Kept as a string match on the phrases `fetch_anchored_window`
+/// produces (there is no typed error across its four callers); the phrases
+/// live here so the coupling is visible.
+fn all_tip_lag(failures: &[String]) -> bool {
+    !failures.is_empty()
+        && failures.iter().all(|f| {
+            f.contains("headers, expected")
+                || f.contains("window head does not match the beacon-anchored head hash")
+        })
+}
+
 /// First-ever receipt scan for a tx hash looks back this many blocks below the
 /// head (the Java `RECEIPT_INITIAL_LOOKBACK_BLOCKS`); the per-tx cursor then
 /// grows coverage forward as the wallet polls.
@@ -4221,7 +4251,45 @@ impl ElReader {
         target: Option<u64>,
         full_transactions: bool,
     ) -> Result<Option<VerifiedBlock>, String> {
-        let (head_num, head_hash) = self.anchored_head()?;
+        // Tip-lag retry for `latest` only — see TIP_LAG_RETRIES. Each attempt
+        // re-reads the anchor (it advances) and the pool ladder (the rotation
+        // may have swapped in fresher peers between attempts).
+        let mut attempt = 0;
+        loop {
+            let (result, tip_lag) = self.get_block_by_number_once(target, full_transactions).await;
+            match result {
+                Err(e) if tip_lag && target.is_none() && attempt < TIP_LAG_RETRIES => {
+                    attempt += 1;
+                    tracing::debug!(attempt, error = %e,
+                        "latest block behind peers' imported tip — retrying");
+                    tokio::time::sleep(TIP_LAG_RETRY_DELAY).await;
+                }
+                other => return other,
+            }
+        }
+    }
+
+    /// One full attempt of [`Self::get_block_by_number`] against the current
+    /// anchor and pool ladder. The bool is true when the attempt failed with
+    /// every peer merely BEHIND the anchored head ([`all_tip_lag`]) — the
+    /// retryable tip-lag shape, as opposed to transport/proof failures.
+    async fn get_block_by_number_once(
+        &self,
+        target: Option<u64>,
+        full_transactions: bool,
+    ) -> (Result<Option<VerifiedBlock>, String>, bool) {
+        match self.get_block_by_number_inner(target, full_transactions).await {
+            Ok(v) => (Ok(v), false),
+            Err((e, tip_lag)) => (Err(e), tip_lag),
+        }
+    }
+
+    async fn get_block_by_number_inner(
+        &self,
+        target: Option<u64>,
+        full_transactions: bool,
+    ) -> Result<Option<VerifiedBlock>, (String, bool)> {
+        let (head_num, head_hash) = self.anchored_head().map_err(|e| (e, false))?;
         let target_num = target.unwrap_or(head_num);
         // A pin above the verified head is future/unknown, not an error.
         if target_num > head_num {
@@ -4229,9 +4297,9 @@ impl ElReader {
         }
         let back = head_num - target_num;
         if back >= BLOCK_LOOKBACK_MAX {
-            return Err(format!(
+            return Err((format!(
                 "block {target_num} is {back} behind the head — beyond the {BLOCK_LOOKBACK_MAX}-block verify window"
-            ));
+            ), false));
         }
         // Serve over the snap pool (the peer set the reader maintains); a block
         // serve is eth-only (headers + bodies), so this is a superset of what's
@@ -4239,14 +4307,18 @@ impl ElReader {
         // (Err → -32000), never a false "null". Reputation reuses the snap sinks.
         let peers = self.pool.snap_peers().await;
         if peers.is_empty() {
-            return Err("no snap peer available".to_string());
+            return Err(("no snap peer available".to_string(), false));
         }
         let total = peers.len();
         let mut failures: Vec<String> = Vec::with_capacity(total);
+        let mut failed: Vec<std::net::SocketAddr> = Vec::with_capacity(total);
         for peer in &peers {
             match self.get_block_from(peer, target_num, back, &head_hash, full_transactions).await
             {
                 Ok(block) => {
+                    // Strikes are DEFERRED: with a success in the batch the
+                    // earlier failures were individual, so bank them now.
+                    self.record_batch_failures(&failed).await;
                     self.pool.record_snap_served(peer.addr()).await;
                     return Ok(Some(block));
                 }
@@ -4256,11 +4328,12 @@ impl ElReader {
                 // (retrying the pool would just re-download the block N times
                 // and burn the shared snap reputation on verified-good peers).
                 Err(BlockFromError::Undecodable(e)) => {
+                    self.record_batch_failures(&failed).await;
                     self.pool.record_snap_served(peer.addr()).await;
-                    return Err(e);
+                    return Err((e, false));
                 }
                 Err(BlockFromError::Peer(e)) => {
-                    self.pool.record_snap_failure(peer.addr()).await;
+                    failed.push(peer.addr());
                     failures.push(e);
                 }
             }
@@ -4272,7 +4345,21 @@ impl ElReader {
         // stale-pool incidents (2026-09-01/02) undiagnosable on-device.
         tracing::warn!(total, target_num, back, summary = %summary,
             "verified block fetch failed against every snap peer");
-        Err(format!("all {total} snap peer(s) failed to serve a verifiable block: {summary}"))
+        let tip_lag = all_tip_lag(&failures);
+        // A whole-pool tip-lag batch carries NO signal about any peer — it's
+        // our anchor running ahead of their imported tip. Banking it would let
+        // one retrying `latest` read (up to 1 + TIP_LAG_RETRIES attempts)
+        // push every healthy peer past READ_FAILS_EVICT and drain the pool the
+        // retry exists to re-use. A genuinely header-less peer still accrues
+        // strikes whenever any other peer succeeds (the success path above) or
+        // fails differently (mixed batch → not tip-lag).
+        if !tip_lag {
+            self.record_batch_failures(&failed).await;
+        }
+        Err((
+            format!("all {total} snap peer(s) failed to serve a verifiable block: {summary}"),
+            tip_lag,
+        ))
     }
 
     /// Fetch + verify one block against a single peer. Fetches the header window
@@ -4855,42 +4942,73 @@ impl ElReader {
         &self,
         target: Option<u64>,
     ) -> Result<Option<([u8; 32], Vec<VerifiedReceipt>)>, String> {
-        let (head_num, head_hash) = self.anchored_head()?;
+        // Tip-lag retry for `latest` only — same shape and rationale as
+        // get_block_by_number (see TIP_LAG_RETRIES).
+        let mut attempt = 0;
+        loop {
+            match self.block_receipts_at_inner(target).await {
+                Err((e, true)) if target.is_none() && attempt < TIP_LAG_RETRIES => {
+                    attempt += 1;
+                    tracing::debug!(attempt, error = %e,
+                        "latest receipts behind peers' imported tip — retrying");
+                    tokio::time::sleep(TIP_LAG_RETRY_DELAY).await;
+                }
+                Err((e, _)) => return Err(e),
+                Ok(v) => return Ok(v),
+            }
+        }
+    }
+
+    /// One full attempt of [`Self::block_receipts_at`]; the error's bool is
+    /// the [`all_tip_lag`] verdict (see get_block_by_number_inner).
+    async fn block_receipts_at_inner(
+        &self,
+        target: Option<u64>,
+    ) -> Result<Option<([u8; 32], Vec<VerifiedReceipt>)>, (String, bool)> {
+        let (head_num, head_hash) = self.anchored_head().map_err(|e| (e, false))?;
         let target_num = target.unwrap_or(head_num);
         if target_num > head_num {
             return Ok(None); // future/unknown block → eth null
         }
         let back = head_num - target_num;
         if back >= BLOCK_LOOKBACK_MAX {
-            return Err(format!(
+            return Err((format!(
                 "block {target_num} is {back} behind the head — beyond the {BLOCK_LOOKBACK_MAX}-block verify window"
-            ));
+            ), false));
         }
         let peers = self.pool.snap_peers().await;
         if peers.is_empty() {
-            return Err("no snap peer available".to_string());
+            return Err(("no snap peer available".to_string(), false));
         }
         let total = peers.len();
         let mut failures: Vec<String> = Vec::with_capacity(total);
+        let mut failed: Vec<std::net::SocketAddr> = Vec::with_capacity(total);
         for peer in &peers {
             match self.block_receipts_from(peer, target_num, back, &head_hash).await {
                 Ok(served) => {
+                    self.record_batch_failures(&failed).await;
                     self.pool.record_snap_served(peer.addr()).await;
                     return Ok(Some(served));
                 }
                 Err(e) => {
-                    self.pool.record_snap_failure(peer.addr()).await;
+                    failed.push(peer.addr());
                     failures.push(e);
                 }
             }
+        }
+        let tip_lag = all_tip_lag(&failures);
+        // Tip-lag batches don't strike peers — see get_block_by_number_inner.
+        if !tip_lag {
+            self.record_batch_failures(&failed).await;
         }
         let summary = summarize_peer_failures(&failures);
         // Same rationale as get_block_by_number: whole-pool failures must be
         // diagnosable from an info+ log ring.
         tracing::warn!(total, target_num, back, summary = %summary,
             "verified receipts fetch failed against every snap peer");
-        Err(format!(
-            "all {total} snap peer(s) failed to serve verifiable block receipts: {summary}"
+        Err((
+            format!("all {total} snap peer(s) failed to serve verifiable block receipts: {summary}"),
+            tip_lag,
         ))
     }
 
@@ -4940,6 +5058,17 @@ impl ElReader {
     fn remember_block_number(&self, block_hash: [u8; 32], number: u64) {
         if let Ok(mut lru) = self.block_hash_numbers.lock() {
             lru.put(block_hash, number);
+        }
+    }
+
+    /// Bank one deferred read-failure strike per peer of a serve batch. The
+    /// block/receipts loops defer recording until the batch's outcome is known
+    /// so a whole-pool TIP-LAG failure (our anchor ahead of the peers' imported
+    /// tip — no peer's fault) strikes nobody; every other outcome banks the
+    /// strikes exactly as immediate recording did.
+    async fn record_batch_failures(&self, failed: &[std::net::SocketAddr]) {
+        for addr in failed {
+            self.pool.record_snap_failure(*addr).await;
         }
     }
 
@@ -5324,8 +5453,18 @@ async fn fetch_anchored_window(
     head_hash: &[u8; 32],
 ) -> Result<Vec<crate::el::eth::messages::VerifiedHeader>, String> {
     let window = peer.get_block_headers_by_number(from, count, 0, false).await?;
-    if window.len() as u64 != count {
+    // Distinct messages on purpose: a SHORT window is tip-lag-shaped (the peer
+    // may simply not have imported up to our anchor yet — all_tip_lag matches
+    // "headers, expected"), while returning MORE than asked is a protocol
+    // violation that must never read as retryable.
+    if (window.len() as u64) < count {
         return Err(format!("peer returned {} headers, expected {count}", window.len()));
+    }
+    if window.len() as u64 != count {
+        return Err(format!(
+            "peer over-served the header request: {} returned for {count} asked",
+            window.len()
+        ));
     }
     if window[0].header.number != from {
         return Err("peer returned the wrong starting block number".to_string());
@@ -5792,6 +5931,57 @@ mod tests {
         #[test]
         fn empty_input_yields_the_defensive_placeholder() {
             assert_eq!(summarize_peer_failures(&[]), "no failures recorded");
+        }
+    }
+
+    /// The tip-lag classifier gating the bounded `latest` retry: it must fire
+    /// only when EVERY peer failed in a way consistent with "the anchored head
+    /// is ahead of the peers' imported tip" — a short-header window or a head
+    /// hash the window doesn't reach. Anything else (transport errors, bad
+    /// proofs) means retrying won't help and must fail fast.
+    mod tip_lag {
+        use super::*;
+
+        fn s(v: &[&str]) -> Vec<String> {
+            v.iter().map(|x| x.to_string()).collect()
+        }
+
+        #[test]
+        fn all_zero_header_windows_is_tip_lag() {
+            assert!(all_tip_lag(&s(&[
+                "peer returned 0 headers, expected 1",
+                "peer returned 0 headers, expected 1",
+            ])));
+        }
+
+        #[test]
+        fn head_hash_mismatch_is_tip_lag() {
+            assert!(all_tip_lag(&s(&[
+                "window head does not match the beacon-anchored head hash",
+                "peer returned 2 headers, expected 3",
+            ])));
+        }
+
+        #[test]
+        fn a_single_transport_failure_disqualifies_the_batch() {
+            assert!(!all_tip_lag(&s(&[
+                "peer returned 0 headers, expected 1",
+                "request timed out",
+            ])));
+        }
+
+        #[test]
+        fn empty_failures_are_not_tip_lag() {
+            assert!(!all_tip_lag(&[]));
+        }
+
+        #[test]
+        fn an_over_served_header_window_is_a_protocol_violation_not_tip_lag() {
+            // fetch_anchored_window words the too-many case differently so it
+            // can never match the classifier — pin both halves of that pact.
+            assert!(!all_tip_lag(&s(&[
+                "peer over-served the header request: 5 returned for 3 asked",
+            ])));
         }
     }
 

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -352,6 +352,22 @@ fn all_tip_lag(failures: &[String]) -> bool {
         })
 }
 
+/// A whole-pool read failure, split by how the caller must handle strikes.
+enum PoolReadError {
+    /// Not tip-lag (or not a whole-pool batch): any strikes are already
+    /// banked; retrying cannot help.
+    Fatal(String),
+    /// Every peer failed tip-lag-shaped ([`all_tip_lag`]). The batch's
+    /// strikes are DEFERRED to the caller: forgiven only for an attempt the
+    /// caller retries (the anchor advances past a transient lag), banked via
+    /// `record_batch_failures` the moment it gives up. So a blip shorter than
+    /// the retry budget strikes nobody, while a persistently lagging pool
+    /// keeps accruing one strike per peer per failed READ — the pre-retry
+    /// rate the 2026-09-02 stale-pool escape (eviction + refill) depends
+    /// on — and a pinned read, which never retries, banks immediately.
+    TipLag { error: String, failed: Vec<std::net::SocketAddr> },
+}
+
 /// First-ever receipt scan for a tx hash looks back this many blocks below the
 /// head (the Java `RECEIPT_INITIAL_LOOKBACK_BLOCKS`); the per-tx cursor then
 /// grows coverage forward as the wallet polls.
@@ -4256,31 +4272,32 @@ impl ElReader {
         // may have swapped in fresher peers between attempts).
         let mut attempt = 0;
         loop {
-            let (result, tip_lag) = self.get_block_by_number_once(target, full_transactions).await;
-            match result {
-                Err(e) if tip_lag && target.is_none() && attempt < TIP_LAG_RETRIES => {
-                    attempt += 1;
-                    tracing::debug!(attempt, error = %e,
-                        "latest block behind peers' imported tip — retrying");
-                    tokio::time::sleep(TIP_LAG_RETRY_DELAY).await;
+            match self.get_block_by_number_inner(target, full_transactions).await {
+                Err(PoolReadError::TipLag { error, failed }) => {
+                    if target.is_none() && attempt < TIP_LAG_RETRIES {
+                        attempt += 1;
+                        tracing::debug!(attempt, error = %error,
+                            "latest block behind peers' imported tip — retrying");
+                        tokio::time::sleep(TIP_LAG_RETRY_DELAY).await;
+                        continue;
+                    }
+                    // Giving up (or a pinned read, which never retries): bank
+                    // this final attempt's deferred strikes — one per peer per
+                    // failed read, the pre-retry rate (PoolReadError::TipLag).
+                    self.record_batch_failures(&failed).await;
+                    return Err(error);
                 }
-                other => return other,
+                Err(PoolReadError::Fatal(e)) => return Err(e),
+                Ok(v) => {
+                    if attempt > 0 {
+                        // Pair the per-attempt WARNs with their outcome in the
+                        // same info+ ring hosts keep (debug is dropped there).
+                        tracing::info!(attempt,
+                            "latest block read recovered after tip-lag retries");
+                    }
+                    return Ok(v);
+                }
             }
-        }
-    }
-
-    /// One full attempt of [`Self::get_block_by_number`] against the current
-    /// anchor and pool ladder. The bool is true when the attempt failed with
-    /// every peer merely BEHIND the anchored head ([`all_tip_lag`]) — the
-    /// retryable tip-lag shape, as opposed to transport/proof failures.
-    async fn get_block_by_number_once(
-        &self,
-        target: Option<u64>,
-        full_transactions: bool,
-    ) -> (Result<Option<VerifiedBlock>, String>, bool) {
-        match self.get_block_by_number_inner(target, full_transactions).await {
-            Ok(v) => (Ok(v), false),
-            Err((e, tip_lag)) => (Err(e), tip_lag),
         }
     }
 
@@ -4288,8 +4305,8 @@ impl ElReader {
         &self,
         target: Option<u64>,
         full_transactions: bool,
-    ) -> Result<Option<VerifiedBlock>, (String, bool)> {
-        let (head_num, head_hash) = self.anchored_head().map_err(|e| (e, false))?;
+    ) -> Result<Option<VerifiedBlock>, PoolReadError> {
+        let (head_num, head_hash) = self.anchored_head().map_err(PoolReadError::Fatal)?;
         let target_num = target.unwrap_or(head_num);
         // A pin above the verified head is future/unknown, not an error.
         if target_num > head_num {
@@ -4297,9 +4314,9 @@ impl ElReader {
         }
         let back = head_num - target_num;
         if back >= BLOCK_LOOKBACK_MAX {
-            return Err((format!(
+            return Err(PoolReadError::Fatal(format!(
                 "block {target_num} is {back} behind the head — beyond the {BLOCK_LOOKBACK_MAX}-block verify window"
-            ), false));
+            )));
         }
         // Serve over the snap pool (the peer set the reader maintains); a block
         // serve is eth-only (headers + bodies), so this is a superset of what's
@@ -4307,7 +4324,7 @@ impl ElReader {
         // (Err → -32000), never a false "null". Reputation reuses the snap sinks.
         let peers = self.pool.snap_peers().await;
         if peers.is_empty() {
-            return Err(("no snap peer available".to_string(), false));
+            return Err(PoolReadError::Fatal("no snap peer available".to_string()));
         }
         let total = peers.len();
         let mut failures: Vec<String> = Vec::with_capacity(total);
@@ -4330,7 +4347,7 @@ impl ElReader {
                 Err(BlockFromError::Undecodable(e)) => {
                     self.record_batch_failures(&failed).await;
                     self.pool.record_snap_served(peer.addr()).await;
-                    return Err((e, false));
+                    return Err(PoolReadError::Fatal(e));
                 }
                 Err(BlockFromError::Peer(e)) => {
                     failed.push(peer.addr());
@@ -4345,21 +4362,18 @@ impl ElReader {
         // stale-pool incidents (2026-09-01/02) undiagnosable on-device.
         tracing::warn!(total, target_num, back, summary = %summary,
             "verified block fetch failed against every snap peer");
-        let tip_lag = all_tip_lag(&failures);
-        // A whole-pool tip-lag batch carries NO signal about any peer — it's
-        // our anchor running ahead of their imported tip. Banking it would let
-        // one retrying `latest` read (up to 1 + TIP_LAG_RETRIES attempts)
-        // push every healthy peer past READ_FAILS_EVICT and drain the pool the
-        // retry exists to re-use. A genuinely header-less peer still accrues
-        // strikes whenever any other peer succeeds (the success path above) or
-        // fails differently (mixed batch → not tip-lag).
-        if !tip_lag {
-            self.record_batch_failures(&failed).await;
+        let error = format!("all {total} snap peer(s) failed to serve a verifiable block: {summary}");
+        if all_tip_lag(&failures) {
+            // Strike DEFERRAL, not forgiveness: the caller banks `failed` the
+            // moment it stops retrying (see PoolReadError::TipLag). Banking
+            // per attempt here would let one retrying read push every healthy
+            // peer past READ_FAILS_EVICT and drain the pool the retry exists
+            // to re-use; never banking would hand a persistently lagging pool
+            // the 2026-09-02 wedge back.
+            return Err(PoolReadError::TipLag { error, failed });
         }
-        Err((
-            format!("all {total} snap peer(s) failed to serve a verifiable block: {summary}"),
-            tip_lag,
-        ))
+        self.record_batch_failures(&failed).await;
+        Err(PoolReadError::Fatal(error))
     }
 
     /// Fetch + verify one block against a single peer. Fetches the header window
@@ -4943,42 +4957,53 @@ impl ElReader {
         target: Option<u64>,
     ) -> Result<Option<([u8; 32], Vec<VerifiedReceipt>)>, String> {
         // Tip-lag retry for `latest` only — same shape and rationale as
-        // get_block_by_number (see TIP_LAG_RETRIES).
+        // get_block_by_number (see TIP_LAG_RETRIES / PoolReadError).
         let mut attempt = 0;
         loop {
             match self.block_receipts_at_inner(target).await {
-                Err((e, true)) if target.is_none() && attempt < TIP_LAG_RETRIES => {
-                    attempt += 1;
-                    tracing::debug!(attempt, error = %e,
-                        "latest receipts behind peers' imported tip — retrying");
-                    tokio::time::sleep(TIP_LAG_RETRY_DELAY).await;
+                Err(PoolReadError::TipLag { error, failed }) => {
+                    if target.is_none() && attempt < TIP_LAG_RETRIES {
+                        attempt += 1;
+                        tracing::debug!(attempt, error = %error,
+                            "latest receipts behind peers' imported tip — retrying");
+                        tokio::time::sleep(TIP_LAG_RETRY_DELAY).await;
+                        continue;
+                    }
+                    self.record_batch_failures(&failed).await;
+                    return Err(error);
                 }
-                Err((e, _)) => return Err(e),
-                Ok(v) => return Ok(v),
+                Err(PoolReadError::Fatal(e)) => return Err(e),
+                Ok(v) => {
+                    if attempt > 0 {
+                        tracing::info!(attempt,
+                            "latest receipts read recovered after tip-lag retries");
+                    }
+                    return Ok(v);
+                }
             }
         }
     }
 
-    /// One full attempt of [`Self::block_receipts_at`]; the error's bool is
-    /// the [`all_tip_lag`] verdict (see get_block_by_number_inner).
+    /// One full attempt of [`Self::block_receipts_at`]; error semantics are
+    /// [`PoolReadError`]'s (see get_block_by_number_inner).
     async fn block_receipts_at_inner(
         &self,
         target: Option<u64>,
-    ) -> Result<Option<([u8; 32], Vec<VerifiedReceipt>)>, (String, bool)> {
-        let (head_num, head_hash) = self.anchored_head().map_err(|e| (e, false))?;
+    ) -> Result<Option<([u8; 32], Vec<VerifiedReceipt>)>, PoolReadError> {
+        let (head_num, head_hash) = self.anchored_head().map_err(PoolReadError::Fatal)?;
         let target_num = target.unwrap_or(head_num);
         if target_num > head_num {
             return Ok(None); // future/unknown block → eth null
         }
         let back = head_num - target_num;
         if back >= BLOCK_LOOKBACK_MAX {
-            return Err((format!(
+            return Err(PoolReadError::Fatal(format!(
                 "block {target_num} is {back} behind the head — beyond the {BLOCK_LOOKBACK_MAX}-block verify window"
-            ), false));
+            )));
         }
         let peers = self.pool.snap_peers().await;
         if peers.is_empty() {
-            return Err(("no snap peer available".to_string(), false));
+            return Err(PoolReadError::Fatal("no snap peer available".to_string()));
         }
         let total = peers.len();
         let mut failures: Vec<String> = Vec::with_capacity(total);
@@ -4996,20 +5021,19 @@ impl ElReader {
                 }
             }
         }
-        let tip_lag = all_tip_lag(&failures);
-        // Tip-lag batches don't strike peers — see get_block_by_number_inner.
-        if !tip_lag {
-            self.record_batch_failures(&failed).await;
-        }
         let summary = summarize_peer_failures(&failures);
         // Same rationale as get_block_by_number: whole-pool failures must be
         // diagnosable from an info+ log ring.
         tracing::warn!(total, target_num, back, summary = %summary,
             "verified receipts fetch failed against every snap peer");
-        Err((
-            format!("all {total} snap peer(s) failed to serve verifiable block receipts: {summary}"),
-            tip_lag,
-        ))
+        let error =
+            format!("all {total} snap peer(s) failed to serve verifiable block receipts: {summary}");
+        if all_tip_lag(&failures) {
+            // Strike deferral — see get_block_by_number_inner.
+            return Err(PoolReadError::TipLag { error, failed });
+        }
+        self.record_batch_failures(&failed).await;
+        Err(PoolReadError::Fatal(error))
     }
 
     /// One peer's block-receipts serve: anchored window, body + receipts in


### PR DESCRIPTION
## Problem

The beacon **optimistic head can outrun the snap peers' imported EL tip** by a slot or two. A `latest` block/receipts read taken in that window asks every peer for a header window ending at a hash none of them has imported yet — so **all of them** fail with `0 headers, expected 1` or a head-hash mismatch, and the read fails hard even though every peer is healthy and sub-second patience would have answered it.

State reads (`eth_call`, balances, ENS) already survive this via the handshake-head fallback in `snap_account_at_best_root`. Block/receipt reads cannot fall back: the anchored head hash **is** the verification input, so the only sound tolerance is a bounded retry that re-takes the advancing anchor.

This is follow-up #1 from the #412/#413 incident chain (the trigger those PRs exposed once the error surfacing and pool rotation were fixed).

## Fix

- `all_tip_lag()` classifies a whole-pool failure batch: true only when **every** peer failed tip-lag-shaped (short header window, or window head ≠ anchored head hash).
- `get_block_by_number` and `block_receipts_at` retry only then, only for `latest` (`target=None`), up to 3 times / 400 ms apart, re-taking the anchor and the current pool each attempt. Explicit-number reads and any batch with a transport/proof failure fail fast as before.
- **Verification is never weakened**: each attempt re-verifies against the then-current anchored head hash; `Undecodable` (deterministic proof/decode failures) still fails fast.

## Hardened after internal review

- **Deferred strikes**: per-peer read-failure recording now waits for the batch outcome — a whole-pool tip-lag batch strikes nobody. Without this, one retrying `latest` read (4 attempts × `READ_FAILS_EVICT`=3) could evict the entire healthy pool that the retry exists to re-use. Every other outcome banks strikes exactly as immediate recording did (a genuinely header-less peer still accrues them whenever any peer succeeds or fails differently).
- **Over-serve exclusion**: `fetch_anchored_window` now words a *short* window (tip-lag-shaped) differently from an *over-served* one (protocol violation), so over-serving can never classify as retryable.

## Tradeoffs / notes

- A read that stays tip-lag for all attempts returns its -32000 ~1.2 s later than before (deliberate: the retryable error is unchanged, callers with tight deadlines see latency, not a different contract).
- Tests pin the classifier (qualifying shapes, one-transport-disqualifies, empty, over-serve exclusion). The retry loop itself isn't integration-tested — it needs live pool/anchor machinery; the gating (`target.is_none()`, bounded attempts) is straightforward and was independently reviewed.
- `evm_setup` (`eth_call` / `estimateGas` / ENS) resolves its head via `get_block_by_number(None, …)` and so transparently inherits the retry — including the +1.2 s worst case on the failing path (reviewer note; consistent with intent).
- After review, strikes are **deferred**, not forgiven: a tip-lag batch banks its per-peer strikes when the retry budget is exhausted (or immediately for a pinned read), so a persistently lagging pool keeps driving eviction/refill at the pre-retry rate while transient blips stay strike-free.
- Rust engine only; the Java engine's eviction/rotation twin is the next work item. `fee_estimate` (gas-price paths) still strikes immediately on the same tip-lag shape — tracked as a follow-up alongside that work.

`cargo test -p myotis-net`: 339 passed. Clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZjDDn6qE9QzhiJHHpKpmx
