### PR TITLE
catch-up: ask Lighthouse for one period per request from the first contact

### DIFF
--- a/rust/myotis-net/src/reqresp.rs
+++ b/rust/myotis-net/src/reqresp.rs
@@ -399,9 +399,10 @@ enum Command {
     Observe {
         peers: Vec<(PeerId, Multiaddr)>,
     },
-    /// One snapshot of both catch-up peer-selection inputs — the LC-server set
-    /// and the per-peer `earliest_available_slot` map — so a round fetches them
-    /// in a single swarm round-trip instead of two.
+    /// One snapshot of the catch-up peer-selection inputs — the LC-server set,
+    /// the per-peer `earliest_available_slot` map, and the per-peer Identify
+    /// agent — so a round fetches them in a single swarm round-trip instead of
+    /// three.
     CatchupMeta {
         reply: oneshot::Sender<CatchupPeerMeta>,
     },

--- a/rust/myotis-net/src/reqresp.rs
+++ b/rust/myotis-net/src/reqresp.rs
@@ -403,7 +403,7 @@ enum Command {
     /// and the per-peer `earliest_available_slot` map — so a round fetches them
     /// in a single swarm round-trip instead of two.
     CatchupMeta {
-        reply: oneshot::Sender<(HashSet<PeerId>, HashMap<PeerId, u64>)>,
+        reply: oneshot::Sender<CatchupPeerMeta>,
     },
     Shutdown,
 }
@@ -506,15 +506,16 @@ impl ReqRespClient {
         rx.await.unwrap_or_default()
     }
 
-    /// Both catch-up peer-selection inputs in one round-trip: the set of
-    /// Identify-confirmed LC servers, and `earliest_available_slot` per peer
-    /// (from the auto-Status exchange). Peers absent from the earliest map
-    /// haven't completed Status yet (unknown — never skipped); a v1 peer
-    /// reports 0 (history from genesis).
-    pub async fn catchup_peer_meta(&self) -> (HashSet<PeerId>, HashMap<PeerId, u64>) {
+    /// The catch-up peer-selection inputs in one round-trip: the set of
+    /// Identify-confirmed LC servers, `earliest_available_slot` per peer
+    /// (from the auto-Status exchange), and each peer's Identify agent string.
+    /// Peers absent from the earliest map haven't completed Status yet
+    /// (unknown — never skipped); a v1 peer reports 0 (history from genesis).
+    /// Peers absent from the agent map haven't completed Identify yet.
+    pub async fn catchup_peer_meta(&self) -> CatchupPeerMeta {
         let (reply, rx) = oneshot::channel();
         if self.tx.send(Command::CatchupMeta { reply }).await.is_err() {
-            return (HashSet::new(), HashMap::new());
+            return CatchupPeerMeta::default();
         }
         rx.await.unwrap_or_default()
     }
@@ -522,6 +523,14 @@ impl ReqRespClient {
     pub async fn shutdown(&self) {
         let _ = self.tx.send(Command::Shutdown).await;
     }
+}
+
+/// Catch-up peer-selection inputs (see `ReqRespClient::catchup_peer_meta`).
+#[derive(Debug, Default, Clone)]
+pub struct CatchupPeerMeta {
+    pub lc_servers: HashSet<PeerId>,
+    pub earliest_slots: HashMap<PeerId, u64>,
+    pub agents: HashMap<PeerId, String>,
 }
 
 /// Shared local view the responder answers from. The sync loop refreshes it as
@@ -990,6 +999,9 @@ struct SwarmCtx {
     lc_servers: HashSet<PeerId>,
     /// `earliest_available_slot` learned from each peer's auto-Status reply.
     peer_earliest: HashMap<PeerId, u64>,
+    /// Identify `agent_version` per peer — the catch-up fan-out sizes its
+    /// request per client family from this (see `sync::agent_serves_one_period`).
+    peer_agents: HashMap<PeerId, String>,
     local_status: Arc<LocalStatus>,
     /// Present only on a serving host; `None` on a wallet, where the
     /// light-client protocols answer `ResourceUnavailable` as before.
@@ -1031,6 +1043,7 @@ async fn run_swarm(
         queued: HashMap::new(),
         lc_servers: HashSet::new(),
         peer_earliest: HashMap::new(),
+        peer_agents: HashMap::new(),
         local_status,
         lc,
         in_flight: HashMap::new(),
@@ -1092,7 +1105,11 @@ async fn run_swarm(
                     }
                 }
                 Some(Command::CatchupMeta { reply }) => {
-                    let _ = reply.send((ctx.lc_servers.clone(), ctx.peer_earliest.clone()));
+                    let _ = reply.send(CatchupPeerMeta {
+                        lc_servers: ctx.lc_servers.clone(),
+                        earliest_slots: ctx.peer_earliest.clone(),
+                        agents: ctx.peer_agents.clone(),
+                    });
                 }
             },
             event = swarm.select_next_some() => handle_swarm_event(&mut swarm, &mut ctx, event),
@@ -1237,6 +1254,7 @@ fn handle_swarm_event(swarm: &mut Swarm<Behaviour>, ctx: &mut SwarmCtx, event: S
                 // re-runs Identify + auto-Status and repopulates both).
                 ctx.status_done.remove(&peer_id);
                 ctx.lc_servers.remove(&peer_id);
+                ctx.peer_agents.remove(&peer_id);
                 ctx.peer_earliest.remove(&peer_id);
                 ctx.observed_ips.remove(&peer_id);
                 ctx.peer_source_ips.remove(&peer_id);
@@ -1285,6 +1303,7 @@ fn handle_behaviour_event(swarm: &mut Swarm<Behaviour>, ctx: &mut SwarmCtx, even
                 let port = inbound.then(|| multiaddr_port(&info.observed_addr)).flatten();
                 ctx.observed_ips.insert(peer_id, Observation { source, ip, port });
             }
+            ctx.peer_agents.insert(peer_id, info.agent_version.clone());
             tracing::debug!(peer = %peer_id, agent = %info.agent_version,
                 protocols = info.protocols.len(), lc_updates = lc, "identify received");
         }

--- a/rust/myotis-net/src/sync.rs
+++ b/rust/myotis-net/src/sync.rs
@@ -559,7 +559,9 @@ const MAINNET_STATIC_PEERS: &[&str] = &[
     // first two served this census a 512/512 period-1840 update; the third
     // was verified via the standalone Nimbus light client):
     //  - 57.129.130.18: Lighthouse v8.2.2; enforces the one_every(10s) updates
-    //    quota, so it serves ONE period per ask (single_period_peers handles it);
+    //    quota, so it serves ONE period per ask (`agent_serves_one_period` asks
+    //    it for one up front; `single_period_peers` is the fallback for peers
+    //    that closed a batch before Identify named them);
     //    also served the Java engine's catch-up (periods 1837-1838).
     //  - 84.112.35.112: served the Java engine (1836-1837) and this census.
     //  - 91.189.182.90: Nimbus fleet; served the standalone Nimbus light client
@@ -2206,7 +2208,8 @@ async fn catch_up(
         tracing::info!(from_period = committee_period, wall_period, span,
             staged = staged.len(), "catch-up: requesting updates_by_range");
 
-        let (mut lc_servers, earliest_slots) = client.catchup_peer_meta().await;
+        let reqresp::CatchupPeerMeta { mut lc_servers, earliest_slots, agents } =
+            client.catchup_peer_meta().await;
         // Reconcile the deny set against the LIVE Identify signal (same protocol
         // nolc tracks, self-expiring on disconnect) BEFORE folding in
         // hunt_confirmed — see clear_no_lc for why the finality-attesting hunt
@@ -2286,8 +2289,15 @@ async fn catch_up(
                 // be redundantly requested. The COUNT is per-peer: a server that
                 // closed on a multi-period ask (Lighthouse's quota) is asked for
                 // exactly one, so it can serve instead of being struck out.
-                let single = pool_wants_single.contains(&peer.id);
+                // Lighthouse gets count=1 from the FIRST ask (its quota makes a
+                // multi-count request yield one chunk then a closed stream); the
+                // reactive single_period_peers mark covers clients we don't know.
+                let single = pool_wants_single.contains(&peer.id)
+                    || agent_serves_one_period(agents.get(&peer.id).map(String::as_str));
                 let (sub_from, sub_count) = (committee_period, if single { 1 } else { span });
+                tracing::debug!(peer = %peer.id, sub_count,
+                    agent = agents.get(&peer.id).map(String::as_str).unwrap_or("?"),
+                    "catch-up: updates_by_range request");
                 let wire = if single { single_wire.clone() } else { wire.clone() };
                 async move {
                     let res = client
@@ -2693,6 +2703,19 @@ fn apply_staged_step(
     out
 }
 
+/// Whether a client family should be asked for ONE period per request.
+///
+/// Lighthouse rate-limits `light_client_updates_by_range` at `one_every(10s)`
+/// (`lighthouse_network/src/rpc/config.rs`): a count=N request costs N tokens
+/// against a one-token bucket, so it serves the first chunk and closes the
+/// stream. Asking it for one period up front turns every first contact into
+/// a served update instead of a truncated one. Nimbus and roost answer whole
+/// spans (a Nimbus node served five periods in one batch), and unknown
+/// agents keep the span until the reactive `single_period_peers` mark fires.
+pub(crate) fn agent_serves_one_period(agent: Option<&str>) -> bool {
+    agent.is_some_and(|a| a.starts_with("Lighthouse"))
+}
+
 /// What one `apply_staged_step` pass did — richer than the old tuple so the
 /// caller can charge verify-rejects to the peers that actually served them.
 #[derive(Default)]
@@ -3056,6 +3079,18 @@ async fn publish_status(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn lighthouse_agents_get_single_period_requests() {
+        assert!(agent_serves_one_period(Some("Lighthouse/v8.2.2-e423a66/x86_64-linux")));
+        assert!(agent_serves_one_period(Some("Lighthouse/v8.1.3-176cce5/x86_64-linux")));
+        assert!(!agent_serves_one_period(Some("nimbus-eth2/v26.4.0")));
+        assert!(!agent_serves_one_period(Some("lodestar/v1.47.0/2aff495")));
+        assert!(!agent_serves_one_period(Some("myotis/0.1.8-rs")));
+        // Case-sensitive on purpose: Lighthouse always capitalises its agent.
+        assert!(!agent_serves_one_period(Some("lighthouse/v8.2.2")));
+        assert!(!agent_serves_one_period(None));
+    }
 
     /// A LightClientHeader with a real (post-merge) execution payload for the
     /// anchor-wiring tests.


### PR DESCRIPTION
## What

Carry each peer's Identify agent string through the existing catch-up metadata round-trip (`CatchupPeerMeta`) and size the first `light_client_updates_by_range` ask per client family: Lighthouse-identified peers get `count=1` up front; everyone else keeps the span; peers without Identify yet still fall through the reactive `single_period_peers` mark. Agent entries are dropped on disconnect like the other per-peer metadata.

## Why

Lighthouse rate-limits `light_client_updates_by_range` at `one_every(10s)` (`lighthouse_network/src/rpc/config.rs`). A `count=N` request costs N tokens against a one-token bucket, so Lighthouse serves the first chunk and closes the stream. The engine only learned this reactively, after a closed multi-count ask, which cost one full round per Lighthouse node. Combined with the gossipsub ban (fixed separately in the companion PR), that one round was the only connection the node would ever grant, so a gnosis wallet whose pinned LC servers are all Lighthouse could not advance once the wall period was two ahead of its anchor.

On-device A/B on gnosis (Pixel 10 Pro Fold, LTE, wall period 3665 vs anchor 3663): `count=1` slots to Lighthouse nodes were served on first contact; `count=2` slots came back as closed streams. Nimbus and roost answer whole spans (a Nimbus node has served five periods in one batch), so they keep the span.

## Not a fix for the ban

This PR alone only makes the single first-contact connection productive. The 12-hour per-id ban and the IP ban are addressed by the gossipsub PR; the two are independent and either may merge first.

## Tests

`cargo test -p myotis-net --lib`: 348 passed, including the new `lighthouse_agents_get_single_period_requests` (case-sensitive on purpose).

Related: #422.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNMr2LJJVj42AoFLuUk35a