### PR TITLE
sepolia: replace two dead CL pins with census-verified Lighthouse servers

### DIFF
--- a/docs/dedicated-sepolia-node.md
+++ b/docs/dedicated-sepolia-node.md
@@ -482,8 +482,8 @@ servers took its place in `clPeerMultiaddrs` (see the list's comment). Re-pin
 the Nimbus once the far end is fixed and its `--netkey-file` identity is
 confirmed from its startup log.
 
-Both are only stable because of the key-persistence flags above (Geth's
-datadir `nodekey`, Nimbus's `--netkey-file`). The **address** in every entry is
+Both are only stable because their keys persist across restarts (Geth's
+datadir `nodekey`; roost's `/data/roost/sepolia.key`). The **address** in every entry is
 the netcup relay (188.68.32.16, a static VPS), not zbox: since 2026-09-06 zbox
 sits behind mobile CGNAT and is reachable only through a WireGuard tunnel to the
 relay, which DNATs the nine serving ports (30405-30407, 9104-9109, tcp+udp) to

--- a/docs/dedicated-sepolia-node.md
+++ b/docs/dedicated-sepolia-node.md
@@ -464,17 +464,23 @@ head.
 
 ## 7. Pinned identities (DONE) and remaining follow-ups
 
-The pair is pinned in `NetworkConfig.SEPOLIA` on both layers and in both
-engines: `elBootEnodes()` returns the enode (Java) / `ElConfig::sepolia()`
-seeds `boot_enodes` into the peer cache for the pool's warm-start dial (Rust),
-and the CL multiaddr is `prependLocal`-ed onto `clPeerMultiaddrs` so the light
-client tries it first.
+The EL enode and the roost CL multiaddr are pinned in `NetworkConfig.SEPOLIA`
+on both layers and in both engines: `elBootEnodes()` returns the enode (Java) /
+`ElConfig::sepolia()` seeds `boot_enodes` into the peer cache for the pool's
+warm-start dial (Rust), and the CL multiaddr is `prependLocal`-ed onto
+`clPeerMultiaddrs` so the light client tries it first.
 
 | layer | identity |
 |---|---|
 | EL | `enode://cfd3572b…c37e1b2c@188.68.32.16:30405` |
 | CL (roost, first) | `/ip4/188.68.32.16/tcp/9105/p2p/16Uiu2HAkyDsNGDq5pbFCqdKTcJxp4Rd5caoy1Xe2KJVtyc94M8S5` |
-| CL (Nimbus, fallback) | `/ip4/188.68.32.16/tcp/9104/p2p/16Uiu2HAkvYx58piGw1oxz34CUoeTv8nNQwTwE2cZZh4jR4wVMYy6` |
+
+The Nimbus CL fallback (`/tcp/9104` through the relay) was **unpinned on
+2026-09-11**: the port still accepts TCP but the libp2p handshake times out, so
+the tunnel's far end is not answering. Three census-verified public Lighthouse
+servers took its place in `clPeerMultiaddrs` (see the list's comment). Re-pin
+the Nimbus once the far end is fixed and its `--netkey-file` identity is
+confirmed from its startup log.
 
 Both are only stable because of the key-persistence flags above (Geth's
 datadir `nodekey`, Nimbus's `--netkey-file`). The **address** in every entry is

--- a/docs/lc-server-design.md
+++ b/docs/lc-server-design.md
@@ -10,7 +10,7 @@ particular do not travel:
 - **~1327 periods ≈ 36 MB is sepolia's archive.** Mainnet's Altair floor and
   Gnosis's own beacon chain (`docs/multichain-design.md`) give different sizes.
 - **Mainnet does not have this problem in the same shape.** `NetworkConfig` pins
-  **18** mainnet CL multiaddrs against sepolia's **2**, so "replace the pinned CL
+  **18** mainnet CL multiaddrs against sepolia's **4**, so "replace the pinned CL
   multiaddr with discovery" is a sepolia-shaped statement. Whether mainnet and
   gnosis follow is deliberately left open.
 

--- a/docs/lc-server-design.md
+++ b/docs/lc-server-design.md
@@ -10,7 +10,7 @@ particular do not travel:
 - **~1327 periods ≈ 36 MB is sepolia's archive.** Mainnet's Altair floor and
   Gnosis's own beacon chain (`docs/multichain-design.md`) give different sizes.
 - **Mainnet does not have this problem in the same shape.** `NetworkConfig` pins
-  **18** mainnet CL multiaddrs against sepolia's **4**, so "replace the pinned CL
+  **12** mainnet CL multiaddrs against sepolia's **4**, so "replace the pinned CL
   multiaddr with discovery" is a sepolia-shaped statement. Whether mainnet and
   gnosis follow is deliberately left open.
 

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/NetworkConfig.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/NetworkConfig.java
@@ -260,8 +260,9 @@ public record NetworkConfig(
             // updates_by_range(1356,1) from a fresh peer id, all Lighthouse
             // v8.2.2. They replace two dead pins — the zbox Nimbus behind the
             // relay (9104: TCP accepts, the libp2p handshake times out) and
-            // 18.185.193.198 (TCP timeout for days) — that cost the Rust
-            // engine's bootstrap fan-out 82 rounds while a wallet sat in
+            // 18.185.193.198 (TCP timeout for days) — that, with roost sepolia
+            // switched off as well, cost the Rust engine's bootstrap fan-out
+            // 82 rounds on three unreachable pins while a wallet sat in
             // SYNCING. Keep this list identical to SEPOLIA_STATIC_PEERS in
             // rust/myotis-net/src/sync.rs (both parity tests pin it).
             prependLocal(

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/NetworkConfig.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/NetworkConfig.java
@@ -250,22 +250,26 @@ public record NetworkConfig(
             // silent regression on the DEFAULT engine, and the reason
             // lc-server-design rollout step 3 wants this settled.
             //
-            // The dedicated Nimbus follows it, so a roost OUTAGE degrades to
-            // exactly the previous behaviour rather than to nothing. That entry's
-            // peer-id is stable only because the node pins --netkey-file; Nimbus
-            // otherwise mints a new one per restart, which invalidates it with
-            // InvalidRemotePubKey (see the doc's §5 note). roost has no such
-            // mode — its identity is persisted by construction.
+            // The roost literal is the netcup relay (188.68.32.16, static VPS)
+            // in front of zbox, which lives behind mobile CGNAT — see the
+            // mainnet list above. ENR publication (lc-server-design §7) is what
+            // removes the need to pin at all.
             //
-            // Both literals are the netcup relay (188.68.32.16, static VPS) in
-            // front of zbox, which lives behind mobile CGNAT — see the mainnet
-            // list above. ENR publication (lc-server-design §7) is what removes
-            // the need to pin at all.
+            // The public servers after it are census-verified 2026-09-11: each
+            // answered light_client_bootstrap for the pinned root AND
+            // updates_by_range(1356,1) from a fresh peer id, all Lighthouse
+            // v8.2.2. They replace two dead pins — the zbox Nimbus behind the
+            // relay (9104: TCP accepts, the libp2p handshake times out) and
+            // 18.185.193.198 (TCP timeout for days) — that cost the Rust
+            // engine's bootstrap fan-out 82 rounds while a wallet sat in
+            // SYNCING. Keep this list identical to SEPOLIA_STATIC_PEERS in
+            // rust/myotis-net/src/sync.rs (both parity tests pin it).
             prependLocal(
                     "/ip4/188.68.32.16/tcp/9105/p2p/16Uiu2HAkyDsNGDq5pbFCqdKTcJxp4Rd5caoy1Xe2KJVtyc94M8S5",
                     List.of(
-                            "/ip4/188.68.32.16/tcp/9104/p2p/16Uiu2HAkvYx58piGw1oxz34CUoeTv8nNQwTwE2cZZh4jR4wVMYy6",
-                            "/ip4/18.185.193.198/tcp/9000/p2p/16Uiu2HAm3mfkjmLPtqnSJzNtKxbDuVjVRXidz5UinaZNpjCCKAkS"
+                            "/ip4/65.109.144.95/tcp/9000/p2p/16Uiu2HAkwKbnJCnfFsNGjGd5TURbXyNBdTWoVZjw8jqiCEf47gc2",
+                            "/ip4/138.201.192.180/tcp/9000/p2p/16Uiu2HAmNHPaVrDFi7zVnEd9vhSHy9e4a5eF5a3aBxNXPPAucWbE",
+                            "/ip4/198.13.138.237/tcp/9000/p2p/16Uiu2HAmMb2mLN12B5vnJGv2LMuXxKsAiKQ8yTdy5gSJY1zKgE5f"
                     )),
             null,
             1655733600L, // sepolia beacon genesis: 2022-06-20 14:00:00 UTC

--- a/networking/src/test/java/com/jaeckel/ethp2p/networking/NetworkConfigGnosisTest.java
+++ b/networking/src/test/java/com/jaeckel/ethp2p/networking/NetworkConfigGnosisTest.java
@@ -170,23 +170,17 @@ class NetworkConfigGnosisTest {
         assertTrue(enode.endsWith("@188.68.32.16:30405"), enode);
 
         // roost, the dedicated light-client server, is tried first — that is the
-        // point of having it. The dedicated Nimbus stays behind it as fallback,
-        // so a roost fault degrades to the previous behaviour.
-        String cl = NetworkConfig.SEPOLIA.clPeerMultiaddrs().get(0);
-        assertEquals("/ip4/188.68.32.16/tcp/9105/p2p/16Uiu2HAkyDsNGDq5pbFCqdKTcJxp4Rd5caoy1Xe2KJVtyc94M8S5", cl,
-                "roost must be the first CL peer tried");
-        // POSITION, not presence: the Rust twin asserts index 1, and index is
-        // load-bearing on this side in particular — addPeer inserts every
-        // discovered peer at Math.min(1, size()), i.e. exactly the slot the
-        // Nimbus occupies, so "somewhere in the list" is a weaker guarantee here
-        // than anywhere else.
-        assertEquals("/ip4/188.68.32.16/tcp/9104/p2p/"
-                        + "16Uiu2HAkvYx58piGw1oxz34CUoeTv8nNQwTwE2cZZh4jR4wVMYy6",
-                NetworkConfig.SEPOLIA.clPeerMultiaddrs().get(1),
-                "the dedicated Nimbus must remain SECOND as fallback — a roost outage "
-                        + "then degrades to exactly the previous behaviour");
-        assertTrue(NetworkConfig.SEPOLIA.clPeerMultiaddrs().size() > 2,
-                "pinning must not drop the existing CL peers");
+        // point of having it. The census-verified public servers follow, so a
+        // roost fault degrades to working peers rather than to dead pins.
+        // The full list, in order — the Rust twin
+        // (sepolia_config_matches_networkconfig_java) pins the same strings.
+        assertEquals(List.of(
+                        "/ip4/188.68.32.16/tcp/9105/p2p/16Uiu2HAkyDsNGDq5pbFCqdKTcJxp4Rd5caoy1Xe2KJVtyc94M8S5",
+                        "/ip4/65.109.144.95/tcp/9000/p2p/16Uiu2HAkwKbnJCnfFsNGjGd5TURbXyNBdTWoVZjw8jqiCEf47gc2",
+                        "/ip4/138.201.192.180/tcp/9000/p2p/16Uiu2HAmNHPaVrDFi7zVnEd9vhSHy9e4a5eF5a3aBxNXPPAucWbE",
+                        "/ip4/198.13.138.237/tcp/9000/p2p/16Uiu2HAmMb2mLN12B5vnJGv2LMuXxKsAiKQ8yTdy5gSJY1zKgE5f"),
+                NetworkConfig.SEPOLIA.clPeerMultiaddrs(),
+                "roost first, then the census-verified public servers, same list as the Rust twin");
     }
 
     @Test

--- a/rust/myotis-net/src/sync.rs
+++ b/rust/myotis-net/src/sync.rs
@@ -430,8 +430,18 @@ const SEPOLIA_STATIC_PEERS: &[&str] = &[
     // The address is the netcup relay (see the ADDRESS note above); ENR
     // publication (design §7) is what removes the need to pin at all.
     "/ip4/188.68.32.16/tcp/9105/p2p/16Uiu2HAkyDsNGDq5pbFCqdKTcJxp4Rd5caoy1Xe2KJVtyc94M8S5",
-    "/ip4/188.68.32.16/tcp/9104/p2p/16Uiu2HAkvYx58piGw1oxz34CUoeTv8nNQwTwE2cZZh4jR4wVMYy6",
-    "/ip4/18.185.193.198/tcp/9000/p2p/16Uiu2HAm3mfkjmLPtqnSJzNtKxbDuVjVRXidz5UinaZNpjCCKAkS",
+    // Public sepolia LC servers, census-verified 2026-09-11: each answered
+    // light_client_bootstrap for the pinned root AND updates_by_range(1356,1)
+    // from a fresh peer id, all Lighthouse v8.2.2 (so the catch-up asks them
+    // for one period at a time — see agent_serves_one_period). They replace
+    // two dead pins: the zbox Nimbus behind the relay (9104: TCP accepts, the
+    // libp2p handshake times out — the tunnel's far end is not answering) and
+    // 18.185.193.198 (TCP timeout for days). A dead pin is not free: the
+    // bootstrap fan-out spent 82 rounds on three unreachable peers while a
+    // wallet sat in SYNCING.
+    "/ip4/65.109.144.95/tcp/9000/p2p/16Uiu2HAkwKbnJCnfFsNGjGd5TURbXyNBdTWoVZjw8jqiCEf47gc2",
+    "/ip4/138.201.192.180/tcp/9000/p2p/16Uiu2HAmNHPaVrDFi7zVnEd9vhSHy9e4a5eF5a3aBxNXPPAucWbE",
+    "/ip4/198.13.138.237/tcp/9000/p2p/16Uiu2HAmMb2mLN12B5vnJGv2LMuXxKsAiKQ8yTdy5gSJY1zKgE5f",
 ];
 
 /// Sepolia CL discv5 bootstrap ENRs (Java `NetworkConfig.SEPOLIA.clDiscv5Bootnodes` —
@@ -3289,11 +3299,12 @@ mod tests {
             c.static_peers,
             vec![
                 "/ip4/188.68.32.16/tcp/9105/p2p/16Uiu2HAkyDsNGDq5pbFCqdKTcJxp4Rd5caoy1Xe2KJVtyc94M8S5",
-                "/ip4/188.68.32.16/tcp/9104/p2p/16Uiu2HAkvYx58piGw1oxz34CUoeTv8nNQwTwE2cZZh4jR4wVMYy6",
-                "/ip4/18.185.193.198/tcp/9000/p2p/16Uiu2HAm3mfkjmLPtqnSJzNtKxbDuVjVRXidz5UinaZNpjCCKAkS",
+                "/ip4/65.109.144.95/tcp/9000/p2p/16Uiu2HAkwKbnJCnfFsNGjGd5TURbXyNBdTWoVZjw8jqiCEf47gc2",
+                "/ip4/138.201.192.180/tcp/9000/p2p/16Uiu2HAmNHPaVrDFi7zVnEd9vhSHy9e4a5eF5a3aBxNXPPAucWbE",
+                "/ip4/198.13.138.237/tcp/9000/p2p/16Uiu2HAmMb2mLN12B5vnJGv2LMuXxKsAiKQ8yTdy5gSJY1zKgE5f",
             ],
-            "roost first (the dedicated LC server), the dedicated Nimbus second as \
-             fallback — same list, order AND addresses as the Java \
+            "roost first (the dedicated LC server), then the census-verified public \
+             servers — same list, order AND addresses as the Java \
              NetworkConfig.SEPOLIA.clPeerMultiaddrs"
         );
         // A malformed pin would otherwise reach run_sync and surface only as a

--- a/rust/myotis-net/src/sync.rs
+++ b/rust/myotis-net/src/sync.rs
@@ -420,12 +420,12 @@ const SEPOLIA_STATIC_PEERS: &[&str] = &[
     // FIRST on purpose: it exists because a general-purpose beacon node is
     // structurally bad at serving wallets — one connection semaphore shared
     // between inbound and outbound, and a trimmer that drops light clients
-    // first. Nimbus stays below it, so a roost fault degrades to exactly
-    // today's behaviour rather than to nothing.
+    // first. The census-verified public servers below it are the fallback,
+    // so a roost fault degrades to working peers rather than to nothing.
     //
     // Its peer id comes from /data/roost/sepolia.key and is stable across
-    // restarts by construction; unlike the Nimbus entry there is no flag to
-    // forget, because roost has no mode in which it mints a fresh one.
+    // restarts by construction — roost has no mode in which it mints a
+    // fresh one.
     //
     // The address is the netcup relay (see the ADDRESS note above); ENR
     // publication (design §7) is what removes the need to pin at all.
@@ -436,9 +436,9 @@ const SEPOLIA_STATIC_PEERS: &[&str] = &[
     // for one period at a time — see agent_serves_one_period). They replace
     // two dead pins: the zbox Nimbus behind the relay (9104: TCP accepts, the
     // libp2p handshake times out — the tunnel's far end is not answering) and
-    // 18.185.193.198 (TCP timeout for days). A dead pin is not free: the
-    // bootstrap fan-out spent 82 rounds on three unreachable peers while a
-    // wallet sat in SYNCING.
+    // 18.185.193.198 (TCP timeout for days). A dead pin is not free: with
+    // roost sepolia switched off as well, the bootstrap fan-out spent 82
+    // rounds on three unreachable pins while a wallet sat in SYNCING.
     "/ip4/65.109.144.95/tcp/9000/p2p/16Uiu2HAkwKbnJCnfFsNGjGd5TURbXyNBdTWoVZjw8jqiCEf47gc2",
     "/ip4/138.201.192.180/tcp/9000/p2p/16Uiu2HAmNHPaVrDFi7zVnEd9vhSHy9e4a5eF5a3aBxNXPPAucWbE",
     "/ip4/198.13.138.237/tcp/9000/p2p/16Uiu2HAmMb2mLN12B5vnJGv2LMuXxKsAiKQ8yTdy5gSJY1zKgE5f",

--- a/rust/myotis-net/src/sync.rs
+++ b/rust/myotis-net/src/sync.rs
@@ -3248,6 +3248,14 @@ mod tests {
         // A malformed pin would otherwise reach run_sync and surface only as a
         // "skipping unparseable static peer multiaddr" warn.
         assert!(c.static_peers.iter().all(|p| parse_static_peer(p).is_some()));
+        // Every pin must also derive a discv5 node id: that is what lets the
+        // targeted lookup recover a pinned server's CURRENT record when its
+        // address rotates, and a re-census that pinned an Ed25519 (12D3KooW…)
+        // id would silently lose that safety net.
+        assert!(c.static_peers.iter().all(|p| crate::discovery::node_id_for_peer(
+            &parse_static_peer(p).expect("parseable pin").id
+        )
+        .is_some()));
         assert_eq!(c.bootstrap_enrs.len(), 18);
         assert_eq!(c.chain_id, 1);
     }
@@ -3310,6 +3318,14 @@ mod tests {
         // A malformed pin would otherwise reach run_sync and surface only as a
         // "skipping unparseable static peer multiaddr" warn.
         assert!(c.static_peers.iter().all(|p| parse_static_peer(p).is_some()));
+        // Every pin must also derive a discv5 node id: that is what lets the
+        // targeted lookup recover a pinned server's CURRENT record when its
+        // address rotates, and a re-census that pinned an Ed25519 (12D3KooW…)
+        // id would silently lose that safety net.
+        assert!(c.static_peers.iter().all(|p| crate::discovery::node_id_for_peer(
+            &parse_static_peer(p).expect("parseable pin").id
+        )
+        .is_some()));
         assert_eq!(c.bootstrap_enrs.len(), 10);
     }
 
@@ -3379,6 +3395,14 @@ mod tests {
             c.static_peers.iter().map(|a| a.rsplit('/').next().unwrap()).collect();
         assert_eq!(ids.len(), 23, "one address per peer id (the pool dedupes by id)");
         assert!(c.static_peers.iter().all(|p| parse_static_peer(p).is_some()));
+        // Every pin must also derive a discv5 node id: that is what lets the
+        // targeted lookup recover a pinned server's CURRENT record when its
+        // address rotates, and a re-census that pinned an Ed25519 (12D3KooW…)
+        // id would silently lose that safety net.
+        assert!(c.static_peers.iter().all(|p| crate::discovery::node_id_for_peer(
+            &parse_static_peer(p).expect("parseable pin").id
+        )
+        .is_some()));
         assert_eq!(c.bootstrap_enrs.len(), 9);
     }
 


### PR DESCRIPTION
## Why

The sepolia consensus-layer pin list held roost plus two entries that no longer answer: the zbox Nimbus behind the relay (port 9104 accepts TCP but the libp2p handshake times out, so the tunnel's far end is not answering) and 18.185.193.198 (TCP timeout). With roost sepolia switched off as well, the Rust engine's bootstrap fan-out spent 82 rounds on three unreachable pins today and a desktop wallet sat in SYNCING for 22 minutes until discovery happened to surface a peer.

## What

Both engines' lists (`SEPOLIA_STATIC_PEERS` in `rust/myotis-net/src/sync.rs`, `NetworkConfig.SEPOLIA` in `networking/`) now hold roost first and then three public servers verified today from a fresh peer id, each answering `light_client_bootstrap` for the embedded root and `light_client_updates_by_range(1356,1)`:

- 65.109.144.95 (Lighthouse 8.2.2)
- 138.201.192.180 (Lighthouse 8.2.2)
- 198.13.138.237 (Lighthouse 8.2.2)

Both parity tests pin the full list in order. The pin-site doc (`docs/dedicated-sepolia-node.md` §7) records the Nimbus as unpinned with the reason, and `docs/lc-server-design.md` gets the updated count.

## Things to know

- **Third-party nodes, no operator agreement.** They can rotate keys or addresses, drop `--light-client-server`, or cap peers at any time, and the parity tests will then guard dead strings, which is the failure mode this PR fixes. The entries carry their census date (2026-09-11) like mainnet's batch; expect a re-census when sepolia stalls again.
- **Lighthouse rate limits.** These nodes serve one `updates_by_range` period per ask (the engine already asks Lighthouse-identified peers for one at a time) and rate-limit bootstrap. Every sepolia wallet now shares three public nodes; under load expect some refusals, which the reactive fallbacks cover.
- **Trust is unchanged.** Pinned third parties can withhold, not forge: every update is BLS-verified against the sync committee, and a stall surfaces as not-SYNCED rather than a wrong answer.
- **Java engine chain fill.** roost serves no `beacon_blocks_by_range`, so on the Java engine the sepolia chain fill now rides on these three public nodes rather than on the dead Nimbus (in practice, on nothing).
- All three new peer ids derive a discv5 node id, so the targeted lookups can recover their current ENR if an address rotates; the old Nimbus pin never could.
- The zbox Nimbus is not decommissioned; re-pin it once the tunnel's far end is fixed and its `--netkey-file` identity confirmed.

Companion: a discovery fix for why the Rust engine surfaces so few sepolia peers on its own is in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNMr2LJJVj42AoFLuUk35a