### PR TITLE
Light client: verify each update under the fork active at its signature slot (fork schedule, both engines)

### DIFF
--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
@@ -1,5 +1,6 @@
 package com.jaeckel.ethp2p.consensus;
 
+import com.jaeckel.ethp2p.core.consensus.ForkSchedule;
 import com.jaeckel.ethp2p.consensus.libp2p.BeaconP2PService;
 import com.jaeckel.ethp2p.consensus.lightclient.BeaconChainSpec;
 import com.jaeckel.ethp2p.consensus.lightclient.LightClientProcessor;
@@ -77,7 +78,7 @@ public class BeaconLightClient implements AutoCloseable {
     private final String beaconApiUrl;            // nullable; HTTP API for peer discovery
     private final byte[] checkpointRoot;      // 32-byte trusted checkpoint block root
     private final long checkpointSlot;        // slot of trusted checkpoint (for pre-bootstrap Status)
-    private final byte[] forkVersion;         // 4-byte fork version
+    private final ForkSchedule forkSchedule;  // per-slot signing-domain selector (#295); its newest entry feeds Status
     /**
      * Active BPO parameters per EIP-7892: {@code (epoch, max_blobs_per_block)}.
      * Folded into {@link #computeForkDigest(byte[])} via the XOR-mix-in
@@ -701,18 +702,18 @@ public class BeaconLightClient implements AutoCloseable {
      *
      * @param clPeerMultiaddrs       list of multiaddr strings for Consensus Layer peers
      * @param checkpointRoot         32-byte trusted checkpoint block root (weak subjectivity)
-     * @param forkVersion            4-byte current fork version
+     * @param forkSchedule           the chain's fork schedule (see {@link ForkSchedule})
      * @param genesisValidatorsRoot  32-byte genesis validators root
      * @param syncState              shared state holder updated as finality advances
      * @param beaconApiUrl           nullable HTTP API URL for local beacon node peer discovery
      */
     public BeaconLightClient(List<String> clPeerMultiaddrs,
                               byte[] checkpointRoot,
-                              byte[] forkVersion,
+                              ForkSchedule forkSchedule,
                               byte[] genesisValidatorsRoot,
                               BeaconSyncState syncState,
                               String beaconApiUrl) {
-        this(clPeerMultiaddrs, checkpointRoot, forkVersion, genesisValidatorsRoot,
+        this(clPeerMultiaddrs, checkpointRoot, forkSchedule, genesisValidatorsRoot,
                 syncState, beaconApiUrl, null, null, BeaconChainSpec.MAINNET_GENESIS_TIME);
     }
 
@@ -721,7 +722,7 @@ public class BeaconLightClient implements AutoCloseable {
      *
      * @param clPeerMultiaddrs       list of multiaddr strings for Consensus Layer peers
      * @param checkpointRoot         32-byte trusted checkpoint block root (weak subjectivity)
-     * @param forkVersion            4-byte current fork version
+     * @param forkSchedule           the chain's fork schedule (see {@link ForkSchedule})
      * @param genesisValidatorsRoot  32-byte genesis validators root
      * @param syncState              shared state holder updated as finality advances
      * @param beaconApiUrl           nullable HTTP API URL for local beacon node peer discovery
@@ -729,12 +730,12 @@ public class BeaconLightClient implements AutoCloseable {
      */
     public BeaconLightClient(List<String> clPeerMultiaddrs,
                               byte[] checkpointRoot,
-                              byte[] forkVersion,
+                              ForkSchedule forkSchedule,
                               byte[] genesisValidatorsRoot,
                               BeaconSyncState syncState,
                               String beaconApiUrl,
                               java.util.function.Consumer<String> onPeerSuccess) {
-        this(clPeerMultiaddrs, checkpointRoot, forkVersion, genesisValidatorsRoot,
+        this(clPeerMultiaddrs, checkpointRoot, forkSchedule, genesisValidatorsRoot,
                 syncState, beaconApiUrl, onPeerSuccess, null, BeaconChainSpec.MAINNET_GENESIS_TIME);
     }
 
@@ -747,13 +748,13 @@ public class BeaconLightClient implements AutoCloseable {
      */
     public BeaconLightClient(List<String> clPeerMultiaddrs,
                               byte[] checkpointRoot,
-                              byte[] forkVersion,
+                              ForkSchedule forkSchedule,
                               byte[] genesisValidatorsRoot,
                               BeaconSyncState syncState,
                               String beaconApiUrl,
                               java.util.function.Consumer<String> onPeerSuccess,
                               java.util.function.Consumer<String> onPeerFailure) {
-        this(clPeerMultiaddrs, checkpointRoot, forkVersion, genesisValidatorsRoot,
+        this(clPeerMultiaddrs, checkpointRoot, forkSchedule, genesisValidatorsRoot,
                 syncState, beaconApiUrl, onPeerSuccess, onPeerFailure,
                 BeaconChainSpec.MAINNET_GENESIS_TIME);
     }
@@ -768,14 +769,14 @@ public class BeaconLightClient implements AutoCloseable {
      */
     public BeaconLightClient(List<String> clPeerMultiaddrs,
                               byte[] checkpointRoot,
-                              byte[] forkVersion,
+                              ForkSchedule forkSchedule,
                               byte[] genesisValidatorsRoot,
                               BeaconSyncState syncState,
                               String beaconApiUrl,
                               java.util.function.Consumer<String> onPeerSuccess,
                               java.util.function.Consumer<String> onPeerFailure,
                               long clGenesisTime) {
-        this(clPeerMultiaddrs, checkpointRoot, 0L, forkVersion, genesisValidatorsRoot,
+        this(clPeerMultiaddrs, checkpointRoot, 0L, forkSchedule, genesisValidatorsRoot,
                 syncState, beaconApiUrl, onPeerSuccess, onPeerFailure, clGenesisTime);
     }
 
@@ -791,7 +792,7 @@ public class BeaconLightClient implements AutoCloseable {
     public BeaconLightClient(List<String> clPeerMultiaddrs,
                               byte[] checkpointRoot,
                               long checkpointSlot,
-                              byte[] forkVersion,
+                              ForkSchedule forkSchedule,
                               byte[] genesisValidatorsRoot,
                               BeaconSyncState syncState,
                               String beaconApiUrl,
@@ -801,8 +802,8 @@ public class BeaconLightClient implements AutoCloseable {
         if (checkpointRoot == null || checkpointRoot.length != 32) {
             throw new IllegalArgumentException("checkpointRoot must be 32 bytes");
         }
-        if (forkVersion == null || forkVersion.length != 4) {
-            throw new IllegalArgumentException("forkVersion must be 4 bytes");
+        if (forkSchedule == null) {
+            throw new IllegalArgumentException("forkSchedule must be set");
         }
         if (genesisValidatorsRoot == null || genesisValidatorsRoot.length != 32) {
             throw new IllegalArgumentException("genesisValidatorsRoot must be 32 bytes");
@@ -812,7 +813,7 @@ public class BeaconLightClient implements AutoCloseable {
         this.beaconApiUrl = beaconApiUrl;
         this.checkpointRoot = checkpointRoot.clone();
         this.checkpointSlot = checkpointSlot;
-        this.forkVersion = forkVersion.clone();
+        this.forkSchedule = forkSchedule;
         this.genesisValidatorsRoot = genesisValidatorsRoot.clone();
         this.clGenesisTime = clGenesisTime;
         this.syncState = syncState;
@@ -820,7 +821,7 @@ public class BeaconLightClient implements AutoCloseable {
         this.onPeerFailure = onPeerFailure;
 
         this.store = new LightClientStore();
-        this.processor = new LightClientProcessor(store, this.forkVersion, genesisValidatorsRoot);
+        this.processor = new LightClientProcessor(store, this.forkSchedule, genesisValidatorsRoot);
         // Supply the local Status on demand so BeaconP2PService can serve
         // inbound /status/{1,2} streams opened by peers — modern CL clients
         // drop us if we don't respond within RESP_TIMEOUT (~5 s).
@@ -874,7 +875,7 @@ public class BeaconLightClient implements AutoCloseable {
         if (running) {
             throw new IllegalStateException("BeaconLightClient is already running");
         }
-        log.info("[beacon] Starting with forkVersion={}", bytesToHex(forkVersion));
+        log.info("[beacon] Starting with forkSchedule={}", forkSchedule);
         p2pService.start();
         running = true;
         syncThread = new Thread(this::syncLoop, "beacon-sync");
@@ -1287,7 +1288,7 @@ public class BeaconLightClient implements AutoCloseable {
      * {@code fork_digest}.
      */
     private StatusMessage buildLocalStatus() {
-        return buildLocalStatusFor(forkVersion);
+        return buildLocalStatusFor(forkSchedule.current());
     }
 
     /**
@@ -1499,9 +1500,9 @@ public class BeaconLightClient implements AutoCloseable {
         }
     }
 
-    /** Fork versions to try for Status. Currently just the one we're configured for. */
+    /** Fork versions to try for Status. Currently just the schedule's newest. */
     private java.util.List<byte[]> acceptedForkVersions() {
-        return java.util.List.of(forkVersion);
+        return java.util.List.of(forkSchedule.current());
     }
 
     /**

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
@@ -78,7 +78,7 @@ public class BeaconLightClient implements AutoCloseable {
     private final String beaconApiUrl;            // nullable; HTTP API for peer discovery
     private final byte[] checkpointRoot;      // 32-byte trusted checkpoint block root
     private final long checkpointSlot;        // slot of trusted checkpoint (for pre-bootstrap Status)
-    private final ForkSchedule forkSchedule;  // per-slot signing-domain selector (#295); its newest entry feeds Status
+    private final ForkSchedule forkSchedule;  // per-slot signing-domain selector (#295); Status uses the wall-clock-active entry
     /**
      * Active BPO parameters per EIP-7892: {@code (epoch, max_blobs_per_block)}.
      * Folded into {@link #computeForkDigest(byte[])} via the XOR-mix-in
@@ -1288,7 +1288,7 @@ public class BeaconLightClient implements AutoCloseable {
      * {@code fork_digest}.
      */
     private StatusMessage buildLocalStatus() {
-        return buildLocalStatusFor(forkSchedule.current());
+        return buildLocalStatusFor(activeForkVersion());
     }
 
     /**
@@ -1500,9 +1500,21 @@ public class BeaconLightClient implements AutoCloseable {
         }
     }
 
-    /** Fork versions to try for Status. Currently just the schedule's newest. */
+    /** Fork versions to try for Status. Currently just the one active now. */
     private java.util.List<byte[]> acceptedForkVersions() {
-        return java.util.List.of(forkSchedule.current());
+        return java.util.List.of(activeForkVersion());
+    }
+
+    /**
+     * The fork version active at the wall clock — the Status/digest input. Read
+     * from the schedule per call so a fork pinned ahead of its activation takes
+     * effect at its epoch with no restart, and never before (a not-yet-active
+     * digest matches no peer). Mirrors {@code NetworkConfig.currentForkVersion}.
+     */
+    private byte[] activeForkVersion() {
+        long wallSlot = Math.max(0L, System.currentTimeMillis() / 1000 - clGenesisTime)
+                / Math.max(1, secondsPerSlot);
+        return forkSchedule.versionAtEpoch(wallSlot / Math.max(1, slotsPerEpoch));
     }
 
     /**

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/lightclient/LightClientProcessor.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/lightclient/LightClientProcessor.java
@@ -43,10 +43,6 @@ public class LightClientProcessor {
         log.info("[lc-processor] Initialized with forkSchedule={}", forkSchedule);
     }
 
-    public ForkSchedule getForkSchedule() {
-        return forkSchedule;
-    }
-
     /**
      * Process a {@link LightClientFinalityUpdate}.
      *

--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/lightclient/LightClientProcessor.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/lightclient/LightClientProcessor.java
@@ -1,6 +1,7 @@
 package com.jaeckel.ethp2p.consensus.lightclient;
 
 import com.jaeckel.ethp2p.consensus.ssz.SszUtil;
+import com.jaeckel.ethp2p.core.consensus.ForkSchedule;
 import com.jaeckel.ethp2p.consensus.types.LightClientFinalityUpdate;
 import com.jaeckel.ethp2p.consensus.types.LightClientHeader;
 import com.jaeckel.ethp2p.consensus.types.LightClientUpdate;
@@ -19,7 +20,11 @@ public class LightClientProcessor {
     private static final Logger log = LoggerFactory.getLogger(LightClientProcessor.class);
 
     private final LightClientStore store;
-    private final byte[] forkVersion;
+    /** Per-slot signing-domain selector. Every update is verified under the fork
+     *  active at its {@code signatureSlot} (spec {@code validate_light_client_update}),
+     *  so the store can walk updates across a fork boundary — a single fixed version
+     *  rejects everything signed on the other side of it (#295). */
+    private final ForkSchedule forkSchedule;
     private final byte[] genesisValidatorsRoot;
 
     /** Aggregate signature of the last successfully applied finality update. The
@@ -31,12 +36,15 @@ public class LightClientProcessor {
      *  core re-proving the same update. */
     private volatile byte[] lastAppliedFinalitySig;
 
-    public LightClientProcessor(LightClientStore store, byte[] forkVersion, byte[] genesisValidatorsRoot) {
+    public LightClientProcessor(LightClientStore store, ForkSchedule forkSchedule, byte[] genesisValidatorsRoot) {
         this.store = store;
-        this.forkVersion = forkVersion.clone();
+        this.forkSchedule = java.util.Objects.requireNonNull(forkSchedule, "forkSchedule");
         this.genesisValidatorsRoot = genesisValidatorsRoot.clone();
-        log.info("[lc-processor] Initialized with forkVersion={}, fv[0]={}, id={}",
-                bytesToHex(this.forkVersion), this.forkVersion[0], System.identityHashCode(this.forkVersion));
+        log.info("[lc-processor] Initialized with forkSchedule={}", forkSchedule);
+    }
+
+    public ForkSchedule getForkSchedule() {
+        return forkSchedule;
     }
 
     /**
@@ -76,7 +84,9 @@ public class LightClientProcessor {
                 attestedSlot, finalizedSlot, update.signatureSlot(),
                 participation, update.finalityBranch().length);
 
-        // Verify sync aggregate over attested header
+        // Verify sync aggregate over attested header, under the fork active at
+        // the signature slot (spec: compute_fork_version(epoch(max(sig_slot,1)-1))).
+        byte[] forkVersion = forkSchedule.versionForSignatureSlot(update.signatureSlot());
         if (!SyncCommitteeVerifier.verify(
                 update.syncAggregate(),
                 committee,
@@ -84,9 +94,8 @@ public class LightClientProcessor {
                 forkVersion,
                 genesisValidatorsRoot)) {
             log.debug("[lc-processor] Finality update rejected: BLS verification failed " +
-                    "(attestedSlot={}, forkVersion={}, fv[0]={}, id={}, participation={})",
-                    attestedSlot, bytesToHex(forkVersion), forkVersion[0],
-                    System.identityHashCode(forkVersion), participation);
+                    "(attestedSlot={}, signatureSlot={}, forkVersion={}, participation={})",
+                    attestedSlot, update.signatureSlot(), bytesToHex(forkVersion), participation);
             return false;
         }
 
@@ -187,15 +196,18 @@ public class LightClientProcessor {
             return false;
         }
 
-        // Verify sync aggregate over attested header
+        // Verify sync aggregate over attested header, under the fork active at
+        // the signature slot (see processFinalityUpdate).
+        byte[] forkVersion = forkSchedule.versionForSignatureSlot(update.signatureSlot());
         if (!SyncCommitteeVerifier.verify(
                 update.syncAggregate(),
                 committee,
                 update.attestedHeader().beacon(),
                 forkVersion,
                 genesisValidatorsRoot)) {
-            log.info("[lc-processor] Update rejected (attestedSlot={}, finalizedSlot={}): BLS sync-aggregate verify failed",
-                    attestedSlot, finalizedSlot);
+            log.info("[lc-processor] Update rejected (attestedSlot={}, finalizedSlot={}, signatureSlot={}, "
+                            + "forkVersion={}): BLS sync-aggregate verify failed",
+                    attestedSlot, finalizedSlot, update.signatureSlot(), bytesToHex(forkVersion));
             return false;
         }
 

--- a/consensus/src/test/java/com/jaeckel/ethp2p/consensus/BeaconLightClientPeerPoolTest.java
+++ b/consensus/src/test/java/com/jaeckel/ethp2p/consensus/BeaconLightClientPeerPoolTest.java
@@ -1,5 +1,6 @@
 package com.jaeckel.ethp2p.consensus;
 
+import com.jaeckel.ethp2p.core.consensus.ForkSchedule;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
@@ -22,7 +23,7 @@ class BeaconLightClientPeerPoolTest {
         // Raw valid-length anchors; addPeer touches no network state and the
         // constructor doesn't start libp2p.
         byte[] root32 = new byte[32];
-        byte[] fork4 = {0, 0, 0, 1};
+        ForkSchedule fork4 = ForkSchedule.single(new byte[]{0, 0, 0, 1});
         byte[] gvr32 = new byte[32];
         return new BeaconLightClient(
                 List.of(), root32, 0L, fork4, gvr32,

--- a/consensus/src/test/java/com/jaeckel/ethp2p/consensus/BeaconLightClientStaleAnchorTest.java
+++ b/consensus/src/test/java/com/jaeckel/ethp2p/consensus/BeaconLightClientStaleAnchorTest.java
@@ -1,5 +1,6 @@
 package com.jaeckel.ethp2p.consensus;
 
+import com.jaeckel.ethp2p.core.consensus.ForkSchedule;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -40,7 +41,7 @@ class BeaconLightClientStaleAnchorTest {
                 List.of(),
                 new byte[32],
                 8192L * 10,
-                new byte[]{0x06, 0x00, 0x00, 0x00},
+                ForkSchedule.single(new byte[]{0x06, 0x00, 0x00, 0x00}),
                 new byte[32],
                 syncState,
                 null,

--- a/consensus/src/test/java/com/jaeckel/ethp2p/consensus/lightclient/LcVectorConformanceTest.java
+++ b/consensus/src/test/java/com/jaeckel/ethp2p/consensus/lightclient/LcVectorConformanceTest.java
@@ -1,5 +1,6 @@
 package com.jaeckel.ethp2p.consensus.lightclient;
 
+import com.jaeckel.ethp2p.core.consensus.ForkSchedule;
 import com.jaeckel.ethp2p.consensus.ssz.SszUtil;
 import com.jaeckel.ethp2p.consensus.types.LightClientBootstrap;
 import com.jaeckel.ethp2p.consensus.types.LightClientFinalityUpdate;
@@ -88,7 +89,8 @@ class LcVectorConformanceTest {
 
         LightClientStore store = new LightClientStore();
         store.initialize(bootstrap.header(), bootstrap.currentSyncCommittee());
-        LightClientProcessor processor = new LightClientProcessor(store, FORK_VERSION, GVR);
+        // The corpus was recorded under one version — a schedule with no boundary.
+        LightClientProcessor processor = new LightClientProcessor(store, ForkSchedule.single(FORK_VERSION), GVR);
 
         // The recorded wall-clock input (see class javadoc). Generation mode computes it
         // once from the clock; assert mode replays the committed value.

--- a/consensus/src/test/java/com/jaeckel/ethp2p/consensus/lightclient/LightClientProcessorTest.java
+++ b/consensus/src/test/java/com/jaeckel/ethp2p/consensus/lightclient/LightClientProcessorTest.java
@@ -180,11 +180,29 @@ class LightClientProcessorTest {
     /** Boundary epoch 10 = slot 320 on the mainnet preset. */
     private static final long BOUNDARY_EPOCH = 10;
     private static final long BOUNDARY_SLOT = BOUNDARY_EPOCH * 32;
+    /** The smallest participation the 2/3 rule accepts (341 is refused above):
+     *  Milagro signing is ~8 ms per signer, so every signer saved is CI time. */
+    private static final int MIN_PARTICIPANTS = 342;
+    /** Signed updates are immutable inputs here, so the four distinct ones are
+     *  built once for all boundary tests (each build signs 342 messages). */
+    private static final java.util.Map<String, Object> SIGNED = new java.util.HashMap<>();
 
     private static ForkSchedule boundarySchedule() {
         return ForkSchedule.of(32,
-                new ForkSchedule.Fork(0, OLD_FORK),
-                new ForkSchedule.Fork(BOUNDARY_EPOCH, NEW_FORK));
+                ForkSchedule.fork(0, 0x05000000),
+                ForkSchedule.fork(BOUNDARY_EPOCH, 0x06000000));
+    }
+
+    private LightClientFinalityUpdate boundaryFinality(long finalizedSlot, long signatureSlot, byte[] fork) {
+        String key = "fin:" + finalizedSlot + ":" + signatureSlot + ":" + fork[0];
+        return (LightClientFinalityUpdate) SIGNED.computeIfAbsent(key,
+                k -> buildFinalityUpdate(finalizedSlot, signatureSlot, MIN_PARTICIPANTS, fork));
+    }
+
+    private LightClientUpdate boundaryUpdate(long finalizedSlot, long signatureSlot, byte[] fork) {
+        String key = "upd:" + finalizedSlot + ":" + signatureSlot + ":" + fork[0];
+        return (LightClientUpdate) SIGNED.computeIfAbsent(key,
+                k -> buildUpdate(finalizedSlot, signatureSlot, fork));
     }
 
     /** Rust twin: tests/fork_boundary.rs. */
@@ -192,10 +210,24 @@ class LightClientProcessorTest {
     void verifiesAcrossForkBoundary() {
         LightClientProcessor p = new LightClientProcessor(store, boundarySchedule(), GVR);
         // signatureSlot 320: the spec verifies epoch(319) = 9 -> still OLD.
-        assertTrue(p.processFinalityUpdate(buildFinalityUpdate(200L, BOUNDARY_SLOT, 512, OLD_FORK)));
+        assertTrue(p.processFinalityUpdate(boundaryFinality(200L, BOUNDARY_SLOT, OLD_FORK)));
         assertEquals(200L, store.getFinalizedSlot());
         // signatureSlot 321: epoch(320) = 10 -> NEW.
-        assertTrue(p.processFinalityUpdate(buildFinalityUpdate(300L, BOUNDARY_SLOT + 1, 512, NEW_FORK)));
+        assertTrue(p.processFinalityUpdate(boundaryFinality(300L, BOUNDARY_SLOT + 1, NEW_FORK)));
+        assertEquals(300L, store.getFinalizedSlot());
+    }
+
+    /** The catch-up path (LightClientUpdate) — how a pre-fork checkpoint walks across. */
+    @Test
+    void catchUpUpdatesVerifyAcrossForkBoundary() {
+        LightClientProcessor p = new LightClientProcessor(store, boundarySchedule(), GVR);
+        assertTrue(p.processUpdate(boundaryUpdate(200L, BOUNDARY_SLOT, OLD_FORK)));
+        assertNotNull(store.getNextSyncCommittee(), "first update proves the next committee");
+        assertTrue(p.processUpdate(boundaryUpdate(300L, BOUNDARY_SLOT + 1, NEW_FORK)));
+        assertEquals(300L, store.getFinalizedSlot());
+        // Cross-signed: rejected on both sides.
+        assertFalse(p.processUpdate(boundaryUpdate(400L, BOUNDARY_SLOT, NEW_FORK)));
+        assertFalse(p.processUpdate(boundaryUpdate(400L, BOUNDARY_SLOT + 1, OLD_FORK)));
         assertEquals(300L, store.getFinalizedSlot());
     }
 
@@ -203,8 +235,8 @@ class LightClientProcessorTest {
     void rejectsUpdateSignedUnderTheOtherSidesFork() {
         LightClientProcessor p = new LightClientProcessor(store, boundarySchedule(), GVR);
         // NEW at the last OLD slot, OLD at the first NEW slot: both must fail.
-        assertFalse(p.processFinalityUpdate(buildFinalityUpdate(200L, BOUNDARY_SLOT, 512, NEW_FORK)));
-        assertFalse(p.processFinalityUpdate(buildFinalityUpdate(200L, BOUNDARY_SLOT + 1, 512, OLD_FORK)));
+        assertFalse(p.processFinalityUpdate(boundaryFinality(200L, BOUNDARY_SLOT, NEW_FORK)));
+        assertFalse(p.processFinalityUpdate(boundaryFinality(200L, BOUNDARY_SLOT + 1, OLD_FORK)));
         assertEquals(100L, store.getFinalizedSlot(), "nothing applied");
     }
 
@@ -212,14 +244,41 @@ class LightClientProcessorTest {
     @Test
     void singleVersionScheduleStallsAtTheBoundary() {
         LightClientProcessor oldOnly = new LightClientProcessor(store, ForkSchedule.single(OLD_FORK), GVR);
-        assertTrue(oldOnly.processFinalityUpdate(buildFinalityUpdate(200L, BOUNDARY_SLOT, 512, OLD_FORK)));
-        assertFalse(oldOnly.processFinalityUpdate(buildFinalityUpdate(300L, BOUNDARY_SLOT + 1, 512, NEW_FORK)));
+        assertTrue(oldOnly.processFinalityUpdate(boundaryFinality(200L, BOUNDARY_SLOT, OLD_FORK)));
+        assertFalse(oldOnly.processFinalityUpdate(boundaryFinality(300L, BOUNDARY_SLOT + 1, NEW_FORK)));
 
         LightClientStore fresh = new LightClientStore();
         fresh.initialize(TestUtil.dummyLightClientHeader(
                 new BeaconBlockHeader(100L, 0L, new byte[32], new byte[32], new byte[32])), syncCommittee);
         LightClientProcessor newOnly = new LightClientProcessor(fresh, ForkSchedule.single(NEW_FORK), GVR);
-        assertFalse(newOnly.processFinalityUpdate(buildFinalityUpdate(200L, BOUNDARY_SLOT, 512, OLD_FORK)));
+        assertFalse(newOnly.processFinalityUpdate(boundaryFinality(200L, BOUNDARY_SLOT, OLD_FORK)));
+    }
+
+    /**
+     * A LightClientUpdate whose finality branch (depth 6, gindex 105) and
+     * next-sync-committee branch (depth 5, gindex 55) both verify against ONE
+     * attested state root: a 32-leaf state tree with the checkpoint container
+     * at field 20 (epoch root || finalized root) and the committee at field 23.
+     */
+    private LightClientUpdate buildUpdate(long finalizedSlot, long signatureSlot, byte[] forkVersion) {
+        LightClientHeader finalizedHeader = TestUtil.consistentLightClientHeader(
+                finalizedSlot, 0L, new byte[32], new byte[32]);
+        byte[] zero = new byte[32];
+        byte[][] leaves = new byte[32][32];
+        leaves[20] = SszUtil.sha256(zero, finalizedHeader.beacon().hashTreeRoot()); // Checkpoint{epoch, root}
+        leaves[23] = syncCommittee.hashTreeRoot();
+        byte[][] tree = TestUtil.buildMerkleTree(leaves);
+        byte[][] checkpointBranch = TestUtil.extractBranch(tree, 5, 20);
+        byte[][] finalityBranch = new byte[6][];
+        finalityBranch[0] = zero; // the epoch leaf, sibling of the root inside Checkpoint
+        System.arraycopy(checkpointBranch, 0, finalityBranch, 1, 5);
+        byte[][] committeeBranch = TestUtil.extractBranch(tree, 5, 23);
+
+        LightClientHeader attestedHeader = TestUtil.consistentLightClientHeader(
+                signatureSlot, 0L, new byte[32], tree[1]);
+        SyncAggregate agg = buildSyncAggregate(attestedHeader.beacon(), MIN_PARTICIPANTS, forkVersion);
+        return new LightClientUpdate(attestedHeader, syncCommittee, committeeBranch,
+                finalizedHeader, finalityBranch, agg, signatureSlot);
     }
 
     @Test

--- a/consensus/src/test/java/com/jaeckel/ethp2p/consensus/lightclient/LightClientProcessorTest.java
+++ b/consensus/src/test/java/com/jaeckel/ethp2p/consensus/lightclient/LightClientProcessorTest.java
@@ -4,6 +4,7 @@ import com.jaeckel.ethp2p.consensus.TestUtil;
 import com.jaeckel.ethp2p.consensus.ssz.SszUtil;
 import com.jaeckel.ethp2p.consensus.types.*;
 import com.jaeckel.ethp2p.consensus.bls.BlsVerifier;
+import com.jaeckel.ethp2p.core.consensus.ForkSchedule;
 import org.apache.milagro.amcl.BLS381.BIG;
 import org.apache.milagro.amcl.BLS381.ECP;
 import org.junit.jupiter.api.BeforeAll;
@@ -48,7 +49,7 @@ class LightClientProcessorTest {
         // Initialize with a header at slot 100
         BeaconBlockHeader initBeacon = new BeaconBlockHeader(100L, 0L, new byte[32], new byte[32], new byte[32]);
         store.initialize(TestUtil.dummyLightClientHeader(initBeacon), syncCommittee);
-        processor = new LightClientProcessor(store, FORK_VERSION, GVR);
+        processor = new LightClientProcessor(store, ForkSchedule.single(FORK_VERSION), GVR);
     }
 
     @Test
@@ -172,11 +173,60 @@ class LightClientProcessorTest {
         assertEquals(100L, store.getFinalizedSlot());
     }
 
+    // ---- #295: the signing domain follows the fork active at signature_slot ----
+
+    private static final byte[] OLD_FORK = {0x05, 0x00, 0x00, 0x00};
+    private static final byte[] NEW_FORK = {0x06, 0x00, 0x00, 0x00};
+    /** Boundary epoch 10 = slot 320 on the mainnet preset. */
+    private static final long BOUNDARY_EPOCH = 10;
+    private static final long BOUNDARY_SLOT = BOUNDARY_EPOCH * 32;
+
+    private static ForkSchedule boundarySchedule() {
+        return ForkSchedule.of(32,
+                new ForkSchedule.Fork(0, OLD_FORK),
+                new ForkSchedule.Fork(BOUNDARY_EPOCH, NEW_FORK));
+    }
+
+    /** Rust twin: tests/fork_boundary.rs. */
+    @Test
+    void verifiesAcrossForkBoundary() {
+        LightClientProcessor p = new LightClientProcessor(store, boundarySchedule(), GVR);
+        // signatureSlot 320: the spec verifies epoch(319) = 9 -> still OLD.
+        assertTrue(p.processFinalityUpdate(buildFinalityUpdate(200L, BOUNDARY_SLOT, 512, OLD_FORK)));
+        assertEquals(200L, store.getFinalizedSlot());
+        // signatureSlot 321: epoch(320) = 10 -> NEW.
+        assertTrue(p.processFinalityUpdate(buildFinalityUpdate(300L, BOUNDARY_SLOT + 1, 512, NEW_FORK)));
+        assertEquals(300L, store.getFinalizedSlot());
+    }
+
+    @Test
+    void rejectsUpdateSignedUnderTheOtherSidesFork() {
+        LightClientProcessor p = new LightClientProcessor(store, boundarySchedule(), GVR);
+        // NEW at the last OLD slot, OLD at the first NEW slot: both must fail.
+        assertFalse(p.processFinalityUpdate(buildFinalityUpdate(200L, BOUNDARY_SLOT, 512, NEW_FORK)));
+        assertFalse(p.processFinalityUpdate(buildFinalityUpdate(200L, BOUNDARY_SLOT + 1, 512, OLD_FORK)));
+        assertEquals(100L, store.getFinalizedSlot(), "nothing applied");
+    }
+
+    /** The pre-#295 behaviour, pinned as a regression: one fixed version cannot cross. */
+    @Test
+    void singleVersionScheduleStallsAtTheBoundary() {
+        LightClientProcessor oldOnly = new LightClientProcessor(store, ForkSchedule.single(OLD_FORK), GVR);
+        assertTrue(oldOnly.processFinalityUpdate(buildFinalityUpdate(200L, BOUNDARY_SLOT, 512, OLD_FORK)));
+        assertFalse(oldOnly.processFinalityUpdate(buildFinalityUpdate(300L, BOUNDARY_SLOT + 1, 512, NEW_FORK)));
+
+        LightClientStore fresh = new LightClientStore();
+        fresh.initialize(TestUtil.dummyLightClientHeader(
+                new BeaconBlockHeader(100L, 0L, new byte[32], new byte[32], new byte[32])), syncCommittee);
+        LightClientProcessor newOnly = new LightClientProcessor(fresh, ForkSchedule.single(NEW_FORK), GVR);
+        assertFalse(newOnly.processFinalityUpdate(buildFinalityUpdate(200L, BOUNDARY_SLOT, 512, OLD_FORK)));
+    }
+
     @Test
     void rejectsNullCommittee() {
         // Fresh store without initialization
         LightClientStore emptyStore = new LightClientStore();
-        LightClientProcessor emptyProcessor = new LightClientProcessor(emptyStore, FORK_VERSION, GVR);
+        LightClientProcessor emptyProcessor = new LightClientProcessor(emptyStore, ForkSchedule.single(FORK_VERSION), GVR);
 
         LightClientFinalityUpdate update = buildValidFinalityUpdate(700L, 701L);
         assertFalse(emptyProcessor.processFinalityUpdate(update));
@@ -205,7 +255,7 @@ class LightClientProcessorTest {
         LightClientHeader attestedHeader = TestUtil.consistentLightClientHeader(
                 signatureSlot, 0L, new byte[32], attestedStateRoot);
 
-        SyncAggregate agg = buildSyncAggregate(attestedHeader.beacon(), 512);
+        SyncAggregate agg = buildSyncAggregate(attestedHeader.beacon(), 512, FORK_VERSION);
 
         // Build a next sync committee with corrupt branch
         byte[][] corruptCommitteeBranch = new byte[5][32];
@@ -262,6 +312,11 @@ class LightClientProcessorTest {
 
     private LightClientFinalityUpdate buildFinalityUpdateWithParticipation(
             long finalizedSlot, long signatureSlot, int participantCount) {
+        return buildFinalityUpdate(finalizedSlot, signatureSlot, participantCount, FORK_VERSION);
+    }
+
+    private LightClientFinalityUpdate buildFinalityUpdate(
+            long finalizedSlot, long signatureSlot, int participantCount, byte[] forkVersion) {
         // Build finalized header (execution payload genuinely committed to its body root)
         LightClientHeader finalizedHeader = TestUtil.consistentLightClientHeader(
                 finalizedSlot, 0L, new byte[32], new byte[32]);
@@ -282,14 +337,15 @@ class LightClientProcessorTest {
         LightClientHeader attestedHeader = TestUtil.consistentLightClientHeader(
                 signatureSlot, 0L, new byte[32], attestedStateRoot);
 
-        SyncAggregate agg = buildSyncAggregate(attestedHeader.beacon(), participantCount);
+        SyncAggregate agg = buildSyncAggregate(attestedHeader.beacon(), participantCount, forkVersion);
 
         return new LightClientFinalityUpdate(
                 attestedHeader, finalizedHeader, finalityBranch, agg, signatureSlot);
     }
 
-    private SyncAggregate buildSyncAggregate(BeaconBlockHeader attestedBeacon, int participantCount) {
-        byte[] domain = ForkData.computeDomain(BeaconChainSpec.DOMAIN_SYNC_COMMITTEE, FORK_VERSION, GVR);
+    private SyncAggregate buildSyncAggregate(BeaconBlockHeader attestedBeacon, int participantCount,
+                                             byte[] forkVersion) {
+        byte[] domain = ForkData.computeDomain(BeaconChainSpec.DOMAIN_SYNC_COMMITTEE, forkVersion, GVR);
         byte[] signingRoot = SszUtil.hashTreeRootContainer(attestedBeacon.hashTreeRoot(), domain);
 
         List<byte[]> sigs = new ArrayList<>();

--- a/core/src/main/java/com/jaeckel/ethp2p/core/consensus/ForkSchedule.java
+++ b/core/src/main/java/com/jaeckel/ethp2p/core/consensus/ForkSchedule.java
@@ -1,0 +1,184 @@
+package com.jaeckel.ethp2p.core.consensus;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A beacon chain's fork schedule: the append-only, ascending list of
+ * {@code (activation epoch, fork version)} pairs that selects the signing domain
+ * for every sync-committee signature. Java twin of the Rust
+ * {@code myotis_consensus::fork::ForkSchedule}.
+ *
+ * <p><b>Why a schedule and not one version.</b> The spec's
+ * {@code validate_light_client_update} verifies a sync aggregate under
+ * {@code compute_fork_version(compute_epoch_at_slot(max(signature_slot, 1) - 1))}
+ * — the fork active when the signature was produced, not the network's current
+ * fork. A store walking updates across a fork boundary needs both versions; a
+ * single configured value verifies one side and rejects every update on the other,
+ * stalling sync at every consensus fork on every install (#295).
+ *
+ * <p><b>Trust posture.</b> Consensus-critical configuration with the same standing
+ * as the genesis validators root: embedded, never fetched at runtime. The beacon
+ * API's {@code /eth/v1/config/fork_schedule} exposes the same data and is the
+ * reference for the pinned lists in {@code NetworkConfig}.
+ *
+ * <p>Lives in {@code :core} because both {@code :networking} (the config) and
+ * {@code :consensus} (the processor) need it and neither depends on the other.
+ * Android-safe: arrays and {@link List} only.
+ */
+public final class ForkSchedule {
+
+    /** One scheduled fork: the epoch it activates at and its 4-byte version. */
+    public record Fork(long epoch, byte[] version) {
+        public Fork {
+            if (epoch < 0) throw new IllegalArgumentException("fork epoch must be >= 0");
+            if (version == null || version.length != 4)
+                throw new IllegalArgumentException("fork version must be 4 bytes");
+            version = version.clone();
+        }
+
+        /** Defensive copy — the record component is a mutable array. */
+        @Override
+        public byte[] version() {
+            return version.clone();
+        }
+    }
+
+    private final int slotsPerEpoch;
+    private final List<Fork> forks;
+
+    private ForkSchedule(int slotsPerEpoch, List<Fork> forks) {
+        this.slotsPerEpoch = slotsPerEpoch;
+        this.forks = forks;
+    }
+
+    /**
+     * Build a schedule. Throws on: a non-positive {@code slotsPerEpoch}, an empty
+     * list, a first entry not at epoch 0, or epochs that are not strictly
+     * ascending. Each would silently select a wrong signing domain for some slot —
+     * the "accepted and silently ignored" failure CLAUDE.md forbids for anything that
+     * can change the answer — so the constructor refuses rather than defaults.
+     *
+     * @param slotsPerEpoch slots per epoch for THIS chain (32 on the mainnet preset,
+     *                      16 on gnosis). Bundled with the schedule so it can never
+     *                      be read with another chain's geometry.
+     */
+    public static ForkSchedule of(int slotsPerEpoch, Fork... forks) {
+        if (slotsPerEpoch <= 0)
+            throw new IllegalArgumentException("fork schedule: slotsPerEpoch must be positive");
+        if (forks == null || forks.length == 0)
+            throw new IllegalArgumentException("fork schedule: at least the genesis fork is required");
+        if (forks[0].epoch() != 0)
+            throw new IllegalArgumentException("fork schedule: the first entry must activate at epoch 0");
+        for (int i = 1; i < forks.length; i++) {
+            if (forks[i - 1].epoch() >= forks[i].epoch())
+                throw new IllegalArgumentException("fork schedule: activation epochs must be strictly ascending ("
+                        + forks[i - 1].epoch() + " then " + forks[i].epoch() + ")");
+        }
+        List<Fork> copy = new ArrayList<>(forks.length);
+        for (Fork f : forks) copy.add(Objects.requireNonNull(f));
+        return new ForkSchedule(slotsPerEpoch, Collections.unmodifiableList(copy));
+    }
+
+    /**
+     * A fork entry from the version written as the usual hex literal, e.g.
+     * {@code fork(1714688, 0x06000064)} is Fulu on Gnosis — big-endian bytes
+     * {@code 06 00 00 64}, exactly the spec's {@code Version} byte order.
+     */
+    public static Fork fork(long epoch, int version) {
+        return new Fork(epoch, new byte[]{
+                (byte) (version >>> 24), (byte) (version >>> 16), (byte) (version >>> 8), (byte) version});
+    }
+
+    /**
+     * One version for every slot — a schedule with no boundary. For tests and for
+     * replaying a corpus recorded under a single version. The slot geometry is
+     * immaterial without a boundary; the mainnet preset is used so it is a real one.
+     */
+    public static ForkSchedule single(byte[] version) {
+        return of(32, new Fork(0, version));
+    }
+
+    public int slotsPerEpoch() {
+        return slotsPerEpoch;
+    }
+
+    /** The pinned entries, ascending by activation epoch; unmodifiable. */
+    public List<Fork> forks() {
+        return forks;
+    }
+
+    /**
+     * The newest scheduled fork's version — what the legacy single
+     * {@code currentForkVersion} held. Feeds the fork DIGEST (discv5 filtering,
+     * Status), never signature verification.
+     */
+    public byte[] current() {
+        return forks.get(forks.size() - 1).version();
+    }
+
+    /** The fork before {@link #current()}, or {@code null} for a one-entry schedule. */
+    public byte[] prior() {
+        return forks.size() >= 2 ? forks.get(forks.size() - 2).version() : null;
+    }
+
+    /**
+     * {@code compute_fork_version(epoch)}: the version of the latest fork whose
+     * activation epoch is {@code <= epoch}. Total — the genesis entry covers epoch 0.
+     */
+    public byte[] versionAtEpoch(long epoch) {
+        Fork chosen = forks.get(0);
+        for (Fork f : forks) {
+            if (f.epoch() <= epoch) chosen = f;
+            else break;
+        }
+        return chosen.version();
+    }
+
+    /**
+     * The fork version a sync aggregate signed at {@code signatureSlot} must be
+     * verified under — spec {@code validate_light_client_update}:
+     * {@code compute_fork_version(compute_epoch_at_slot(max(signature_slot, 1) - 1))}.
+     *
+     * <p>The {@code - 1} is not a detail: the aggregate is over the block of the
+     * previous slot, so a signature at the first slot of a fork's activation epoch
+     * still uses the old version, and only the next slot switches.
+     */
+    public byte[] versionForSignatureSlot(long signatureSlot) {
+        long slot = Math.max(signatureSlot, 1L) - 1L;
+        return versionAtEpoch(slot / slotsPerEpoch);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ForkSchedule other)) return false;
+        if (slotsPerEpoch != other.slotsPerEpoch || forks.size() != other.forks.size()) return false;
+        for (int i = 0; i < forks.size(); i++) {
+            if (forks.get(i).epoch() != other.forks.get(i).epoch()) return false;
+            if (!java.util.Arrays.equals(forks.get(i).version(), other.forks.get(i).version())) return false;
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int h = slotsPerEpoch;
+        for (Fork f : forks) h = 31 * h + Long.hashCode(f.epoch()) * 31 + java.util.Arrays.hashCode(f.version());
+        return h;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder("ForkSchedule{slotsPerEpoch=").append(slotsPerEpoch).append(", [");
+        for (int i = 0; i < forks.size(); i++) {
+            Fork f = forks.get(i);
+            if (i > 0) sb.append(", ");
+            sb.append(f.epoch()).append(':');
+            for (byte b : f.version()) sb.append(String.format("%02x", b));
+        }
+        return sb.append("]}").toString();
+    }
+}

--- a/core/src/main/java/com/jaeckel/ethp2p/core/consensus/ForkSchedule.java
+++ b/core/src/main/java/com/jaeckel/ethp2p/core/consensus/ForkSchedule.java
@@ -1,7 +1,7 @@
 package com.jaeckel.ethp2p.core.consensus;
 
-import java.util.ArrayList;
-import java.util.Collections;
+import com.jaeckel.ethp2p.core.encoding.Hex;
+
 import java.util.List;
 import java.util.Objects;
 
@@ -19,6 +19,14 @@ import java.util.Objects;
  * single configured value verifies one side and rejects every update on the other,
  * stalling sync at every consensus fork on every install (#295).
  *
+ * <p><b>Shippable ahead of activation.</b> The schedule may (and should) carry the
+ * NEXT scheduled fork before it activates: signature verification is keyed by the
+ * update's own slot, and the digest-side "active" version is read with
+ * {@link #versionAtEpoch(long)} at the wall-clock epoch — see
+ * {@code NetworkConfig.currentForkVersion()} — so a future entry changes nothing
+ * until its epoch arrives. Only the blob-parameter (EIP-7892) digest fold remains a
+ * single configured value.
+ *
  * <p><b>Trust posture.</b> Consensus-critical configuration with the same standing
  * as the genesis validators root: embedded, never fetched at runtime. The beacon
  * API's {@code /eth/v1/config/fork_schedule} exposes the same data and is the
@@ -27,69 +35,69 @@ import java.util.Objects;
  * <p>Lives in {@code :core} because both {@code :networking} (the config) and
  * {@code :consensus} (the processor) need it and neither depends on the other.
  * Android-safe: arrays and {@link List} only.
+ *
+ * @param slotsPerEpoch slots per epoch for THIS chain (32 on the mainnet preset,
+ *                      16 on gnosis). Bundled with the schedule so it can never be
+ *                      read with another chain's geometry; {@code NetworkConfig}
+ *                      refuses a schedule whose geometry differs from the chain's.
+ * @param forks         the entries, ascending by activation epoch, genesis first
  */
-public final class ForkSchedule {
+public record ForkSchedule(int slotsPerEpoch, List<Fork> forks) {
 
-    /** One scheduled fork: the epoch it activates at and its 4-byte version. */
-    public record Fork(long epoch, byte[] version) {
+    /**
+     * One scheduled fork. The version is held as the {@code int} the usual hex
+     * literal denotes — {@code fork(1714688, 0x06000064)} is Fulu on Gnosis — and
+     * rendered big-endian by {@link #versionBytes()}, the spec's {@code Version}
+     * byte order. An {@code int} rather than a {@code byte[]} so the record's
+     * generated equality is by value.
+     */
+    public record Fork(long epoch, int version) {
         public Fork {
             if (epoch < 0) throw new IllegalArgumentException("fork epoch must be >= 0");
-            if (version == null || version.length != 4)
-                throw new IllegalArgumentException("fork version must be 4 bytes");
-            version = version.clone();
         }
 
-        /** Defensive copy — the record component is a mutable array. */
-        @Override
-        public byte[] version() {
-            return version.clone();
+        /** The 4-byte fork version, big-endian. A fresh array on every call. */
+        public byte[] versionBytes() {
+            return new byte[]{
+                    (byte) (version >>> 24), (byte) (version >>> 16), (byte) (version >>> 8), (byte) version};
         }
-    }
-
-    private final int slotsPerEpoch;
-    private final List<Fork> forks;
-
-    private ForkSchedule(int slotsPerEpoch, List<Fork> forks) {
-        this.slotsPerEpoch = slotsPerEpoch;
-        this.forks = forks;
     }
 
     /**
-     * Build a schedule. Throws on: a non-positive {@code slotsPerEpoch}, an empty
-     * list, a first entry not at epoch 0, or epochs that are not strictly
+     * Validates on construction. Throws on: a non-positive {@code slotsPerEpoch},
+     * an empty list, a first entry not at epoch 0, or epochs that are not strictly
      * ascending. Each would silently select a wrong signing domain for some slot —
      * the "accepted and silently ignored" failure CLAUDE.md forbids for anything that
      * can change the answer — so the constructor refuses rather than defaults.
-     *
-     * @param slotsPerEpoch slots per epoch for THIS chain (32 on the mainnet preset,
-     *                      16 on gnosis). Bundled with the schedule so it can never
-     *                      be read with another chain's geometry.
      */
-    public static ForkSchedule of(int slotsPerEpoch, Fork... forks) {
+    public ForkSchedule {
         if (slotsPerEpoch <= 0)
             throw new IllegalArgumentException("fork schedule: slotsPerEpoch must be positive");
-        if (forks == null || forks.length == 0)
+        if (forks == null || forks.isEmpty())
             throw new IllegalArgumentException("fork schedule: at least the genesis fork is required");
-        if (forks[0].epoch() != 0)
+        for (Fork f : forks) Objects.requireNonNull(f, "fork schedule: null entry");
+        if (forks.get(0).epoch() != 0)
             throw new IllegalArgumentException("fork schedule: the first entry must activate at epoch 0");
-        for (int i = 1; i < forks.length; i++) {
-            if (forks[i - 1].epoch() >= forks[i].epoch())
+        for (int i = 1; i < forks.size(); i++) {
+            if (forks.get(i - 1).epoch() >= forks.get(i).epoch())
                 throw new IllegalArgumentException("fork schedule: activation epochs must be strictly ascending ("
-                        + forks[i - 1].epoch() + " then " + forks[i].epoch() + ")");
+                        + forks.get(i - 1).epoch() + " then " + forks.get(i).epoch() + ")");
         }
-        List<Fork> copy = new ArrayList<>(forks.length);
-        for (Fork f : forks) copy.add(Objects.requireNonNull(f));
-        return new ForkSchedule(slotsPerEpoch, Collections.unmodifiableList(copy));
+        forks = List.copyOf(forks);
     }
 
-    /**
-     * A fork entry from the version written as the usual hex literal, e.g.
-     * {@code fork(1714688, 0x06000064)} is Fulu on Gnosis — big-endian bytes
-     * {@code 06 00 00 64}, exactly the spec's {@code Version} byte order.
-     */
+    /** Build a schedule from entries (see the canonical constructor for what is refused). */
+    public static ForkSchedule of(int slotsPerEpoch, Fork... forks) {
+        if (forks == null) throw new IllegalArgumentException("fork schedule: at least the genesis fork is required");
+        for (Fork f : forks) {
+            if (f == null) throw new IllegalArgumentException("fork schedule: null entry");
+        }
+        return new ForkSchedule(slotsPerEpoch, List.of(forks));
+    }
+
+    /** A fork entry: {@code fork(1714688, 0x06000064)} is Fulu on Gnosis. */
     public static Fork fork(long epoch, int version) {
-        return new Fork(epoch, new byte[]{
-                (byte) (version >>> 24), (byte) (version >>> 16), (byte) (version >>> 8), (byte) version});
+        return new Fork(epoch, version);
     }
 
     /**
@@ -98,30 +106,20 @@ public final class ForkSchedule {
      * immaterial without a boundary; the mainnet preset is used so it is a real one.
      */
     public static ForkSchedule single(byte[] version) {
-        return of(32, new Fork(0, version));
-    }
-
-    public int slotsPerEpoch() {
-        return slotsPerEpoch;
-    }
-
-    /** The pinned entries, ascending by activation epoch; unmodifiable. */
-    public List<Fork> forks() {
-        return forks;
+        if (version == null || version.length != 4)
+            throw new IllegalArgumentException("fork version must be 4 bytes");
+        int v = ((version[0] & 0xff) << 24) | ((version[1] & 0xff) << 16) | ((version[2] & 0xff) << 8) | (version[3] & 0xff);
+        return of(32, fork(0, v));
     }
 
     /**
-     * The newest scheduled fork's version — what the legacy single
-     * {@code currentForkVersion} held. Feeds the fork DIGEST (discv5 filtering,
-     * Status), never signature verification.
+     * The newest scheduled fork's version — possibly not yet active. Callers that
+     * need the fork active NOW (the digest, Status) must use
+     * {@link #versionAtEpoch(long)} with the wall-clock epoch instead; this is for
+     * pins and diagnostics.
      */
-    public byte[] current() {
-        return forks.get(forks.size() - 1).version();
-    }
-
-    /** The fork before {@link #current()}, or {@code null} for a one-entry schedule. */
-    public byte[] prior() {
-        return forks.size() >= 2 ? forks.get(forks.size() - 2).version() : null;
+    public byte[] newest() {
+        return forks.get(forks.size() - 1).versionBytes();
     }
 
     /**
@@ -129,12 +127,26 @@ public final class ForkSchedule {
      * activation epoch is {@code <= epoch}. Total — the genesis entry covers epoch 0.
      */
     public byte[] versionAtEpoch(long epoch) {
+        return forkAtEpoch(epoch).versionBytes();
+    }
+
+    /**
+     * The version of the fork BEFORE the one active at {@code epoch}, or
+     * {@code null} when that is the genesis fork. The discv5 prior-digest fallback
+     * input (see {@code NetworkConfig.acceptedForkDigests}).
+     */
+    public byte[] priorVersionAtEpoch(long epoch) {
+        int i = forks.indexOf(forkAtEpoch(epoch));
+        return i >= 1 ? forks.get(i - 1).versionBytes() : null;
+    }
+
+    private Fork forkAtEpoch(long epoch) {
         Fork chosen = forks.get(0);
         for (Fork f : forks) {
             if (f.epoch() <= epoch) chosen = f;
             else break;
         }
-        return chosen.version();
+        return chosen;
     }
 
     /**
@@ -145,29 +157,15 @@ public final class ForkSchedule {
      * <p>The {@code - 1} is not a detail: the aggregate is over the block of the
      * previous slot, so a signature at the first slot of a fork's activation epoch
      * still uses the old version, and only the next slot switches.
+     *
+     * <p>{@code signatureSlot} is an SSZ {@code uint64}; a value at or above
+     * 2^63 arrives negative in a {@code long} and is treated as the far future
+     * (newest fork), never as slot 0.
      */
     public byte[] versionForSignatureSlot(long signatureSlot) {
+        if (signatureSlot < 0) return newest();
         long slot = Math.max(signatureSlot, 1L) - 1L;
         return versionAtEpoch(slot / slotsPerEpoch);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof ForkSchedule other)) return false;
-        if (slotsPerEpoch != other.slotsPerEpoch || forks.size() != other.forks.size()) return false;
-        for (int i = 0; i < forks.size(); i++) {
-            if (forks.get(i).epoch() != other.forks.get(i).epoch()) return false;
-            if (!java.util.Arrays.equals(forks.get(i).version(), other.forks.get(i).version())) return false;
-        }
-        return true;
-    }
-
-    @Override
-    public int hashCode() {
-        int h = slotsPerEpoch;
-        for (Fork f : forks) h = 31 * h + Long.hashCode(f.epoch()) * 31 + java.util.Arrays.hashCode(f.version());
-        return h;
     }
 
     @Override
@@ -176,8 +174,7 @@ public final class ForkSchedule {
         for (int i = 0; i < forks.size(); i++) {
             Fork f = forks.get(i);
             if (i > 0) sb.append(", ");
-            sb.append(f.epoch()).append(':');
-            for (byte b : f.version()) sb.append(String.format("%02x", b));
+            sb.append(f.epoch()).append(':').append(Hex.formatHex(f.versionBytes()));
         }
         return sb.append("]}").toString();
     }

--- a/core/src/test/java/com/jaeckel/ethp2p/core/consensus/ForkScheduleTest.java
+++ b/core/src/test/java/com/jaeckel/ethp2p/core/consensus/ForkScheduleTest.java
@@ -1,0 +1,101 @@
+package com.jaeckel.ethp2p.core.consensus;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/** Rust twin: {@code rust/myotis-consensus/src/fork.rs} unit tests. */
+class ForkScheduleTest {
+
+    private static final byte[] A = {0x05, 0, 0, 0};
+    private static final byte[] B = {0x06, 0, 0, 0};
+    private static final byte[] C = {0x07, 0, 0, 0};
+
+    private static ForkSchedule three() {
+        return ForkSchedule.of(32,
+                new ForkSchedule.Fork(0, A), new ForkSchedule.Fork(10, B), new ForkSchedule.Fork(20, C));
+    }
+
+    @Test
+    void versionAtEpochPicksLatestActivated() {
+        ForkSchedule s = three();
+        assertArrayEquals(A, s.versionAtEpoch(0));
+        assertArrayEquals(A, s.versionAtEpoch(9));
+        assertArrayEquals(B, s.versionAtEpoch(10));
+        assertArrayEquals(B, s.versionAtEpoch(19));
+        assertArrayEquals(C, s.versionAtEpoch(20));
+        assertArrayEquals(C, s.versionAtEpoch(Long.MAX_VALUE));
+    }
+
+    /** The spec's max(signature_slot, 1) - 1: the FIRST slot of the activation epoch still signs OLD. */
+    @Test
+    void signatureSlotBoundaryIsOffByOnePerSpec() {
+        ForkSchedule s = three();
+        assertArrayEquals(A, s.versionForSignatureSlot(0));
+        assertArrayEquals(A, s.versionForSignatureSlot(1));
+        assertArrayEquals(A, s.versionForSignatureSlot(320)); // slot 319 -> epoch 9
+        assertArrayEquals(B, s.versionForSignatureSlot(321)); // slot 320 -> epoch 10
+        assertArrayEquals(B, s.versionForSignatureSlot(640));
+        assertArrayEquals(C, s.versionForSignatureSlot(641));
+    }
+
+    @Test
+    void slotsPerEpochIsPartOfTheSchedule() {
+        ForkSchedule s = ForkSchedule.of(16, new ForkSchedule.Fork(0, A), new ForkSchedule.Fork(10, B));
+        assertArrayEquals(A, s.versionForSignatureSlot(160)); // slot 159 -> epoch 9
+        assertArrayEquals(B, s.versionForSignatureSlot(161)); // slot 160 -> epoch 10
+    }
+
+    @Test
+    void currentAndPriorAreTheTail() {
+        ForkSchedule s = three();
+        assertArrayEquals(C, s.current());
+        assertArrayEquals(B, s.prior());
+        ForkSchedule one = ForkSchedule.single(A);
+        assertArrayEquals(A, one.current());
+        assertNull(one.prior());
+        assertArrayEquals(A, one.versionForSignatureSlot(Long.MAX_VALUE));
+    }
+
+    @Test
+    void forkLiteralIsBigEndian() {
+        assertArrayEquals(new byte[]{0x06, 0x00, 0x00, 0x64}, ForkSchedule.fork(1, 0x06000064).version());
+        assertArrayEquals(new byte[]{(byte) 0x90, 0x00, 0x00, 0x75}, ForkSchedule.fork(1, 0x90000075).version());
+    }
+
+    @Test
+    void valueSemantics() {
+        assertEquals(three(), three());
+        assertEquals(three().hashCode(), three().hashCode());
+        assertNotEquals(three(), ForkSchedule.of(16,
+                new ForkSchedule.Fork(0, A), new ForkSchedule.Fork(10, B), new ForkSchedule.Fork(20, C)));
+        assertEquals("ForkSchedule{slotsPerEpoch=32, [0:05000000, 10:06000000, 20:07000000]}", three().toString());
+    }
+
+    @Test
+    void rejectsMalformedSchedules() {
+        assertThrows(IllegalArgumentException.class, () -> ForkSchedule.of(32));
+        assertThrows(IllegalArgumentException.class, () -> ForkSchedule.of(32, new ForkSchedule.Fork(5, A)));
+        assertThrows(IllegalArgumentException.class, () -> ForkSchedule.of(32,
+                new ForkSchedule.Fork(0, A), new ForkSchedule.Fork(20, B), new ForkSchedule.Fork(10, C)));
+        assertThrows(IllegalArgumentException.class, () -> ForkSchedule.of(32,
+                new ForkSchedule.Fork(0, A), new ForkSchedule.Fork(10, B), new ForkSchedule.Fork(10, C)));
+        assertThrows(IllegalArgumentException.class, () -> ForkSchedule.of(0, new ForkSchedule.Fork(0, A)));
+        assertThrows(IllegalArgumentException.class, () -> new ForkSchedule.Fork(0, new byte[3]));
+        assertThrows(IllegalArgumentException.class, () -> new ForkSchedule.Fork(-1, A));
+    }
+
+    @Test
+    void forkVersionIsDefensivelyCopied() {
+        byte[] v = {1, 2, 3, 4};
+        ForkSchedule.Fork f = new ForkSchedule.Fork(0, v);
+        v[0] = 9;
+        assertArrayEquals(new byte[]{1, 2, 3, 4}, f.version());
+        f.version()[0] = 9;
+        assertArrayEquals(new byte[]{1, 2, 3, 4}, f.version());
+    }
+}

--- a/core/src/test/java/com/jaeckel/ethp2p/core/consensus/ForkScheduleTest.java
+++ b/core/src/test/java/com/jaeckel/ethp2p/core/consensus/ForkScheduleTest.java
@@ -2,6 +2,8 @@ package com.jaeckel.ethp2p.core.consensus;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -17,7 +19,7 @@ class ForkScheduleTest {
 
     private static ForkSchedule three() {
         return ForkSchedule.of(32,
-                new ForkSchedule.Fork(0, A), new ForkSchedule.Fork(10, B), new ForkSchedule.Fork(20, C));
+                ForkSchedule.fork(0, 0x05000000), ForkSchedule.fork(10, 0x06000000), ForkSchedule.fork(20, 0x07000000));
     }
 
     @Test
@@ -29,6 +31,16 @@ class ForkScheduleTest {
         assertArrayEquals(B, s.versionAtEpoch(19));
         assertArrayEquals(C, s.versionAtEpoch(20));
         assertArrayEquals(C, s.versionAtEpoch(Long.MAX_VALUE));
+    }
+
+    @Test
+    void priorVersionAtEpochIsTheOneBeforeTheActiveFork() {
+        ForkSchedule s = three();
+        assertNull(s.priorVersionAtEpoch(0));
+        assertNull(s.priorVersionAtEpoch(9));
+        assertArrayEquals(A, s.priorVersionAtEpoch(10));
+        assertArrayEquals(B, s.priorVersionAtEpoch(20));
+        assertArrayEquals(B, s.priorVersionAtEpoch(Long.MAX_VALUE));
     }
 
     /** The spec's max(signature_slot, 1) - 1: the FIRST slot of the activation epoch still signs OLD. */
@@ -43,59 +55,61 @@ class ForkScheduleTest {
         assertArrayEquals(C, s.versionForSignatureSlot(641));
     }
 
+    /** SSZ uint64 >= 2^63 arrives negative in a long: far future, not slot 0. */
+    @Test
+    void hugeUnsignedSlotSelectsTheNewestFork() {
+        ForkSchedule s = three();
+        assertArrayEquals(C, s.versionForSignatureSlot(Long.MIN_VALUE));
+        assertArrayEquals(C, s.versionForSignatureSlot(-1L));
+        assertArrayEquals(C, s.versionForSignatureSlot(Long.MAX_VALUE));
+    }
+
     @Test
     void slotsPerEpochIsPartOfTheSchedule() {
-        ForkSchedule s = ForkSchedule.of(16, new ForkSchedule.Fork(0, A), new ForkSchedule.Fork(10, B));
+        ForkSchedule s = ForkSchedule.of(16, ForkSchedule.fork(0, 0x05000000), ForkSchedule.fork(10, 0x06000000));
         assertArrayEquals(A, s.versionForSignatureSlot(160)); // slot 159 -> epoch 9
         assertArrayEquals(B, s.versionForSignatureSlot(161)); // slot 160 -> epoch 10
     }
 
     @Test
-    void currentAndPriorAreTheTail() {
-        ForkSchedule s = three();
-        assertArrayEquals(C, s.current());
-        assertArrayEquals(B, s.prior());
+    void newestAndSingle() {
+        assertArrayEquals(C, three().newest());
         ForkSchedule one = ForkSchedule.single(A);
-        assertArrayEquals(A, one.current());
-        assertNull(one.prior());
+        assertArrayEquals(A, one.newest());
+        assertNull(one.priorVersionAtEpoch(Long.MAX_VALUE));
         assertArrayEquals(A, one.versionForSignatureSlot(Long.MAX_VALUE));
+        assertArrayEquals(new byte[]{(byte) 0x90, 0, 0, 0x75}, ForkSchedule.single(new byte[]{(byte) 0x90, 0, 0, 0x75}).newest());
     }
 
     @Test
-    void forkLiteralIsBigEndian() {
-        assertArrayEquals(new byte[]{0x06, 0x00, 0x00, 0x64}, ForkSchedule.fork(1, 0x06000064).version());
-        assertArrayEquals(new byte[]{(byte) 0x90, 0x00, 0x00, 0x75}, ForkSchedule.fork(1, 0x90000075).version());
+    void forkVersionBytesAreBigEndian() {
+        assertArrayEquals(new byte[]{0x06, 0x00, 0x00, 0x64}, ForkSchedule.fork(1, 0x06000064).versionBytes());
+        assertArrayEquals(new byte[]{(byte) 0x90, 0x00, 0x00, 0x75}, ForkSchedule.fork(1, 0x90000075).versionBytes());
     }
 
     @Test
     void valueSemantics() {
         assertEquals(three(), three());
         assertEquals(three().hashCode(), three().hashCode());
+        assertEquals(ForkSchedule.fork(0, 0x05000000), ForkSchedule.fork(0, 0x05000000));
         assertNotEquals(three(), ForkSchedule.of(16,
-                new ForkSchedule.Fork(0, A), new ForkSchedule.Fork(10, B), new ForkSchedule.Fork(20, C)));
+                ForkSchedule.fork(0, 0x05000000), ForkSchedule.fork(10, 0x06000000), ForkSchedule.fork(20, 0x07000000)));
         assertEquals("ForkSchedule{slotsPerEpoch=32, [0:05000000, 10:06000000, 20:07000000]}", three().toString());
+        assertEquals(List.of(ForkSchedule.fork(0, 0x05000000), ForkSchedule.fork(10, 0x06000000), ForkSchedule.fork(20, 0x07000000)),
+                three().forks());
     }
 
     @Test
     void rejectsMalformedSchedules() {
         assertThrows(IllegalArgumentException.class, () -> ForkSchedule.of(32));
-        assertThrows(IllegalArgumentException.class, () -> ForkSchedule.of(32, new ForkSchedule.Fork(5, A)));
+        assertThrows(IllegalArgumentException.class, () -> ForkSchedule.of(32, (ForkSchedule.Fork) null));
+        assertThrows(IllegalArgumentException.class, () -> ForkSchedule.of(32, ForkSchedule.fork(5, 0x05000000)));
         assertThrows(IllegalArgumentException.class, () -> ForkSchedule.of(32,
-                new ForkSchedule.Fork(0, A), new ForkSchedule.Fork(20, B), new ForkSchedule.Fork(10, C)));
+                ForkSchedule.fork(0, 0x05000000), ForkSchedule.fork(20, 0x06000000), ForkSchedule.fork(10, 0x07000000)));
         assertThrows(IllegalArgumentException.class, () -> ForkSchedule.of(32,
-                new ForkSchedule.Fork(0, A), new ForkSchedule.Fork(10, B), new ForkSchedule.Fork(10, C)));
-        assertThrows(IllegalArgumentException.class, () -> ForkSchedule.of(0, new ForkSchedule.Fork(0, A)));
-        assertThrows(IllegalArgumentException.class, () -> new ForkSchedule.Fork(0, new byte[3]));
-        assertThrows(IllegalArgumentException.class, () -> new ForkSchedule.Fork(-1, A));
-    }
-
-    @Test
-    void forkVersionIsDefensivelyCopied() {
-        byte[] v = {1, 2, 3, 4};
-        ForkSchedule.Fork f = new ForkSchedule.Fork(0, v);
-        v[0] = 9;
-        assertArrayEquals(new byte[]{1, 2, 3, 4}, f.version());
-        f.version()[0] = 9;
-        assertArrayEquals(new byte[]{1, 2, 3, 4}, f.version());
+                ForkSchedule.fork(0, 0x05000000), ForkSchedule.fork(10, 0x06000000), ForkSchedule.fork(10, 0x07000000)));
+        assertThrows(IllegalArgumentException.class, () -> ForkSchedule.of(0, ForkSchedule.fork(0, 0x05000000)));
+        assertThrows(IllegalArgumentException.class, () -> ForkSchedule.fork(-1, 0x05000000));
+        assertThrows(IllegalArgumentException.class, () -> ForkSchedule.single(new byte[3]));
     }
 }

--- a/docs/reimplementation/01-consensus-light-client.md
+++ b/docs/reimplementation/01-consensus-light-client.md
@@ -148,8 +148,15 @@ signing_root  = hash_tree_root(SigningData{ object_root, domain })
               = sha256(object_root ‖ domain)                                              // 2-leaf container
 ```
 
-`forkVersion` is the network's **current** fork version (not the attested header's epoch — the
-client is forward-only from a recent checkpoint, so the current version always applies).
+`forkVersion` is the fork version **active at the update's `signature_slot`**, per the spec's
+`validate_light_client_update`:
+`compute_fork_version(compute_epoch_at_slot(max(signature_slot, 1) - 1))`. It comes from the
+network's embedded **fork schedule** (`ForkSchedule` — Java `:core`, Rust
+`myotis_consensus::fork`; pinned per network in `NetworkConfig.forkSchedule` /
+`ChainConfig.fork_schedule`), NOT from a single "current" version: a store walking updates across
+a fork boundary needs both versions, and one fixed value stalls sync at every consensus fork
+(#295). Note the `- 1`: the aggregate signs the previous slot's block, so a signature at the first
+slot of a fork's activation epoch still uses the old version.
 
 ---
 

--- a/docs/reimplementation/README.md
+++ b/docs/reimplementation/README.md
@@ -390,9 +390,12 @@ fields a re-implementation needs:
 (ip:port), elEnrTreeUrls (EIP-1459 trees), elBootEnodes (full enode:// for direct dial — used
 by chains with no DNS tree, e.g. Gnosis)`.
 
-**CL:** `genesisValidatorsRoot (32B), checkpointRoot (32B), checkpointSlot, currentForkVersion
-(4B), priorForkVersion (4B, nullable), activeBlobParamsEpoch/MaxBlobs (EIP-7892 BPO),
+**CL:** `genesisValidatorsRoot (32B), checkpointRoot (32B), checkpointSlot, forkSchedule
+(ascending (activation epoch, 4B version) list, genesis first, with the chain's slotsPerEpoch),
+acceptPriorForkDigest (bool), activeBlobParamsEpoch/MaxBlobs (EIP-7892 BPO),
 clPeerMultiaddrs, clGenesisTime, clEnrTreeUrls, clDiscv5Bootnodes (ENR strings)`.
+`currentForkVersion` / `priorForkVersion` are derived from the schedule (newest entry; the one
+before it when `acceptPriorForkDigest`).
 
 | | Mainnet | Gnosis | Sepolia |
 |---|---|---|---|
@@ -400,8 +403,9 @@ clPeerMultiaddrs, clGenesisTime, clEnrTreeUrls, clDiscv5Bootnodes (ENR strings)`
 | genesis hash | `d4e56740…cb8fa3` | `4f1dd231…da79756` | `25a5cc10…93e6dd9` |
 | EL forkIdHash | `07c9462e` | `cfca387c` | `268956b6` |
 | genesisValidatorsRoot | `4b363db9…fe95` | `f5dcb556…9d47` | `d8ea171f…8078` |
-| currentForkVersion | `06000000` (Fulu) | `06000064` (Fulu) | `90000073` (Electra) |
-| priorForkVersion | — | `05000064` | — |
+| forkSchedule (epoch:version) | 0:`00000000`, 74240:`01000000`, 144896:`02000000`, 194048:`03000000`, 269568:`04000000`, 364032:`05000000`, 411392:`06000000` | 0:`00000064`, 512:`01000064`, 385536:`02000064`, 648704:`03000064`, 889856:`04000064`, 1337856:`05000064`, 1714688:`06000064` | 0:`90000069`, 50:`90000070`, 100:`90000071`, 56832:`90000072`, 132608:`90000073`, 222464:`90000074`, 272640:`90000075` |
+| currentForkVersion (derived) | `06000000` (Fulu) | `06000064` (Fulu) | `90000075` (Fulu) |
+| acceptPriorForkDigest → priorForkVersion | no → — | yes → `05000064` | no → — |
 | BPO (epoch, maxBlobs) | (419072, 21) | (1337856, 2) | (0, 0) |
 | clGenesisTime | 1606824023 | 1638993340 | 1655733600 |
 | secondsPerSlot / slotsPerEpoch | 12 / 32 | **5 / 16** | 12 / 32 |

--- a/docs/reimplementation/README.md
+++ b/docs/reimplementation/README.md
@@ -394,8 +394,9 @@ by chains with no DNS tree, e.g. Gnosis)`.
 (ascending (activation epoch, 4B version) list, genesis first, with the chain's slotsPerEpoch),
 acceptPriorForkDigest (bool), activeBlobParamsEpoch/MaxBlobs (EIP-7892 BPO),
 clPeerMultiaddrs, clGenesisTime, clEnrTreeUrls, clDiscv5Bootnodes (ENR strings)`.
-`currentForkVersion` / `priorForkVersion` are derived from the schedule (newest entry; the one
-before it when `acceptPriorForkDigest`).
+`currentForkVersion` / `priorForkVersion` are derived from the schedule at the WALL-CLOCK epoch
+(the active entry; the one before it when `acceptPriorForkDigest`), so the next fork can be
+pinned ahead of its activation without flipping the digest early.
 
 | | Mainnet | Gnosis | Sepolia |
 |---|---|---|---|
@@ -406,7 +407,7 @@ before it when `acceptPriorForkDigest`).
 | forkSchedule (epoch:version) | 0:`00000000`, 74240:`01000000`, 144896:`02000000`, 194048:`03000000`, 269568:`04000000`, 364032:`05000000`, 411392:`06000000` | 0:`00000064`, 512:`01000064`, 385536:`02000064`, 648704:`03000064`, 889856:`04000064`, 1337856:`05000064`, 1714688:`06000064` | 0:`90000069`, 50:`90000070`, 100:`90000071`, 56832:`90000072`, 132608:`90000073`, 222464:`90000074`, 272640:`90000075` |
 | currentForkVersion (derived) | `06000000` (Fulu) | `06000064` (Fulu) | `90000075` (Fulu) |
 | acceptPriorForkDigest → priorForkVersion | no → — | yes → `05000064` | no → — |
-| BPO (epoch, maxBlobs) | (419072, 21) | (1337856, 2) | (0, 0) |
+| BPO (epoch, maxBlobs) | (419072, 21) | (1337856, 2) | (275712, 21) |
 | clGenesisTime | 1606824023 | 1638993340 | 1655733600 |
 | secondsPerSlot / slotsPerEpoch | 12 / 32 | **5 / 16** | 12 / 32 |
 | EL/discv5/RPC ports | 30303/9000/8545 | 30304/9001/8546 | 30305/9002/8547 |

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/NetworkConfig.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/NetworkConfig.java
@@ -1,5 +1,6 @@
 package com.jaeckel.ethp2p.networking;
 
+import com.jaeckel.ethp2p.core.consensus.ForkSchedule;
 import com.jaeckel.ethp2p.core.enr.Enr;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
@@ -28,16 +29,25 @@ public record NetworkConfig(
         long checkpointSlot,            // slot of the trusted checkpoint. Used to populate
                                         // Status.finalized_epoch before bootstrap so Lighthouse
                                         // doesn't goodbye us with IrrelevantNetwork(code=2).
-        byte[] currentForkVersion,      // 4 bytes: current fork version for signing domain
+        ForkSchedule forkSchedule,      // the chain's FULL fork schedule (activation epoch -> 4-byte version,
+                                        // ascending, genesis first). Every sync-committee signature is
+                                        // verified under the version active at its signature_slot, so the
+                                        // light client can walk updates across a fork boundary (#295); the
+                                        // newest entry also feeds the fork digest. Append-only,
+                                        // consensus-critical, same trust standing as genesisValidatorsRoot:
+                                        // pinned from the network's published config
+                                        // (/eth/v1/config/fork_schedule), never fetched. Keep in lockstep
+                                        // with the Rust ChainConfig.fork_schedule (rust/myotis-net/src/sync.rs).
         long activeBlobParamsEpoch,     // EIP-7892: epoch of the currently-active BPO fork, or 0 if none.
                                         // Folded into compute_fork_digest via the XOR formula so our digest
                                         // tracks the network's post-Fulu BPO activations.
         long activeBlobParamsMaxBlobs,  // EIP-7892: MAX_BLOBS_PER_BLOCK for the active BPO entry (paired
                                         // with activeBlobParamsEpoch). Ignored when activeBlobParamsEpoch == 0.
-        byte[] priorForkVersion,        // 4 bytes: immediately preceding fork (nullable). Accepted as
-                                        // a discv5 fork_digest fallback so a configured "current" fork
+        boolean acceptPriorForkDigest,  // accept the PRIOR scheduled fork's digest as a discv5 fork_digest
+                                        // fallback next to the current one, so a configured "current" fork
                                         // that hasn't yet activated on the network doesn't filter every
-                                        // peer out. Null skips the fallback (testnets, genesis fork).
+                                        // peer out. A policy knob — the version itself comes from the
+                                        // schedule. Off for mainnet/sepolia, on for gnosis.
         List<String> clPeerMultiaddrs,  // libp2p multiaddrs of known CL peers
         String beaconApiUrl,            // HTTP API URL for local beacon node (e.g. http://172.17.0.1:5052)
         long clGenesisTime,             // beacon chain genesis time (seconds since epoch) for wall-clock period estimation
@@ -45,6 +55,19 @@ public record NetworkConfig(
         List<String> clEnrTreeUrls,     // EIP-1459 enrtree:// URLs for consensus-layer libp2p peers
         List<String> clDiscv5Bootnodes  // ENR strings of CL discv5 bootnodes (seed for DHT discovery)
 ) {
+
+    public NetworkConfig {
+        // The schedule maps signature slots to epochs with its own slotsPerEpoch;
+        // it must be THIS chain's geometry or every boundary lands on the wrong
+        // slot. Refused at construction rather than defaulted (CLAUDE.md: a
+        // parameter that can change the answer is applied or refused).
+        java.util.Objects.requireNonNull(forkSchedule, "forkSchedule");
+        if (forkSchedule.slotsPerEpoch() != slotsPerEpochFor(networkId)) {
+            throw new IllegalArgumentException(name + ": forkSchedule.slotsPerEpoch="
+                    + forkSchedule.slotsPerEpoch() + " but the chain's preset has "
+                    + slotsPerEpochFor(networkId));
+        }
+    }
 
     // -------------------------------------------------------------------------
     // Lighthouse mainnet CL bootstrap ENRs
@@ -97,17 +120,26 @@ public record NetworkConfig(
             Bytes.fromHexString("16d197d597d795c05cb9a195a1bd34c77acd6c1f8ba336f75c5cfbc395710d68").toArrayUnsafe(),
             15185856L, // checkpoint slot (epoch = slot/32). Must stay in sync with the root above.
             // @checkpoint:mainnet:end
-            // current fork version: Fulu (0x06000000) — activated at slot 13164544 (2025-12-03)
-            new byte[]{0x06, 0x00, 0x00, 0x00},
+            // Fork schedule — consensus-specs configs/mainnet.yaml *_FORK_EPOCH /
+            // *_FORK_VERSION. Fulu activated at epoch 411392 = slot 13164544 (2025-12-03).
+            ForkSchedule.of(32,
+                    ForkSchedule.fork(0, 0x00000000),      // phase0 (genesis)
+                    ForkSchedule.fork(74240, 0x01000000),  // altair
+                    ForkSchedule.fork(144896, 0x02000000), // bellatrix
+                    ForkSchedule.fork(194048, 0x03000000), // capella
+                    ForkSchedule.fork(269568, 0x04000000), // deneb
+                    ForkSchedule.fork(364032, 0x05000000), // electra
+                    ForkSchedule.fork(411392, 0x06000000)  // fulu
+            ),
             // EIP-7892 BLOB_SCHEDULE — latest active entry on mainnet.
             // BPO2 (Fusaka) at epoch 419072, MAX_BLOBS_PER_BLOCK=21, 2026-01-07.
             // Feeds into compute_fork_digest (XOR of base_digest with sha256 of
             // (epoch_le || max_blobs_le)).
             419072L, 21L,
-            // No prior-fork fallback: mainnet is on Fulu; peers still advertising
+            // No prior-fork digest fallback: mainnet is on Fulu; peers still advertising
             // an older digest are either stale ENRs or unupgraded nodes — matching
             // them wouldn't help us sync to the current head anyway.
-            null,
+            false,
             // CL peer multiaddrs: known light-client-serving peers. Provenance:
             // originally discovered via the Lighthouse peer API 2026-03-11,
             // re-censused via period_census 2026-09-01 (#410), re-verified and
@@ -211,15 +243,24 @@ public record NetworkConfig(
             Bytes.fromHexString("3fdfc6b7c39990c859ca1ea0a73d4f072a49a7d3dfe7f6e416bf90006d6f079b").toArrayUnsafe(),
             11110080L, // checkpoint slot (epoch = slot/32). Must stay in sync with the root above.
             // @checkpoint:sepolia:end
-            // current fork version: Fulu on sepolia (0x90000075) — activated at epoch 272640 (2025-10-14)
-            new byte[]{(byte) 0x90, 0x00, 0x00, 0x75},
+            // Fork schedule — eth-clients/sepolia metadata/config.yaml *_FORK_EPOCH /
+            // *_FORK_VERSION. Fulu (0x90000075) activated at epoch 272640 (2025-10-14).
+            ForkSchedule.of(32,
+                    ForkSchedule.fork(0, 0x90000069),      // phase0 (genesis)
+                    ForkSchedule.fork(50, 0x90000070),     // altair
+                    ForkSchedule.fork(100, 0x90000071),    // bellatrix
+                    ForkSchedule.fork(56832, 0x90000072),  // capella
+                    ForkSchedule.fork(132608, 0x90000073), // deneb
+                    ForkSchedule.fork(222464, 0x90000074), // electra
+                    ForkSchedule.fork(272640, 0x90000075)  // fulu
+            ),
             // EIP-7892 BLOB_SCHEDULE — latest active entry on sepolia:
             // BPO2 at epoch 275712, MAX_BLOBS_PER_BLOCK=21 (2025-10-28). Folds into
             // the fork digest XOR — see activeBlobParams.
             275712L, 21L,
-            // No prior-fork fallback (same rationale as mainnet: stale digests
+            // No prior-fork digest fallback (same rationale as mainnet: stale digests
             // wouldn't help us sync to the current head anyway).
-            null,
+            false,
             // CL peer multiaddrs for sepolia. First entry is roost, the
             // dedicated light-client server (rust/roost, docs/lc-server-design.md).
             // It is first because it exists precisely for this: a general-purpose
@@ -340,13 +381,23 @@ public record NetworkConfig(
             Bytes.fromHexString("ed1faabdc3c3a7cac06a67bc7d6c483c2a4af00c37f754a4d3860d06e1745997").toArrayUnsafe(),
             30012384L, // checkpoint slot (epoch = slot/16). Must stay in sync with the root above.
             // @checkpoint:gnosis:end
-            // current fork version: Fulu on Gnosis (0x06000064), active since 2026-04-14
-            new byte[]{0x06, 0x00, 0x00, 0x64},
+            // Fork schedule — gnosischain/configs mainnet/config.yaml *_FORK_EPOCH /
+            // *_FORK_VERSION, on 16-slot epochs. Fulu (0x06000064) active since epoch
+            // 1714688 (2026-04-14); Electra's epoch is also the blob-params epoch below.
+            ForkSchedule.of(16,
+                    ForkSchedule.fork(0, 0x00000064),       // phase0 (genesis)
+                    ForkSchedule.fork(512, 0x01000064),     // altair
+                    ForkSchedule.fork(385536, 0x02000064),  // bellatrix
+                    ForkSchedule.fork(648704, 0x03000064),  // capella
+                    ForkSchedule.fork(889856, 0x04000064),  // deneb
+                    ForkSchedule.fork(1337856, 0x05000064), // electra
+                    ForkSchedule.fork(1714688, 0x06000064)  // fulu
+            ),
             // EIP-7892: Gnosis has no explicit BLOB_SCHEDULE, so clients fold the
             // Electra-baseline blob params (ELECTRA_FORK_EPOCH=1337856, MAX_BLOBS_PER_BLOCK_ELECTRA=2)
             // into the Fulu fork digest. Yields the live-verified eth2 digest 0x3237dab6.
             1337856L, 2L,
-            new byte[]{0x05, 0x00, 0x00, 0x64}, // prior fork: Electra — accepted as a discv5 fork-digest fallback
+            true, // Electra's digest (the prior scheduled fork) is accepted as a discv5 fork-digest fallback
             // CL peer multiaddrs for Gnosis: Identify-confirmed LC servers harvested
             // from a long-running desktop profile's cl-peers-gnosis.cache (2026-08-06,
             // issue #291 — a cold Gnosis pool starves catch-up because so few nodes
@@ -504,10 +555,28 @@ public record NetworkConfig(
     public List<byte[]> acceptedForkDigests() {
         List<byte[]> digests = new ArrayList<>(2);
         digests.add(currentForkDigest());
-        if (priorForkVersion != null) {
-            digests.add(forkDigestFor(priorForkVersion));
+        byte[] prior = priorForkVersion();
+        if (prior != null) {
+            digests.add(forkDigestFor(prior));
         }
         return List.copyOf(digests);
+    }
+
+    /**
+     * The newest scheduled fork's version — the fork DIGEST input (discv5
+     * filtering, Status). Not a signing-domain input: the light client reads
+     * the schedule per update ({@link ForkSchedule#versionForSignatureSlot}).
+     */
+    public byte[] currentForkVersion() {
+        return forkSchedule.current();
+    }
+
+    /**
+     * The prior scheduled fork's version when its digest is accepted
+     * ({@link #acceptPriorForkDigest()}), else {@code null}.
+     */
+    public byte[] priorForkVersion() {
+        return acceptPriorForkDigest ? forkSchedule.prior() : null;
     }
 
     /**
@@ -640,6 +709,10 @@ public record NetworkConfig(
      * period is 8192 on both presets, so that helper is shared.)
      */
     public int slotsPerEpoch() {
+        return slotsPerEpochFor(networkId);
+    }
+
+    private static int slotsPerEpochFor(long networkId) {
         return networkId == 100 ? 16 : 32;
     }
 

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/NetworkConfig.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/NetworkConfig.java
@@ -33,7 +33,8 @@ public record NetworkConfig(
                                         // ascending, genesis first). Every sync-committee signature is
                                         // verified under the version active at its signature_slot, so the
                                         // light client can walk updates across a fork boundary (#295); the
-                                        // newest entry also feeds the fork digest. Append-only,
+                                        // entry active at the wall-clock epoch feeds the fork digest, so
+                                        // the NEXT fork may be pinned ahead of activation. Append-only,
                                         // consensus-critical, same trust standing as genesisValidatorsRoot:
                                         // pinned from the network's published config
                                         // (/eth/v1/config/fork_schedule), never fetched. Keep in lockstep
@@ -563,20 +564,32 @@ public record NetworkConfig(
     }
 
     /**
-     * The newest scheduled fork's version — the fork DIGEST input (discv5
-     * filtering, Status). Not a signing-domain input: the light client reads
-     * the schedule per update ({@link ForkSchedule#versionForSignatureSlot}).
+     * The fork version active NOW — the fork DIGEST input (discv5 filtering,
+     * Status, gossip topics). Read from the schedule at the wall-clock epoch, so
+     * the next fork can be pinned ahead of its activation without flipping the
+     * digest early (a not-yet-active digest matches no peer). Not a
+     * signing-domain input: the light client reads the schedule per update
+     * ({@link ForkSchedule#versionForSignatureSlot}).
      */
     public byte[] currentForkVersion() {
-        return forkSchedule.current();
+        return forkSchedule.versionAtEpoch(wallClockEpoch());
     }
 
     /**
-     * The prior scheduled fork's version when its digest is accepted
+     * The version of the fork before the active one when its digest is accepted
      * ({@link #acceptPriorForkDigest()}), else {@code null}.
      */
     public byte[] priorForkVersion() {
-        return acceptPriorForkDigest ? forkSchedule.prior() : null;
+        return acceptPriorForkDigest ? forkSchedule.priorVersionAtEpoch(wallClockEpoch()) : null;
+    }
+
+    /**
+     * Wall-clock beacon epoch of this chain. Clamped at 0 for a clock set before
+     * genesis (Rust twin: {@code ChainConfig::current_slot_estimate}, saturating).
+     */
+    public long wallClockEpoch() {
+        long wallSlot = Math.max(0L, System.currentTimeMillis() / 1000L - clGenesisTime) / secondsPerSlot();
+        return wallSlot / slotsPerEpoch();
     }
 
     /**

--- a/networking/src/main/java/com/jaeckel/ethp2p/networking/NetworkConfig.java
+++ b/networking/src/main/java/com/jaeckel/ethp2p/networking/NetworkConfig.java
@@ -556,6 +556,14 @@ public record NetworkConfig(
     public List<byte[]> acceptedForkDigests() {
         List<byte[]> digests = new ArrayList<>(2);
         digests.add(currentForkDigest());
+        // KNOWN LIMIT: the prior digest is the plain pre-EIP-7892 form, which is
+        // what Electra-era peers advertise (gnosis today: 0x7D5AAB40). Once the
+        // prior fork is Fulu or later, stale peers advertise the BPO-FOLDED digest
+        // of their era, so this fallback matches nobody (fail-safe, never a wrong
+        // acceptance). Folding it needs the blob-params entry active in the prior
+        // fork's era — the blob-schedule follow-up deferred in PR #430; until then
+        // this knob is a no-op past the next fork. Rust twin: ChainConfig
+        // ::accepted_fork_digests carries the same note.
         byte[] prior = priorForkVersion();
         if (prior != null) {
             digests.add(forkDigestFor(prior));

--- a/networking/src/test/java/com/jaeckel/ethp2p/networking/NetworkConfigForkScheduleTest.java
+++ b/networking/src/test/java/com/jaeckel/ethp2p/networking/NetworkConfigForkScheduleTest.java
@@ -1,0 +1,94 @@
+package com.jaeckel.ethp2p.networking;
+
+import com.jaeckel.ethp2p.core.consensus.ForkSchedule;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins every network's fork schedule (#295). The Rust twin
+ * ({@code rust/myotis-net/src/sync.rs}, {@code *_config_matches_networkconfig_java})
+ * pins the same lists, so a one-sided edit fails on the side that was not
+ * updated. Sources: consensus-specs {@code configs/mainnet.yaml},
+ * eth-clients/sepolia {@code metadata/config.yaml}, gnosischain/configs
+ * {@code mainnet/config.yaml}.
+ */
+class NetworkConfigForkScheduleTest {
+
+    private static void assertSchedule(ForkSchedule s, int slotsPerEpoch, long[] epochs, int[] versions) {
+        assertEquals(slotsPerEpoch, s.slotsPerEpoch());
+        List<ForkSchedule.Fork> forks = s.forks();
+        assertEquals(epochs.length, forks.size(), "entry count");
+        for (int i = 0; i < epochs.length; i++) {
+            assertEquals(epochs[i], forks.get(i).epoch(), "epoch of entry " + i);
+            assertArrayEquals(ForkSchedule.fork(0, versions[i]).version(), forks.get(i).version(),
+                    "version of entry " + i);
+        }
+    }
+
+    @Test
+    void mainnetSchedule() {
+        NetworkConfig c = NetworkConfig.MAINNET;
+        assertSchedule(c.forkSchedule(), 32,
+                new long[]{0, 74240, 144896, 194048, 269568, 364032, 411392},
+                new int[]{0x00000000, 0x01000000, 0x02000000, 0x03000000, 0x04000000, 0x05000000, 0x06000000});
+        assertArrayEquals(new byte[]{0x06, 0, 0, 0}, c.currentForkVersion());
+        assertFalse(c.acceptPriorForkDigest());
+        assertNull(c.priorForkVersion(), "fallback digest off on mainnet");
+        // Fulu's first slot (411392 * 32 = 13164544) still verifies under Electra;
+        // the next slot switches — the spec's max(signature_slot, 1) - 1.
+        assertArrayEquals(new byte[]{0x05, 0, 0, 0}, c.forkSchedule().versionForSignatureSlot(13164544L));
+        assertArrayEquals(new byte[]{0x06, 0, 0, 0}, c.forkSchedule().versionForSignatureSlot(13164545L));
+    }
+
+    @Test
+    void sepoliaSchedule() {
+        NetworkConfig c = NetworkConfig.SEPOLIA;
+        assertSchedule(c.forkSchedule(), 32,
+                new long[]{0, 50, 100, 56832, 132608, 222464, 272640},
+                new int[]{0x90000069, 0x90000070, 0x90000071, 0x90000072, 0x90000073, 0x90000074, 0x90000075});
+        assertArrayEquals(new byte[]{(byte) 0x90, 0, 0, 0x75}, c.currentForkVersion());
+        assertFalse(c.acceptPriorForkDigest());
+        assertNull(c.priorForkVersion());
+    }
+
+    @Test
+    void gnosisSchedule() {
+        NetworkConfig c = NetworkConfig.GNOSIS;
+        assertSchedule(c.forkSchedule(), 16,
+                new long[]{0, 512, 385536, 648704, 889856, 1337856, 1714688},
+                new int[]{0x00000064, 0x01000064, 0x02000064, 0x03000064, 0x04000064, 0x05000064, 0x06000064});
+        assertArrayEquals(new byte[]{0x06, 0, 0, 0x64}, c.currentForkVersion());
+        assertTrue(c.acceptPriorForkDigest());
+        assertArrayEquals(new byte[]{0x05, 0, 0, 0x64}, c.priorForkVersion());
+        // Fulu epoch 1714688 x 16 = slot 27435008: the first slot is still Electra.
+        assertArrayEquals(new byte[]{0x05, 0, 0, 0x64}, c.forkSchedule().versionForSignatureSlot(27435008L));
+        assertArrayEquals(new byte[]{0x06, 0, 0, 0x64}, c.forkSchedule().versionForSignatureSlot(27435009L));
+    }
+
+    /** The schedule's geometry must be the chain's — the record constructor refuses otherwise. */
+    @Test
+    void everyScheduleCarriesItsChainsGeometry() {
+        for (NetworkConfig c : List.of(NetworkConfig.MAINNET, NetworkConfig.SEPOLIA, NetworkConfig.GNOSIS)) {
+            assertEquals(c.slotsPerEpoch(), c.forkSchedule().slotsPerEpoch(), c.name());
+        }
+    }
+
+    /** The digest inputs are unchanged by the schedule refactor (live-verified values). */
+    @Test
+    void digestsUnchanged() {
+        assertArrayEquals(new byte[]{(byte) 0x8C, (byte) 0x9F, 0x62, (byte) 0xFE}, NetworkConfig.MAINNET.currentForkDigest());
+        assertArrayEquals(new byte[]{0x74, (byte) 0xD0, 0x14, 0x59}, NetworkConfig.SEPOLIA.currentForkDigest());
+        assertArrayEquals(new byte[]{0x32, 0x37, (byte) 0xDA, (byte) 0xB6}, NetworkConfig.GNOSIS.currentForkDigest());
+        assertEquals(1, NetworkConfig.MAINNET.acceptedForkDigests().size());
+        assertEquals(1, NetworkConfig.SEPOLIA.acceptedForkDigests().size());
+        assertEquals(2, NetworkConfig.GNOSIS.acceptedForkDigests().size());
+        assertArrayEquals(new byte[]{0x7D, 0x5A, (byte) 0xAB, 0x40}, NetworkConfig.GNOSIS.acceptedForkDigests().get(1));
+    }
+}

--- a/networking/src/test/java/com/jaeckel/ethp2p/networking/NetworkConfigForkScheduleTest.java
+++ b/networking/src/test/java/com/jaeckel/ethp2p/networking/NetworkConfigForkScheduleTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -27,8 +28,7 @@ class NetworkConfigForkScheduleTest {
         assertEquals(epochs.length, forks.size(), "entry count");
         for (int i = 0; i < epochs.length; i++) {
             assertEquals(epochs[i], forks.get(i).epoch(), "epoch of entry " + i);
-            assertArrayEquals(ForkSchedule.fork(0, versions[i]).version(), forks.get(i).version(),
-                    "version of entry " + i);
+            assertEquals(versions[i], forks.get(i).version(), "version of entry " + i);
         }
     }
 
@@ -72,12 +72,47 @@ class NetworkConfigForkScheduleTest {
         assertArrayEquals(new byte[]{0x06, 0, 0, 0x64}, c.forkSchedule().versionForSignatureSlot(27435009L));
     }
 
-    /** The schedule's geometry must be the chain's — the record constructor refuses otherwise. */
+    /**
+     * The digest-side "current" version is the schedule entry active at the WALL
+     * CLOCK, so the next fork can be pinned before it activates without flipping
+     * the digest early. Pinned with a far-future entry appended to each real
+     * schedule: every digest and version must be exactly what it is today.
+     */
     @Test
-    void everyScheduleCarriesItsChainsGeometry() {
+    void aFutureForkPinnedAheadDoesNotChangeTodaysDigest() {
         for (NetworkConfig c : List.of(NetworkConfig.MAINNET, NetworkConfig.SEPOLIA, NetworkConfig.GNOSIS)) {
-            assertEquals(c.slotsPerEpoch(), c.forkSchedule().slotsPerEpoch(), c.name());
+            assertArrayEquals(c.forkSchedule().newest(), c.currentForkVersion(),
+                    c.name() + ": every pinned fork is active today");
+            List<ForkSchedule.Fork> forks = new java.util.ArrayList<>(c.forkSchedule().forks());
+            forks.add(ForkSchedule.fork(Long.MAX_VALUE / 64, 0x7F000000)); // never activates in this test's lifetime
+            NetworkConfig ahead = new NetworkConfig(c.name(), c.networkId(), c.genesisHash(), c.bestBlockHash(),
+                    c.forkIdHash(), c.forkNext(), c.bootnodes(), c.genesisValidatorsRoot(), c.checkpointRoot(),
+                    c.checkpointSlot(), new ForkSchedule(c.forkSchedule().slotsPerEpoch(), forks),
+                    c.activeBlobParamsEpoch(), c.activeBlobParamsMaxBlobs(), c.acceptPriorForkDigest(),
+                    c.clPeerMultiaddrs(), c.beaconApiUrl(), c.clGenesisTime(), c.elEnrTreeUrls(),
+                    c.clEnrTreeUrls(), c.clDiscv5Bootnodes());
+            assertArrayEquals(c.currentForkVersion(), ahead.currentForkVersion(), c.name());
+            assertArrayEquals(c.currentForkDigest(), ahead.currentForkDigest(), c.name());
+            assertEquals(c.acceptedForkDigests().size(), ahead.acceptedForkDigests().size(), c.name());
+            for (int i = 0; i < c.acceptedForkDigests().size(); i++) {
+                assertArrayEquals(c.acceptedForkDigests().get(i), ahead.acceptedForkDigests().get(i), c.name());
+            }
+            // ...while signatures from that far future would already verify under it.
+            assertArrayEquals(new byte[]{0x7F, 0, 0, 0}, ahead.forkSchedule().versionForSignatureSlot(Long.MAX_VALUE));
         }
+    }
+
+    /** A schedule with another chain's geometry is refused at construction. */
+    @Test
+    void mismatchedGeometryIsRefused() {
+        NetworkConfig c = NetworkConfig.GNOSIS;
+        ForkSchedule mainnetGeometry = new ForkSchedule(32, c.forkSchedule().forks());
+        assertThrows(IllegalArgumentException.class, () -> new NetworkConfig(c.name(), c.networkId(),
+                c.genesisHash(), c.bestBlockHash(), c.forkIdHash(), c.forkNext(), c.bootnodes(),
+                c.genesisValidatorsRoot(), c.checkpointRoot(), c.checkpointSlot(), mainnetGeometry,
+                c.activeBlobParamsEpoch(), c.activeBlobParamsMaxBlobs(), c.acceptPriorForkDigest(),
+                c.clPeerMultiaddrs(), c.beaconApiUrl(), c.clGenesisTime(), c.elEnrTreeUrls(),
+                c.clEnrTreeUrls(), c.clDiscv5Bootnodes()));
     }
 
     /** The digest inputs are unchanged by the schedule refactor (live-verified values). */

--- a/networking/src/test/java/com/jaeckel/ethp2p/networking/NetworkConfigGnosisTest.java
+++ b/networking/src/test/java/com/jaeckel/ethp2p/networking/NetworkConfigGnosisTest.java
@@ -57,8 +57,11 @@ class NetworkConfigGnosisTest {
                 Bytes.wrap(G.genesisValidatorsRoot()));
         assertEquals(4, G.currentForkVersion().length, "fork version must be 4 bytes");
         assertArrayEquals(new byte[]{0x06, 0x00, 0x00, 0x64}, G.currentForkVersion(), "Fulu fork version");
+        assertTrue(G.acceptPriorForkDigest());
         assertNotNull(G.priorForkVersion());
         assertArrayEquals(new byte[]{0x05, 0x00, 0x00, 0x64}, G.priorForkVersion(), "Electra prior fork version");
+        // The full schedule is pinned in NetworkConfigForkScheduleTest.
+        assertEquals(16, G.forkSchedule().slotsPerEpoch(), "schedule carries the gnosis geometry");
         assertEquals(32, G.checkpointRoot().length, "checkpoint root must be 32 bytes");
         assertTrue(G.checkpointSlot() > 0, "checkpoint slot must be set");
         // EIP-7892: Gnosis folds the Electra-baseline blob params into the Fulu digest.

--- a/node-core/src/main/java/io/myotis/node/ChainStack.java
+++ b/node-core/src/main/java/io/myotis/node/ChainStack.java
@@ -975,7 +975,7 @@ public final class ChainStack implements io.myotis.api.NodeLifecycle {
         }
         BeaconLightClient blc = new BeaconLightClient(
                 clPeers, network.checkpointRoot(), network.checkpointSlot(),
-                network.currentForkVersion(), network.genesisValidatorsRoot(),
+                network.forkSchedule(), network.genesisValidatorsRoot(),
                 beaconSyncState, network.beaconApiUrl(),
                 clPeerCache::add, clPeerCache::markFailure, network.clGenesisTime());
         blc.setBlobParameters(network.activeBlobParamsEpoch(), network.activeBlobParamsMaxBlobs());

--- a/node-core/src/main/java/io/myotis/node/ChainStack.java
+++ b/node-core/src/main/java/io/myotis/node/ChainStack.java
@@ -902,7 +902,10 @@ public final class ChainStack implements io.myotis.api.NodeLifecycle {
      *  during the first start's brief pre-BLC window (peers land in the cache and
      *  are picked up moments later), already-set on resume. */
     private void startDiscV5() {
-        List<byte[]> acceptedForkDigests = network.acceptedForkDigests();
+        // The accepted digests are re-read per candidate ENR (two SHA-256s), not
+        // captured here: NetworkConfig.acceptedForkDigests() follows the fork
+        // schedule at the wall clock, so a fork pinned ahead of its activation
+        // rotates the filter at its epoch without a restart (#295 review).
         AtomicInteger mismatchesLogged = new AtomicInteger();
 
         // Targeted lookups (#347): derive the discv5 node ids of the pinned CL
@@ -932,6 +935,7 @@ public final class ChainStack implements io.myotis.api.NodeLifecycle {
             var eth2 = enr.eth2();
             if (eth2.isEmpty()) return;
             byte[] peerDigest = eth2.get().forkDigest();
+            List<byte[]> acceptedForkDigests = network.acceptedForkDigests();
             int matchIdx = -1;
             for (int i = 0; i < acceptedForkDigests.size(); i++) {
                 if (java.util.Arrays.equals(peerDigest, acceptedForkDigests.get(i))) { matchIdx = i; break; }

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4172,6 +4172,7 @@ dependencies = [
 name = "myotis-consensus"
 version = "0.1.8"
 dependencies = [
+ "blst",
  "myotis-bls",
  "sha2",
  "tracing",

--- a/rust/myotis-consensus/Cargo.toml
+++ b/rust/myotis-consensus/Cargo.toml
@@ -14,3 +14,8 @@ sha2 = "0.10"
 # Diagnostics only (debug-level rejection reasons in store.rs): the tracing
 # facade is I/O-free and wasm-safe, so the sans-I/O canary is unaffected.
 tracing = "=0.1.44"
+
+[dev-dependencies]
+# Signing side of BLS for the synthetic fork-boundary test (tests/fork_boundary.rs).
+# Already in the lock file via myotis-bls, so no new dependency tree.
+blst = "0.3"

--- a/rust/myotis-consensus/src/fork.rs
+++ b/rust/myotis-consensus/src/fork.rs
@@ -14,6 +14,15 @@
 //! one fixed version and were correct only because every checkpoint pin
 //! happened to sit after its network's newest fork.
 //!
+//! # Shippable ahead of activation
+//!
+//! The schedule may (and should) carry the NEXT scheduled fork before it
+//! activates: verification is keyed by the update's own slot, and the
+//! digest-side "active" version is read with [`ForkSchedule::version_at_epoch`]
+//! at the wall-clock epoch (`ChainConfig::current_fork_version`), so a future
+//! entry changes nothing until its epoch arrives. Only the blob-parameter
+//! (EIP-7892) digest fold remains a single configured value.
+//!
 //! # Trust posture
 //!
 //! Consensus-critical configuration with the same standing as the genesis
@@ -76,32 +85,38 @@ impl ForkSchedule {
         &self.forks
     }
 
-    /// The newest scheduled fork's version — what the legacy single
-    /// `fork_version` field held. Feeds the fork DIGEST (discv5 filtering,
-    /// Status), never signature verification.
-    pub fn current(&self) -> [u8; 4] {
+    /// The newest scheduled fork's version — possibly not yet active. Callers
+    /// that need the fork active NOW (the digest, Status) must use
+    /// [`version_at_epoch`](Self::version_at_epoch) with the wall-clock epoch;
+    /// this is for pins and diagnostics.
+    pub fn newest(&self) -> [u8; 4] {
         self.forks[self.forks.len() - 1].1
-    }
-
-    /// The fork before [`current`](Self::current), when the schedule has one.
-    pub fn prior(&self) -> Option<[u8; 4]> {
-        let n = self.forks.len();
-        (n >= 2).then(|| self.forks[n - 2].1)
     }
 
     /// `compute_fork_version(epoch)`: the version of the latest fork whose
     /// activation epoch is `<= epoch`. Total — the genesis entry covers epoch 0.
     pub fn version_at_epoch(&self, epoch: u64) -> [u8; 4] {
+        self.forks[self.index_at_epoch(epoch)].1
+    }
+
+    /// The version of the fork BEFORE the one active at `epoch`, or `None`
+    /// when that is the genesis fork — the discv5 prior-digest fallback input.
+    pub fn prior_version_at_epoch(&self, epoch: u64) -> Option<[u8; 4]> {
+        let i = self.index_at_epoch(epoch);
+        (i >= 1).then(|| self.forks[i - 1].1)
+    }
+
+    fn index_at_epoch(&self, epoch: u64) -> usize {
         // Ascending list; the last entry with activation <= epoch wins.
-        let mut version = self.forks[0].1;
-        for (activation, v) in &self.forks {
+        let mut idx = 0;
+        for (i, (activation, _)) in self.forks.iter().enumerate() {
             if *activation <= epoch {
-                version = *v;
+                idx = i;
             } else {
                 break;
             }
         }
-        version
+        idx
     }
 
     /// The fork version a sync aggregate signed at `signature_slot` must be
@@ -112,9 +127,8 @@ impl ForkSchedule {
     /// PREVIOUS slot, so a signature at the first slot of a fork's activation
     /// epoch still uses the old version, and only the next slot switches.
     pub fn version_for_signature_slot(&self, signature_slot: u64) -> [u8; 4] {
-        let epoch =
-            spec::compute_epoch_at_slot_with(signature_slot.max(1) - 1, self.slots_per_epoch);
-        self.version_at_epoch(epoch)
+        // slots_per_epoch is non-zero by construction (see `new`).
+        self.version_at_epoch((signature_slot.max(1) - 1) / self.slots_per_epoch)
     }
 }
 
@@ -164,13 +178,21 @@ mod tests {
     }
 
     #[test]
-    fn current_and_prior_are_the_tail() {
+    fn prior_version_is_the_one_before_the_active_fork() {
         let s = three();
-        assert_eq!(s.current(), C);
-        assert_eq!(s.prior(), Some(B));
+        assert_eq!(s.prior_version_at_epoch(0), None);
+        assert_eq!(s.prior_version_at_epoch(9), None);
+        assert_eq!(s.prior_version_at_epoch(10), Some(A));
+        assert_eq!(s.prior_version_at_epoch(20), Some(B));
+        assert_eq!(s.prior_version_at_epoch(u64::MAX), Some(B));
+    }
+
+    #[test]
+    fn newest_and_single() {
+        assert_eq!(three().newest(), C);
         let one = ForkSchedule::single(A);
-        assert_eq!(one.current(), A);
-        assert_eq!(one.prior(), None);
+        assert_eq!(one.newest(), A);
+        assert_eq!(one.prior_version_at_epoch(u64::MAX), None);
         assert_eq!(one.version_for_signature_slot(u64::MAX), A);
     }
 

--- a/rust/myotis-consensus/src/fork.rs
+++ b/rust/myotis-consensus/src/fork.rs
@@ -1,0 +1,206 @@
+//! Fork schedule — the per-network, append-only list of `(activation epoch,
+//! fork version)` pairs that selects the signing domain for every sync-committee
+//! signature. Rust twin of the Java `ForkSchedule` (`:core`).
+//!
+//! # Why a schedule and not one version
+//!
+//! The spec's `validate_light_client_update` verifies a sync aggregate under
+//! `compute_fork_version(compute_epoch_at_slot(max(signature_slot, 1) - 1))`
+//! — the fork active when the signature was produced, NOT the network's
+//! current fork. A store walking updates across a fork boundary therefore
+//! needs both versions: a single configured value verifies one side of the
+//! boundary and rejects every update on the other, which stalls sync at every
+//! consensus fork on every install (#295). Before this type both engines held
+//! one fixed version and were correct only because every checkpoint pin
+//! happened to sit after its network's newest fork.
+//!
+//! # Trust posture
+//!
+//! Consensus-critical configuration with the same standing as the genesis
+//! validators root: embedded, never fetched at runtime. The beacon API's
+//! `/eth/v1/config/fork_schedule` exposes the same data and is the reference
+//! for the pinned lists in `myotis-net`'s `ChainConfig` constructors.
+
+use crate::spec;
+
+/// Ordered fork schedule for one chain. Constructed once per network from
+/// compile-time constants; invalid geometry is a build error surfacing, so the
+/// constructor panics rather than returning a `Result` nobody would handle.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ForkSchedule {
+    /// Slots per epoch for THIS chain (32 on the mainnet preset, 16 on
+    /// gnosis). Needed to map a signature slot to the epoch the schedule is
+    /// keyed by. Bundled here — rather than passed alongside every lookup —
+    /// so a schedule can never be read with another chain's geometry.
+    slots_per_epoch: u64,
+    /// `(activation_epoch, fork_version)`, strictly ascending by epoch, first
+    /// entry at epoch 0 (the genesis fork).
+    forks: Vec<(u64, [u8; 4])>,
+}
+
+impl ForkSchedule {
+    /// Build a schedule. PANICS (in every build) on: zero `slots_per_epoch`, an
+    /// empty list, a first entry not at epoch 0, or epochs that are not
+    /// strictly ascending. Each of those would silently select a wrong signing
+    /// domain for some slot — the "accepted and silently ignored" failure
+    /// CLAUDE.md forbids for anything that can change the answer.
+    pub fn new(slots_per_epoch: u64, forks: &[(u64, [u8; 4])]) -> Self {
+        assert!(slots_per_epoch > 0, "fork schedule: slots_per_epoch must be non-zero");
+        assert!(!forks.is_empty(), "fork schedule: at least the genesis fork is required");
+        assert_eq!(forks[0].0, 0, "fork schedule: the first entry must activate at epoch 0");
+        for w in forks.windows(2) {
+            assert!(
+                w[0].0 < w[1].0,
+                "fork schedule: activation epochs must be strictly ascending ({} then {})",
+                w[0].0,
+                w[1].0
+            );
+        }
+        Self { slots_per_epoch, forks: forks.to_vec() }
+    }
+
+    /// One version for every slot — a schedule with no boundary. For tests and
+    /// for callers replaying a corpus recorded under a single version. The
+    /// slot geometry is immaterial without a boundary; the mainnet preset is
+    /// used so the value is at least a real one.
+    pub fn single(version: [u8; 4]) -> Self {
+        Self::new(spec::SLOTS_PER_EPOCH, &[(0, version)])
+    }
+
+    pub fn slots_per_epoch(&self) -> u64 {
+        self.slots_per_epoch
+    }
+
+    /// The pinned `(activation_epoch, fork_version)` list, ascending.
+    pub fn forks(&self) -> &[(u64, [u8; 4])] {
+        &self.forks
+    }
+
+    /// The newest scheduled fork's version — what the legacy single
+    /// `fork_version` field held. Feeds the fork DIGEST (discv5 filtering,
+    /// Status), never signature verification.
+    pub fn current(&self) -> [u8; 4] {
+        self.forks[self.forks.len() - 1].1
+    }
+
+    /// The fork before [`current`](Self::current), when the schedule has one.
+    pub fn prior(&self) -> Option<[u8; 4]> {
+        let n = self.forks.len();
+        (n >= 2).then(|| self.forks[n - 2].1)
+    }
+
+    /// `compute_fork_version(epoch)`: the version of the latest fork whose
+    /// activation epoch is `<= epoch`. Total — the genesis entry covers epoch 0.
+    pub fn version_at_epoch(&self, epoch: u64) -> [u8; 4] {
+        // Ascending list; the last entry with activation <= epoch wins.
+        let mut version = self.forks[0].1;
+        for (activation, v) in &self.forks {
+            if *activation <= epoch {
+                version = *v;
+            } else {
+                break;
+            }
+        }
+        version
+    }
+
+    /// The fork version a sync aggregate signed at `signature_slot` must be
+    /// verified under — spec `validate_light_client_update`:
+    /// `compute_fork_version(compute_epoch_at_slot(max(signature_slot, 1) - 1))`.
+    ///
+    /// The `- 1` is not a detail: the aggregate is over the block of the
+    /// PREVIOUS slot, so a signature at the first slot of a fork's activation
+    /// epoch still uses the old version, and only the next slot switches.
+    pub fn version_for_signature_slot(&self, signature_slot: u64) -> [u8; 4] {
+        let epoch =
+            spec::compute_epoch_at_slot_with(signature_slot.max(1) - 1, self.slots_per_epoch);
+        self.version_at_epoch(epoch)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const A: [u8; 4] = [0x05, 0, 0, 0];
+    const B: [u8; 4] = [0x06, 0, 0, 0];
+    const C: [u8; 4] = [0x07, 0, 0, 0];
+
+    fn three() -> ForkSchedule {
+        ForkSchedule::new(32, &[(0, A), (10, B), (20, C)])
+    }
+
+    #[test]
+    fn version_at_epoch_picks_latest_activated() {
+        let s = three();
+        assert_eq!(s.version_at_epoch(0), A);
+        assert_eq!(s.version_at_epoch(9), A);
+        assert_eq!(s.version_at_epoch(10), B);
+        assert_eq!(s.version_at_epoch(19), B);
+        assert_eq!(s.version_at_epoch(20), C);
+        assert_eq!(s.version_at_epoch(u64::MAX), C);
+    }
+
+    /// The spec's `max(signature_slot, 1) - 1`: the FIRST slot of the
+    /// activation epoch still signs under the old fork.
+    #[test]
+    fn signature_slot_boundary_is_off_by_one_per_spec() {
+        let s = three();
+        assert_eq!(s.version_for_signature_slot(0), A); // max(0,1)-1 = 0
+        assert_eq!(s.version_for_signature_slot(1), A);
+        assert_eq!(s.version_for_signature_slot(320), A); // slot 319 -> epoch 9
+        assert_eq!(s.version_for_signature_slot(321), B); // slot 320 -> epoch 10
+        assert_eq!(s.version_for_signature_slot(640), B); // slot 639 -> epoch 19
+        assert_eq!(s.version_for_signature_slot(641), C); // slot 640 -> epoch 20
+    }
+
+    /// Gnosis geometry: 16-slot epochs move the same epoch boundary to a
+    /// different slot — the schedule must carry its own slots_per_epoch.
+    #[test]
+    fn slots_per_epoch_is_part_of_the_schedule() {
+        let s = ForkSchedule::new(16, &[(0, A), (10, B)]);
+        assert_eq!(s.version_for_signature_slot(160), A); // slot 159 -> epoch 9
+        assert_eq!(s.version_for_signature_slot(161), B); // slot 160 -> epoch 10
+    }
+
+    #[test]
+    fn current_and_prior_are_the_tail() {
+        let s = three();
+        assert_eq!(s.current(), C);
+        assert_eq!(s.prior(), Some(B));
+        let one = ForkSchedule::single(A);
+        assert_eq!(one.current(), A);
+        assert_eq!(one.prior(), None);
+        assert_eq!(one.version_for_signature_slot(u64::MAX), A);
+    }
+
+    #[test]
+    #[should_panic(expected = "epoch 0")]
+    fn rejects_schedule_not_starting_at_genesis() {
+        ForkSchedule::new(32, &[(5, A)]);
+    }
+
+    #[test]
+    #[should_panic(expected = "strictly ascending")]
+    fn rejects_unsorted_schedule() {
+        ForkSchedule::new(32, &[(0, A), (20, B), (10, C)]);
+    }
+
+    #[test]
+    #[should_panic(expected = "strictly ascending")]
+    fn rejects_duplicate_epochs() {
+        ForkSchedule::new(32, &[(0, A), (10, B), (10, C)]);
+    }
+
+    #[test]
+    #[should_panic(expected = "genesis fork")]
+    fn rejects_empty_schedule() {
+        ForkSchedule::new(32, &[]);
+    }
+
+    #[test]
+    #[should_panic(expected = "slots_per_epoch")]
+    fn rejects_zero_slots_per_epoch() {
+        ForkSchedule::new(0, &[(0, A)]);
+    }
+}

--- a/rust/myotis-consensus/src/lib.rs
+++ b/rust/myotis-consensus/src/lib.rs
@@ -12,6 +12,7 @@
 //! This is a pure-Rust library crate — no JNI here; the JVM boundary lives in
 //! `myotis-engine`.
 
+pub mod fork;
 pub mod snapshot;
 pub mod spec;
 pub mod ssz;

--- a/rust/myotis-consensus/src/spec.rs
+++ b/rust/myotis-consensus/src/spec.rs
@@ -45,15 +45,6 @@ pub fn finalized_root_gindex(branch_depth: usize) -> u64 {
     checkpoint_gindex * 2 + 1
 }
 
-/// `compute_epoch_at_slot` for a chain whose epoch is `slots_per_epoch` slots
-/// long. PANICS on zero for the same reason
-/// [`compute_sync_committee_period_with`] does: the fork schedule is keyed by
-/// epoch, so a defaulted geometry would silently pick a wrong signing domain.
-pub fn compute_epoch_at_slot_with(slot: u64, slots_per_epoch: u64) -> u64 {
-    assert!(slots_per_epoch > 0, "slots_per_epoch must be non-zero");
-    slot / slots_per_epoch
-}
-
 /// Mainnet-preset period math. Prefer [`compute_sync_committee_period_with`]
 /// wherever the chain is known — see its note.
 pub fn compute_sync_committee_period(slot: u64) -> u64 {

--- a/rust/myotis-consensus/src/spec.rs
+++ b/rust/myotis-consensus/src/spec.rs
@@ -45,6 +45,15 @@ pub fn finalized_root_gindex(branch_depth: usize) -> u64 {
     checkpoint_gindex * 2 + 1
 }
 
+/// `compute_epoch_at_slot` for a chain whose epoch is `slots_per_epoch` slots
+/// long. PANICS on zero for the same reason
+/// [`compute_sync_committee_period_with`] does: the fork schedule is keyed by
+/// epoch, so a defaulted geometry would silently pick a wrong signing domain.
+pub fn compute_epoch_at_slot_with(slot: u64, slots_per_epoch: u64) -> u64 {
+    assert!(slots_per_epoch > 0, "slots_per_epoch must be non-zero");
+    slot / slots_per_epoch
+}
+
 /// Mainnet-preset period math. Prefer [`compute_sync_committee_period_with`]
 /// wherever the chain is known — see its note.
 pub fn compute_sync_committee_period(slot: u64) -> u64 {

--- a/rust/myotis-consensus/src/store.rs
+++ b/rust/myotis-consensus/src/store.rs
@@ -192,10 +192,6 @@ impl LightClientProcessor {
         Self { store, fork_schedule, genesis_validators_root }
     }
 
-    pub fn fork_schedule(&self) -> &ForkSchedule {
-        &self.fork_schedule
-    }
-
     /// `is_valid_light_client_header` (Capella+): the execution payload header is
     /// bound to the beacon body solely through this branch — the sync-committee
     /// signature does NOT cover it.

--- a/rust/myotis-consensus/src/store.rs
+++ b/rust/myotis-consensus/src/store.rs
@@ -3,6 +3,7 @@
 //! clock input (the slot estimate behind `force_rotate_if_past_period`) is a
 //! plain parameter, exactly as the conformance corpus records it.
 
+use crate::fork::ForkSchedule;
 use crate::spec;
 use crate::ssz::{self, Root};
 use crate::types::{
@@ -174,13 +175,25 @@ impl LightClientStore {
 /// re-verifying a duplicate reaches the same `true`).
 pub struct LightClientProcessor {
     pub store: LightClientStore,
-    fork_version: [u8; 4],
+    /// Per-slot signing-domain selector. Every update is verified under the
+    /// fork active at its `signature_slot` (spec `validate_light_client_update`),
+    /// so a store can walk updates across a fork boundary — a single fixed
+    /// version rejects everything signed on the other side of it (#295).
+    fork_schedule: ForkSchedule,
     genesis_validators_root: Root,
 }
 
 impl LightClientProcessor {
-    pub fn new(store: LightClientStore, fork_version: [u8; 4], genesis_validators_root: Root) -> Self {
-        Self { store, fork_version, genesis_validators_root }
+    pub fn new(
+        store: LightClientStore,
+        fork_schedule: ForkSchedule,
+        genesis_validators_root: Root,
+    ) -> Self {
+        Self { store, fork_schedule, genesis_validators_root }
+    }
+
+    pub fn fork_schedule(&self) -> &ForkSchedule {
+        &self.fork_schedule
     }
 
     /// `is_valid_light_client_header` (Capella+): the execution payload header is
@@ -220,17 +233,19 @@ impl LightClientProcessor {
             return false;
         }
 
+        let fork_version = self.fork_schedule.version_for_signature_slot(update.signature_slot);
         if !verify::verify_sync_aggregate(
             &update.sync_aggregate,
             committee,
             &update.attested_header.beacon,
-            &self.fork_version,
+            &fork_version,
             &self.genesis_validators_root,
         ) {
             tracing::debug!(store_period, sig_period,
                 signature_slot = update.signature_slot,
                 attested_slot = update.attested_header.beacon.slot,
                 participants = update.sync_aggregate.count_participants(),
+                fork_version = ?fork_version,
                 "update rejected: sync-aggregate BLS verification failed");
             return false;
         }
@@ -293,13 +308,19 @@ impl LightClientProcessor {
             return false;
         };
 
+        let fork_version = self.fork_schedule.version_for_signature_slot(update.signature_slot);
         if !verify::verify_sync_aggregate(
             &update.sync_aggregate,
             committee,
             &update.attested_header.beacon,
-            &self.fork_version,
+            &fork_version,
             &self.genesis_validators_root,
         ) {
+            tracing::debug!(
+                signature_slot = update.signature_slot,
+                attested_slot = update.attested_header.beacon.slot,
+                fork_version = ?fork_version,
+                "finality update rejected: sync-aggregate BLS verification failed");
             return false;
         }
 

--- a/rust/myotis-consensus/tests/fork_boundary.rs
+++ b/rust/myotis-consensus/tests/fork_boundary.rs
@@ -11,7 +11,7 @@ use myotis_consensus::ssz::{self, Root};
 use myotis_consensus::store::{LightClientProcessor, LightClientStore};
 use myotis_consensus::types::{
     BeaconBlockHeader, ExecutionPayloadHeader, LightClientFinalityUpdate, LightClientHeader,
-    SyncAggregate, SyncCommittee, SYNC_COMMITTEE_SIZE,
+    LightClientUpdate, SyncAggregate, SyncCommittee, SYNC_COMMITTEE_SIZE,
 };
 use myotis_consensus::verify;
 
@@ -65,28 +65,8 @@ fn branch(levels: &[Vec<Root>], mut idx: usize) -> Vec<Root> {
 }
 
 fn execution_header() -> ExecutionPayloadHeader {
-    ExecutionPayloadHeader {
-        parent_hash: [0; 32],
-        fee_recipient: [0; 20],
-        state_root: [0; 32],
-        receipts_root: [0; 32],
-        logs_bloom: vec![0; 256],
-        prev_randao: [0; 32],
-        block_number: 0,
-        gas_limit: 0,
-        gas_used: 0,
-        timestamp: 0,
-        extra_data: vec![],
-        base_fee_per_gas: [0; 32],
-        block_hash: [0; 32],
-        transactions_root: [0; 32],
-        withdrawals_root: [0; 32],
-        blob_gas_used: 0,
-        excess_blob_gas: 0,
-        deposit_requests_root: None,
-        withdrawal_requests_root: None,
-        consolidation_requests_root: None,
-    }
+    // Any consistent header will do; only the bloom needs its real width.
+    ExecutionPayloadHeader { logs_bloom: vec![0; 256], ..Default::default() }
 }
 
 /// A header whose execution payload is genuinely committed to its body root
@@ -125,22 +105,56 @@ fn finality_update(
     leaves[leaf] = finalized_header.beacon.hash_tree_root();
     let lv = levels(leaves);
     let attested_header = header(signature_slot, lv.last().unwrap()[0]);
-
-    let domain = verify::compute_domain(&spec::DOMAIN_SYNC_COMMITTEE, &fork_version, &GVR);
-    let signing_root =
-        verify::compute_signing_root(&attested_header.beacon.hash_tree_root(), &domain);
-    let sigs: Vec<_> = keys.iter().map(|k| k.sign(&signing_root, myotis_bls::DST, &[])).collect();
-    let refs: Vec<_> = sigs.iter().collect();
-    let agg = AggregateSignature::aggregate(&refs, false).unwrap().to_signature();
-
+    let sync_aggregate = sign(keys, &attested_header, fork_version);
     LightClientFinalityUpdate {
         attested_header,
         finalized_header,
         finality_branch: branch(&lv, leaf),
-        sync_aggregate: SyncAggregate {
-            sync_committee_bits: [0xff; 64],
-            sync_committee_signature: agg.compress(),
-        },
+        sync_aggregate,
+        signature_slot,
+    }
+}
+
+/// The whole committee signs `attested` under `fork_version`.
+fn sign(keys: &[SecretKey], attested: &LightClientHeader, fork_version: [u8; 4]) -> SyncAggregate {
+    let domain = verify::compute_domain(&spec::DOMAIN_SYNC_COMMITTEE, &fork_version, &GVR);
+    let signing_root = verify::compute_signing_root(&attested.beacon.hash_tree_root(), &domain);
+    let sigs: Vec<_> = keys.iter().map(|k| k.sign(&signing_root, myotis_bls::DST, &[])).collect();
+    let refs: Vec<_> = sigs.iter().collect();
+    let agg = AggregateSignature::aggregate(&refs, false).unwrap().to_signature();
+    SyncAggregate { sync_committee_bits: [0xff; 64], sync_committee_signature: agg.compress() }
+}
+
+/// A catch-up update whose finality branch (depth 6, gindex 105) and
+/// next-sync-committee branch (depth 5, gindex 55) both verify against ONE
+/// attested state root: a 32-leaf state tree with the Checkpoint container at
+/// field 20 (epoch root || finalized root) and the committee at field 23.
+fn catch_up_update(
+    keys: &[SecretKey],
+    finalized_slot: u64,
+    signature_slot: u64,
+    fork_version: [u8; 4],
+) -> LightClientUpdate {
+    let finalized_header = header(finalized_slot, [0; 32]);
+    let next = committee(keys);
+    let zero = [0u8; 32];
+    let mut leaves = vec![zero; 32];
+    leaves[20] = ssz::sha256_pair(&zero, &finalized_header.beacon.hash_tree_root()); // Checkpoint{epoch, root}
+    leaves[23] = next.hash_tree_root();
+    let lv = levels(leaves);
+    let mut finality_branch = vec![zero]; // the epoch leaf, sibling of root inside Checkpoint
+    finality_branch.extend(branch(&lv, 20));
+    assert_eq!(finality_branch.len(), 6);
+    let next_sync_committee_branch = branch(&lv, 23);
+    let attested_header = header(signature_slot, lv.last().unwrap()[0]);
+    let sync_aggregate = sign(keys, &attested_header, fork_version);
+    LightClientUpdate {
+        attested_header,
+        next_sync_committee: next,
+        next_sync_committee_branch,
+        finalized_header,
+        finality_branch,
+        sync_aggregate,
         signature_slot,
     }
 }
@@ -163,6 +177,25 @@ fn verifies_one_update_on_each_side_of_a_fork_boundary() {
     assert_eq!(p.store.finalized_slot(), 200);
     // signature_slot 321: epoch(320) = 10 -> NEW.
     assert!(p.process_finality_update(&finality_update(&keys, 300, boundary_slot + 1, NEW)));
+    assert_eq!(p.store.finalized_slot(), 300);
+}
+
+/// The catch-up path (`LightClientUpdate`) — how a pre-fork checkpoint walks
+/// across the boundary. Java twin: `catchUpUpdatesVerifyAcrossForkBoundary`.
+#[test]
+fn catch_up_updates_verify_across_a_fork_boundary() {
+    let keys = keys();
+    let schedule = ForkSchedule::new(32, &[(0, OLD), (BOUNDARY_EPOCH, NEW)]);
+    let boundary_slot = BOUNDARY_EPOCH * 32;
+    let mut p = processor(&keys, schedule);
+
+    assert!(p.process_update(&catch_up_update(&keys, 200, boundary_slot, OLD)));
+    assert!(p.store.next_sync_committee().is_some(), "first update proves the next committee");
+    assert!(p.process_update(&catch_up_update(&keys, 300, boundary_slot + 1, NEW)));
+    assert_eq!(p.store.finalized_slot(), 300);
+    // Cross-signed: rejected on both sides.
+    assert!(!p.process_update(&catch_up_update(&keys, 400, boundary_slot, NEW)));
+    assert!(!p.process_update(&catch_up_update(&keys, 400, boundary_slot + 1, OLD)));
     assert_eq!(p.store.finalized_slot(), 300);
 }
 

--- a/rust/myotis-consensus/tests/fork_boundary.rs
+++ b/rust/myotis-consensus/tests/fork_boundary.rs
@@ -1,0 +1,195 @@
+//! #295: the processor must verify each update under the fork version active
+//! at ITS `signature_slot`, not one fixed version. Synthetic committee, real
+//! BLS: one finality update signed on each side of a schedule boundary, plus
+//! the cross-signed variants that must be rejected. Java twin:
+//! `LightClientProcessorTest.verifiesAcrossForkBoundary`.
+
+use blst::min_pk::{AggregatePublicKey, AggregateSignature, SecretKey};
+use myotis_consensus::fork::ForkSchedule;
+use myotis_consensus::spec;
+use myotis_consensus::ssz::{self, Root};
+use myotis_consensus::store::{LightClientProcessor, LightClientStore};
+use myotis_consensus::types::{
+    BeaconBlockHeader, ExecutionPayloadHeader, LightClientFinalityUpdate, LightClientHeader,
+    SyncAggregate, SyncCommittee, SYNC_COMMITTEE_SIZE,
+};
+use myotis_consensus::verify;
+
+const OLD: [u8; 4] = [0x05, 0, 0, 0];
+const NEW: [u8; 4] = [0x06, 0, 0, 0];
+const GVR: Root = [0u8; 32];
+/// Boundary epoch 10 = slot 320 on the mainnet preset.
+const BOUNDARY_EPOCH: u64 = 10;
+
+fn keys() -> Vec<SecretKey> {
+    (0..SYNC_COMMITTEE_SIZE)
+        .map(|i| {
+            let mut ikm = [0u8; 32];
+            ikm[..8].copy_from_slice(&(8000 + i as u64).to_le_bytes());
+            SecretKey::key_gen(&ikm, &[]).unwrap()
+        })
+        .collect()
+}
+
+fn committee(keys: &[SecretKey]) -> SyncCommittee {
+    let pks: Vec<_> = keys.iter().map(|k| k.sk_to_pk()).collect();
+    let mut flat = Vec::with_capacity(SYNC_COMMITTEE_SIZE * 48);
+    for pk in &pks {
+        flat.extend_from_slice(&pk.compress());
+    }
+    let refs: Vec<_> = pks.iter().collect();
+    let agg = AggregatePublicKey::aggregate(&refs, false).unwrap().to_public_key();
+    SyncCommittee { pubkeys: flat, aggregate_pubkey: agg.compress() }
+}
+
+/// Full binary tree over `leaves` (a power of two): level 0 = leaves.
+fn levels(leaves: Vec<Root>) -> Vec<Vec<Root>> {
+    let mut out = vec![leaves];
+    while out.last().unwrap().len() > 1 {
+        let prev = out.last().unwrap();
+        let next: Vec<Root> =
+            prev.chunks(2).map(|p| ssz::sha256_pair(&p[0], &p[1])).collect();
+        out.push(next);
+    }
+    out
+}
+
+/// Sibling path for leaf `idx`, bottom-up — the order `verify_merkle_branch` walks.
+fn branch(levels: &[Vec<Root>], mut idx: usize) -> Vec<Root> {
+    let mut b = Vec::new();
+    for level in &levels[..levels.len() - 1] {
+        b.push(level[idx ^ 1]);
+        idx /= 2;
+    }
+    b
+}
+
+fn execution_header() -> ExecutionPayloadHeader {
+    ExecutionPayloadHeader {
+        parent_hash: [0; 32],
+        fee_recipient: [0; 20],
+        state_root: [0; 32],
+        receipts_root: [0; 32],
+        logs_bloom: vec![0; 256],
+        prev_randao: [0; 32],
+        block_number: 0,
+        gas_limit: 0,
+        gas_used: 0,
+        timestamp: 0,
+        extra_data: vec![],
+        base_fee_per_gas: [0; 32],
+        block_hash: [0; 32],
+        transactions_root: [0; 32],
+        withdrawals_root: [0; 32],
+        blob_gas_used: 0,
+        excess_blob_gas: 0,
+        deposit_requests_root: None,
+        withdrawal_requests_root: None,
+        consolidation_requests_root: None,
+    }
+}
+
+/// A header whose execution payload is genuinely committed to its body root
+/// (gindex 25 = leaf 9 of a depth-4 body tree).
+fn header(slot: u64, state_root: Root) -> LightClientHeader {
+    let execution = execution_header();
+    let mut leaves = vec![[0u8; 32]; 1 << spec::EXECUTION_PAYLOAD_DEPTH];
+    let leaf = (spec::EXECUTION_PAYLOAD_GINDEX as usize) - (1 << spec::EXECUTION_PAYLOAD_DEPTH);
+    leaves[leaf] = execution.hash_tree_root();
+    let lv = levels(leaves);
+    LightClientHeader {
+        beacon: BeaconBlockHeader {
+            slot,
+            proposer_index: 0,
+            parent_root: [0; 32],
+            state_root,
+            body_root: lv.last().unwrap()[0],
+        },
+        execution,
+        execution_branch: branch(&lv, leaf),
+    }
+}
+
+/// A finality update with a valid depth-7 (Electra) finality branch, signed by
+/// the whole committee under `fork_version`.
+fn finality_update(
+    keys: &[SecretKey],
+    finalized_slot: u64,
+    signature_slot: u64,
+    fork_version: [u8; 4],
+) -> LightClientFinalityUpdate {
+    let finalized_header = header(finalized_slot, [0; 32]);
+    const DEPTH: usize = 7;
+    let leaf = (spec::finalized_root_gindex(DEPTH) as usize) - (1 << DEPTH);
+    let mut leaves = vec![[0u8; 32]; 1 << DEPTH];
+    leaves[leaf] = finalized_header.beacon.hash_tree_root();
+    let lv = levels(leaves);
+    let attested_header = header(signature_slot, lv.last().unwrap()[0]);
+
+    let domain = verify::compute_domain(&spec::DOMAIN_SYNC_COMMITTEE, &fork_version, &GVR);
+    let signing_root =
+        verify::compute_signing_root(&attested_header.beacon.hash_tree_root(), &domain);
+    let sigs: Vec<_> = keys.iter().map(|k| k.sign(&signing_root, myotis_bls::DST, &[])).collect();
+    let refs: Vec<_> = sigs.iter().collect();
+    let agg = AggregateSignature::aggregate(&refs, false).unwrap().to_signature();
+
+    LightClientFinalityUpdate {
+        attested_header,
+        finalized_header,
+        finality_branch: branch(&lv, leaf),
+        sync_aggregate: SyncAggregate {
+            sync_committee_bits: [0xff; 64],
+            sync_committee_signature: agg.compress(),
+        },
+        signature_slot,
+    }
+}
+
+fn processor(keys: &[SecretKey], schedule: ForkSchedule) -> LightClientProcessor {
+    let mut store = LightClientStore::new_mainnet_preset();
+    store.initialize(header(100, [0; 32]), committee(keys));
+    LightClientProcessor::new(store, schedule, GVR)
+}
+
+#[test]
+fn verifies_one_update_on_each_side_of_a_fork_boundary() {
+    let keys = keys();
+    let schedule = ForkSchedule::new(32, &[(0, OLD), (BOUNDARY_EPOCH, NEW)]);
+    let boundary_slot = BOUNDARY_EPOCH * 32; // 320
+    let mut p = processor(&keys, schedule);
+
+    // signature_slot 320: spec verifies epoch(319) = 9 -> still OLD.
+    assert!(p.process_finality_update(&finality_update(&keys, 200, boundary_slot, OLD)));
+    assert_eq!(p.store.finalized_slot(), 200);
+    // signature_slot 321: epoch(320) = 10 -> NEW.
+    assert!(p.process_finality_update(&finality_update(&keys, 300, boundary_slot + 1, NEW)));
+    assert_eq!(p.store.finalized_slot(), 300);
+}
+
+#[test]
+fn rejects_an_update_signed_under_the_other_sides_version() {
+    let keys = keys();
+    let schedule = ForkSchedule::new(32, &[(0, OLD), (BOUNDARY_EPOCH, NEW)]);
+    let boundary_slot = BOUNDARY_EPOCH * 32;
+    let mut p = processor(&keys, schedule);
+
+    // NEW at the last OLD slot, OLD at the first NEW slot: both must fail.
+    assert!(!p.process_finality_update(&finality_update(&keys, 200, boundary_slot, NEW)));
+    assert!(!p.process_finality_update(&finality_update(&keys, 200, boundary_slot + 1, OLD)));
+    assert_eq!(p.store.finalized_slot(), 100, "nothing applied");
+}
+
+/// The pre-#295 behaviour, pinned as a regression: a single-version schedule
+/// cannot cross the boundary in either direction.
+#[test]
+fn single_version_schedule_stalls_at_the_boundary() {
+    let keys = keys();
+    let boundary_slot = BOUNDARY_EPOCH * 32;
+
+    let mut old_only = processor(&keys, ForkSchedule::single(OLD));
+    assert!(old_only.process_finality_update(&finality_update(&keys, 200, boundary_slot, OLD)));
+    assert!(!old_only.process_finality_update(&finality_update(&keys, 300, boundary_slot + 1, NEW)));
+
+    let mut new_only = processor(&keys, ForkSchedule::single(NEW));
+    assert!(!new_only.process_finality_update(&finality_update(&keys, 200, boundary_slot, OLD)));
+}

--- a/rust/myotis-consensus/tests/lc_conformance.rs
+++ b/rust/myotis-consensus/tests/lc_conformance.rs
@@ -15,6 +15,7 @@ use std::path::PathBuf;
 
 use myotis_consensus::spec;
 use myotis_consensus::ssz;
+use myotis_consensus::fork::ForkSchedule;
 use myotis_consensus::store::{LightClientProcessor, LightClientStore};
 use myotis_consensus::types::{
     LightClientBootstrap, LightClientFinalityUpdate, LightClientUpdate,
@@ -99,7 +100,9 @@ fn replay_reproduces_recorded_verdicts() {
 
     let mut store = LightClientStore::new_mainnet_preset();
     store.initialize(bootstrap.header.clone(), bootstrap.current_sync_committee.clone());
-    let mut processor = LightClientProcessor::new(store, fork_version, gvr);
+    // The corpus was recorded under one version — a schedule with no boundary.
+    let mut processor =
+        LightClientProcessor::new(store, ForkSchedule::single(fork_version), gvr);
 
     // ---- catch-up updates, filename order (3-digit corpus convention) ----
     let mut update_files: Vec<_> = fs::read_dir(&dir)

--- a/rust/myotis-consensus/tests/resume_equivalence.rs
+++ b/rust/myotis-consensus/tests/resume_equivalence.rs
@@ -16,6 +16,7 @@ use std::fs;
 use std::path::PathBuf;
 
 use myotis_consensus::snapshot;
+use myotis_consensus::fork::ForkSchedule;
 use myotis_consensus::store::{LightClientProcessor, LightClientStore};
 use myotis_consensus::types::{LightClientBootstrap, LightClientFinalityUpdate, LightClientUpdate};
 
@@ -125,7 +126,7 @@ fn replay_from(
 fn organic_processor(c: &Corpus) -> LightClientProcessor {
     let mut store = LightClientStore::new_mainnet_preset();
     store.initialize(c.bootstrap.header.clone(), c.bootstrap.current_sync_committee.clone());
-    LightClientProcessor::new(store, c.fork_version, c.gvr)
+    LightClientProcessor::new(store, ForkSchedule::single(c.fork_version), c.gvr)
 }
 
 #[test]
@@ -169,7 +170,7 @@ fn resume_at_every_split_point_matches_uninterrupted_replay() {
             .unwrap_or_else(|| panic!("split {k}: snapshot must deserialize"));
         let mut resumed_store = LightClientStore::new_mainnet_preset();
         resumed_store.restore(restored);
-        let mut resumed = LightClientProcessor::new(resumed_store, c.fork_version, c.gvr);
+        let mut resumed = LightClientProcessor::new(resumed_store, ForkSchedule::single(c.fork_version), c.gvr);
 
         // Continue from the split; verdicts and final state must match the
         // uninterrupted replay exactly.

--- a/rust/myotis-net/examples/lc_crawl.rs
+++ b/rust/myotis-net/examples/lc_crawl.rs
@@ -92,7 +92,7 @@ async fn main() {
     let (disc_task, table_size) = discovery::spawn(
         DiscoveryConfig {
             bootstrap_enrs: config.bootstrap_enrs.clone(),
-            accepted_fork_digests: config.accepted_fork_digests(),
+            accepted_fork_digests: config.accepted_fork_digests().into(),
             listen_port: 0,
             // The census is a hunt by definition: crawl at the boosted cadence.
             hunt_boost: Arc::new(std::sync::atomic::AtomicBool::new(true)),

--- a/rust/myotis-net/examples/period_census.rs
+++ b/rust/myotis-net/examples/period_census.rs
@@ -111,7 +111,7 @@ async fn main() {
     let (disc_task, table_size) = discovery::spawn(
         DiscoveryConfig {
             bootstrap_enrs: config.bootstrap_enrs.clone(),
-            accepted_fork_digests: config.accepted_fork_digests(),
+            accepted_fork_digests: config.accepted_fork_digests().into(),
             listen_port: 0,
             // The census is a hunt by definition: crawl at the boosted cadence.
             hunt_boost: Arc::new(std::sync::atomic::AtomicBool::new(true)),

--- a/rust/myotis-net/src/discovery.rs
+++ b/rust/myotis-net/src/discovery.rs
@@ -64,6 +64,27 @@ impl From<Vec<[u8; 4]>> for AcceptedForkDigests {
     }
 }
 
+/// Forget every once-ever decision when the accepted list changes. The
+/// `seen` set records node IDs, including ones rejected as off-fork; after a
+/// fork activation those same nodes republish with the new digest and would
+/// otherwise never be re-checked, so the dynamic list alone could not rotate
+/// the filter for a long-running process (PR #430 review). Returns whether a
+/// rotation happened; `last` is updated in place.
+fn rotate_seen_if_changed(
+    seen: &mut HashSet<NodeId>,
+    last: &mut Vec<[u8; 4]>,
+    now: &[[u8; 4]],
+) -> bool {
+    if last.as_slice() == now {
+        return false;
+    }
+    tracing::info!(from = ?last, to = ?now, forgotten = seen.len(),
+        "accepted fork digests changed — re-checking every known node");
+    seen.clear();
+    *last = now.to_vec();
+    true
+}
+
 #[derive(Clone)]
 pub struct DiscoveryConfig {
     pub bootstrap_enrs: Vec<String>,
@@ -223,6 +244,10 @@ async fn run_lookups(
     let mut pinned_seq: std::collections::HashMap<NodeId, u64> = std::collections::HashMap::new();
     let mut empty_rounds = 0u32;
     let mut round: usize = 0;
+    // The accepted list this round filters with; re-read per round and, when
+    // it rotates (a pinned-ahead fork activating), `seen` is cleared so nodes
+    // once rejected as off-fork are re-checked (`rotate_seen_if_changed`).
+    let mut last_digests: Vec<[u8; 4]> = accepted_digests.current();
     // A lookup RETURNS only the k nodes closest to its target, and its walk
     // only CONTACTS the nodes on the path there. Everything else a NODES
     // response mentions — on the shared eth2 DHT, that is where nearly all
@@ -262,6 +287,8 @@ async fn run_lookups(
         };
         round = round.wrapping_add(1);
         let mut emitted = 0usize;
+        let digests = accepted_digests.current();
+        rotate_seen_if_changed(&mut seen.lock().expect("seen lock"), &mut last_digests, &digests);
         match discv5.find_node(target).await {
             Ok(enrs) => {
                 for enr in enrs {
@@ -278,7 +305,7 @@ async fn run_lookups(
                     } else if !seen.lock().expect("seen lock").insert(enr.node_id()) {
                         continue;
                     }
-                    if let Some(peer) = filter_candidate(&enr, &accepted_digests.current()) {
+                    if let Some(peer) = filter_candidate(&enr, &digests) {
                         emitted += 1;
                         if tx.send(peer).await.is_err() {
                             return; // receiver gone — sync loop shut down
@@ -389,6 +416,7 @@ async fn consume_discovered(
     seen: Arc<std::sync::Mutex<HashSet<NodeId>>>,
     tx: mpsc::Sender<DiscoveredPeer>,
 ) {
+    let mut last_digests: Vec<[u8; 4]> = accepted_digests.current();
     while let Some(event) = events.recv().await {
         let Event::Discovered(enr) = event else { continue };
         // A full channel drops the node unmarked (see below), so deciding
@@ -405,8 +433,11 @@ async fn consume_discovered(
         // duplicate into the pool channel between the other's check and
         // insert. try_send never blocks, so holding a std mutex across it is
         // fine; nothing awaits while it is held.
+        let digests = accepted_digests.current();
         let mut guard = seen.lock().expect("seen lock");
-        match classify_heard(&enr, &guard, &pinned_targets, &accepted_digests.current()) {
+        // Either task may notice the rotation first; clearing twice is harmless.
+        rotate_seen_if_changed(&mut guard, &mut last_digests, &digests);
+        match classify_heard(&enr, &guard, &pinned_targets, &digests) {
             Heard::Skip => {}
             Heard::NeverCandidate => {
                 guard.insert(id);
@@ -523,6 +554,22 @@ mod tests {
     /// A live Gnosis bootnode ENR from NetworkConfig — known to carry an eth2
     /// field (digest 0x824be431), ip4+tcp, and a secp256k1 key.
     const GNOSIS_BOOT_ENR: &str = "enr:-Ly4QIAhiTHk6JdVhCdiLwT83wAolUFo5J4nI5HrF7-zJO_QEw3cmEGxC1jvqNNUN64Vu-xxqDKSM528vKRNCehZAfEBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpCCS-QxAgAAZP__________gmlkgnY0gmlwhEFtZ5SJc2VjcDI1NmsxoQJwgL5C-30E8RJmW8gCb7sfwWvvfre7wGcCeV4X1G2wJYhzeW5jbmV0cwCDdGNwgiMog3VkcIIjKA";
+
+    /// A fork activating while the process is up: nodes rejected as off-fork
+    /// (recorded in `seen`) must be re-checked once the accepted list rotates.
+    #[test]
+    fn rotating_accepted_digests_forgets_seen_nodes() {
+        let mut seen: HashSet<NodeId> = HashSet::new();
+        seen.insert(NodeId::random());
+        seen.insert(NodeId::random());
+        let mut last = vec![[1, 1, 1, 1]];
+        assert!(!rotate_seen_if_changed(&mut seen, &mut last, &[[1, 1, 1, 1]]));
+        assert_eq!(seen.len(), 2, "same list: nothing forgotten");
+        assert!(rotate_seen_if_changed(&mut seen, &mut last, &[[2, 2, 2, 2], [1, 1, 1, 1]]));
+        assert!(seen.is_empty(), "rotated list: every once-ever decision forgotten");
+        assert_eq!(last, vec![[2, 2, 2, 2], [1, 1, 1, 1]]);
+        assert!(!rotate_seen_if_changed(&mut seen, &mut last, &[[2, 2, 2, 2], [1, 1, 1, 1]]));
+    }
 
     #[test]
     fn a_heard_node_is_emitted_once_and_pins_are_left_to_the_lookup_path() {

--- a/rust/myotis-net/src/discovery.rs
+++ b/rust/myotis-net/src/discovery.rs
@@ -33,12 +33,43 @@ pub struct DiscoveredPeer {
     pub addr: Multiaddr,
 }
 
+/// The accepted `eth2` fork digests: current first, then the prior fork's
+/// when the chain configures one (`NetworkConfig.acceptedForkDigests`).
+///
+/// `Dynamic` is re-read per candidate ENR (two SHA-256s — noise next to the
+/// UDP round trip that produced the ENR), so a fork pinned ahead of its
+/// activation rotates the filter at its epoch without a restart; a list
+/// captured once at spawn would reject every upgraded peer from that epoch
+/// on and starve CL discovery silently (#295 review). `Fixed` is for tools
+/// and tests that mean one list for the run.
+#[derive(Clone)]
+pub enum AcceptedForkDigests {
+    Fixed(Vec<[u8; 4]>),
+    Dynamic(Arc<dyn Fn() -> Vec<[u8; 4]> + Send + Sync>),
+}
+
+impl AcceptedForkDigests {
+    /// The list to filter the NEXT candidate with.
+    pub fn current(&self) -> Vec<[u8; 4]> {
+        match self {
+            AcceptedForkDigests::Fixed(v) => v.clone(),
+            AcceptedForkDigests::Dynamic(f) => f(),
+        }
+    }
+}
+
+impl From<Vec<[u8; 4]>> for AcceptedForkDigests {
+    fn from(v: Vec<[u8; 4]>) -> Self {
+        AcceptedForkDigests::Fixed(v)
+    }
+}
+
 #[derive(Clone)]
 pub struct DiscoveryConfig {
     pub bootstrap_enrs: Vec<String>,
-    /// Accepted `eth2` fork digests: current first, then the prior fork's when
-    /// the chain configures one (`NetworkConfig.acceptedForkDigests`).
-    pub accepted_fork_digests: Vec<[u8; 4]>,
+    /// See [`AcceptedForkDigests`] — the sync loop passes a `Dynamic` reader
+    /// over `ChainConfig::accepted_fork_digests`.
+    pub accepted_fork_digests: AcceptedForkDigests,
     /// UDP port to bind. 0 lets the OS pick.
     pub listen_port: u16,
     /// libp2p ids of the chain's PINNED peers (the static-peer list). Lookups
@@ -173,7 +204,7 @@ const PINNED_ROUND_EVERY: usize = 4;
 async fn run_lookups(
     discv5: Discv5,
     events: mpsc::Receiver<Event>,
-    accepted_digests: Vec<[u8; 4]>,
+    accepted_digests: AcceptedForkDigests,
     bootnodes: Vec<Enr>,
     pinned_targets: Vec<NodeId>,
     table_size: Arc<AtomicUsize>,
@@ -247,7 +278,7 @@ async fn run_lookups(
                     } else if !seen.lock().expect("seen lock").insert(enr.node_id()) {
                         continue;
                     }
-                    if let Some(peer) = filter_candidate(&enr, &accepted_digests) {
+                    if let Some(peer) = filter_candidate(&enr, &accepted_digests.current()) {
                         emitted += 1;
                         if tx.send(peer).await.is_err() {
                             return; // receiver gone — sync loop shut down
@@ -353,7 +384,7 @@ fn reseed_due(empty_rounds: &mut u32, live_nodes: usize, bootnode_count: usize) 
 /// goes away.
 async fn consume_discovered(
     mut events: mpsc::Receiver<Event>,
-    accepted_digests: Vec<[u8; 4]>,
+    accepted_digests: AcceptedForkDigests,
     pinned_targets: Vec<NodeId>,
     seen: Arc<std::sync::Mutex<HashSet<NodeId>>>,
     tx: mpsc::Sender<DiscoveredPeer>,
@@ -375,7 +406,7 @@ async fn consume_discovered(
         // insert. try_send never blocks, so holding a std mutex across it is
         // fine; nothing awaits while it is held.
         let mut guard = seen.lock().expect("seen lock");
-        match classify_heard(&enr, &guard, &pinned_targets, &accepted_digests) {
+        match classify_heard(&enr, &guard, &pinned_targets, &accepted_digests.current()) {
             Heard::Skip => {}
             Heard::NeverCandidate => {
                 guard.insert(id);

--- a/rust/myotis-net/src/sync.rs
+++ b/rust/myotis-net/src/sync.rs
@@ -401,6 +401,13 @@ impl ChainConfig {
     /// the prior fork's when configured (`NetworkConfig.acceptedForkDigests`).
     pub fn accepted_fork_digests(&self) -> Vec<[u8; 4]> {
         let mut out = vec![self.current_fork_digest()];
+        // KNOWN LIMIT (Java twin `NetworkConfig.acceptedForkDigests` carries the
+        // same note): the prior digest is the plain pre-EIP-7892 form, which is
+        // what Electra-era peers advertise (gnosis today: 0x7D5AAB40). Once the
+        // prior fork is Fulu or later, stale peers advertise the BPO-FOLDED
+        // digest of their era, so this fallback matches nobody (fail-safe, never
+        // a wrong acceptance). Folding it needs the blob-params entry active in
+        // the prior fork's era — the blob-schedule follow-up deferred in PR #430.
         if let Some(prior) = self.prior_fork_version() {
             out.push(fork_digest(prior, self.genesis_validators_root));
         }
@@ -826,7 +833,13 @@ impl SyncHandle {
 
         let discovery_cfg = DiscoveryConfig {
             bootstrap_enrs: config.bootstrap_enrs.clone(),
-            accepted_fork_digests: config.accepted_fork_digests(),
+            // Re-read per candidate ENR so the filter follows the fork schedule
+            // at the wall clock (a fork pinned ahead rotates it at its epoch
+            // without a restart) — see `AcceptedForkDigests`.
+            accepted_fork_digests: {
+                let chain = config.clone();
+                discovery::AcceptedForkDigests::Dynamic(Arc::new(move || chain.accepted_fork_digests()))
+            },
             listen_port: config.discv5_port,
             // Shared with run_sync's hunt trigger; discovery re-spawns reuse
             // the same flag, so a boost survives a discv5 restart.

--- a/rust/myotis-net/src/sync.rs
+++ b/rust/myotis-net/src/sync.rs
@@ -19,6 +19,7 @@ use futures::stream::{FuturesUnordered, StreamExt};
 use libp2p::{Multiaddr, PeerId};
 use tokio::sync::{mpsc, watch};
 
+use myotis_consensus::fork::ForkSchedule;
 use myotis_consensus::spec;
 use myotis_consensus::store::{LightClientProcessor, LightClientStore};
 use myotis_consensus::types::{LightClientBootstrap, LightClientFinalityUpdate, LightClientUpdate};
@@ -64,11 +65,22 @@ pub struct ChainConfig {
     /// The EL chain id (EIP-155) — threaded into the EVM reads (eth_call /
     /// estimateGas / ENS) so nothing downstream hardcodes a network.
     pub chain_id: u64,
-    pub fork_version: [u8; 4],
-    /// Prior fork version, accepted as a discv5 fork-digest fallback (the Java
-    /// `NetworkConfig.acceptedForkDigests`). None for mainnet (on Fulu; stale
-    /// digests wouldn't help us sync).
-    pub prior_fork_version: Option<[u8; 4]>,
+    /// The chain's full fork schedule — `(activation epoch, fork version)`,
+    /// ascending, genesis first. Every sync-committee signature is verified
+    /// under the version active at its `signature_slot`, so the store can walk
+    /// updates across a fork boundary (#295); the newest entry also feeds the
+    /// fork digest. Append-only, consensus-critical, same trust standing as
+    /// `genesis_validators_root`: pinned from the network's published config
+    /// (`/eth/v1/config/fork_schedule`), never fetched at runtime. Keep in
+    /// lockstep with the Java `NetworkConfig.forkSchedule` — both sides pin
+    /// the same lists in their config tests.
+    pub fork_schedule: ForkSchedule,
+    /// Whether the PRIOR fork's digest is accepted as a discv5 fork-digest
+    /// fallback next to the current one (the Java
+    /// `NetworkConfig.acceptedForkDigests`). Off for mainnet and sepolia (stale
+    /// digests wouldn't help us sync); on for gnosis. A policy knob, not a
+    /// fork version — the version itself comes from the schedule.
+    pub accept_prior_fork_digest: bool,
     pub genesis_validators_root: [u8; 32],
     /// Beacon chain genesis time (seconds since epoch) for wall-clock slot estimates.
     pub genesis_time: u64,
@@ -182,9 +194,18 @@ impl ChainConfig {
         Self {
             name: "mainnet",
             chain_id: 1,
-            // Fulu, activated at slot 13164544 (2025-12-03).
-            fork_version: [0x06, 0x00, 0x00, 0x00],
-            prior_fork_version: None,
+            // consensus-specs configs/mainnet.yaml *_FORK_EPOCH / *_FORK_VERSION.
+            // Fulu activated at epoch 411392 = slot 13164544 (2025-12-03).
+            fork_schedule: ForkSchedule::new(32, &[
+                (0, [0x00, 0x00, 0x00, 0x00]),       // phase0 (genesis)
+                (74_240, [0x01, 0x00, 0x00, 0x00]),  // altair
+                (144_896, [0x02, 0x00, 0x00, 0x00]), // bellatrix
+                (194_048, [0x03, 0x00, 0x00, 0x00]), // capella
+                (269_568, [0x04, 0x00, 0x00, 0x00]), // deneb
+                (364_032, [0x05, 0x00, 0x00, 0x00]), // electra
+                (411_392, [0x06, 0x00, 0x00, 0x00]), // fulu
+            ]),
+            accept_prior_fork_digest: false,
             genesis_validators_root: hex32(
                 "4b363db94e286120d76eb905340fdd4e54bfe9f06bf33ff6cf5ad27f511bfe95",
             ),
@@ -223,11 +244,20 @@ impl ChainConfig {
         Self {
             name: "sepolia",
             chain_id: 11_155_111,
-            // Fulu on sepolia (0x90000075) — activated at epoch 272640 (2025-10-14).
-            fork_version: [0x90, 0x00, 0x00, 0x75],
+            // eth-clients/sepolia metadata/config.yaml *_FORK_EPOCH / *_FORK_VERSION.
+            // Fulu (0x90000075) activated at epoch 272640 (2025-10-14).
+            fork_schedule: ForkSchedule::new(32, &[
+                (0, [0x90, 0x00, 0x00, 0x69]),       // phase0 (genesis)
+                (50, [0x90, 0x00, 0x00, 0x70]),      // altair
+                (100, [0x90, 0x00, 0x00, 0x71]),     // bellatrix
+                (56_832, [0x90, 0x00, 0x00, 0x72]),  // capella
+                (132_608, [0x90, 0x00, 0x00, 0x73]), // deneb
+                (222_464, [0x90, 0x00, 0x00, 0x74]), // electra
+                (272_640, [0x90, 0x00, 0x00, 0x75]), // fulu
+            ]),
             // No prior-fork fallback (same rationale as mainnet: stale digests
             // wouldn't help us sync to the current head anyway).
-            prior_fork_version: None,
+            accept_prior_fork_digest: false,
             genesis_validators_root: hex32(
                 "d8ea171f3c94aea21ebc42a1ed61052acf3f9209c00e4efbaaddac09ed9b8078",
             ),
@@ -273,10 +303,20 @@ impl ChainConfig {
         Self {
             name: "gnosis",
             chain_id: 100,
-            // Fulu on Gnosis (0x06000064), active since 2026-04-14.
-            fork_version: [0x06, 0x00, 0x00, 0x64],
-            // Electra — accepted as a discv5 fork-digest fallback.
-            prior_fork_version: Some([0x05, 0x00, 0x00, 0x64]),
+            // gnosischain/configs mainnet/config.yaml *_FORK_EPOCH / *_FORK_VERSION
+            // (16-slot epochs). Fulu (0x06000064) active since epoch 1714688
+            // (2026-04-14); Electra's epoch is also the blob_params_epoch below.
+            fork_schedule: ForkSchedule::new(16, &[
+                (0, [0x00, 0x00, 0x00, 0x64]),         // phase0 (genesis)
+                (512, [0x01, 0x00, 0x00, 0x64]),       // altair
+                (385_536, [0x02, 0x00, 0x00, 0x64]),   // bellatrix
+                (648_704, [0x03, 0x00, 0x00, 0x64]),   // capella
+                (889_856, [0x04, 0x00, 0x00, 0x64]),   // deneb
+                (1_337_856, [0x05, 0x00, 0x00, 0x64]), // electra
+                (1_714_688, [0x06, 0x00, 0x00, 0x64]), // fulu
+            ]),
+            // Electra's digest is accepted as a discv5 fork-digest fallback.
+            accept_prior_fork_digest: true,
             genesis_validators_root: hex32(
                 "f5dcb5564e829aab27264b9becd5dfaa017085611224cb3036f573368dbb9d47",
             ),
@@ -344,15 +384,32 @@ impl ChainConfig {
     /// the prior fork's when configured (`NetworkConfig.acceptedForkDigests`).
     pub fn accepted_fork_digests(&self) -> Vec<[u8; 4]> {
         let mut out = vec![self.current_fork_digest()];
-        if let Some(prior) = self.prior_fork_version {
+        if let Some(prior) = self.prior_fork_version() {
             out.push(fork_digest(prior, self.genesis_validators_root));
         }
         out
     }
 
+    /// The newest scheduled fork's version — the digest input (discv5 filter,
+    /// Status). NOT a signing-domain input: verification reads the schedule
+    /// per update (`ForkSchedule::version_for_signature_slot`).
+    pub fn current_fork_version(&self) -> [u8; 4] {
+        self.fork_schedule.current()
+    }
+
+    /// The prior fork's version when its digest is accepted
+    /// (`accept_prior_fork_digest`), else `None`.
+    pub fn prior_fork_version(&self) -> Option<[u8; 4]> {
+        if self.accept_prior_fork_digest {
+            self.fork_schedule.prior()
+        } else {
+            None
+        }
+    }
+
     pub fn current_fork_digest(&self) -> [u8; 4] {
         fork_digest_bpo(
-            self.fork_version,
+            self.current_fork_version(),
             self.genesis_validators_root,
             self.blob_params_epoch,
             self.blob_params_max_blobs,
@@ -1410,7 +1467,7 @@ async fn run_sync(
 
     let mut processor = LightClientProcessor::new(
         LightClientStore::new(config.slots_per_period()),
-        config.fork_version,
+        config.fork_schedule.clone(),
         config.genesis_validators_root,
     );
 
@@ -3196,7 +3253,27 @@ mod tests {
     #[test]
     fn mainnet_config_matches_networkconfig_java() {
         let c = ChainConfig::mainnet();
-        assert_eq!(c.fork_version, [6, 0, 0, 0]);
+        assert_eq!(c.current_fork_version(), [6, 0, 0, 0]);
+        assert_eq!(c.prior_fork_version(), None); // fallback digest off
+        // The FULL schedule (consensus-specs configs/mainnet.yaml) — the Java
+        // twin (NetworkConfigForkScheduleTest) pins the same list.
+        assert_eq!(c.fork_schedule.slots_per_epoch(), 32);
+        assert_eq!(
+            c.fork_schedule.forks(),
+            &[
+                (0, [0x00, 0x00, 0x00, 0x00]),
+                (74_240, [0x01, 0x00, 0x00, 0x00]),
+                (144_896, [0x02, 0x00, 0x00, 0x00]),
+                (194_048, [0x03, 0x00, 0x00, 0x00]),
+                (269_568, [0x04, 0x00, 0x00, 0x00]),
+                (364_032, [0x05, 0x00, 0x00, 0x00]),
+                (411_392, [0x06, 0x00, 0x00, 0x00]),
+            ]
+        );
+        // Fulu's first slot (13164544) still verifies under Electra; the next
+        // slot switches — the spec's max(signature_slot,1)-1.
+        assert_eq!(c.fork_schedule.version_for_signature_slot(13_164_544), [5, 0, 0, 0]);
+        assert_eq!(c.fork_schedule.version_for_signature_slot(13_164_545), [6, 0, 0, 0]);
         // @checkpoint:mainnet:test:begin — managed by `./gradlew refreshCheckpoint`
         assert_eq!(c.checkpoint_slot, 15_185_856);
         assert_eq!(
@@ -3264,7 +3341,22 @@ mod tests {
     fn sepolia_config_matches_networkconfig_java() {
         let c = ChainConfig::sepolia();
         assert_eq!(c.chain_id, 11_155_111);
-        assert_eq!(c.fork_version, [0x90, 0x00, 0x00, 0x75]); // Fulu on sepolia
+        assert_eq!(c.current_fork_version(), [0x90, 0x00, 0x00, 0x75]); // Fulu on sepolia
+        assert_eq!(c.prior_fork_version(), None); // fallback digest off
+        // eth-clients/sepolia metadata/config.yaml — Java twin pins the same.
+        assert_eq!(c.fork_schedule.slots_per_epoch(), 32);
+        assert_eq!(
+            c.fork_schedule.forks(),
+            &[
+                (0, [0x90, 0x00, 0x00, 0x69]),
+                (50, [0x90, 0x00, 0x00, 0x70]),
+                (100, [0x90, 0x00, 0x00, 0x71]),
+                (56_832, [0x90, 0x00, 0x00, 0x72]),
+                (132_608, [0x90, 0x00, 0x00, 0x73]),
+                (222_464, [0x90, 0x00, 0x00, 0x74]),
+                (272_640, [0x90, 0x00, 0x00, 0x75]),
+            ]
+        );
         // @checkpoint:sepolia:test:begin — managed by `./gradlew refreshCheckpoint`
         assert_eq!(c.checkpoint_slot, 11_110_080);
         assert_eq!(
@@ -3333,8 +3425,26 @@ mod tests {
     fn gnosis_config_matches_networkconfig_java() {
         let c = ChainConfig::gnosis();
         assert_eq!(c.chain_id, 100);
-        assert_eq!(c.fork_version, [0x06, 0x00, 0x00, 0x64]); // Fulu on Gnosis
-        assert_eq!(c.prior_fork_version, Some([0x05, 0x00, 0x00, 0x64])); // Electra
+        assert_eq!(c.current_fork_version(), [0x06, 0x00, 0x00, 0x64]); // Fulu on Gnosis
+        assert_eq!(c.prior_fork_version(), Some([0x05, 0x00, 0x00, 0x64])); // Electra
+        // gnosischain/configs mainnet/config.yaml — Java twin pins the same.
+        // 16-slot epochs: the schedule carries its own geometry.
+        assert_eq!(c.fork_schedule.slots_per_epoch(), 16);
+        assert_eq!(
+            c.fork_schedule.forks(),
+            &[
+                (0, [0x00, 0x00, 0x00, 0x64]),
+                (512, [0x01, 0x00, 0x00, 0x64]),
+                (385_536, [0x02, 0x00, 0x00, 0x64]),
+                (648_704, [0x03, 0x00, 0x00, 0x64]),
+                (889_856, [0x04, 0x00, 0x00, 0x64]),
+                (1_337_856, [0x05, 0x00, 0x00, 0x64]),
+                (1_714_688, [0x06, 0x00, 0x00, 0x64]),
+            ]
+        );
+        // Fulu epoch 1714688 x 16 = slot 27435008: first slot still Electra.
+        assert_eq!(c.fork_schedule.version_for_signature_slot(27_435_008), [0x05, 0, 0, 0x64]);
+        assert_eq!(c.fork_schedule.version_for_signature_slot(27_435_009), [0x06, 0, 0, 0x64]);
         // @checkpoint:gnosis:test:begin — managed by `./gradlew refreshCheckpoint`
         assert_eq!(c.checkpoint_slot, 30_012_384);
         assert_eq!(
@@ -3961,7 +4071,7 @@ mod tests {
         let expected_period = store.current_period();
         let mut processor = LightClientProcessor::new(
             store,
-            crate::sync::ChainConfig::mainnet().fork_version,
+            crate::sync::ChainConfig::mainnet().fork_schedule,
             crate::sync::ChainConfig::mainnet().genesis_validators_root,
         );
 

--- a/rust/myotis-net/src/sync.rs
+++ b/rust/myotis-net/src/sync.rs
@@ -1608,6 +1608,9 @@ async fn run_sync(
             status.period = anchor_period;
             status.ws_bound_periods = bound;
             let _ = status_tx.send(status);
+            // Parked across a fork activation, the served Status digest must
+            // still follow the schedule (see refresh_local_status).
+            refresh_local_status(&config, &processor, &local_status);
             tokio::time::sleep(Duration::from_secs(1)).await;
         }
         if parked {
@@ -1754,6 +1757,10 @@ async fn run_sync(
                 // bound raised) — without it the watch keeps the park on display
                 // until the first SUCCESSFUL bootstrap, however long that takes —
                 // and it keeps peer/discovery counts moving during long stalls.
+                // The served Status digest follows the schedule here too — a
+                // peer-starved process can otherwise never bootstrap from
+                // post-fork peers (refresh_local_status's pre-bootstrap path).
+                refresh_local_status(&config, &processor, &local_status);
                 publish_status(&config, &client, &processor, &pool, &status_tx, &anchor, hunting).await;
                 tokio::time::sleep(Duration::from_secs(5)).await;
                 continue;
@@ -3076,6 +3083,19 @@ fn refresh_local_status(
     let store = &processor.store;
     let (Some(finalized), Some(optimistic)) = (store.finalized_header(), store.optimistic_header())
     else {
+        // Not bootstrapped yet: the checkpoint fields stay, but the digest must
+        // still follow the fork schedule at the wall clock. A process parked or
+        // peer-starved across a fork activation otherwise keeps offering the
+        // old digest on every new connection and can never bootstrap from
+        // post-fork peers (PR #430 review).
+        let mut s = local_status.get();
+        let digest = config.current_fork_digest();
+        if s.fork_digest != digest {
+            tracing::info!(from = %hex_str(&s.fork_digest), to = %hex_str(&digest),
+                "pre-bootstrap Status fork digest follows the schedule");
+            s.fork_digest = digest;
+            local_status.set(s);
+        }
         return;
     };
     let finalized_root = finalized.beacon.hash_tree_root();
@@ -3373,6 +3393,37 @@ mod tests {
         .is_some()));
         assert_eq!(c.bootstrap_enrs.len(), 18);
         assert_eq!(c.chain_id, 1);
+    }
+
+    /// Pre-bootstrap, `refresh_local_status` still moves the Status digest to
+    /// the schedule's wall-clock value (everything else untouched).
+    /// Copilot on PR #430: a parked process kept the start-time digest forever.
+    #[test]
+    fn pre_bootstrap_status_digest_follows_the_schedule() {
+        let config = ChainConfig::mainnet();
+        let stale = StatusMessage {
+            fork_digest: [0xDE, 0xAD, 0xBE, 0xEF],
+            finalized_root: config.checkpoint_root,
+            finalized_epoch: 7,
+            head_root: config.checkpoint_root,
+            head_slot: 8,
+            earliest_available_slot: 0,
+        };
+        let local = LocalStatus::new(stale.clone());
+        let processor = LightClientProcessor::new(
+            LightClientStore::new(config.slots_per_period()),
+            config.fork_schedule.clone(),
+            config.genesis_validators_root,
+        );
+        assert!(!processor.store.is_initialized());
+        refresh_local_status(&config, &processor, &local);
+        let got = local.get();
+        assert_eq!(got.fork_digest, config.current_fork_digest());
+        assert_eq!(
+            (got.finalized_root, got.finalized_epoch, got.head_root, got.head_slot),
+            (stale.finalized_root, stale.finalized_epoch, stale.head_root, stale.head_slot),
+            "only the digest moves before bootstrap"
+        );
     }
 
     /// The digest-side "current" version is the schedule entry active at the

--- a/rust/myotis-net/src/sync.rs
+++ b/rust/myotis-net/src/sync.rs
@@ -68,8 +68,9 @@ pub struct ChainConfig {
     /// The chain's full fork schedule — `(activation epoch, fork version)`,
     /// ascending, genesis first. Every sync-committee signature is verified
     /// under the version active at its `signature_slot`, so the store can walk
-    /// updates across a fork boundary (#295); the newest entry also feeds the
-    /// fork digest. Append-only, consensus-critical, same trust standing as
+    /// updates across a fork boundary (#295); the entry active at the
+    /// wall-clock epoch feeds the fork digest, so the NEXT fork may be pinned
+    /// ahead of activation. Append-only, consensus-critical, same trust standing as
     /// `genesis_validators_root`: pinned from the network's published config
     /// (`/eth/v1/config/fork_schedule`), never fetched at runtime. Keep in
     /// lockstep with the Java `NetworkConfig.forkSchedule` — both sides pin
@@ -131,6 +132,16 @@ impl ChainConfig {
         // committee for every update, silently. Both factors are compile-time
         // constants in every shipped config, so a panic here is a build error
         // surfacing, never a runtime condition.
+        // The fork schedule carries its own copy of slots_per_epoch (it maps
+        // signature slots to epochs); the Java NetworkConfig refuses a
+        // mismatch in its constructor and this is the Rust twin of that check,
+        // on the accessor every period division goes through.
+        assert_eq!(
+            self.fork_schedule.slots_per_epoch(),
+            self.slots_per_epoch,
+            "{}: fork_schedule geometry must match the chain's slots_per_epoch",
+            self.name
+        );
         self.slots_per_epoch
             .checked_mul(self.epochs_per_sync_committee_period)
             .filter(|p| *p > 0)
@@ -191,12 +202,14 @@ impl ChainConfig {
     }
 
     pub fn mainnet() -> Self {
+        // One binding for both the period math and the schedule's slot->epoch map.
+        let slots_per_epoch: u64 = 32;
         Self {
             name: "mainnet",
             chain_id: 1,
             // consensus-specs configs/mainnet.yaml *_FORK_EPOCH / *_FORK_VERSION.
             // Fulu activated at epoch 411392 = slot 13164544 (2025-12-03).
-            fork_schedule: ForkSchedule::new(32, &[
+            fork_schedule: ForkSchedule::new(slots_per_epoch, &[
                 (0, [0x00, 0x00, 0x00, 0x00]),       // phase0 (genesis)
                 (74_240, [0x01, 0x00, 0x00, 0x00]),  // altair
                 (144_896, [0x02, 0x00, 0x00, 0x00]), // bellatrix
@@ -211,7 +224,7 @@ impl ChainConfig {
             ),
             genesis_time: 1_606_824_023, // 2020-12-01 12:00:23 UTC
             seconds_per_slot: 12,
-            slots_per_epoch: 32,
+            slots_per_epoch,
             epochs_per_sync_committee_period: 256,
             // BPO2 (Fusaka) blob schedule entry: epoch 419072, MAX_BLOBS=21.
             blob_params_epoch: 419_072,
@@ -241,12 +254,14 @@ impl ChainConfig {
     /// `NetworkConfig.SEPOLIA` (networking/src/main/java/.../NetworkConfig.java),
     /// whose sepolia CL wiring landed in PR #192.
     pub fn sepolia() -> Self {
+        // One binding for both the period math and the schedule's slot->epoch map.
+        let slots_per_epoch: u64 = 32;
         Self {
             name: "sepolia",
             chain_id: 11_155_111,
             // eth-clients/sepolia metadata/config.yaml *_FORK_EPOCH / *_FORK_VERSION.
             // Fulu (0x90000075) activated at epoch 272640 (2025-10-14).
-            fork_schedule: ForkSchedule::new(32, &[
+            fork_schedule: ForkSchedule::new(slots_per_epoch, &[
                 (0, [0x90, 0x00, 0x00, 0x69]),       // phase0 (genesis)
                 (50, [0x90, 0x00, 0x00, 0x70]),      // altair
                 (100, [0x90, 0x00, 0x00, 0x71]),     // bellatrix
@@ -263,7 +278,7 @@ impl ChainConfig {
             ),
             genesis_time: 1_655_733_600, // 2022-06-20 14:00:00 UTC
             seconds_per_slot: 12, // mainnet preset
-            slots_per_epoch: 32,
+            slots_per_epoch,
             epochs_per_sync_committee_period: 256,
             // EIP-7892 BLOB_SCHEDULE — latest active entry on sepolia: BPO2 at
             // epoch 275712, MAX_BLOBS_PER_BLOCK=21 (2025-10-28).
@@ -300,13 +315,15 @@ impl ChainConfig {
     /// (still 8192 slots per sync-committee period: 512 epochs × 16), and a
     /// prior-fork digest fallback (Electra) accepted alongside the Fulu digest.
     pub fn gnosis() -> Self {
+        // One binding for both the period math and the schedule's slot->epoch map.
+        let slots_per_epoch: u64 = 16;
         Self {
             name: "gnosis",
             chain_id: 100,
             // gnosischain/configs mainnet/config.yaml *_FORK_EPOCH / *_FORK_VERSION
             // (16-slot epochs). Fulu (0x06000064) active since epoch 1714688
             // (2026-04-14); Electra's epoch is also the blob_params_epoch below.
-            fork_schedule: ForkSchedule::new(16, &[
+            fork_schedule: ForkSchedule::new(slots_per_epoch, &[
                 (0, [0x00, 0x00, 0x00, 0x64]),         // phase0 (genesis)
                 (512, [0x01, 0x00, 0x00, 0x64]),       // altair
                 (385_536, [0x02, 0x00, 0x00, 0x64]),   // bellatrix
@@ -322,7 +339,7 @@ impl ChainConfig {
             ),
             genesis_time: 1_638_993_340, // 2021-12-08 19:55:40 UTC
             seconds_per_slot: 5,
-            slots_per_epoch: 16,
+            slots_per_epoch,
             epochs_per_sync_committee_period: 512,
             // EIP-7892: Gnosis has no explicit BLOB_SCHEDULE — clients fold the
             // Electra-baseline params (ELECTRA_FORK_EPOCH=1337856, MAX_BLOBS=2)
@@ -390,21 +407,29 @@ impl ChainConfig {
         out
     }
 
-    /// The newest scheduled fork's version — the digest input (discv5 filter,
-    /// Status). NOT a signing-domain input: verification reads the schedule
-    /// per update (`ForkSchedule::version_for_signature_slot`).
+    /// The fork version active NOW — the digest input (discv5 filter, Status).
+    /// Read from the schedule at the wall-clock epoch, so the next fork can be
+    /// pinned ahead of its activation without flipping the digest early (a
+    /// not-yet-active digest matches no peer). NOT a signing-domain input:
+    /// verification reads the schedule per update
+    /// (`ForkSchedule::version_for_signature_slot`).
     pub fn current_fork_version(&self) -> [u8; 4] {
-        self.fork_schedule.current()
+        self.fork_schedule.version_at_epoch(self.wall_clock_epoch())
     }
 
-    /// The prior fork's version when its digest is accepted
-    /// (`accept_prior_fork_digest`), else `None`.
+    /// The version of the fork before the active one when its digest is
+    /// accepted (`accept_prior_fork_digest`), else `None`.
     pub fn prior_fork_version(&self) -> Option<[u8; 4]> {
         if self.accept_prior_fork_digest {
-            self.fork_schedule.prior()
+            self.fork_schedule.prior_version_at_epoch(self.wall_clock_epoch())
         } else {
             None
         }
+    }
+
+    /// Wall-clock beacon epoch (Java twin: `NetworkConfig.wallClockEpoch`).
+    pub fn wall_clock_epoch(&self) -> u64 {
+        self.current_slot_estimate() / self.slots_per_epoch.max(1)
     }
 
     pub fn current_fork_digest(&self) -> [u8; 4] {
@@ -3257,7 +3282,7 @@ mod tests {
         assert_eq!(c.prior_fork_version(), None); // fallback digest off
         // The FULL schedule (consensus-specs configs/mainnet.yaml) — the Java
         // twin (NetworkConfigForkScheduleTest) pins the same list.
-        assert_eq!(c.fork_schedule.slots_per_epoch(), 32);
+        assert_eq!(c.fork_schedule.slots_per_epoch(), c.slots_per_epoch);
         assert_eq!(
             c.fork_schedule.forks(),
             &[
@@ -3337,6 +3362,43 @@ mod tests {
         assert_eq!(c.chain_id, 1);
     }
 
+    /// The digest-side "current" version is the schedule entry active at the
+    /// WALL CLOCK, so the next fork can be pinned before it activates without
+    /// flipping the digest early. Pinned with a far-future entry appended to
+    /// each real schedule: every digest and version must be what it is today.
+    /// Java twin: NetworkConfigForkScheduleTest.aFutureForkPinnedAheadDoesNotChangeTodaysDigest.
+    #[test]
+    fn a_future_fork_pinned_ahead_does_not_change_todays_digest() {
+        for c in [ChainConfig::mainnet(), ChainConfig::sepolia(), ChainConfig::gnosis()] {
+            assert_eq!(c.current_fork_version(), c.fork_schedule.newest(),
+                "{}: every pinned fork is active today", c.name);
+            let mut forks = c.fork_schedule.forks().to_vec();
+            forks.push((u64::MAX / 64, [0x7F, 0, 0, 0])); // never activates in this test's lifetime
+            let ahead = ChainConfig {
+                fork_schedule: ForkSchedule::new(c.fork_schedule.slots_per_epoch(), &forks),
+                ..c.clone()
+            };
+            assert_eq!(ahead.current_fork_version(), c.current_fork_version(), "{}", c.name);
+            assert_eq!(ahead.current_fork_digest(), c.current_fork_digest(), "{}", c.name);
+            assert_eq!(ahead.accepted_fork_digests(), c.accepted_fork_digests(), "{}", c.name);
+            // ...while signatures from that far future would already verify under it.
+            assert_eq!(ahead.fork_schedule.version_for_signature_slot(u64::MAX), [0x7F, 0, 0, 0]);
+            // The geometry twin-check fires on the shared accessor.
+            let _ = ahead.slots_per_period();
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "geometry must match")]
+    fn mismatched_schedule_geometry_is_refused() {
+        let c = ChainConfig::gnosis();
+        let wrong = ChainConfig {
+            fork_schedule: ForkSchedule::new(32, c.fork_schedule.forks()),
+            ..c
+        };
+        let _ = wrong.slots_per_period();
+    }
+
     #[test]
     fn sepolia_config_matches_networkconfig_java() {
         let c = ChainConfig::sepolia();
@@ -3344,7 +3406,7 @@ mod tests {
         assert_eq!(c.current_fork_version(), [0x90, 0x00, 0x00, 0x75]); // Fulu on sepolia
         assert_eq!(c.prior_fork_version(), None); // fallback digest off
         // eth-clients/sepolia metadata/config.yaml — Java twin pins the same.
-        assert_eq!(c.fork_schedule.slots_per_epoch(), 32);
+        assert_eq!(c.fork_schedule.slots_per_epoch(), c.slots_per_epoch);
         assert_eq!(
             c.fork_schedule.forks(),
             &[
@@ -3429,7 +3491,7 @@ mod tests {
         assert_eq!(c.prior_fork_version(), Some([0x05, 0x00, 0x00, 0x64])); // Electra
         // gnosischain/configs mainnet/config.yaml — Java twin pins the same.
         // 16-slot epochs: the schedule carries its own geometry.
-        assert_eq!(c.fork_schedule.slots_per_epoch(), 16);
+        assert_eq!((c.fork_schedule.slots_per_epoch(), c.slots_per_epoch), (16, 16));
         assert_eq!(
             c.fork_schedule.forks(),
             &[


### PR DESCRIPTION
Fixes #295.

## Problem

Both engines' light-client processors verified every sync-committee signature under **one fixed fork version** for the lifetime of the store. The spec (`validate_light_client_update`) requires the version active at `compute_epoch_at_slot(max(signature_slot, 1) - 1)`. A store walking updates across a fork boundary needs both versions, so a single configured value stalls sync at the next consensus fork on every install: with the old version shipped, nothing signed after the fork verifies; with the new one, nothing signed before it does, so a cold start from a pre-fork pin can never catch up.

## Fix

- **`ForkSchedule`** — the per-network, ascending `(activation epoch, fork version)` list, bundled with the chain's `slotsPerEpoch` so it can never be read with another chain's geometry. Java: `:core` (`com.jaeckel.ethp2p.core.consensus.ForkSchedule`, needed by both `:networking` and `:consensus`). Rust: `myotis_consensus::fork::ForkSchedule`. Both refuse malformed schedules (empty, not starting at epoch 0, non-ascending, zero geometry) at construction rather than defaulting; `NetworkConfig`'s constructor and `ChainConfig::slots_per_period()` refuse a schedule whose geometry differs from the chain's.
- **Processors** (`LightClientProcessor` on both sides) take a schedule and derive the domain per update via `versionForSignatureSlot(update.signatureSlot)`.
- **Config**: `NetworkConfig.currentForkVersion` / `priorForkVersion` → `forkSchedule` + `acceptPriorForkDigest`; `ChainConfig.fork_version` / `prior_fork_version` → `fork_schedule` + `accept_prior_fork_digest`. The old accessors are now **derived at the wall-clock epoch** (the active entry; the one before it when the fallback digest is accepted), so the NEXT fork can be pinned ahead of its activation without flipping the Status/discv5 digest early — without that, the schedule could still only be appended after activation and installs in the field would still stall at the boundary (review finding). The digest fallback stayed a boolean policy knob so discovery behaviour is unchanged: mainnet/sepolia accept one digest, gnosis two — all pinned values unchanged.
- **Schedules** for mainnet, sepolia and gnosis, verified against consensus-specs `configs/mainnet.yaml`, eth-clients/sepolia `metadata/config.yaml` and gnosischain/configs `mainnet/config.yaml`.

## Tests

- Cross-engine pins: `NetworkConfigForkScheduleTest` (Java) and the three `*_config_matches_networkconfig_java` tests (Rust) pin the same three lists, plus the boundary slots (Fulu's first slot still verifies under Electra on mainnet and gnosis), plus "a far-future fork appended to each real schedule changes no digest today" on both sides, plus the geometry refusal.
- Synthetic fork boundary with real BLS on both engines, for **both** the finality path and the catch-up (`LightClientUpdate`, next-committee-proving) path: `LightClientProcessorTest.{verifiesAcrossForkBoundary, catchUpUpdatesVerifyAcrossForkBoundary, rejectsUpdateSignedUnderTheOtherSidesFork, singleVersionScheduleStallsAtTheBoundary}` and `rust/myotis-consensus/tests/fork_boundary.rs` (blst added as a dev-dependency; already in the lock via myotis-bls).
- Unit tests for the schedule itself on both sides (`ForkScheduleTest`, `fork.rs`), including the spec's off-by-one at the boundary and the u64-in-a-long edge.
- Existing conformance/resume corpora replay unchanged via `ForkSchedule.single(...)`.

## Review

Internal no-context review ran before this PR (8 angles); everything with a concrete failure scenario was fixed: the clock-derived digest-side version, the Rust geometry twin-check, catch-up-path boundary coverage, `Fork` value equality (version held as `int`), u64 slots ≥ 2^63, Java boundary tests memoized and signed at the 2/3 minimum (~11 s instead of ~30 s).

Deferred as owner decisions (not changed here): deriving the prior-digest policy from the schedule instead of the boolean (changes discovery behaviour on mainnet/sepolia); a single golden fixture read by both engines' pin tests (the two lists are hand-maintained twins today, like the checkpoints); sharing the type with `roost`'s REST-derived schedule; adding "append the next scheduled fork on both engines" to the release checklist in CLAUDE.md.

Pre-existing, out of scope: `rust/tor-poc` (outside the workspace) does not compile on `main` (`EthConfig` gained `genesis_header_rlp`), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
