### PR TITLE
Speak gossipsub on both engines so Lighthouse stops banning the wallet

### DIFF
--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -1764,7 +1764,9 @@ public final class NodeService extends Service {
                 EngineConfig config = new EngineConfig(
                         n, 0, 0, rpcPort,
                         netCacheFor(n, "sync-state", ".snapshot").getAbsolutePath(),
-                        /*gossipsub*/ false,
+                        // Gossipsub on: Lighthouse fatally bans a peer whose /meshsub/
+                        // negotiation fails (one connection per peer id per 12 h).
+                        /*gossipsub*/ true,
                         snapTarget(this),
                         strictStateFreshness(this),
                         // Reconstructible engine-owned state belongs with the other network

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -1764,9 +1764,6 @@ public final class NodeService extends Service {
                 EngineConfig config = new EngineConfig(
                         n, 0, 0, rpcPort,
                         netCacheFor(n, "sync-state", ".snapshot").getAbsolutePath(),
-                        // Gossipsub on: Lighthouse fatally bans a peer whose /meshsub/
-                        // negotiation fails (one connection per peer id per 12 h).
-                        /*gossipsub*/ true,
                         snapTarget(this),
                         strictStateFreshness(this),
                         // Reconstructible engine-owned state belongs with the other network

--- a/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
@@ -122,7 +122,7 @@ class DesktopNodeController(
                 val config = EngineConfig(
                     canonical, 0, 0, settings.rpcPortFor(canonical),
                     dataDir.resolve("sync-state$suffix.snapshot").toString(),
-                    false,
+                    true, // gossipsub: Lighthouse bans peers whose /meshsub/ negotiation fails
                     settings.snapTarget(),
                     settings.strictStateFreshness(),
                     dataDir.toString(),

--- a/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
+++ b/app-desktop/src/main/kotlin/io/myotis/desktop/DesktopNode.kt
@@ -122,7 +122,6 @@ class DesktopNodeController(
                 val config = EngineConfig(
                     canonical, 0, 0, settings.rpcPortFor(canonical),
                     dataDir.resolve("sync-state$suffix.snapshot").toString(),
-                    true, // gossipsub: Lighthouse bans peers whose /meshsub/ negotiation fails
                     settings.snapTarget(),
                     settings.strictStateFreshness(),
                     dataDir.toString(),

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -102,11 +102,14 @@ tasks.register<JavaExec>("run") {
         appArgs.add("--port")
         appArgs.add(portArg)
     }
-    // -Pgossipsub=true enables the (observation-only) light-client gossipsub
-    // subscription. Off by default because short-session clients churn the mesh.
+    // Gossipsub is ON by default (Lighthouse bans peers whose /meshsub/ negotiation
+    // fails); -Pgossipsub=false passes --no-gossipsub, -Pgossipsub=true is a no-op
+    // kept for older invocations.
     val gossipsubArg = project.findProperty("gossipsub") as String?
     if (gossipsubArg != null && gossipsubArg.equals("true", ignoreCase = true)) {
         appArgs.add("--gossipsub")
+    } else if (gossipsubArg != null && gossipsubArg.equals("false", ignoreCase = true)) {
+        appArgs.add("--no-gossipsub")
     }
     val cmdArgs = (project.findProperty("args") as String?)
         ?.split("\\s+".toRegex())

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -102,15 +102,6 @@ tasks.register<JavaExec>("run") {
         appArgs.add("--port")
         appArgs.add(portArg)
     }
-    // Gossipsub is ON by default (Lighthouse bans peers whose /meshsub/ negotiation
-    // fails); -Pgossipsub=false passes --no-gossipsub, -Pgossipsub=true is a no-op
-    // kept for older invocations.
-    val gossipsubArg = project.findProperty("gossipsub") as String?
-    if (gossipsubArg != null && gossipsubArg.equals("true", ignoreCase = true)) {
-        appArgs.add("--gossipsub")
-    } else if (gossipsubArg != null && gossipsubArg.equals("false", ignoreCase = true)) {
-        appArgs.add("--no-gossipsub")
-    }
     val cmdArgs = (project.findProperty("args") as String?)
         ?.split("\\s+".toRegex())
         ?.filter { it.isNotEmpty() }

--- a/app/src/main/java/com/jaeckel/ethp2p/app/Main.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/Main.java
@@ -156,10 +156,12 @@ public final class Main {
 
 
     public static void main(String[] args) throws Exception {
-        // Parse --network (comma-separated list), --port, --gossipsub from anywhere in args.
+        // Parse --network (comma-separated list), --port, --[no-]gossipsub from anywhere in args.
         List<String> networkNames = new ArrayList<>();
         int port = DEFAULT_PORT;
-        boolean gossipsubEnabled = false;
+        // On by default: Lighthouse fatally bans a peer whose /meshsub/ negotiation
+        // fails, so a req/resp-only client gets one connection per peer id per 12 h.
+        boolean gossipsubEnabled = !"false".equalsIgnoreCase(System.getProperty("beacon.gossipsub", "true"));
         List<String> remaining = new ArrayList<>();
         for (int i = 0; i < args.length; i++) {
             if ("--network".equals(args[i]) && i + 1 < args.length) {
@@ -171,17 +173,13 @@ public final class Main {
                 port = Integer.parseInt(args[++i]);
             } else if ("--gossipsub".equals(args[i])) {
                 gossipsubEnabled = true;
+            } else if ("--no-gossipsub".equals(args[i])) {
+                gossipsubEnabled = false;
             } else {
                 remaining.add(args[i]);
             }
         }
         if (networkNames.isEmpty()) networkNames.add("mainnet");
-        // System property fallback so Android / other embedders can opt in
-        // without touching CLI args.
-        if (!gossipsubEnabled
-                && Boolean.parseBoolean(System.getProperty("beacon.gossipsub", "false"))) {
-            gossipsubEnabled = true;
-        }
         String[] cmdArgs = remaining.toArray(new String[0]);
 
         // The selector replaces the old `new JavaMyotisEngine()` composition-root line:

--- a/app/src/main/java/com/jaeckel/ethp2p/app/Main.java
+++ b/app/src/main/java/com/jaeckel/ethp2p/app/Main.java
@@ -156,12 +156,9 @@ public final class Main {
 
 
     public static void main(String[] args) throws Exception {
-        // Parse --network (comma-separated list), --port, --[no-]gossipsub from anywhere in args.
+        // Parse --network (comma-separated list) and --port from anywhere in args.
         List<String> networkNames = new ArrayList<>();
         int port = DEFAULT_PORT;
-        // On by default: Lighthouse fatally bans a peer whose /meshsub/ negotiation
-        // fails, so a req/resp-only client gets one connection per peer id per 12 h.
-        boolean gossipsubEnabled = !"false".equalsIgnoreCase(System.getProperty("beacon.gossipsub", "true"));
         List<String> remaining = new ArrayList<>();
         for (int i = 0; i < args.length; i++) {
             if ("--network".equals(args[i]) && i + 1 < args.length) {
@@ -171,10 +168,6 @@ public final class Main {
                 }
             } else if ("--port".equals(args[i]) && i + 1 < args.length) {
                 port = Integer.parseInt(args[++i]);
-            } else if ("--gossipsub".equals(args[i])) {
-                gossipsubEnabled = true;
-            } else if ("--no-gossipsub".equals(args[i])) {
-                gossipsubEnabled = false;
             } else {
                 remaining.add(args[i]);
             }
@@ -245,15 +238,15 @@ public final class Main {
                 System.exit(1);
             }
         }
-        runDaemon(engine, canonical, port, gossipsubEnabled);
+        runDaemon(engine, canonical, port);
     }
 
     // -------------------------------------------------------------------------
     // Daemon
     // -------------------------------------------------------------------------
 
-    private static void runDaemon(MyotisEngine engine, List<String> networks, int portOverride,
-                                  boolean gossipsubEnabled) throws Exception {
+    private static void runDaemon(MyotisEngine engine, List<String> networks, int portOverride)
+            throws Exception {
         boolean multi = networks.size() > 1;
         log.info("=== ethp2p Daemon ({}) ===", String.join(", ", networks));
 
@@ -296,7 +289,7 @@ public final class Main {
             String dataDir = Path.of("").toAbsolutePath().toString();
             EngineConfig config = multi
                     ? new EngineConfig(network, 0, 0, 0,
-                            syncSnapshotFile(network).toString(), gossipsubEnabled,
+                            syncSnapshotFile(network).toString(),
                             SNAP_PEER_TARGET, strict, dataDir)
                     : new EngineConfig(network, portOverride, 9000,
                             // Legacy 8545 stays pinned for mainnet (byte-identical
@@ -304,7 +297,7 @@ public final class Main {
                             // catalog default (0 = engine default; sepolia 8547) so a
                             // sepolia daemon beside a mainnet one doesn't collide.
                             "mainnet".equals(network) ? 8545 : 0,
-                            syncSnapshotFile(network).toString(), gossipsubEnabled,
+                            syncSnapshotFile(network).toString(),
                             SNAP_PEER_TARGET, strict, dataDir);
             // dnsServers=null → resolver's default DNS (the daemon, unlike Android, has
             // system DNS config). The snap maintainer (SNAP_PEER_TARGET) keeps snap peers

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
@@ -1429,11 +1429,10 @@ public class BeaconLightClient implements AutoCloseable {
     }
 
     /**
-     * Enable gossipsub subscription to the light-client topics. Off by
-     * default because short-session clients (Android app that runs ~2 min
-     * once per day) don't benefit from mesh participation and churn the
-     * mesh by joining-then-disappearing. Must be called before
-     * {@link #start()}.
+     * Register gossipsub on the libp2p host (no topic subscriptions). Every
+     * host enables this: Lighthouse fatally bans a peer whose {@code /meshsub/}
+     * negotiation fails, see {@code BeaconP2PService#gossip}. Must be called
+     * before {@link #start()}.
      */
     public void setGossipsubEnabled(boolean enabled) {
         p2pService.setGossipsubEnabled(enabled);

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
@@ -1429,16 +1429,6 @@ public class BeaconLightClient implements AutoCloseable {
     }
 
     /**
-     * Register gossipsub on the libp2p host (no topic subscriptions). Every
-     * host enables this: Lighthouse fatally bans a peer whose {@code /meshsub/}
-     * negotiation fails, see {@code BeaconP2PService#gossip}. Must be called
-     * before {@link #start()}.
-     */
-    public void setGossipsubEnabled(boolean enabled) {
-        p2pService.setGossipsubEnabled(enabled);
-    }
-
-    /**
      * Send Status to a peer, trying {@code /status/2} first and falling back
      * to {@code /status/1} if the peer doesn't support v2. Each protocol is
      * additionally tried with each candidate fork version in sequence.

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/libp2p/BeaconP2PService.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/libp2p/BeaconP2PService.java
@@ -183,16 +183,39 @@ public class BeaconP2PService implements AutoCloseable {
     /**
      * Gossipsub instance. Observation-only: handler logs incoming messages
      * and always returns {@code Ignore}. Only created when
-     * {@link #gossipsubEnabled} is true, which defaults to {@code false}
-     * because the primary target (short-lived Android sessions) doesn't
-     * benefit from mesh participation — mesh-join latency is longer than a
-     * whole session, and churning the mesh every 24 h is worse citizenship
-     * than not joining.
+     * {@link #gossipsubEnabled} is true. Every host now enables it: Lighthouse
+     * reports a peer whose {@code /meshsub/} negotiation fails as
+     * {@code PeerAction::Fatal} ("does_not_support_gossipsub"), which bans the
+     * peer id for 12 h after one connection and bans the IP once more than five
+     * of its peer ids are banned — a req/resp-only client got exactly one
+     * connection per Lighthouse node per start. Registering the protocol is
+     * what the check needs, so that is all {@link #gossipsubEnabled} does;
+     * joining the light-client topics is a separate, off-by-default switch
+     * ({@link #setGossipTopicSubscriptionEnabled(boolean)}): a short-lived
+     * wallet that joins a mesh and vanishes churns it for everyone else, the
+     * jvm-libp2p default message id (from+seqno) collapses eth2's unsigned
+     * messages, and the subscription is pinned to the fork digest at start.
      */
     private io.libp2p.pubsub.gossip.Gossip gossip;
 
     /** Off by default; call {@link #setGossipsubEnabled(boolean)} before {@link #start()}. */
     private boolean gossipsubEnabled = false;
+
+    /**
+     * Whether to also SUBSCRIBE to the light-client gossip topics once gossipsub
+     * is registered. Off by default — see the {@link #gossip} field doc. No host
+     * enables it yet; it stays as the hook for the live-finality plan
+     * (plan-gossipsub-subscription.md).
+     */
+    private boolean gossipTopicSubscriptionEnabled = false;
+
+    /** Toggle topic subscription (requires gossipsub). Must be called before {@link #start()}. */
+    public void setGossipTopicSubscriptionEnabled(boolean enabled) {
+        if (host != null) {
+            throw new IllegalStateException("gossip topic flag cannot change after start()");
+        }
+        this.gossipTopicSubscriptionEnabled = enabled;
+    }
 
     /** Toggle gossipsub subscription. Must be called before {@link #start()}. */
     public void setGossipsubEnabled(boolean enabled) {
@@ -361,7 +384,7 @@ public class BeaconP2PService implements AutoCloseable {
         keepaliveExecutor.scheduleAtFixedRate(this::pingAllConnections,
                 PING_INTERVAL_SECS, PING_INTERVAL_SECS, java.util.concurrent.TimeUnit.SECONDS);
 
-        if (gossipsubEnabled) {
+        if (gossipsubEnabled && gossipTopicSubscriptionEnabled) {
             subscribeLightClientGossipTopics();
         }
     }
@@ -521,8 +544,8 @@ public class BeaconP2PService implements AutoCloseable {
      * (Lighthouse-style application codes &ge; 128, plus spec's FaultError
      * (3) and ClientShutdown (1) where reconnecting doesn't help). For the
      * spec's IrrelevantNetwork (2) we do <em>not</em> cooldown: that's a
-     * static-capability mismatch (we don't advertise gossipsub, so we stay
-     * "irrelevant" until we subscribe), and cooldowning locks us out of
+     * static-capability mismatch (a fork-digest or network disagreement in
+     * Status that re-dialing cannot change), and cooldowning locks us out of
      * every peer at once without reducing abuse — the peer already decided
      * based on Identify, they won't be angrier if we re-dial.
      */

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/libp2p/BeaconP2PService.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/libp2p/BeaconP2PService.java
@@ -31,6 +31,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -209,6 +210,9 @@ public class BeaconP2PService implements AutoCloseable {
      */
     private boolean gossipTopicSubscriptionEnabled = false;
 
+    /** Topics {@link #subscribeLightClientGossipTopics()} joined; empty unless the topic switch is on. */
+    private final Set<String> subscribedGossipTopics = ConcurrentHashMap.newKeySet();
+
     /** Toggle topic subscription (requires gossipsub). Must be called before {@link #start()}. */
     public void setGossipTopicSubscriptionEnabled(boolean enabled) {
         if (host != null) {
@@ -273,13 +277,14 @@ public class BeaconP2PService implements AutoCloseable {
      * Start the underlying libp2p host and register light client protocol handlers.
      */
     public void start() {
-        // Observation-only gossipsub: installed so we appear as a mesh-
-        // capable peer in Identify, subscribe to light-client topics and
-        // log messages without propagating them. PR 1 of the gossipsub
-        // rollout plan (see plan-gossipsub-subscription.md).
-        //
-        // Gated off by default — mesh participation is net-negative for
-        // short-session clients (see commit message / gossipsub plan).
+        if (gossipTopicSubscriptionEnabled && !gossipsubEnabled) {
+            throw new IllegalStateException(
+                    "gossip topic subscription requires gossipsub (setGossipsubEnabled(true))");
+        }
+        // Gossipsub is registered so the /meshsub/ protocol negotiates (see the
+        // `gossip` field doc: Lighthouse fatally bans peers that lack it). Topic
+        // subscription is a separate switch, off by default — PR 1 of the
+        // gossipsub rollout plan (plan-gossipsub-subscription.md) is on hold.
         HostBuilder hostBuilder = new HostBuilder()
                 .transport(TcpTransport::new)
                 .secureChannel((key, muxers) -> new NoiseXXSecureChannel(key, muxers))
@@ -426,6 +431,8 @@ public class BeaconP2PService implements AutoCloseable {
                     msg -> handleGossipMessage(optimisticTopic, msg);
             gossip.subscribe(finalityFn, new io.libp2p.core.pubsub.Topic(finalityTopic));
             gossip.subscribe(optimisticFn, new io.libp2p.core.pubsub.Topic(optimisticTopic));
+            subscribedGossipTopics.add(finalityTopic);
+            subscribedGossipTopics.add(optimisticTopic);
             log.info("[beacon-p2p] gossipsub subscribed (observation-only) to: {} and {}",
                     finalityTopic, optimisticTopic);
         } catch (Exception e) {
@@ -764,6 +771,59 @@ public class BeaconP2PService implements AutoCloseable {
     // -------------------------------------------------------------------------
     // Public API
     // -------------------------------------------------------------------------
+
+    /**
+     * Diagnostic: open one stream to a peer negotiating exactly {@code protocolId}.
+     * Completes with the negotiated id, or fails when the peer does not speak it —
+     * the same multistream-select outcome a remote Lighthouse gets when it opens
+     * its {@code /meshsub/} stream toward us.
+     */
+    public CompletableFuture<String> probeProtocol(String peerMultiaddr, String protocolId) {
+        Host h = host;
+        if (h == null) return Futures.failedFuture(new IllegalStateException("not started"));
+        Multiaddr peerAddr;
+        PeerId peerId;
+        try {
+            peerAddr = new Multiaddr(peerMultiaddr);
+            peerId = peerAddr.getPeerId();
+        } catch (Exception e) {
+            return Futures.failedFuture(e);
+        }
+        if (peerId == null) return Futures.failedFuture(new IllegalArgumentException("no peer id"));
+        ProtocolBinding<String> probe = new ProtocolBinding<>() {
+            @Override
+            public ProtocolDescriptor getProtocolDescriptor() {
+                return new ProtocolDescriptor(protocolId);
+            }
+
+            @Override
+            public CompletableFuture<String> initChannel(P2PChannel channel, String negotiatedProtocol) {
+                channel.close();
+                return CompletableFuture.completedFuture(negotiatedProtocol);
+            }
+        };
+        return findOrConnect(h, peerId, peerAddr)
+                .thenCompose(conn -> conn.muxerSession().createStream(probe).getController());
+    }
+
+    /** Gossip topics this host has joined (empty unless topic subscription is enabled). */
+    public Set<String> subscribedGossipTopics() {
+        return Set.copyOf(subscribedGossipTopics);
+    }
+
+    /**
+     * Our dialable listen multiaddrs, {@code /p2p/<peerId>} included; empty
+     * before {@link #start()}. Loopback tests dial these.
+     */
+    public List<String> listenAddresses() {
+        Host h = host;
+        if (h == null) return List.of();
+        String suffix = "/p2p/" + h.getPeerId();
+        return h.listenAddresses().stream()
+                .map(Object::toString)
+                .map(a -> a.contains("/p2p/") ? a : a + suffix)
+                .toList();
+    }
 
     /** Info about a connected CL peer. */
     public record PeerInfo(String peerId, String remoteAddress, List<String> protocols, String agentVersion) {

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/libp2p/BeaconP2PService.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/libp2p/BeaconP2PService.java
@@ -198,6 +198,14 @@ public class BeaconP2PService implements AutoCloseable {
     private io.libp2p.pubsub.gossip.Gossip gossip;
 
     /**
+     * The gossip router's event/heartbeat executor. Owned here because
+     * jvm-libp2p's default {@code GossipRouterBuilder} creates one per router
+     * and exposes no shutdown, and this service is restarted in place on every
+     * pause/resume — an unowned executor would strand one thread per cycle.
+     */
+    private java.util.concurrent.ScheduledExecutorService gossipExecutor;
+
+    /**
      * Whether to also SUBSCRIBE to the light-client gossip topics. Off by
      * default — see the {@link #gossip} field doc. No host enables it yet; it
      * stays as the hook for the live-finality plan (plan-gossipsub-subscription.md).
@@ -275,7 +283,15 @@ public class BeaconP2PService implements AutoCloseable {
                 .listen("/ip4/0.0.0.0/tcp/0") // ephemeral port; some peers reject dial-only hosts
                 // Ethereum CL spec requires secp256k1 identity keys
                 .builderModifier(b -> b.getIdentity().random(KeyType.SECP256K1));
-        gossip = new io.libp2p.pubsub.gossip.Gossip();
+        gossipExecutor = java.util.concurrent.Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "beacon-gossip-router");
+            t.setDaemon(true);
+            return t;
+        });
+        io.libp2p.pubsub.gossip.builders.GossipRouterBuilder routerBuilder =
+                new io.libp2p.pubsub.gossip.builders.GossipRouterBuilder();
+        routerBuilder.setScheduledAsyncExecutor(gossipExecutor);
+        gossip = new io.libp2p.pubsub.gossip.Gossip(routerBuilder.build());
         hostBuilder.protocol(gossip);
         host = hostBuilder.build();
 
@@ -447,6 +463,12 @@ public class BeaconP2PService implements AutoCloseable {
             keepaliveExecutor.shutdownNow();
             keepaliveExecutor = null;
         }
+        if (gossipExecutor != null) {
+            gossipExecutor.shutdownNow();
+            gossipExecutor = null;
+        }
+        gossip = null;
+        subscribedGossipTopics.clear();
         Host h = host;
         // Null the reference so a close→start cycle (BeaconLightClient pause/resume)
         // gets a fresh host, double-close is a no-op, and doReqResp/getConnectedPeers

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/libp2p/BeaconP2PService.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/libp2p/BeaconP2PService.java
@@ -182,16 +182,14 @@ public class BeaconP2PService implements AutoCloseable {
     private static final long PING_INTERVAL_SECS = 15;
 
     /**
-     * Gossipsub instance. Observation-only: handler logs incoming messages
-     * and always returns {@code Ignore}. Only created when
-     * {@link #gossipsubEnabled} is true. Every host now enables it: Lighthouse
-     * reports a peer whose {@code /meshsub/} negotiation fails as
-     * {@code PeerAction::Fatal} ("does_not_support_gossipsub"), which bans the
-     * peer id for 12 h after one connection and bans the IP once more than five
-     * of its peer ids are banned — a req/resp-only client got exactly one
-     * connection per Lighthouse node per start. Registering the protocol is
-     * what the check needs, so that is all {@link #gossipsubEnabled} does;
-     * joining the light-client topics is a separate, off-by-default switch
+     * Gossipsub instance, always registered so the {@code /meshsub/} protocol
+     * negotiates on every connection. Lighthouse reports a peer whose
+     * negotiation fails as {@code PeerAction::Fatal} ("does_not_support_gossipsub"),
+     * which bans the peer id for 12 h after one connection and bans the IP once
+     * more than five of its peer ids are banned — a req/resp-only client got
+     * exactly one connection per Lighthouse node per start. Registering the
+     * protocol is all that check needs. Joining the light-client topics is a
+     * separate, off-by-default switch
      * ({@link #setGossipTopicSubscriptionEnabled(boolean)}): a short-lived
      * wallet that joins a mesh and vanishes churns it for everyone else, the
      * jvm-libp2p default message id (from+seqno) collapses eth2's unsigned
@@ -199,34 +197,22 @@ public class BeaconP2PService implements AutoCloseable {
      */
     private io.libp2p.pubsub.gossip.Gossip gossip;
 
-    /** Off by default; call {@link #setGossipsubEnabled(boolean)} before {@link #start()}. */
-    private boolean gossipsubEnabled = false;
-
     /**
-     * Whether to also SUBSCRIBE to the light-client gossip topics once gossipsub
-     * is registered. Off by default — see the {@link #gossip} field doc. No host
-     * enables it yet; it stays as the hook for the live-finality plan
-     * (plan-gossipsub-subscription.md).
+     * Whether to also SUBSCRIBE to the light-client gossip topics. Off by
+     * default — see the {@link #gossip} field doc. No host enables it yet; it
+     * stays as the hook for the live-finality plan (plan-gossipsub-subscription.md).
      */
     private boolean gossipTopicSubscriptionEnabled = false;
 
     /** Topics {@link #subscribeLightClientGossipTopics()} joined; empty unless the topic switch is on. */
     private final Set<String> subscribedGossipTopics = ConcurrentHashMap.newKeySet();
 
-    /** Toggle topic subscription (requires gossipsub). Must be called before {@link #start()}. */
+    /** Toggle topic subscription. Must be called before {@link #start()}. */
     public void setGossipTopicSubscriptionEnabled(boolean enabled) {
         if (host != null) {
             throw new IllegalStateException("gossip topic flag cannot change after start()");
         }
         this.gossipTopicSubscriptionEnabled = enabled;
-    }
-
-    /** Toggle gossipsub subscription. Must be called before {@link #start()}. */
-    public void setGossipsubEnabled(boolean enabled) {
-        if (host != null) {
-            throw new IllegalStateException("gossipsub flag cannot change after start()");
-        }
-        this.gossipsubEnabled = enabled;
     }
 
     public BeaconP2PService() {
@@ -277,10 +263,6 @@ public class BeaconP2PService implements AutoCloseable {
      * Start the underlying libp2p host and register light client protocol handlers.
      */
     public void start() {
-        if (gossipTopicSubscriptionEnabled && !gossipsubEnabled) {
-            throw new IllegalStateException(
-                    "gossip topic subscription requires gossipsub (setGossipsubEnabled(true))");
-        }
         // Gossipsub is registered so the /meshsub/ protocol negotiates (see the
         // `gossip` field doc: Lighthouse fatally bans peers that lack it). Topic
         // subscription is a separate switch, off by default — PR 1 of the
@@ -293,10 +275,8 @@ public class BeaconP2PService implements AutoCloseable {
                 .listen("/ip4/0.0.0.0/tcp/0") // ephemeral port; some peers reject dial-only hosts
                 // Ethereum CL spec requires secp256k1 identity keys
                 .builderModifier(b -> b.getIdentity().random(KeyType.SECP256K1));
-        if (gossipsubEnabled) {
-            gossip = new io.libp2p.pubsub.gossip.Gossip();
-            hostBuilder.protocol(gossip);
-        }
+        gossip = new io.libp2p.pubsub.gossip.Gossip();
+        hostBuilder.protocol(gossip);
         host = hostBuilder.build();
 
         // Log connection events and auto-query Identify for protocol support
@@ -389,7 +369,7 @@ public class BeaconP2PService implements AutoCloseable {
         keepaliveExecutor.scheduleAtFixedRate(this::pingAllConnections,
                 PING_INTERVAL_SECS, PING_INTERVAL_SECS, java.util.concurrent.TimeUnit.SECONDS);
 
-        if (gossipsubEnabled && gossipTopicSubscriptionEnabled) {
+        if (gossipTopicSubscriptionEnabled) {
             subscribeLightClientGossipTopics();
         }
     }

--- a/consensus/src/test/java/com/jaeckel/ethp2p/consensus/libp2p/BeaconP2PServiceGossipsubTest.java
+++ b/consensus/src/test/java/com/jaeckel/ethp2p/consensus/libp2p/BeaconP2PServiceGossipsubTest.java
@@ -1,6 +1,7 @@
 package com.jaeckel.ethp2p.consensus.libp2p;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -9,10 +10,10 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
 /**
- * The Lighthouse-ban regression: a host with gossipsub enabled must negotiate a
- * {@code /meshsub/} stream opened toward it — that negotiation is what
- * Lighthouse's {@code does_not_support_gossipsub} Fatal report keys on — while
- * joining no light-client topic unless the separate topic switch is on.
+ * The Lighthouse-ban regression: every host must negotiate a {@code /meshsub/}
+ * stream opened toward it — that negotiation is what Lighthouse's
+ * {@code does_not_support_gossipsub} Fatal report keys on — while joining no
+ * light-client topic unless the separate topic switch is on.
  */
 class BeaconP2PServiceGossipsubTest {
 
@@ -29,37 +30,25 @@ class BeaconP2PServiceGossipsubTest {
     }
 
     @Test
-    void gossipsubNegotiatesMeshsubWithoutJoiningTopics() throws Exception {
-        BeaconP2PService withGossip = new BeaconP2PService(null);
-        withGossip.setGossipsubEnabled(true);
-        BeaconP2PService without = new BeaconP2PService(null);
+    void everyHostNegotiatesMeshsubWithoutJoiningTopics() throws Exception {
+        BeaconP2PService target = new BeaconP2PService(null);
         BeaconP2PService observer = new BeaconP2PService(null);
-        withGossip.start();
-        without.start();
+        target.start();
         observer.start();
         try {
-            String negotiated = observer.probeProtocol(loopbackAddress(withGossip), MESHSUB)
-                    .get(20, TimeUnit.SECONDS);
-            assertEquals(MESHSUB, negotiated);
-            assertTrue(withGossip.subscribedGossipTopics().isEmpty(),
+            String addr = loopbackAddress(target);
+            assertEquals(MESHSUB, observer.probeProtocol(addr, MESHSUB).get(20, TimeUnit.SECONDS));
+            assertTrue(target.subscribedGossipTopics().isEmpty(),
                     "protocol registration must not join any topic");
 
-            // Control: the same probe against a host without gossipsub must fail
-            // negotiation — exactly the outcome that used to earn the Fatal report.
+            // Control for the probe itself: a protocol nobody registered must fail
+            // negotiation — the outcome that used to earn the Fatal report.
             ExecutionException refused = assertThrows(ExecutionException.class, () ->
-                    observer.probeProtocol(loopbackAddress(without), MESHSUB).get(20, TimeUnit.SECONDS));
-            assertTrue(refused.getCause() != null, "negotiation failure must carry a cause");
+                    observer.probeProtocol(addr, "/meshsub/9.9.9").get(20, TimeUnit.SECONDS));
+            assertNotNull(refused.getCause(), "negotiation failure must carry a cause");
         } finally {
             observer.close();
-            without.close();
-            withGossip.close();
+            target.close();
         }
-    }
-
-    @Test
-    void topicSubscriptionWithoutGossipsubIsRefused() {
-        BeaconP2PService svc = new BeaconP2PService(null);
-        svc.setGossipTopicSubscriptionEnabled(true);
-        assertThrows(IllegalStateException.class, svc::start);
     }
 }

--- a/consensus/src/test/java/com/jaeckel/ethp2p/consensus/libp2p/BeaconP2PServiceGossipsubTest.java
+++ b/consensus/src/test/java/com/jaeckel/ethp2p/consensus/libp2p/BeaconP2PServiceGossipsubTest.java
@@ -1,0 +1,65 @@
+package com.jaeckel.ethp2p.consensus.libp2p;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The Lighthouse-ban regression: a host with gossipsub enabled must negotiate a
+ * {@code /meshsub/} stream opened toward it — that negotiation is what
+ * Lighthouse's {@code does_not_support_gossipsub} Fatal report keys on — while
+ * joining no light-client topic unless the separate topic switch is on.
+ */
+class BeaconP2PServiceGossipsubTest {
+
+    private static final String MESHSUB = "/meshsub/1.1.0";
+
+    private static String loopbackAddress(BeaconP2PService target) {
+        return target.listenAddresses().stream()
+                // jvm-libp2p reports the wildcard bind as /ip4/0.0.0.0/ or /ip6/::/;
+                // either one is reachable on loopback.
+                .map(a -> a.replace("/ip4/0.0.0.0/", "/ip4/127.0.0.1/").replace("/ip6/::/", "/ip4/127.0.0.1/"))
+                .filter(a -> a.startsWith("/ip4/127.0.0.1/"))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    @Test
+    void gossipsubNegotiatesMeshsubWithoutJoiningTopics() throws Exception {
+        BeaconP2PService withGossip = new BeaconP2PService(null);
+        withGossip.setGossipsubEnabled(true);
+        BeaconP2PService without = new BeaconP2PService(null);
+        BeaconP2PService observer = new BeaconP2PService(null);
+        withGossip.start();
+        without.start();
+        observer.start();
+        try {
+            String negotiated = observer.probeProtocol(loopbackAddress(withGossip), MESHSUB)
+                    .get(20, TimeUnit.SECONDS);
+            assertEquals(MESHSUB, negotiated);
+            assertTrue(withGossip.subscribedGossipTopics().isEmpty(),
+                    "protocol registration must not join any topic");
+
+            // Control: the same probe against a host without gossipsub must fail
+            // negotiation — exactly the outcome that used to earn the Fatal report.
+            ExecutionException refused = assertThrows(ExecutionException.class, () ->
+                    observer.probeProtocol(loopbackAddress(without), MESHSUB).get(20, TimeUnit.SECONDS));
+            assertTrue(refused.getCause() != null, "negotiation failure must carry a cause");
+        } finally {
+            observer.close();
+            without.close();
+            withGossip.close();
+        }
+    }
+
+    @Test
+    void topicSubscriptionWithoutGossipsubIsRefused() {
+        BeaconP2PService svc = new BeaconP2PService(null);
+        svc.setGossipTopicSubscriptionEnabled(true);
+        assertThrows(IllegalStateException.class, svc::start);
+    }
+}

--- a/consensus/src/test/java/com/jaeckel/ethp2p/consensus/libp2p/BeaconP2PServiceGossipsubTest.java
+++ b/consensus/src/test/java/com/jaeckel/ethp2p/consensus/libp2p/BeaconP2PServiceGossipsubTest.java
@@ -30,6 +30,26 @@ class BeaconP2PServiceGossipsubTest {
     }
 
     @Test
+    void restartCyclesLeaveNoGossipRouterThreadBehind() throws Exception {
+        BeaconP2PService svc = new BeaconP2PService(null);
+        for (int i = 0; i < 3; i++) {
+            svc.start();
+            assertTrue(gossipRouterThreads() >= 1, "router executor thread should exist while started");
+            svc.close();
+        }
+        // shutdownNow() interrupts the idle worker; give it a moment to exit.
+        long deadline = System.currentTimeMillis() + 5_000;
+        while (gossipRouterThreads() > 0 && System.currentTimeMillis() < deadline) Thread.sleep(50);
+        assertEquals(0, gossipRouterThreads(), "every close() must stop its gossip router executor");
+    }
+
+    private static long gossipRouterThreads() {
+        return Thread.getAllStackTraces().keySet().stream()
+                .filter(t -> t.isAlive() && t.getName().startsWith("beacon-gossip-router"))
+                .count();
+    }
+
+    @Test
     void everyHostNegotiatesMeshsubWithoutJoiningTopics() throws Exception {
         BeaconP2PService target = new BeaconP2PService(null);
         BeaconP2PService observer = new BeaconP2PService(null);

--- a/docs/disk-and-network-usage.md
+++ b/docs/disk-and-network-usage.md
@@ -348,7 +348,7 @@ order of magnitude.
 | Served-block window (`setServedBlockWindow`) | 32 (max 4096) | RAM (~500 B/header) and what we serve peers; not a big wire term. |
 | Idle pause (Android Settings) | 5 min | Everything → 0 while asleep. |
 | CL finality fan-out | 16 (32 hunting) | Multiplies per-slot CL response bytes. Compile-time today (`BeaconLightClient`). |
-| Gossipsub observation (`setGossipsubEnabled`) | **off** | When on, adds inbound finality/optimistic gossip per slot (observation-only). |
+| Gossip topic subscription (`BeaconP2PService.setGossipTopicSubscriptionEnabled`) | **off** | The gossipsub protocol itself is always negotiated (Lighthouse bans peers without it) at no traffic cost; joining the topics would add inbound finality/optimistic gossip per slot. |
 | Fee snapshot refresh / tip window | 12 s / 3 blocks | The body-warming term (§3.2) scales with refresh rate × window. |
 | Deep-pool threshold, dial budgets (`DNS_DIALS_PER_MIN` etc.) | see `ChainStack` | Discovery/dial churn traffic. |
 

--- a/docs/multichain-android-phase-b.md
+++ b/docs/multichain-android-phase-b.md
@@ -60,7 +60,7 @@ ChainStack stack = new ChainStack(net, ports, key,
         new AndroidPeerCacheAdapter(pc), new AndroidClPeerCacheAdapter(cl),
         new com.jaeckel.ethp2p.android.ens.AndroidCcipGateway(ccipPool),
         netCacheFor(n, "sync-state", ".snapshot").toPath(),
-        /*gossipsub*/ false);
+        /*gossipsub*/ true);
 stack.configureSnapMaintainer(snapTarget(this), this::activeNetworkDnsServers); // DnsServerProvider
 stacks.put(n, stack);
 new Thread(() -> { if (!stack.start()) stacks.remove(n); }, "ethp2p-boot-" + n).start();

--- a/docs/multichain-android-phase-b.md
+++ b/docs/multichain-android-phase-b.md
@@ -59,8 +59,7 @@ AndroidCLPeerCache cl = new AndroidCLPeerCache(netCacheFor(n, "cl-peers", ".cach
 ChainStack stack = new ChainStack(net, ports, key,
         new AndroidPeerCacheAdapter(pc), new AndroidClPeerCacheAdapter(cl),
         new com.jaeckel.ethp2p.android.ens.AndroidCcipGateway(ccipPool),
-        netCacheFor(n, "sync-state", ".snapshot").toPath(),
-        /*gossipsub*/ true);
+        netCacheFor(n, "sync-state", ".snapshot").toPath());
 stack.configureSnapMaintainer(snapTarget(this), this::activeNetworkDnsServers); // DnsServerProvider
 stacks.put(n, stack);
 new Thread(() -> { if (!stack.start()) stacks.remove(n); }, "ethp2p-boot-" + n).start();

--- a/docs/reimplementation/01-consensus-light-client.md
+++ b/docs/reimplementation/01-consensus-light-client.md
@@ -423,11 +423,15 @@ Accept the current digest plus the prior-fork digest (eases fork-transition wind
 
 ### 10.6 What is stubbed (flag for any port)
 
-- **Gossipsub is OFF by default and observation-only**: it subscribes to the
-  `light_client_finality_update` / `light_client_optimistic_update` topics, but the handler just
-  logs and returns `Ignore` — **no snappy decode, no SSZ decode, no validation, no message-id, no
-  mesh forwarding**. A real implementation that relied on gossip for liveness would need all of
-  that, plus fork-change resubscribe. The reference relies on req/resp polling instead.
+- **Gossipsub is always negotiated but never used for data.** The `/meshsub/` protocol must be
+  registered on every connection: Lighthouse reports a peer whose gossipsub negotiation fails as
+  `PeerAction::Fatal` ("does_not_support_gossipsub"), bans the peer id for 12 h, and bans the IP
+  once more than five of its peer ids are banned. Registering the protocol is all that check
+  needs. Topic subscription is a separate switch, OFF by default and observation-only: when on it
+  subscribes to the `light_client_finality_update` / `light_client_optimistic_update` topics, but
+  the handler just logs and returns `Ignore` — **no snappy decode, no SSZ decode, no validation,
+  no message-id, no mesh forwarding**. A real implementation that relied on gossip for liveness
+  would need all of that, plus fork-change resubscribe. The reference relies on req/resp polling.
 - `light_client_updates_by_range` / `beacon_blocks_by_range` **responders are absent** (the client
   can initiate, not serve; deliberately not advertised in Identify).
 - Metadata responder is hardcoded (seq 0, all-zero attnets/syncnets); finality/optimistic/bootstrap

--- a/docs/reimplementation/04-engine-and-hosts.md
+++ b/docs/reimplementation/04-engine-and-hosts.md
@@ -48,7 +48,7 @@ Constructed with everything platform-specific **injected**:
 ```
 ChainStack(NetworkConfig network, ChainPorts ports, NodeKey nodeKey,
            PeerCache peerCache, ClPeerCache clPeerCache, CcipGateway ccipGateway,
-           Path syncSnapshotFile, bool gossipsubEnabled)
+           Path syncSnapshotFile)
 ```
 
 Owns, on its own ports & identity: the RLPx connector, discv4, discv5, the beacon light client +
@@ -74,7 +74,7 @@ snap-peer maintainer.
 3. discv4.start(elPort)  — EL is ESSENTIAL: a bind failure throws and fails the stack.
 4. BeaconSyncState; then discv5 (CL discovery — NON-essential: a failure logs and continues)
    + BeaconLightClient (checkpoint root/slot, fork version, gvr, CL-peer-cache wiring via
-   method refs, sync snapshot file, gossipsub flag); blc.start().
+   method refs, sync snapshot file); blc.start().
 5. Verified JSON-RPC (best-effort — a bind failure does NOT fail the stack): up-front loopback
    bind probe, build VerifiedRpcBackend, start MyotisRpcServer on 127.0.0.1:rpcPort.
 6. Snap-peer maintainer (optional; daemon/mobile enable it): a 10s loop keeping
@@ -322,8 +322,7 @@ re-implementation as the reference desktop host (mobile hosts replace this with 
 
 ### 4.1 Daemon vs client mode
 
-- Parse `--network <csv>` (host several networks in one process), `--port`, `--[no-]gossipsub`
-  (on by default), and a
+- Parse `--network <csv>` (host several networks in one process), `--port`, and a
   remaining command.
 - A command token + a *running* daemon → **client mode**: connect to the network's socket, send one
   JSON line, print responses, exit.

--- a/docs/reimplementation/04-engine-and-hosts.md
+++ b/docs/reimplementation/04-engine-and-hosts.md
@@ -322,7 +322,8 @@ re-implementation as the reference desktop host (mobile hosts replace this with 
 
 ### 4.1 Daemon vs client mode
 
-- Parse `--network <csv>` (host several networks in one process), `--port`, `--gossipsub`, and a
+- Parse `--network <csv>` (host several networks in one process), `--port`, `--[no-]gossipsub`
+  (on by default), and a
   remaining command.
 - A command token + a *running* daemon → **client mode**: connect to the network's socket, send one
   JSON line, print responses, exit.

--- a/docs/reimplementation/README.md
+++ b/docs/reimplementation/README.md
@@ -314,7 +314,7 @@ hashes/addresses as bytes on the read API and 0x-hex strings in result records.
   throw; programmer/state errors (malformed address, network not running) DO throw the
   API's single `EngineException`.
 - **`EngineConfig`** — `(networkName, elPort, discv5Port, rpcPort [0 = per-network
-  default], syncSnapshotPath, gossipsubEnabled, targetSnapPeers [0 = maintainer off],
+  default], syncSnapshotPath, targetSnapPeers [0 = maintainer off],
   strictStateFreshness)`.
 - **Status**: `status() -> StatusSnapshot` (EL + beacon counts, per-peer rows),
   `discoveredPeers()`, `connectedPeers()`, `beaconStatus() -> BeaconStatus` (deep CL

--- a/myotis-api/src/main/java/io/myotis/api/EngineConfig.java
+++ b/myotis-api/src/main/java/io/myotis/api/EngineConfig.java
@@ -11,8 +11,11 @@ package io.myotis.api;
  * @param rpcPort              verified JSON-RPC HTTP port (loopback); 0 → the network's default
  * @param syncSnapshotPath     file path for the light-client sync snapshot (a private
  *                             cache, not a trust anchor); null → no snapshot persistence
- * @param gossipsubEnabled     subscribe to CL gossipsub (live finality updates) in
- *                             addition to polling
+ * @param gossipsubEnabled     register the gossipsub protocol on the CL libp2p host
+ *                             (no topic subscriptions). Hosts enable it: Lighthouse
+ *                             fatally bans a peer whose /meshsub/ negotiation fails.
+ *                             The Java engine honours it; the Rust engine always
+ *                             negotiates gossipsub and ignores the flag
  * @param targetSnapPeers      snap-peer maintainer target; 0 → maintainer disabled
  *                             (bare daemons rely on continuous discv4; NAT'd/mobile
  *                             hosts should enable it)

--- a/myotis-api/src/main/java/io/myotis/api/EngineConfig.java
+++ b/myotis-api/src/main/java/io/myotis/api/EngineConfig.java
@@ -11,11 +11,6 @@ package io.myotis.api;
  * @param rpcPort              verified JSON-RPC HTTP port (loopback); 0 → the network's default
  * @param syncSnapshotPath     file path for the light-client sync snapshot (a private
  *                             cache, not a trust anchor); null → no snapshot persistence
- * @param gossipsubEnabled     register the gossipsub protocol on the CL libp2p host
- *                             (no topic subscriptions). Hosts enable it: Lighthouse
- *                             fatally bans a peer whose /meshsub/ negotiation fails.
- *                             The Java engine honours it; the Rust engine always
- *                             negotiates gossipsub and ignores the flag
  * @param targetSnapPeers      snap-peer maintainer target; 0 → maintainer disabled
  *                             (bare daemons rely on continuous discv4; NAT'd/mobile
  *                             hosts should enable it)
@@ -33,7 +28,6 @@ public record EngineConfig(
         int discv5Port,
         int rpcPort,
         String syncSnapshotPath,
-        boolean gossipsubEnabled,
         int targetSnapPeers,
         boolean strictStateFreshness,
         String dataDir) {

--- a/myotis-engines/src/test/java/io/myotis/engines/RustCatalogParityTest.java
+++ b/myotis-engines/src/test/java/io/myotis/engines/RustCatalogParityTest.java
@@ -63,7 +63,7 @@ class RustCatalogParityTest {
         // raising a named EngineException (auto mode falls back to Java).
         RustMyotisEngine rust = new RustMyotisEngine();
         EngineConfig cfg = new EngineConfig(
-                "not-a-real-network", 0, 0, 0, null, false, 0, true, "/tmp/myotis-test");
+                "not-a-real-network", 0, 0, 0, null, 0, true, "/tmp/myotis-test");
         EngineException e = assertThrows(EngineException.class,
                 () -> rust.create(cfg, null));
         org.junit.jupiter.api.Assertions.assertTrue(

--- a/myotis-engines/src/test/java/io/myotis/engines/RustStatusJsonTest.java
+++ b/myotis-engines/src/test/java/io/myotis/engines/RustStatusJsonTest.java
@@ -321,7 +321,7 @@ class RustStatusJsonTest {
                 "libmyotis_engine not on java.library.path — skipping live JNI status test");
         RustMyotisEngine rust = new RustMyotisEngine();
         EngineConfig cfg = new EngineConfig(
-                "mainnet", 0, 0, 0, null, false, 0, true, "/tmp/myotis-r1-test");
+                "mainnet", 0, 0, 0, null, 0, true, "/tmp/myotis-r1-test");
         var handle = rust.create(cfg, null);
         try {
             // A created-but-not-started handle reports not-running / STARTING.

--- a/myotis-engines/src/test/java/io/myotis/engines/SelectorEngineTest.java
+++ b/myotis-engines/src/test/java/io/myotis/engines/SelectorEngineTest.java
@@ -80,7 +80,7 @@ class SelectorEngineTest {
 
     private static EngineConfig config(String network) {
         // Non-default ports so a create-only test can't collide with a live daemon.
-        return new EngineConfig(network, 42303, 42900, 42545, null, false, 0, true, null);
+        return new EngineConfig(network, 42303, 42900, 42545, null, 0, true, null);
     }
 
     @Test

--- a/node-core/src/main/java/io/myotis/node/ChainStack.java
+++ b/node-core/src/main/java/io/myotis/node/ChainStack.java
@@ -117,7 +117,6 @@ public final class ChainStack implements io.myotis.api.NodeLifecycle {
     private final ClPeerCachePort clPeerCache;
     private final io.myotis.evm.ccipread.CcipGateway ccipGateway;
     private final Path syncSnapshotFile;
-    private final boolean gossipsubEnabled;
 
     // -- per-stack mutable state (formerly Main/NodeService singletons) ---------
     private final Set<String> attempted = ConcurrentHashMap.newKeySet();
@@ -190,8 +189,7 @@ public final class ChainStack implements io.myotis.api.NodeLifecycle {
                       PeerCachePort peerCache,
                       ClPeerCachePort clPeerCache,
                       io.myotis.evm.ccipread.CcipGateway ccipGateway,
-                      Path syncSnapshotFile,
-                      boolean gossipsubEnabled) {
+                      Path syncSnapshotFile) {
         this.network = network;
         this.ports = ports;
         this.nodeKey = nodeKey;
@@ -199,7 +197,6 @@ public final class ChainStack implements io.myotis.api.NodeLifecycle {
         this.clPeerCache = clPeerCache;
         this.ccipGateway = ccipGateway;
         this.syncSnapshotFile = syncSnapshotFile;
-        this.gossipsubEnabled = gossipsubEnabled;
         this.wakeGate = new WakeGate(phase::get, this::readyForReads,
                 () -> resume(io.myotis.api.WakeReason.REQUEST),
                 System::currentTimeMillis, WAKE_POLL_MS, "wake-resume-" + network.name());
@@ -991,7 +988,6 @@ public final class ChainStack implements io.myotis.api.NodeLifecycle {
         blc.setProvenNonLightClient(clPeerCache.lightClientDenied());
         blc.setOnLightClientVerdict(clPeerCache::markLightClientBatch);
         blc.setSnapshotFile(syncSnapshotFile);
-        blc.setGossipsubEnabled(gossipsubEnabled);
         // Weak-subjectivity anchor-age bound: network default + any host override,
         // plus a pre-start stale-anchor consent — all must land before start() so
         // the cold-start gate judges with them.

--- a/node-core/src/main/java/io/myotis/node/api/JavaMyotisEngine.java
+++ b/node-core/src/main/java/io/myotis/node/api/JavaMyotisEngine.java
@@ -96,8 +96,7 @@ public final class JavaMyotisEngine implements MyotisEngine {
                 ports.httpGateway() != null
                         ? PortBridges.toCcipGateway(ports.httpGateway(), httpExecutor)
                         : null,
-                config.syncSnapshotPath() != null ? Paths.get(config.syncSnapshotPath()) : null,
-                config.gossipsubEnabled());
+                config.syncSnapshotPath() != null ? Paths.get(config.syncSnapshotPath()) : null);
         if (config.targetSnapPeers() > 0) {
             stack.configureSnapMaintainer(config.targetSnapPeers(),
                     PortBridges.toDnsServerProvider(ports.dnsServers()));

--- a/node-core/src/test/java/io/myotis/node/api/JavaMyotisEngineTest.java
+++ b/node-core/src/test/java/io/myotis/node/api/JavaMyotisEngineTest.java
@@ -66,7 +66,7 @@ class JavaMyotisEngineTest {
     void createDefaultsPortsGeneratesKeyAndRegisters() {
         JavaMyotisEngine engine = new JavaMyotisEngine();
         MemoryKeyStore keyStore = new MemoryKeyStore();
-        EngineConfig config = new EngineConfig("gnosis", 0, 0, 0, null, false, 0, true, null);
+        EngineConfig config = new EngineConfig("gnosis", 0, 0, 0, null, 0, true, null);
 
         ChainHandle handle = engine.create(config, testPorts(keyStore));
         assertNotNull(handle);
@@ -91,7 +91,7 @@ class JavaMyotisEngineTest {
     @Test
     void lifecycleSurfaceOnNeverStartedHandle() {
         JavaMyotisEngine engine = new JavaMyotisEngine();
-        EngineConfig config = new EngineConfig("gnosis", 0, 0, 0, null, false, 0, true, null);
+        EngineConfig config = new EngineConfig("gnosis", 0, 0, 0, null, 0, true, null);
         ChainHandle handle = engine.create(config, testPorts(new MemoryKeyStore()));
 
         assertEquals(io.myotis.api.LifecycleState.STOPPED, handle.lifecycle());
@@ -130,7 +130,7 @@ class JavaMyotisEngineTest {
         secret[31] = 1; // valid non-zero scalar
         keyStore.keys.put("sepolia", secret.clone());
 
-        engine.create(new EngineConfig("sepolia", 0, 0, 0, null, false, 0, true, null),
+        engine.create(new EngineConfig("sepolia", 0, 0, 0, null, 0, true, null),
                 testPorts(keyStore));
         // The stored key was used, not overwritten.
         assertEquals(1, keyStore.keys.get("sepolia")[31]);
@@ -143,7 +143,7 @@ class JavaMyotisEngineTest {
         MemoryKeyStore keyStore = new MemoryKeyStore();
         keyStore.keys.put("mainnet", new byte[16]); // wrong length
         assertThrows(EngineException.class, () ->
-                engine.create(new EngineConfig("mainnet", 0, 0, 0, null, false, 0, true, null),
+                engine.create(new EngineConfig("mainnet", 0, 0, 0, null, 0, true, null),
                         testPorts(keyStore)));
     }
 }

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -813,6 +813,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2320,6 +2332,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2787,6 +2809,15 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -2813,6 +2844,15 @@ dependencies = [
  "foldhash 0.2.0",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -2868,6 +2908,12 @@ checksum = "830e599c2904b08f0834ee6337d8fe8f0ed4a63b5d9e7a7f49c0ffa06d08d360"
 dependencies = [
  "arrayvec",
 ]
+
+[[package]]
+name = "hex_fmt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
 
 [[package]]
 name = "hickory-proto"
@@ -3560,6 +3606,7 @@ dependencies = [
  "libp2p-connection-limits",
  "libp2p-core",
  "libp2p-dns",
+ "libp2p-gossipsub",
  "libp2p-identify",
  "libp2p-identity",
  "libp2p-mdns",
@@ -3641,6 +3688,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "libp2p-gossipsub"
+version = "0.49.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3573f3d8e30bd62cda336df5c7c1041a1caa40a648376b8e1e274d585c0ed25c"
+dependencies = [
+ "async-channel",
+ "asynchronous-codec",
+ "base64",
+ "byteorder",
+ "bytes",
+ "either",
+ "fnv",
+ "futures",
+ "futures-timer",
+ "getrandom 0.2.17",
+ "hashlink 0.9.1",
+ "hex_fmt",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "quick-protobuf",
+ "quick-protobuf-codec",
+ "rand 0.8.6",
+ "regex",
+ "sha2",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
 name = "libp2p-identify"
 version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3708,6 +3785,7 @@ checksum = "805a555148522cb3414493a5153451910cb1a146c53ffbf4385708349baf62b7"
 dependencies = [
  "futures",
  "libp2p-core",
+ "libp2p-gossipsub",
  "libp2p-identify",
  "libp2p-identity",
  "libp2p-swarm",

--- a/rust/myotis-net/Cargo.toml
+++ b/rust/myotis-net/Cargo.toml
@@ -22,7 +22,7 @@ myotis-evm = { path = "../myotis-evm" }
 # discv5 packet format). Cargo.lock would pin them anyway; the `=` makes the
 # intent explicit and survives lockfile regeneration.
 tokio = { version = "=1.52.3", features = ["rt-multi-thread", "macros", "time", "sync", "signal", "net", "io-util"] }
-libp2p = { version = "=0.56.0", features = ["tokio", "tcp", "dns", "noise", "yamux", "identify", "request-response", "secp256k1", "macros"] }
+libp2p = { version = "=0.56.0", features = ["tokio", "tcp", "dns", "noise", "yamux", "identify", "request-response", "gossipsub", "secp256k1", "macros"] }
 discv5 = "=0.11.0"
 snap = "=1.1.1"
 tracing = "=0.1.44"

--- a/rust/myotis-net/src/reqresp.rs
+++ b/rust/myotis-net/src/reqresp.rs
@@ -1903,6 +1903,62 @@ mod dial_resolution_tests {
         std::sync::Mutex::new(HashMap::new())
     }
 
+    /// The Lighthouse-ban regression: a peer that has subscriptions to announce
+    /// (Lighthouse always does) opens a `/meshsub/` stream toward us right after
+    /// the connection is established. If our swarm cannot negotiate it, that
+    /// peer's gossipsub emits `GossipsubNotSupported` — which Lighthouse turns
+    /// into `PeerAction::Fatal` and a 12 h ban. Here peer A plays Lighthouse
+    /// (subscribed), peer B is our wallet host (no subscriptions), and the
+    /// negotiation must complete with B recorded as a gossipsub peer.
+    #[tokio::test]
+    async fn meshsub_negotiates_without_any_subscription() {
+        let mut a = build_swarm(libp2p::identity::Keypair::generate_secp256k1(), false, None, false)
+            .expect("swarm a");
+        let mut b = build_swarm(libp2p::identity::Keypair::generate_secp256k1(), false, None, false)
+            .expect("swarm b");
+        b.listen_on("/ip4/127.0.0.1/tcp/0".parse().unwrap()).unwrap();
+        let addr = loop {
+            if let SwarmEvent::NewListenAddr { address, .. } = b.select_next_some().await {
+                break address;
+            }
+        };
+        a.behaviour_mut()
+            .gossipsub
+            .subscribe(&gossipsub::IdentTopic::new(
+                "/eth2/00000000/light_client_finality_update/ssz_snappy",
+            ))
+            .unwrap();
+        a.dial(addr).unwrap();
+        let b_id = *b.local_peer_id();
+        let deadline = tokio::time::sleep(Duration::from_secs(15));
+        tokio::pin!(deadline);
+        loop {
+            tokio::select! {
+                ev = a.select_next_some() => {
+                    if let SwarmEvent::Behaviour(BehaviourEvent::Gossipsub(
+                        gossipsub::Event::GossipsubNotSupported { peer_id },
+                    )) = &ev
+                    {
+                        panic!("peer {peer_id} failed /meshsub/ negotiation — this is the Lighthouse ban");
+                    }
+                    // `peer_protocol` starts every peer as Floodsub and moves it to a
+                    // Gossipsub* kind once the stream negotiated (or NotSupported).
+                    if let Some((_, kind)) =
+                        a.behaviour().gossipsub.peer_protocol().find(|(p, _)| **p == b_id)
+                    {
+                        let kind = format!("{kind:?}");
+                        assert_ne!(kind, "NotSupported");
+                        if kind.starts_with("Gossipsub") {
+                            return;
+                        }
+                    }
+                }
+                _ = b.select_next_some() => {}
+                _ = &mut deadline => panic!("no /meshsub/ negotiation within 15 s"),
+            }
+        }
+    }
+
     #[tokio::test]
     async fn a_plain_ip_address_passes_through_untouched() {
         let a: Multiaddr = "/ip4/87.154.209.161/tcp/9105/p2p/\

--- a/rust/myotis-net/src/reqresp.rs
+++ b/rust/myotis-net/src/reqresp.rs
@@ -25,7 +25,7 @@ use libp2p::identify;
 use libp2p::request_response::{self, InboundRequestId, OutboundRequestId, ProtocolSupport};
 use libp2p::connection_limits::{self, ConnectionLimits};
 use libp2p::swarm::{NetworkBehaviour, SwarmEvent};
-use libp2p::{Multiaddr, PeerId, StreamProtocol, Swarm};
+use libp2p::{gossipsub, Multiaddr, PeerId, StreamProtocol, Swarm};
 use tokio::sync::{mpsc, oneshot};
 
 use crate::codec;
@@ -278,6 +278,16 @@ pub struct Behaviour {
     // established connections so a peer flood can't exhaust fds/memory.
     pub limits: connection_limits::Behaviour,
     pub identify: identify::Behaviour,
+    /// Gossipsub with NO subscriptions. It exists so the `/meshsub/` protocol
+    /// negotiates on every connection: Lighthouse (v8.1.3–v8.2.2 verified in
+    /// `lighthouse_network/src/service/mod.rs`) reports a peer whose gossipsub
+    /// upgrade fails with `PeerAction::Fatal` ("does_not_support_gossipsub"),
+    /// which bans the peer id for 12 h after ONE goodbye (reason 0) and bans
+    /// the whole IP once more than five of its peer ids are banned. A wallet
+    /// therefore got exactly one first-contact connection per Lighthouse
+    /// node per start, and the IP ban after a handful of restarts. Negotiating
+    /// the protocol is all the check needs; the mesh is never joined.
+    pub gossipsub: gossipsub::Behaviour,
     pub status_v2: RR,
     pub status_v1: RR,
     pub ping: RR,
@@ -311,6 +321,17 @@ impl Behaviour {
                 identify::Config::new("eth2/1.0.0".into(), local_public_key)
                     .with_agent_version(concat!("myotis/", env!("CARGO_PKG_VERSION"), "-rs").into()),
             ),
+            // Anonymous on both sides matches the eth2 wire (StrictNoSign:
+            // messages carry no signature, key or seqno); nothing is ever
+            // published or subscribed, so this only shapes the handshake.
+            gossipsub: gossipsub::Behaviour::new(
+                gossipsub::MessageAuthenticity::Anonymous,
+                gossipsub::ConfigBuilder::default()
+                    .validation_mode(gossipsub::ValidationMode::Anonymous)
+                    .build()
+                    .expect("static gossipsub config"),
+            )
+            .expect("static gossipsub behaviour"),
             status_v2: rr(protocols::STATUS_V2, ProtocolSupport::Full, RESP_TIMEOUT),
             status_v1: rr(protocols::STATUS_V1, ProtocolSupport::Full, RESP_TIMEOUT),
             ping: rr(protocols::PING, ProtocolSupport::Full, RESP_TIMEOUT),
@@ -1289,6 +1310,9 @@ fn handle_behaviour_event(swarm: &mut Swarm<Behaviour>, ctx: &mut SwarmCtx, even
                 protocols = info.protocols.len(), lc_updates = lc, "identify received");
         }
         E::Identify(_) => {}
+        // No subscriptions, so the only events are peers' subscription
+        // announcements and unsupported-protocol notices; none needs handling.
+        E::Gossipsub(_) => {}
         E::StatusV2(ev) => on_rr_event(swarm, ctx, protocols::STATUS_V2, ev),
         E::StatusV1(ev) => on_rr_event(swarm, ctx, protocols::STATUS_V1, ev),
         E::Ping(ev) => on_rr_event(swarm, ctx, protocols::PING, ev),

--- a/rust/roost/Cargo.lock
+++ b/rust/roost/Cargo.lock
@@ -639,6 +639,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4858a9d740c5007a9069007c3b4e91152d0506f13c1b31dd49051fd537656156"
 
 [[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-io"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1616,6 +1628,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
+dependencies = [
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fastbloom"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1961,6 +1993,15 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1987,6 +2028,15 @@ dependencies = [
  "foldhash 0.2.0",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -2042,6 +2092,12 @@ checksum = "35431185f361ccf3ffc58254628af5f1f5d5f28531da2e02e5d6c82bbc282a10"
 dependencies = [
  "arrayvec",
 ]
+
+[[package]]
+name = "hex_fmt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
 
 [[package]]
 name = "hickory-proto"
@@ -2609,6 +2665,7 @@ dependencies = [
  "libp2p-connection-limits",
  "libp2p-core",
  "libp2p-dns",
+ "libp2p-gossipsub",
  "libp2p-identify",
  "libp2p-identity",
  "libp2p-mdns",
@@ -2690,6 +2747,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "libp2p-gossipsub"
+version = "0.49.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3573f3d8e30bd62cda336df5c7c1041a1caa40a648376b8e1e274d585c0ed25c"
+dependencies = [
+ "async-channel",
+ "asynchronous-codec",
+ "base64",
+ "byteorder",
+ "bytes",
+ "either",
+ "fnv",
+ "futures",
+ "futures-timer",
+ "getrandom 0.2.17",
+ "hashlink 0.9.1",
+ "hex_fmt",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "quick-protobuf",
+ "quick-protobuf-codec",
+ "rand 0.8.7",
+ "regex",
+ "sha2",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
 name = "libp2p-identify"
 version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2757,6 +2844,7 @@ checksum = "805a555148522cb3414493a5153451910cb1a146c53ffbf4385708349baf62b7"
 dependencies = [
  "futures",
  "libp2p-core",
+ "libp2p-gossipsub",
  "libp2p-identify",
  "libp2p-identity",
  "libp2p-swarm",
@@ -3947,6 +4035,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]

--- a/rust/roost/src/serve.rs
+++ b/rust/roost/src/serve.rs
@@ -55,7 +55,9 @@ const REFRESH: Duration = Duration::from_secs(12);
 /// node's limit is sized for gossip peers and shared with its outbound dials,
 /// and inheriting it is what starved wallets in the first place. Per-connection
 /// cost here is a Noise session and a yamux stream — tens of KB — with no
-/// gossipsub mesh, no peer scoring and no per-peer computation.
+/// gossipsub mesh (the `/meshsub/` protocol negotiates, because Lighthouse
+/// bans peers that lack it, but nothing is subscribed so no mesh forms), no
+/// peer scoring and no per-peer computation.
 const MAX_INBOUND: u32 = 1024;
 
 /// How often to re-read the chain's fork/blob schedule, in ticks.

--- a/rust/tor-poc/Cargo.lock
+++ b/rust/tor-poc/Cargo.lock
@@ -754,6 +754,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2149,6 +2161,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2596,6 +2618,15 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -2622,6 +2653,15 @@ dependencies = [
  "foldhash 0.2.0",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -2677,6 +2717,12 @@ checksum = "35431185f361ccf3ffc58254628af5f1f5d5f28531da2e02e5d6c82bbc282a10"
 dependencies = [
  "arrayvec",
 ]
+
+[[package]]
+name = "hex_fmt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
 
 [[package]]
 name = "hickory-proto"
@@ -3324,6 +3370,7 @@ dependencies = [
  "libp2p-connection-limits",
  "libp2p-core",
  "libp2p-dns",
+ "libp2p-gossipsub",
  "libp2p-identify",
  "libp2p-identity",
  "libp2p-mdns",
@@ -3405,6 +3452,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "libp2p-gossipsub"
+version = "0.49.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3573f3d8e30bd62cda336df5c7c1041a1caa40a648376b8e1e274d585c0ed25c"
+dependencies = [
+ "async-channel",
+ "asynchronous-codec",
+ "base64",
+ "byteorder",
+ "bytes",
+ "either",
+ "fnv",
+ "futures",
+ "futures-timer",
+ "getrandom 0.2.17",
+ "hashlink 0.9.1",
+ "hex_fmt",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "quick-protobuf",
+ "quick-protobuf-codec",
+ "rand 0.8.7",
+ "regex",
+ "sha2",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
 name = "libp2p-identify"
 version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3472,6 +3549,7 @@ checksum = "805a555148522cb3414493a5153451910cb1a146c53ffbf4385708349baf62b7"
 dependencies = [
  "futures",
  "libp2p-core",
+ "libp2p-gossipsub",
  "libp2p-identify",
  "libp2p-identity",
  "libp2p-swarm",


### PR DESCRIPTION
## Why

Lighthouse reports any peer whose `/meshsub/` (gossipsub) negotiation fails with `PeerAction::Fatal` and goodbye reason 0 (`does_not_support_gossipsub`, `lighthouse_network/src/service/mod.rs`, verified at v8.1.3 and v8.2.2, the versions the gnosis pinned peers run). Fatal sets the score to -100, frozen for 12 hours before decay, and the peer id is refused on every later connection; more than five banned ids from one IP ban the IP at TCP accept. Both engines generate a fresh libp2p identity per start and neither negotiated gossipsub, so every start got exactly one first-contact connection per Lighthouse node and a handful of restarts banned the host's IP. On gnosis, whose pinned light-client servers are all Lighthouse, catch-up requests always went out after the bootstrap round had spent every window, so a cold start could never advance (#422 is the released-artifact report of this).

## What

- **Rust engine**: `gossipsub::Behaviour` with no subscriptions in the swarm (`Anonymous` authenticity and validation, the eth2 StrictNoSign wire). Nothing is published or subscribed, no mesh forms, and the swarm's idle timeout still governs connections. roost inherits this through the shared host builder; its comment says so.
- **Java engine**: `BeaconP2PService` registers the jvm-libp2p `Gossip` protocol unconditionally. Topic subscription stays behind a separate off-by-default `setGossipTopicSubscriptionEnabled`: registering the protocol is all Lighthouse's check needs, and joining the light-client mesh from a short-lived wallet has its own problems (mesh churn, jvm-libp2p's `from+seqno` message id on unsigned eth2 messages, fork-pinned subscriptions) that the live-finality plan has to solve first.
- **The flag is gone.** There is no configuration under which turning gossipsub off is useful, and it never reached the Rust engine (`nativeCreate` takes only the network and data dir). `EngineConfig.gossipsubEnabled`, the daemon's `--gossipsub`/`--no-gossipsub` and `-Dbeacon.gossipsub`, the Gradle `-Pgossipsub` mapping, `ChainStack`'s constructor parameter and `BeaconLightClient.setGossipsubEnabled` are removed; hosts, tests and docs follow.
- **Regression tests.** Rust: a loopback two-swarm test where a subscribed peer (as Lighthouse always is) opens the `/meshsub/` stream toward our host and must record it as a gossipsub peer. Java: `BeaconP2PService.probeProtocol` negotiates exactly one protocol id over a fresh stream; the test proves `/meshsub/1.1.0` negotiates, no topic is joined, and an unregistered id fails as a control.
- All three `Cargo.lock` files gain `libp2p-gossipsub` and its transitive crates; each resolves `--locked`. The arm64 engine library grows by about 1 MB.

## Evidence

On a Pixel 10 Pro Fold on LTE against the gnosis pinned peers, Lighthouse connections went from 8 to 17 ms (goodbye 0, then refused) to 8 to 16 s (goodbye 250, a plain bad-score disconnect that allows reconnects). A cold gnosis bootstrap plus two catch-up periods completed in 11 s through the same nodes that had refused everything for the previous three hours.

Companion to #424 (merged): Lighthouse count=1 first ask.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNMr2LJJVj42AoFLuUk35a
