### PR TITLE
discv5: feed the sync pool from Discovered events, not just lookup results

### DIFF
--- a/rust/myotis-net/src/discovery.rs
+++ b/rust/myotis-net/src/discovery.rs
@@ -11,7 +11,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use discv5::enr::{CombinedKey, CombinedPublicKey, EnrPublicKey, NodeId};
-use discv5::{ConfigBuilder, Discv5, Enr, ListenConfig};
+use discv5::{Event, ConfigBuilder, Discv5, Enr, ListenConfig};
 use libp2p::{Multiaddr, PeerId};
 use tokio::sync::mpsc;
 
@@ -103,9 +103,18 @@ pub async fn spawn(
         "discv5 started"
     );
 
+    // Every ENR that comes back in a NODES response during a query, live or
+    // not — see the consumer in run_lookups for why this, and not the lookup
+    // results, is where a small network's peers surface.
+    let events = discv5
+        .event_stream()
+        .await
+        .map_err(|e| format!("discv5 event stream failed: {e}"))?;
+
     let table_size = Arc::new(AtomicUsize::new(0));
     let task = tokio::spawn(run_lookups(
         discv5,
+        events,
         config.accepted_fork_digests,
         bootnodes,
         pinned_targets,
@@ -163,6 +172,7 @@ const PINNED_ROUND_EVERY: usize = 4;
 
 async fn run_lookups(
     discv5: Discv5,
+    events: mpsc::Receiver<Event>,
     accepted_digests: Vec<[u8; 4]>,
     bootnodes: Vec<Enr>,
     pinned_targets: Vec<NodeId>,
@@ -180,6 +190,23 @@ async fn run_lookups(
     let mut pinned_seq: std::collections::HashMap<NodeId, u64> = std::collections::HashMap::new();
     let mut empty_rounds = 0u32;
     let mut round: usize = 0;
+    // A lookup RETURNS only the k nodes closest to its target, and its walk
+    // only CONTACTS the nodes on the path there. Everything else a NODES
+    // response mentions — on the shared eth2 DHT, that is where nearly all
+    // of a small network's peers appear, since a random target is almost
+    // never near a sepolia node — was thrown away. The Java twin
+    // (DiscV5Service.poll over streamLiveNodes()) sees those records and
+    // emitted 28 fork-matched sepolia peers in ten seconds where this loop
+    // emitted one per ~2 minutes from the same address. So consume the
+    // Discovered event, which fires for EVERY ENR in every NODES response,
+    // and emit the fork-matched ones once each. Pinned ids stay on the
+    // seq-gated lookup path (a hearsay copy may be an older record).
+    tokio::spawn(consume_discovered(
+        events,
+        accepted_digests.clone(),
+        pinned_targets.clone(),
+        tx.clone(),
+    ));
     loop {
         // The FIRST rounds walk toward each pinned server id in turn — that is
         // the startup fast path (O(log n) hops instead of random-walk luck) —
@@ -197,9 +224,9 @@ async fn run_lookups(
             NodeId::random()
         };
         round = round.wrapping_add(1);
+        let mut emitted = 0usize;
         match discv5.find_node(target).await {
             Ok(enrs) => {
-                let mut emitted = 0usize;
                 for enr in enrs {
                     if pinned_targets.contains(&enr.node_id()) {
                         // Pinned ids bypass the once-ever dedup, but only on a
@@ -221,10 +248,10 @@ async fn run_lookups(
                         }
                     }
                 }
-                tracing::debug!(emitted, known = seen.len(), "discv5 lookup round complete");
             }
             Err(e) => tracing::debug!(error = %e, "discv5 lookup failed"),
         }
+        tracing::debug!(emitted, known = seen.len(), "discv5 lookup round complete");
 
         // Status metric: TOTAL routing-table entries (never a misleading 0
         // during a connectivity blip that flips entries Disconnected-in-place).
@@ -301,6 +328,50 @@ fn reseed_due(empty_rounds: &mut u32, live_nodes: usize, bootnode_count: usize) 
     true
 }
 
+/// Forward every fork-matched ENR the discv5 service hears about — the
+/// `Discovered` event fires per ENR in every NODES response, contacted or not
+/// — to the sync pool, once per node id. Ends when the service or the pool
+/// goes away.
+async fn consume_discovered(
+    mut events: mpsc::Receiver<Event>,
+    accepted_digests: Vec<[u8; 4]>,
+    pinned_targets: Vec<NodeId>,
+    tx: mpsc::Sender<DiscoveredPeer>,
+) {
+    let mut seen: HashSet<NodeId> = HashSet::new();
+    let mut heard = 0usize;
+    while let Some(event) = events.recv().await {
+        let Event::Discovered(enr) = event else { continue };
+        heard += 1;
+        if pinned_targets.contains(&enr.node_id()) {
+            continue;
+        }
+        for peer in collect_new_candidates(std::iter::once(enr), &mut seen, &accepted_digests) {
+            tracing::debug!(heard, known = seen.len(), "CL peer heard in a NODES response");
+            if tx.send(peer).await.is_err() {
+                return;
+            }
+        }
+        if seen.len() > 16_384 {
+            seen.clear();
+        }
+    }
+}
+
+/// The fork-matched, TCP-bearing peers among `enrs` that `seen` has not yet
+/// recorded — recording them as it goes, so a node is emitted once ever (until
+/// the caller clears `seen` on a re-seed).
+fn collect_new_candidates(
+    enrs: impl IntoIterator<Item = Enr>,
+    seen: &mut HashSet<NodeId>,
+    accepted_digests: &[[u8; 4]],
+) -> Vec<DiscoveredPeer> {
+    enrs.into_iter()
+        .filter(|enr| seen.insert(enr.node_id()))
+        .filter_map(|enr| filter_candidate(&enr, accepted_digests))
+        .collect()
+}
+
 /// ENR → dial candidate, applying the same gates the Java discv5 callback does:
 /// must carry an `eth2` field whose fork digest is in our accepted set, a TCP
 /// endpoint, and a secp256k1 key we can turn into a libp2p PeerId.
@@ -372,6 +443,23 @@ mod tests {
     const GNOSIS_BOOT_ENR: &str = "enr:-Ly4QIAhiTHk6JdVhCdiLwT83wAolUFo5J4nI5HrF7-zJO_QEw3cmEGxC1jvqNNUN64Vu-xxqDKSM528vKRNCehZAfEBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpCCS-QxAgAAZP__________gmlkgnY0gmlwhEFtZ5SJc2VjcDI1NmsxoQJwgL5C-30E8RJmW8gCb7sfwWvvfre7wGcCeV4X1G2wJYhzeW5jbmV0cwCDdGNwgiMog3VkcIIjKA";
 
     #[test]
+    #[test]
+    fn a_table_sweep_emits_each_matching_node_once() {
+        let enr: Enr = GNOSIS_BOOT_ENR.parse().expect("boot ENR parses");
+        let digest = enr_eth2_fork_digest(&enr).expect("eth2 field");
+        let mut seen = HashSet::new();
+        // First sweep: the node is new and fork-matched → emitted.
+        let first = collect_new_candidates(vec![enr.clone()], &mut seen, &[digest]);
+        assert_eq!(first.len(), 1);
+        assert_eq!(Some(first[0].peer_id), enr_to_peer_id(&enr));
+        // Second sweep of the same table: already seen → nothing, no churn.
+        assert!(collect_new_candidates(vec![enr.clone()], &mut seen, &[digest]).is_empty());
+        // A node on another fork is recorded as seen but never emitted.
+        let mut seen2 = HashSet::new();
+        assert!(collect_new_candidates(vec![enr.clone()], &mut seen2, &[[0, 0, 0, 0]]).is_empty());
+        assert!(seen2.contains(&enr.node_id()));
+    }
+
     fn parses_eth2_field_and_peer_id_from_real_enr() {
         let enr: Enr = GNOSIS_BOOT_ENR.parse().unwrap();
         let digest = enr_eth2_fork_digest(&enr).unwrap();

--- a/rust/myotis-net/src/discovery.rs
+++ b/rust/myotis-net/src/discovery.rs
@@ -369,22 +369,22 @@ async fn consume_discovered(
             continue;
         }
         let id = enr.node_id();
-        let verdict = classify_heard(
-            &enr,
-            &seen.lock().expect("seen lock"),
-            &pinned_targets,
-            &accepted_digests,
-        );
-        match verdict {
+        // One critical section from check to claim: the lookup loop claims
+        // its own emissions under the same lock, so neither path can slip a
+        // duplicate into the pool channel between the other's check and
+        // insert. try_send never blocks, so holding a std mutex across it is
+        // fine; nothing awaits while it is held.
+        let mut guard = seen.lock().expect("seen lock");
+        match classify_heard(&enr, &guard, &pinned_targets, &accepted_digests) {
             Heard::Skip => {}
             Heard::NeverCandidate => {
-                seen.lock().expect("seen lock").insert(id);
+                guard.insert(id);
             }
             Heard::Emit(peer) => match tx.try_send(peer) {
                 // Marked seen only once the pool has it: a node dropped on a
                 // full channel is heard again later and emitted then.
                 Ok(()) => {
-                    seen.lock().expect("seen lock").insert(id);
+                    guard.insert(id);
                 }
                 Err(mpsc::error::TrySendError::Full(_)) => {}
                 Err(mpsc::error::TrySendError::Closed(_)) => return,

--- a/rust/myotis-net/src/discovery.rs
+++ b/rust/myotis-net/src/discovery.rs
@@ -360,44 +360,67 @@ async fn consume_discovered(
 ) {
     while let Some(event) = events.recv().await {
         let Event::Discovered(enr) = event else { continue };
+        // A full channel drops the node unmarked (see below), so deciding
+        // anything about it now — the key decode behind filter_candidate and
+        // its debug line — would only be repeated on the next hearing. On
+        // mainnet, where nearly every ENR matches, a full channel is the
+        // steady state between sync-loop drains.
+        if tx.capacity() == 0 {
+            continue;
+        }
         let id = enr.node_id();
-        // Pinned ids keep the lookup path's seq gate: a hearsay copy may be
-        // an older record than the one already emitted.
-        if pinned_targets.contains(&id) {
-            continue;
-        }
-        if seen.lock().expect("seen lock").contains(&id) {
-            continue;
-        }
-        let Some(peer) = filter_candidate(&enr, &accepted_digests) else {
-            // Off-fork or no TCP endpoint: never a candidate, never re-checked.
-            seen.lock().expect("seen lock").insert(id);
-            continue;
-        };
-        match tx.try_send(peer) {
-            Ok(()) => {
+        let verdict = classify_heard(
+            &enr,
+            &seen.lock().expect("seen lock"),
+            &pinned_targets,
+            &accepted_digests,
+        );
+        match verdict {
+            Heard::Skip => {}
+            Heard::NeverCandidate => {
                 seen.lock().expect("seen lock").insert(id);
             }
-            Err(mpsc::error::TrySendError::Full(_)) => {
-                // Not recorded: heard again later, emitted then.
-            }
-            Err(mpsc::error::TrySendError::Closed(_)) => return,
+            Heard::Emit(peer) => match tx.try_send(peer) {
+                // Marked seen only once the pool has it: a node dropped on a
+                // full channel is heard again later and emitted then.
+                Ok(()) => {
+                    seen.lock().expect("seen lock").insert(id);
+                }
+                Err(mpsc::error::TrySendError::Full(_)) => {}
+                Err(mpsc::error::TrySendError::Closed(_)) => return,
+            },
         }
     }
 }
 
-/// The fork-matched, TCP-bearing peers among `enrs` that `seen` has not yet
-/// recorded — recording them as it goes, so a node is emitted once per `seen`
-/// lifetime. The lookup loop's once-ever rule in one place, with a test.
-fn collect_new_candidates(
-    enrs: impl IntoIterator<Item = Enr>,
-    seen: &mut HashSet<NodeId>,
+/// What to do with one ENR heard in a NODES response.
+enum Heard {
+    /// Pinned (the lookup path's seq gate owns it) or already emitted.
+    Skip,
+    /// Off-fork or no TCP endpoint: never a candidate, record it so it is
+    /// never re-checked.
+    NeverCandidate,
+    /// A fresh fork-matched node — emit, and record it once the pool has it.
+    Emit(DiscoveredPeer),
+}
+
+/// The per-ENR decision behind [`consume_discovered`], pure so the once-ever
+/// rule is testable: `seen` is read here and written by the caller, because
+/// only the caller knows whether the emission landed.
+fn classify_heard(
+    enr: &Enr,
+    seen: &HashSet<NodeId>,
+    pinned_targets: &[NodeId],
     accepted_digests: &[[u8; 4]],
-) -> Vec<DiscoveredPeer> {
-    enrs.into_iter()
-        .filter(|enr| seen.insert(enr.node_id()))
-        .filter_map(|enr| filter_candidate(&enr, accepted_digests))
-        .collect()
+) -> Heard {
+    let id = enr.node_id();
+    if pinned_targets.contains(&id) || seen.contains(&id) {
+        return Heard::Skip;
+    }
+    match filter_candidate(enr, accepted_digests) {
+        Some(peer) => Heard::Emit(peer),
+        None => Heard::NeverCandidate,
+    }
 }
 
 /// ENR → dial candidate, applying the same gates the Java discv5 callback does:
@@ -471,20 +494,28 @@ mod tests {
     const GNOSIS_BOOT_ENR: &str = "enr:-Ly4QIAhiTHk6JdVhCdiLwT83wAolUFo5J4nI5HrF7-zJO_QEw3cmEGxC1jvqNNUN64Vu-xxqDKSM528vKRNCehZAfEBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpCCS-QxAgAAZP__________gmlkgnY0gmlwhEFtZ5SJc2VjcDI1NmsxoQJwgL5C-30E8RJmW8gCb7sfwWvvfre7wGcCeV4X1G2wJYhzeW5jbmV0cwCDdGNwgiMog3VkcIIjKA";
 
     #[test]
-    fn heard_nodes_are_emitted_once_each() {
+    fn a_heard_node_is_emitted_once_and_pins_are_left_to_the_lookup_path() {
         let enr: Enr = GNOSIS_BOOT_ENR.parse().expect("boot ENR parses");
         let digest = enr_eth2_fork_digest(&enr).expect("eth2 field");
+        let id = enr.node_id();
         let mut seen = HashSet::new();
-        // First sweep: the node is new and fork-matched → emitted.
-        let first = collect_new_candidates(vec![enr.clone()], &mut seen, &[digest]);
-        assert_eq!(first.len(), 1);
-        assert_eq!(Some(first[0].peer_id), enr_to_peer_id(&enr));
-        // Second sweep of the same table: already seen → nothing, no churn.
-        assert!(collect_new_candidates(vec![enr.clone()], &mut seen, &[digest]).is_empty());
-        // A node on another fork is recorded as seen but never emitted.
-        let mut seen2 = HashSet::new();
-        assert!(collect_new_candidates(vec![enr.clone()], &mut seen2, &[[0, 0, 0, 0]]).is_empty());
-        assert!(seen2.contains(&enr.node_id()));
+        // Fresh and fork-matched → emit, with the peer id the ENR's key yields.
+        match classify_heard(&enr, &seen, &[], &[digest]) {
+            Heard::Emit(peer) => assert_eq!(Some(peer.peer_id), enr_to_peer_id(&enr)),
+            _ => panic!("a fresh fork-matched node must be emitted"),
+        }
+        // Not yet marked (the send has not landed) → still emitted next time.
+        assert!(matches!(classify_heard(&enr, &seen, &[], &[digest]), Heard::Emit(_)));
+        // Once the caller marks it → skipped for good.
+        seen.insert(id);
+        assert!(matches!(classify_heard(&enr, &seen, &[], &[digest]), Heard::Skip));
+        // Pinned ids are never emitted from hearsay, marked or not.
+        assert!(matches!(classify_heard(&enr, &HashSet::new(), &[id], &[digest]), Heard::Skip));
+        // Off-fork → never a candidate (the caller records it as seen).
+        assert!(matches!(
+            classify_heard(&enr, &HashSet::new(), &[], &[[0, 0, 0, 0]]),
+            Heard::NeverCandidate
+        ));
     }
 
     #[test]

--- a/rust/myotis-net/src/discovery.rs
+++ b/rust/myotis-net/src/discovery.rs
@@ -11,7 +11,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use discv5::enr::{CombinedKey, CombinedPublicKey, EnrPublicKey, NodeId};
-use discv5::{Event, ConfigBuilder, Discv5, Enr, ListenConfig};
+use discv5::{ConfigBuilder, Discv5, Enr, Event, ListenConfig};
 use libp2p::{Multiaddr, PeerId};
 use tokio::sync::mpsc;
 
@@ -180,7 +180,9 @@ async fn run_lookups(
     hunt_boost: Arc<AtomicBool>,
     tx: mpsc::Sender<DiscoveredPeer>,
 ) {
-    let mut seen: HashSet<NodeId> = HashSet::new();
+    // Once-ever emission set, SHARED with the Discovered-event consumer so a
+    // re-seed (which clears it) refills the pool from both paths.
+    let seen: Arc<std::sync::Mutex<HashSet<NodeId>>> = Arc::new(std::sync::Mutex::new(HashSet::new()));
     // Last emitted ENR sequence number per PINNED id. A pinned server may be
     // re-found on every targeted round, but only a STRICTLY newer record — a
     // genuine republication, e.g. after an address change — re-emits. Gating on
@@ -195,16 +197,20 @@ async fn run_lookups(
     // response mentions — on the shared eth2 DHT, that is where nearly all
     // of a small network's peers appear, since a random target is almost
     // never near a sepolia node — was thrown away. The Java twin
-    // (DiscV5Service.poll over streamLiveNodes()) sees those records and
+    // (DiscV5Service.poll over streamLiveNodes(), its liveness-checked
+    // bucket entries) fills its buckets from those same responses and
     // emitted 28 fork-matched sepolia peers in ten seconds where this loop
     // emitted one per ~2 minutes from the same address. So consume the
     // Discovered event, which fires for EVERY ENR in every NODES response,
-    // and emit the fork-matched ones once each. Pinned ids stay on the
-    // seq-gated lookup path (a hearsay copy may be an older record).
+    // and emit the fork-matched ones once each (measured: first sepolia peer
+    // 4 s after start instead of 2 min 12 s, 39 within 150 s). See
+    // consume_discovered for why these are hearsay and why its sends never
+    // block.
     tokio::spawn(consume_discovered(
         events,
         accepted_digests.clone(),
         pinned_targets.clone(),
+        Arc::clone(&seen),
         tx.clone(),
     ));
     loop {
@@ -235,10 +241,10 @@ async fn run_lookups(
                             Some(&last) if enr.seq() <= last => continue,
                             _ => {
                                 pinned_seq.insert(enr.node_id(), enr.seq());
-                                seen.insert(enr.node_id());
+                                seen.lock().expect("seen lock").insert(enr.node_id());
                             }
                         }
-                    } else if !seen.insert(enr.node_id()) {
+                    } else if !seen.lock().expect("seen lock").insert(enr.node_id()) {
                         continue;
                     }
                     if let Some(peer) = filter_candidate(&enr, &accepted_digests) {
@@ -251,7 +257,8 @@ async fn run_lookups(
             }
             Err(e) => tracing::debug!(error = %e, "discv5 lookup failed"),
         }
-        tracing::debug!(emitted, known = seen.len(), "discv5 lookup round complete");
+        tracing::debug!(emitted, known = seen.lock().expect("seen lock").len(),
+            "discv5 lookup round complete");
 
         // Status metric: TOTAL routing-table entries (never a misleading 0
         // during a connectivity blip that flips entries Disconnected-in-place).
@@ -265,7 +272,7 @@ async fn run_lookups(
             // every re-found peer fails the seen-dedup and is never re-emitted
             // (emission is once-ever per NodeId), leaving the pool starved
             // even after a successful re-seed.
-            seen.clear();
+            seen.lock().expect("seen lock").clear();
             tracing::info!(pinged = bootnodes.len(), readded, rounds = RESEED_EMPTY_ROUNDS,
                 "discv5 live table empty — pinged bootnodes and cleared the dedup set");
         }
@@ -280,8 +287,9 @@ async fn run_lookups(
         let pause = if hunt_boost.load(Ordering::Relaxed) { 2 } else { 15 };
         tokio::time::sleep(std::time::Duration::from_secs(pause)).await;
         // Bound the dedup set: discovery on mainnet finds thousands of nodes.
-        if seen.len() > 16_384 {
-            seen.clear();
+        let mut guard = seen.lock().expect("seen lock");
+        if guard.len() > 16_384 {
+            guard.clear();
         }
     }
 }
@@ -329,38 +337,58 @@ fn reseed_due(empty_rounds: &mut u32, live_nodes: usize, bootnode_count: usize) 
 }
 
 /// Forward every fork-matched ENR the discv5 service hears about — the
-/// `Discovered` event fires per ENR in every NODES response, contacted or not
-/// — to the sync pool, once per node id. Ends when the service or the pool
+/// `Discovered` event fires per ENR in every NODES response — to the sync
+/// pool, once per node id. These records are HEARSAY (sigp: "not guaranteed
+/// to be live or contactable"), unlike lookup results, which only name nodes
+/// that answered: the pool's dial is what verifies them, an unreachable one is
+/// struck out on its first failure, and the ENR signature was checked on
+/// decode so a wrong record cannot impersonate anyone at the Noise handshake.
+///
+/// Sends are non-blocking on purpose. The pool channel is small and drained
+/// at the sync loop's cadence; on mainnet nearly every heard ENR matches, so a
+/// blocking send here would park behind hundreds of emissions and stall the
+/// lookup loop's own sends, its cadence and its re-seed check. A node dropped
+/// on a full channel is not recorded as seen, so it is re-emitted the next
+/// time it is heard. Ends when the service drops its event sender or the pool
 /// goes away.
 async fn consume_discovered(
     mut events: mpsc::Receiver<Event>,
     accepted_digests: Vec<[u8; 4]>,
     pinned_targets: Vec<NodeId>,
+    seen: Arc<std::sync::Mutex<HashSet<NodeId>>>,
     tx: mpsc::Sender<DiscoveredPeer>,
 ) {
-    let mut seen: HashSet<NodeId> = HashSet::new();
-    let mut heard = 0usize;
     while let Some(event) = events.recv().await {
         let Event::Discovered(enr) = event else { continue };
-        heard += 1;
-        if pinned_targets.contains(&enr.node_id()) {
+        let id = enr.node_id();
+        // Pinned ids keep the lookup path's seq gate: a hearsay copy may be
+        // an older record than the one already emitted.
+        if pinned_targets.contains(&id) {
             continue;
         }
-        for peer in collect_new_candidates(std::iter::once(enr), &mut seen, &accepted_digests) {
-            tracing::debug!(heard, known = seen.len(), "CL peer heard in a NODES response");
-            if tx.send(peer).await.is_err() {
-                return;
-            }
+        if seen.lock().expect("seen lock").contains(&id) {
+            continue;
         }
-        if seen.len() > 16_384 {
-            seen.clear();
+        let Some(peer) = filter_candidate(&enr, &accepted_digests) else {
+            // Off-fork or no TCP endpoint: never a candidate, never re-checked.
+            seen.lock().expect("seen lock").insert(id);
+            continue;
+        };
+        match tx.try_send(peer) {
+            Ok(()) => {
+                seen.lock().expect("seen lock").insert(id);
+            }
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                // Not recorded: heard again later, emitted then.
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => return,
         }
     }
 }
 
 /// The fork-matched, TCP-bearing peers among `enrs` that `seen` has not yet
-/// recorded — recording them as it goes, so a node is emitted once ever (until
-/// the caller clears `seen` on a re-seed).
+/// recorded — recording them as it goes, so a node is emitted once per `seen`
+/// lifetime. The lookup loop's once-ever rule in one place, with a test.
 fn collect_new_candidates(
     enrs: impl IntoIterator<Item = Enr>,
     seen: &mut HashSet<NodeId>,
@@ -443,8 +471,7 @@ mod tests {
     const GNOSIS_BOOT_ENR: &str = "enr:-Ly4QIAhiTHk6JdVhCdiLwT83wAolUFo5J4nI5HrF7-zJO_QEw3cmEGxC1jvqNNUN64Vu-xxqDKSM528vKRNCehZAfEBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpCCS-QxAgAAZP__________gmlkgnY0gmlwhEFtZ5SJc2VjcDI1NmsxoQJwgL5C-30E8RJmW8gCb7sfwWvvfre7wGcCeV4X1G2wJYhzeW5jbmV0cwCDdGNwgiMog3VkcIIjKA";
 
     #[test]
-    #[test]
-    fn a_table_sweep_emits_each_matching_node_once() {
+    fn heard_nodes_are_emitted_once_each() {
         let enr: Enr = GNOSIS_BOOT_ENR.parse().expect("boot ENR parses");
         let digest = enr_eth2_fork_digest(&enr).expect("eth2 field");
         let mut seen = HashSet::new();
@@ -460,6 +487,7 @@ mod tests {
         assert!(seen2.contains(&enr.node_id()));
     }
 
+    #[test]
     fn parses_eth2_field_and_peer_id_from_real_enr() {
         let enr: Enr = GNOSIS_BOOT_ENR.parse().unwrap();
         let digest = enr_eth2_fork_digest(&enr).unwrap();


### PR DESCRIPTION
## Why

The Rust light client's discovery loop only ever emitted the ENRs that `find_node` returned: the 16 nodes closest to the lookup's target. Its walk contacts only the nodes on the path there, and every other ENR mentioned in the NODES responses along the way was discarded. On the shared eth2 DHT that is where nearly all of a small network's peers appear, because a random target is almost never near a sepolia node. The Java engine's poll walks its liveness-checked bucket entries, which are filled from those same responses, and surfaced 28 fork-matched sepolia peers within 10 seconds from the same address. A desktop wallet on the Rust engine sat in SYNCING on sepolia for 22 minutes today for lack of exactly these peers.

## What

Consume the discv5 service's `Discovered` event stream, one event per ENR in every NODES response, in a spawned task alongside the lookup loop, emitting each fork-matched, TCP-bearing node once. Details the review shaped:

- The once-ever emission set is shared between the loop and the consumer, so a re-seed (which clears it) refills the pool from both paths.
- The consumer sends non-blocking. The pool channel is small and drained at the sync loop's cadence, and on mainnet nearly every heard ENR matches; a node dropped on a full channel is not recorded and is re-emitted when heard again. The lookup loop's own sends and its re-seed check are never gated by the consumer.
- Pinned ids stay on the lookup path's seq-gated route so a hearsay copy cannot regress a pinned address.
- These records are hearsay (sigp: "not guaranteed to be live or contactable"). The pool's dial is what verifies them, an unreachable one is struck out on its first failure, dial fan-outs are fixed, and ENR signatures are checked on decode, so a wrong record cannot impersonate anyone.
- roost's server discovery path never opens the event stream and is unaffected.

## Measured

Standalone sepolia sync loop, 150 s, same address, before and after:

| | before | after |
|---|---|---|
| first fork-matched peer | 2 min 12 s | 4 s |
| fork-matched peers surfaced | 1 | 39 |
| ENRs heard | – | 4796 (1413 distinct) |

Re-measured after the review changes (shared dedup set, non-blocking sends): first fork-matched peer 4 s after start, 36 within 150 s, bootstrap and current at 40 s.

`cargo test -p myotis-net --lib`: all pass, including the new once-only emission test and the ENR-parsing test the first draft had accidentally unregistered.

Companion: #426 refreshes the sepolia pins that were dead; this PR is what makes the Rust engine find peers without pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNMr2LJJVj42AoFLuUk35a