### PR TITLE
Keep Node reads off libuv and cancel in-flight work on shutdown

### DIFF
--- a/rust/include/myotis_engine.h
+++ b/rust/include/myotis_engine.h
@@ -11,7 +11,9 @@
  *  - Errors are sentinels, not exceptions: negative handle ids from
  *    myotis_create, false from start/pause/resume, "{}" status for an unknown
  *    handle, {"error": "..."} objects from the verified reads.
- *  - All verified reads are BLOCKING (up to ~90 s) — call off the UI thread.
+ *  - Verified reads are BLOCKING with a cooperative ~90 s operation budget.
+ *    Cancellation drains started native execution; indivisible native work may
+ *    overrun the budget. Call off the UI thread.
  */
 
 #ifndef MYOTIS_ENGINE_H
@@ -65,7 +67,9 @@ int32_t myotis_tor_status(void);
 /* Status JSON object (camelCase keys), or "{}" for an unknown handle. */
 char *myotis_status_json(int64_t handle);
 
-/* Remove + shut down; no-op for an unknown id. */
+/* Signal pending readers, drain registered work, remove + shut down.
+ * Synchronous; no-op for an unknown id. No hard wall-clock termination bound.
+ * Serialize start/pause/resume/stop on each handle. */
 void myotis_stop(int64_t handle);
 
 /* Idle-sleep: Running->Paused (tear down networking, keep warm state).

--- a/rust/include/myotis_engine.h
+++ b/rust/include/myotis_engine.h
@@ -14,6 +14,10 @@
  *  - Verified reads are BLOCKING with a cooperative ~90 s operation budget.
  *    Cancellation drains started native execution; indivisible native work may
  *    overrun the budget. Call off the UI thread.
+ *  - EVM execution admits at most eight actual closures process-wide; further
+ *    execution fails immediately with "native execution busy". Hosts must bound
+ *    their queues and retry busy reads within their own deadline; there is no
+ *    additional native semaphore-wait queue.
  */
 
 #ifndef MYOTIS_ENGINE_H

--- a/rust/myotis-engine/src/capi.rs
+++ b/rust/myotis-engine/src/capi.rs
@@ -671,3 +671,7 @@ pub unsafe extern "C" fn myotis_export_log_index(
         None => std::ptr::null_mut(),
     }
 }
+
+/// Rust-only scheduler bridge. Does not add or change a C ABI symbol. Carries
+/// the admission-time deadline and cancellation bit through the blocking seam.
+pub use myotis_net::el::request::{submitted, Submission};

--- a/rust/myotis-engine/src/host.rs
+++ b/rust/myotis-engine/src/host.rs
@@ -1425,12 +1425,28 @@ pub fn fee_history_json(
     // The raw request strings ARE the stale-serve signature (the Java
     // `blockCount + "|" + newestBlock + "|" + Arrays.toString(percentiles)`).
     let key = format!("{block_count}|{}|{}", newest_block_tag.trim(), percentiles_json.trim());
-    match engine.rt.block_on(reader.request(async {
+    let result = engine.rt.block_on(reader.request(async {
         Ok(reader.fee_history(block_count as u64, newest, percentiles.as_deref()).await)
-    })).unwrap_or_else(|msg| Err(myotis_net::el::reader::FeeHistoryError::Reject(msg))) {
+    }));
+    fee_history_response(result, &engine.fee_history_cache, handle, key)
+}
+
+// Keep host result/cache policy independent of the live engine for finite tests.
+fn fee_history_response(
+    result: Result<
+        Result<myotis_net::el::reader::FeeHistory, myotis_net::el::reader::FeeHistoryError>,
+        String,
+    >,
+    cache: &Mutex<HashMap<i64, (String, String, std::time::Instant)>>,
+    handle: i64,
+    key: String,
+) -> String {
+    // An outer operation failure is a build/availability failure, just like
+    // an inner peer timeout. Explicit request Rejects retain their meaning.
+    match result.unwrap_or_else(|msg| Err(myotis_net::el::reader::FeeHistoryError::Build(msg))) {
         Ok(history) => {
             let json = eljson::fee_history_json(&history);
-            if let Ok(mut cache) = engine.fee_history_cache.lock() {
+            if let Ok(mut cache) = cache.lock() {
                 cache.insert(handle, (key, json.clone(), std::time::Instant::now()));
             }
             json
@@ -1440,7 +1456,7 @@ pub fn fee_history_json(
         // BUILD failures reach serveStaleFeeHistory).
         Err(myotis_net::el::reader::FeeHistoryError::Reject(msg)) => eljson::error_json(&msg),
         Err(myotis_net::el::reader::FeeHistoryError::Build(msg)) => {
-            if let Ok(cache) = engine.fee_history_cache.lock() {
+            if let Ok(cache) = cache.lock() {
                 if let Some((last_key, json, at)) = cache.get(&handle) {
                     // saturating + read once: explicit panic-free style (the
                     // workspace convention under panic="abort"), and the gate
@@ -1845,6 +1861,68 @@ const NOT_STARTED_FALLBACK: &str = concat!(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn fee_history_outer_failure_preserves_stale_cache_policy() {
+        use myotis_net::el::reader::FeeHistoryError;
+        let key = "2|latest|null".to_string();
+        let json = r#"{"oldestBlock":"0x1","baseFeePerGas":["0x1"]}"#.to_string();
+        let cache = Mutex::new(HashMap::from([(
+            7,
+            (key.clone(), json.clone(), std::time::Instant::now()),
+        )]));
+        for message in ["request deadline exceeded", "request cancelled"] {
+            assert_eq!(
+                fee_history_response(Err(message.into()), &cache, 7, key.clone()),
+                json
+            );
+            assert_eq!(
+                fee_history_response(
+                    Ok(Err(FeeHistoryError::Build(message.into()))),
+                    &cache,
+                    7,
+                    key.clone()
+                ),
+                json
+            );
+        }
+        let reject = "newest block is beyond the verified head";
+        assert_eq!(
+            fee_history_response(
+                Ok(Err(FeeHistoryError::Reject(reject.into()))),
+                &cache,
+                7,
+                key.clone()
+            ),
+            eljson::error_json(reject)
+        );
+        assert_eq!(
+            fee_history_response(
+                Err("request cancelled".into()),
+                &cache,
+                7,
+                "different request".into()
+            ),
+            eljson::error_json("request cancelled")
+        );
+        assert_eq!(
+            fee_history_response(Err("request cancelled".into()), &cache, 8, key),
+            eljson::error_json("request cancelled")
+        );
+    }
+
+    #[test]
+    fn fee_history_outer_failure_does_not_serve_expired_cache() {
+        let key = "2|latest|null".to_string();
+        let expired = std::time::Instant::now()
+            .checked_sub(FEE_HISTORY_STALE_MAX)
+            .unwrap();
+        let cache = Mutex::new(HashMap::from([(7, (key.clone(), "stale".into(), expired))]));
+        assert_eq!(
+            fee_history_response(Err("request deadline exceeded".into()), &cache, 7, key),
+            eljson::error_json("request deadline exceeded")
+        );
+    }
 
     #[test]
     fn create_makes_the_data_dir() {

--- a/rust/myotis-engine/src/host.rs
+++ b/rust/myotis-engine/src/host.rs
@@ -418,14 +418,10 @@ pub fn pause(handle: i64) -> bool {
     };
     // Await the async teardown outside the map lock, like stop().
     engine.rt.block_on(async move {
+        if let Some(reader) = &reader { reader.cancel_requests(); }
         sync.stop().await;
         if let Some(reader) = reader {
-            reader.stop_log_index_appender().await;
-            if let Ok(reader) = Arc::try_unwrap(reader) {
-                reader.stop().await;
-            }
-            // An in-flight verified read still holds a clone: its Drop aborts
-            // the reader's tasks when the last Arc goes (same as stop()).
+            reader.stop().await;
         }
     });
     tracing::info!(handle, "paused (networking torn down; warm state persisted)");
@@ -436,17 +432,10 @@ pub fn pause(handle: i64) -> bool {
 /// path). Runs the async stops on the engine runtime.
 fn shutdown(engine: &EngineState, sync: SyncHandle, reader: Option<Arc<ElReader>>) {
     engine.rt.block_on(async move {
+        if let Some(reader) = &reader { reader.cancel_requests(); }
         sync.stop().await;
         if let Some(reader) = reader {
-            // Only our just-started reader holds an Arc here, so unwrapping the
-            // Arc to consume `stop(self)` succeeds; if it somehow doesn't, the
-            // reader's Drop still aborts its tasks. The appender is stopped
-            // (abort + await) FIRST so its per-tick strong Arc can't defeat
-            // the unwrap.
-            reader.stop_log_index_appender().await;
-            if let Ok(reader) = Arc::try_unwrap(reader) {
-                reader.stop().await;
-            }
+            reader.stop().await;
         }
     });
 }
@@ -580,12 +569,10 @@ pub fn stop(handle: i64) {
     }
     if let Some(ChainEntry::Running(_, sync, reader)) = entry {
         engine.rt.block_on(async move {
+            if let Some(reader) = &reader { reader.cancel_requests(); }
             sync.stop().await;
             if let Some(reader) = reader {
-                reader.stop_log_index_appender().await;
-                if let Ok(reader) = Arc::try_unwrap(reader) {
-                    reader.stop().await;
-                }
+                reader.stop().await;
             }
         });
     }
@@ -690,7 +677,7 @@ pub fn request_account_json(handle: i64, address_hex: &str) -> String {
         Ok(snap) => snap,
         Err(msg) => return eljson::error_json(msg),
     };
-    match engine.rt.block_on(async { reader.get_account(address).await }) {
+    match engine.rt.block_on(reader.request(async { reader.get_account(address).await })) {
         Ok(account) => eljson::account_json(address_hex, &account, finalized_period, wall_period),
         Err(e) => eljson::error_json(&e),
     }
@@ -725,7 +712,7 @@ pub fn get_storage_proof_json(
         Ok(snap) => snap,
         Err(msg) => return eljson::error_json(msg),
     };
-    match engine.rt.block_on(async { reader.get_storage(address, slot, holder).await }) {
+    match engine.rt.block_on(reader.request(async { reader.get_storage(address, slot, holder).await })) {
         Ok(storage) => eljson::storage_json(
             address_hex,
             holder_hex,
@@ -751,7 +738,7 @@ pub fn get_code_json(handle: i64, address_hex: &str) -> String {
         Ok(snap) => snap,
         Err(msg) => return eljson::error_json(msg),
     };
-    match engine.rt.block_on(async { reader.get_code(address).await }) {
+    match engine.rt.block_on(reader.request(async { reader.get_code(address).await })) {
         Ok(code) => eljson::code_json(address_hex, &code, finalized_period, wall_period),
         Err(e) => eljson::error_json(&e),
     }
@@ -775,7 +762,7 @@ pub fn get_storage_at_json(handle: i64, address_hex: &str, position_hex: &str) -
         Ok(snap) => snap,
         Err(msg) => return eljson::error_json(msg),
     };
-    match engine.rt.block_on(async { reader.get_storage_at(address, position).await }) {
+    match engine.rt.block_on(reader.request(async { reader.get_storage_at(address, position).await })) {
         Ok(storage) => {
             eljson::storage_json(address_hex, None, &storage, finalized_slot, optimistic_slot)
         }
@@ -860,13 +847,13 @@ pub fn eth_call_overrides_json(
     };
     match engine
         .rt
-        .block_on(async {
+        .block_on(reader.request(async {
             if creation {
                 reader.eth_call_create(from, data, value, chain_id, overrides).await
             } else {
                 reader.eth_call_overridden(from, to, data, value, chain_id, overrides).await
             }
-        })
+        }))
     {
         Ok(outcome) => eljson::call_json(&outcome),
         Err(e) => eljson::error_json(&e),
@@ -998,7 +985,7 @@ pub fn resolve_ens_json(handle: i64, name: &str) -> String {
     let owned = name.to_string();
     match engine
         .rt
-        .block_on(async { reader.resolve_ens(owned, chain_id).await })
+        .block_on(reader.request(async { reader.resolve_ens(owned, chain_id).await }))
     {
         Ok(outcome) => eljson::ens_json(&outcome),
         Err(e) => eljson::error_json(&e),
@@ -1107,20 +1094,20 @@ pub fn ens_record_json(handle: i64, params_json: &str) -> String {
         let Some(finalized) = params.get("finalized").and_then(|v| v.as_bool()) else {
             return eljson::error_json("missing finalized");
         };
-        return match engine.rt.block_on(async {
+        return match engine.rt.block_on(reader.request(async {
             reader
                 .ens_ccip_callback(
                     query, chain_id, finalized, sender, callback, response, extra, wrapped,
                 )
                 .await
-        }) {
+        })) {
             Ok(outcome) => eljson::ens_record_json(&outcome),
             Err(e) => eljson::error_json(&e),
         };
     }
     match engine
         .rt
-        .block_on(async { reader.resolve_ens_query(query, chain_id, root).await })
+        .block_on(reader.request(async { reader.resolve_ens_query(query, chain_id, root).await }))
     {
         Ok(outcome) => eljson::ens_record_json(&outcome),
         Err(e) => eljson::error_json(&e),
@@ -1174,7 +1161,7 @@ pub fn estimate_gas_json(
     };
     match engine
         .rt
-        .block_on(async { reader.estimate_gas(from, to, data, value, chain_id).await })
+        .block_on(reader.request(async { reader.estimate_gas(from, to, data, value, chain_id).await }))
     {
         Ok(outcome) => eljson::estimate_json(&outcome),
         Err(e) => eljson::error_json(&e),
@@ -1200,7 +1187,7 @@ pub fn get_block_by_number_json(handle: i64, block_tag: &str, full_transactions:
     };
     match engine
         .rt
-        .block_on(async { reader.get_block_by_number(target, full_transactions).await })
+        .block_on(reader.request(async { reader.get_block_by_number(target, full_transactions).await }))
     {
         Ok(Some(block)) => eljson::block_json(&block),
         Ok(None) => "null".to_string(), // verified future/unknown block → eth null
@@ -1249,7 +1236,7 @@ pub fn get_transaction_receipt_json(handle: i64, tx_hash_hex: &str) -> String {
         Ok(snap) => snap,
         Err(msg) => return eljson::error_json(msg),
     };
-    match engine.rt.block_on(async { reader.get_transaction_receipt(tx_hash).await }) {
+    match engine.rt.block_on(reader.request(async { reader.get_transaction_receipt(tx_hash).await })) {
         Ok(Some(receipt)) => eljson::receipt_json(&receipt),
         Ok(None) => "null".to_string(), // verified "not seen" → eth null
         Err(e) => eljson::error_json(&e),
@@ -1273,7 +1260,7 @@ pub fn get_transaction_by_hash_json(handle: i64, tx_hash_hex: &str) -> String {
         Ok(snap) => snap,
         Err(msg) => return eljson::error_json(msg),
     };
-    match engine.rt.block_on(async { reader.get_transaction_by_hash(tx_hash).await }) {
+    match engine.rt.block_on(reader.request(async { reader.get_transaction_by_hash(tx_hash).await })) {
         Ok(myotis_net::el::reader::TxLookup::Mined(tx)) => eljson::tx_json(&tx),
         Ok(myotis_net::el::reader::TxLookup::Pending { tx_hash, tx }) => {
             eljson::pending_tx_json(&tx_hash, &tx)
@@ -1305,7 +1292,7 @@ pub fn get_block_by_hash_json(
     };
     match engine
         .rt
-        .block_on(async { reader.get_block_by_hash(block_hash, full_transactions).await })
+        .block_on(reader.request(async { reader.get_block_by_hash(block_hash, full_transactions).await }))
     {
         Ok(Some(block)) => eljson::block_json(&block),
         Ok(None) => "null".to_string(), // never-verified/reorged-away hash → eth null
@@ -1331,7 +1318,7 @@ pub fn send_raw_transaction_json(handle: i64, raw_hex: &str) -> String {
         Ok(snap) => snap,
         Err(msg) => return eljson::error_json(msg),
     };
-    match engine.rt.block_on(async { reader.send_raw_transaction(&raw).await }) {
+    match engine.rt.block_on(reader.request(async { reader.send_raw_transaction(&raw).await })) {
         Ok(hash) => eljson::tx_hash_json(&hash),
         Err(e) => eljson::error_json(&e),
     }
@@ -1350,7 +1337,7 @@ pub fn fee_estimate_json(handle: i64) -> String {
         Ok(snap) => snap,
         Err(msg) => return eljson::error_json(msg),
     };
-    match engine.rt.block_on(async { reader.fee_estimate().await }) {
+    match engine.rt.block_on(reader.request(async { reader.fee_estimate().await })) {
         Ok(est) => eljson::fee_json(&est),
         Err(e) => eljson::error_json(&e),
     }
@@ -1379,7 +1366,7 @@ pub fn get_block_receipts_json(handle: i64, selector: &str) -> String {
         let Some(hash) = parse_word32(selector) else {
             return eljson::error_json("invalid block hash (expected 32-byte hex)");
         };
-        engine.rt.block_on(async { reader.get_block_receipts_by_hash(hash).await })
+        engine.rt.block_on(reader.request(async { reader.get_block_receipts_by_hash(hash).await }))
     } else {
         let tag = if selector.is_empty() { "latest" } else { selector };
         let is_tag = matches!(tag, "latest" | "pending" | "safe" | "finalized" | "earliest");
@@ -1392,7 +1379,7 @@ pub fn get_block_receipts_json(handle: i64, selector: &str) -> String {
             Ok(t) => t,
             Err(msg) => return eljson::error_json(msg),
         };
-        engine.rt.block_on(async { reader.get_block_receipts(target).await })
+        engine.rt.block_on(reader.request(async { reader.get_block_receipts(target).await }))
     };
     match outcome {
         Ok(Some(receipts)) => eljson::block_receipts_json(&receipts),
@@ -1438,9 +1425,9 @@ pub fn fee_history_json(
     // The raw request strings ARE the stale-serve signature (the Java
     // `blockCount + "|" + newestBlock + "|" + Arrays.toString(percentiles)`).
     let key = format!("{block_count}|{}|{}", newest_block_tag.trim(), percentiles_json.trim());
-    match engine.rt.block_on(async {
-        reader.fee_history(block_count as u64, newest, percentiles.as_deref()).await
-    }) {
+    match engine.rt.block_on(reader.request(async {
+        Ok(reader.fee_history(block_count as u64, newest, percentiles.as_deref()).await)
+    })).unwrap_or_else(|msg| Err(myotis_net::el::reader::FeeHistoryError::Reject(msg))) {
         Ok(history) => {
             let json = eljson::fee_history_json(&history);
             if let Ok(mut cache) = engine.fee_history_cache.lock() {
@@ -2685,7 +2672,12 @@ fn get_logs_json_impl(handle: i64, filter_json: &str) -> String {
             })
     );
     if needs_fill {
-        engine.rt.block_on(async { reader.advance_log_index_tail_now(filter.to_block).await });
+        if let Err(error) = engine.rt.block_on(reader.request(async {
+            reader.advance_log_index_tail_now(filter.to_block).await;
+            Ok(())
+        })) {
+            return eljson::error_json(&error);
+        }
         result = reader.with_log_index(|ix| ix.query(&filter));
     }
     match result {

--- a/rust/myotis-engine/src/host.rs
+++ b/rust/myotis-engine/src/host.rs
@@ -847,13 +847,13 @@ pub fn eth_call_overrides_json(
     };
     match engine
         .rt
-        .block_on(reader.request(async {
+        .block_on(async {
             if creation {
                 reader.eth_call_create(from, data, value, chain_id, overrides).await
             } else {
                 reader.eth_call_overridden(from, to, data, value, chain_id, overrides).await
             }
-        }))
+        })
     {
         Ok(outcome) => eljson::call_json(&outcome),
         Err(e) => eljson::error_json(&e),
@@ -985,7 +985,7 @@ pub fn resolve_ens_json(handle: i64, name: &str) -> String {
     let owned = name.to_string();
     match engine
         .rt
-        .block_on(reader.request(async { reader.resolve_ens(owned, chain_id).await }))
+        .block_on(async { reader.resolve_ens(owned, chain_id).await })
     {
         Ok(outcome) => eljson::ens_json(&outcome),
         Err(e) => eljson::error_json(&e),
@@ -1094,20 +1094,20 @@ pub fn ens_record_json(handle: i64, params_json: &str) -> String {
         let Some(finalized) = params.get("finalized").and_then(|v| v.as_bool()) else {
             return eljson::error_json("missing finalized");
         };
-        return match engine.rt.block_on(reader.request(async {
+        return match engine.rt.block_on(async {
             reader
                 .ens_ccip_callback(
                     query, chain_id, finalized, sender, callback, response, extra, wrapped,
                 )
                 .await
-        })) {
+        }) {
             Ok(outcome) => eljson::ens_record_json(&outcome),
             Err(e) => eljson::error_json(&e),
         };
     }
     match engine
         .rt
-        .block_on(reader.request(async { reader.resolve_ens_query(query, chain_id, root).await }))
+        .block_on(async { reader.resolve_ens_query(query, chain_id, root).await })
     {
         Ok(outcome) => eljson::ens_record_json(&outcome),
         Err(e) => eljson::error_json(&e),
@@ -1161,7 +1161,7 @@ pub fn estimate_gas_json(
     };
     match engine
         .rt
-        .block_on(reader.request(async { reader.estimate_gas(from, to, data, value, chain_id).await }))
+        .block_on(async { reader.estimate_gas(from, to, data, value, chain_id).await })
     {
         Ok(outcome) => eljson::estimate_json(&outcome),
         Err(e) => eljson::error_json(&e),

--- a/rust/myotis-evm/src/executor.rs
+++ b/rust/myotis-evm/src/executor.rs
@@ -27,7 +27,22 @@ use revm::context::result::{ExecutionResult, HaltReason, Output};
 use revm::context::{CfgEnv, TxEnv};
 use revm::database_interface::{DBErrorMarker, DatabaseRef};
 use revm::primitives::{Address, TxKind, U256};
-use revm::{Context, ExecuteEvm, MainBuilder, MainContext};
+use revm::{Context, InspectEvm, Inspector, MainBuilder, MainContext};
+use revm::interpreter::{Interpreter, InterpreterAction, InterpreterResult, InstructionResult};
+use revm::interpreter::interpreter_types::LoopControl;
+
+struct RequestInspector<'a>(&'a dyn SnapStateOracle);
+impl<CTX> Inspector<CTX> for RequestInspector<'_> {
+    fn step(&mut self, interp: &mut Interpreter, _context: &mut CTX) {
+        if self.0.check_request().is_err() {
+            interp.bytecode.set_action(InterpreterAction::Return(InterpreterResult {
+                result: InstructionResult::Stop,
+                output: Default::default(),
+                gas: interp.gas,
+            }));
+        }
+    }
+}
 
 use crate::block::BlockContext;
 use crate::cache::{BytecodeCache, StateProofCache};
@@ -240,6 +255,7 @@ impl EvmExecutor {
         value: U256,
         ctx: &BlockContext,
     ) -> Result<ExecutionResult, EvmError> {
+        self.oracle.check_request()?;
         let mut cfg = CfgEnv::new_with_spec(spec);
         cfg.chain_id = ctx.chain_id;
         // Not a real tx: relax the transaction-level checks (see the module docs).
@@ -276,9 +292,13 @@ impl EvmExecutor {
             .with_ref_db(db)
             .with_block(ctx.block_env())
             .with_cfg(cfg)
-            .build_mainnet();
+            .build_mainnet_with_inspector(RequestInspector(self.oracle.as_ref()));
 
-        Ok(evm.transact(tx).map_err(map_evm_error)?.result)
+        let result = evm.inspect_tx(tx);
+        // Cancellation takes precedence over an interpreter stop (including a
+        // cancelled nested call) or a just-finished indivisible precompile.
+        self.oracle.check_request()?;
+        Ok(result.map_err(map_evm_error)?.result)
     }
 
     /// Run a call and return its output bytes (revert/halt → `Err`), via the
@@ -325,6 +345,7 @@ impl EvmExecutor {
         cap: usize,
         overrides: StateOverrides,
     ) -> Result<Vec<u8>, EvmError> {
+        self.oracle.check_request()?;
         let spec = spec_for(ctx.chain_id, ctx.block_number, ctx.timestamp)?;
         let db = self.database_for_with(ctx, overrides);
 
@@ -342,6 +363,7 @@ impl EvmExecutor {
         let mut seen = AccessSet::default();
         let mut discovering = true;
         for iter in 0..cap {
+            self.oracle.check_request()?;
             // Sentinel while still discovering, but the LAST TWO iterations are
             // always real (one final wave + one warm real run).
             let sentinel = discovering && iter + 2 < cap;
@@ -426,6 +448,7 @@ impl EvmExecutor {
         value: U256,
         ctx: &BlockContext,
     ) -> Result<u64, EvmError> {
+        self.oracle.check_request()?;
         // Java `rpcEstimateGas` parity: a plain transfer (empty calldata) to a
         // CODELESS account costs exactly 21000 — no EVM run and NO 1.15 buffer
         // (it's exact). One verified account fetch through the caching database
@@ -446,6 +469,7 @@ impl EvmExecutor {
                 .basic_ref(Address::from(target))?
                 .is_none_or(|a| a.code_hash.0 == myotis_core::trie::EMPTY_CODE_HASH);
             if no_code {
+                self.oracle.check_request()?;
                 return Ok(PLAIN_TRANSFER_GAS);
             }
         }
@@ -517,6 +541,37 @@ mod tests {
     use crate::fork::{CANCUN_TIME, LONDON_BLOCK};
     use crate::oracle::{FixtureSnapStateOracle, OracleAccount};
     use myotis_core::keccak::keccak256;
+
+    struct CancelledOracle;
+    impl SnapStateOracle for CancelledOracle {
+        fn check_request(&self) -> Result<(), OracleError> {
+            Err(OracleError::Cancelled { reason: "test cancellation".into() })
+        }
+        fn fetch_account(&self, _: &[u8; 32], _: [u8; 20]) -> Result<Option<OracleAccount>, OracleError> {
+            panic!("cancelled executor must not fetch")
+        }
+        fn fetch_storage(&self, _: &[u8; 32], _: [u8; 20], _: U256) -> Result<U256, OracleError> {
+            panic!("cancelled executor must not fetch")
+        }
+        fn fetch_bytecode(&self, _: &[u8; 32]) -> Result<Vec<u8>, OracleError> {
+            panic!("cancelled executor must not fetch")
+        }
+    }
+
+    #[test]
+    fn cancelled_call_and_estimate_refuse_before_fetch() {
+        let executor = EvmExecutor::new(Arc::new(CancelledOracle), Arc::new(NoopStateProofCache), Arc::new(NoopBytecodeCache));
+        let context = ctx(LONDON_BLOCK, CANCUN_TIME);
+        assert!(matches!(executor.call_view(TARGET, &[], &context), Err(EvmError::Oracle(OracleError::Cancelled { .. }))));
+        assert!(matches!(executor.estimate_gas([0; 20], TARGET, &[], U256::ZERO, &context), Err(EvmError::Oracle(OracleError::Cancelled { .. }))));
+    }
+
+    #[test]
+    fn cancelled_instruction_sets_stop_without_running_bytecode() {
+        let mut interpreter = Interpreter::default_ext();
+        RequestInspector(&CancelledOracle).step(&mut interpreter, &mut ());
+        assert!(interpreter.bytecode.action().is_some());
+    }
 
     const ROOT: [u8; 32] = [0xAA; 32];
     const TARGET: [u8; 20] = [0x11; 20];

--- a/rust/myotis-evm/src/oracle.rs
+++ b/rust/myotis-evm/src/oracle.rs
@@ -62,6 +62,8 @@ impl OracleAccount {
 /// OutOfGas, …) belong to the executor, added in a later Milestone-C slice.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum OracleError {
+    /// The operation was cancelled or its whole-operation deadline expired.
+    Cancelled { reason: String },
     /// State for `address` (and `slot`, if a storage read) could not be fetched
     /// or verified against `state_root` — peers exhausted, transport failure, or
     /// no anchored head. Not necessarily an attack; retryable.
@@ -88,6 +90,7 @@ pub enum OracleError {
 impl std::fmt::Display for OracleError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            OracleError::Cancelled { reason } => write!(f, "{reason}"),
             OracleError::StateUnavailable { address, slot, .. } => match slot {
                 Some(s) => write!(
                     f,
@@ -131,6 +134,10 @@ fn hex(bytes: &[u8]) -> String {
 /// The verified world-state source the EVM reads through. See the module docs
 /// for the verification and threading contract.
 pub trait SnapStateOracle: Send + Sync {
+    /// Cooperative execution check, including cache-only EVM instruction runs.
+    /// Fixtures and sans-I/O consumers may leave this unlimited.
+    fn check_request(&self) -> Result<(), OracleError> { Ok(()) }
+
     /// The proof-verified account at `address`, or `Ok(None)` when an exclusion
     /// proof shows it absent. `Err` only when it cannot be verified.
     fn fetch_account(

--- a/rust/myotis-net/src/el/discv4.rs
+++ b/rust/myotis-net/src/el/discv4.rs
@@ -387,9 +387,8 @@ pub struct Discv4Service {
     stop_tx: tokio::sync::watch::Sender<bool>,
     /// Probe requests into the service loop (see [`Discv4Service::probe_sender`]).
     probe_tx: tokio::sync::mpsc::Sender<SocketAddr>,
-    /// `Option` so `stop(self)` can take the handle while `Drop` (the
-    /// forgot-to-stop path) leaves it `None`.
-    task: Option<tokio::task::JoinHandle<()>>,
+    /// Shared-borrow shutdown still owns and joins the service task exactly once.
+    task: tokio::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
 }
 
 impl Discv4Service {
@@ -428,7 +427,7 @@ impl Discv4Service {
             local_port,
             stop_tx,
             probe_tx,
-            task: Some(task),
+            task: tokio::sync::Mutex::new(Some(task)),
         })
     }
 
@@ -458,9 +457,9 @@ impl Discv4Service {
         self.local_port
     }
 
-    pub async fn stop(mut self) {
+    pub async fn stop(&self) {
         let _ = self.stop_tx.send(true);
-        if let Some(task) = self.task.take() {
+        if let Some(task) = self.task.lock().await.take() {
             let _ = task.await;
         }
     }

--- a/rust/myotis-net/src/el/evm.rs
+++ b/rust/myotis-net/src/el/evm.rs
@@ -224,6 +224,7 @@ fn u256_be(bytes: &[u8]) -> Option<U256> {
 /// A [`SnapStateOracle`] over a fixed snapshot of snap peers, bridging the sync
 /// trait to the async snap fetch path. Created per `eth_call`.
 pub struct PoolOracle {
+    operation: Option<Arc<super::request::Operation>>,
     peers: Vec<Arc<ManagedPeer>>,
     handle: Handle,
     /// Snap-quality reputation sink (None in tests): serves confirm a peer,
@@ -244,11 +245,21 @@ impl PoolOracle {
         quality: Option<crate::el::pool::SnapQualitySink>,
     ) -> PoolOracle {
         PoolOracle {
+            operation: super::request::Operation::current(),
             peers,
             handle,
             quality,
             leaf_memo: Mutex::new(HashMap::new()),
         }
+    }
+
+    fn wait<T>(&self, future: impl std::future::Future<Output = T>) -> Result<T, OracleError> {
+        self.handle.block_on(async {
+            match &self.operation {
+                Some(op) => op.wait(future).await.map_err(|reason| OracleError::Cancelled { reason }),
+                None => Ok(future.await),
+            }
+        })
     }
 
     /// Record one per-peer fetch outcome (no-op without a sink).
@@ -269,12 +280,13 @@ impl PoolOracle {
         state_root: &[u8; 32],
         address: [u8; 20],
     ) -> Result<Option<AccountLeaf>, OracleError> {
+        self.check_request()?;
         if let Some(cached) = self.leaf_memo.lock().unwrap().get(&address) {
             return Ok(cached.clone());
         }
         // No lock held across the network fetch.
         let quality = self.quality.clone();
-        let fetched = self.handle.block_on(async {
+        let fetched = self.wait(async {
             for peer in &self.peers {
                 match peer.snap_get_account(state_root, &address).await {
                     Ok(AccountOutcome::Present(leaf)) => {
@@ -290,7 +302,7 @@ impl PoolOracle {
                 }
             }
             None
-        });
+        })?;
         match fetched {
             Some(leaf) => {
                 self.leaf_memo.lock().unwrap().insert(address, leaf.clone());
@@ -306,6 +318,13 @@ impl PoolOracle {
 }
 
 impl SnapStateOracle for PoolOracle {
+    fn check_request(&self) -> Result<(), OracleError> {
+        match &self.operation {
+            Some(op) => op.check().map_err(|reason| OracleError::Cancelled { reason }),
+            None => Ok(()),
+        }
+    }
+
     fn fetch_account(
         &self,
         state_root: &[u8; 32],
@@ -538,7 +557,7 @@ impl SnapStateOracle for PoolOracle {
         // The whole wave is bounded (Java PREFETCH_WAVE_TIMEOUT_SEC): on timeout
         // whatever landed is kept and the loop's next iteration proceeds — an
         // eth_call must never hang on a slow warm-up.
-        self.handle.block_on(async {
+        let _ = self.wait(async {
             let _ = tokio::time::timeout(WAVE_TIMEOUT, wave).await;
         });
     }
@@ -559,7 +578,7 @@ impl SnapStateOracle for PoolOracle {
         }
         let position = slot.to_be_bytes::<32>();
         let quality = self.quality.clone();
-        let fetched = self.handle.block_on(async {
+        let fetched = self.wait(async {
             for peer in &self.peers {
                 match peer
                     .snap_get_storage(state_root, &address, &leaf, &position)
@@ -573,7 +592,7 @@ impl SnapStateOracle for PoolOracle {
                 }
             }
             None
-        });
+        })?;
         match fetched {
             // Empty bytes = a proven-zero / absent slot.
             Some(value) => u256_be(&value).ok_or_else(|| OracleError::InvalidProof {
@@ -593,7 +612,7 @@ impl SnapStateOracle for PoolOracle {
         // Content-addressed: snap_get_bytecode checks keccak(code) == code_hash,
         // so any peer's bytes are trusted iff they hash correctly.
         let quality = self.quality.clone();
-        let fetched = self.handle.block_on(async {
+        let fetched = self.wait(async {
             for peer in &self.peers {
                 match peer.snap_get_bytecode(code_hash).await {
                     Ok(code) => {
@@ -604,7 +623,7 @@ impl SnapStateOracle for PoolOracle {
                 }
             }
             None
-        });
+        })?;
         fetched.ok_or(OracleError::BytecodeUnavailable {
             code_hash: *code_hash,
         })

--- a/rust/myotis-net/src/el/mod.rs
+++ b/rust/myotis-net/src/el/mod.rs
@@ -15,6 +15,8 @@ pub mod logindex;
 pub mod peercache;
 pub mod pool;
 pub mod reader;
+pub mod request;
+mod tasks;
 pub mod receipt;
 pub mod rlpx;
 /// Tor transport for the verified-read path (docs/privacy-and-tor.md). Only

--- a/rust/myotis-net/src/el/peer.rs
+++ b/rust/myotis-net/src/el/peer.rs
@@ -61,7 +61,7 @@ type PendingMap = Arc<Mutex<HashMap<u64, Pending>>>;
 /// when the send completes, so the next lock holder observes the tear and
 /// refuses the corrupt stream instead of writing MAC-garbage after it.
 struct GuardedWriter {
-    inner: RlpxWriter,
+    inner: Option<RlpxWriter>,
     torn: bool,
 }
 
@@ -76,7 +76,10 @@ async fn send_frame(writer: &SharedWriter, code: u64, body: &[u8]) -> Result<(),
         return Err("egress stream torn by a cancelled frame write".to_string());
     }
     w.torn = true;
-    let result = w.inner.send(code, body).await;
+    let result = match w.inner.as_mut() {
+        Some(writer) => writer.send(code, body).await,
+        None => Err("peer writer closed".to_string()),
+    };
     // A completed-Err send (write error / frame-write timeout) leaves the
     // stream just as mid-frame-corrupt as a cancelled one — keep the marker
     // set so a request already queued on the writer lock (racing `fail_all`'s
@@ -122,7 +125,7 @@ pub struct ManagedPeer {
     /// Set once the read loop terminates (disconnect / read error); requests
     /// short-circuit instead of hanging until timeout.
     closed: Arc<AtomicBool>,
-    reader_task: JoinHandle<()>,
+    reader_task: std::sync::Mutex<Option<JoinHandle<()>>>,
 
     /// Negotiated eth version (66-69).
     pub eth_version: u64,
@@ -143,6 +146,15 @@ pub struct ManagedPeer {
 }
 
 impl ManagedPeer {
+    /// Invalidate snapshots too: active oracle Arcs must not keep reads alive.
+    pub async fn close(&self) {
+        self.closed.store(true, Ordering::Release);
+        let task = self.reader_task.lock().unwrap_or_else(|e| e.into_inner()).take();
+        if let Some(task) = task { task.abort(); let _ = task.await; }
+        self.pending.lock().await.clear();
+        self.writer.lock().await.inner.take();
+    }
+
     /// Take over a handshook [`EthSession`], splitting its connection and
     /// spawning the background read loop. From here the peer serves concurrent
     /// requests and answers Ping/Get\* on its own.
@@ -186,7 +198,7 @@ impl ManagedPeer {
     ) -> ManagedPeer {
         let (reader, writer, peer_pubkey) = conn.split();
         let snap_codes = snap.then(|| snap::SnapCodes::for_eth_version(eth_version));
-        let writer = Arc::new(Mutex::new(GuardedWriter { inner: writer, torn: false }));
+        let writer = Arc::new(Mutex::new(GuardedWriter { inner: Some(writer), torn: false }));
         let pending: PendingMap = Arc::new(Mutex::new(HashMap::new()));
         let closed = Arc::new(AtomicBool::new(false));
 
@@ -205,7 +217,7 @@ impl ManagedPeer {
             pending,
             next_id: AtomicU64::new(1),
             closed,
-            reader_task,
+            reader_task: std::sync::Mutex::new(Some(reader_task)),
             eth_version,
             snap,
             peer_status,
@@ -614,7 +626,7 @@ impl ManagedPeer {
 impl Drop for ManagedPeer {
     fn drop(&mut self) {
         // Stop the background read loop when the last handle goes away.
-        self.reader_task.abort();
+        if let Some(task) = self.reader_task.get_mut().unwrap_or_else(|e| e.into_inner()).take() { task.abort(); }
     }
 }
 

--- a/rust/myotis-net/src/el/pool.rs
+++ b/rust/myotis-net/src/el/pool.rs
@@ -23,7 +23,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use tokio::sync::{mpsc, Mutex, Semaphore};
-use tokio::task::JoinHandle;
 use tokio::time::Instant;
 
 use myotis_core::nodekey::NodeKey;
@@ -204,6 +203,7 @@ fn read_failure_verdict(fails_before: u32, pool_len: usize) -> (u32, bool) {
 }
 
 struct PoolInner {
+    tasks: super::tasks::Tasks,
     key: Arc<NodeKey>,
     local_pubkey: [u8; 64],
     cfg: Arc<EthConfig>,
@@ -535,10 +535,6 @@ impl PoolInner {
 /// dialer task is aborted; held peers close as their `Arc`s drop).
 pub struct PeerPool {
     inner: Arc<PoolInner>,
-    dialer_task: JoinHandle<()>,
-    /// Keeps the live snap-peer count at target by re-dialing cached peers when
-    /// they die (twin of the Java `ChainStack.maintainSnapPeers` loop).
-    maintainer_task: JoinHandle<()>,
 }
 
 impl PeerPool {
@@ -567,6 +563,7 @@ impl PeerPool {
             }),
         ));
         let inner = Arc::new(PoolInner {
+            tasks: super::tasks::Tasks::default(),
             key,
             local_pubkey,
             cfg,
@@ -591,9 +588,9 @@ impl PeerPool {
         // Both the discv4 dialer and the maintainer dial through one shared
         // concurrency budget.
         let dial_slots = Arc::new(Semaphore::new(inner.pool_cfg.max_concurrent_dials));
-        let dialer_task = tokio::spawn(dialer_loop(Arc::clone(&inner), rx, Arc::clone(&dial_slots)));
-        let maintainer_task = tokio::spawn(maintainer_loop(Arc::clone(&inner), dial_slots));
-        PeerPool { inner, dialer_task, maintainer_task }
+        inner.tasks.spawn(dialer_loop(Arc::clone(&inner), rx, Arc::clone(&dial_slots)));
+        inner.tasks.spawn(maintainer_loop(Arc::clone(&inner), dial_slots));
+        PeerPool { inner }
     }
 
     /// A live snap-capable peer for a verified read, or `None` if the pool has
@@ -694,18 +691,21 @@ impl PeerPool {
 
     /// Stop the pool: flush the peer cache, abort the background tasks, and drop
     /// all held peers (closing them).
-    pub async fn stop(self) {
+    pub async fn stop(&self) {
+        // Close admission and join parent loops AND their dial/backfill/send
+        // jobs before flushing caches or clearing peers. No late dial can
+        // publish a fresh peer after stop has cleared the set.
+        self.inner.tasks.stop().await;
         self.inner.cache.lock().await.flush();
-        self.dialer_task.abort();
-        self.maintainer_task.abort();
-        self.inner.peers.lock().await.clear();
+        let mut peers = self.inner.peers.lock().await;
+        for peer in peers.iter() { peer.peer.close().await; }
+        peers.clear();
     }
 }
 
 impl Drop for PeerPool {
     fn drop(&mut self) {
-        self.dialer_task.abort();
-        self.maintainer_task.abort();
+        self.inner.tasks.abort();
     }
 }
 
@@ -808,7 +808,7 @@ async fn try_dial(
         return false;
     };
     let inner2 = Arc::clone(inner);
-    tokio::spawn(async move {
+    inner.tasks.spawn(async move {
         inner2.dial_one(addr, pubkey).await;
         drop(permit);
     });
@@ -940,7 +940,7 @@ async fn backfill_served_headers(inner: &Arc<PoolInner>) {
         return;
     }
     let inner2 = Arc::clone(inner);
-    tokio::spawn(async move {
+    inner.tasks.spawn(async move {
         tracing::debug!(from, count, head = anchored.0, "header backfill: anchored fetch");
         let result = peer.get_block_headers_by_number_raw(from, count).await;
         inner2.backfill_inflight.store(false, std::sync::atomic::Ordering::Release);
@@ -999,7 +999,7 @@ async fn broadcast_range_if_changed(inner: &Arc<PoolInner>) {
     // maintainer's prune/re-dial work. Spawned, the tick is bounded by nothing —
     // a failed write closes its own peer (send_block_range_update fail_alls).
     for peer in peers {
-        tokio::spawn(async move {
+        inner.tasks.spawn(async move {
             peer.send_block_range_update(earliest, latest, latest_hash).await;
         });
     }

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -4110,7 +4110,7 @@ impl ElReader {
                 }
             }
         };
-        super::request::run(self.request_shutdown.subscribe(), RESOLVE_ENS_DEADLINE, ladder).await
+        self.request(super::request::run(self.request_shutdown.subscribe(), RESOLVE_ENS_DEADLINE, ladder)).await
     }
 
     /// One ERC-3668 CALLBACK re-entry (EL-C-5-3): the host drove the gateway;
@@ -4170,7 +4170,7 @@ impl ElReader {
                 Err(e) => Err(e.to_string()),
             }
         };
-        super::request::run(self.request_shutdown.subscribe(), RESOLVE_ENS_ATTEMPT_DEADLINE, attempt).await
+        self.request(super::request::run(self.request_shutdown.subscribe(), RESOLVE_ENS_ATTEMPT_DEADLINE, attempt)).await
     }
 
     /// One resolution attempt against one root (finalized or optimistic).

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -781,6 +781,8 @@ pub struct FeeEstimate {
 
 /// A running EL reader: owns discv4 + the peer pool, borrows the beacon anchor.
 pub struct ElReader {
+    request_shutdown: tokio::sync::watch::Sender<bool>,
+    requests: std::sync::Mutex<Vec<std::sync::Weak<super::request::Operation>>>,
     discovery: Discv4Service,
     pool: PeerPool,
     anchor: Arc<ExecAnchor>,
@@ -935,6 +937,14 @@ const RESOLVE_ENS_DEADLINE: std::time::Duration = std::time::Duration::from_secs
 const RESOLVE_ENS_ATTEMPT_DEADLINE: std::time::Duration = std::time::Duration::from_secs(60);
 
 impl ElReader {
+    /// Budget a host operation, including its network and blocking EVM work.
+    pub async fn request<T>(&self, future: impl std::future::Future<Output = Result<T, String>>) -> Result<T, String> {
+        super::request::run_registered(&self.requests, self.request_shutdown.subscribe(), future).await
+    }
+
+    /// Signal active readers before waiting for any other shutdown work.
+    pub fn cancel_requests(&self) { self.request_shutdown.send_replace(true); }
+
     /// Start a mainnet reader with a freshly-generated ephemeral node key (the
     /// CL side generates its libp2p identity per run too; a persistent EL
     /// identity is an EL-A8 concern). `cache_path` is the EL peer cache for
@@ -1022,6 +1032,8 @@ impl ElReader {
             })),
         );
         Ok(ElReader {
+            request_shutdown: tokio::sync::watch::channel(false).0,
+            requests: std::sync::Mutex::new(Vec::new()),
             discovery,
             pool,
             anchor,
@@ -3923,8 +3935,19 @@ impl ElReader {
         chain_id: u64,
         overrides: myotis_evm::overrides::StateOverrides,
     ) -> Result<CallOutcome, String> {
+        self.request(self.eth_call_create_inner(from, init_code, value, chain_id, overrides)).await
+    }
+
+    async fn eth_call_create_inner(
+        &self,
+        from: Option<[u8; 20]>,
+        init_code: Vec<u8>,
+        value: U256,
+        chain_id: u64,
+        overrides: myotis_evm::overrides::StateOverrides,
+    ) -> Result<CallOutcome, String> {
         let (ctx, executor) = self.evm_setup(chain_id, "eth_call (create)").await?;
-        let joined = tokio::task::spawn_blocking(move || {
+        let joined = super::request::blocking(move || {
             let sender = from.unwrap_or([0u8; 20]);
             executor.create_view(sender, &init_code, value, &ctx, overrides)
         })
@@ -3950,10 +3973,22 @@ impl ElReader {
         chain_id: u64,
         overrides: myotis_evm::overrides::StateOverrides,
     ) -> Result<CallOutcome, String> {
+        self.request(self.eth_call_overridden_inner(from, to, data, value, chain_id, overrides)).await
+    }
+
+    async fn eth_call_overridden_inner(
+        &self,
+        from: Option<[u8; 20]>,
+        to: [u8; 20],
+        data: Vec<u8>,
+        value: U256,
+        chain_id: u64,
+        overrides: myotis_evm::overrides::StateOverrides,
+    ) -> Result<CallOutcome, String> {
         let (ctx, executor) = self.evm_setup(chain_id, "eth_call").await?;
         // Run the SYNCHRONOUS executor off the runtime worker so the oracle's
         // per-fetch `block_on` is a fresh (non-nested) runtime entry.
-        let joined = tokio::task::spawn_blocking(move || {
+        let joined = super::request::blocking(move || {
             // A from-less call still honours `value` — the default sender is the zero
             // ADDRESS, not zero value — so always thread `value` through
             // call_view_from (call_view would force value = 0 and drop it).
@@ -3983,8 +4018,19 @@ impl ElReader {
         value: U256,
         chain_id: u64,
     ) -> Result<GasOutcome, String> {
+        self.request(self.estimate_gas_inner(from, to, data, value, chain_id)).await
+    }
+
+    async fn estimate_gas_inner(
+        &self,
+        from: Option<[u8; 20]>,
+        to: [u8; 20],
+        data: Vec<u8>,
+        value: U256,
+        chain_id: u64,
+    ) -> Result<GasOutcome, String> {
         let (ctx, executor) = self.evm_setup(chain_id, "estimateGas").await?;
-        let joined = tokio::task::spawn_blocking(move || {
+        let joined = super::request::blocking(move || {
             let sender = from.unwrap_or([0u8; 20]);
             executor.estimate_gas(sender, to, &data, value, &ctx)
         })
@@ -4007,20 +4053,19 @@ impl ElReader {
     /// is `Err`; an offchain (CCIP) name is the distinguishable
     /// [`EnsOutcome::Offchain`].
     pub async fn resolve_ens(&self, name: String, chain_id: u64) -> Result<EnsOutcome, String> {
+        self.request(self.resolve_ens_inner(name, chain_id)).await
+    }
+
+    async fn resolve_ens_inner(&self, name: String, chain_id: u64) -> Result<EnsOutcome, String> {
         let (ctx, executor) = self.evm_setup(chain_id, "resolve-ens").await?;
         let block_number = ctx.block_number;
-        let walk = tokio::task::spawn_blocking(move || {
+        let walk = super::request::blocking(move || {
             let caller = ExecutorCaller { executor: &executor, ctx: &ctx };
             myotis_evm::resolve_address(&caller, &name)
         });
-        // Overall deadline (the EnsApi contract promises a bounded worst case): the
-        // walk is a chain of per-request-bounded peer calls, but a many-label name
-        // against stalling peers could multiply far past that. On timeout the
-        // abandoned closure still runs out its in-flight peer call on the blocking
-        // thread (spawn_blocking can't be cancelled) — only the caller is released.
-        let joined = tokio::time::timeout(RESOLVE_ENS_DEADLINE, walk)
-            .await
-            .map_err(|_| "resolve-ens timed out".to_string())?
+        // The enclosing request scope cancels and drains this worker on deadline.
+        // Its oracle waits and interpreter steps observe the same operation.
+        let joined = walk.await
             .map_err(|e| format!("resolve-ens task join error: {e}"))?;
         match joined {
             Ok(Some(address)) => Ok(EnsOutcome::Resolved { address, block_number }),
@@ -4065,9 +4110,7 @@ impl ElReader {
                 }
             }
         };
-        tokio::time::timeout(RESOLVE_ENS_DEADLINE, ladder)
-            .await
-            .map_err(|_| "resolve-ens timed out".to_string())?
+        super::request::run(self.request_shutdown.subscribe(), RESOLVE_ENS_DEADLINE, ladder).await
     }
 
     /// One ERC-3668 CALLBACK re-entry (EL-C-5-3): the host drove the gateway;
@@ -4096,7 +4139,7 @@ impl ElReader {
                 self.evm_setup(chain_id, "resolve-ens").await?
             };
             let block_number = ctx.block_number;
-            let walk = tokio::task::spawn_blocking(move || {
+            let walk = super::request::blocking(move || {
                 let caller = ExecutorCaller { executor: &executor, ctx: &ctx };
                 let raw = myotis_evm::ccip_callback(
                     &caller,
@@ -4109,9 +4152,7 @@ impl ElReader {
                 let Some(raw) = raw else { return Ok(None) };
                 decode_ccip_answer(&caller, &query, &raw)
             });
-            let joined = tokio::time::timeout(RESOLVE_ENS_ATTEMPT_DEADLINE, walk)
-                .await
-                .map_err(|_| "resolve-ens attempt timed out".to_string())?
+            let joined = walk.await
                 .map_err(|e| format!("resolve-ens task join error: {e}"))?;
             match joined {
                 Ok(Some(value)) => {
@@ -4129,9 +4170,7 @@ impl ElReader {
                 Err(e) => Err(e.to_string()),
             }
         };
-        tokio::time::timeout(RESOLVE_ENS_DEADLINE, attempt)
-            .await
-            .map_err(|_| "resolve-ens timed out".to_string())?
+        super::request::run(self.request_shutdown.subscribe(), RESOLVE_ENS_ATTEMPT_DEADLINE, attempt).await
     }
 
     /// One resolution attempt against one root (finalized or optimistic).
@@ -4141,23 +4180,23 @@ impl ElReader {
         chain_id: u64,
         finalized: bool,
     ) -> Result<EnsQueryOutcome, String> {
+        super::request::run(self.request_shutdown.subscribe(), RESOLVE_ENS_ATTEMPT_DEADLINE,
+            self.ens_attempt_inner(query, chain_id, finalized)).await
+    }
+
+    async fn ens_attempt_inner(&self, query: EnsQuery, chain_id: u64, finalized: bool) -> Result<EnsQueryOutcome, String> {
         let (ctx, executor) = if finalized {
             self.evm_setup_finalized(chain_id, "resolve-ens").await?
         } else {
             self.evm_setup(chain_id, "resolve-ens").await?
         };
         let block_number = ctx.block_number;
-        let walk = tokio::task::spawn_blocking(move || {
+        let walk = super::request::blocking(move || {
             let caller = ExecutorCaller { executor: &executor, ctx: &ctx };
             run_ens_query(&caller, &query)
         });
-        // Per-attempt deadline (Java ENS_TIMEOUT_SEC twin): a stalled finalized
-        // walk must leave budget for AUTO's optimistic attempt under the outer
-        // cap. The timed-out spawn_blocking closure still runs out its in-flight
-        // peer call (can't be cancelled) — only the caller is released.
-        let joined = tokio::time::timeout(RESOLVE_ENS_ATTEMPT_DEADLINE, walk)
-            .await
-            .map_err(|_| "resolve-ens attempt timed out".to_string())?
+        // The attempt scope drains this worker before AUTO can start another root.
+        let joined = walk.await
             .map_err(|e| format!("resolve-ens task join error: {e}"))?;
         match joined {
             Ok(Some(value)) => Ok(EnsQueryOutcome::Value { value, block_number, verified: finalized }),
@@ -5380,7 +5419,11 @@ impl ElReader {
     }
 
     /// Stop discovery + the pool.
-    pub async fn stop(self) {
+    pub async fn stop(&self) {
+        self.cancel_requests();
+        let requests: Vec<_> = self.requests.lock().map(|requests| requests.iter().filter_map(std::sync::Weak::upgrade).collect()).unwrap_or_default();
+        for request in requests { request.settled().await; }
+        self.stop_log_index_appender().await;
         if let Ok(mut t) = self.log_index_task.lock() {
             if let Some(h) = t.take() {
                 h.abort();

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -3948,8 +3948,7 @@ impl ElReader {
             let sender = from.unwrap_or([0u8; 20]);
             executor.create_view(sender, &init_code, value, &ctx, overrides)
         })
-        .await
-        .map_err(|e| format!("eth_call task join error: {e}"))?;
+        .await?;
         Ok(match joined {
             Ok(bytes) => CallOutcome::Success(bytes),
             Err(EvmError::Reverted { data }) => CallOutcome::Revert(data),
@@ -3992,8 +3991,7 @@ impl ElReader {
             let sender = from.unwrap_or([0u8; 20]);
             executor.call_view_overridden(sender, to, &data, value, &ctx, overrides)
         })
-        .await
-        .map_err(|e| format!("eth_call task join error: {e}"))?;
+        .await?;
         Ok(match joined {
             Ok(bytes) => CallOutcome::Success(bytes),
             Err(EvmError::Reverted { data }) => CallOutcome::Revert(data),
@@ -4031,8 +4029,7 @@ impl ElReader {
             let sender = from.unwrap_or([0u8; 20]);
             executor.estimate_gas(sender, to, &data, value, &ctx)
         })
-        .await
-        .map_err(|e| format!("estimateGas task join error: {e}"))?;
+        .await?;
         Ok(match joined {
             Ok(gas) => GasOutcome::Estimate(gas),
             // The typed error survives to here — don't stringify the revert
@@ -4062,8 +4059,7 @@ impl ElReader {
         });
         // The enclosing request scope cancels and drains this worker on deadline.
         // Its oracle waits and interpreter steps observe the same operation.
-        let joined = walk.await
-            .map_err(|e| format!("resolve-ens task join error: {e}"))?;
+        let joined = walk.await?;
         match joined {
             Ok(Some(address)) => Ok(EnsOutcome::Resolved { address, block_number }),
             Ok(None) => Ok(EnsOutcome::NoRecord { block_number }),
@@ -4153,8 +4149,7 @@ impl ElReader {
                 let Some(raw) = raw else { return Ok(None) };
                 decode_ccip_answer(&caller, &query, &raw)
             });
-            let joined = walk.await
-                .map_err(|e| format!("resolve-ens task join error: {e}"))?;
+            let joined = walk.await?;
             match joined {
                 Ok(Some(value)) => {
                     Ok(EnsQueryOutcome::Value { value, block_number, verified: finalized })
@@ -4197,8 +4192,7 @@ impl ElReader {
             run_ens_query(&caller, &query)
         });
         // The attempt scope drains this worker before AUTO can start another root.
-        let joined = walk.await
-            .map_err(|e| format!("resolve-ens task join error: {e}"))?;
+        let joined = walk.await?;
         match joined {
             Ok(Some(value)) => Ok(EnsQueryOutcome::Value { value, block_number, verified: finalized }),
             Ok(None) => Ok(EnsQueryOutcome::NoRecord { block_number, verified: finalized }),

--- a/rust/myotis-net/src/el/reader.rs
+++ b/rust/myotis-net/src/el/reader.rs
@@ -923,23 +923,21 @@ struct TxScanMap {
 /// cache at the same count; eviction is LRU.
 const EVM_PROOF_CACHE_ENTRIES: usize = 65_536;
 
-/// Overall deadline for one ENS resolution walk (mirrors the Java
-/// `JavaEnsApi.RESOLVE_TIMEOUT_SEC` order of magnitude — the EnsApi contract
-/// promises a bounded worst case of ~2 min).
-const RESOLVE_ENS_DEADLINE: std::time::Duration = std::time::Duration::from_secs(120);
-
-/// Per-ATTEMPT deadline inside the ENS root ladder (the Java
-/// `VerifiedRpcBackend.ENS_TIMEOUT_SEC` twin): AUTO runs up to two attempts
-/// (finalized, then optimistic), each bounded here, with
-/// [`RESOLVE_ENS_DEADLINE`] as the outer cap on the whole query — so a stalled
-/// finalized attempt can't consume the optimistic attempt's budget, and the
-/// JNI caller's total block time stays within the API's ~2 min contract.
+/// ENS whole-query budget is 90 s (REQUEST_BUDGET), including setup and AUTO.
+/// Each root attempt gets at most 60 s and is clamped to the remaining query
+/// budget: a full finalized attempt leaves about 30 s for the optimistic root.
+/// Cancellation drains native work; indivisible segments may overrun.
 const RESOLVE_ENS_ATTEMPT_DEADLINE: std::time::Duration = std::time::Duration::from_secs(60);
 
 impl ElReader {
     /// Budget a host operation, including its network and blocking EVM work.
     pub async fn request<T>(&self, future: impl std::future::Future<Output = Result<T, String>>) -> Result<T, String> {
-        super::request::run_registered(&self.requests, self.request_shutdown.subscribe(), future).await
+        self.request_with_budget(super::request::REQUEST_BUDGET, future).await
+    }
+
+    async fn request_with_budget<T>(&self, budget: std::time::Duration,
+        future: impl std::future::Future<Output = Result<T, String>>) -> Result<T, String> {
+        super::request::run_registered(&self.requests, self.request_shutdown.subscribe(), budget, future).await
     }
 
     /// Signal active readers before waiting for any other shutdown work.
@@ -1669,12 +1667,11 @@ impl ElReader {
         let chain_id = self.eth_cfg.network_id;
         // Tightly bounded (see the throttle note above): this shares the
         // appender loop, and a stalled resolution must not starve appends.
-        let out = tokio::time::timeout(
+        let out = self.resolve_ens_query_with_budget(
+            EnsQuery::Reverse { address }, chain_id, EnsRootMode::Auto,
             std::time::Duration::from_secs(8),
-            self.resolve_ens_query(EnsQuery::Reverse { address }, chain_id, EnsRootMode::Auto),
-        )
-        .await;
-        if let Ok(Ok(EnsQueryOutcome::Value { value: EnsRecordValue::Name(name), .. })) = out {
+        ).await;
+        if let Ok(EnsQueryOutcome::Value { value: EnsRecordValue::Name(name), .. }) = out {
             if let Ok(mut slot) = self.log_index.lock() {
                 if let Some(ix) = slot.as_mut() {
                     if ix.set_name(&address, &name) {
@@ -4088,9 +4085,13 @@ impl ElReader {
         chain_id: u64,
         root: EnsRootMode,
     ) -> Result<EnsQueryOutcome, String> {
-        // ONE outer deadline over the whole query — including context setups and
-        // both AUTO attempts — so the (synchronously blocking) JNI caller's worst
-        // case stays within the API's ~2 min contract regardless of root mode.
+        self.resolve_ens_query_with_budget(query, chain_id, root, super::request::REQUEST_BUDGET).await
+    }
+
+    async fn resolve_ens_query_with_budget(&self, query: EnsQuery, chain_id: u64,
+        root: EnsRootMode, budget: std::time::Duration) -> Result<EnsQueryOutcome, String> {
+        // One registered whole-query scope; AUTO's second attempt gets only
+        // the remainder after the finalized attempt has cancelled and drained.
         let ladder = async {
             match root {
                 EnsRootMode::Finalized => self.ens_attempt(query, chain_id, true).await,
@@ -4110,7 +4111,7 @@ impl ElReader {
                 }
             }
         };
-        self.request(super::request::run(self.request_shutdown.subscribe(), RESOLVE_ENS_DEADLINE, ladder)).await
+        self.request_with_budget(budget, ladder).await
     }
 
     /// One ERC-3668 CALLBACK re-entry (EL-C-5-3): the host drove the gateway;
@@ -4170,7 +4171,7 @@ impl ElReader {
                 Err(e) => Err(e.to_string()),
             }
         };
-        self.request(super::request::run(self.request_shutdown.subscribe(), RESOLVE_ENS_ATTEMPT_DEADLINE, attempt)).await
+        self.request_with_budget(RESOLVE_ENS_ATTEMPT_DEADLINE, attempt).await
     }
 
     /// One resolution attempt against one root (finalized or optimistic).
@@ -5421,9 +5422,10 @@ impl ElReader {
     /// Stop discovery + the pool.
     pub async fn stop(&self) {
         self.cancel_requests();
+        // Stop producers before collecting/draining registered work.
+        self.stop_log_index_appender().await;
         let requests: Vec<_> = self.requests.lock().map(|requests| requests.iter().filter_map(std::sync::Weak::upgrade).collect()).unwrap_or_default();
         for request in requests { request.settled().await; }
-        self.stop_log_index_appender().await;
         if let Ok(mut t) = self.log_index_task.lock() {
             if let Some(h) = t.take() {
                 h.abort();

--- a/rust/myotis-net/src/el/request.rs
+++ b/rust/myotis-net/src/el/request.rs
@@ -106,7 +106,9 @@ impl Operation {
             tokio::select! {
                 biased;
                 _ = tokio::time::sleep(Duration::from_millis(10)) => self.check()?,
-                value = &mut future => { self.check()?; return Ok(value); }
+                // Ready is a committed result, including side effects. A late
+                // cancellation must not replace it with a false failure.
+                value = &mut future => return Ok(value),
             }
         }
     }
@@ -254,6 +256,50 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn ready_result_survives_cancellation_during_commit() {
+        let (shutdown, receiver) = watch::channel(false);
+        let committed = AtomicBool::new(false);
+        let result = run(receiver, REQUEST_BUDGET, async {
+            committed.store(true, Ordering::Release);
+            shutdown.send_replace(true);
+            Ok("committed transaction hash")
+        })
+        .await;
+        assert!(committed.load(Ordering::Acquire));
+        assert_eq!(result.unwrap(), "committed transaction hash");
+    }
+
+    #[tokio::test]
+    async fn ready_error_is_not_replaced_by_late_cancellation() {
+        let (shutdown, receiver) = watch::channel(false);
+        let result: Result<(), String> = run(receiver, REQUEST_BUDGET, async {
+            shutdown.send_replace(true);
+            Err("verified execution reverted".into())
+        })
+        .await;
+        assert_eq!(result.unwrap_err(), "verified execution reverted");
+    }
+
+    #[tokio::test]
+    async fn cancelled_submission_never_polls_work() {
+        let touched = AtomicBool::new(false);
+        let op = submitted(
+            Submission {
+                deadline: Instant::now() + REQUEST_BUDGET,
+                cancelled: Arc::new(AtomicBool::new(true)),
+            },
+            || Operation::new(watch::channel(false).1, REQUEST_BUDGET),
+        );
+        let result = run_operation(op, async {
+            touched.store(true, Ordering::Relaxed);
+            Ok(())
+        })
+        .await;
+        assert_eq!(result.unwrap_err(), "request cancelled");
+        assert!(!touched.load(Ordering::Relaxed));
+    }
+
+    #[tokio::test]
     async fn shutdown_with_live_receiver_refuses_new_work() {
         let (shutdown, receiver) = watch::channel(false);
         shutdown.send_replace(true);
@@ -302,8 +348,7 @@ mod tests {
             let current = Operation::current().unwrap();
             let child = Operation::new(shutdown.subscribe(), REQUEST_BUDGET);
             current.cancel();
-            assert!(child.check().is_err());
-            Ok(42)
+            child.check().map(|()| 42)
         })
         .await;
         assert_eq!(result.unwrap_err(), "request cancelled");

--- a/rust/myotis-net/src/el/request.rs
+++ b/rust/myotis-net/src/el/request.rs
@@ -1,0 +1,301 @@
+//! Cooperative request lifetime, shared by async reads and synchronous EVM work.
+//!
+//! A timeout cancels the operation and then drains its started blocking jobs.
+//! Permits belong to jobs, never to the caller's patience. Indivisible native
+//! work (proof verification, precompiles, filesystem calls) is not preempted.
+use std::future::Future;
+use std::sync::{
+    atomic::{AtomicBool, AtomicUsize, Ordering},
+    Arc, Mutex, Weak,
+};
+use std::time::{Duration, Instant};
+use tokio::sync::{watch, Notify, Semaphore};
+
+pub const REQUEST_BUDGET: Duration = Duration::from_secs(90);
+static BLOCKING_SLOTS: Semaphore = Semaphore::const_new(8);
+
+/// Submission metadata supplied by the native scheduler before entering the C ABI.
+#[derive(Clone)]
+pub struct Submission {
+    pub deadline: Instant,
+    pub cancelled: Arc<AtomicBool>,
+}
+thread_local! { static SUBMISSION: std::cell::RefCell<Option<Submission>> = const { std::cell::RefCell::new(None) }; }
+
+pub fn submitted<T>(submission: Submission, f: impl FnOnce() -> T) -> T {
+    struct Restore(Option<Submission>);
+    impl Drop for Restore {
+        fn drop(&mut self) {
+            SUBMISSION.with(|s| {
+                s.replace(self.0.take());
+            });
+        }
+    }
+    let _restore = Restore(SUBMISSION.with(|s| s.replace(Some(submission))));
+    f()
+}
+
+tokio::task_local! { static CURRENT: Arc<Operation>; }
+
+pub struct Operation {
+    deadline: Instant,
+    submission: Option<Submission>,
+    cancelled: watch::Sender<bool>,
+    shutdown: watch::Receiver<bool>,
+    parent: Option<Arc<Operation>>,
+    active: AtomicBool,
+    workers: AtomicUsize,
+    drained: Notify,
+}
+
+impl Operation {
+    fn new(shutdown: watch::Receiver<bool>, budget: Duration) -> Arc<Self> {
+        let parent = CURRENT.try_with(Arc::clone).ok();
+        let submission = SUBMISSION.with(|s| s.borrow().clone());
+        let deadline = Instant::now() + budget;
+        let deadline = submission
+            .as_ref()
+            .map_or(deadline, |s| deadline.min(s.deadline));
+        Arc::new(Self {
+            deadline: parent
+                .as_ref()
+                .map_or(deadline, |p| deadline.min(p.deadline)),
+            submission,
+            cancelled: watch::channel(false).0,
+            shutdown,
+            parent,
+            active: AtomicBool::new(true),
+            workers: AtomicUsize::new(0),
+            drained: Notify::new(),
+        })
+    }
+
+    pub fn current() -> Option<Arc<Self>> {
+        CURRENT.try_with(Arc::clone).ok()
+    }
+
+    pub fn check(&self) -> Result<(), String> {
+        if self
+            .submission
+            .as_ref()
+            .is_some_and(|s| s.cancelled.load(Ordering::Acquire))
+        {
+            return Err("request cancelled".into());
+        }
+        if *self.shutdown.borrow() || *self.cancelled.borrow() {
+            return Err("request cancelled".into());
+        }
+        if Instant::now() >= self.deadline {
+            return Err("request deadline exceeded".into());
+        }
+        if let Some(parent) = &self.parent {
+            parent.check()?;
+        }
+        Ok(())
+    }
+
+    fn cancel(&self) {
+        self.cancelled.send_replace(true);
+    }
+
+    /// Also wraps writer-lock/send waits, not just peer response timeouts.
+    pub async fn wait<T>(&self, future: impl Future<Output = T>) -> Result<T, String> {
+        self.check()?;
+        tokio::pin!(future);
+        loop {
+            tokio::select! {
+                biased;
+                _ = tokio::time::sleep(Duration::from_millis(10)) => self.check()?,
+                value = &mut future => { self.check()?; return Ok(value); }
+            }
+        }
+    }
+
+    pub async fn settled(&self) {
+        loop {
+            let notified = self.drained.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+            if !self.active.load(Ordering::Acquire) && self.workers.load(Ordering::Acquire) == 0 {
+                return;
+            }
+            notified.await;
+        }
+    }
+
+    async fn drain(&self) {
+        loop {
+            let notified = self.drained.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+            if self.workers.load(Ordering::Acquire) == 0 {
+                return;
+            }
+            notified.await;
+        }
+    }
+}
+
+struct CancelOnDrop(Arc<Operation>);
+impl Drop for CancelOnDrop {
+    fn drop(&mut self) {
+        self.0.cancel();
+        self.0.active.store(false, Ordering::Release);
+        self.0.drained.notify_waiters();
+    }
+}
+
+struct Worker(Arc<Operation>);
+impl Worker {
+    fn new(op: Arc<Operation>) -> Self {
+        let mut current = Some(&op);
+        while let Some(o) = current {
+            o.workers.fetch_add(1, Ordering::AcqRel);
+            current = o.parent.as_ref();
+        }
+        Self(op)
+    }
+}
+impl Drop for Worker {
+    fn drop(&mut self) {
+        let mut current = Some(&self.0);
+        while let Some(o) = current {
+            if o.workers.fetch_sub(1, Ordering::AcqRel) == 1 {
+                o.drained.notify_waiters();
+            }
+            current = o.parent.as_ref();
+        }
+    }
+}
+
+pub async fn run<T>(
+    shutdown: watch::Receiver<bool>,
+    budget: Duration,
+    future: impl Future<Output = Result<T, String>>,
+) -> Result<T, String> {
+    run_operation(Operation::new(shutdown, budget), future).await
+}
+
+pub async fn run_registered<T>(
+    registry: &Mutex<Vec<Weak<Operation>>>,
+    shutdown: watch::Receiver<bool>,
+    future: impl Future<Output = Result<T, String>>,
+) -> Result<T, String> {
+    let op = Operation::new(shutdown, REQUEST_BUDGET);
+    {
+        let mut registry = registry
+            .lock()
+            .map_err(|_| "request registry unavailable".to_string())?;
+        op.check()?;
+        registry.retain(|o| o.strong_count() > 0);
+        registry.push(Arc::downgrade(&op));
+    }
+    run_operation(op, future).await
+}
+
+async fn run_operation<T>(
+    op: Arc<Operation>,
+    future: impl Future<Output = Result<T, String>>,
+) -> Result<T, String> {
+    let guard = CancelOnDrop(Arc::clone(&op));
+    let result = CURRENT
+        .scope(Arc::clone(&op), op.wait(future))
+        .await
+        .and_then(|r| r);
+    drop(guard);
+    op.drain().await;
+    result
+}
+
+/// No unbounded Tokio blocking queue. A started job owns both its permit and
+/// its accounting guard until the closure returns, even if its future is dropped.
+pub async fn blocking<T: Send + 'static>(
+    f: impl FnOnce() -> T + Send + 'static,
+) -> Result<T, String> {
+    let permit = BLOCKING_SLOTS
+        .try_acquire()
+        .map_err(|_| "native execution busy".to_string())?;
+    let op = Operation::current();
+    if let Some(o) = &op {
+        o.check()?;
+    }
+    let worker = op.map(Worker::new);
+    tokio::task::spawn_blocking(move || {
+        let _permit = permit;
+        let _worker = worker;
+        f()
+    })
+    .await
+    .map_err(|e| format!("native task join error: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn expired_submission_never_polls_work() {
+        let touched = AtomicBool::new(false);
+        let submission = Submission {
+            deadline: Instant::now(),
+            cancelled: Arc::new(AtomicBool::new(false)),
+        };
+        let op = submitted(submission, || {
+            Operation::new(watch::channel(false).1, REQUEST_BUDGET)
+        });
+        let result = run_operation(op, async {
+            touched.store(true, Ordering::Relaxed);
+            Ok(())
+        })
+        .await;
+        assert_eq!(result.unwrap_err(), "request deadline exceeded");
+        assert!(!touched.load(Ordering::Relaxed));
+    }
+
+    #[tokio::test]
+    async fn shutdown_with_live_receiver_refuses_new_work() {
+        let (shutdown, receiver) = watch::channel(false);
+        shutdown.send_replace(true);
+        let result = run(receiver, REQUEST_BUDGET, async { Ok(42) }).await;
+        assert_eq!(result.unwrap_err(), "request cancelled");
+    }
+
+    #[tokio::test]
+    async fn child_worker_is_counted_against_parent_until_actual_drop() {
+        let parent = Operation::new(watch::channel(false).1, REQUEST_BUDGET);
+        let child = CURRENT
+            .scope(Arc::clone(&parent), async {
+                Operation::new(watch::channel(false).1, Duration::from_secs(180))
+            })
+            .await;
+        assert!(child.deadline <= parent.deadline);
+        let worker = Worker::new(Arc::clone(&child));
+        assert_eq!(parent.workers.load(Ordering::Acquire), 1);
+        assert_eq!(child.workers.load(Ordering::Acquire), 1);
+        child.cancel();
+        assert_eq!(parent.workers.load(Ordering::Acquire), 1);
+        assert!(parent.check().is_ok()); // an ENS attempt does not cancel AUTO
+        drop(worker);
+        assert_eq!(parent.workers.load(Ordering::Acquire), 0);
+        assert_eq!(child.workers.load(Ordering::Acquire), 0);
+    }
+
+    #[tokio::test]
+    async fn parent_cancellation_reaches_child_and_registered_scope_settles() {
+        let registry = Mutex::new(Vec::new());
+        let (shutdown, receiver) = watch::channel(false);
+        let result = run_registered(&registry, receiver, async {
+            let current = Operation::current().unwrap();
+            let child = Operation::new(shutdown.subscribe(), REQUEST_BUDGET);
+            current.cancel();
+            assert!(child.check().is_err());
+            Ok(42)
+        })
+        .await;
+        assert_eq!(result.unwrap_err(), "request cancelled");
+        for operation in registry.lock().unwrap().iter().filter_map(Weak::upgrade) {
+            assert!(!operation.active.load(Ordering::Acquire));
+            assert_eq!(operation.workers.load(Ordering::Acquire), 0);
+        }
+    }
+}

--- a/rust/myotis-net/src/el/request.rs
+++ b/rust/myotis-net/src/el/request.rs
@@ -179,9 +179,10 @@ pub async fn run<T>(
 pub async fn run_registered<T>(
     registry: &Mutex<Vec<Weak<Operation>>>,
     shutdown: watch::Receiver<bool>,
+    budget: Duration,
     future: impl Future<Output = Result<T, String>>,
 ) -> Result<T, String> {
-    let op = Operation::new(shutdown, REQUEST_BUDGET);
+    let op = Operation::new(shutdown, budget);
     {
         let mut registry = registry
             .lock()
@@ -261,6 +262,19 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn registered_custom_budget_refuses_expired_setup() {
+        let registry = Mutex::new(Vec::new());
+        let touched = AtomicBool::new(false);
+        let result = run_registered(&registry, watch::channel(false).1, Duration::ZERO, async {
+            touched.store(true, Ordering::Relaxed);
+            Ok(())
+        })
+        .await;
+        assert_eq!(result.unwrap_err(), "request deadline exceeded");
+        assert!(!touched.load(Ordering::Relaxed));
+    }
+
+    #[tokio::test]
     async fn child_worker_is_counted_against_parent_until_actual_drop() {
         let parent = Operation::new(watch::channel(false).1, REQUEST_BUDGET);
         let child = CURRENT
@@ -284,7 +298,7 @@ mod tests {
     async fn parent_cancellation_reaches_child_and_registered_scope_settles() {
         let registry = Mutex::new(Vec::new());
         let (shutdown, receiver) = watch::channel(false);
-        let result = run_registered(&registry, receiver, async {
+        let result = run_registered(&registry, receiver, REQUEST_BUDGET, async {
             let current = Operation::current().unwrap();
             let child = Operation::new(shutdown.subscribe(), REQUEST_BUDGET);
             current.cancel();

--- a/rust/myotis-net/src/el/tasks.rs
+++ b/rust/myotis-net/src/el/tasks.rs
@@ -1,0 +1,40 @@
+//! Ownership for the peer pool's parent loops and their spawned network jobs.
+use std::future::Future;
+use std::sync::Mutex;
+use tokio::task::JoinHandle;
+
+#[derive(Default)]
+pub(super) struct Tasks(Mutex<(bool, Vec<JoinHandle<()>>)>);
+impl Tasks {
+    pub fn spawn(&self, future: impl Future<Output = ()> + Send + 'static) {
+        let mut tasks = self.0.lock().unwrap_or_else(|e| e.into_inner());
+        if tasks.0 {
+            return;
+        }
+        tasks.1.retain(|task| !task.is_finished());
+        tasks.1.push(tokio::spawn(future));
+    }
+
+    fn take(&self) -> Vec<JoinHandle<()>> {
+        let mut tasks = self.0.lock().unwrap_or_else(|e| e.into_inner());
+        tasks.0 = true;
+        for task in &tasks.1 {
+            task.abort();
+        }
+        std::mem::take(&mut tasks.1)
+    }
+
+    pub async fn stop(&self) {
+        for task in self.take() {
+            let _ = task.await;
+        }
+    }
+    pub fn abort(&self) {
+        drop(self.take());
+    }
+}
+impl Drop for Tasks {
+    fn drop(&mut self) {
+        self.abort();
+    }
+}

--- a/rust/myotis-node/README.md
+++ b/rust/myotis-node/README.md
@@ -160,3 +160,19 @@ reports the loss. JS-side allocation and pending-exception errors never use
 `napi_fatal_error`. A proven live worker-side TSFN enqueue invariant
 failure is process-fatal (including in standalone Node); ordinary engine errors
 and environment closing do not use that path.
+
+Queued stop/pause cancellations are removed immediately under the queue lock
+and delivered through the TSFN; they do not wait for workers occupied by other
+chains, and they never release the slot of an actually executing sibling.
+Stop/pause wait only for the target handle's active native job. Poisoning also
+cancels queued jobs directly. An impossible owner-thread TSFN enqueue failure
+retains the completion for one JS-thread settlement after native lifecycle
+returns; ordinary lifecycle cancellation does not run synchronous Promise hooks.
+
+Initialization/read calls from a Node `async_hooks` init hook during scheduler
+creation are unsupported and throw. An uncaught exception inside that hook can
+terminate Node; the initialization guard prevents a second scheduler from
+replacing the first owner's state. Ownership-gated status/lifecycle calls in
+that window return their unavailable sentinels. Synchronous `create`, `pause`
+and `stop` may also throw scheduler/Node-API infrastructure errors; engine-level
+read failures still use JSON error results.

--- a/rust/myotis-node/README.md
+++ b/rust/myotis-node/README.md
@@ -176,3 +176,10 @@ replacing the first owner's state. Ownership-gated status/lifecycle calls in
 that window return their unavailable sentinels. Synchronous `create`, `pause`
 and `stop` may also throw scheduler/Node-API infrastructure errors; engine-level
 read failures still use JSON error results.
+
+ENS queries use one registered 90-second whole-query scope. A finalized root
+attempt may use up to 60 seconds; AUTO's optimistic attempt receives only the
+remaining budget (about 30 seconds after a full first attempt). CCIP callbacks
+use a 60-second operation scope, and appender name lookups use an 8-second scope.
+All retain the indivisible-work overrun limitation. Stop first aborts/joins the
+appender, then drains its retained actual execution along with other requests.

--- a/rust/myotis-node/README.md
+++ b/rust/myotis-node/README.md
@@ -183,3 +183,27 @@ remaining budget (about 30 seconds after a full first attempt). CCIP callbacks
 use a 60-second operation scope, and appender name lookups use an 8-second scope.
 All retain the indivisible-work overrun limitation. Stop first aborts/joins the
 appender, then drains its retained actual execution along with other requests.
+
+Once a wrapped operation returns a ready success or error, cancellation does
+not replace that committed result. Cancellation or connection loss after a
+partial transaction broadcast but before the operation returns still has an
+uncertain outcome; there is no exactly-once broadcast guarantee. Outer
+fee-history cancellation/expiry follows the existing stale-cache policy: only
+the same request signature within the cache age limit may be served, and an
+explicit invalid-request rejection never uses stale data.
+
+The global EVM cap deliberately refuses an additional execution immediately
+with `native execution busy`, including C/JNI/UniFFI callers and appender ENS
+lookups. It does not add semaphore waiters. Hosts should bound their own queue
+and retry busy verified reads within their own request deadline. Node's one
+executing request per handle is intentional: a slow ENS call delays queued
+calls on the same chain, while another chain can execute concurrently. The
+ABI 25 migration must account for the four queued/executing requests per
+handle and treat `native scheduler busy` as admission refusal.
+
+A cancelled partial RLPx frame cannot be resumed safely. The torn-write marker
+prevents further writes on that stream; the next attempted send fails the peer,
+and lifecycle cleanup closes it. Under write backpressure this can require
+re-dialing an otherwise healthy peer. Cancellation does not grant an unbounded
+write grace or delay stop to preserve the connection. Cancellation-check
+frequency and polling performance remain unmeasured optimization follow-ups.

--- a/rust/myotis-node/README.md
+++ b/rust/myotis-node/README.md
@@ -29,11 +29,11 @@ myotis.init();   // ABI handshake — returns the engine ABI version; gate on
 const h = myotis.create('mainnet', '/path/to/data-dir');  // dir is created if missing
 myotis.start(h);
 
-// Lifecycle + status are cheap and synchronous:
+// Lifecycle and status are synchronous (stop/pause can wait for native work):
 JSON.parse(myotis.statusJson(h));   // { beaconState, peerCount, snapPeers, ... }
 
-// Verified reads BLOCK up to ~90 s in the engine — the binding runs them on
-// the libuv thread pool, so they surface as ordinary Promises:
+// Verified reads run on bounded Myotis workers, with a 90 s operation budget
+// including queue wait. Cancellation drains native work before completion:
 const acct = JSON.parse(await myotis.requestAccountJson(h, '0xd8dA…6045'));
 const ens = JSON.parse(await myotis.resolveEnsJson(h, 'vitalik.eth'));
 const ch = JSON.parse(await myotis.ensRecordJson(h, JSON.stringify({
@@ -99,3 +99,64 @@ unit-tested in `smoke-gate.test.mjs` (`node --test smoke-gate.test.mjs`).
   host's job (not yet wrapped here).
 - The addon is loadable from Electron main/utility processes as-is (N-API is
   ABI-stable across Node and Electron).
+
+## Request ownership and cancellation
+
+This implementation preserves the current engine's **ABI 25** and existing JS
+argument/result shapes. It is not a drop-in artifact for a host pinned to ABI 22.
+Engine failures, admission refusal, cancellation, and deadline expiry remain
+in-band JSON errors. Node-API infrastructure failures may throw/reject.
+
+Each Node environment owns two native workers, with a process-wide ceiling of
+eight workers. Admission is capped at 32 requests including completions awaiting
+JS delivery, with at most four queued/executing requests per handle and one
+executing request per handle. Two chains can execute concurrently. Saturation
+fails immediately with `{"error":"native scheduler busy"}`; there is no unbounded
+thread creation or libuv work item. A fifth concurrent environment fails to initialize at the process worker cap.
+Handles belong to the environment that created them and cannot be transferred to another Node worker environment.
+
+A 90-second budget starts at submission, before scheduler setup and queue wait.
+Expired or cancelled queued jobs never call the engine. The same deadline and
+cancellation bit cross the C seam into async reader setup/network waits, EVM
+oracle waits (including writer locks and sends), and EVM instruction checks.
+ENS attempts use a shorter child budget and drain before AUTO changes roots.
+Proof validation and cache trust rules are unchanged. An indivisible proof,
+precompile, filesystem call, or OS operation can overrun the cooperative budget.
+
+`stop` and `pause` remain **synchronous**. They cancel and drain native jobs before
+teardown or a new reader generation; Promise delivery follows when JS can run.
+The shared engine signals readers even while other `Arc`s own them and drains
+registered read/execution work. Started EVM closures retain their global permits
+(maximum eight) and accounting until they actually return. Pool shutdown joins
+owned parent loops and spawned dial/backfill/send work before closing peers.
+Pause/resume/start/stop on a handle must be serialized by C/JNI/UniFFI callers.
+
+Environment cleanup closes admission and the completion producer, cancels queued
+and active work, joins native workers without waiting for JS callbacks, and stops
+owned handles. It never drops the shared Tokio runtime. The completion TSFN is
+referenced while requests await delivery and unreferenced when idle. Cleanup
+cannot preempt indivisible work: **this is not a hard-stop or crash-isolation
+contract**. Hosts needing a hard shutdown deadline still need a supervised
+process boundary. Cancelled/timed-out transaction gossip does not prove that a
+transaction was not broadcast; do not blindly retry a signed submission.
+
+Qualification of Node/Electron cleanup, forced environment teardown, parent DNS
+liveness, queue cancellation, cross-chain fairness, and native overruns belongs
+on disposable hosts. Exact-lock Node build/runtime qualification is required
+before releasing a new artifact; a type-check with cached dependency patch
+versions does not qualify that artifact.
+
+The completion bridge makes exactly one resolve/reject attempt per deferred.
+A result-string allocation failure selects rejection before settlement. If
+Node's settlement itself fails, deferred ownership is consumed/unknown: the
+addon releases its admission/keepalive accounting, marks the scheduler poisoned,
+cancels remaining native work, and reports an uncaught exception plus a stderr
+diagnostic, without retrying that pointer. New reads resolve with
+`{"error":"native scheduler poisoned"}`; lifecycle cleanup remains available. A host
+`uncaughtException` handler can suppress termination, so this is not a guarantee
+that the failed Promise settles. If even the preallocated error reference cannot be obtained, no settlement is
+attempted: the scheduler is poisoned and the pending exception or stderr
+reports the loss. JS-side allocation and pending-exception errors never use
+`napi_fatal_error`. A proven live worker-side TSFN enqueue invariant
+failure is process-fatal (including in standalone Node); ordinary engine errors
+and environment closing do not use that path.

--- a/rust/myotis-node/src/admission.rs
+++ b/rust/myotis-node/src/admission.rs
@@ -1,0 +1,95 @@
+//! Pure queue ownership. Cancelling queued work never releases an active slot.
+use std::collections::{HashSet, VecDeque};
+
+pub(crate) trait HasHandle {
+    fn handle(&self) -> i64;
+}
+
+pub(crate) struct Admission<T> {
+    queued: VecDeque<T>,
+    active: HashSet<i64>,
+}
+
+impl<T: HasHandle> Admission<T> {
+    pub fn new() -> Self {
+        Self {
+            queued: VecDeque::new(),
+            active: HashSet::new(),
+        }
+    }
+    pub fn push(&mut self, job: T) {
+        self.queued.push_back(job);
+    }
+    pub fn take_ready(&mut self) -> Option<T> {
+        let index = self
+            .queued
+            .iter()
+            .position(|job| !self.active.contains(&job.handle()))?;
+        let job = self.queued.remove(index)?;
+        self.active.insert(job.handle());
+        Some(job)
+    }
+    pub fn finish(&mut self, handle: i64) {
+        self.active.remove(&handle);
+    }
+    pub fn is_active(&self, handle: i64) -> bool {
+        self.active.contains(&handle)
+    }
+    pub fn cancel_queued(&mut self, handle: Option<i64>) -> Vec<T> {
+        let mut cancelled = Vec::new();
+        let mut index = 0;
+        while index < self.queued.len() {
+            if handle.is_none_or(|h| self.queued[index].handle() == h) {
+                if let Some(job) = self.queued.remove(index) {
+                    cancelled.push(job);
+                }
+            } else {
+                index += 1;
+            }
+        }
+        cancelled
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[derive(Debug, PartialEq)]
+    struct Job(i64, u32);
+    impl HasHandle for Job {
+        fn handle(&self) -> i64 {
+            self.0
+        }
+    }
+
+    #[test]
+    fn queued_target_cancels_with_both_workers_owned_by_other_chains() {
+        let mut queue = Admission::new();
+        queue.push(Job(1, 1));
+        queue.push(Job(2, 2));
+        assert_eq!(queue.take_ready(), Some(Job(1, 1)));
+        assert_eq!(queue.take_ready(), Some(Job(2, 2)));
+        queue.push(Job(3, 3));
+        queue.push(Job(3, 4));
+        // No worker completion is needed to return ownership of target jobs.
+        assert_eq!(queue.cancel_queued(Some(3)), vec![Job(3, 3), Job(3, 4)]);
+        assert!(!queue.is_active(3));
+        assert!(queue.is_active(1));
+        assert!(queue.is_active(2));
+        assert!(queue.take_ready().is_none());
+    }
+
+    #[test]
+    fn cancelling_queued_sibling_does_not_release_actual_active_owner() {
+        let mut queue = Admission::new();
+        queue.push(Job(1, 1));
+        assert_eq!(queue.take_ready(), Some(Job(1, 1)));
+        queue.push(Job(1, 2));
+        assert_eq!(queue.cancel_queued(Some(1)), vec![Job(1, 2)]);
+        assert!(queue.is_active(1));
+        queue.push(Job(1, 3));
+        assert!(queue.take_ready().is_none());
+        queue.finish(1);
+        assert_eq!(queue.take_ready(), Some(Job(1, 3)));
+    }
+}

--- a/rust/myotis-node/src/lib.rs
+++ b/rust/myotis-node/src/lib.rs
@@ -25,6 +25,7 @@ use std::ffi::{c_char, CStr, CString};
 
 use napi::bindgen_prelude::Object;
 mod scheduler;
+mod admission;
 use napi::{Env, Result};
 use napi_derive::napi;
 
@@ -138,8 +139,10 @@ pub fn status_json(env: &Env, handle: i64) -> String {
 /// Idle-sleep: Running→Paused (tear down networking, keep warm state).
 #[napi]
 pub fn pause(env: &Env, handle: i64) -> Result<bool> {
-    if !scheduler::cancel_handle(env, handle, false)? { return Ok(false); }
-    Ok(unsafe { myotis_pause(handle) })
+    let cancellation = scheduler::cancel_handle(env, handle, false)?;
+    let result = cancellation.owned && unsafe { myotis_pause(handle) };
+    cancellation.finish(env);
+    Ok(result)
 }
 
 /// Paused→Running warm restart. False = rebuild failed (still PAUSED, retry).
@@ -153,7 +156,9 @@ pub fn resume(env: &Env, handle: i64) -> bool {
 /// Promise callbacks deliver once JS regains control. Unknown id is a no-op.
 #[napi]
 pub fn stop(env: &Env, handle: i64) -> Result<()> {
-    if scheduler::cancel_handle(env, handle, true)? { unsafe { myotis_stop(handle) }; }
+    let cancellation = scheduler::cancel_handle(env, handle, true)?;
+    if cancellation.owned { unsafe { myotis_stop(handle) }; }
+    cancellation.finish(env);
     Ok(())
 }
 

--- a/rust/myotis-node/src/lib.rs
+++ b/rust/myotis-node/src/lib.rs
@@ -11,12 +11,10 @@
 //!   imports of its `no_mangle` symbols, so the functions are called by Rust
 //!   path instead (see the note on the module in myotis-engine's lib.rs).
 //! - Compound values cross as JSON strings; parsing is the JS side's job.
-//! - The verified reads BLOCK (up to ~90 s). Every one of them is exposed as an
-//!   `AsyncTask` — napi-rs runs `compute()` on the libuv thread pool, so the
-//!   host's event loop (Electron main/utility process) never blocks and JS sees
-//!   an ordinary `Promise<string>`.
-//! - Lifecycle calls (`create`/`start`/`status`/`pause`/`resume`/`stop`) are
-//!   cheap and synchronous, same as on the other seams.
+//! - Verified reads run on bounded Myotis-owned workers, never libuv workers.
+//!   Their Promise completion uses a referenced-while-busy Node-API TSFN.
+//! - Stop/pause stay synchronous: cancel and drain native requests, then tear
+//!   down the reader. They may block on indivisible native/filesystem work.
 //! - Errors stay **in-band** (`{"error": ...}` objects, negative handles,
 //!   `false`), exactly as the C header documents — no JS exceptions for
 //!   engine-level failures, so all three seams behave identically.
@@ -25,8 +23,9 @@
 
 use std::ffi::{c_char, CStr, CString};
 
-use napi::bindgen_prelude::AsyncTask;
-use napi::{Env, Result, Task};
+use napi::bindgen_prelude::Object;
+mod scheduler;
+use napi::{Env, Result};
 use napi_derive::napi;
 
 // The C ABI of myotis-engine (capi.rs / rust/include/myotis_engine.h; the
@@ -60,34 +59,6 @@ fn take(ptr: *mut c_char) -> String {
 /// workspace builds with `panic = "abort"`).
 fn c_arg(s: &str) -> std::result::Result<CString, String> {
     CString::new(s).map_err(|_| r#"{"error":"argument contains NUL"}"#.to_string())
-}
-
-/// One blocking C-ABI call scheduled on the libuv thread pool. Boxing a closure
-/// keeps every `#[napi]` export a two-liner instead of one Task struct each.
-pub struct BlockingJson {
-    run: Option<Box<dyn FnOnce() -> String + Send>>,
-}
-
-impl Task for BlockingJson {
-    type Output = String;
-    type JsValue = String;
-
-    fn compute(&mut self) -> Result<Self::Output> {
-        // `compute` runs exactly once per AsyncTask; the Option guards the
-        // FnOnce so a hypothetical re-entry errors instead of panicking.
-        match self.run.take() {
-            Some(f) => Ok(f()),
-            None => Ok(r#"{"error":"task already ran"}"#.to_string()),
-        }
-    }
-
-    fn resolve(&mut self, _env: Env, output: String) -> Result<String> {
-        Ok(output)
-    }
-}
-
-fn blocking(f: impl FnOnce() -> String + Send + 'static) -> AsyncTask<BlockingJson> {
-    AsyncTask::new(BlockingJson { run: Some(Box::new(f)) })
 }
 
 // ---------------------------------------------------------------------------
@@ -133,48 +104,57 @@ pub fn canonical_network_name(name_or_alias: String) -> Option<String> {
 }
 
 // ---------------------------------------------------------------------------
-// Lifecycle (synchronous — cheap by the C header's contract)
+// Lifecycle (synchronous; stop/pause drain native work)
 // ---------------------------------------------------------------------------
 
 /// Allocate a not-yet-started handle (≥ 1); -1 unknown name / runtime-init
 /// failure, -2 canonical-but-unsupported network. `data_dir` is where the
 /// engine persists sync snapshots and peer caches.
 #[napi]
-pub fn create(network: String, data_dir: String) -> i64 {
+pub fn create(env: &Env, network: String, data_dir: String) -> Result<i64> {
+    scheduler::prepare(env)?;
     let (Ok(n), Ok(d)) = (c_arg(&network), c_arg(&data_dir)) else {
-        return -1;
+        return Ok(-1);
     };
-    unsafe { myotis_create(n.as_ptr(), d.as_ptr()) }
+    let handle = unsafe { myotis_create(n.as_ptr(), d.as_ptr()) };
+    if handle > 0 { scheduler::created(env, handle)?; }
+    Ok(handle)
 }
 
 /// Start the sync loop. False for an unknown/already-running handle.
 #[napi]
-pub fn start(handle: i64) -> bool {
+pub fn start(env: &Env, handle: i64) -> bool {
+    if !scheduler::owns(env, handle) { return false; }
     unsafe { myotis_start(handle) }
 }
 
 /// Status JSON object (camelCase keys), or "{}" for an unknown handle.
 #[napi]
-pub fn status_json(handle: i64) -> String {
+pub fn status_json(env: &Env, handle: i64) -> String {
+    if !scheduler::owns(env, handle) { return "{}".into(); }
     take(unsafe { myotis_status_json(handle) })
 }
 
 /// Idle-sleep: Running→Paused (tear down networking, keep warm state).
 #[napi]
-pub fn pause(handle: i64) -> bool {
-    unsafe { myotis_pause(handle) }
+pub fn pause(env: &Env, handle: i64) -> Result<bool> {
+    if !scheduler::cancel_handle(env, handle, false)? { return Ok(false); }
+    Ok(unsafe { myotis_pause(handle) })
 }
 
 /// Paused→Running warm restart. False = rebuild failed (still PAUSED, retry).
 #[napi]
-pub fn resume(handle: i64) -> bool {
+pub fn resume(env: &Env, handle: i64) -> bool {
+    if !scheduler::owns(env, handle) { return false; }
     unsafe { myotis_resume(handle) }
 }
 
-/// Remove + shut down; no-op for an unknown id.
+/// Cancel queued/active native work, drain it, then remove and shut down.
+/// Promise callbacks deliver once JS regains control. Unknown id is a no-op.
 #[napi]
-pub fn stop(handle: i64) {
-    unsafe { myotis_stop(handle) }
+pub fn stop(env: &Env, handle: i64) -> Result<()> {
+    if scheduler::cancel_handle(env, handle, true)? { unsafe { myotis_stop(handle) }; }
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -197,7 +177,8 @@ pub fn stop(handle: i64) {
 /// Applied live over the shared policy, so a parked handle re-evaluates within
 /// ~1 s. Per-host, never persisted. Returns `false` for an unknown handle.
 #[napi]
-pub fn set_ws_bound_periods(handle: i64, periods: i64) -> bool {
+pub fn set_ws_bound_periods(env: &Env, handle: i64, periods: i64) -> bool {
+    if !scheduler::owns(env, handle) { return false; }
     unsafe { myotis_set_ws_bound_periods(handle, periods) }
 }
 
@@ -208,19 +189,20 @@ pub fn set_ws_bound_periods(handle: i64, periods: i64) -> bool {
 /// a fresh `create()` starts gated again. Returns `false` for an unknown
 /// handle.
 #[napi]
-pub fn accept_stale_anchor(handle: i64) -> bool {
+pub fn accept_stale_anchor(env: &Env, handle: i64) -> bool {
+    if !scheduler::owns(env, handle) { return false; }
     unsafe { myotis_accept_stale_anchor(handle) }
 }
 
 // ---------------------------------------------------------------------------
-// Verified reads (blocking → libuv thread pool → Promise<string>)
+// Verified reads (bounded owned workers → Promise<string>)
 // ---------------------------------------------------------------------------
 
 /// Verified account read (balance/nonce/code hash + Merkle proof + beacon
 /// verification fields). Resolves to the AccountProofResult JSON.
 #[napi(ts_return_type = "Promise<string>")]
-pub fn request_account_json(handle: i64, address: String) -> AsyncTask<BlockingJson> {
-    blocking(move || match c_arg(&address) {
+pub fn request_account_json<'env>(env: &'env Env, handle: i64, address: String) -> Result<Object<'env>> {
+    scheduler::submit(env, handle, move || match c_arg(&address) {
         Ok(a) => take(unsafe { myotis_request_account_json(handle, a.as_ptr()) }),
         Err(e) => e,
     })
@@ -229,15 +211,15 @@ pub fn request_account_json(handle: i64, address: String) -> AsyncTask<BlockingJ
 /// Verified eth_call over the revm executor. `from` empty = anonymous sender;
 /// `value` is wei as a decimal string; `block` is a tag or 0x-number.
 #[napi(ts_return_type = "Promise<string>")]
-pub fn eth_call_json(
+pub fn eth_call_json<'env>(env: &'env Env,
     handle: i64,
     from: String,
     to: String,
     data: String,
     value: String,
     block: String,
-) -> AsyncTask<BlockingJson> {
-    blocking(move || {
+) -> Result<Object<'env>> {
+    scheduler::submit(env, handle, move || {
         match (c_arg(&from), c_arg(&to), c_arg(&data), c_arg(&value), c_arg(&block)) {
             (Ok(f), Ok(t), Ok(d), Ok(v), Ok(b)) => take(unsafe {
                 myotis_eth_call_json(handle, f.as_ptr(), t.as_ptr(), d.as_ptr(), v.as_ptr(), b.as_ptr())
@@ -249,14 +231,14 @@ pub fn eth_call_json(
 
 /// Verified eth_estimateGas (local EVM metering + safety buffer).
 #[napi(ts_return_type = "Promise<string>")]
-pub fn estimate_gas_json(
+pub fn estimate_gas_json<'env>(env: &'env Env,
     handle: i64,
     from: String,
     to: String,
     data: String,
     value: String,
-) -> AsyncTask<BlockingJson> {
-    blocking(move || {
+) -> Result<Object<'env>> {
+    scheduler::submit(env, handle, move || {
         match (c_arg(&from), c_arg(&to), c_arg(&data), c_arg(&value)) {
             (Ok(f), Ok(t), Ok(d), Ok(v)) => take(unsafe {
                 myotis_estimate_gas_json(handle, f.as_ptr(), t.as_ptr(), d.as_ptr(), v.as_ptr())
@@ -268,8 +250,8 @@ pub fn estimate_gas_json(
 
 /// Verified ENS forward resolution (name → address).
 #[napi(ts_return_type = "Promise<string>")]
-pub fn resolve_ens_json(handle: i64, name: String) -> AsyncTask<BlockingJson> {
-    blocking(move || match c_arg(&name) {
+pub fn resolve_ens_json<'env>(env: &'env Env, handle: i64, name: String) -> Result<Object<'env>> {
+    scheduler::submit(env, handle, move || match c_arg(&name) {
         Ok(n) => take(unsafe { myotis_resolve_ens_json(handle, n.as_ptr()) }),
         Err(e) => e,
     })
@@ -279,8 +261,8 @@ pub fn resolve_ens_json(handle: i64, name: String) -> AsyncTask<BlockingJson> {
 /// `{"method":"contenthash","name":"vitalik.eth"}` (the record freedom-browser
 /// navigation needs), `{"method":"text","name":"a.eth","key":"avatar"}`, …
 #[napi(ts_return_type = "Promise<string>")]
-pub fn ens_record_json(handle: i64, params_json: String) -> AsyncTask<BlockingJson> {
-    blocking(move || match c_arg(&params_json) {
+pub fn ens_record_json<'env>(env: &'env Env, handle: i64, params_json: String) -> Result<Object<'env>> {
+    scheduler::submit(env, handle, move || match c_arg(&params_json) {
         Ok(p) => take(unsafe { myotis_ens_record_json(handle, p.as_ptr()) }),
         Err(e) => e,
     })
@@ -288,14 +270,14 @@ pub fn ens_record_json(handle: i64, params_json: String) -> AsyncTask<BlockingJs
 
 /// Verified fee suggestions: `{"gasPriceWei","maxPriorityFeePerGasWei"}`.
 #[napi(ts_return_type = "Promise<string>")]
-pub fn fee_estimate_json(handle: i64) -> AsyncTask<BlockingJson> {
-    blocking(move || take(unsafe { myotis_fee_estimate_json(handle) }))
+pub fn fee_estimate_json<'env>(env: &'env Env, handle: i64) -> Result<Object<'env>> {
+    scheduler::submit(env, handle, move || take(unsafe { myotis_fee_estimate_json(handle) }))
 }
 
 /// Gossip a signed raw transaction to devp2p peers: `{"txHash":"0x…"}`.
 #[napi(ts_return_type = "Promise<string>")]
-pub fn send_raw_transaction_json(handle: i64, raw_tx_hex: String) -> AsyncTask<BlockingJson> {
-    blocking(move || match c_arg(&raw_tx_hex) {
+pub fn send_raw_transaction_json<'env>(env: &'env Env, handle: i64, raw_tx_hex: String) -> Result<Object<'env>> {
+    scheduler::submit(env, handle, move || match c_arg(&raw_tx_hex) {
         Ok(r) => take(unsafe { myotis_send_raw_transaction_json(handle, r.as_ptr()) }),
         Err(e) => e,
     })

--- a/rust/myotis-node/src/scheduler.rs
+++ b/rust/myotis-node/src/scheduler.rs
@@ -1,0 +1,621 @@
+//! Environment-owned workers and Promise completion, independent of libuv work.
+//!
+//! Two workers per environment, at most eight process-wide; 32 admitted calls
+//! (including undelivered JS completions), at most four per handle and one
+//! executing per handle. Different chains can progress concurrently.
+use std::cell::RefCell;
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::ffi::c_void;
+use std::sync::{
+    atomic::{AtomicBool, AtomicUsize, Ordering},
+    Arc, Condvar, Mutex,
+};
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
+
+use myotis_engine::capi::{myotis_stop, submitted, Submission};
+use napi::bindgen_prelude::{FromNapiValue, Object};
+use napi::{sys, Env, Error, Result};
+
+const WORKERS: usize = 2;
+const MAX_WORKERS: usize = 8;
+const CAPACITY: usize = 32;
+const PER_HANDLE: usize = 4;
+const BUDGET: Duration = Duration::from_secs(90);
+static LIVE_WORKERS: AtomicUsize = AtomicUsize::new(0);
+thread_local! { static ENVS: RefCell<HashMap<usize, Arc<State>>> = RefCell::new(HashMap::new()); }
+
+type Work = Box<dyn FnOnce() -> String + Send>;
+struct Job {
+    id: u64,
+    handle: i64,
+    deferred: usize,
+    submission: Submission,
+    run: Work,
+}
+struct Completion {
+    deferred: usize,
+    value: String,
+}
+struct Inner {
+    // Used only under this mutex; cleared BEFORE cleanup cancels/joins workers.
+    tsfn: Option<usize>,
+    closing: bool,
+    cleanup_started: bool,
+    poisoned: bool,
+    fallback_error: Option<usize>,
+    queue: VecDeque<Job>,
+    active: HashSet<i64>,
+    requests: HashMap<u64, (i64, Arc<AtomicBool>)>,
+    handles: HashSet<i64>,
+    pending: usize,
+    next_id: u64,
+}
+struct State {
+    inner: Mutex<Inner>,
+    changed: Condvar,
+    workers: Mutex<Vec<JoinHandle<()>>>,
+}
+
+fn check(status: sys::napi_status) -> Result<()> {
+    if status == sys::Status::napi_ok {
+        Ok(())
+    } else {
+        Err(Error::from_reason(format!(
+            "Node-API scheduler error: {status}"
+        )))
+    }
+}
+
+unsafe extern "C" fn complete(
+    env: sys::napi_env,
+    _callback: sys::napi_value,
+    context: *mut c_void,
+    data: *mut c_void,
+) {
+    if data.is_null() {
+        return;
+    }
+    let completion = unsafe { Box::from_raw(data.cast::<Completion>()) };
+    let state = unsafe { &*context.cast::<Arc<State>>() };
+    // Node drains aborted TSFN items with null env. Account the item but never
+    // call Node-API; the TSFN context remains owned until its finalizer.
+    if env.is_null()
+        || state
+            .inner
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .closing
+    {
+        delivered(state, std::ptr::null_mut());
+        return;
+    }
+    let fallback = state
+        .inner
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .fallback_error;
+    let mut error = std::ptr::null_mut();
+    let got_error = fallback
+        .map(|fallback| unsafe {
+            sys::napi_get_reference_value(env, fallback as sys::napi_ref, &mut error)
+        })
+        .unwrap_or(sys::Status::napi_invalid_arg);
+    if got_error != sys::Status::napi_ok || error.is_null() {
+        // Closing/pending exceptions can prevent even the preallocated error
+        // lookup. No settlement is attempted and no JS-side fatal_error is used.
+        poison(state);
+        delivered(state, env);
+        eprintln!("Myotis: completion error reference unavailable; scheduler poisoned");
+        let mut pending = false;
+        unsafe {
+            sys::napi_is_exception_pending(env, &mut pending);
+        }
+        if !pending && !error.is_null() {
+            unsafe {
+                sys::napi_fatal_exception(env, error);
+            }
+        }
+        return;
+    }
+    let mut value = std::ptr::null_mut();
+    let created = unsafe {
+        sys::napi_create_string_utf8(
+            env,
+            completion.value.as_ptr().cast(),
+            completion.value.len() as isize,
+            &mut value,
+        )
+    };
+    // Choose success/error BEFORE touching the deferred. Node's ConcludeDeferred
+    // deletes its deferred_ref even if Resolve/Reject returns generic_failure:
+    // https://github.com/nodejs/node/blob/v24.17.0/src/js_native_api_v8.cc#L309
+    // Never retry settlement or inspect that pointer after this one attempt.
+    let settled = if created == sys::Status::napi_ok {
+        unsafe { sys::napi_resolve_deferred(env, completion.deferred as sys::napi_deferred, value) }
+    } else {
+        let mut pending = false;
+        unsafe {
+            sys::napi_is_exception_pending(env, &mut pending);
+        }
+        if pending {
+            let mut exception = std::ptr::null_mut();
+            unsafe {
+                sys::napi_get_and_clear_last_exception(env, &mut exception);
+            }
+            if !exception.is_null() {
+                error = exception;
+            }
+        }
+        unsafe { sys::napi_reject_deferred(env, completion.deferred as sys::napi_deferred, error) }
+    };
+    if settled != sys::Status::napi_ok {
+        poison(state);
+    }
+    delivered(state, env);
+    if settled != sys::Status::napi_ok {
+        // The deferred is consumed/unknown. Report after releasing accounting
+        // and locks: uncaughtException may run user JS and is NOT guaranteed to
+        // terminate Node. This is explicitly a failed completion, never success.
+        eprintln!("Myotis: Node-API Promise settlement failed ({settled}); scheduler poisoned; deferred not retried");
+        unsafe {
+            sys::napi_fatal_exception(env, error);
+        }
+    }
+}
+
+fn poison(state: &State) {
+    let mut inner = state.inner.lock().unwrap_or_else(|e| e.into_inner());
+    inner.poisoned = true;
+    for (_, token) in inner.requests.values() {
+        token.store(true, Ordering::Release);
+    }
+}
+
+fn delivered(state: &State, env: sys::napi_env) {
+    let mut inner = state.inner.lock().unwrap_or_else(|e| e.into_inner());
+    inner.pending -= 1;
+    if inner.pending == 0 && !env.is_null() && !inner.closing {
+        if let Some(tsfn) = inner.tsfn {
+            let status = unsafe {
+                sys::napi_unref_threadsafe_function(env, tsfn as sys::napi_threadsafe_function)
+            };
+            if status != sys::Status::napi_ok {
+                inner.poisoned = true;
+                eprintln!("Myotis: completion unref failed ({status}); scheduler poisoned");
+            }
+        }
+    }
+}
+
+unsafe extern "C" fn finalize(_env: sys::napi_env, data: *mut c_void, _hint: *mut c_void) {
+    unsafe {
+        drop(Box::from_raw(data.cast::<Arc<State>>()));
+    }
+}
+
+impl State {
+    fn finish(&self, job: Job, value: String) {
+        let mut inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        inner.requests.remove(&job.id);
+        inner.active.remove(&job.handle);
+        if let Some(tsfn) = inner.tsfn {
+            let completion = Box::into_raw(Box::new(Completion {
+                deferred: job.deferred,
+                value,
+            }));
+            // Nonblocking: a worker NEVER needs the JS thread to make progress.
+            // Admission bounds this otherwise-unbounded TSFN queue to CAPACITY.
+            let status = unsafe {
+                sys::napi_call_threadsafe_function(
+                    tsfn as sys::napi_threadsafe_function,
+                    completion.cast(),
+                    sys::ThreadsafeFunctionCallMode::nonblocking,
+                )
+            };
+            if status != sys::Status::napi_ok {
+                unsafe {
+                    drop(Box::from_raw(completion));
+                }
+                if status == sys::Status::napi_closing {
+                    // No more Node-API operations on a closing TSFN. The env
+                    // cleanup hook owns worker joins and remaining bookkeeping.
+                    inner.tsfn = None;
+                    inner.closing = true;
+                    inner.pending -= 1;
+                    for (_, token) in inner.requests.values() {
+                        token.store(true, Ordering::Release);
+                    }
+                } else {
+                    // Queue-full is impossible (max_queue_size=0); invalid-arg
+                    // indicates a broken lifetime invariant. There is no safe
+                    // JS-thread delivery path through an invalid TSFN.
+                    fatal_completion();
+                }
+            }
+        } else {
+            inner.pending -= 1;
+        }
+        self.changed.notify_all();
+    }
+
+    fn worker(self: Arc<Self>) {
+        struct Slot;
+        impl Drop for Slot {
+            fn drop(&mut self) {
+                LIVE_WORKERS.fetch_sub(1, Ordering::AcqRel);
+            }
+        }
+        let _slot = Slot;
+        loop {
+            let mut job = {
+                let mut inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+                loop {
+                    if inner.closing {
+                        return;
+                    }
+                    if let Some(index) = inner
+                        .queue
+                        .iter()
+                        .position(|j| !inner.active.contains(&j.handle))
+                    {
+                        let Some(job) = inner.queue.remove(index) else {
+                            continue;
+                        };
+                        inner.active.insert(job.handle);
+                        break job;
+                    }
+                    inner = self.changed.wait(inner).unwrap_or_else(|e| e.into_inner());
+                }
+            };
+            let value = if job.submission.cancelled.load(Ordering::Acquire) {
+                r#"{"error":"request cancelled"}"#.to_string()
+            } else if Instant::now() >= job.submission.deadline {
+                r#"{"error":"request deadline exceeded in queue"}"#.to_string()
+            } else {
+                let run = std::mem::replace(&mut job.run, Box::new(String::new));
+                submitted(job.submission.clone(), run)
+            };
+            self.finish(job, value);
+        }
+    }
+
+    fn cleanup(&self, env: sys::napi_env) {
+        let handles = {
+            let mut inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+            if inner.cleanup_started {
+                return;
+            }
+            inner.cleanup_started = true;
+            inner.closing = true;
+            // Serialize invalidation with worker completion. No worker can call
+            // Node-API once the TSFN is removed, including after this hook returns.
+            if let Some(tsfn) = inner.tsfn.take() {
+                unsafe {
+                    sys::napi_release_threadsafe_function(
+                        tsfn as sys::napi_threadsafe_function,
+                        sys::ThreadsafeFunctionReleaseMode::abort,
+                    );
+                }
+            }
+            for (_, cancelled) in inner.requests.values() {
+                cancelled.store(true, Ordering::Release);
+            }
+            while let Some(job) = inner.queue.pop_front() {
+                inner.requests.remove(&job.id);
+                inner.pending -= 1;
+            }
+            if let Some(error) = inner.fallback_error.take() {
+                unsafe {
+                    sys::napi_delete_reference(env, error as sys::napi_ref);
+                }
+            }
+            inner.handles.drain().collect::<Vec<_>>()
+        };
+        self.changed.notify_all();
+        let workers = std::mem::take(&mut *self.workers.lock().unwrap_or_else(|e| e.into_inner()));
+        for worker in workers {
+            let _ = worker.join();
+        }
+        // Workers have actually exited; no callback delivery is needed to join.
+        // Native teardown still includes non-preemptible filesystem/CL work.
+        for handle in handles {
+            myotis_stop(handle);
+        }
+        ENVS.with(|envs| {
+            envs.borrow_mut().remove(&(env as usize));
+        });
+    }
+}
+
+fn state(env: &Env) -> Result<Arc<State>> {
+    let key = env.raw() as usize;
+    if let Some(state) = ENVS.with(|envs| envs.borrow().get(&key).cloned()) {
+        return Ok(state);
+    }
+    LIVE_WORKERS
+        .fetch_update(Ordering::AcqRel, Ordering::Acquire, |n| {
+            (n + WORKERS <= MAX_WORKERS).then_some(n + WORKERS)
+        })
+        .map_err(|_| Error::from_reason("Myotis environment worker limit reached"))?;
+    let state = Arc::new(State {
+        inner: Mutex::new(Inner {
+            tsfn: None,
+            closing: false,
+            cleanup_started: false,
+            poisoned: false,
+            fallback_error: None,
+            queue: VecDeque::new(),
+            active: HashSet::new(),
+            requests: HashMap::new(),
+            handles: HashSet::new(),
+            pending: 0,
+            next_id: 1,
+        }),
+        changed: Condvar::new(),
+        workers: Mutex::new(Vec::new()),
+    });
+    let setup = (|| {
+        let mut message = std::ptr::null_mut();
+        let mut error = std::ptr::null_mut();
+        let mut error_ref = std::ptr::null_mut();
+        check(unsafe {
+            sys::napi_create_string_utf8(
+                env.raw(),
+                c"Myotis Promise completion failed".as_ptr(),
+                32,
+                &mut message,
+            )
+        })?;
+        check(unsafe {
+            sys::napi_create_error(env.raw(), std::ptr::null_mut(), message, &mut error)
+        })?;
+        check(unsafe { sys::napi_create_reference(env.raw(), error, 1, &mut error_ref) })?;
+        state
+            .inner
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .fallback_error = Some(error_ref as usize);
+        let mut resource_name = std::ptr::null_mut();
+        check(unsafe {
+            sys::napi_create_string_utf8(
+                env.raw(),
+                c"myotis-completion".as_ptr(),
+                17,
+                &mut resource_name,
+            )
+        })?;
+        let context = Box::into_raw(Box::new(Arc::clone(&state)));
+        let mut tsfn = std::ptr::null_mut();
+        let status = unsafe {
+            sys::napi_create_threadsafe_function(
+                env.raw(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                resource_name,
+                0,
+                1,
+                context.cast(),
+                Some(finalize),
+                context.cast(),
+                Some(complete),
+                &mut tsfn,
+            )
+        };
+        if status != sys::Status::napi_ok {
+            unsafe {
+                drop(Box::from_raw(context));
+            }
+            check(status)?;
+        }
+        state.inner.lock().unwrap_or_else(|e| e.into_inner()).tsfn = Some(tsfn as usize);
+        // Idle addon does not keep Node alive. Ref once on first admission and
+        // unref after the last JS completion; no premature normal process exit.
+        check(unsafe { sys::napi_unref_threadsafe_function(env.raw(), tsfn) })?;
+        let cleanup = Arc::clone(&state);
+        // Registered after TSFN creation: LIFO cleanup invalidates our producer
+        // before Node's own TSFN teardown hook can run.
+        env.add_env_cleanup_hook(key, move |key| cleanup.cleanup(key as sys::napi_env))?;
+        Ok(())
+    })();
+    if let Err(error) = setup {
+        if let Some(tsfn) = state
+            .inner
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .tsfn
+            .take()
+        {
+            unsafe {
+                sys::napi_release_threadsafe_function(
+                    tsfn as sys::napi_threadsafe_function,
+                    sys::ThreadsafeFunctionReleaseMode::abort,
+                );
+            }
+        }
+        if let Some(reference) = state
+            .inner
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .fallback_error
+            .take()
+        {
+            unsafe {
+                sys::napi_delete_reference(env.raw(), reference as sys::napi_ref);
+            }
+        }
+        LIVE_WORKERS.fetch_sub(WORKERS, Ordering::AcqRel);
+        return Err(error);
+    }
+    for index in 0..WORKERS {
+        let worker_state = Arc::clone(&state);
+        match std::thread::Builder::new()
+            .name(format!("myotis-node-{index}"))
+            .spawn(move || worker_state.worker())
+        {
+            Ok(worker) => state
+                .workers
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .push(worker),
+            Err(error) => {
+                LIVE_WORKERS.fetch_sub(WORKERS - index, Ordering::AcqRel);
+                state.cleanup(env.raw());
+                return Err(Error::from_reason(format!(
+                    "Myotis worker creation failed: {error}"
+                )));
+            }
+        }
+    }
+    ENVS.with(|envs| {
+        envs.borrow_mut().insert(key, Arc::clone(&state));
+    });
+    Ok(state)
+}
+
+pub fn created(env: &Env, handle: i64) -> Result<()> {
+    state(env)?
+        .inner
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .handles
+        .insert(handle);
+    Ok(())
+}
+
+pub fn prepare(env: &Env) -> Result<()> {
+    state(env).map(|_| ())
+}
+
+/// Cancel and drain native jobs before pause/stop can publish a new generation.
+/// This waits for native completion, never JS completion. The caller is the
+/// environment thread, so another submission cannot race this lifecycle call.
+pub fn cancel_handle(env: &Env, handle: i64, remove: bool) -> Result<bool> {
+    let state = state(env)?;
+    let mut inner = state.inner.lock().unwrap_or_else(|e| e.into_inner());
+    if !inner.handles.contains(&handle) {
+        return Ok(false);
+    }
+    for (h, token) in inner.requests.values() {
+        if *h == handle {
+            token.store(true, Ordering::Release);
+        }
+    }
+    state.changed.notify_all();
+    while inner.requests.values().any(|(h, _)| *h == handle) {
+        inner = state.changed.wait(inner).unwrap_or_else(|e| e.into_inner());
+    }
+    if remove {
+        inner.handles.remove(&handle);
+    }
+    Ok(true)
+}
+
+pub fn submit<'env>(
+    env: &'env Env,
+    handle: i64,
+    run: impl FnOnce() -> String + Send + 'static,
+) -> Result<Object<'env>> {
+    let deadline = Instant::now() + BUDGET;
+    let state = state(env)?;
+    let mut deferred = std::ptr::null_mut();
+    let mut promise = std::ptr::null_mut();
+    // Promise hooks may synchronously reenter the addon. Never hold our lock
+    // while creating or settling a Promise.
+    check(unsafe { sys::napi_create_promise(env.raw(), &mut deferred, &mut promise) })?;
+    let mut inner = state.inner.lock().unwrap_or_else(|e| e.into_inner());
+    let error = if !inner.handles.contains(&handle) {
+        Some("handle does not belong to this environment")
+    } else if inner.closing {
+        Some("environment closing")
+    } else if inner.poisoned {
+        Some("native scheduler poisoned")
+    } else if inner.pending >= CAPACITY
+        || inner
+            .requests
+            .values()
+            .filter(|(h, _)| *h == handle)
+            .count()
+            >= PER_HANDLE
+    {
+        Some("native scheduler busy")
+    } else {
+        None
+    };
+    if let Some(error) = error {
+        drop(inner);
+        let json = format!(r#"{{"error":"{error}"}}"#);
+        let mut value = std::ptr::null_mut();
+        check(unsafe {
+            sys::napi_create_string_utf8(
+                env.raw(),
+                json.as_ptr().cast(),
+                json.len() as isize,
+                &mut value,
+            )
+        })?;
+        check(unsafe { sys::napi_resolve_deferred(env.raw(), deferred, value) })?;
+    } else {
+        let next_id = inner
+            .next_id
+            .checked_add(1)
+            .ok_or_else(|| Error::from_reason("request id exhausted"))?;
+        if inner.pending == 0 {
+            if let Some(tsfn) = inner.tsfn {
+                check(unsafe {
+                    sys::napi_ref_threadsafe_function(
+                        env.raw(),
+                        tsfn as sys::napi_threadsafe_function,
+                    )
+                })?;
+            }
+        }
+        let id = inner.next_id;
+        inner.next_id = next_id;
+        let cancelled = Arc::new(AtomicBool::new(false));
+        inner.pending += 1;
+        inner.requests.insert(id, (handle, Arc::clone(&cancelled)));
+        inner.queue.push_back(Job {
+            id,
+            handle,
+            deferred: deferred as usize,
+            submission: Submission {
+                deadline,
+                cancelled,
+            },
+            run: Box::new(run),
+        });
+        state.changed.notify_all();
+    }
+    unsafe { Object::from_napi_value(env.raw(), promise) }
+}
+
+pub fn owns(env: &Env, handle: i64) -> bool {
+    ENVS.with(|envs| {
+        envs.borrow()
+            .get(&(env.raw() as usize))
+            .is_some_and(|state| {
+                state
+                    .inner
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .handles
+                    .contains(&handle)
+            })
+    })
+}
+
+/// Node-API invariant failure, not an engine/query failure. Never leave a live
+/// environment with an orphaned promise and a permanent TSFN reference.
+fn fatal_completion() -> ! {
+    unsafe {
+        sys::napi_fatal_error(
+            c"myotis".as_ptr(),
+            6,
+            c"unrecoverable Node-API completion failure".as_ptr(),
+            41,
+        )
+    }
+    // Node documents fatal_error as non-returning; the FFI signature is void.
+    std::process::abort()
+}

--- a/rust/myotis-node/src/scheduler.rs
+++ b/rust/myotis-node/src/scheduler.rs
@@ -380,6 +380,17 @@ impl State {
     }
 }
 
+struct Cleanup {
+    env: usize,
+    state: Arc<State>,
+}
+
+unsafe extern "C" fn cleanup_environment(data: *mut c_void) {
+    // Successful registration transfers this box to Node, exactly once.
+    let cleanup = unsafe { Box::from_raw(data.cast::<Cleanup>()) };
+    cleanup.state.cleanup(cleanup.env as sys::napi_env);
+}
+
 fn state(env: &Env) -> Result<Arc<State>> {
     let key = env.raw() as usize;
     if let Some(state) = ENVS.with(|envs| envs.borrow().get(&key).cloned()) {
@@ -481,10 +492,6 @@ fn state(env: &Env) -> Result<Arc<State>> {
         // Idle addon does not keep Node alive. Ref once on first admission and
         // unref after the last JS completion; no premature normal process exit.
         check(unsafe { sys::napi_unref_threadsafe_function(env.raw(), tsfn) })?;
-        let cleanup = Arc::clone(&state);
-        // Registered after TSFN creation: LIFO cleanup invalidates our producer
-        // before Node's own TSFN teardown hook can run.
-        env.add_env_cleanup_hook(key, move |key| cleanup.cleanup(key as sys::napi_env))?;
         Ok(())
     })();
     if let Err(error) = setup {
@@ -535,6 +542,25 @@ fn state(env: &Env) -> Result<Arc<State>> {
                 )));
             }
         }
+    }
+    // Register only after worker startup: failed spawn/retry must retain no
+    // stale hook. This still follows TSFN creation, so LIFO cleanup invalidates
+    // our producer before Node's own TSFN teardown hook. No work is published.
+    // Own the box explicitly: napi 3.12's remove_env_cleanup_hook unregisters
+    // its hook but does not reclaim the wrapper's boxed closure.
+    let cleanup = Box::into_raw(Box::new(Cleanup {
+        env: key,
+        state: Arc::clone(&state),
+    }));
+    let status = unsafe {
+        sys::napi_add_env_cleanup_hook(env.raw(), Some(cleanup_environment), cleanup.cast())
+    };
+    if status != sys::Status::napi_ok {
+        unsafe {
+            drop(Box::from_raw(cleanup));
+        }
+        state.cleanup(env.raw());
+        check(status)?;
     }
     ENVS.with(|envs| {
         envs.borrow_mut().insert(key, Arc::clone(&state));

--- a/rust/myotis-node/src/scheduler.rs
+++ b/rust/myotis-node/src/scheduler.rs
@@ -4,7 +4,7 @@
 //! (including undelivered JS completions), at most four per handle and one
 //! executing per handle. Different chains can progress concurrently.
 use std::cell::RefCell;
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{HashMap, HashSet};
 use std::ffi::c_void;
 use std::sync::{
     atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -13,6 +13,7 @@ use std::sync::{
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
+use super::admission::{Admission, HasHandle};
 use myotis_engine::capi::{myotis_stop, submitted, Submission};
 use napi::bindgen_prelude::{FromNapiValue, Object};
 use napi::{sys, Env, Error, Result};
@@ -36,6 +37,12 @@ struct Job {
     submission: Submission,
     run: Work,
 }
+impl HasHandle for Job {
+    fn handle(&self) -> i64 {
+        self.handle
+    }
+}
+
 struct Completion {
     deferred: usize,
     value: String,
@@ -47,8 +54,7 @@ struct Inner {
     cleanup_started: bool,
     poisoned: bool,
     fallback_error: Option<usize>,
-    queue: VecDeque<Job>,
-    active: HashSet<i64>,
+    queue: Admission<Job>,
     requests: HashMap<u64, (i64, Arc<AtomicBool>)>,
     handles: HashSet<i64>,
     pending: usize,
@@ -81,6 +87,10 @@ unsafe extern "C" fn complete(
     }
     let completion = unsafe { Box::from_raw(data.cast::<Completion>()) };
     let state = unsafe { &*context.cast::<Arc<State>>() };
+    deliver_completion(env, state, *completion);
+}
+
+fn deliver_completion(env: sys::napi_env, state: &State, completion: Completion) {
     // Node drains aborted TSFN items with null env. Account the item but never
     // call Node-API; the TSFN context remains owned until its finalizer.
     if env.is_null()
@@ -107,7 +117,7 @@ unsafe extern "C" fn complete(
     if got_error != sys::Status::napi_ok || error.is_null() {
         // Closing/pending exceptions can prevent even the preallocated error
         // lookup. No settlement is attempted and no JS-side fatal_error is used.
-        poison(state);
+        poison(state, env);
         delivered(state, env);
         eprintln!("Myotis: completion error reference unavailable; scheduler poisoned");
         let mut pending = false;
@@ -153,7 +163,7 @@ unsafe extern "C" fn complete(
         unsafe { sys::napi_reject_deferred(env, completion.deferred as sys::napi_deferred, error) }
     };
     if settled != sys::Status::napi_ok {
-        poison(state);
+        poison(state, env);
     }
     delivered(state, env);
     if settled != sys::Status::napi_ok {
@@ -167,17 +177,52 @@ unsafe extern "C" fn complete(
     }
 }
 
-fn poison(state: &State) {
-    let mut inner = state.inner.lock().unwrap_or_else(|e| e.into_inner());
-    inner.poisoned = true;
-    for (_, token) in inner.requests.values() {
-        token.store(true, Ordering::Release);
+fn cancel_queued(inner: &mut Inner, handle: Option<i64>) -> Vec<Completion> {
+    let mut failed = Vec::new();
+    for job in inner.queue.cancel_queued(handle) {
+        inner.requests.remove(&job.id);
+        if let Some(completion) =
+            post_completion(inner, job, r#"{"error":"request cancelled"}"#.into())
+        {
+            failed.push(completion);
+        }
+    }
+    failed
+}
+
+fn poison(state: &State, env: sys::napi_env) {
+    let failed = {
+        let mut inner = state.inner.lock().unwrap_or_else(|e| e.into_inner());
+        inner.poisoned = true;
+        for (_, token) in inner.requests.values() {
+            token.store(true, Ordering::Release);
+        }
+        cancel_queued(&mut inner, None)
+    };
+    state.changed.notify_all();
+    // Only the impossible enqueue-invariant path needs direct fallback. No
+    // scheduler/lifecycle lock is held and poison prevents new native work.
+    for completion in failed {
+        deliver_completion(env, state, completion);
+    }
+}
+
+fn decrement_pending(inner: &mut Inner) {
+    match inner.pending.checked_sub(1) {
+        Some(pending) => inner.pending = pending,
+        None => {
+            inner.poisoned = true;
+            for (_, token) in inner.requests.values() {
+                token.store(true, Ordering::Release);
+            }
+            eprintln!("Myotis: admission accounting underflow; scheduler poisoned");
+        }
     }
 }
 
 fn delivered(state: &State, env: sys::napi_env) {
     let mut inner = state.inner.lock().unwrap_or_else(|e| e.into_inner());
-    inner.pending -= 1;
+    decrement_pending(&mut inner);
     if inner.pending == 0 && !env.is_null() && !inner.closing {
         if let Some(tsfn) = inner.tsfn {
             let status = unsafe {
@@ -197,47 +242,59 @@ unsafe extern "C" fn finalize(_env: sys::napi_env, data: *mut c_void, _hint: *mu
     }
 }
 
+/// Enqueue under the producer/cleanup mutex. Unexpected failure returns the
+/// still-owned completion for a JS-thread caller; workers must fail the invariant.
+fn post_completion(inner: &mut Inner, job: Job, value: String) -> Option<Completion> {
+    if let Some(tsfn) = inner.tsfn {
+        let completion = Box::into_raw(Box::new(Completion {
+            deferred: job.deferred,
+            value,
+        }));
+        // Nonblocking: a worker NEVER needs the JS thread to make progress.
+        // Admission bounds this otherwise-unbounded TSFN queue to CAPACITY.
+        let status = unsafe {
+            sys::napi_call_threadsafe_function(
+                tsfn as sys::napi_threadsafe_function,
+                completion.cast(),
+                sys::ThreadsafeFunctionCallMode::nonblocking,
+            )
+        };
+        if status != sys::Status::napi_ok {
+            let failed = unsafe { *Box::from_raw(completion) };
+            if status == sys::Status::napi_closing {
+                // No more Node-API operations on a closing TSFN. The env
+                // cleanup hook owns worker joins and remaining bookkeeping.
+                inner.tsfn = None;
+                inner.closing = true;
+                decrement_pending(inner);
+                for (_, token) in inner.requests.values() {
+                    token.store(true, Ordering::Release);
+                }
+            } else {
+                // Queue-full is impossible (max_queue_size=0); invalid-arg
+                // indicates a broken lifetime invariant. There is no safe
+                // JS-thread delivery path through an invalid TSFN.
+                inner.poisoned = true;
+                for (_, token) in inner.requests.values() {
+                    token.store(true, Ordering::Release);
+                }
+                return Some(failed);
+            }
+        }
+    } else {
+        decrement_pending(inner);
+    }
+    None
+}
+
 impl State {
     fn finish(&self, job: Job, value: String) {
         let mut inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         inner.requests.remove(&job.id);
-        inner.active.remove(&job.handle);
-        if let Some(tsfn) = inner.tsfn {
-            let completion = Box::into_raw(Box::new(Completion {
-                deferred: job.deferred,
-                value,
-            }));
-            // Nonblocking: a worker NEVER needs the JS thread to make progress.
-            // Admission bounds this otherwise-unbounded TSFN queue to CAPACITY.
-            let status = unsafe {
-                sys::napi_call_threadsafe_function(
-                    tsfn as sys::napi_threadsafe_function,
-                    completion.cast(),
-                    sys::ThreadsafeFunctionCallMode::nonblocking,
-                )
-            };
-            if status != sys::Status::napi_ok {
-                unsafe {
-                    drop(Box::from_raw(completion));
-                }
-                if status == sys::Status::napi_closing {
-                    // No more Node-API operations on a closing TSFN. The env
-                    // cleanup hook owns worker joins and remaining bookkeeping.
-                    inner.tsfn = None;
-                    inner.closing = true;
-                    inner.pending -= 1;
-                    for (_, token) in inner.requests.values() {
-                        token.store(true, Ordering::Release);
-                    }
-                } else {
-                    // Queue-full is impossible (max_queue_size=0); invalid-arg
-                    // indicates a broken lifetime invariant. There is no safe
-                    // JS-thread delivery path through an invalid TSFN.
-                    fatal_completion();
-                }
-            }
-        } else {
-            inner.pending -= 1;
+        inner.queue.finish(job.handle);
+        if post_completion(&mut inner, job, value).is_some() {
+            // A worker has no alternate JS-thread delivery path.
+            fatal_completion();
         }
         self.changed.notify_all();
     }
@@ -257,15 +314,7 @@ impl State {
                     if inner.closing {
                         return;
                     }
-                    if let Some(index) = inner
-                        .queue
-                        .iter()
-                        .position(|j| !inner.active.contains(&j.handle))
-                    {
-                        let Some(job) = inner.queue.remove(index) else {
-                            continue;
-                        };
-                        inner.active.insert(job.handle);
+                    if let Some(job) = inner.queue.take_ready() {
                         break job;
                     }
                     inner = self.changed.wait(inner).unwrap_or_else(|e| e.into_inner());
@@ -304,9 +353,9 @@ impl State {
             for (_, cancelled) in inner.requests.values() {
                 cancelled.store(true, Ordering::Release);
             }
-            while let Some(job) = inner.queue.pop_front() {
+            for job in inner.queue.cancel_queued(None) {
                 inner.requests.remove(&job.id);
-                inner.pending -= 1;
+                decrement_pending(&mut inner);
             }
             if let Some(error) = inner.fallback_error.take() {
                 unsafe {
@@ -339,6 +388,9 @@ fn state(env: &Env) -> Result<Arc<State>> {
     // TSFN creation may invoke async_hooks synchronously before ENVS can
     // publish a fully initialized state. Refuse recursive initialization rather
     // than create a second owner whose handles the outer insertion would lose.
+    // Calling initialization/read APIs from that hook is unsupported. The error
+    // thrown here is process-fatal if an async_hooks init hook doesn't catch it;
+    // owns()-gated lifecycle/status calls return false/{} during this window.
     if !INITIALIZING.with(|initializing| initializing.borrow_mut().insert(key)) {
         return Err(Error::from_reason("Myotis scheduler initializing"));
     }
@@ -363,8 +415,7 @@ fn state(env: &Env) -> Result<Arc<State>> {
             cleanup_started: false,
             poisoned: false,
             fallback_error: None,
-            queue: VecDeque::new(),
-            active: HashSet::new(),
+            queue: Admission::new(),
             requests: HashMap::new(),
             handles: HashSet::new(),
             pending: 0,
@@ -508,25 +559,55 @@ pub fn prepare(env: &Env) -> Result<()> {
 /// Cancel and drain native jobs before pause/stop can publish a new generation.
 /// This waits for native completion, never JS completion. The caller is the
 /// environment thread, so another submission cannot race this lifecycle call.
-pub fn cancel_handle(env: &Env, handle: i64, remove: bool) -> Result<bool> {
+#[must_use]
+pub struct Cancellation {
+    state: Arc<State>,
+    pub owned: bool,
+    failed: Vec<Completion>,
+}
+impl Cancellation {
+    /// Rare enqueue-invariant fallback, after native stop/pause has completed.
+    /// Ordinary cancellations use the TSFN and never reenter JS in lifecycle.
+    pub fn finish(self, env: &Env) {
+        if !self.failed.is_empty() {
+            poison(&self.state, env.raw());
+        }
+        for completion in self.failed {
+            deliver_completion(env.raw(), &self.state, completion);
+        }
+    }
+}
+
+pub fn cancel_handle(env: &Env, handle: i64, remove: bool) -> Result<Cancellation> {
     let state = state(env)?;
     let mut inner = state.inner.lock().unwrap_or_else(|e| e.into_inner());
     if !inner.handles.contains(&handle) {
-        return Ok(false);
+        drop(inner);
+        return Ok(Cancellation {
+            state,
+            owned: false,
+            failed: Vec::new(),
+        });
     }
     for (h, token) in inner.requests.values() {
         if *h == handle {
             token.store(true, Ordering::Release);
         }
     }
+    let failed = cancel_queued(&mut inner, Some(handle));
     state.changed.notify_all();
-    while inner.requests.values().any(|(h, _)| *h == handle) {
+    while inner.queue.is_active(handle) {
         inner = state.changed.wait(inner).unwrap_or_else(|e| e.into_inner());
     }
     if remove {
         inner.handles.remove(&handle);
     }
-    Ok(true)
+    drop(inner);
+    Ok(Cancellation {
+        state,
+        owned: true,
+        failed,
+    })
 }
 
 pub fn submit<'env>(
@@ -593,7 +674,7 @@ pub fn submit<'env>(
         let cancelled = Arc::new(AtomicBool::new(false));
         inner.pending += 1;
         inner.requests.insert(id, (handle, Arc::clone(&cancelled)));
-        inner.queue.push_back(Job {
+        inner.queue.push(Job {
             id,
             handle,
             deferred: deferred as usize,

--- a/rust/myotis-node/src/scheduler.rs
+++ b/rust/myotis-node/src/scheduler.rs
@@ -23,7 +23,10 @@ const CAPACITY: usize = 32;
 const PER_HANDLE: usize = 4;
 const BUDGET: Duration = Duration::from_secs(90);
 static LIVE_WORKERS: AtomicUsize = AtomicUsize::new(0);
-thread_local! { static ENVS: RefCell<HashMap<usize, Arc<State>>> = RefCell::new(HashMap::new()); }
+thread_local! {
+    static ENVS: RefCell<HashMap<usize, Arc<State>>> = RefCell::new(HashMap::new());
+    static INITIALIZING: RefCell<HashSet<usize>> = RefCell::new(HashSet::new());
+}
 
 type Work = Box<dyn FnOnce() -> String + Send>;
 struct Job {
@@ -333,6 +336,21 @@ fn state(env: &Env) -> Result<Arc<State>> {
     if let Some(state) = ENVS.with(|envs| envs.borrow().get(&key).cloned()) {
         return Ok(state);
     }
+    // TSFN creation may invoke async_hooks synchronously before ENVS can
+    // publish a fully initialized state. Refuse recursive initialization rather
+    // than create a second owner whose handles the outer insertion would lose.
+    if !INITIALIZING.with(|initializing| initializing.borrow_mut().insert(key)) {
+        return Err(Error::from_reason("Myotis scheduler initializing"));
+    }
+    struct Initializing(usize);
+    impl Drop for Initializing {
+        fn drop(&mut self) {
+            INITIALIZING.with(|initializing| {
+                initializing.borrow_mut().remove(&self.0);
+            });
+        }
+    }
+    let _initializing = Initializing(key);
     LIVE_WORKERS
         .fetch_update(Ordering::AcqRel, Ordering::Acquire, |n| {
             (n + WORKERS <= MAX_WORKERS).then_some(n + WORKERS)


### PR DESCRIPTION
## Summary

Move long-running Node reads off libuv’s shared worker pool and make shutdown cancel readers even when requests still hold references to them. This addresses worker starvation and a shutdown failure we encountered while embedding Myotis in **Freedom, an Electron browser**.

**Ready for maintainer review.** Internal source review, builds, finite regressions and the targeted Node scheduler/runtime checks below have passed. Live blockchain-reader cancellation and release qualification remain separate, explicitly unverified work.

## What prompted this

Freedom embeds Myotis for Ethereum/Gnosis reads while also making unrelated network requests. During longer browser-agent sessions, those requests began failing, and quitting the browser could leave the OS process alive after Electron had emitted its quit/exit events.

A native sample taken during a reproduced shutdown hang showed:

- All **four libuv workers** occupied by Myotis `BlockingJson` / `eth_call_json` calls.
- Node shutdown waiting in `CleanupHandles`, with a backlog of DNS requests (`GetAddrInfoReqWrap`).
- In a comparable user smoke test with Myotis disabled, both the long agent session and application Quit worked normally.

The affected installation used Myotis v0.1.7. Source inspection found the same two mechanisms in the upstream base of this PR (`8e925320`):

1. **Node reads use `napi::AsyncTask`, sharing libuv workers with unrelated host operations such as DNS resolution.** Several slow reads can occupy the entire default pool.
2. **Reader shutdown depends on `Arc::try_unwrap` succeeding.** An in-flight read retains an `Arc<ElReader>`, so shutdown can skip the reader precisely when it still has work to cancel.

This establishes saturation during shutdown, not the cause of every preceding network failure.

## What changes

### Node binding: bounded workers owned by Myotis

Replace `AsyncTask<BlockingJson>` with dedicated native workers and deliver Promise results back through a Node-API thread-safe function. Admission is bounded, including results waiting for JavaScript delivery, so slow work cannot create an unlimited queue.

Each environment has two workers and up to 32 outstanding requests. Per handle, admission is limited to four requests with one executing at a time. Separate handles can progress concurrently; total scheduler workers are capped at eight per process.

### Shared engine: cancellation reaches the work that must stop

Propagate deadlines and cancellation through reader setup, network/oracle waits and EVM instruction checks. Node deadlines include queue time. Stop/pause signal readers without requiring exclusive `Arc` ownership, then drain registered work and owned background tasks.

Started EVM closures retain their permits until they actually finish. Environment cleanup closes admission, cancels work and joins workers without depending on JavaScript callbacks to run.

### Preserve results and existing fallback behavior

Preserve completed results when cancellation arrives late, including broadcast results. Keep fee-history’s existing bounded stale-cache fallback for operation timeouts; invalid requests still return errors.

## Compatibility and limits

- **ABI 25 and the existing C/JNI/UniFFI signatures are unchanged relative to the upstream base.** No dependency or lockfile changes. This is not a drop-in ABI 22 artifact for Freedom’s currently pinned release.
- `stop` and `pause` remain synchronous. The usual 90-second operation budget is **cooperative**: indivisible proof/precompile/filesystem work can overrun it. This PR does not guarantee a hard shutdown deadline.
- Saturated admission returns an explicit busy result; hosts must bound and retry their work appropriately. Node handles belong to the environment that created them.
- A cancelled or interrupted broadcast may already have reached a peer. It must not be blindly retried on the assumption that nothing was sent.

The [Node lifecycle contract](https://github.com/flotob/myotis/blob/02a183d86474a263cf8e85e5c2c2399672645535/rust/myotis-node/README.md#request-ownership-and-cancellation) documents the detailed limits and exceptional completion-failure behavior, including process-fatal invariant failures.

Freedom’s separate [process-isolation PR](https://github.com/solardev-xyz/freedom-browser/pull/295) protects the host from native stalls that cooperative cancellation cannot preempt. That integration does not replace the upstream fix here.

## Validation

At candidate `02a183d8`:

- **Linux:** exact-lock offline Node check and build/link passed, along with **18 finite tests** covering request deadlines/cancellation, completed-result preservation, fee-history fallback, EVM execution, ABI and admission accounting.
- **macOS:** exact-lock offline Node check and ten targeted request/fee-history tests passed.
- **CI:** build/test, Android APK and API-29 emulator smoke, macOS DMG, iOS framework, roost and smoke/replay unit-test workflows passed. Automated fork review was skipped by repository policy; internal Claude review and manual correction reviews were completed.

### Targeted Node runtime checks: 8/8 passed on disposable Linux

Two cases loaded the original `02a183d8` addon and an ordinary no-feature build to check handle ownership and natural idle exit. Six further cases used an explicitly test-only derivative with byte-identical production scheduler/admission bodies and finite native gate jobs:

- DNS lookup and a file read completed together in **8 ms while a Myotis native worker remained occupied**, with `UV_THREADPOOL_SIZE=1`.
- Queued cancellation, per-handle admission limits, active-gate stop/pause, and Promise completion before natural exit passed.
- Terminating two successive Node Worker environments cancelled entered native work and reclaimed/reused the dedicated worker slots.

All enclosing Node processes exited naturally with code 0; no timeout or containment intervention counted as a pass. The coordinator independently checked the raw results, original-owner exit/retirement/reap records and all 160 exported payload hashes.

[Exact source/artifact identities, results and reproduction instructions](https://github.com/flotob/myotis/blob/86dd617bf62c96ae3c631be464e2e8e8e077dbba/qualification/native/RESULTS-linux-bb963e00.md) are published on the supporting test branch. The production PR remains at `02a183d8`; the test-only exports are not part of this PR.

**Scope:** these are real scheduler/TSFN/environment-cleanup tests with Created, unstarted handles. They do not establish cancellation through an active blockchain reader, the EVM/network operation bridge, the full 90-second budget, or fatal/stress behavior. A separate user smoke test of Freedom with process isolation and a checkpoint-only derivative of this patch completed a long agent session and Cmd+Q without either reported symptom; it is combined acceptance evidence, not an isolated proof of these upstream mechanisms.

These remaining checks are disclosed for maintainer review. Merge/rollout scope and applicable packaged/release checks still need their own decision; this PR makes no hard shutdown guarantee.

## Suggested review order

1. `rust/myotis-node/src/scheduler.rs` and `admission.rs` — admission, Promise completion and environment-cleanup ownership.
2. `rust/myotis-net/src/el/request.rs` — operation budgets, cancellation and retention of actual blocking work.
3. `host.rs`, `reader.rs` and `tasks.rs` — shared-reader shutdown and background-task draining; then the EVM/oracle propagation changes.

Implemented with Codex; internally reviewed with Claude.
