### PR TITLE
Java engine: evict snap peers on repeated verified-read failures

### DIFF
--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/AndroidPeerCache.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/AndroidPeerCache.java
@@ -78,7 +78,14 @@ public final class AndroidPeerCache implements Closeable {
     private static final String TAG = "ethp2p.cache";
     private static final char SEP = '\t';
 
-    /** Consecutive snap-serve failures before a peer is marked {@code DENIED}. */
+    /** Consecutive snap-serve failures before a peer is marked {@code DENIED}.
+     *  Deliberately equal to {@code RLPxConnector.READ_FAILS_EVICT}: the read
+     *  that evicts a peer from the live pool is the read whose persisted
+     *  verdict flips to DENIED, like the Rust engine's compile-asserted twin
+     *  thresholds (pool.rs / peercache.rs). This host module can't reference
+     *  the constant and has no JVM test source set; the daemon twin's
+     *  {@code PeerCacheTest} pins the equality — keep this mirror in step with
+     *  {@code PeerCache.SNAP_FAILURE_THRESHOLD} when it moves. */
     public static final int SNAP_FAILURE_THRESHOLD = 3;
 
     /** Consecutive TCP connect failures before a peer reports {@code DENIED}

--- a/app/src/main/java/com/jaeckel/ethp2p/app/PeerCache.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/PeerCache.java
@@ -82,7 +82,12 @@ public final class PeerCache implements Closeable {
     private static final Logger log = LoggerFactory.getLogger(PeerCache.class);
     private static final char SEP = '\t';
 
-    /** Consecutive snap-serve failures before a peer is marked {@code DENIED}. */
+    /** Consecutive snap-serve failures before a peer is marked {@code DENIED}.
+     *  Deliberately equal to {@code RLPxConnector.READ_FAILS_EVICT} (which this
+     *  host module can't reference at runtime — {@code PeerCacheTest} pins the
+     *  equality): the read that evicts a peer from the live pool is the read
+     *  whose persisted verdict flips to DENIED, like the Rust engine's
+     *  compile-asserted twin thresholds (pool.rs / peercache.rs). */
     public static final int SNAP_FAILURE_THRESHOLD = 3;
 
     /** Consecutive TCP connect failures before a peer reports {@code DENIED}

--- a/app/src/test/java/com/jaeckel/ethp2p/app/PeerCacheTest.java
+++ b/app/src/test/java/com/jaeckel/ethp2p/app/PeerCacheTest.java
@@ -23,6 +23,19 @@ class PeerCacheTest {
     }
 
     @Test
+    void snapFailureThresholdMatchesThePoolEvictionLadder() {
+        // The read that evicts (RLPxConnector.READ_FAILS_EVICT, the in-pool
+        // consecutive-failure ladder) must be the read whose cache verdict
+        // flips to DENIED — the two counters move in lockstep, like the Rust
+        // engine's compile-asserted READ_FAILS_EVICT == FAILURE_THRESHOLD
+        // (pool.rs). The classes can't reference each other (hosts don't see
+        // :networking at runtime), so this test carries the assertion.
+        assertEquals(
+            com.jaeckel.ethp2p.networking.rlpx.RLPxConnector.READ_FAILS_EVICT,
+            PeerCache.SNAP_FAILURE_THRESHOLD);
+    }
+
+    @Test
     void connectFailuresDemoteThenEvict(@TempDir Path dir) {
         PeerCache cache = new PeerCache(dir.resolve("peers.cache"));
         cache.add(A, PK, true);

--- a/myotis-evm/src/main/java/io/myotis/evm/world/SnapBackedStateOracle.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/world/SnapBackedStateOracle.java
@@ -451,6 +451,11 @@ public final class SnapBackedStateOracle implements SnapStateOracle {
         }
         future.whenComplete((value, error) -> {
             if (error == null) {
+                // Every op run through here proves or hash-checks what it
+                // fetched before completing, so success == VERIFIED serve —
+                // the only point trustworthy enough to credit the peer
+                // (routing preference, pool streak reset, cache verdict).
+                try { peer.reportServed(); } catch (RuntimeException ignore) {}
                 sink.complete(value);
                 return;
             }

--- a/myotis-evm/src/main/java/io/myotis/evm/world/SnapBackedStateOracle.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/world/SnapBackedStateOracle.java
@@ -154,7 +154,11 @@ public final class SnapBackedStateOracle implements SnapStateOracle {
             if (cached.isPresent()) return CompletableFuture.completedFuture(cached.get());
             return tryWithRetries(peer -> peer
                     .getTrieNodes(root, List.of(SnapPeer.PathSet.storageSlot(accountHash, slotHash)))
-                    .thenApply(nodes -> verifyAndDecodeStorage(storageRoot, slotHash, address, nodes)))
+                    .thenApply(nodes -> {
+                        BigInteger v = verifyAndDecodeStorage(storageRoot, slotHash, address, nodes);
+                        credit(peer);
+                        return v;
+                    }))
                     .thenApply(value -> {
                         stateCache.putStorage(storageRootBytes, slot, value);
                         return value;
@@ -237,7 +241,15 @@ public final class SnapBackedStateOracle implements SnapStateOracle {
             // a chunk that can't be verified after retries is left uncached (the caller's
             // per-item path re-fetches it), so the batch never weakens correctness.
             CompletableFuture<Void> cf = tryWithRetries(peer -> peer.getTrieNodes(root, paths)
-                    .thenApply(nodes -> { verifyAndCacheChunk(stateRoot, root, chunk, nodes); return (Void) null; }))
+                    .thenApply(nodes -> {
+                        // Credit only when the chunk verified something from THIS
+                        // response: a fully cache-filled chunk (concurrent batch)
+                        // checks nothing of this peer's bytes.
+                        if (verifyAndCacheChunk(stateRoot, root, chunk, nodes)) {
+                            credit(peer);
+                        }
+                        return (Void) null;
+                    }))
                     .exceptionally(t -> {
                         log.debug("[snap-oracle] batch chunk ({} accounts) failed: {}",
                                 chunk.size(), t.getMessage());
@@ -252,9 +264,14 @@ public final class SnapBackedStateOracle implements SnapStateOracle {
      *  list the peer returned. Each proof is checked with the same verifier the
      *  per-item path uses (the verifier builds a hash→node map, so a combined node set
      *  verifies each key independently); a bad proof throws InvalidProof, failing the
-     *  whole chunk so tryWithRetries rotates to another peer. */
-    private void verifyAndCacheChunk(byte[] stateRoot, Bytes32 root,
-                                     List<BatchItem> chunk, List<Bytes> nodes) {
+     *  whole chunk so tryWithRetries rotates to another peer.
+     *
+     *  @return true iff at least one account or slot was verified from THIS
+     *      response (false = everything was already cache-filled, so nothing of
+     *      this peer's bytes was checked and no serve credit is deserved) */
+    private boolean verifyAndCacheChunk(byte[] stateRoot, Bytes32 root,
+                                        List<BatchItem> chunk, List<Bytes> nodes) {
+        boolean verifiedAny = false;
         for (BatchItem it : chunk) {
             // Query the cache live (not a static per-build snapshot): on a chunk retry
             // against a different peer, items the previous attempt already verified are
@@ -268,6 +285,7 @@ public final class SnapBackedStateOracle implements SnapStateOracle {
                         Bytes32.wrap(cached.get().storageRoot()));
             } else {
                 awr = verifyAndDecodeAccount(root, it.accountHash(), it.address(), nodes);
+                verifiedAny = true;
                 stateCache.putAccount(stateRoot, it.addr(),
                         new StateProofCache.AccountEntry(awr.account(), awr.storageRoot().toArrayUnsafe()));
             }
@@ -281,9 +299,11 @@ public final class SnapBackedStateOracle implements SnapStateOracle {
                 if (stateCache.getStorage(storageRootBytes, slot).isPresent()) continue;
                 BigInteger value = verifyAndDecodeStorage(
                         storageRoot, it.slotHashes().get(s), it.address(), nodes);
+                verifiedAny = true;
                 stateCache.putStorage(storageRootBytes, slot, value);
             }
         }
+        return verifiedAny;
     }
 
     @Override
@@ -314,6 +334,7 @@ public final class SnapBackedStateOracle implements SnapStateOracle {
                                                 + " got " + Hex.formatHexPrefixed(actualHash)));
                     }
                     bytecodeCache.put(codeHash, code);
+                    credit(peer);
                     return code;
                 }));
     }
@@ -344,7 +365,12 @@ public final class SnapBackedStateOracle implements SnapStateOracle {
         return accountCache.computeIfAbsent(key, k -> {
             CompletableFuture<AccountWithStorageRoot> f = tryWithRetries(peer -> peer
                     .getTrieNodes(root, List.of(SnapPeer.PathSet.account(accountHash)))
-                    .thenApply(nodes -> verifyAndDecodeAccount(root, accountHash, address, nodes)));
+                    .thenApply(nodes -> {
+                        AccountWithStorageRoot awr =
+                                verifyAndDecodeAccount(root, accountHash, address, nodes);
+                        credit(peer);
+                        return awr;
+                    }));
             // Evict failed fetches so a later read can retry across peers; on success
             // promote the verified record to the cross-call cache. Use *Async so
             // neither runs synchronously inside computeIfAbsent (a reentrant map
@@ -377,6 +403,16 @@ public final class SnapBackedStateOracle implements SnapStateOracle {
      * the worst case from {@code maxAttempts × request-timeout} (~30s of
      * zombie latency, longer than wallet client timeouts) to a single attempt.
      */
+    /** Credit {@code peer} with a VERIFIED serve ({@link SnapPeer#reportServed}).
+     *  Called only at the concrete verification sites, immediately after a proof
+     *  or hash check on THIS peer's bytes passed — never centrally on op success,
+     *  because an op can succeed without checking anything from this peer (a
+     *  batch chunk whose items a concurrent batch already cache-filled), and a
+     *  slow junk peer must not be able to farm serve credit off that race. */
+    private static void credit(SnapPeer peer) {
+        try { peer.reportServed(); } catch (RuntimeException ignore) {}
+    }
+
     private <T> CompletableFuture<T> tryWithRetries(java.util.function.Function<SnapPeer, CompletableFuture<T>> op) {
         CompletableFuture<T> result = new CompletableFuture<>();
         // Keys are SnapPeer.identity() tokens, compared by reference.
@@ -451,11 +487,6 @@ public final class SnapBackedStateOracle implements SnapStateOracle {
         }
         future.whenComplete((value, error) -> {
             if (error == null) {
-                // Every op run through here proves or hash-checks what it
-                // fetched before completing, so success == VERIFIED serve —
-                // the only point trustworthy enough to credit the peer
-                // (routing preference, pool streak reset, cache verdict).
-                try { peer.reportServed(); } catch (RuntimeException ignore) {}
                 sink.complete(value);
                 return;
             }

--- a/myotis-evm/src/main/java/io/myotis/evm/world/SnapPeer.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/world/SnapPeer.java
@@ -83,7 +83,9 @@ public interface SnapPeer {
      *  NOT off a merely non-empty response: a structurally valid but junk
      *  response otherwise clears failure streaks before its verification
      *  fails, letting a byzantine peer oscillate a strike ladder 0↔1 and
-     *  dodge eviction forever. Default no-op. */
+     *  dodge eviction forever. Fired at the oracle's concrete verification
+     *  sites (not centrally on op success, which a fully cache-filled batch
+     *  chunk can reach without checking this peer's bytes). Default no-op. */
     default void reportServed() {}
 
     /**

--- a/myotis-evm/src/main/java/io/myotis/evm/world/SnapPeer.java
+++ b/myotis-evm/src/main/java/io/myotis/evm/world/SnapPeer.java
@@ -77,6 +77,15 @@ public interface SnapPeer {
      */
     default void reportRootUnavailable() {}
 
+    /** Reported when a fetch through this peer VERIFIED (Merkle proof or hash
+     *  checked by the oracle) — the trustworthy "this peer served" signal.
+     *  Routing preference and any pool/cache serve credit must hang off this,
+     *  NOT off a merely non-empty response: a structurally valid but junk
+     *  response otherwise clears failure streaks before its verification
+     *  fails, letting a byzantine peer oscillate a strike ladder 0↔1 and
+     *  dodge eviction forever. Default no-op. */
+    default void reportServed() {}
+
     /**
      * Short human-readable identity for logs ("ip:port" for network-backed
      * implementations). Purely diagnostic — never used for routing decisions.

--- a/myotis-evm/src/test/java/io/myotis/evm/world/SnapBackedStateOracleTest.java
+++ b/myotis-evm/src/test/java/io/myotis/evm/world/SnapBackedStateOracleTest.java
@@ -524,6 +524,72 @@ class SnapBackedStateOracleTest {
     }
 
     @Test
+    void chunkFullyCacheFilledMidFlightGrantsNoServeCredit() throws Exception {
+        // The serve credit (SnapPeer.reportServed — it resets the pool's eviction
+        // streak and re-confirms the peer cache) must fire only when something of
+        // THIS peer's bytes verified. The hole this pins shut: a batch chunk built
+        // while the cache was cold can find every item cache-filled by a CONCURRENT
+        // batch by the time its response arrives — verifyAndCacheChunk then checks
+        // nothing, and a slow peer answering garbage would have been credited for a
+        // "serve" nobody verified, farming streak resets off the race.
+        Address addr = Address.fromHex("0xabcdef0102030405060708090a0b0c0d0e0f1011");
+        BigInteger slot = BigInteger.valueOf(7);
+        Bytes32 slotHash = Bytes32.wrap(Hash.keccak256(paddedSlot(slot)).toArrayUnsafe());
+        Bytes valueRlp = RLP.encode(w -> w.writeBigInteger(new BigInteger("42")));
+        var storageTrie = TrieFixture.singleLeaf(slotHash, valueRlp);
+        Bytes accountValue = encodeAccount(1L, BigInteger.TEN, storageTrie.root,
+                Bytes32.wrap(Hash.keccak256(Bytes.EMPTY).toArrayUnsafe()));
+        var accountTrie = TrieFixture.singleLeaf(keccak(addr.toByteArray()), accountValue);
+        List<Bytes> combined = new ArrayList<>();
+        combined.addAll(accountTrie.proof);
+        combined.addAll(storageTrie.proof);
+        byte[] root = accountTrie.root.toArrayUnsafe();
+        var shared = StateProofCache.inMemory(1024);
+        Map<Address, Set<BigInteger>> req = new HashMap<>();
+        req.put(addr, Set.of(slot));
+
+        // The junk peer's batch is BUILT against the cold cache (items included),
+        // but its response hangs in flight...
+        AtomicInteger junkCredits = new AtomicInteger();
+        CompletableFuture<List<Bytes>> junkResponse = new CompletableFuture<>();
+        SnapPeer junk = new SnapPeer() {
+            @Override public CompletableFuture<List<Bytes>> getTrieNodes(Bytes32 sr, List<PathSet> p) {
+                return junkResponse;
+            }
+            @Override public CompletableFuture<List<Bytes>> getByteCodes(List<Bytes32> h) {
+                return CompletableFuture.completedFuture(List.of());
+            }
+            @Override public void reportServed() { junkCredits.incrementAndGet(); }
+        };
+        CompletableFuture<Void> inFlight = new SnapBackedStateOracle(
+                () -> junk, BytecodeCache.inMemory(), 2, shared).fetchBatch(root, req);
+
+        // ...while a concurrent honest batch verifies and fills the SHARED cache
+        // (and earns the credit — the positive half of the pin)...
+        AtomicInteger honestCredits = new AtomicInteger();
+        SnapPeer honest = new SnapPeer() {
+            @Override public CompletableFuture<List<Bytes>> getTrieNodes(Bytes32 sr, List<PathSet> p) {
+                return CompletableFuture.completedFuture(combined);
+            }
+            @Override public CompletableFuture<List<Bytes>> getByteCodes(List<Bytes32> h) {
+                return CompletableFuture.completedFuture(List.of());
+            }
+            @Override public void reportServed() { honestCredits.incrementAndGet(); }
+        };
+        new SnapBackedStateOracle(() -> honest, BytecodeCache.inMemory(), 2, shared)
+                .fetchBatch(root, req).get();
+        assertEquals(1, honestCredits.get(), "a verified batch chunk must credit its peer");
+
+        // ...and only then does the junk peer answer, with garbage. Every item is
+        // now a cache hit, so the chunk completes without touching those bytes —
+        // and must therefore credit nothing.
+        junkResponse.complete(List.of(Bytes.fromHexString("0xdeadbeef")));
+        inFlight.get();
+        assertEquals(0, junkCredits.get(),
+                "a chunk that verified nothing of this peer's bytes must not credit it");
+    }
+
+    @Test
     void fetchBatchRetryServesAlreadyVerifiedItemsFromCache() throws Exception {
         // Retry robustness across peer rotation. Attempt 1 proves the account but NOT
         // the slot, so the slot verify fails and the whole chunk retries on the next

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/EthHandler.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/eth/EthHandler.java
@@ -107,6 +107,14 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
      *  snap serving pool (0 = not benched). nanoTime, not currentTimeMillis: a wall-clock
      *  adjustment (NTP / manual) must not extend or prematurely expire the cooldown. */
     private volatile long snapServingFailedUntilNs = 0L;
+    /** CONSECUTIVE verified-read failures (a serve resets it). Banked and judged by
+     *  {@code RLPxConnector.recordReadFailure} — the bench above handles a momentary
+     *  lag, this counter is the escalation for a peer that KEEPS failing after its
+     *  cooldowns: at {@code RLPxConnector.READ_FAILS_EVICT} the peer is disconnected
+     *  so the maintainer refills the slot with a fresh candidate (twin of the Rust
+     *  engine's read-failure eviction, pool.rs). */
+    private final java.util.concurrent.atomic.AtomicInteger snapReadFails =
+        new java.util.concurrent.atomic.AtomicInteger();
     private volatile org.apache.tuweni.bytes.Bytes32 latestStateRoot;
     private volatile long latestStateRootBlockNumber = -1;
 
@@ -1657,6 +1665,41 @@ public final class EthHandler extends ChannelInboundHandlerAdapter {
         long until = System.nanoTime() + SNAP_SERVING_COOLDOWN_NS;
         // nanoTime can legitimately be 0; remap so 0 keeps meaning "not benched".
         snapServingFailedUntilNs = (until == 0L) ? 1L : until;
+    }
+
+    /** Current consecutive verified-read failure streak. */
+    public int snapReadFailStreak() {
+        return snapReadFails.get();
+    }
+
+    /** Bank one consecutive verified-read failure and return the new streak.
+     *  Policy (bench vs evict) lives in {@code RLPxConnector.recordReadFailure}. */
+    public int bankSnapReadFailure() {
+        return snapReadFails.incrementAndGet();
+    }
+
+    /** A verified read served — reset the CONSECUTIVE-failure streak. */
+    public void clearSnapReadFailures() {
+        snapReadFails.set(0);
+    }
+
+    /** Close this peer's connection, sending a best-effort p2p Disconnect(0x03
+     *  useless peer) first. The channel's close future does the rest (pending
+     *  requests fail, {@code activeHandlers} removal, the host's close callback
+     *  applies its transient backoff), and the snap maintainer refills the freed
+     *  slot on its next tick. Used by the read-failure eviction ladder. */
+    public void evict() {
+        ChannelHandlerContext ctx = readyCtx;
+        if (ctx == null) {
+            return;
+        }
+        try {
+            // RLP([reason]) with reason 0x03 = "useless peer".
+            rlpxHandler.sendMessage(ctx, P2P_DISCONNECT, new byte[] {(byte) 0xC1, 0x03});
+        } catch (RuntimeException ignore) {
+            // Best-effort courtesy only — the close below is what matters.
+        }
+        ctx.close();
     }
 
     public State getState() {

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/rlpx/RLPxConnector.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/rlpx/RLPxConnector.java
@@ -647,7 +647,10 @@ public final class RLPxConnector implements AutoCloseable {
                 benchReadFailure(handler);
                 return trySnapStoragePeer(contractAddress, storageKeyHash, stateRoot, peers, index + 1);
             }
-            recordReadServed(handler);
+            // No streak clear here: nothing on this path is verified (the proof
+            // check happens in the caller), and the serve credit must not be
+            // spoofable with junk bytes — clears, like strikes, come only from
+            // the oracle path, post-verification (SnapPeer.reportServed).
             return CompletableFuture.completedFuture(result);
         }).thenCompose(Function.identity());
     }
@@ -725,17 +728,30 @@ public final class RLPxConnector implements AutoCloseable {
      *  serve: routing prefers proven servers, so a struck peer may not be re-tried
      *  soon, and strikes from unrelated transient lags can accumulate to an eviction —
      *  acceptable, since eviction only costs a re-dial and the cache verdict needs the
-     *  same three failures it always did. */
-    public synchronized void recordReadFailure(EthHandler failed) {
+     *  same three failures it always did.
+     *
+     *  @return true when a strike was banked (BENCH/EVICT); false on the sole-peer
+     *      SHIELD — callers pairing this with a persisted failure verdict must skip
+     *      that write too, or three shielded outages would persist DENIED against
+     *      the one peer that kept serving (the guard Rust's record_quality keeps). */
+    public synchronized boolean recordReadFailure(EthHandler failed) {
         boolean anotherServing = anotherServing(failed);
         // Judged on the post-bank streak; the bank itself happens per branch because
         // the shield must not strike. Bank and clear both happen under the connector
         // monitor (recordReadServed is synchronized too), so streak+1 IS the
         // post-bank value.
         switch (readFailureVerdict(anotherServing, failed.snapReadFailStreak() + 1)) {
-            case SHIELD -> log.info(
-                "[rlpx] Not benching {} — last serving snap peer (empty response likely "
-                    + "a stale-root request)", failed.getRemoteAddress());
+            case SHIELD -> {
+                // Zero the streak, matching the Rust twin: keeping banked
+                // strikes frozen through a shielded phase would evict the peer
+                // on its very next failure the instant the pool regrows,
+                // before it has actually failed as a NON-sole peer.
+                failed.clearSnapReadFailures();
+                log.info(
+                    "[rlpx] Not benching {} — last serving snap peer (empty response likely "
+                        + "a stale-root request)", failed.getRemoteAddress());
+                return false;
+            }
             case BENCH -> {
                 failed.bankSnapReadFailure();
                 failed.markSnapServingFailed();
@@ -755,6 +771,7 @@ public final class RLPxConnector implements AutoCloseable {
                 failed.evict();
             }
         }
+        return true;
     }
 
     /** A verified read served from this peer — reset its consecutive-failure streak.

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/rlpx/RLPxConnector.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/rlpx/RLPxConnector.java
@@ -644,30 +644,124 @@ public final class RLPxConnector implements AutoCloseable {
             if (result.slots().isEmpty() && result.proof().isEmpty()) {
                 log.warn("[rlpx] Peer {} returned empty storage response, trying next peer",
                     handler.getRemoteAddress());
-                benchUnlessLastServing(handler);
+                benchReadFailure(handler);
                 return trySnapStoragePeer(contractAddress, storageKeyHash, stateRoot, peers, index + 1);
             }
+            recordReadServed(handler);
             return CompletableFuture.completedFuture(result);
         }).thenCompose(Function.identity());
     }
 
-    /** Bench a peer that failed to serve — unless it is the last un-benched serving
-     *  snap peer. An empty snap response usually means WE asked for a state root
-     *  outside the peer's ~128-block snapshot window (stale local head), not that
-     *  the peer is broken; benching the sole server empties the serving pool and
-     *  flaps the status (and the EL hunt) between 0 and 1 until the bench expires.
-     *  Synchronized so two concurrent failures on the last two serving peers
-     *  can't each see the other as still serving and both bench — the scan and
-     *  the mark must be atomic against other benchers. */
-    private synchronized void benchUnlessLastServing(EthHandler failed) {
+    /** Consecutive verified-read failures at which a peer is DISCONNECTED instead of
+     *  benched, freeing its slot for a fresh candidate (the snap maintainer refills on
+     *  serving count). Twin of the Rust engine's {@code READ_FAILS_EVICT}
+     *  (rust/myotis-net/src/el/pool.rs), and deliberately equal to the peer caches'
+     *  snap-failure DENIED threshold ({@code PeerCache}/{@code AndroidPeerCache}
+     *  {@code SNAP_FAILURE_THRESHOLD} — they can't import this constant, hosts don't
+     *  see {@code :networking}; {@code PeerCacheTest} pins the equality) so eviction
+     *  and the persisted verdict move in lockstep: the read that evicts is the read
+     *  that denies. */
+    public static final int READ_FAILS_EVICT = 3;
+
+    /** Outcome of one banked verified-read failure. */
+    enum ReadFailureVerdict { SHIELD, BENCH, EVICT }
+
+    /** The pure ladder, extracted for tests: the sole serving peer is shielded (an
+     *  empty response there is likelier OUR stale root than a broken peer, and
+     *  benching it flaps the serving pool between 0 and 1); otherwise the streak
+     *  benches until it reaches {@link #READ_FAILS_EVICT}, then evicts. */
+    static ReadFailureVerdict readFailureVerdict(boolean anotherServing, int failsAfterBank) {
+        if (!anotherServing) {
+            return ReadFailureVerdict.SHIELD;
+        }
+        return failsAfterBank >= READ_FAILS_EVICT ? ReadFailureVerdict.EVICT
+                                                  : ReadFailureVerdict.BENCH;
+    }
+
+    /** True when a serving snap peer other than {@code failed} exists. Caller must hold
+     *  the connector monitor (the scan and the subsequent bench/evict must be atomic
+     *  against other benchers, or the last two serving peers can each see the other as
+     *  still serving and both leave the pool). Counts UN-BENCHED peers — deliberately
+     *  narrower than the Rust twin's shield (any live pool peer, benched included,
+     *  pool.rs): it mirrors the pre-eviction {@code benchUnlessLastServing} predicate,
+     *  and stops striking once the rest of the pool is already benched, which a
+     *  whole-pool outage (our stale root, not the peers') would otherwise turn into a
+     *  pool-wide eviction. */
+    private boolean anotherServing(EthHandler failed) {
         for (EthHandler h : activeHandlers) {
             if (h != failed && h.isReady() && h.isSnapNegotiated() && !h.isSnapServingFailed()) {
-                failed.markSnapServingFailed();
-                return;
+                return true;
             }
         }
-        log.info("[rlpx] Not benching {} — last serving snap peer (empty response likely "
-            + "a stale-root request)", failed.getRemoteAddress());
+        return false;
+    }
+
+    /** Bench a peer whose response failed a read, without banking an eviction strike —
+     *  for PER-RESPONSE failure paths (one storage request rotating N peers fires this
+     *  N times, and concurrent requests multiply it): banking here would let a couple
+     *  of stale-root queries walk healthy peers to eviction, and this path has no
+     *  cache access, so an eviction from it could not write the DENIED verdict the
+     *  ladder promises ("the read that evicts is the read that denies"). Strikes come
+     *  only from {@link #recordReadFailure}, whose oracle caller dedupes per root
+     *  context and pairs each strike with a cache verdict. */
+    public synchronized void benchReadFailure(EthHandler failed) {
+        if (anotherServing(failed)) {
+            failed.markSnapServingFailed();
+        } else {
+            log.info("[rlpx] Not benching {} — last serving snap peer (empty response likely "
+                + "a stale-root request)", failed.getRemoteAddress());
+        }
+    }
+
+    /** A verified read failed against this peer: bench it for the cooldown, or — on the
+     *  {@link #READ_FAILS_EVICT}th CONSECUTIVE failure — disconnect it so the maintainer
+     *  replaces it (a 30s bench routes around a momentary lag; it cannot rotate out a
+     *  peer that keeps failing, which is how a stale pool held every slot in the Rust
+     *  engine's 2026-09-02 incident). The last un-benched serving snap peer is shielded
+     *  (no strike banked either — matching the Rust pool's sole-peer shield). Callers
+     *  must dedupe to at most one call per peer per failed READ (the oracle gates on
+     *  its per-root-context deny set) — per-response paths use
+     *  {@link #benchReadFailure} instead. Note "consecutive" means no intervening
+     *  serve: routing prefers proven servers, so a struck peer may not be re-tried
+     *  soon, and strikes from unrelated transient lags can accumulate to an eviction —
+     *  acceptable, since eviction only costs a re-dial and the cache verdict needs the
+     *  same three failures it always did. */
+    public synchronized void recordReadFailure(EthHandler failed) {
+        boolean anotherServing = anotherServing(failed);
+        // Judged on the post-bank streak; the bank itself happens per branch because
+        // the shield must not strike. Bank and clear both happen under the connector
+        // monitor (recordReadServed is synchronized too), so streak+1 IS the
+        // post-bank value.
+        switch (readFailureVerdict(anotherServing, failed.snapReadFailStreak() + 1)) {
+            case SHIELD -> log.info(
+                "[rlpx] Not benching {} — last serving snap peer (empty response likely "
+                    + "a stale-root request)", failed.getRemoteAddress());
+            case BENCH -> {
+                failed.bankSnapReadFailure();
+                failed.markSnapServingFailed();
+            }
+            case EVICT -> {
+                failed.bankSnapReadFailure();
+                // Bench BEFORE the close: removal from activeHandlers happens
+                // asynchronously in the close-future listener, so without this
+                // a just-evicted peer still satisfies the anotherServing scan
+                // above and two concurrent evictions could drain the pool past
+                // the shield (the Rust twin's prune_closed guards the same
+                // corpse-counting hole, pool.rs).
+                failed.markSnapServingFailed();
+                log.info("[rlpx] Evicting snap peer {} after {} consecutive verified-read "
+                    + "failures — freeing the slot for a fresh candidate",
+                    failed.getRemoteAddress(), READ_FAILS_EVICT);
+                failed.evict();
+            }
+        }
+    }
+
+    /** A verified read served from this peer — reset its consecutive-failure streak.
+     *  Synchronized with {@link #recordReadFailure} so a concurrent serve can't zero a
+     *  streak between that method's read and its bank. */
+    public synchronized void recordReadServed(EthHandler served) {
+        served.clearSnapReadFailures();
     }
 
     public record PeerInfo(String remoteAddress, String state, boolean snapSupported, String clientId) {}

--- a/networking/src/test/java/com/jaeckel/ethp2p/networking/rlpx/ReadFailureVerdictTest.java
+++ b/networking/src/test/java/com/jaeckel/ethp2p/networking/rlpx/ReadFailureVerdictTest.java
@@ -1,0 +1,48 @@
+package com.jaeckel.ethp2p.networking.rlpx;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.jaeckel.ethp2p.networking.rlpx.RLPxConnector.ReadFailureVerdict;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The verified-read failure ladder (twin of the Rust engine's
+ * {@code read_failure_verdict}, rust/myotis-net/src/el/pool.rs): the sole
+ * serving peer is shielded (no strike, no bench — benching it flaps the
+ * serving pool between 0 and 1, and an empty response there is likelier OUR
+ * stale root); otherwise consecutive failures bench until the
+ * {@code READ_FAILS_EVICT}th, which evicts so the maintainer can refill the
+ * slot. Pinned here because the 2026-09-02 stale-pool incident was exactly a
+ * pool that benching alone could never rotate out.
+ */
+class ReadFailureVerdictTest {
+
+    @Test
+    void soleServingPeerIsShieldedRegardlessOfStreak() {
+        assertEquals(ReadFailureVerdict.SHIELD, RLPxConnector.readFailureVerdict(false, 1));
+        assertEquals(ReadFailureVerdict.SHIELD, RLPxConnector.readFailureVerdict(false, 99));
+    }
+
+    @Test
+    void failuresBelowTheThresholdBench() {
+        for (int fails = 1; fails < RLPxConnector.READ_FAILS_EVICT; fails++) {
+            assertEquals(ReadFailureVerdict.BENCH, RLPxConnector.readFailureVerdict(true, fails));
+        }
+    }
+
+    @Test
+    void theThresholdFailureEvicts() {
+        assertEquals(ReadFailureVerdict.EVICT,
+            RLPxConnector.readFailureVerdict(true, RLPxConnector.READ_FAILS_EVICT));
+        assertEquals(ReadFailureVerdict.EVICT,
+            RLPxConnector.readFailureVerdict(true, RLPxConnector.READ_FAILS_EVICT + 1));
+    }
+
+    @Test
+    void thresholdMatchesTheRustEngine() {
+        // rust/myotis-net/src/el/pool.rs READ_FAILS_EVICT — the two engines
+        // must rotate at the same rate (the caches' DENIED threshold equality
+        // is pinned by PeerCacheTest, which sees both classes).
+        assertEquals(3, RLPxConnector.READ_FAILS_EVICT);
+    }
+}

--- a/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
+++ b/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
@@ -3969,8 +3969,22 @@ public final class VerifiedRpcBackend implements io.myotis.api.VerifiedReads,
      *  updated before the oracle's fail-fast skim re-consults the supplier), so
      *  the potentially blocking sink call moves off-thread here instead. */
     private void recordSnapQualityAsync(EthHandler peer, boolean served) {
-        java.util.concurrent.CompletableFuture.runAsync(() -> recordSnapQuality(peer, served));
+        // FIFO-chained, not independent runAsync tasks: the cache counts
+        // CONSECUTIVE failures, so a stale serve task overtaking three failure
+        // tasks would re-confirm a peer the pool just evicted and undo the
+        // DENIED verdict the eviction ladder pairs with. Appending under the
+        // lock fixes each event's position at callback time; the chain runs on
+        // the common pool, so callbacks still never block on the sink. Old
+        // stages become unreachable as the chain advances (no growth).
+        synchronized (snapQualityOrder) {
+            snapQualityTail = snapQualityTail.thenRunAsync(() -> recordSnapQuality(peer, served));
+        }
     }
+
+    /** Tail of the FIFO quality-write chain; guarded by {@link #snapQualityOrder}. */
+    private java.util.concurrent.CompletableFuture<Void> snapQualityTail =
+            java.util.concurrent.CompletableFuture.completedFuture(null);
+    private final Object snapQualityOrder = new Object();
 
     private void recordSnapQuality(EthHandler peer, boolean served) {
         if (peer == null) return;

--- a/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
+++ b/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
@@ -1785,8 +1785,13 @@ public final class VerifiedRpcBackend implements io.myotis.api.VerifiedReads,
         final java.util.function.Consumer<EthHandler> onRootDenied = p -> {
             if (rootDenied.add(p)) {
                 rootServed.remove(p);
-                recordSnapQualityAsync(p, false);
-                oracleConn.recordReadFailure(p);
+                // Strike first: on the sole-peer SHIELD (no strike banked) the
+                // persisted failure verdict is skipped too, or three shielded
+                // outages would persist DENIED against the one peer that kept
+                // serving — the same guard the Rust record_quality keeps.
+                if (oracleConn.recordReadFailure(p)) {
+                    recordSnapQualityAsync(p, false);
+                }
             }
         };
         final java.util.function.Consumer<EthHandler> onRootServed = p -> {

--- a/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
+++ b/rpc-backend/src/main/java/io/myotis/rpc/VerifiedRpcBackend.java
@@ -1776,7 +1776,25 @@ public final class VerifiedRpcBackend implements io.myotis.api.VerifiedReads,
         // non-empty proof confirms the peer as snap-serving (dialed first on
         // restart); the same root-unavailable event that deprioritizes it for this
         // head also feeds a failure verdict so repeat hangers are deprioritized
-        // across restarts.
+        // across restarts — and, in lockstep, a pool strike (bench, and at
+        // READ_FAILS_EVICT consecutive contexts a disconnect, so the maintainer
+        // replaces a peer that keeps failing instead of re-benching it forever).
+        // Gated on the routing set's add() so one context banks AT MOST ONE strike
+        // and one cache verdict per peer, however many concurrent fetches report
+        // the same deny (the strike ladder counts CONTEXTS, not fetches).
+        final java.util.function.Consumer<EthHandler> onRootDenied = p -> {
+            if (rootDenied.add(p)) {
+                rootServed.remove(p);
+                recordSnapQualityAsync(p, false);
+                oracleConn.recordReadFailure(p);
+            }
+        };
+        final java.util.function.Consumer<EthHandler> onRootServed = p -> {
+            if (rootServed.add(p)) {
+                recordSnapQualityAsync(p, true);
+                oracleConn.recordReadServed(p);
+            }
+        };
         io.myotis.evm.world.SnapBackedStateOracle oracle =
                 new io.myotis.evm.world.SnapBackedStateOracle(
                         () -> {
@@ -1792,10 +1810,8 @@ public final class VerifiedRpcBackend implements io.myotis.api.VerifiedReads,
                                 final EthHandler chosen = served.get(Math.floorMod(n, served.size()));
                                 return new EthHandlerSnapPeer(
                                         chosen,
-                                        () -> { rootDenied.add(chosen); rootServed.remove(chosen);
-                                                recordSnapQualityAsync(chosen, false); },
-                                        () -> { rootServed.add(chosen);
-                                                recordSnapQualityAsync(chosen, true); },
+                                        () -> onRootDenied.accept(chosen),
+                                        () -> onRootServed.accept(chosen),
                                         snapLaneGate);
                             }
                             // Discovery phase (none proven yet): probed peer first (known to
@@ -1805,10 +1821,8 @@ public final class VerifiedRpcBackend implements io.myotis.api.VerifiedReads,
                                 final EthHandler pp = probedPeer;
                                 return new EthHandlerSnapPeer(
                                         pp,
-                                        () -> { rootDenied.add(pp); rootServed.remove(pp);
-                                                recordSnapQualityAsync(pp, false); },
-                                        () -> { rootServed.add(pp);
-                                                recordSnapQualityAsync(pp, true); },
+                                        () -> onRootDenied.accept(pp),
+                                        () -> onRootServed.accept(pp),
                                         snapLaneGate);
                             }
                             // activeSnapHandlers() already returns only ready, snap-negotiated,
@@ -1822,10 +1836,8 @@ public final class VerifiedRpcBackend implements io.myotis.api.VerifiedReads,
                                     ready.get(Math.floorMod(n, ready.size()));
                             return new EthHandlerSnapPeer(
                                     chosen,
-                                    () -> { rootDenied.add(chosen); rootServed.remove(chosen);
-                                            recordSnapQualityAsync(chosen, false); },
-                                    () -> { rootServed.add(chosen);
-                                            recordSnapQualityAsync(chosen, true); });
+                                    () -> onRootDenied.accept(chosen),
+                                    () -> onRootServed.accept(chosen));
                         },
                         bytecodeCache,
                         SNAP_ORACLE_MAX_ATTEMPTS,

--- a/rpc-backend/src/main/java/io/myotis/rpc/snap/EthHandlerSnapPeer.java
+++ b/rpc-backend/src/main/java/io/myotis/rpc/snap/EthHandlerSnapPeer.java
@@ -57,11 +57,12 @@ public final class EthHandlerSnapPeer implements SnapPeer {
      *  current state root (deprioritize it for this head). Runs SYNCHRONOUSLY on
      *  the reporting thread (often the Netty event loop): keep it to lock-free
      *  routing mutations and offload anything that can block.
-     * @param onRootServed run when this peer returns a usable (non-empty) proof, so
-     *  the EL peer cache can record it as a proven snap-serving peer to dial first
-     *  on a restart. The two callbacks are mutually exclusive per fetch: a non-empty
-     *  proof fires {@code onRootServed}; an empty one is treated by the oracle as
-     *  no-state and ultimately fires {@code onRootUnavailable}.
+     * @param onRootServed run when a fetch through this peer VERIFIES (fired via
+     *  {@link #reportServed} from the oracle, never on a merely non-empty
+     *  response), so the EL peer cache can record it as a proven snap-serving
+     *  peer to dial first on a restart. The two callbacks are mutually exclusive
+     *  per fetch: a verified fetch fires {@code onRootServed}; an empty or
+     *  unverifiable one ultimately fires {@code onRootUnavailable}.
      */
     public EthHandlerSnapPeer(EthHandler handler, Runnable onRootUnavailable,
                               Runnable onRootServed, SnapLaneGate laneGate) {
@@ -79,6 +80,18 @@ public final class EthHandlerSnapPeer implements SnapPeer {
     @Override
     public String describe() {
         return handler.getRemoteAddress();
+    }
+
+    @Override
+    public void reportServed() {
+        // Fired by the oracle AFTER the fetched proof verified (never on a
+        // merely non-empty response — see SnapPeer.reportServed): the serve
+        // credit must not be spoofable with junk bytes. Synchronous, mirroring
+        // reportRootUnavailable: the supplier's rootServed preference should
+        // see the serve before the next consult.
+        if (onRootServed != null) {
+            try { onRootServed.run(); } catch (RuntimeException ignore) {}
+        }
     }
 
     @Override
@@ -147,17 +160,12 @@ public final class EthHandlerSnapPeer implements SnapPeer {
                 for (CompletableFuture<List<Bytes>> f : perSet) {
                     all.addAll(f.join());
                 }
-                // A non-empty proof means this peer actually retains the trie for
-                // this root — the durable "snap-serving" signal the EL cache wants.
-                // Empty proofs fall through to the oracle's no-state path, which
-                // calls reportRootUnavailable instead. Synchronous, mirroring
-                // reportRootUnavailable: the supplier's rootServed preference
-                // should see the serve before the next consult, and the callback
-                // contract requires callbacks to offload their own blocking work
-                // (see reportRootUnavailable).
-                if (!all.isEmpty() && onRootServed != null) {
-                    try { onRootServed.run(); } catch (RuntimeException ignore) {}
-                }
+                // NO serve credit here: a non-empty node list is not yet a
+                // serve — the oracle still has to verify it, and fires
+                // reportServed only when it does. Crediting on non-empty bytes
+                // let a junk response clear failure streaks (review finding on
+                // the eviction ladder). Empty proofs fall through to the
+                // oracle's no-state path → reportRootUnavailable.
                 return all;
             });
     }

--- a/rpc-backend/src/main/java/io/myotis/rpc/snap/EthHandlerSnapPeer.java
+++ b/rpc-backend/src/main/java/io/myotis/rpc/snap/EthHandlerSnapPeer.java
@@ -88,9 +88,12 @@ public final class EthHandlerSnapPeer implements SnapPeer {
         // state (rootDenied/rootServed in VerifiedRpcBackend) must already
         // reflect the deny — an async offload here loses that race and the
         // skim sees the pre-failure world, failing operations fast while
-        // untried peers exist. The callback contract is therefore: routing
-        // mutations only (lock-free sets); any potentially blocking work
-        // (quality sinks, persistence) must be offloaded BY THE CALLBACK.
+        // untried peers exist. The callback contract is therefore: routing and
+        // pool-discipline mutations only — lock-free sets, plus the connector's
+        // read-failure monitor, which is verified non-blocking (a short scan, a
+        // volatile bench, an async close; no I/O and no other lock is ever held
+        // with it); any potentially blocking work (quality sinks, persistence)
+        // must be offloaded BY THE CALLBACK.
         if (onRootUnavailable != null) {
             try { onRootUnavailable.run(); } catch (RuntimeException ignore) {}
         }


### PR DESCRIPTION
## Problem

Work item #2 from the #412/#413 incident chain — the Java twin of the Rust engine's read-failure rotation (#413). The Java snap pool had the 30 s bench (`markSnapServingFailed`) but **no escalation**: a peer that kept failing verified reads returned from every cooldown and held its slot forever — the same shape as the Rust engine's 2026-09-02 stale-pool incident. The refill half already exists (`ChainStack.maintainSnapPeers` keys on `activeSnapHandlers()`, which excludes benched peers); what was missing is the strike ladder that frees a slot.

## Fix

- **`EthHandler`**: consecutive verified-read failure streak + `evict()` (best-effort p2p `Disconnect(0x03 useless peer)` + channel close; the close future handles `activeHandlers` removal and host backoff, the maintainer refills on its next 10 s tick).
- **`RLPxConnector.recordReadFailure`**: sole-serving-peer shield (unchanged semantics, no strike), bench below `READ_FAILS_EVICT=3`, disconnect at 3. The evicted peer is *also benched* so it stops satisfying the shield scan immediately — `activeHandlers` removal is async, and without this two concurrent evictions could drain the pool past the shield (the corpse-counting hole Rust's `prune_closed` guards).
- **Strike source discipline**: strikes come *only* from the oracle's per-root deny/serve callbacks (`VerifiedRpcBackend`), deduped per root context via the routing set's `add()` and paired 1:1 with the persisted cache verdict — one context banks at most one strike and one cache failure per peer, so eviction coincides with the DENIED write (*the read that evicts is the read that denies*). The per-response `trySnapStoragePeer` path keeps the old bench-only behavior (`benchReadFailure`): it fires once per rotated peer per request with no dedupe and no cache access, so banking there would over-strike healthy peers on a stale-root query burst and evict without the verdict.
- **Threshold lockstep**: `PeerCache`/`AndroidPeerCache` `SNAP_FAILURE_THRESHOLD` stays 3, documented and test-pinned equal to `READ_FAILS_EVICT` (mirroring the Rust engine's compile-asserted twin constants).

## Notes / deliberate divergences

- The Java shield counts *un-benched* peers (mirrors the pre-existing `benchUnlessLastServing` predicate); Rust's counts any live pool peer. Java therefore stops striking once the rest of the pool is benched — which turns a whole-pool outage (our stale root) into benches, not a pool wipe. Documented at the scan.
- An eviction mid-oracle-fetch surfaces to that fetch as an IOException and can file one deny against the just-evicted peer; the per-context dedupe swallows the strike in the common case.
- Cache DENIED now needs 3 distinct root contexts rather than potentially one concurrent-fetch storm — a deliberate slowdown that aligns the persisted verdict with the eviction ladder.
- The SHIELD/BENCH/EVICT *wiring* (as opposed to the pure ladder, which is pinned) is untested: exercising it needs constructible READY+snap `EthHandler`s, i.e. a test seam that doesn't exist yet. Flagged during internal review; deferred with this note rather than a heavier refactor.

## After PR review (629129a5)

The PR reviewer found the ladder's *reset* signal was unverified — a byzantine peer serving well-formed junk got its streak cleared on every non-empty response before verification failed, oscillating 0↔1 and dodging eviction forever. All four findings accepted and fixed:

- **Serve credit is now verification-gated**: `SnapPeer.reportServed()`, fired by the oracle's retry loop on success — every op it runs proves or hash-checks before completing. Junk peers now only accrue denies, and never enter the `rootServed` routing preference.
- The unverified `trySnapStoragePeer` clear is removed; clears, like strikes, come only from the oracle path.
- **SHIELD gates the persisted verdict** (`recordReadFailure` returns whether a strike was banked; the cache failure write is skipped on the sole-peer shield — Rust's `record_quality` guard) and **zeroes the streak** (matching Rust: frozen strikes would evict the sole survivor on its first post-regrowth failure).

Internal review before the PR: two majors found (shield pierceable via async close; storage-path strike amplification without cache lockstep) — both fixed as described above. `:networking` / `:app` / `:rpc-backend` / `:myotis-evm` tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZjDDn6qE9QzhiJHHpKpmx
