### PR TITLE
lc: verify a next-period signature with the next committee, on updates and finality updates

### DIFF
--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/lightclient/LightClientProcessor.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/lightclient/LightClientProcessor.java
@@ -52,6 +52,18 @@ public class LightClientProcessor {
      * @param update the finality update to process
      * @return true if the update was successfully applied
      */
+    /**
+     * The committee that signs {@code sigPeriod}, given the store at {@code storePeriod}
+     * with {@code current} as its current committee: {@code current} for the store's own
+     * period, the held next committee for the one after, {@code null} otherwise (spec
+     * validate_light_client_update's applicability + key selection).
+     */
+    private SyncCommittee committeeFor(long sigPeriod, long storePeriod, SyncCommittee current) {
+        if (sigPeriod == storePeriod) return current;
+        if (sigPeriod == storePeriod + 1) return store.getNextSyncCommittee();
+        return null;
+    }
+
     public boolean processFinalityUpdate(LightClientFinalityUpdate update) {
         SyncCommittee committee = store.getCurrentSyncCommittee();
         if (committee == null) {
@@ -76,6 +88,19 @@ public class LightClientProcessor {
                 attestedSlot, finalizedSlot, update.signatureSlot(),
                 participation, update.finalityBranch().length);
 
+        // Same period rule as processUpdate. This path had no gate at all and always
+        // used the current keys, so at every period boundary — store at P holding
+        // next, wall in P+1 — every P+1-signed finality update was rejected until a
+        // catch-up round happened to force-rotate.
+        long storePeriod = store.getCurrentSyncCommitteePeriod();
+        long sigPeriod = BeaconChainSpec.computeSyncCommitteePeriod(update.signatureSlot());
+        committee = committeeFor(sigPeriod, storePeriod, committee);
+        if (committee == null) {
+            log.debug("[lc-processor] Finality update rejected: signaturePeriod={} not applicable to "
+                    + "storePeriod={} (attestedSlot={})", sigPeriod, storePeriod, attestedSlot);
+            return false;
+        }
+
         // Verify sync aggregate over attested header
         if (!SyncCommitteeVerifier.verify(
                 update.syncAggregate(),
@@ -84,8 +109,8 @@ public class LightClientProcessor {
                 forkVersion,
                 genesisValidatorsRoot)) {
             log.debug("[lc-processor] Finality update rejected: BLS verification failed " +
-                    "(attestedSlot={}, forkVersion={}, fv[0]={}, id={}, participation={})",
-                    attestedSlot, bytesToHex(forkVersion), forkVersion[0],
+                    "(attestedSlot={}, usedNext={}, forkVersion={}, fv[0]={}, id={}, participation={})",
+                    attestedSlot, sigPeriod != storePeriod, bytesToHex(forkVersion), forkVersion[0],
                     System.identityHashCode(forkVersion), participation);
             return false;
         }
@@ -166,9 +191,9 @@ public class LightClientProcessor {
 
         // Cheap applicability gate BEFORE the expensive BLS verify. An update's
         // sync aggregate is signed by the committee of signature_slot's period,
-        // so it can only verify against our current committee when that period
-        // matches store_period (or store_period+1 once we already hold the next
-        // committee) — per spec validate_light_client_update. This is critical
+        // so it can only verify against the committee of THAT period: ours for
+        // store_period, the held next one for store_period+1 — per spec
+        // validate_light_client_update. This is critical
         // on Android: each BLS sync-aggregate verify costs ~17-30s on ART, and a
         // catch-up updates_by_range response routinely contains far-future
         // periods (e.g. period 1766 while the store is at 1728). Without this
@@ -176,28 +201,16 @@ public class LightClientProcessor {
         // check, so catch-up from an old checkpoint never makes progress.
         long storePeriod = store.getCurrentSyncCommitteePeriod();
         long sigPeriod = BeaconChainSpec.computeSyncCommitteePeriod(update.signatureSlot());
-        boolean haveNext = store.getNextSyncCommittee() != null;
-        boolean applicable = haveNext
-                ? (sigPeriod == storePeriod || sigPeriod == storePeriod + 1)
-                : (sigPeriod == storePeriod);
-        if (!applicable) {
+        // Selecting the keys IS the gate. Verifying both admitted periods with the
+        // current keys rejected genuine next-committee updates before rotation and
+        // accepted a current-committee signature whose unsigned signatureSlot had
+        // been relabelled into the next period (#423).
+        committee = committeeFor(sigPeriod, storePeriod, committee);
+        if (committee == null) {
             log.debug("[lc-processor] Update skipped pre-verify: signaturePeriod={} not applicable to "
                             + "storePeriod={} (haveNext={}, attestedSlot={})",
-                    sigPeriod, storePeriod, haveNext, attestedSlot);
+                    sigPeriod, storePeriod, store.getNextSyncCommittee() != null, attestedSlot);
             return false;
-        }
-
-        // The aggregate is signed by the committee of signatureSlot's PERIOD (spec
-        // validate_light_client_update): the current committee for storePeriod, the
-        // held next committee for storePeriod + 1. Verifying both admitted periods
-        // with the current keys rejected genuine next-committee updates before
-        // rotation and accepted a current-committee signature whose unsigned
-        // signatureSlot had been relabelled into the next period (#423).
-        if (sigPeriod != storePeriod) {
-            committee = store.getNextSyncCommittee();
-            if (committee == null) {
-                return false; // unreachable: the gate admitted P+1 only with a next committee
-            }
         }
 
         // Verify sync aggregate over attested header
@@ -207,8 +220,9 @@ public class LightClientProcessor {
                 update.attestedHeader().beacon(),
                 forkVersion,
                 genesisValidatorsRoot)) {
-            log.info("[lc-processor] Update rejected (attestedSlot={}, finalizedSlot={}): BLS sync-aggregate verify failed",
-                    attestedSlot, finalizedSlot);
+            log.info("[lc-processor] Update rejected (attestedSlot={}, finalizedSlot={}, usedNext={}): "
+                            + "BLS sync-aggregate verify failed",
+                    attestedSlot, finalizedSlot, sigPeriod != storePeriod);
             return false;
         }
 

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/lightclient/LightClientProcessor.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/lightclient/LightClientProcessor.java
@@ -40,6 +40,18 @@ public class LightClientProcessor {
     }
 
     /**
+     * The committee that signs {@code sigPeriod}: the store's current committee for its own
+     * period, the held next committee for the period after, {@code null} otherwise (spec
+     * validate_light_client_update's applicability + key selection in one place).
+     */
+    private SyncCommittee committeeFor(long sigPeriod) {
+        long storePeriod = store.getCurrentSyncCommitteePeriod();
+        if (sigPeriod == storePeriod) return store.getCurrentSyncCommittee();
+        if (sigPeriod == storePeriod + 1) return store.getNextSyncCommittee();
+        return null;
+    }
+
+    /**
      * Process a {@link LightClientFinalityUpdate}.
      *
      * <ol>
@@ -52,18 +64,6 @@ public class LightClientProcessor {
      * @param update the finality update to process
      * @return true if the update was successfully applied
      */
-    /**
-     * The committee that signs {@code sigPeriod}, given the store at {@code storePeriod}
-     * with {@code current} as its current committee: {@code current} for the store's own
-     * period, the held next committee for the one after, {@code null} otherwise (spec
-     * validate_light_client_update's applicability + key selection).
-     */
-    private SyncCommittee committeeFor(long sigPeriod, long storePeriod, SyncCommittee current) {
-        if (sigPeriod == storePeriod) return current;
-        if (sigPeriod == storePeriod + 1) return store.getNextSyncCommittee();
-        return null;
-    }
-
     public boolean processFinalityUpdate(LightClientFinalityUpdate update) {
         SyncCommittee committee = store.getCurrentSyncCommittee();
         if (committee == null) {
@@ -89,12 +89,13 @@ public class LightClientProcessor {
                 participation, update.finalityBranch().length);
 
         // Same period rule as processUpdate. This path had no gate at all and always
-        // used the current keys, so at every period boundary — store at P holding
-        // next, wall in P+1 — every P+1-signed finality update was rejected until a
+        // used the current keys, so with the store at P holding next and a P+1-signed
+        // finality update in hand (a local clock lagging the chain; the Rust engine's
+        // hunt path while catch-up is starved) the update was rejected until a
         // catch-up round happened to force-rotate.
         long storePeriod = store.getCurrentSyncCommitteePeriod();
         long sigPeriod = BeaconChainSpec.computeSyncCommitteePeriod(update.signatureSlot());
-        committee = committeeFor(sigPeriod, storePeriod, committee);
+        committee = committeeFor(sigPeriod);
         if (committee == null) {
             log.debug("[lc-processor] Finality update rejected: signaturePeriod={} not applicable to "
                     + "storePeriod={} (attestedSlot={})", sigPeriod, storePeriod, attestedSlot);
@@ -205,7 +206,7 @@ public class LightClientProcessor {
         // current keys rejected genuine next-committee updates before rotation and
         // accepted a current-committee signature whose unsigned signatureSlot had
         // been relabelled into the next period (#423).
-        committee = committeeFor(sigPeriod, storePeriod, committee);
+        committee = committeeFor(sigPeriod);
         if (committee == null) {
             log.debug("[lc-processor] Update skipped pre-verify: signaturePeriod={} not applicable to "
                             + "storePeriod={} (haveNext={}, attestedSlot={})",

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/lightclient/LightClientProcessor.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/lightclient/LightClientProcessor.java
@@ -30,6 +30,12 @@ public class LightClientProcessor {
      *  costs ~18s on Android/ART, so without this the steady-state loop burns a full
      *  core re-proving the same update. */
     private volatile byte[] lastAppliedFinalitySig;
+    /** The signature slot that {@link #lastAppliedFinalitySig} was applied under. The slot is not
+     *  covered by the signature, so the memo must key on both: the same aggregate relabelled into
+     *  another period is a different update that has to face the period gate and the next
+     *  committee's keys (#423), not the memo — and a memo hit must never be a verdict that
+     *  re-verification would not reach. */
+    private volatile long lastAppliedFinalitySigSlot = -1;
 
     public LightClientProcessor(LightClientStore store, byte[] forkVersion, byte[] genesisValidatorsRoot) {
         this.store = store;
@@ -75,20 +81,9 @@ public class LightClientProcessor {
         long finalizedSlot = update.finalizedHeader().beacon().slot();
         int participation = update.syncAggregate().countParticipants();
 
-        byte[] sig = update.syncAggregate().syncCommitteeSignature();
-        byte[] lastSig = lastAppliedFinalitySig;
-        if (lastSig != null && java.util.Arrays.equals(lastSig, sig)) {
-            log.debug("[lc-processor] Finality update is a duplicate of the already-applied one "
-                    + "(attestedSlot={}) — skipping re-verify", attestedSlot);
-            return true;
-        }
-
-        log.debug("[lc-processor] Processing finality update: attestedSlot={}, finalizedSlot={}, " +
-                "signatureSlot={}, participation={}/512, finalityBranchLen={}",
-                attestedSlot, finalizedSlot, update.signatureSlot(),
-                participation, update.finalityBranch().length);
-
-        // Same period rule as processUpdate. This path had no gate at all and always
+        // Same period rule as processUpdate, and BEFORE the duplicate memo, so a memo hit
+        // can never be a verdict that re-verification would not reach. This path had no
+        // gate at all and always
         // used the current keys, so with the store at P holding next and a P+1-signed
         // finality update in hand (a local clock lagging the chain; the Rust engine's
         // hunt path while catch-up is starved) the update was rejected until a
@@ -101,6 +96,20 @@ public class LightClientProcessor {
                     + "storePeriod={} (attestedSlot={})", sigPeriod, storePeriod, attestedSlot);
             return false;
         }
+
+        byte[] sig = update.syncAggregate().syncCommitteeSignature();
+        byte[] lastSig = lastAppliedFinalitySig;
+        if (lastSig != null && java.util.Arrays.equals(lastSig, sig)
+                && lastAppliedFinalitySigSlot == update.signatureSlot()) {
+            log.debug("[lc-processor] Finality update is a duplicate of the already-applied one "
+                    + "(attestedSlot={}) — skipping re-verify", attestedSlot);
+            return true;
+        }
+
+        log.debug("[lc-processor] Processing finality update: attestedSlot={}, finalizedSlot={}, " +
+                "signatureSlot={}, participation={}/512, finalityBranchLen={}",
+                attestedSlot, finalizedSlot, update.signatureSlot(),
+                participation, update.finalityBranch().length);
 
         // Verify sync aggregate over attested header
         if (!SyncCommitteeVerifier.verify(
@@ -161,6 +170,7 @@ public class LightClientProcessor {
         }
 
         lastAppliedFinalitySig = sig.clone();
+        lastAppliedFinalitySigSlot = update.signatureSlot();
         log.debug("[lc-processor] Finality update applied: finalizedSlot {} → {}", oldFinalizedSlot, finalizedSlot);
         return true;
     }

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/lightclient/LightClientProcessor.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/lightclient/LightClientProcessor.java
@@ -187,6 +187,19 @@ public class LightClientProcessor {
             return false;
         }
 
+        // The aggregate is signed by the committee of signatureSlot's PERIOD (spec
+        // validate_light_client_update): the current committee for storePeriod, the
+        // held next committee for storePeriod + 1. Verifying both admitted periods
+        // with the current keys rejected genuine next-committee updates before
+        // rotation and accepted a current-committee signature whose unsigned
+        // signatureSlot had been relabelled into the next period (#423).
+        if (sigPeriod != storePeriod) {
+            committee = store.getNextSyncCommittee();
+            if (committee == null) {
+                return false; // unreachable: the gate admitted P+1 only with a next committee
+            }
+        }
+
         // Verify sync aggregate over attested header
         if (!SyncCommitteeVerifier.verify(
                 update.syncAggregate(),

--- a/consensus/src/test/java/com/jaeckel/ethp2p/consensus/lightclient/LightClientProcessorTest.java
+++ b/consensus/src/test/java/com/jaeckel/ethp2p/consensus/lightclient/LightClientProcessorTest.java
@@ -232,11 +232,21 @@ class LightClientProcessorTest {
         // Store the next committee
         store.updateNextSyncCommittee(nextCommittee);
 
-        // Process a finality update that crosses into period 1 (slot 8192+)
+        // Process a finality update that crosses into period 1 (slot 8192+). Its
+        // signature slot is in period 1, so it is signed by the NEXT committee
+        // (spec validate_light_client_update, #423) — the same bytes signed with the
+        // period-0 keys are a relabelled current-committee signature and must fail.
         long newSlot = BeaconChainSpec.SLOTS_PER_SYNC_COMMITTEE_PERIOD + 10; // period 1
-        LightClientFinalityUpdate update = buildValidFinalityUpdate(newSlot, newSlot + 1);
+        LightClientFinalityUpdate relabelled = buildValidFinalityUpdate(newSlot, newSlot + 1);
+        assertFalse(processor.processFinalityUpdate(relabelled),
+                "period-1 signature slot must be verified with the next committee, not the current one");
+        LightClientFinalityUpdate update =
+                buildFinalityUpdateWithParticipation(newSlot, newSlot + 1, 512, nextKeys);
         assertTrue(processor.processFinalityUpdate(update));
         assertEquals(newSlot, store.getFinalizedSlot());
+        // Finality crossed into period 1, so the store rotated: next is now current.
+        assertNull(store.getNextSyncCommittee());
+        assertArrayEquals(nextCommittee.aggregatePubkey(), store.getCurrentSyncCommittee().aggregatePubkey());
 
         // The processor calls applyNextSyncCommitteeWhenPeriodChanges after updateFinalized,
         // so finalizedSlot is already at the new period. Test rotation via the store directly:
@@ -262,6 +272,11 @@ class LightClientProcessorTest {
 
     private LightClientFinalityUpdate buildFinalityUpdateWithParticipation(
             long finalizedSlot, long signatureSlot, int participantCount) {
+        return buildFinalityUpdateWithParticipation(finalizedSlot, signatureSlot, participantCount, secretKeys);
+    }
+
+    private LightClientFinalityUpdate buildFinalityUpdateWithParticipation(
+            long finalizedSlot, long signatureSlot, int participantCount, BIG[] keys) {
         // Build finalized header (execution payload genuinely committed to its body root)
         LightClientHeader finalizedHeader = TestUtil.consistentLightClientHeader(
                 finalizedSlot, 0L, new byte[32], new byte[32]);
@@ -282,19 +297,23 @@ class LightClientProcessorTest {
         LightClientHeader attestedHeader = TestUtil.consistentLightClientHeader(
                 signatureSlot, 0L, new byte[32], attestedStateRoot);
 
-        SyncAggregate agg = buildSyncAggregate(attestedHeader.beacon(), participantCount);
+        SyncAggregate agg = buildSyncAggregate(attestedHeader.beacon(), participantCount, keys);
 
         return new LightClientFinalityUpdate(
                 attestedHeader, finalizedHeader, finalityBranch, agg, signatureSlot);
     }
 
     private SyncAggregate buildSyncAggregate(BeaconBlockHeader attestedBeacon, int participantCount) {
+        return buildSyncAggregate(attestedBeacon, participantCount, secretKeys);
+    }
+
+    private SyncAggregate buildSyncAggregate(BeaconBlockHeader attestedBeacon, int participantCount, BIG[] keys) {
         byte[] domain = ForkData.computeDomain(BeaconChainSpec.DOMAIN_SYNC_COMMITTEE, FORK_VERSION, GVR);
         byte[] signingRoot = SszUtil.hashTreeRootContainer(attestedBeacon.hashTreeRoot(), domain);
 
         List<byte[]> sigs = new ArrayList<>();
         for (int i = 0; i < participantCount; i++) {
-            sigs.add(TestUtil.blsSign(secretKeys[i], signingRoot));
+            sigs.add(TestUtil.blsSign(keys[i], signingRoot));
         }
         byte[] aggSig = TestUtil.aggregateSignatures(sigs);
 

--- a/consensus/src/test/java/com/jaeckel/ethp2p/consensus/lightclient/NextCommitteeSelectionTest.java
+++ b/consensus/src/test/java/com/jaeckel/ethp2p/consensus/lightclient/NextCommitteeSelectionTest.java
@@ -1,0 +1,114 @@
+package com.jaeckel.ethp2p.consensus.lightclient;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import com.jaeckel.ethp2p.consensus.types.LightClientBootstrap;
+import com.jaeckel.ethp2p.consensus.types.LightClientUpdate;
+import com.jaeckel.ethp2p.consensus.types.SyncAggregate;
+import com.jaeckel.ethp2p.consensus.types.SyncCommittee;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+/**
+ * #423 — the Java twin of {@code rust/myotis-consensus/tests/next_committee_selection.rs}.
+ * An update's aggregate is signed by the committee of its signature slot's PERIOD. With
+ * the store at period P holding the next committee, a P+1-signed update must verify
+ * against the NEXT committee (and be accepted), while a current-committee signature
+ * whose unsigned signature slot was relabelled into P+1 must be rejected. Uses the
+ * committed, genuinely signed mainnet corpus; no network, and no force-rotation
+ * between updates (rotation is what hides the selection on the live path).
+ */
+class NextCommitteeSelectionTest {
+
+    private static final Path CORPUS = Path.of("..", "rust", "testdata", "lc", "mainnet");
+    private static final byte[] FORK_VERSION = {0x06, 0x00, 0x00, 0x00};
+    private static final byte[] GVR = hex("4b363db94e286120d76eb905340fdd4e54bfe9f06bf33ff6cf5ad27f511bfe95");
+
+    private record Fixture(LightClientStore store, LightClientProcessor processor) {}
+
+    private static byte[] hex(String h) {
+        byte[] out = new byte[h.length() / 2];
+        for (int i = 0; i < out.length; i++) out[i] = (byte) Integer.parseInt(h.substring(2 * i, 2 * i + 2), 16);
+        return out;
+    }
+
+    private static byte[] corpus(String name) throws IOException {
+        return Files.readAllBytes(CORPUS.resolve(name));
+    }
+
+    /** Store at period 1777 holding BOTH committees: bootstrap, then 001-update, no rotation. */
+    private static Fixture withNext() throws IOException {
+        assumeTrue(Files.isDirectory(CORPUS), "lc corpus not present at " + CORPUS.toAbsolutePath());
+        LightClientBootstrap b = LightClientBootstrap.decode(corpus("bootstrap.ssz"));
+        LightClientStore store = new LightClientStore();
+        store.initialize(b.header(), b.currentSyncCommittee());
+        LightClientProcessor p = new LightClientProcessor(store, FORK_VERSION, GVR);
+        assertTrue(p.processUpdate(LightClientUpdate.decode(corpus("001-update.ssz"))));
+        assertEquals(1777, store.getCurrentSyncCommitteePeriod());
+        assertFalse(Arrays.equals(store.getCurrentSyncCommittee().hashTreeRoot(),
+                store.getNextSyncCommittee().hashTreeRoot()), "distinct current and next committees");
+        return new Fixture(store, p);
+    }
+
+    private static boolean signatureValid(LightClientUpdate u, SyncCommittee committee) {
+        return SyncCommitteeVerifier.verify(u.syncAggregate(), committee, u.attestedHeader().beacon(),
+                FORK_VERSION, GVR);
+    }
+
+    private static LightClientUpdate with(LightClientUpdate u, SyncAggregate aggregate, long signatureSlot) {
+        return new LightClientUpdate(u.attestedHeader(), u.nextSyncCommittee(), u.nextSyncCommitteeBranch(),
+                u.finalizedHeader(), u.finalityBranch(), aggregate, signatureSlot);
+    }
+
+    @Test
+    void nextPeriodSignatureVerifiesWithTheNextCommittee() throws IOException {
+        Fixture f = withNext();
+        LightClientUpdate second = LightClientUpdate.decode(corpus("002-update.ssz"));
+        assertEquals(1778, BeaconChainSpec.computeSyncCommitteePeriod(second.signatureSlot()));
+        assertFalse(signatureValid(second, f.store().getCurrentSyncCommittee()), "signed by the NEXT committee");
+        assertTrue(signatureValid(second, f.store().getNextSyncCommittee()));
+        assertTrue(f.processor().processUpdate(second),
+                "a valid next-committee update must be accepted before rotation");
+        assertEquals(1778, f.store().getCurrentSyncCommitteePeriod());
+        assertEquals(second.finalizedHeader().beacon().slot(), f.store().getFinalizedSlot());
+    }
+
+    @Test
+    void currentCommitteeSignatureRelabelledIntoTheNextPeriodIsRejected() throws IOException {
+        Fixture f = withNext();
+        LightClientUpdate first = LightClientUpdate.decode(corpus("001-update.ssz"));
+        // signatureSlot is not itself signed: claiming next-period participation must
+        // select the next keys, under which this genuine current-committee signature fails.
+        LightClientUpdate relabelled = with(first, first.syncAggregate(),
+                first.signatureSlot() + BeaconChainSpec.SLOTS_PER_SYNC_COMMITTEE_PERIOD);
+        assertTrue(signatureValid(relabelled, f.store().getCurrentSyncCommittee()));
+        assertFalse(signatureValid(relabelled, f.store().getNextSyncCommittee()));
+        assertFalse(f.processor().processUpdate(relabelled),
+                "current keys must not authenticate next-period participation");
+    }
+
+    @Test
+    void currentPeriodSignatureStillUsesTheCurrentCommittee() throws IOException {
+        Fixture f = withNext();
+        LightClientUpdate first = LightClientUpdate.decode(corpus("001-update.ssz"));
+        assertEquals(1777, BeaconChainSpec.computeSyncCommitteePeriod(first.signatureSlot()));
+        assertTrue(f.processor().processUpdate(first));
+    }
+
+    @Test
+    void corruptedSignaturesAreRejectedInBothPeriods() throws IOException {
+        for (String name : new String[] {"001-update.ssz", "002-update.ssz"}) {
+            Fixture f = withNext();
+            LightClientUpdate u = LightClientUpdate.decode(corpus(name));
+            LightClientUpdate bad = with(u,
+                    new SyncAggregate(u.syncAggregate().syncCommitteeBits(), new byte[96]), u.signatureSlot());
+            assertFalse(f.processor().processUpdate(bad), name);
+        }
+    }
+}

--- a/consensus/src/test/java/com/jaeckel/ethp2p/consensus/lightclient/NextCommitteeSelectionTest.java
+++ b/consensus/src/test/java/com/jaeckel/ethp2p/consensus/lightclient/NextCommitteeSelectionTest.java
@@ -75,10 +75,15 @@ class NextCommitteeSelectionTest {
         assertEquals(1778, BeaconChainSpec.computeSyncCommitteePeriod(second.signatureSlot()));
         assertFalse(signatureValid(second, f.store().getCurrentSyncCommittee()), "signed by the NEXT committee");
         assertTrue(signatureValid(second, f.store().getNextSyncCommittee()));
+        byte[] heldNextRoot = f.store().getNextSyncCommittee().hashTreeRoot();
         assertTrue(f.processor().processUpdate(second),
                 "a valid next-committee update must be accepted before rotation");
         assertEquals(1778, f.store().getCurrentSyncCommitteePeriod());
         assertEquals(second.finalizedHeader().beacon().slot(), f.store().getFinalizedSlot());
+        // The rotation installed the HELD next committee, not the P+2 committee this
+        // update carries (processUpdate stores an embedded next only when none is held).
+        assertTrue(Arrays.equals(heldNextRoot, f.store().getCurrentSyncCommittee().hashTreeRoot()));
+        assertNull(f.store().getNextSyncCommittee());
     }
 
     @Test
@@ -135,6 +140,21 @@ class NextCommitteeSelectionTest {
         // Its finalized slot is the first of period 1778, so the store rotated on apply.
         assertEquals(1778, f.store().getCurrentSyncCommitteePeriod());
         assertNull(f.store().getNextSyncCommittee());
+    }
+
+    @Test
+    void appliedFinalityUpdateReplayedWithARelabelledSlotIsRejected() throws IOException {
+        Fixture f = withNext();
+        LightClientUpdate first = LightClientUpdate.decode(corpus("001-update.ssz"));
+        LightClientFinalityUpdate applied = finalityOf(first, first.signatureSlot());
+        assertTrue(f.processor().processFinalityUpdate(applied));
+        // Same aggregate bytes, unsigned signature slot moved into period 1778: the
+        // duplicate memo must not answer for it — it faces the next committee's keys.
+        LightClientFinalityUpdate relabelled = finalityOf(first,
+                first.signatureSlot() + BeaconChainSpec.SLOTS_PER_SYNC_COMMITTEE_PERIOD);
+        assertFalse(f.processor().processFinalityUpdate(relabelled));
+        // The genuine duplicate is still memoised.
+        assertTrue(f.processor().processFinalityUpdate(applied));
     }
 
     @Test

--- a/consensus/src/test/java/com/jaeckel/ethp2p/consensus/lightclient/NextCommitteeSelectionTest.java
+++ b/consensus/src/test/java/com/jaeckel/ethp2p/consensus/lightclient/NextCommitteeSelectionTest.java
@@ -2,6 +2,7 @@ package com.jaeckel.ethp2p.consensus.lightclient;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -131,6 +132,17 @@ class NextCommitteeSelectionTest {
         LightClientFinalityUpdate fin = finalityOf(second, second.signatureSlot());
         assertTrue(f.processor().processFinalityUpdate(fin), "signed by the held next committee");
         assertEquals(second.finalizedHeader().beacon().slot(), f.store().getFinalizedSlot());
+        // Its finalized slot is the first of period 1778, so the store rotated on apply.
+        assertEquals(1778, f.store().getCurrentSyncCommitteePeriod());
+        assertNull(f.store().getNextSyncCommittee());
+    }
+
+    @Test
+    void currentPeriodFinalityUpdateStillVerifies() throws IOException {
+        Fixture f = withNext();
+        LightClientUpdate first = LightClientUpdate.decode(corpus("001-update.ssz"));
+        assertEquals(1777, BeaconChainSpec.computeSyncCommitteePeriod(first.signatureSlot()));
+        assertTrue(f.processor().processFinalityUpdate(finalityOf(first, first.signatureSlot())));
     }
 
     @Test

--- a/consensus/src/test/java/com/jaeckel/ethp2p/consensus/lightclient/NextCommitteeSelectionTest.java
+++ b/consensus/src/test/java/com/jaeckel/ethp2p/consensus/lightclient/NextCommitteeSelectionTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import com.jaeckel.ethp2p.consensus.types.LightClientBootstrap;
+import com.jaeckel.ethp2p.consensus.types.LightClientFinalityUpdate;
 import com.jaeckel.ethp2p.consensus.types.LightClientUpdate;
 import com.jaeckel.ethp2p.consensus.types.SyncAggregate;
 import com.jaeckel.ethp2p.consensus.types.SyncCommittee;
@@ -99,6 +100,46 @@ class NextCommitteeSelectionTest {
         LightClientUpdate first = LightClientUpdate.decode(corpus("001-update.ssz"));
         assertEquals(1777, BeaconChainSpec.computeSyncCommitteePeriod(first.signatureSlot()));
         assertTrue(f.processor().processUpdate(first));
+    }
+
+    @Test
+    void unknownNextCommitteeAndOutOfRangePeriodAreRejected() throws IOException {
+        // Bootstrapped only: no next committee held, so period 1778 is not admissible.
+        assumeTrue(Files.isDirectory(CORPUS));
+        LightClientBootstrap b = LightClientBootstrap.decode(corpus("bootstrap.ssz"));
+        LightClientStore store = new LightClientStore();
+        store.initialize(b.header(), b.currentSyncCommittee());
+        LightClientProcessor bare = new LightClientProcessor(store, FORK_VERSION, GVR);
+        LightClientUpdate second = LightClientUpdate.decode(corpus("002-update.ssz"));
+        assertFalse(bare.processUpdate(second));
+        // Two periods ahead is never admissible, next committee or not.
+        Fixture f = withNext();
+        LightClientUpdate tooFar = with(second, second.syncAggregate(),
+                second.signatureSlot() + BeaconChainSpec.SLOTS_PER_SYNC_COMMITTEE_PERIOD);
+        assertFalse(f.processor().processUpdate(tooFar));
+    }
+
+    private static LightClientFinalityUpdate finalityOf(LightClientUpdate u, long signatureSlot) {
+        return new LightClientFinalityUpdate(u.attestedHeader(), u.finalizedHeader(), u.finalityBranch(),
+                u.syncAggregate(), signatureSlot);
+    }
+
+    @Test
+    void nextPeriodFinalityUpdateIsAcceptedBeforeRotation() throws IOException {
+        Fixture f = withNext();
+        LightClientUpdate second = LightClientUpdate.decode(corpus("002-update.ssz"));
+        LightClientFinalityUpdate fin = finalityOf(second, second.signatureSlot());
+        assertTrue(f.processor().processFinalityUpdate(fin), "signed by the held next committee");
+        assertEquals(second.finalizedHeader().beacon().slot(), f.store().getFinalizedSlot());
+    }
+
+    @Test
+    void relabelledCurrentCommitteeFinalityUpdateIsRejected() throws IOException {
+        Fixture f = withNext();
+        LightClientUpdate first = LightClientUpdate.decode(corpus("001-update.ssz"));
+        LightClientFinalityUpdate fin = finalityOf(first,
+                first.signatureSlot() + BeaconChainSpec.SLOTS_PER_SYNC_COMMITTEE_PERIOD);
+        assertFalse(f.processor().processFinalityUpdate(fin));
     }
 
     @Test

--- a/rust/myotis-consensus/src/store.rs
+++ b/rust/myotis-consensus/src/store.rs
@@ -206,34 +206,21 @@ impl LightClientProcessor {
         // validate_light_client_update; mirrors the Java gate exactly).
         let store_period = self.store.current_period();
         let sig_period = self.store.period_of(update.signature_slot);
-        let have_next = self.store.next_sync_committee().is_some();
-        let applicable = if have_next {
-            sig_period == store_period || sig_period == store_period + 1
-        } else {
-            sig_period == store_period
-        };
-        if !applicable {
-            tracing::debug!(store_period, sig_period, have_next,
+        // The aggregate is signed by the committee of signature_slot's PERIOD
+        // (spec validate_light_client_update): our current committee for
+        // store_period, the held next committee for store_period + 1, nothing
+        // for anything else. Selecting the keys IS the gate. Verifying both
+        // admitted periods with the current keys rejected genuine
+        // next-committee updates before rotation and accepted a
+        // current-committee signature whose unsigned signature_slot had been
+        // relabelled into the next period (#423).
+        let Some(committee) = self.committee_for(sig_period, store_period, committee) else {
+            tracing::debug!(store_period, sig_period,
+                have_next = self.store.next_sync_committee().is_some(),
                 signature_slot = update.signature_slot,
                 attested_slot = update.attested_header.beacon.slot,
                 "update rejected: not applicable to the store's period");
             return false;
-        }
-
-        // The aggregate is signed by the committee of signature_slot's PERIOD
-        // (spec validate_light_client_update): the current committee for
-        // store_period, the held next committee for store_period + 1. Using
-        // the current keys for both admitted periods rejected genuine
-        // next-committee updates before rotation and accepted a
-        // current-committee signature whose unsigned signature_slot had been
-        // relabelled into the next period (#423).
-        let committee = if sig_period == store_period {
-            committee
-        } else {
-            let Some(next) = self.store.next_sync_committee() else {
-                return false; // unreachable: the gate admitted P+1 only with a next committee
-            };
-            next
         };
 
         if !verify::verify_sync_aggregate(
@@ -243,7 +230,7 @@ impl LightClientProcessor {
             &self.fork_version,
             &self.genesis_validators_root,
         ) {
-            tracing::debug!(store_period, sig_period,
+            tracing::debug!(store_period, sig_period, used_next = sig_period != store_period,
                 signature_slot = update.signature_slot,
                 attested_slot = update.attested_header.beacon.slot,
                 participants = update.sync_aggregate.count_participants(),
@@ -304,8 +291,39 @@ impl LightClientProcessor {
         true
     }
 
+    /// The committee that signs `sig_period`, given the store at `store_period`
+    /// with `current` as its current committee: `current` for the store's own
+    /// period, the held next committee for the one after, `None` otherwise
+    /// (spec validate_light_client_update's applicability + key selection).
+    fn committee_for<'a>(
+        &'a self,
+        sig_period: u64,
+        store_period: u64,
+        current: &'a SyncCommittee,
+    ) -> Option<&'a SyncCommittee> {
+        if sig_period == store_period {
+            Some(current)
+        } else if sig_period == store_period + 1 {
+            self.store.next_sync_committee()
+        } else {
+            None
+        }
+    }
+
     pub fn process_finality_update(&mut self, update: &LightClientFinalityUpdate) -> bool {
         let Some(committee) = self.store.current_sync_committee() else {
+            return false;
+        };
+        // Same period rule as process_update. This path had no gate at all and
+        // always used the current keys, so at every period boundary — store at
+        // P holding next, wall in P+1 — every P+1-signed finality update was
+        // rejected until a catch-up round happened to force-rotate.
+        let store_period = self.store.current_period();
+        let sig_period = self.store.period_of(update.signature_slot);
+        let Some(committee) = self.committee_for(sig_period, store_period, committee) else {
+            tracing::debug!(store_period, sig_period,
+                signature_slot = update.signature_slot,
+                "finality update rejected: not applicable to the store's period");
             return false;
         };
 
@@ -316,6 +334,8 @@ impl LightClientProcessor {
             &self.fork_version,
             &self.genesis_validators_root,
         ) {
+            tracing::debug!(store_period, sig_period, used_next = sig_period != store_period,
+                "finality update rejected: sync-aggregate BLS verification failed");
             return false;
         }
 

--- a/rust/myotis-consensus/src/store.rs
+++ b/rust/myotis-consensus/src/store.rs
@@ -220,6 +220,22 @@ impl LightClientProcessor {
             return false;
         }
 
+        // The aggregate is signed by the committee of signature_slot's PERIOD
+        // (spec validate_light_client_update): the current committee for
+        // store_period, the held next committee for store_period + 1. Using
+        // the current keys for both admitted periods rejected genuine
+        // next-committee updates before rotation and accepted a
+        // current-committee signature whose unsigned signature_slot had been
+        // relabelled into the next period (#423).
+        let committee = if sig_period == store_period {
+            committee
+        } else {
+            let Some(next) = self.store.next_sync_committee() else {
+                return false; // unreachable: the gate admitted P+1 only with a next committee
+            };
+            next
+        };
+
         if !verify::verify_sync_aggregate(
             &update.sync_aggregate,
             committee,

--- a/rust/myotis-consensus/src/store.rs
+++ b/rust/myotis-consensus/src/store.rs
@@ -197,10 +197,10 @@ impl LightClientProcessor {
     }
 
     pub fn process_update(&mut self, update: &LightClientUpdate) -> bool {
-        let Some(committee) = self.store.current_sync_committee() else {
+        if self.store.current_sync_committee().is_none() {
             tracing::debug!("update rejected: store has no current sync committee");
             return false;
-        };
+        }
 
         // Applicability gate BEFORE the expensive BLS verify (per spec
         // validate_light_client_update; mirrors the Java gate exactly).
@@ -214,7 +214,7 @@ impl LightClientProcessor {
         // next-committee updates before rotation and accepted a
         // current-committee signature whose unsigned signature_slot had been
         // relabelled into the next period (#423).
-        let Some(committee) = self.committee_for(sig_period, store_period, committee) else {
+        let Some(committee) = self.committee_for(sig_period) else {
             tracing::debug!(store_period, sig_period,
                 have_next = self.store.next_sync_committee().is_some(),
                 signature_slot = update.signature_slot,
@@ -291,18 +291,14 @@ impl LightClientProcessor {
         true
     }
 
-    /// The committee that signs `sig_period`, given the store at `store_period`
-    /// with `current` as its current committee: `current` for the store's own
-    /// period, the held next committee for the one after, `None` otherwise
-    /// (spec validate_light_client_update's applicability + key selection).
-    fn committee_for<'a>(
-        &'a self,
-        sig_period: u64,
-        store_period: u64,
-        current: &'a SyncCommittee,
-    ) -> Option<&'a SyncCommittee> {
+    /// The committee that signs `sig_period`: the store's current committee
+    /// for its own period, the held next committee for the period after,
+    /// `None` otherwise (spec validate_light_client_update's applicability +
+    /// key selection in one place).
+    fn committee_for(&self, sig_period: u64) -> Option<&SyncCommittee> {
+        let store_period = self.store.current_period();
         if sig_period == store_period {
-            Some(current)
+            self.store.current_sync_committee()
         } else if sig_period == store_period + 1 {
             self.store.next_sync_committee()
         } else {
@@ -311,16 +307,17 @@ impl LightClientProcessor {
     }
 
     pub fn process_finality_update(&mut self, update: &LightClientFinalityUpdate) -> bool {
-        let Some(committee) = self.store.current_sync_committee() else {
+        if self.store.current_sync_committee().is_none() {
             return false;
-        };
+        }
         // Same period rule as process_update. This path had no gate at all and
-        // always used the current keys, so at every period boundary — store at
-        // P holding next, wall in P+1 — every P+1-signed finality update was
-        // rejected until a catch-up round happened to force-rotate.
+        // always used the current keys, so with the store at P holding next
+        // and a P+1-signed finality update in hand — the hunt path while
+        // catch-up is starved, or a local clock lagging the chain — the update
+        // was rejected until a catch-up round happened to force-rotate.
         let store_period = self.store.current_period();
         let sig_period = self.store.period_of(update.signature_slot);
-        let Some(committee) = self.committee_for(sig_period, store_period, committee) else {
+        let Some(committee) = self.committee_for(sig_period) else {
             tracing::debug!(store_period, sig_period,
                 signature_slot = update.signature_slot,
                 "finality update rejected: not applicable to the store's period");
@@ -335,6 +332,7 @@ impl LightClientProcessor {
             &self.genesis_validators_root,
         ) {
             tracing::debug!(store_period, sig_period, used_next = sig_period != store_period,
+                attested_slot = update.attested_header.beacon.slot,
                 "finality update rejected: sync-aggregate BLS verification failed");
             return false;
         }

--- a/rust/myotis-consensus/src/store.rs
+++ b/rust/myotis-consensus/src/store.rs
@@ -170,8 +170,10 @@ impl LightClientStore {
 }
 
 /// Processes updates against a store — Rust twin of `LightClientProcessor` (minus
-/// the duplicate-signature fast path, which is a perf memo, not a verdict change:
-/// re-verifying a duplicate reaches the same `true`).
+/// the duplicate-signature fast path, which is a perf memo keyed on the applied
+/// signature AND its slot, behind the period gate — not a verdict change:
+/// re-verifying a duplicate reaches the same `true`, and a relabelled slot is
+/// not a duplicate).
 pub struct LightClientProcessor {
     pub store: LightClientStore,
     fork_version: [u8; 4],

--- a/rust/myotis-consensus/tests/next_committee_finality.rs
+++ b/rust/myotis-consensus/tests/next_committee_finality.rs
@@ -58,6 +58,9 @@ fn next_period_finality_update_is_accepted_before_rotation() {
     assert_eq!(spec::compute_sync_committee_period(fin.signature_slot), 1778);
     assert!(p.process_finality_update(&fin), "signed by the held next committee");
     assert_eq!(p.store.finalized_slot(), fin.finalized_header.beacon.slot);
+    // Its finalized slot is the first of period 1778, so the store rotated on apply.
+    assert_eq!(p.store.current_period(), 1778);
+    assert!(p.store.next_sync_committee().is_none());
 }
 
 #[test]

--- a/rust/myotis-consensus/tests/next_committee_finality.rs
+++ b/rust/myotis-consensus/tests/next_committee_finality.rs
@@ -1,0 +1,90 @@
+//! #423, finality path: a finality update is signed by the committee of its
+//! signature slot's period too. Built from the committed mainnet update corpus
+//! (a finality update is the finality-relevant subset of an update), with the
+//! store left at period 1777 holding the next committee — no force-rotation.
+
+use std::{fs, path::PathBuf};
+
+use myotis_consensus::{
+    spec,
+    store::{LightClientProcessor, LightClientStore},
+    types::{LightClientBootstrap, LightClientFinalityUpdate, LightClientUpdate},
+};
+
+const FORK: [u8; 4] = [6, 0, 0, 0];
+const GENESIS: &str = "4b363db94e286120d76eb905340fdd4e54bfe9f06bf33ff6cf5ad27f511bfe95";
+
+fn root(hex: &str) -> [u8; 32] {
+    std::array::from_fn(|i| u8::from_str_radix(&hex[i * 2..i * 2 + 2], 16).unwrap())
+}
+
+fn corpus(name: &str) -> Vec<u8> {
+    fs::read(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../testdata/lc/mainnet").join(name)).unwrap()
+}
+
+fn update(name: &str) -> LightClientUpdate {
+    LightClientUpdate::decode(&corpus(name)).unwrap()
+}
+
+fn finality_of(u: &LightClientUpdate) -> LightClientFinalityUpdate {
+    LightClientFinalityUpdate {
+        attested_header: u.attested_header.clone(),
+        finalized_header: u.finalized_header.clone(),
+        finality_branch: u.finality_branch.clone(),
+        sync_aggregate: u.sync_aggregate.clone(),
+        signature_slot: u.signature_slot,
+    }
+}
+
+fn processor() -> LightClientProcessor {
+    let b = LightClientBootstrap::decode(&corpus("bootstrap.ssz")).unwrap();
+    let mut store = LightClientStore::new_mainnet_preset();
+    store.initialize(b.header, b.current_sync_committee);
+    LightClientProcessor::new(store, FORK, root(GENESIS))
+}
+
+fn with_next() -> LightClientProcessor {
+    let mut p = processor();
+    assert!(p.process_update(&update("001-update.ssz")));
+    assert_eq!(p.store.current_period(), 1777);
+    assert!(p.store.next_sync_committee().is_some());
+    p
+}
+
+#[test]
+fn next_period_finality_update_is_accepted_before_rotation() {
+    let mut p = with_next();
+    let fin = finality_of(&update("002-update.ssz"));
+    assert_eq!(spec::compute_sync_committee_period(fin.signature_slot), 1778);
+    assert!(p.process_finality_update(&fin), "signed by the held next committee");
+    assert_eq!(p.store.finalized_slot(), fin.finalized_header.beacon.slot);
+}
+
+#[test]
+fn relabelled_current_committee_finality_update_is_rejected() {
+    let mut p = with_next();
+    let mut fin = finality_of(&update("001-update.ssz"));
+    fin.signature_slot += spec::SLOTS_PER_SYNC_COMMITTEE_PERIOD;
+    assert!(!p.process_finality_update(&fin), "current keys must not authenticate next-period participation");
+}
+
+#[test]
+fn next_period_finality_update_without_a_next_committee_is_rejected() {
+    // Bootstrapped only: no next committee held, so period 1778 is not admissible.
+    let mut p = processor();
+    let fin = finality_of(&update("002-update.ssz"));
+    assert!(!p.process_finality_update(&fin));
+    // Two periods ahead is never admissible, next committee or not.
+    let mut p = with_next();
+    let mut far = finality_of(&update("002-update.ssz"));
+    far.signature_slot += spec::SLOTS_PER_SYNC_COMMITTEE_PERIOD;
+    assert!(!p.process_finality_update(&far));
+}
+
+#[test]
+fn current_period_finality_update_still_verifies() {
+    let mut p = with_next();
+    let fin = finality_of(&update("001-update.ssz"));
+    assert_eq!(spec::compute_sync_committee_period(fin.signature_slot), 1777);
+    assert!(p.process_finality_update(&fin));
+}

--- a/rust/myotis-consensus/tests/next_committee_selection.rs
+++ b/rust/myotis-consensus/tests/next_committee_selection.rs
@@ -1,0 +1,169 @@
+//! Network-free regression using the committed, genuinely signed mainnet corpus.
+//! Do not force-rotate between updates: process_update explicitly admits a next
+//! period signature when the current store already holds its next committee.
+
+use std::{fs, path::PathBuf};
+
+use myotis_consensus::{
+    spec, ssz,
+    store::{LightClientProcessor, LightClientStore},
+    types::{LightClientBootstrap, LightClientUpdate, SyncCommittee},
+    verify,
+};
+
+const FORK: [u8; 4] = [6, 0, 0, 0];
+const GENESIS: &str = "4b363db94e286120d76eb905340fdd4e54bfe9f06bf33ff6cf5ad27f511bfe95";
+
+fn root(hex: &str) -> [u8; 32] {
+    std::array::from_fn(|i| u8::from_str_radix(&hex[i * 2..i * 2 + 2], 16).unwrap())
+}
+
+fn corpus(name: &str) -> Vec<u8> {
+    fs::read(PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../testdata/lc/mainnet").join(name)).unwrap()
+}
+
+fn update(name: &str) -> LightClientUpdate {
+    LightClientUpdate::decode(&corpus(name)).unwrap()
+}
+
+fn processor() -> LightClientProcessor {
+    let b = LightClientBootstrap::decode(&corpus("bootstrap.ssz")).unwrap();
+    assert_eq!(b.header.beacon.hash_tree_root(),
+        root("58cb432571912a434ab7fb83317bb60d09632cce53839fc2541417710465b42e"));
+    let depth = b.current_sync_committee_branch.len();
+    assert!(ssz::verify_merkle_branch(
+        &b.current_sync_committee.hash_tree_root(), &b.current_sync_committee_branch,
+        depth, spec::sync_committee_gindex(depth), &b.header.beacon.state_root,
+    ));
+    assert!(LightClientProcessor::verify_execution_branch(&b.header));
+    let mut store = LightClientStore::new_mainnet_preset();
+    store.initialize(b.header, b.current_sync_committee);
+    LightClientProcessor::new(store, FORK, root(GENESIS))
+}
+
+fn signature_valid(u: &LightClientUpdate, committee: &SyncCommittee) -> bool {
+    verify::verify_sync_aggregate(
+        &u.sync_aggregate, committee, &u.attested_header.beacon, &FORK, &root(GENESIS),
+    )
+}
+
+fn assert_proofs(u: &LightClientUpdate) {
+    assert!(u.signature_slot > u.attested_header.beacon.slot);
+    assert!(u.attested_header.beacon.slot >= u.finalized_header.beacon.slot);
+    assert!(LightClientProcessor::verify_execution_branch(&u.attested_header));
+    assert!(LightClientProcessor::verify_execution_branch(&u.finalized_header));
+    let depth = u.finality_branch.len();
+    assert!(ssz::verify_merkle_branch(
+        &u.finalized_header.beacon.hash_tree_root(), &u.finality_branch,
+        depth, spec::finalized_root_gindex(depth), &u.attested_header.beacon.state_root,
+    ));
+    let depth = u.next_sync_committee_branch.len();
+    assert!(ssz::verify_merkle_branch(
+        &u.next_sync_committee.hash_tree_root(), &u.next_sync_committee_branch,
+        depth, spec::next_sync_committee_gindex(depth), &u.attested_header.beacon.state_root,
+    ));
+}
+
+fn with_next() -> LightClientProcessor {
+    let mut p = processor();
+    let first = update("001-update.ssz");
+    assert_proofs(&first);
+    assert!(signature_valid(&first, p.store.current_sync_committee().unwrap()));
+    assert!(p.process_update(&first));
+    assert_eq!(p.store.current_period(), 1777);
+    assert_ne!(p.store.current_sync_committee().unwrap().hash_tree_root(),
+        p.store.next_sync_committee().unwrap().hash_tree_root());
+    p
+}
+
+#[test]
+fn current_period_signature_uses_current_committee() {
+    let mut p = with_next();
+    let first = update("001-update.ssz");
+    assert_eq!(spec::compute_sync_committee_period(first.signature_slot), 1777);
+    assert!(!signature_valid(&first, p.store.next_sync_committee().unwrap()));
+    assert!(p.process_update(&first));
+}
+
+#[test]
+fn next_period_signature_uses_next_committee() {
+    let mut p = with_next();
+    let second = update("002-update.ssz");
+    assert_proofs(&second);
+    assert_eq!(spec::compute_sync_committee_period(second.signature_slot), 1778);
+    assert!(!signature_valid(&second, p.store.current_sync_committee().unwrap()));
+    assert!(signature_valid(&second, p.store.next_sync_committee().unwrap()));
+    println!("valid real update: store={}, signature_slot={}, signature_period={}, finalized_slot={}",
+        p.store.current_period(), second.signature_slot,
+        spec::compute_sync_committee_period(second.signature_slot), second.finalized_header.beacon.slot);
+    assert!(p.process_update(&second), "valid next-committee signature must be accepted");
+    assert_eq!(p.store.current_period(), 1778);
+    assert_eq!(p.store.finalized_slot(), second.finalized_header.beacon.slot);
+}
+
+#[test]
+fn wrong_committee_signature_is_rejected() {
+    let mut p = with_next();
+    let mut first = update("001-update.ssz");
+    // Signature slot is not itself signed. Claiming next-period participation
+    // must select next keys, rather than accept an old-committee signature.
+    first.signature_slot += spec::SLOTS_PER_SYNC_COMMITTEE_PERIOD;
+    assert_proofs(&first);
+    assert!(signature_valid(&first, p.store.current_sync_committee().unwrap()));
+    assert!(!signature_valid(&first, p.store.next_sync_committee().unwrap()));
+    assert!(!p.process_update(&first), "current keys must not authenticate next-period participation");
+}
+
+#[test]
+fn corrupted_signatures_are_rejected_in_both_periods() {
+    for name in ["001-update.ssz", "002-update.ssz"] {
+        let mut p = with_next();
+        let mut u = update(name);
+        u.sync_aggregate.sync_committee_signature = [0; 96];
+        assert!(!p.process_update(&u));
+    }
+}
+
+#[test]
+fn unknown_next_committee_and_out_of_range_period_are_rejected() {
+    let second = update("002-update.ssz");
+    assert!(!processor().process_update(&second));
+    let mut p = with_next();
+    let mut too_far = second;
+    too_far.signature_slot += spec::SLOTS_PER_SYNC_COMMITTEE_PERIOD;
+    assert!(!p.process_update(&too_far));
+}
+
+#[test]
+fn ordinary_catch_up_force_rotation_avoids_next_selection_branch() {
+    let mut p = with_next();
+    // The real catch-up caller uses its wall-slot estimate after every apply.
+    p.store.force_rotate_if_past_period(14_704_714);
+    assert_eq!(p.store.current_period(), 1778);
+    assert!(p.store.next_sync_committee().is_none());
+    let second = update("002-update.ssz");
+    assert!(signature_valid(&second, p.store.current_sync_committee().unwrap()));
+    assert!(p.process_update(&second));
+}
+
+#[test]
+fn invalid_required_proof_branches_are_rejected_in_both_periods() {
+    for name in ["001-update.ssz", "002-update.ssz"] {
+        for branch in ["finality", "attested_execution", "finalized_execution"] {
+            let mut p = with_next();
+            let mut u = update(name);
+            match branch {
+                "finality" => u.finality_branch[0][0] ^= 1,
+                "attested_execution" => u.attested_header.execution_branch[0][0] ^= 1,
+                _ => u.finalized_header.execution_branch[0][0] ^= 1,
+            }
+            assert!(!p.process_update(&u), "{name}: {branch}");
+        }
+    }
+    // The next-committee proof is required when the store does not hold it yet.
+    let mut first = update("001-update.ssz");
+    first.next_sync_committee_branch[0][0] ^= 1;
+    assert!(!processor().process_update(&first));
+}
+

--- a/rust/myotis-consensus/tests/next_committee_selection.rs
+++ b/rust/myotis-consensus/tests/next_committee_selection.rs
@@ -97,9 +97,14 @@ fn next_period_signature_uses_next_committee() {
     println!("valid real update: store={}, signature_slot={}, signature_period={}, finalized_slot={}",
         p.store.current_period(), second.signature_slot,
         spec::compute_sync_committee_period(second.signature_slot), second.finalized_header.beacon.slot);
+    let held_next_root = p.store.next_sync_committee().unwrap().hash_tree_root();
     assert!(p.process_update(&second), "valid next-committee signature must be accepted");
     assert_eq!(p.store.current_period(), 1778);
     assert_eq!(p.store.finalized_slot(), second.finalized_header.beacon.slot);
+    // The rotation installed the HELD next committee, not the P+2 committee this
+    // update carries (process_update stores an embedded next only when none is held).
+    assert_eq!(p.store.current_sync_committee().unwrap().hash_tree_root(), held_next_root);
+    assert!(p.store.next_sync_committee().is_none());
 }
 
 #[test]

--- a/rust/testdata/lc/mainnet/expected.txt
+++ b/rust/testdata/lc/mainnet/expected.txt
@@ -8,8 +8,10 @@
 # 001..018-update.ssz is the accepted catch-up chain (periods 1777→1795);
 # 099-update.ssz is a STALE negative (= 018 replayed after rotation: rejected by
 # the applicability gate, signaturePeriod 1794 vs storePeriod 1795);
-# 001-finality.ssz is a negative (BLS verify fails: captured while the live store
-# was mid-catch-up on a different committee); 002-finality.ssz applies.
+# 001-finality.ssz is a negative (captured while the live store was mid-catch-up
+# on a different committee: its signature period 1794 is neither the replay
+# store's 1795 nor 1796, so the period gate rejects it before BLS — it failed
+# BLS under the pre-#423 processor); 002-finality.ssz applies.
 # input.currentSlotEstimate is the ONE wall-clock input, replayed verbatim
 # (drives forceRotateIfPastPeriod between applied updates).
 bootstrap.headerRoot=58cb432571912a434ab7fb83317bb60d09632cce53839fc2541417710465b42e


### PR DESCRIPTION
Fixes #423.

## The bug

A light-client update's sync aggregate is signed by the committee of its signature slot's period. Both processors admitted a signature period of store+1 when the next committee was held, per spec `validate_light_client_update`, but then verified the aggregate with the **current** committee regardless. Reproduced on the committed mainnet corpus, both engines: a genuine next-committee update processed before rotation was rejected, and a current-committee signature whose unsigned `signature_slot` was relabelled into the next period was accepted. The live catch-up path force-rotates on the wall-clock estimate after every apply, which is why production rarely reached the bad branch; the relabelled acceptance could never forge state (the signature still authenticates the header under real keys), so the practical effect was liveness.

## The fix

One helper per engine, `committee_for(sig_period)` / `committeeFor(sigPeriod)`, is both the applicability gate and the key selection: the store's current committee for its own period, the held next committee for the period after, nothing otherwise. Used in `process_update` / `processUpdate` **and** in `process_finality_update` / `processFinalityUpdate`, which the first internal review found had no gate at all and always used the current keys. The BLS-failure logs now say which committee was used.

**The finality path gains a new pre-verify gate.** Every case it now rejects before BLS was a BLS failure on main (store leading by one, trailing by two or more, or P+1 without a held next), so no verdict changes except the fixed one. Where it bites live: the sync loops route a period boundary through catch-up and force-rotate before polling finality, so the finality-path bug surfaced on the Rust hunt path while catch-up was starved, and under a local clock lagging the chain.

## Tests

- Rust: the reporter's seven-test file from the issue, verbatim (5/7 on main, 7/7 here), plus four finality-path tests built from the same corpus.
- Java: an eight-test twin covering the same cases; verified red without the fix on exactly the two intended cases. One pre-existing test, `syncCommitteeRotatesOnPeriodBoundary`, signed a period-1 finality update with period-0 keys and passed only because of the bug; it now asserts that is rejected, that the next-committee-signed version applies, and that the store rotates.
- The shared corpus conformance replay is unchanged on both engines (`001-finality` is now a period-gate reject rather than a BLS failure, same verdict; header note updated). No API, FFI, or snapshot-format change.

## Follow-ups the reviews surfaced (pre-existing, not in this PR)

- The spec's `update_attested_period == store_period` guard when storing `next_sync_committee` is absent in both engines; a boundary update could store the current committee as next.
- `apply_next_when_period_changes` rotates on the finalized-slot crossing without checking the committee counter, so a force-rotate followed by an apply can rotate twice.
- `update_optimistic` is keyed by the unsigned `signature_slot`; the spec keys by attested slot.
- Each period boundary costs one redundant catch-up round before finality polling resumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNMr2LJJVj42AoFLuUk35a