### PR TITLE
[DO NOT MERGE] debug: month-old trust anchors on all three networks (cold-sync timing)

### DIFF
--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/NetworkConfig.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/NetworkConfig.java
@@ -93,9 +93,9 @@ public record NetworkConfig(
             // genesis_validators_root (mainnet)
             Bytes.fromHexString("4b363db94e286120d76eb905340fdd4e54bfe9f06bf33ff6cf5ad27f511bfe95").toArrayUnsafe(),
             // @checkpoint:mainnet:begin — managed by `./gradlew refreshCheckpoint`
-            // trusted checkpoint: recent finalized mainnet block root (slot 15185856, 2026-09-10, period 1853)
-            Bytes.fromHexString("16d197d597d795c05cb9a195a1bd34c77acd6c1f8ba336f75c5cfbc395710d68").toArrayUnsafe(),
-            15185856L, // checkpoint slot (epoch = slot/32). Must stay in sync with the root above.
+            // trusted checkpoint: pinned mainnet block root (slot 14966784, 2026-08-11, period 1827)
+            Bytes.fromHexString("6f4f119735ca52823fbf8f44a6775278da4399cdf2f341e276957905a4f7e8cc").toArrayUnsafe(),
+            14966784L, // checkpoint slot (epoch = slot/32). Must stay in sync with the root above.
             // @checkpoint:mainnet:end
             // current fork version: Fulu (0x06000000) — activated at slot 13164544 (2025-12-03)
             new byte[]{0x06, 0x00, 0x00, 0x00},
@@ -207,9 +207,9 @@ public record NetworkConfig(
             // genesis_validators_root (sepolia)
             Bytes.fromHexString("d8ea171f3c94aea21ebc42a1ed61052acf3f9209c00e4efbaaddac09ed9b8078").toArrayUnsafe(),
             // @checkpoint:sepolia:begin — managed by `./gradlew refreshCheckpoint`
-            // trusted checkpoint: recent finalized sepolia block root (slot 11110080, 2026-09-10, period 1356)
-            Bytes.fromHexString("3fdfc6b7c39990c859ca1ea0a73d4f072a49a7d3dfe7f6e416bf90006d6f079b").toArrayUnsafe(),
-            11110080L, // checkpoint slot (epoch = slot/32). Must stay in sync with the root above.
+            // trusted checkpoint: pinned sepolia block root (slot 10887168, 2026-08-10, period 1329)
+            Bytes.fromHexString("01258b494e29d9b22aa4aabdbc576a6eeb73ed6f3ce71662d844a43f9c516cc6").toArrayUnsafe(),
+            10887168L, // checkpoint slot (epoch = slot/32). Must stay in sync with the root above.
             // @checkpoint:sepolia:end
             // current fork version: Fulu on sepolia (0x90000075) — activated at epoch 272640 (2025-10-14)
             new byte[]{(byte) 0x90, 0x00, 0x00, 0x75},
@@ -336,9 +336,9 @@ public record NetworkConfig(
             // genesis_validators_root (Gnosis Beacon Chain)
             Bytes.fromHexString("f5dcb5564e829aab27264b9becd5dfaa017085611224cb3036f573368dbb9d47").toArrayUnsafe(),
             // @checkpoint:gnosis:begin — managed by `./gradlew refreshCheckpoint`
-            // trusted checkpoint: recent finalized gnosis block root (slot 30012384, 2026-09-10, period 3663)
-            Bytes.fromHexString("ed1faabdc3c3a7cac06a67bc7d6c483c2a4af00c37f754a4d3860d06e1745997").toArrayUnsafe(),
-            30012384L, // checkpoint slot (epoch = slot/16). Must stay in sync with the root above.
+            // trusted checkpoint: pinned gnosis block root (slot 29491200, 2026-08-11, period 3600)
+            Bytes.fromHexString("dd3a9196c045d5b886739c2ff351f38fa5ee03b8e885446498ea8b2b4a7cf299").toArrayUnsafe(),
+            29491200L, // checkpoint slot (epoch = slot/16). Must stay in sync with the root above.
             // @checkpoint:gnosis:end
             // current fork version: Fulu on Gnosis (0x06000064), active since 2026-04-14
             new byte[]{0x06, 0x00, 0x00, 0x64},

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/NetworkConfig.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/NetworkConfig.java
@@ -93,9 +93,9 @@ public record NetworkConfig(
             // genesis_validators_root (mainnet)
             Bytes.fromHexString("4b363db94e286120d76eb905340fdd4e54bfe9f06bf33ff6cf5ad27f511bfe95").toArrayUnsafe(),
             // @checkpoint:mainnet:begin — managed by `./gradlew refreshCheckpoint`
-            // trusted checkpoint: pinned mainnet block root (slot 14966784, 2026-08-11, period 1827)
-            Bytes.fromHexString("6f4f119735ca52823fbf8f44a6775278da4399cdf2f341e276957905a4f7e8cc").toArrayUnsafe(),
-            14966784L, // checkpoint slot (epoch = slot/32). Must stay in sync with the root above.
+            // trusted checkpoint: pinned mainnet block root (slot 14954496, 2026-08-09, period 1825)
+            Bytes.fromHexString("241fb8db4830e82940d4d494233500068d94e99a087370f97239299003bccaef").toArrayUnsafe(),
+            14954496L, // checkpoint slot (epoch = slot/32). Must stay in sync with the root above.
             // @checkpoint:mainnet:end
             // current fork version: Fulu (0x06000000) — activated at slot 13164544 (2025-12-03)
             new byte[]{0x06, 0x00, 0x00, 0x00},
@@ -207,9 +207,9 @@ public record NetworkConfig(
             // genesis_validators_root (sepolia)
             Bytes.fromHexString("d8ea171f3c94aea21ebc42a1ed61052acf3f9209c00e4efbaaddac09ed9b8078").toArrayUnsafe(),
             // @checkpoint:sepolia:begin — managed by `./gradlew refreshCheckpoint`
-            // trusted checkpoint: pinned sepolia block root (slot 10887168, 2026-08-10, period 1329)
-            Bytes.fromHexString("01258b494e29d9b22aa4aabdbc576a6eeb73ed6f3ce71662d844a43f9c516cc6").toArrayUnsafe(),
-            10887168L, // checkpoint slot (epoch = slot/32). Must stay in sync with the root above.
+            // trusted checkpoint: pinned sepolia block root (slot 10838080, 2026-08-03, period 1323)
+            Bytes.fromHexString("a00884e558ff8a4b721ab7ab4b2e3452a1cc45b4212c60de39d033bdcf75c5de").toArrayUnsafe(),
+            10838080L, // checkpoint slot (epoch = slot/32). Must stay in sync with the root above.
             // @checkpoint:sepolia:end
             // current fork version: Fulu on sepolia (0x90000075) — activated at epoch 272640 (2025-10-14)
             new byte[]{(byte) 0x90, 0x00, 0x00, 0x75},
@@ -336,9 +336,9 @@ public record NetworkConfig(
             // genesis_validators_root (Gnosis Beacon Chain)
             Bytes.fromHexString("f5dcb5564e829aab27264b9becd5dfaa017085611224cb3036f573368dbb9d47").toArrayUnsafe(),
             // @checkpoint:gnosis:begin — managed by `./gradlew refreshCheckpoint`
-            // trusted checkpoint: pinned gnosis block root (slot 29491200, 2026-08-11, period 3600)
-            Bytes.fromHexString("dd3a9196c045d5b886739c2ff351f38fa5ee03b8e885446498ea8b2b4a7cf299").toArrayUnsafe(),
-            29491200L, // checkpoint slot (epoch = slot/16). Must stay in sync with the root above.
+            // trusted checkpoint: pinned gnosis block root (slot 29458624, 2026-08-09, period 3596)
+            Bytes.fromHexString("018e7948b6690981d53eb3d4778b3a2c2c88a3aa65421f903e6011f69eb92f22").toArrayUnsafe(),
+            29458624L, // checkpoint slot (epoch = slot/16). Must stay in sync with the root above.
             // @checkpoint:gnosis:end
             // current fork version: Fulu on Gnosis (0x06000064), active since 2026-04-14
             new byte[]{0x06, 0x00, 0x00, 0x64},

--- a/rust/myotis-net/src/sync.rs
+++ b/rust/myotis-net/src/sync.rs
@@ -199,11 +199,11 @@ impl ChainConfig {
             // `./gradlew refreshCheckpoint` rewrites both from one fetch, and
             // `java_and_rust_checkpoints_agree` fails if they ever diverge.
             // @checkpoint:mainnet:begin — managed by `./gradlew refreshCheckpoint`
-            // trusted checkpoint: pinned mainnet block root (slot 14966784, 2026-08-11, period 1827)
+            // trusted checkpoint: pinned mainnet block root (slot 14954496, 2026-08-09, period 1825)
             checkpoint_root: hex32(
-                "6f4f119735ca52823fbf8f44a6775278da4399cdf2f341e276957905a4f7e8cc",
+                "241fb8db4830e82940d4d494233500068d94e99a087370f97239299003bccaef",
             ),
-            checkpoint_slot: 14_966_784,
+            checkpoint_slot: 14_954_496,
             // @checkpoint:mainnet:end
             static_peers: MAINNET_STATIC_PEERS.iter().map(|s| s.to_string()).collect(),
             bootstrap_enrs: MAINNET_BOOTSTRAP_ENRS.iter().map(|s| s.to_string()).collect(),
@@ -248,11 +248,11 @@ impl ChainConfig {
             // serving node's trustedNodeSync point, or that node cannot answer
             // the bootstrap for it (docs/dedicated-sepolia-node.md §5).
             // @checkpoint:sepolia:begin — managed by `./gradlew refreshCheckpoint`
-            // trusted checkpoint: pinned sepolia block root (slot 10887168, 2026-08-10, period 1329)
+            // trusted checkpoint: pinned sepolia block root (slot 10838080, 2026-08-03, period 1323)
             checkpoint_root: hex32(
-                "01258b494e29d9b22aa4aabdbc576a6eeb73ed6f3ce71662d844a43f9c516cc6",
+                "a00884e558ff8a4b721ab7ab4b2e3452a1cc45b4212c60de39d033bdcf75c5de",
             ),
-            checkpoint_slot: 10_887_168,
+            checkpoint_slot: 10_838_080,
             // @checkpoint:sepolia:end
             static_peers: SEPOLIA_STATIC_PEERS.iter().map(|s| s.to_string()).collect(),
             bootstrap_enrs: SEPOLIA_BOOTSTRAP_ENRS.iter().map(|s| s.to_string()).collect(),
@@ -305,11 +305,11 @@ impl ChainConfig {
             // anything older than a few periods anyway — and use `-Pperiod=<n>`
             // only to pin a retained state for testing, never one below the floor.
             // @checkpoint:gnosis:begin — managed by `./gradlew refreshCheckpoint`
-            // trusted checkpoint: pinned gnosis block root (slot 29491200, 2026-08-11, period 3600)
+            // trusted checkpoint: pinned gnosis block root (slot 29458624, 2026-08-09, period 3596)
             checkpoint_root: hex32(
-                "dd3a9196c045d5b886739c2ff351f38fa5ee03b8e885446498ea8b2b4a7cf299",
+                "018e7948b6690981d53eb3d4778b3a2c2c88a3aa65421f903e6011f69eb92f22",
             ),
-            checkpoint_slot: 29_491_200,
+            checkpoint_slot: 29_458_624,
             // @checkpoint:gnosis:end
             static_peers: GNOSIS_STATIC_PEERS.iter().map(|s| s.to_string()).collect(),
             bootstrap_enrs: GNOSIS_BOOTSTRAP_ENRS.iter().map(|s| s.to_string()).collect(),
@@ -3198,10 +3198,10 @@ mod tests {
         let c = ChainConfig::mainnet();
         assert_eq!(c.fork_version, [6, 0, 0, 0]);
         // @checkpoint:mainnet:test:begin — managed by `./gradlew refreshCheckpoint`
-        assert_eq!(c.checkpoint_slot, 14_966_784);
+        assert_eq!(c.checkpoint_slot, 14_954_496);
         assert_eq!(
             hex_str(&c.checkpoint_root),
-            "6f4f119735ca52823fbf8f44a6775278da4399cdf2f341e276957905a4f7e8cc"
+            "241fb8db4830e82940d4d494233500068d94e99a087370f97239299003bccaef"
         );
         // @checkpoint:mainnet:test:end
         assert_eq!(
@@ -3266,10 +3266,10 @@ mod tests {
         assert_eq!(c.chain_id, 11_155_111);
         assert_eq!(c.fork_version, [0x90, 0x00, 0x00, 0x75]); // Fulu on sepolia
         // @checkpoint:sepolia:test:begin — managed by `./gradlew refreshCheckpoint`
-        assert_eq!(c.checkpoint_slot, 10_887_168);
+        assert_eq!(c.checkpoint_slot, 10_838_080);
         assert_eq!(
             hex_str(&c.checkpoint_root),
-            "01258b494e29d9b22aa4aabdbc576a6eeb73ed6f3ce71662d844a43f9c516cc6"
+            "a00884e558ff8a4b721ab7ab4b2e3452a1cc45b4212c60de39d033bdcf75c5de"
         );
         // @checkpoint:sepolia:test:end
         assert_eq!(
@@ -3336,10 +3336,10 @@ mod tests {
         assert_eq!(c.fork_version, [0x06, 0x00, 0x00, 0x64]); // Fulu on Gnosis
         assert_eq!(c.prior_fork_version, Some([0x05, 0x00, 0x00, 0x64])); // Electra
         // @checkpoint:gnosis:test:begin — managed by `./gradlew refreshCheckpoint`
-        assert_eq!(c.checkpoint_slot, 29_491_200);
+        assert_eq!(c.checkpoint_slot, 29_458_624);
         assert_eq!(
             hex_str(&c.checkpoint_root),
-            "dd3a9196c045d5b886739c2ff351f38fa5ee03b8e885446498ea8b2b4a7cf299"
+            "018e7948b6690981d53eb3d4778b3a2c2c88a3aa65421f903e6011f69eb92f22"
         );
         // @checkpoint:gnosis:test:end
         assert_eq!(

--- a/rust/myotis-net/src/sync.rs
+++ b/rust/myotis-net/src/sync.rs
@@ -199,11 +199,11 @@ impl ChainConfig {
             // `./gradlew refreshCheckpoint` rewrites both from one fetch, and
             // `java_and_rust_checkpoints_agree` fails if they ever diverge.
             // @checkpoint:mainnet:begin — managed by `./gradlew refreshCheckpoint`
-            // trusted checkpoint: recent finalized mainnet block root (slot 15185856, 2026-09-10, period 1853)
+            // trusted checkpoint: pinned mainnet block root (slot 14966784, 2026-08-11, period 1827)
             checkpoint_root: hex32(
-                "16d197d597d795c05cb9a195a1bd34c77acd6c1f8ba336f75c5cfbc395710d68",
+                "6f4f119735ca52823fbf8f44a6775278da4399cdf2f341e276957905a4f7e8cc",
             ),
-            checkpoint_slot: 15_185_856,
+            checkpoint_slot: 14_966_784,
             // @checkpoint:mainnet:end
             static_peers: MAINNET_STATIC_PEERS.iter().map(|s| s.to_string()).collect(),
             bootstrap_enrs: MAINNET_BOOTSTRAP_ENRS.iter().map(|s| s.to_string()).collect(),
@@ -248,11 +248,11 @@ impl ChainConfig {
             // serving node's trustedNodeSync point, or that node cannot answer
             // the bootstrap for it (docs/dedicated-sepolia-node.md §5).
             // @checkpoint:sepolia:begin — managed by `./gradlew refreshCheckpoint`
-            // trusted checkpoint: recent finalized sepolia block root (slot 11110080, 2026-09-10, period 1356)
+            // trusted checkpoint: pinned sepolia block root (slot 10887168, 2026-08-10, period 1329)
             checkpoint_root: hex32(
-                "3fdfc6b7c39990c859ca1ea0a73d4f072a49a7d3dfe7f6e416bf90006d6f079b",
+                "01258b494e29d9b22aa4aabdbc576a6eeb73ed6f3ce71662d844a43f9c516cc6",
             ),
-            checkpoint_slot: 11_110_080,
+            checkpoint_slot: 10_887_168,
             // @checkpoint:sepolia:end
             static_peers: SEPOLIA_STATIC_PEERS.iter().map(|s| s.to_string()).collect(),
             bootstrap_enrs: SEPOLIA_BOOTSTRAP_ENRS.iter().map(|s| s.to_string()).collect(),
@@ -305,11 +305,11 @@ impl ChainConfig {
             // anything older than a few periods anyway — and use `-Pperiod=<n>`
             // only to pin a retained state for testing, never one below the floor.
             // @checkpoint:gnosis:begin — managed by `./gradlew refreshCheckpoint`
-            // trusted checkpoint: recent finalized gnosis block root (slot 30012384, 2026-09-10, period 3663)
+            // trusted checkpoint: pinned gnosis block root (slot 29491200, 2026-08-11, period 3600)
             checkpoint_root: hex32(
-                "ed1faabdc3c3a7cac06a67bc7d6c483c2a4af00c37f754a4d3860d06e1745997",
+                "dd3a9196c045d5b886739c2ff351f38fa5ee03b8e885446498ea8b2b4a7cf299",
             ),
-            checkpoint_slot: 30_012_384,
+            checkpoint_slot: 29_491_200,
             // @checkpoint:gnosis:end
             static_peers: GNOSIS_STATIC_PEERS.iter().map(|s| s.to_string()).collect(),
             bootstrap_enrs: GNOSIS_BOOTSTRAP_ENRS.iter().map(|s| s.to_string()).collect(),
@@ -3198,10 +3198,10 @@ mod tests {
         let c = ChainConfig::mainnet();
         assert_eq!(c.fork_version, [6, 0, 0, 0]);
         // @checkpoint:mainnet:test:begin — managed by `./gradlew refreshCheckpoint`
-        assert_eq!(c.checkpoint_slot, 15_185_856);
+        assert_eq!(c.checkpoint_slot, 14_966_784);
         assert_eq!(
             hex_str(&c.checkpoint_root),
-            "16d197d597d795c05cb9a195a1bd34c77acd6c1f8ba336f75c5cfbc395710d68"
+            "6f4f119735ca52823fbf8f44a6775278da4399cdf2f341e276957905a4f7e8cc"
         );
         // @checkpoint:mainnet:test:end
         assert_eq!(
@@ -3266,10 +3266,10 @@ mod tests {
         assert_eq!(c.chain_id, 11_155_111);
         assert_eq!(c.fork_version, [0x90, 0x00, 0x00, 0x75]); // Fulu on sepolia
         // @checkpoint:sepolia:test:begin — managed by `./gradlew refreshCheckpoint`
-        assert_eq!(c.checkpoint_slot, 11_110_080);
+        assert_eq!(c.checkpoint_slot, 10_887_168);
         assert_eq!(
             hex_str(&c.checkpoint_root),
-            "3fdfc6b7c39990c859ca1ea0a73d4f072a49a7d3dfe7f6e416bf90006d6f079b"
+            "01258b494e29d9b22aa4aabdbc576a6eeb73ed6f3ce71662d844a43f9c516cc6"
         );
         // @checkpoint:sepolia:test:end
         assert_eq!(
@@ -3336,10 +3336,10 @@ mod tests {
         assert_eq!(c.fork_version, [0x06, 0x00, 0x00, 0x64]); // Fulu on Gnosis
         assert_eq!(c.prior_fork_version, Some([0x05, 0x00, 0x00, 0x64])); // Electra
         // @checkpoint:gnosis:test:begin — managed by `./gradlew refreshCheckpoint`
-        assert_eq!(c.checkpoint_slot, 30_012_384);
+        assert_eq!(c.checkpoint_slot, 29_491_200);
         assert_eq!(
             hex_str(&c.checkpoint_root),
-            "ed1faabdc3c3a7cac06a67bc7d6c483c2a4af00c37f754a4d3860d06e1745997"
+            "dd3a9196c045d5b886739c2ff351f38fa5ee03b8e885446498ea8b2b4a7cf299"
         );
         // @checkpoint:gnosis:test:end
         assert_eq!(


### PR DESCRIPTION
## DO NOT MERGE — debug branch

Every embedded trust checkpoint is pinned to the **oldest block each roost instance still serves a `light_client_bootstrap` for**, so a cold-cache, no-snapshot start walks the whole span roost can serve. Every anchor is past the weak-subjectivity bound (13 periods mainnet/sepolia, 3 gnosis), so each network parks in `STALE_ANCHOR` and needs explicit consent — which is the point of the experiment, and the reason this must never land on `main`.

| network | period | slot | date | periods behind head (2026-09-11) |
|---|---|---|---|---|
| mainnet | 1825 | 14954496 | 2026-08-09 | ~29 |
| sepolia | 1323 | 10838080 | 2026-08-03 | ~34 |
| gnosis  | 3596 | 29458624 | 2026-08-09 | ~69 |

### How the pins were found (live, over libp2p, `examples/roost_floor.rs` — not committed)
1. `updates_by_range(period, 1)` binary search from the wall-clock period down: floors mainnet 1825, sepolia 1323, gnosis 3596 (period below each refused).
2. Bootstraps are servable only from the upstream Nimbus's trusted-sync point, not from the period's first slot. Roost registers a miss on the first ask and fills it from Nimbus within a 12 s tick, so every epoch-start candidate was asked twice. The oldest served epoch start per network is the pin above; the epoch before it was refused definitively.

### Provenance
- sepolia and gnosis: `./gradlew refreshCheckpoint -Pslot=<n>` with its two-operator gate satisfied (publicnode + ChainSafe Lodestar for sepolia; publicnode + rpc-gbc.gnosischain.com for gnosis).
- mainnet: slot 14954496 is below ChainSafe's history floor, so the task could only get publicnode's root. The second voice is roost mainnet's own upstream, which served the bootstrap for exactly this root; the region was written by hand in the task's output form.
- `java_and_rust_checkpoints_agree` and the three `*_config_matches_networkconfig_java` tests pass; `:networking:test --tests "*NetworkConfig*"` passes.

### How to measure a genuinely cold sync
1. `./gradlew :app:run -Pargs=purge-cache` (and `-Pnetwork=sepolia|gnosis` variants) — deletes the EL peer cache, the CL peer cache **and** `sync-state[-net].snapshot`. Without this the engine resumes from the newer snapshot and never touches the anchor (both engines anchor at `max(checkpoint_period, snapshot_period)`). Repeat before **every** timed run; the hosts' "Clear peer caches" button does the same.
2. Start; it parks in `STALE_ANCHOR`. Consent with `-Pargs=accept-stale-anchor` (or pre-consent with `-Dmyotis.beacon.acceptStaleAnchor=true`), or tap "Sync anyway" in the hosts.
3. On `main` the walk is paced by the 11 s serve quota, one period per round; #431 changes that to a per-peer pipeline.

### Review notes (internal review, no code change)
- The dispatched node-binding smoke job and the ignored `live_mainnet` test would park in `STALE_ANCHOR` on this branch — don't dispatch them here.
- The sepolia LC-peer comment in `sync.rs` cites a bootstrap census done against an earlier pin.

Before any branch-off from here, restore the anchors with `./gradlew refreshCheckpoint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
