### PR TITLE
Pins: zbox now fronted by the netcup relay 188.68.32.16

### DIFF
--- a/docs/dedicated-sepolia-node.md
+++ b/docs/dedicated-sepolia-node.md
@@ -274,6 +274,12 @@ UPnP/NAT-PMP autodetect) can come up empty on a router with UPnP disabled.
 Verify what it settled on (the enode must carry the PUBLIC IP, and it is the
 line myotis pins in §7):
 
+**Relay exception (2026-09-06).** Behind the netcup relay (§7, "Remaining")
+zbox runs `--nat extip:188.68.32.16`: the address to advertise is the relay's,
+which STUN would never observe (zbox's own uplink is mobile CGNAT), and the
+relay is a static VPS, so the assertion cannot go stale the way a residential
+IP does.
+
 ```bash
 geth-myotis attach --datadir /data/geth --exec admin.nodeInfo.enode
 ```
@@ -368,6 +374,11 @@ Notes:
   correct itself once peers report otherwise. Check the startup line and
   confirm the public IP:
 
+  **Relay exception (2026-09-06):** behind the netcup relay the unit runs
+  `--nat=extip:188.68.32.16` (with `--enr-auto-update=true` kept), for the
+  same reason as Geth's `extip` above — the relay's address is static and is
+  not what any peer-observation of zbox's own uplink would report.
+
   ```bash
   journalctl -u nimbus-sepolia --since '2 min ago' | grep 'Discovery ENR initialized'
   # ... enrAutoUpdate=true seqNum=1 ip=ok(<PUBLIC_IP>) tcpPort=ok(<port>) ...
@@ -460,31 +471,25 @@ client tries it first.
 
 | layer | identity |
 |---|---|
-| EL | `enode://cfd3572b…c37e1b2c@87.154.209.161:30405` |
-| CL (roost, first) | `/ip4/87.154.209.161/tcp/9105/p2p/16Uiu2HAkyDsNGDq5pbFCqdKTcJxp4Rd5caoy1Xe2KJVtyc94M8S5` |
-| CL (Nimbus, fallback) | `/ip4/87.154.209.161/tcp/9104/p2p/16Uiu2HAkvYx58piGw1oxz34CUoeTv8nNQwTwE2cZZh4jR4wVMYy6` |
+| EL | `enode://cfd3572b…c37e1b2c@188.68.32.16:30405` |
+| CL (roost, first) | `/ip4/188.68.32.16/tcp/9105/p2p/16Uiu2HAkyDsNGDq5pbFCqdKTcJxp4Rd5caoy1Xe2KJVtyc94M8S5` |
+| CL (Nimbus, fallback) | `/ip4/188.68.32.16/tcp/9104/p2p/16Uiu2HAkvYx58piGw1oxz34CUoeTv8nNQwTwE2cZZh4jR4wVMYy6` |
 
 Both are only stable because of the key-persistence flags above (Geth's
-datadir `nodekey`, Nimbus's `--netkey-file`). The **IP** in both entries is
-literal, so an address rotation makes the pins stale even though the clients
-themselves self-correct (§4, §5) — wallets then fall back to discovery until
-someone refreshes the constants.
+datadir `nodekey`, Nimbus's `--netkey-file`). The **address** in every entry is
+the netcup relay (188.68.32.16, a static VPS), not zbox: since 2026-09-06 zbox
+sits behind mobile CGNAT and is reachable only through a WireGuard tunnel to the
+relay, which DNATs the nine serving ports (30405-30407, 9104-9109, tcp+udp) to
+zbox without rewriting peer source addresses. On zbox, uid-based ip rules route
+the geth/nimbus/roost processes through the tunnel and the clients announce the
+relay as their own address (`--nat extip:188.68.32.16`, `--nat=extip:…`, roost
+via the upstream's ENR), so every discovery layer agrees on one public address
+and zbox's own uplink rotating no longer touches the pins.
 
 Remaining:
 
-- **Use a DNS name in the pins** instead of the literal IP, so a rotation
-  stops mattering. Three pieces of work, none blocking: the Java EL path
-  already resolves hostnames (`ChainStack.parseStaticEnodes` builds
-  `InetSocketAddress(host, port)`); the Rust `parse_boot_enodes`
-  (`el/reader.rs`) currently parses `SocketAddr` and would silently SKIP a
-  hostname — it needs `to_socket_addrs()`; and the CL pin would become
-  `/dns4/<host>/tcp/<port>/p2p/<peerId>`, which jvm-libp2p can represent
-  (`Protocol.DNS4`, `MultiaddrDns`) but whose dial path needs verifying —
-  the TCP transport ultimately needs an A record resolved, and the Rust CL
-  (`rust/myotis-net/src/{reqresp,discovery}.rs`) needs the same. Note ENRs
-  cannot carry a hostname at all (they have `ip`/`ip6` fields only), so
-  discovery stays IP-based regardless — which is exactly why §4/§5 make the
-  clients detect their own address.
+- ~~Use a DNS name in the pins~~ — superseded by the relay (above): the VPS
+  address is static, so the pins carry that literal and the DynDNS name is gone.
 - **Drop the `ethp2p` match** from the Geth patch once all deployed wallets
   send the renamed `myotis/…` Hello client id.
 - **No CL equivalent of the EL cap bypass exists.** The Geth patch admits

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/NetworkConfig.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/NetworkConfig.java
@@ -180,10 +180,12 @@ public record NetworkConfig(
                     "enr:-IS4QPi-onjNsT5xAIAenhCGTDl4z-4UOR25Uq-3TmG4V3kwB9ljLTb_Kp1wdjHNj-H8VVLRBSSWVZo3GUe3z6k0E-IBgmlkgnY0gmlwhKB3_qGJc2VjcDI1NmsxoQMvAfgB4cJXvvXeM6WbCG86CstbSxbQBSGx31FAwVtOTYN1ZHCCIyg",
                     "enr:-KG4QPUf8-g_jU-KrwzG42AGt0wWM1BTnQxgZXlvCEIfTQ5hSmptkmgmMbRkpOqv6kzb33SlhPHJp7x4rLWWiVq5lSECgmlkgnY0gmlwhFPlR9KDaXA2kCoGxcAJAAAVAAAAAAAAABCJc2VjcDI1NmsxoQLdUv9Eo9sxCt0tc_CheLOWnX59yHJtkBSOL7kpxdJ6GYN1ZHCCIyiEdWRwNoIjKA",
                     // roost mainnet (this project's dedicated LC server) — a snapshot of
-                    // its published record (2026-09-06, from behind the netcup relay). Seeded so wallets have roost in
-                    // the table from the first second; if its IP rotates this snapshot
-                    // goes stale and discovery's targeted lookup (Rust engine) or the
-                    // random walk recovers the current record from the DHT.
+                    // its published record (2026-09-06, from behind the netcup relay).
+                    // Seeded so wallets have roost in the table from the first second.
+                    // The relay address is static, so the only way this snapshot goes
+                    // stale is an operator-driven relay move; then discovery's targeted
+                    // lookup (Rust engine) or the random walk recovers the current
+                    // record from the DHT.
                     "enr:-KG4QKUnChEU8InNkAxOj6e_KZzebsvUQYJ850DJaEQAygKJb_8Y2Mv5IxDEOacUs0pkVctDN1f8CjrCfG7Vf2leulkIhGV0aDKQjJ9i_gYAAAD__________4JpZIJ2NIJpcIS8RCAQiXNlY3AyNTZrMaEC41NP_bzrL7-rq6KmsQIeTl2Nw9yvIlgEvz-Pjz2dwTmDdGNwgiOVg3VkcIIjlQ"
             )
     );
@@ -289,10 +291,12 @@ public record NetworkConfig(
                     "enr:-Iq4QMCTfIMXnow27baRUb35Q8iiFHSIDBJh6hQM5Axohhf4b6Kr_cOCu0htQ5WvVqKvFgY28893DHAg8gnBAXsAVqmGAX53x8JggmlkgnY0gmlwhLKAlv6Jc2VjcDI1NmsxoQK6S-Cii_KmfFdUJL2TANL3ksaKUnNXvTCv1tLwXs0QgIN1ZHCCIyk",
                     "enr:-L64QC9Hhov4DhQ7mRukTOz4_jHm4DHlGL726NWH4ojH1wFgEwSin_6H95Gs6nW2fktTWbPachHJ6rUFu0iJNgA0SB2CARqHYXR0bmV0c4j__________4RldGgykDb6UBOQAABx__________-CaWSCdjSCaXCEA-2vzolzZWNwMjU2azGhA17lsUg60R776rauYMdrAz383UUgESoaHEzMkvm4K6k6iHN5bmNuZXRzD4N0Y3CCIyiDdWRwgiMo",
                     // roost sepolia (this project's dedicated LC server) — a snapshot of
-                    // its published record (2026-09-06, from behind the netcup relay). Seeded so wallets have roost in
-                    // the table from the first second; if its IP rotates this snapshot
-                    // goes stale and discovery's targeted lookup (Rust engine) or the
-                    // random walk recovers the current record from the DHT.
+                    // its published record (2026-09-06, from behind the netcup relay).
+                    // Seeded so wallets have roost in the table from the first second.
+                    // The relay address is static, so the only way this snapshot goes
+                    // stale is an operator-driven relay move; then discovery's targeted
+                    // lookup (Rust engine) or the random walk recovers the current
+                    // record from the DHT.
                     "enr:-KG4QOZNbpU9w2wGBTa5tMaJKfLFOBvygYCYCtSewcQcXnWnNLbuZFar-gCtb70gJTLrAki7efXD5yBj1tSXOEBgul4HhGV0aDKQdNAUWZAAAHX__________4JpZIJ2NIJpcIS8RCAQiXNlY3AyNTZrMaECOGinXjNuey5xwLNiO0Cd-MB7I3zLqCC5rbLWG6Bo9rqDdGNwgiORg3VkcIIjkQ"
             )
     );
@@ -389,10 +393,12 @@ public record NetworkConfig(
                     "enr:-LO4QO87Rn2ejN3SZdXkx7kv8m11EZ3KWWqoIN5oXwQ7iXR9CVGd1dmSyWxOL1PGsdIqeMf66OZj4QGEJckSi6okCdWBpIdhdHRuZXRziAAAAABgAAAAhGV0aDKQPr_UhAQAAGT__________4JpZIJ2NIJpcIQj0iX1iXNlY3AyNTZrMaEDd-_eqFlWWJrUfEp8RhKT9NxdYaZoLHvsp3bbejPyOoeDdGNwgiMog3VkcIIjKA",
                     "enr:-LK4QIJUAxX9uNgW4ACkq8AixjnSTcs9sClbEtWRq9F8Uy9OEExsr4ecpBTYpxX66cMk6pUHejCSX3wZkK2pOCCHWHEBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpA-v9SEBAAAZP__________gmlkgnY0gmlwhCPSnDuJc2VjcDI1NmsxoQNuaAjFE-ANkH3pbeBdPiEIwjR5kxFuKaBWxHkqFuPz5IN0Y3CCIyiDdWRwgiMo",
                     // roost gnosis (this project's dedicated LC server) — a snapshot of
-                    // its published record (2026-09-06, from behind the netcup relay). Seeded so wallets have roost in
-                    // the table from the first second; if its IP rotates this snapshot
-                    // goes stale and discovery's targeted lookup (Rust engine) or the
-                    // random walk recovers the current record from the DHT.
+                    // its published record (2026-09-06, from behind the netcup relay).
+                    // Seeded so wallets have roost in the table from the first second.
+                    // The relay address is static, so the only way this snapshot goes
+                    // stale is an operator-driven relay move; then discovery's targeted
+                    // lookup (Rust engine) or the random walk recovers the current
+                    // record from the DHT.
                     "enr:-KG4QCjwDSRCD6CysnECiWR9i6LBDoETDWI-0zU9bHBbFvgwKHZBGM4LBOBLl15zPJdgPePLlUNJrcbO8l9CGY6aagQHhGV0aDKQMjfatgYAAGT__________4JpZIJ2NIJpcIS8RCAQiXNlY3AyNTZrMaEDM0NY9iNV9hZMrtkoRrPEKj7tm2TLriwZv-m1ctszvvKDdGNwgiOUg3VkcIIjlA"
             )
     );

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/NetworkConfig.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/NetworkConfig.java
@@ -112,19 +112,18 @@ public record NetworkConfig(
             // originally discovered via the Lighthouse peer API 2026-03-11,
             // re-censused via period_census 2026-09-01 (#410), re-verified and
             // pruned 2026-09-02 (#411 — per-entry evidence in the list comments).
-            // NOTE the order: the LITERAL leads and the NAME follows. That looks
-            // backwards and is not — see ROOST_PIN_ORDER in the Rust twin. Java
-            // walks this list in order and falls through, so a stale literal
-            // costs one failed dial before the name resolves; the Rust pool
-            // refreshes a static's address in place and keeps the LAST entry,
-            // which must be the name because a static there can never self-heal.
+            // roost is pinned by the literal address of the netcup relay
+            // (188.68.32.16, a static VPS): zbox itself sits behind mobile CGNAT
+            // and is reachable only through a WireGuard tunnel that DNATs the
+            // serving ports to it, so zbox's own uplink rotating no longer moves
+            // this pin. The earlier DynDNS-name + residential-literal pair is gone.
             // roost mainnet is prepended for the same reason as sepolia's: it is a
             // dedicated LC server, so it neither trims us nor shares its inbound
             // budget with a gossip mesh. 9109/tcp was verified forwarded before
             // pinning. See the Rust twin (MAINNET_STATIC_PEERS) for the full
             // reasoning; keep the two lists and their ORDER in step.
             prependLocal(
-                    "/dns4/be833f3590cd0388.dyndns.dappnode.io/tcp/9109/p2p/16Uiu2HAmAj4D6YGK1kvVL2ZtnoCjp3hdz3j6QLCNh6afhSuwYjLC",
+                    "/ip4/188.68.32.16/tcp/9109/p2p/16Uiu2HAmAj4D6YGK1kvVL2ZtnoCjp3hdz3j6QLCNh6afhSuwYjLC",
             List.of(
                     // Re-verified 2026-09-02 — the first two served the census a
                     // 512/512 period-1840 update, the third served the standalone
@@ -181,11 +180,11 @@ public record NetworkConfig(
                     "enr:-IS4QPi-onjNsT5xAIAenhCGTDl4z-4UOR25Uq-3TmG4V3kwB9ljLTb_Kp1wdjHNj-H8VVLRBSSWVZo3GUe3z6k0E-IBgmlkgnY0gmlwhKB3_qGJc2VjcDI1NmsxoQMvAfgB4cJXvvXeM6WbCG86CstbSxbQBSGx31FAwVtOTYN1ZHCCIyg",
                     "enr:-KG4QPUf8-g_jU-KrwzG42AGt0wWM1BTnQxgZXlvCEIfTQ5hSmptkmgmMbRkpOqv6kzb33SlhPHJp7x4rLWWiVq5lSECgmlkgnY0gmlwhFPlR9KDaXA2kCoGxcAJAAAVAAAAAAAAABCJc2VjcDI1NmsxoQLdUv9Eo9sxCt0tc_CheLOWnX59yHJtkBSOL7kpxdJ6GYN1ZHCCIyiEdWRwNoIjKA",
                     // roost mainnet (this project's dedicated LC server) — a snapshot of
-                    // its published record (2026-08-10). Seeded so wallets have roost in
+                    // its published record (2026-09-06, from behind the netcup relay). Seeded so wallets have roost in
                     // the table from the first second; if its IP rotates this snapshot
                     // goes stale and discovery's targeted lookup (Rust engine) or the
                     // random walk recovers the current record from the DHT.
-                    "enr:-KG4QCbsE9s7xHdLK_32iZh-P840CxuQ3rbJAtuoFgh3IVLqQP0-Hhkllnv-k9qLfZb47V4sxPw0Ynmj4UaabQ3-RjkChGV0aDKQjJ9i_gYAAAD__________4JpZIJ2NIJpcIRXmtGhiXNlY3AyNTZrMaEC41NP_bzrL7-rq6KmsQIeTl2Nw9yvIlgEvz-Pjz2dwTmDdGNwgiOVg3VkcIIjlQ"
+                    "enr:-KG4QKUnChEU8InNkAxOj6e_KZzebsvUQYJ850DJaEQAygKJb_8Y2Mv5IxDEOacUs0pkVctDN1f8CjrCfG7Vf2leulkIhGV0aDKQjJ9i_gYAAAD__________4JpZIJ2NIJpcIS8RCAQiXNlY3AyNTZrMaEC41NP_bzrL7-rq6KmsQIeTl2Nw9yvIlgEvz-Pjz2dwTmDdGNwgiOVg3VkcIIjlQ"
             )
     );
 
@@ -256,13 +255,14 @@ public record NetworkConfig(
             // InvalidRemotePubKey (see the doc's §5 note). roost has no such
             // mode — its identity is persisted by construction.
             //
-            // Both literal IPs carry the same exposure: the line is residential
-            // and the address is not guaranteed stable. ENR publication
-            // (lc-server-design §7) is what removes the need to pin at all.
+            // Both literals are the netcup relay (188.68.32.16, static VPS) in
+            // front of zbox, which lives behind mobile CGNAT — see the mainnet
+            // list above. ENR publication (lc-server-design §7) is what removes
+            // the need to pin at all.
             prependLocal(
-                    "/dns4/be833f3590cd0388.dyndns.dappnode.io/tcp/9105/p2p/16Uiu2HAkyDsNGDq5pbFCqdKTcJxp4Rd5caoy1Xe2KJVtyc94M8S5",
+                    "/ip4/188.68.32.16/tcp/9105/p2p/16Uiu2HAkyDsNGDq5pbFCqdKTcJxp4Rd5caoy1Xe2KJVtyc94M8S5",
                     List.of(
-                            "/ip4/87.154.209.161/tcp/9104/p2p/16Uiu2HAkvYx58piGw1oxz34CUoeTv8nNQwTwE2cZZh4jR4wVMYy6",
+                            "/ip4/188.68.32.16/tcp/9104/p2p/16Uiu2HAkvYx58piGw1oxz34CUoeTv8nNQwTwE2cZZh4jR4wVMYy6",
                             "/ip4/18.185.193.198/tcp/9000/p2p/16Uiu2HAm3mfkjmLPtqnSJzNtKxbDuVjVRXidz5UinaZNpjCCKAkS"
                     )),
             null,
@@ -289,11 +289,11 @@ public record NetworkConfig(
                     "enr:-Iq4QMCTfIMXnow27baRUb35Q8iiFHSIDBJh6hQM5Axohhf4b6Kr_cOCu0htQ5WvVqKvFgY28893DHAg8gnBAXsAVqmGAX53x8JggmlkgnY0gmlwhLKAlv6Jc2VjcDI1NmsxoQK6S-Cii_KmfFdUJL2TANL3ksaKUnNXvTCv1tLwXs0QgIN1ZHCCIyk",
                     "enr:-L64QC9Hhov4DhQ7mRukTOz4_jHm4DHlGL726NWH4ojH1wFgEwSin_6H95Gs6nW2fktTWbPachHJ6rUFu0iJNgA0SB2CARqHYXR0bmV0c4j__________4RldGgykDb6UBOQAABx__________-CaWSCdjSCaXCEA-2vzolzZWNwMjU2azGhA17lsUg60R776rauYMdrAz383UUgESoaHEzMkvm4K6k6iHN5bmNuZXRzD4N0Y3CCIyiDdWRwgiMo",
                     // roost sepolia (this project's dedicated LC server) — a snapshot of
-                    // its published record (2026-08-10). Seeded so wallets have roost in
+                    // its published record (2026-09-06, from behind the netcup relay). Seeded so wallets have roost in
                     // the table from the first second; if its IP rotates this snapshot
                     // goes stale and discovery's targeted lookup (Rust engine) or the
                     // random walk recovers the current record from the DHT.
-                    "enr:-KG4QGERMtMCoXY2T1Jwp3zk2fpdn9e-Q8p9IeUCuJ1ZA7JjVLXvrtuxMHqP6iRWbkO3O2eWETkvMBcIRAV3SkBgKAADhGV0aDKQdNAUWZAAAHX__________4JpZIJ2NIJpcIRXmtGhiXNlY3AyNTZrMaECOGinXjNuey5xwLNiO0Cd-MB7I3zLqCC5rbLWG6Bo9rqDdGNwgiORg3VkcIIjkQ"
+                    "enr:-KG4QOZNbpU9w2wGBTa5tMaJKfLFOBvygYCYCtSewcQcXnWnNLbuZFar-gCtb70gJTLrAki7efXD5yBj1tSXOEBgul4HhGV0aDKQdNAUWZAAAHX__________4JpZIJ2NIJpcIS8RCAQiXNlY3AyNTZrMaECOGinXjNuey5xwLNiO0Cd-MB7I3zLqCC5rbLWG6Bo9rqDdGNwgiORg3VkcIIjkQ"
             )
     );
 
@@ -346,11 +346,10 @@ public record NetworkConfig(
             // step, one address per peer id: the Rust PeerPool dedupes by peer id, so a
             // second address for a known id would be dropped there while Java (which
             // dedupes by multiaddr string) dialed both.
-            // roost gnosis first, by name then by literal — same shape as the
-            // other two chains. See the Rust GNOSIS_STATIC_PEERS for why the
-            // literal stays behind the name.
+            // roost gnosis first, by the relay literal — same shape as the other
+            // two chains.
             prependLocal(
-                    "/dns4/be833f3590cd0388.dyndns.dappnode.io/tcp/9108/p2p/16Uiu2HAmG76htC8Bht97af8tEoH5yeNbPatxz6zeHpWoYc4cHdzh",
+                    "/ip4/188.68.32.16/tcp/9108/p2p/16Uiu2HAmG76htC8Bht97af8tEoH5yeNbPatxz6zeHpWoYc4cHdzh",
             List.of(
                     "/ip4/104.37.190.86/tcp/15974/p2p/16Uiu2HAky9pZH5QBGwtPgXm3A58ahKLSuuUJbZpreBMZrmksUW59",
                     "/ip4/134.65.194.144/tcp/9500/p2p/16Uiu2HAmLZasEWSgafRb5hqW5M2jSN7YcERyVQ81AeCGCFZmynsQ",
@@ -390,11 +389,11 @@ public record NetworkConfig(
                     "enr:-LO4QO87Rn2ejN3SZdXkx7kv8m11EZ3KWWqoIN5oXwQ7iXR9CVGd1dmSyWxOL1PGsdIqeMf66OZj4QGEJckSi6okCdWBpIdhdHRuZXRziAAAAABgAAAAhGV0aDKQPr_UhAQAAGT__________4JpZIJ2NIJpcIQj0iX1iXNlY3AyNTZrMaEDd-_eqFlWWJrUfEp8RhKT9NxdYaZoLHvsp3bbejPyOoeDdGNwgiMog3VkcIIjKA",
                     "enr:-LK4QIJUAxX9uNgW4ACkq8AixjnSTcs9sClbEtWRq9F8Uy9OEExsr4ecpBTYpxX66cMk6pUHejCSX3wZkK2pOCCHWHEBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpA-v9SEBAAAZP__________gmlkgnY0gmlwhCPSnDuJc2VjcDI1NmsxoQNuaAjFE-ANkH3pbeBdPiEIwjR5kxFuKaBWxHkqFuPz5IN0Y3CCIyiDdWRwgiMo",
                     // roost gnosis (this project's dedicated LC server) — a snapshot of
-                    // its published record (2026-08-10). Seeded so wallets have roost in
+                    // its published record (2026-09-06, from behind the netcup relay). Seeded so wallets have roost in
                     // the table from the first second; if its IP rotates this snapshot
                     // goes stale and discovery's targeted lookup (Rust engine) or the
                     // random walk recovers the current record from the DHT.
-                    "enr:-KG4QM_0UweYmWFjBAaZ1JnMTeUkeGgHWEVp3N2vewhkzNtlRlnObTaz3ki1RP1lNvOvMBh_iOu0-LnEacfdZN8dx4IChGV0aDKQMjfatgYAAGT__________4JpZIJ2NIJpcIRXmtGhiXNlY3AyNTZrMaEDM0NY9iNV9hZMrtkoRrPEKj7tm2TLriwZv-m1ctszvvKDdGNwgiOUg3VkcIIjlA"
+                    "enr:-KG4QCjwDSRCD6CysnECiWR9i6LBDoETDWI-0zU9bHBbFvgwKHZBGM4LBOBLl15zPJdgPePLlUNJrcbO8l9CGY6aagQHhGV0aDKQMjfatgYAAGT__________4JpZIJ2NIJpcIS8RCAQiXNlY3AyNTZrMaEDM0NY9iNV9hZMrtkoRrPEKj7tm2TLriwZv-m1ctszvvKDdGNwgiOUg3VkcIIjlA"
             )
     );
 
@@ -565,11 +564,11 @@ public record NetworkConfig(
      *  this node runs the name-based cap bypass so a myotis wallet is admitted even when
      *  it is full. Direct-dialing it removes the wait for discovery to surface it.
      *
-     *  <p>Operational caveat: the key is stable (persisted nodekey), the IP is a
-     *  residential address — if it rotates this entry goes stale and discovery carries
-     *  the load until it is refreshed. */
+     *  <p>Operational caveat: the key is stable (persisted nodekey); the address is the
+     *  netcup relay (188.68.32.16, static VPS) that DNATs 30405 to zbox over WireGuard —
+     *  zbox itself is behind mobile CGNAT, so its own uplink rotating no longer matters. */
     private static final List<String> SEPOLIA_EL_ENODES = List.of(
-            "enode://cfd3572bd7691fe03baf52106b873e01d9b5dca1714a74b316cb94151127dfd20adae3be559e3e6b44b78a5af1ed6f92ecc8676a2555fc7cdb2d29a0c37e1b2c@87.154.209.161:30405"
+            "enode://cfd3572bd7691fe03baf52106b873e01d9b5dca1714a74b316cb94151127dfd20adae3be559e3e6b44b78a5af1ed6f92ecc8676a2555fc7cdb2d29a0c37e1b2c@188.68.32.16:30405"
     );
 
     /** Gnosis EL enodes (chainspec {@code nodes}) — Gnosis publishes no EL enrtree, so these

--- a/networking/src/test/java/com/jaeckel/ethp2p/networking/NetworkConfigEnrTest.java
+++ b/networking/src/test/java/com/jaeckel/ethp2p/networking/NetworkConfigEnrTest.java
@@ -13,10 +13,10 @@ class NetworkConfigEnrTest {
         // We have 17 ENRs; some may lack tcp port, but most should convert
         assertTrue(addrs.size() >= 5, "Expected at least 5 CL multiaddrs, got " + addrs.size());
         for (String ma : addrs) {
-            // /dns4/ is allowed alongside /ip4/: roost is pinned by DynDNS name so a
-            // changing residential IP costs one failed dial rather than a release.
-            // What this test is actually protecting is DIALABILITY — a transport and
-            // a peer id — not the address family.
+            // /dns4/ stays allowed alongside /ip4/ even though no current pin uses a
+            // name (roost moved from a DynDNS name to the netcup relay literal): what
+            // this test is actually protecting is DIALABILITY — a transport and a
+            // peer id — not the address family.
             assertTrue(ma.startsWith("/ip4/") || ma.startsWith("/dns4/"),
                     "Multiaddr should start with /ip4/ or /dns4/: " + ma);
             assertTrue(ma.contains("/tcp/"), "Multiaddr should contain /tcp/: " + ma);

--- a/networking/src/test/java/com/jaeckel/ethp2p/networking/NetworkConfigGnosisTest.java
+++ b/networking/src/test/java/com/jaeckel/ethp2p/networking/NetworkConfigGnosisTest.java
@@ -144,10 +144,10 @@ class NetworkConfigGnosisTest {
         // (issue #291) — same list and ORDER as the Rust GNOSIS_STATIC_PEERS
         // (sync.rs gnosis_config_matches_networkconfig_java pins the twin side).
         List<String> cl = G.clPeerMultiaddrs();
-        assertEquals(23, cl.size(), "22 harvested peers + roost, pinned by NAME only");
-        // roost FIRST, and by NAME — no literal behind it. A dynamic address is
-        // absorbed by DNS instead of by a second entry.
-        assertEquals("/dns4/be833f3590cd0388.dyndns.dappnode.io/tcp/9108/p2p/16Uiu2HAmG76htC8Bht97af8tEoH5yeNbPatxz6zeHpWoYc4cHdzh", cl.get(0));
+        assertEquals(23, cl.size(), "22 harvested peers + roost, pinned by the relay literal");
+        // roost FIRST, by the netcup relay literal (188.68.32.16, static VPS in
+        // front of zbox) — one entry, no name; see the Rust GNOSIS_STATIC_PEERS.
+        assertEquals("/ip4/188.68.32.16/tcp/9108/p2p/16Uiu2HAmG76htC8Bht97af8tEoH5yeNbPatxz6zeHpWoYc4cHdzh", cl.get(0));
         // The harvested list is unchanged, just shifted by the one roost entry.
         assertEquals("/ip4/104.37.190.86/tcp/15974/p2p/"
                 + "16Uiu2HAky9pZH5QBGwtPgXm3A58ahKLSuuUJbZpreBMZrmksUW59", cl.get(1));
@@ -167,20 +167,20 @@ class NetworkConfigGnosisTest {
         // waiting on discovery. The CL entry must come FIRST: the light client walks
         // clPeerMultiaddrs in order, and this is the peer we know serves bootstraps.
         String enode = NetworkConfig.SEPOLIA.elBootEnodes().get(0);
-        assertTrue(enode.endsWith("@87.154.209.161:30405"), enode);
+        assertTrue(enode.endsWith("@188.68.32.16:30405"), enode);
 
         // roost, the dedicated light-client server, is tried first — that is the
         // point of having it. The dedicated Nimbus stays behind it as fallback,
         // so a roost fault degrades to the previous behaviour.
         String cl = NetworkConfig.SEPOLIA.clPeerMultiaddrs().get(0);
-        assertEquals("/dns4/be833f3590cd0388.dyndns.dappnode.io/tcp/9105/p2p/16Uiu2HAkyDsNGDq5pbFCqdKTcJxp4Rd5caoy1Xe2KJVtyc94M8S5", cl,
+        assertEquals("/ip4/188.68.32.16/tcp/9105/p2p/16Uiu2HAkyDsNGDq5pbFCqdKTcJxp4Rd5caoy1Xe2KJVtyc94M8S5", cl,
                 "roost must be the first CL peer tried");
         // POSITION, not presence: the Rust twin asserts index 1, and index is
         // load-bearing on this side in particular — addPeer inserts every
         // discovered peer at Math.min(1, size()), i.e. exactly the slot the
         // Nimbus occupies, so "somewhere in the list" is a weaker guarantee here
         // than anywhere else.
-        assertEquals("/ip4/87.154.209.161/tcp/9104/p2p/"
+        assertEquals("/ip4/188.68.32.16/tcp/9104/p2p/"
                         + "16Uiu2HAkvYx58piGw1oxz34CUoeTv8nNQwTwE2cZZh4jR4wVMYy6",
                 NetworkConfig.SEPOLIA.clPeerMultiaddrs().get(1),
                 "the dedicated Nimbus must remain SECOND as fallback — a roost outage "
@@ -208,7 +208,7 @@ class NetworkConfigGnosisTest {
         // machine-unchecked (PR #411 review).
         List<String> cl = NetworkConfig.MAINNET.clPeerMultiaddrs();
         assertEquals(List.of(
-                "/dns4/be833f3590cd0388.dyndns.dappnode.io/tcp/9109/p2p/16Uiu2HAmAj4D6YGK1kvVL2ZtnoCjp3hdz3j6QLCNh6afhSuwYjLC",
+                "/ip4/188.68.32.16/tcp/9109/p2p/16Uiu2HAmAj4D6YGK1kvVL2ZtnoCjp3hdz3j6QLCNh6afhSuwYjLC",
                 "/ip4/57.129.130.18/tcp/9000/p2p/16Uiu2HAkwmBd7zSRAiBkGar6ghHYfKCKTpGbGL1igrD6mC4W99T9",
                 "/ip4/84.112.35.112/tcp/9000/p2p/16Uiu2HAm6YkLaGLMH1Q9caGi4A2WctHPhENumfQMJXVCMVpc7GQY",
                 "/ip4/91.189.182.90/tcp/9000/p2p/16Uiu2HAmJJUAs17wxW1i4HM5Fce1zYPCvvavxsYorWr4EQVx1Ui8",

--- a/networking/src/test/java/com/jaeckel/ethp2p/networking/discv5/PinnedNodeIdDerivationTest.java
+++ b/networking/src/test/java/com/jaeckel/ethp2p/networking/discv5/PinnedNodeIdDerivationTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class PinnedNodeIdDerivationTest {
 
-    /** (pinned libp2p peer id, the ENR that node published on 2026-08-10). */
+    /** (pinned libp2p peer id, the ENR that node published on 2026-09-06 from behind the netcup relay). */
     private static final String[][] ROOST_VECTORS = {
         { // mainnet, tcp 9109
             "16Uiu2HAmAj4D6YGK1kvVL2ZtnoCjp3hdz3j6QLCNh6afhSuwYjLC",

--- a/networking/src/test/java/com/jaeckel/ethp2p/networking/discv5/PinnedNodeIdDerivationTest.java
+++ b/networking/src/test/java/com/jaeckel/ethp2p/networking/discv5/PinnedNodeIdDerivationTest.java
@@ -27,15 +27,15 @@ class PinnedNodeIdDerivationTest {
     private static final String[][] ROOST_VECTORS = {
         { // mainnet, tcp 9109
             "16Uiu2HAmAj4D6YGK1kvVL2ZtnoCjp3hdz3j6QLCNh6afhSuwYjLC",
-            "enr:-KG4QCbsE9s7xHdLK_32iZh-P840CxuQ3rbJAtuoFgh3IVLqQP0-Hhkllnv-k9qLfZb47V4sxPw0Ynmj4UaabQ3-RjkChGV0aDKQjJ9i_gYAAAD__________4JpZIJ2NIJpcIRXmtGhiXNlY3AyNTZrMaEC41NP_bzrL7-rq6KmsQIeTl2Nw9yvIlgEvz-Pjz2dwTmDdGNwgiOVg3VkcIIjlQ"
+            "enr:-KG4QKUnChEU8InNkAxOj6e_KZzebsvUQYJ850DJaEQAygKJb_8Y2Mv5IxDEOacUs0pkVctDN1f8CjrCfG7Vf2leulkIhGV0aDKQjJ9i_gYAAAD__________4JpZIJ2NIJpcIS8RCAQiXNlY3AyNTZrMaEC41NP_bzrL7-rq6KmsQIeTl2Nw9yvIlgEvz-Pjz2dwTmDdGNwgiOVg3VkcIIjlQ"
         },
         { // sepolia, tcp 9105
             "16Uiu2HAkyDsNGDq5pbFCqdKTcJxp4Rd5caoy1Xe2KJVtyc94M8S5",
-            "enr:-KG4QGERMtMCoXY2T1Jwp3zk2fpdn9e-Q8p9IeUCuJ1ZA7JjVLXvrtuxMHqP6iRWbkO3O2eWETkvMBcIRAV3SkBgKAADhGV0aDKQdNAUWZAAAHX__________4JpZIJ2NIJpcIRXmtGhiXNlY3AyNTZrMaECOGinXjNuey5xwLNiO0Cd-MB7I3zLqCC5rbLWG6Bo9rqDdGNwgiORg3VkcIIjkQ"
+            "enr:-KG4QOZNbpU9w2wGBTa5tMaJKfLFOBvygYCYCtSewcQcXnWnNLbuZFar-gCtb70gJTLrAki7efXD5yBj1tSXOEBgul4HhGV0aDKQdNAUWZAAAHX__________4JpZIJ2NIJpcIS8RCAQiXNlY3AyNTZrMaECOGinXjNuey5xwLNiO0Cd-MB7I3zLqCC5rbLWG6Bo9rqDdGNwgiORg3VkcIIjkQ"
         },
         { // gnosis, tcp 9108
             "16Uiu2HAmG76htC8Bht97af8tEoH5yeNbPatxz6zeHpWoYc4cHdzh",
-            "enr:-KG4QM_0UweYmWFjBAaZ1JnMTeUkeGgHWEVp3N2vewhkzNtlRlnObTaz3ki1RP1lNvOvMBh_iOu0-LnEacfdZN8dx4IChGV0aDKQMjfatgYAAGT__________4JpZIJ2NIJpcIRXmtGhiXNlY3AyNTZrMaEDM0NY9iNV9hZMrtkoRrPEKj7tm2TLriwZv-m1ctszvvKDdGNwgiOUg3VkcIIjlA"
+            "enr:-KG4QCjwDSRCD6CysnECiWR9i6LBDoETDWI-0zU9bHBbFvgwKHZBGM4LBOBLl15zPJdgPePLlUNJrcbO8l9CGY6aagQHhGV0aDKQMjfatgYAAGT__________4JpZIJ2NIJpcIS8RCAQiXNlY3AyNTZrMaEDM0NY9iNV9hZMrtkoRrPEKj7tm2TLriwZv-m1ctszvvKDdGNwgiOUg3VkcIIjlA"
         },
     };
 

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -79,10 +79,11 @@ pub struct ElConfig {
 }
 
 /// The dedicated myotis-serving sepolia node (docs/dedicated-sepolia-node.md).
-/// Key stable (persisted nodekey); the IP is residential, so a rotation makes
-/// this entry stale and discovery carries the load until it is refreshed.
+/// Key stable (persisted nodekey); the address is the netcup relay
+/// (188.68.32.16, static VPS) that DNATs 30405 to zbox over WireGuard — zbox
+/// itself is behind mobile CGNAT, so its own uplink rotating no longer matters.
 const SEPOLIA_MYOTIS_ENODE: &str =
-    "enode://cfd3572bd7691fe03baf52106b873e01d9b5dca1714a74b316cb94151127dfd20adae3be559e3e6b44b78a5af1ed6f92ecc8676a2555fc7cdb2d29a0c37e1b2c@87.154.209.161:30405";
+    "enode://cfd3572bd7691fe03baf52106b873e01d9b5dca1714a74b316cb94151127dfd20adae3be559e3e6b44b78a5af1ed6f92ecc8676a2555fc7cdb2d29a0c37e1b2c@188.68.32.16:30405";
 
 /// Parse `enode://<128 hex pubkey>@host:port` entries into dialable
 /// `(addr, pubkey)` pairs, skipping anything malformed — a bad pin must not
@@ -6381,7 +6382,7 @@ mod tests {
         let cfg = ElConfig::sepolia();
         assert_eq!(cfg.boot_enodes.len(), 1, "sepolia pins the dedicated serving node");
         let (addr, pubkey) = cfg.boot_enodes[0];
-        assert_eq!(addr.to_string(), "87.154.209.161:30405");
+        assert_eq!(addr.to_string(), "188.68.32.16:30405");
         assert_eq!(pubkey[0], 0xcf);
         assert_eq!(pubkey[63], 0x2c);
         // The other networks ship none (mainnet/gnosis reach peers via discovery).

--- a/rust/myotis-net/src/sync.rs
+++ b/rust/myotis-net/src/sync.rs
@@ -539,7 +539,12 @@ const MAINNET_STATIC_PEERS: &[&str] = &[
     //
     // The address is the netcup relay (see the ADDRESS note above); ENR
     // publication (docs/lc-server-design.md §7) is what removes the need to
-    // pin at all.
+    // pin at all. Recovery from a RELAY move is operator-driven, not automatic:
+    // behind the tunnel the address is configuration on both ends (this pin
+    // and the upstream Nimbus's --nat=extip), and roost takes its external
+    // address from that upstream's ENR (rust/roost/src/serve.rs,
+    // track_upstream_ip) — so repoint Nimbus, roost republishes with a bumped
+    // seq, then refresh this pin and the bootstrap ENR below.
     "/ip4/188.68.32.16/tcp/9109/p2p/16Uiu2HAmAj4D6YGK1kvVL2ZtnoCjp3hdz3j6QLCNh6afhSuwYjLC",
     // Re-verified 2026-09-02 (census: updates_by_range(1840,1) answered with a
     // 512/512 update, or TCP-alive at minimum; TCP-dead entries pruned — the

--- a/rust/myotis-net/src/sync.rs
+++ b/rust/myotis-net/src/sync.rs
@@ -397,23 +397,12 @@ fn hex32(s: &str) -> [u8; 32] {
 }
 
 ///
-/// ORDER LOOKS BACKWARDS AND IS NOT. The literal comes FIRST and the name LAST
-/// because the two engines consume the pair differently, and the engine that
-/// cannot recover is the one that must end up on the name:
-///
-///   Rust  — `PeerPool::add` REFRESHES a static peer's address in place (the
-///           #322 fix), so for one peer id the LAST entry wins. Statics are
-///           un-evictable and roost publishes no ENR, so a stale literal here
-///           could never self-heal: no eviction, no rediscovery, undialable
-///           until a release. Ending on the name is what makes an address
-///           change survivable.
-///   Java  — dedupes by multiaddr string and walks the list in order, so it
-///           tries the literal first and falls through to the name. A stale
-///           literal costs one failed dial, then the name resolves. That is why
-///           the "worse" order is harmless there.
-///
-/// Putting the name first inverts both: Rust would keep the literal (the case
-/// that cannot recover) and gain nothing.
+/// ADDRESS: every roost/zbox literal below is the netcup relay (188.68.32.16, a
+/// static VPS). zbox itself sits behind mobile CGNAT and is reachable only via
+/// a WireGuard tunnel that DNATs the serving ports to it, so its own uplink
+/// rotating no longer moves these pins. The earlier "DynDNS name last, literal
+/// first" pair (name for self-healing, literal for the unverified Java DNS
+/// path) went with it: one literal per peer id, identical on both engines.
 
 /// Pinned sepolia LC-serving peer multiaddrs (Java `NetworkConfig.SEPOLIA.clPeerMultiaddrs`
 /// — keep the two lists, their ORDER and their addresses in step;
@@ -434,24 +423,10 @@ const SEPOLIA_STATIC_PEERS: &[&str] = &[
     // restarts by construction; unlike the Nimbus entry there is no flag to
     // forget, because roost has no mode in which it mints a fresh one.
     //
-    // Pinning a literal IP has the same exposure as the entries below: the line
-    // is residential and the address is not guaranteed stable. ENR publication
-    // (design §7) is what removes it. See ROOST_PIN_ORDER above for why the
-    // literal precedes the name.
-    // roost BY NAME, ahead of its own literal IP.
-    //
-    // The line is residential and the address is not guaranteed stable; the
-    // name is DynDNS with a ~30s TTL and libp2p resolves it AT DIAL TIME, every
-    // dial, so an address change costs one failed dial instead of a release.
-    //
-    // The literal below is kept deliberately as the next entry: DNS resolution
-    // is verified working on the RUST engine (live sync from roost over this
-    // name) but NOT on the Java one, which is the default — jvm-libp2p parses
-    // the multiaddr and extracts the peer id, but its transport's DNS handling
-    // is unverified. If it cannot dial a name it falls through to the IP and
-    // behaves exactly as before. Drop the literal once Java is confirmed.
-    "/dns4/be833f3590cd0388.dyndns.dappnode.io/tcp/9105/p2p/16Uiu2HAkyDsNGDq5pbFCqdKTcJxp4Rd5caoy1Xe2KJVtyc94M8S5",
-    "/ip4/87.154.209.161/tcp/9104/p2p/16Uiu2HAkvYx58piGw1oxz34CUoeTv8nNQwTwE2cZZh4jR4wVMYy6",
+    // The address is the netcup relay (see the ADDRESS note above); ENR
+    // publication (design §7) is what removes the need to pin at all.
+    "/ip4/188.68.32.16/tcp/9105/p2p/16Uiu2HAkyDsNGDq5pbFCqdKTcJxp4Rd5caoy1Xe2KJVtyc94M8S5",
+    "/ip4/188.68.32.16/tcp/9104/p2p/16Uiu2HAkvYx58piGw1oxz34CUoeTv8nNQwTwE2cZZh4jR4wVMYy6",
     "/ip4/18.185.193.198/tcp/9000/p2p/16Uiu2HAm3mfkjmLPtqnSJzNtKxbDuVjVRXidz5UinaZNpjCCKAkS",
 ];
 
@@ -472,12 +447,12 @@ const SEPOLIA_BOOTSTRAP_ENRS: &[&str] = &[
     "enr:-Iq4QMCTfIMXnow27baRUb35Q8iiFHSIDBJh6hQM5Axohhf4b6Kr_cOCu0htQ5WvVqKvFgY28893DHAg8gnBAXsAVqmGAX53x8JggmlkgnY0gmlwhLKAlv6Jc2VjcDI1NmsxoQK6S-Cii_KmfFdUJL2TANL3ksaKUnNXvTCv1tLwXs0QgIN1ZHCCIyk",
     "enr:-L64QC9Hhov4DhQ7mRukTOz4_jHm4DHlGL726NWH4ojH1wFgEwSin_6H95Gs6nW2fktTWbPachHJ6rUFu0iJNgA0SB2CARqHYXR0bmV0c4j__________4RldGgykDb6UBOQAABx__________-CaWSCdjSCaXCEA-2vzolzZWNwMjU2azGhA17lsUg60R776rauYMdrAz383UUgESoaHEzMkvm4K6k6iHN5bmNuZXRzD4N0Y3CCIyiDdWRwgiMo",
     // roost sepolia (this project's dedicated LC server) — a SNAPSHOT of its
-    // published record (2026-08-10): seeding it makes roost dialable from the
+    // published record (2026-09-06, from behind the netcup relay): seeding it makes roost dialable from the
     // first table without waiting for any walk. The embedded IP goes stale if
     // the server's address rotates; the targeted-lookup path (node_id derived
     // from the position-0 static peer pin, `discovery::node_id_for_peer`)
     // is what recovers the CURRENT record then.
-    "enr:-KG4QGERMtMCoXY2T1Jwp3zk2fpdn9e-Q8p9IeUCuJ1ZA7JjVLXvrtuxMHqP6iRWbkO3O2eWETkvMBcIRAV3SkBgKAADhGV0aDKQdNAUWZAAAHX__________4JpZIJ2NIJpcIRXmtGhiXNlY3AyNTZrMaECOGinXjNuey5xwLNiO0Cd-MB7I3zLqCC5rbLWG6Bo9rqDdGNwgiORg3VkcIIjkQ",
+    "enr:-KG4QOZNbpU9w2wGBTa5tMaJKfLFOBvygYCYCtSewcQcXnWnNLbuZFar-gCtb70gJTLrAki7efXD5yBj1tSXOEBgul4HhGV0aDKQdNAUWZAAAHX__________4JpZIJ2NIJpcIS8RCAQiXNlY3AyNTZrMaECOGinXjNuey5xwLNiO0Cd-MB7I3zLqCC5rbLWG6Bo9rqDdGNwgiORg3VkcIIjkQ",
 ];
 
 /// Pinned Gnosis LC-serving peer multiaddrs (Java `NetworkConfig.GNOSIS.clPeerMultiaddrs`
@@ -499,7 +474,7 @@ const GNOSIS_STATIC_PEERS: &[&str] = &[
     // digest and every peer answered Goodbye(IrrelevantNetwork). Pinning a
     // server in that state would have cost every gnosis wallet its
     // strikes-to-eviction on a peer that could never answer.
-    "/dns4/be833f3590cd0388.dyndns.dappnode.io/tcp/9108/p2p/16Uiu2HAmG76htC8Bht97af8tEoH5yeNbPatxz6zeHpWoYc4cHdzh",
+    "/ip4/188.68.32.16/tcp/9108/p2p/16Uiu2HAmG76htC8Bht97af8tEoH5yeNbPatxz6zeHpWoYc4cHdzh",
     "/ip4/104.37.190.86/tcp/15974/p2p/16Uiu2HAky9pZH5QBGwtPgXm3A58ahKLSuuUJbZpreBMZrmksUW59",
     "/ip4/134.65.194.144/tcp/9500/p2p/16Uiu2HAmLZasEWSgafRb5hqW5M2jSN7YcERyVQ81AeCGCFZmynsQ",
     "/ip4/135.129.103.34/tcp/9006/p2p/16Uiu2HAmA5FYL7dQftsHktHvuVTRyPdc1sH6qcWiXaVEPM6FMyN2",
@@ -536,12 +511,12 @@ const GNOSIS_BOOTSTRAP_ENRS: &[&str] = &[
     "enr:-LO4QO87Rn2ejN3SZdXkx7kv8m11EZ3KWWqoIN5oXwQ7iXR9CVGd1dmSyWxOL1PGsdIqeMf66OZj4QGEJckSi6okCdWBpIdhdHRuZXRziAAAAABgAAAAhGV0aDKQPr_UhAQAAGT__________4JpZIJ2NIJpcIQj0iX1iXNlY3AyNTZrMaEDd-_eqFlWWJrUfEp8RhKT9NxdYaZoLHvsp3bbejPyOoeDdGNwgiMog3VkcIIjKA",
     "enr:-LK4QIJUAxX9uNgW4ACkq8AixjnSTcs9sClbEtWRq9F8Uy9OEExsr4ecpBTYpxX66cMk6pUHejCSX3wZkK2pOCCHWHEBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpA-v9SEBAAAZP__________gmlkgnY0gmlwhCPSnDuJc2VjcDI1NmsxoQNuaAjFE-ANkH3pbeBdPiEIwjR5kxFuKaBWxHkqFuPz5IN0Y3CCIyiDdWRwgiMo",
     // roost gnosis (this project's dedicated LC server) — a SNAPSHOT of its
-    // published record (2026-08-10): seeding it makes roost dialable from the
+    // published record (2026-09-06, from behind the netcup relay): seeding it makes roost dialable from the
     // first table without waiting for any walk. The embedded IP goes stale if
     // the server's address rotates; the targeted-lookup path (node_id derived
     // from the position-0 static peer pin, `discovery::node_id_for_peer`)
     // is what recovers the CURRENT record then.
-    "enr:-KG4QM_0UweYmWFjBAaZ1JnMTeUkeGgHWEVp3N2vewhkzNtlRlnObTaz3ki1RP1lNvOvMBh_iOu0-LnEacfdZN8dx4IChGV0aDKQMjfatgYAAGT__________4JpZIJ2NIJpcIRXmtGhiXNlY3AyNTZrMaEDM0NY9iNV9hZMrtkoRrPEKj7tm2TLriwZv-m1ctszvvKDdGNwgiOUg3VkcIIjlA",
+    "enr:-KG4QCjwDSRCD6CysnECiWR9i6LBDoETDWI-0zU9bHBbFvgwKHZBGM4LBOBLl15zPJdgPePLlUNJrcbO8l9CGY6aagQHhGV0aDKQMjfatgYAAGT__________4JpZIJ2NIJpcIS8RCAQiXNlY3AyNTZrMaEDM0NY9iNV9hZMrtkoRrPEKj7tm2TLriwZv-m1ctszvvKDdGNwgiOUg3VkcIIjlA",
 ];
 
 /// Known light-client-serving mainnet peers — mirrored with the Java
@@ -562,12 +537,10 @@ const MAINNET_STATIC_PEERS: &[&str] = &[
     // the neighbouring 9107). Pinning an unreachable address is not free — a
     // wallet spends its strikes-to-eviction on a node that is actually fine.
     //
-    // Same residential-IP exposure as every literal here; ENR publication
-    // (docs/lc-server-design.md §7) is what removes it. NOTE that roost cannot
-    // currently notice its own IP changing — its Identify quorum never settles
-    // because it makes no outbound connections — so this line is the thing that
-    // breaks if the address moves.
-    "/dns4/be833f3590cd0388.dyndns.dappnode.io/tcp/9109/p2p/16Uiu2HAmAj4D6YGK1kvVL2ZtnoCjp3hdz3j6QLCNh6afhSuwYjLC",
+    // The address is the netcup relay (see the ADDRESS note above); ENR
+    // publication (docs/lc-server-design.md §7) is what removes the need to
+    // pin at all.
+    "/ip4/188.68.32.16/tcp/9109/p2p/16Uiu2HAmAj4D6YGK1kvVL2ZtnoCjp3hdz3j6QLCNh6afhSuwYjLC",
     // Re-verified 2026-09-02 (census: updates_by_range(1840,1) answered with a
     // 512/512 update, or TCP-alive at minimum; TCP-dead entries pruned — the
     // roost comment above says why pinning an unreachable address is not free).
@@ -623,12 +596,12 @@ const MAINNET_BOOTSTRAP_ENRS: &[&str] = &[
     "enr:-IS4QPi-onjNsT5xAIAenhCGTDl4z-4UOR25Uq-3TmG4V3kwB9ljLTb_Kp1wdjHNj-H8VVLRBSSWVZo3GUe3z6k0E-IBgmlkgnY0gmlwhKB3_qGJc2VjcDI1NmsxoQMvAfgB4cJXvvXeM6WbCG86CstbSxbQBSGx31FAwVtOTYN1ZHCCIyg",
     "enr:-KG4QPUf8-g_jU-KrwzG42AGt0wWM1BTnQxgZXlvCEIfTQ5hSmptkmgmMbRkpOqv6kzb33SlhPHJp7x4rLWWiVq5lSECgmlkgnY0gmlwhFPlR9KDaXA2kCoGxcAJAAAVAAAAAAAAABCJc2VjcDI1NmsxoQLdUv9Eo9sxCt0tc_CheLOWnX59yHJtkBSOL7kpxdJ6GYN1ZHCCIyiEdWRwNoIjKA",
     // roost mainnet (this project's dedicated LC server) — a SNAPSHOT of its
-    // published record (2026-08-10): seeding it makes roost dialable from the
+    // published record (2026-09-06, from behind the netcup relay): seeding it makes roost dialable from the
     // first table without waiting for any walk. The embedded IP goes stale if
     // the server's address rotates; the targeted-lookup path (node_id derived
     // from the position-0 static peer pin, `discovery::node_id_for_peer`)
     // is what recovers the CURRENT record then.
-    "enr:-KG4QCbsE9s7xHdLK_32iZh-P840CxuQ3rbJAtuoFgh3IVLqQP0-Hhkllnv-k9qLfZb47V4sxPw0Ynmj4UaabQ3-RjkChGV0aDKQjJ9i_gYAAAD__________4JpZIJ2NIJpcIRXmtGhiXNlY3AyNTZrMaEC41NP_bzrL7-rq6KmsQIeTl2Nw9yvIlgEvz-Pjz2dwTmDdGNwgiOVg3VkcIIjlQ",
+    "enr:-KG4QKUnChEU8InNkAxOj6e_KZzebsvUQYJ850DJaEQAygKJb_8Y2Mv5IxDEOacUs0pkVctDN1f8CjrCfG7Vf2leulkIhGV0aDKQjJ9i_gYAAAD__________4JpZIJ2NIJpcIS8RCAQiXNlY3AyNTZrMaEC41NP_bzrL7-rq6KmsQIeTl2Nw9yvIlgEvz-Pjz2dwTmDdGNwgiOVg3VkcIIjlQ",
 ];
 
 // -------------------------------------------------------------------------
@@ -3200,7 +3173,7 @@ mod tests {
         assert_eq!(
             c.static_peers,
             vec![
-                "/dns4/be833f3590cd0388.dyndns.dappnode.io/tcp/9109/p2p/16Uiu2HAmAj4D6YGK1kvVL2ZtnoCjp3hdz3j6QLCNh6afhSuwYjLC",
+                "/ip4/188.68.32.16/tcp/9109/p2p/16Uiu2HAmAj4D6YGK1kvVL2ZtnoCjp3hdz3j6QLCNh6afhSuwYjLC",
                 "/ip4/57.129.130.18/tcp/9000/p2p/16Uiu2HAkwmBd7zSRAiBkGar6ghHYfKCKTpGbGL1igrD6mC4W99T9",
                 "/ip4/84.112.35.112/tcp/9000/p2p/16Uiu2HAm6YkLaGLMH1Q9caGi4A2WctHPhENumfQMJXVCMVpc7GQY",
                 "/ip4/91.189.182.90/tcp/9000/p2p/16Uiu2HAmJJUAs17wxW1i4HM5Fce1zYPCvvavxsYorWr4EQVx1Ui8",
@@ -3268,8 +3241,8 @@ mod tests {
         assert_eq!(
             c.static_peers,
             vec![
-                "/dns4/be833f3590cd0388.dyndns.dappnode.io/tcp/9105/p2p/16Uiu2HAkyDsNGDq5pbFCqdKTcJxp4Rd5caoy1Xe2KJVtyc94M8S5",
-                "/ip4/87.154.209.161/tcp/9104/p2p/16Uiu2HAkvYx58piGw1oxz34CUoeTv8nNQwTwE2cZZh4jR4wVMYy6",
+                "/ip4/188.68.32.16/tcp/9105/p2p/16Uiu2HAkyDsNGDq5pbFCqdKTcJxp4Rd5caoy1Xe2KJVtyc94M8S5",
+                "/ip4/188.68.32.16/tcp/9104/p2p/16Uiu2HAkvYx58piGw1oxz34CUoeTv8nNQwTwE2cZZh4jR4wVMYy6",
                 "/ip4/18.185.193.198/tcp/9000/p2p/16Uiu2HAm3mfkjmLPtqnSJzNtKxbDuVjVRXidz5UinaZNpjCCKAkS",
             ],
             "roost first (the dedicated LC server), the dedicated Nimbus second as \
@@ -3330,11 +3303,11 @@ mod tests {
         // NetworkConfig.GNOSIS.clPeerMultiaddrs, ONE ADDRESS PER PEER ID
         // (`PeerPool::add` dedupes by peer id, so a second address for a known
         // id would never be dialed here while Java dialed both).
-        // 22 discovered gnosis peers + roost, pinned by NAME only.
+        // 22 discovered gnosis peers + roost, pinned by the relay literal.
         assert_eq!(c.static_peers.len(), 23);
         // POSITION, like the other two chains: both engines must agree on which
         // peer the light client tries FIRST, not merely that roost is present.
-        assert_eq!(c.static_peers[0], "/dns4/be833f3590cd0388.dyndns.dappnode.io/tcp/9108/p2p/16Uiu2HAmG76htC8Bht97af8tEoH5yeNbPatxz6zeHpWoYc4cHdzh");
+        assert_eq!(c.static_peers[0], "/ip4/188.68.32.16/tcp/9108/p2p/16Uiu2HAmG76htC8Bht97af8tEoH5yeNbPatxz6zeHpWoYc4cHdzh");
         // The discovered list is unchanged, just shifted by the one roost entry.
         assert!(c.static_peers[1].ends_with(
             "/tcp/15974/p2p/16Uiu2HAky9pZH5QBGwtPgXm3A58ahKLSuuUJbZpreBMZrmksUW59"

--- a/rust/myotis-net/src/sync.rs
+++ b/rust/myotis-net/src/sync.rs
@@ -447,11 +447,12 @@ const SEPOLIA_BOOTSTRAP_ENRS: &[&str] = &[
     "enr:-Iq4QMCTfIMXnow27baRUb35Q8iiFHSIDBJh6hQM5Axohhf4b6Kr_cOCu0htQ5WvVqKvFgY28893DHAg8gnBAXsAVqmGAX53x8JggmlkgnY0gmlwhLKAlv6Jc2VjcDI1NmsxoQK6S-Cii_KmfFdUJL2TANL3ksaKUnNXvTCv1tLwXs0QgIN1ZHCCIyk",
     "enr:-L64QC9Hhov4DhQ7mRukTOz4_jHm4DHlGL726NWH4ojH1wFgEwSin_6H95Gs6nW2fktTWbPachHJ6rUFu0iJNgA0SB2CARqHYXR0bmV0c4j__________4RldGgykDb6UBOQAABx__________-CaWSCdjSCaXCEA-2vzolzZWNwMjU2azGhA17lsUg60R776rauYMdrAz383UUgESoaHEzMkvm4K6k6iHN5bmNuZXRzD4N0Y3CCIyiDdWRwgiMo",
     // roost sepolia (this project's dedicated LC server) — a SNAPSHOT of its
-    // published record (2026-09-06, from behind the netcup relay): seeding it makes roost dialable from the
-    // first table without waiting for any walk. The embedded IP goes stale if
-    // the server's address rotates; the targeted-lookup path (node_id derived
-    // from the position-0 static peer pin, `discovery::node_id_for_peer`)
-    // is what recovers the CURRENT record then.
+    // published record (2026-09-06, from behind the netcup relay): seeding it
+    // makes roost dialable from the first table without waiting for any walk.
+    // The relay address is static, so the only way the embedded IP goes stale
+    // is an operator-driven relay move; the targeted-lookup path (node_id
+    // derived from the position-0 static peer pin,
+    // `discovery::node_id_for_peer`) is what recovers the CURRENT record then.
     "enr:-KG4QOZNbpU9w2wGBTa5tMaJKfLFOBvygYCYCtSewcQcXnWnNLbuZFar-gCtb70gJTLrAki7efXD5yBj1tSXOEBgul4HhGV0aDKQdNAUWZAAAHX__________4JpZIJ2NIJpcIS8RCAQiXNlY3AyNTZrMaECOGinXjNuey5xwLNiO0Cd-MB7I3zLqCC5rbLWG6Bo9rqDdGNwgiORg3VkcIIjkQ",
 ];
 
@@ -511,11 +512,12 @@ const GNOSIS_BOOTSTRAP_ENRS: &[&str] = &[
     "enr:-LO4QO87Rn2ejN3SZdXkx7kv8m11EZ3KWWqoIN5oXwQ7iXR9CVGd1dmSyWxOL1PGsdIqeMf66OZj4QGEJckSi6okCdWBpIdhdHRuZXRziAAAAABgAAAAhGV0aDKQPr_UhAQAAGT__________4JpZIJ2NIJpcIQj0iX1iXNlY3AyNTZrMaEDd-_eqFlWWJrUfEp8RhKT9NxdYaZoLHvsp3bbejPyOoeDdGNwgiMog3VkcIIjKA",
     "enr:-LK4QIJUAxX9uNgW4ACkq8AixjnSTcs9sClbEtWRq9F8Uy9OEExsr4ecpBTYpxX66cMk6pUHejCSX3wZkK2pOCCHWHEBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpA-v9SEBAAAZP__________gmlkgnY0gmlwhCPSnDuJc2VjcDI1NmsxoQNuaAjFE-ANkH3pbeBdPiEIwjR5kxFuKaBWxHkqFuPz5IN0Y3CCIyiDdWRwgiMo",
     // roost gnosis (this project's dedicated LC server) — a SNAPSHOT of its
-    // published record (2026-09-06, from behind the netcup relay): seeding it makes roost dialable from the
-    // first table without waiting for any walk. The embedded IP goes stale if
-    // the server's address rotates; the targeted-lookup path (node_id derived
-    // from the position-0 static peer pin, `discovery::node_id_for_peer`)
-    // is what recovers the CURRENT record then.
+    // published record (2026-09-06, from behind the netcup relay): seeding it
+    // makes roost dialable from the first table without waiting for any walk.
+    // The relay address is static, so the only way the embedded IP goes stale
+    // is an operator-driven relay move; the targeted-lookup path (node_id
+    // derived from the position-0 static peer pin,
+    // `discovery::node_id_for_peer`) is what recovers the CURRENT record then.
     "enr:-KG4QCjwDSRCD6CysnECiWR9i6LBDoETDWI-0zU9bHBbFvgwKHZBGM4LBOBLl15zPJdgPePLlUNJrcbO8l9CGY6aagQHhGV0aDKQMjfatgYAAGT__________4JpZIJ2NIJpcIS8RCAQiXNlY3AyNTZrMaEDM0NY9iNV9hZMrtkoRrPEKj7tm2TLriwZv-m1ctszvvKDdGNwgiOUg3VkcIIjlA",
 ];
 
@@ -601,11 +603,12 @@ const MAINNET_BOOTSTRAP_ENRS: &[&str] = &[
     "enr:-IS4QPi-onjNsT5xAIAenhCGTDl4z-4UOR25Uq-3TmG4V3kwB9ljLTb_Kp1wdjHNj-H8VVLRBSSWVZo3GUe3z6k0E-IBgmlkgnY0gmlwhKB3_qGJc2VjcDI1NmsxoQMvAfgB4cJXvvXeM6WbCG86CstbSxbQBSGx31FAwVtOTYN1ZHCCIyg",
     "enr:-KG4QPUf8-g_jU-KrwzG42AGt0wWM1BTnQxgZXlvCEIfTQ5hSmptkmgmMbRkpOqv6kzb33SlhPHJp7x4rLWWiVq5lSECgmlkgnY0gmlwhFPlR9KDaXA2kCoGxcAJAAAVAAAAAAAAABCJc2VjcDI1NmsxoQLdUv9Eo9sxCt0tc_CheLOWnX59yHJtkBSOL7kpxdJ6GYN1ZHCCIyiEdWRwNoIjKA",
     // roost mainnet (this project's dedicated LC server) — a SNAPSHOT of its
-    // published record (2026-09-06, from behind the netcup relay): seeding it makes roost dialable from the
-    // first table without waiting for any walk. The embedded IP goes stale if
-    // the server's address rotates; the targeted-lookup path (node_id derived
-    // from the position-0 static peer pin, `discovery::node_id_for_peer`)
-    // is what recovers the CURRENT record then.
+    // published record (2026-09-06, from behind the netcup relay): seeding it
+    // makes roost dialable from the first table without waiting for any walk.
+    // The relay address is static, so the only way the embedded IP goes stale
+    // is an operator-driven relay move; the targeted-lookup path (node_id
+    // derived from the position-0 static peer pin,
+    // `discovery::node_id_for_peer`) is what recovers the CURRENT record then.
     "enr:-KG4QKUnChEU8InNkAxOj6e_KZzebsvUQYJ850DJaEQAygKJb_8Y2Mv5IxDEOacUs0pkVctDN1f8CjrCfG7Vf2leulkIhGV0aDKQjJ9i_gYAAAD__________4JpZIJ2NIJpcIS8RCAQiXNlY3AyNTZrMaEC41NP_bzrL7-rq6KmsQIeTl2Nw9yvIlgEvz-Pjz2dwTmDdGNwgiOVg3VkcIIjlQ",
 ];
 

--- a/rust/myotis-net/tests/live_dedicated_node.rs
+++ b/rust/myotis-net/tests/live_dedicated_node.rs
@@ -13,7 +13,7 @@ use myotis_net::el::eth::session::{EthConfig, EthSession};
 use myotis_net::el::peer::ManagedPeer;
 use myotis_net::el::rlpx::transport::RlpxConnection;
 
-const NODE_ADDR: &str = "87.154.209.161:30405";
+const NODE_ADDR: &str = "188.68.32.16:30405";
 const NODE_PUBKEY_HEX: &str =
     "cfd3572bd7691fe03baf52106b873e01d9b5dca1714a74b316cb94151127dfd2\
      0adae3be559e3e6b44b78a5af1ed6f92ecc8676a2555fc7cdb2d29a0c37e1b2c";

--- a/rust/myotis-net/tests/live_pipeline_bench.rs
+++ b/rust/myotis-net/tests/live_pipeline_bench.rs
@@ -24,7 +24,7 @@ use myotis_net::el::eth::session::{EthConfig, EthSession};
 use myotis_net::el::peer::ManagedPeer;
 use myotis_net::el::rlpx::transport::RlpxConnection;
 
-const NODE_ADDR: &str = "87.154.209.161:30405";
+const NODE_ADDR: &str = "188.68.32.16:30405";
 const NODE_PUBKEY_HEX: &str =
     "cfd3572bd7691fe03baf52106b873e01d9b5dca1714a74b316cb94151127dfd2\
      0adae3be559e3e6b44b78a5af1ed6f92ecc8676a2555fc7cdb2d29a0c37e1b2c";

--- a/rust/roost/README.md
+++ b/rust/roost/README.md
@@ -84,9 +84,10 @@ record without publishing, for inspection.
   updates only from the period its states reach; everything older is
   irreplaceable once collected.
 - **Dropping the wallet-side pins** (#335 step 4): both engines still pin
-  roost's multiaddr by DynDNS name. That stays until discovery is proven on all
-  three networks — a wallet with no pin and discovery enabled finds roost,
-  bootstraps, and stays synced.
+  roost's multiaddr, by the literal address of the netcup relay (188.68.32.16,
+  a static VPS that DNATs the serving ports to zbox over WireGuard). That stays
+  until discovery is proven on all three networks — a wallet with no pin and
+  discovery enabled finds roost, bootstraps, and stays synced.
 
 ## Run locally
 
@@ -223,9 +224,9 @@ serving handlers and the archive together.
 address is confirmed, publishes its ENR — wallets can DISCOVER it (#335).
 Deploy in two steps: start with `--no-publish` and confirm the table populates
 and the node is pingable on UDP from outside; then drop the flag. The pinned
-multiaddrs in both engines stay for now (mainnet, gnosis and sepolia, by
-DynDNS name, resolved at dial time) — removing them is #335 step 4, gated on
-discovery being proven end to end.
+multiaddrs in both engines stay for now (mainnet, gnosis and sepolia, by the
+relay's static literal) — removing them is #335 step 4, gated on discovery
+being proven end to end.
 
 ## Why it is not a workspace member
 


### PR DESCRIPTION
## Why

zbox (the dedicated serving node) lost inbound reachability: its uplink moved to Telekom mobile CGNAT (public IP 80.187.x, double NAT behind a GL.iNet router). It now dials a WireGuard tunnel to the netcup VPS at **188.68.32.16** (static), which DNATs the nine serving ports (30405-30407, 9104-9109, tcp+udp) to zbox without rewriting peer source addresses. On zbox, uid-range ip rules route the geth/nimbus/roost processes through the tunnel, and the clients announce the relay as their own address (`--nat extip:188.68.32.16`, Nimbus `--nat=extip:…`, roost via the upstream's ENR).

## What changes

Every wallet-side pin of the dedicated node moves to the relay address, on both engines:

- geth sepolia enode (`NetworkConfig.SEPOLIA_EL_ENODES`, `ElConfig::sepolia` / `SEPOLIA_MYOTIS_ENODE`)
- Nimbus sepolia multiaddr (`/ip4/188.68.32.16/tcp/9104/…`)
- roost mainnet/gnosis/sepolia multiaddrs: the `be833f3590cd0388.dyndns.dappnode.io` name is dropped; one literal per peer id, same list order as before
- the three seeded roost bootstrap ENRs, replaced by the records roost published from behind the relay (seq 8/7/7 vs 2/3/2, same secp256k1 keys, `ip=188.68.32.16`) — decoded and checked
- `NODE_ADDR` in the two live tests, the parity tests on both sides, `docs/dedicated-sepolia-node.md` (pin table, the "DNS name in the pins" follow-up is superseded, §4/§5 get a relay exception for the `extip` flags), and the roost README's description of the pins

Comments that explained the old name-last/literal-first ordering and the residential-IP exposure are rewritten around the relay. Unit-test fixture IPs that merely reuse `87.154.209.161` as an arbitrary address (`discovery.rs`, `reqresp.rs`, `roost/serve.rs`) are deliberately untouched — they are not pins.

## Verification

- `./gradlew :networking:test` for `NetworkConfig*` + `PinnedNodeIdDerivationTest`: 22 tests green
- `cargo test -p myotis-net --lib -- config static_peers pins`: 16 green (both parity tests, `mainnet_config_pins_known_values`, `sepolia_pins_the_dedicated_serving_node_enode`)
- Live: geth mainnet holds 17 inbound peers through the relay; the `enr_lookup` verifier established a discv5 session with roost mainnet at `188.68.32.16:9109` and got back its seq-9 record; all three roosts log `ENR published … ip=188.68.32.16`
- `grep -rn 87.154.209.161 / dyndns.dappnode.io` over the tree: no pin, config, or live test left

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WTPh82Wm2SnpcQvsHsghHo
