### PR TITLE
sync: pipeline the LC catch-up across peers; hunt for batch-capable servers when throughput-bound

### DIFF
--- a/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
+++ b/consensus/src/main/java/com/jaeckel/ethp2p/consensus/BeaconLightClient.java
@@ -1738,7 +1738,13 @@ public class BeaconLightClient implements AutoCloseable {
      *  would add up to ~77 s of dead time per 8-batch call), and the fire stamp
      *  lives on an instance field so the NEXT call's batch 0 can't re-ask
      *  inside the window either (Gnosis's 5 s poll cycle would otherwise do
-     *  exactly that at every batch-cap call boundary). */
+     *  exactly that at every batch-cap call boundary).
+     *  DIVERGENCE: the Rust engine no longer paces the whole walk. Its
+     *  catch-up pipelines across peers — a per-peer quota mark of the same
+     *  length after each single-period serve, distinct look-ahead periods per
+     *  quota-limited server, batch asks kept streaming — so with more than one
+     *  serving peer it catches up faster than this engine. The apply/credit
+     *  rules (#342, #410) stay mirrored; only the request schedule differs. */
     private static final long CATCHUP_QUOTA_PACE_MS = 11_000;
     /** nanoTime (monotonic — an NTP step must not skew the pace, same rule as
      *  the uptime stamps) of the last catch-up batch request fire — the quota

--- a/rust/myotis-net/examples/period_census.rs
+++ b/rust/myotis-net/examples/period_census.rs
@@ -132,10 +132,7 @@ async fn main() {
 
     let deadline = Instant::now() + Duration::from_secs(crawl_secs);
     // updates_by_range request body: SSZ (start_period u64 LE, count u64 LE).
-    let mut ssz_request = Vec::with_capacity(16);
-    ssz_request.extend_from_slice(&period.to_le_bytes());
-    ssz_request.extend_from_slice(&1u64.to_le_bytes());
-    let finality_wire: Vec<u8> = codec::encode_request(&ssz_request);
+    let finality_wire: Vec<u8> = codec::encode_updates_by_range_request(period, 1);
 
     let mut results: Vec<(String, String, Verdict, f64)> = Vec::new();
     let spawn_probe = |peer_id: libp2p::PeerId,

--- a/rust/myotis-net/examples/probe_updates.rs
+++ b/rust/myotis-net/examples/probe_updates.rs
@@ -41,10 +41,7 @@ async fn main() {
     });
     let client = reqresp::start_host(Arc::clone(&local)).expect("host");
 
-    let mut ssz_request = Vec::with_capacity(16);
-    ssz_request.extend_from_slice(&from_period.to_le_bytes());
-    ssz_request.extend_from_slice(&span.to_le_bytes());
-    let wire = codec::encode_request(&ssz_request);
+    let wire = codec::encode_updates_by_range_request(from_period, span);
 
     for peer_str in &config.static_peers {
         // Split /p2p/<id> off the multiaddr (same as sync's parse_static_peer).

--- a/rust/myotis-net/src/codec.rs
+++ b/rust/myotis-net/src/codec.rs
@@ -138,6 +138,17 @@ pub fn encode_request(ssz_payload: &[u8]) -> Vec<u8> {
     out
 }
 
+/// The `light_client_updates_by_range` request body — `(start_period,
+/// count)` as two little-endian u64s, framed by [`encode_request`]. The one
+/// place the wire shape lives: the sync pipeline, the examples and the tests
+/// all build asks through it.
+pub fn encode_updates_by_range_request(start_period: u64, count: u64) -> Vec<u8> {
+    let mut ssz = Vec::with_capacity(16);
+    ssz.extend_from_slice(&start_period.to_le_bytes());
+    ssz.extend_from_slice(&count.to_le_bytes());
+    encode_request(&ssz)
+}
+
 /// varint(0) = single byte 0x00, no snappy data follows.
 pub fn encode_empty_request() -> Vec<u8> {
     vec![0x00]

--- a/rust/myotis-net/src/sync.rs
+++ b/rust/myotis-net/src/sync.rs
@@ -679,7 +679,8 @@ pub struct SyncStatus {
     pub discv5_table_size: usize,
     /// Period this run's catch-up started from; -1 until bootstrap/resume.
     pub sync_start_period: i64,
-    /// LC hunt engaged (starved of light-client servers — see hunt_due).
+    /// LC hunt engaged: starved of light-client servers, or catching up
+    /// throughput-bound on a few quota-limited ones — see hunt_due.
     pub hunting: bool,
     /// The weak-subjectivity bound (periods) currently enforced — host override
     /// if set, else the network default. While `state == StaleAnchor`, `period`
@@ -851,9 +852,9 @@ struct PeerPool {
     /// verify-reject rotation steers toward. Nimbus-class servers stay on the
     /// big span (one answered five periods in a single batch).
     single_period_peers: HashSet<PeerId>,
-    /// Peers whose ONE response applied two or more periods (verified) in a
-    /// single catch-up round — Nimbus/Lodestar/roost-class servers with no
-    /// per-request quota. They lead the proven tier in `candidates` so a
+    /// Peers whose ONE multi-count response applied two or more periods
+    /// (verified) — Nimbus/Lodestar/roost-class servers with no per-request
+    /// quota. They lead the proven tier in `candidates` so a
     /// month-long walk rides the batch server instead of the Lighthouse peer
     /// that happens to have served most recently: the proven tier used to
     /// rank by recency alone, and a count=1 chunk lands first almost every
@@ -1070,6 +1071,8 @@ impl PeerPool {
         self.known.remove(id);
         self.no_lc_updates.remove(id);
         self.proven.remove(id);
+        self.batch_servers.remove(id);
+        self.single_period_peers.remove(id);
         self.cooldown_until.remove(id);
         self.fail_counts.remove(id);
     }
@@ -1096,6 +1099,19 @@ impl PeerPool {
     /// count — they cannot be asked).
     fn has_batch_server(&self) -> bool {
         self.peers.iter().any(|p| self.batch_servers.contains(&p.id))
+    }
+
+    /// Any pool peer that could be asked right now: not excluded by `pred`
+    /// (the caller's busy set) and outside its cooldown window. The cheap
+    /// pre-check before a top-up pays for the swarm meta round-trip.
+    fn has_free_peer(&self, pred: impl Fn(&PeerId) -> bool) -> bool {
+        self.peers.iter().any(|p| pred(&p.id) && self.cooled_down(&p.id))
+    }
+
+    /// The shared-cache key of a peer — the same `addr/p2p/id` shape
+    /// `cache_key` derives from the pool, for a `Peer` already in hand.
+    fn key_for(&self, peer: &Peer) -> String {
+        format!("{}/p2p/{}", peer.addr, peer.id)
     }
 
     /// When the soonest serve-quota / rotation cooldown among pool peers
@@ -1597,14 +1613,7 @@ async fn run_sync(
     // cycle burst-probes the unproven pool tail; confirmations persist into
     // the CL peer cache so the next start dials them first.
     let sync_started = Instant::now();
-    let mut hunt_probed: HashMap<PeerId, Instant> = HashMap::new();
-    let mut hunt_confirmed: HashSet<PeerId> = HashSet::new();
-    let mut hunting = false;
-    // Raised by catch_up when the walk is throughput-bound on a few
-    // quota-limited servers with a long span ahead (see
-    // update_throughput_hunt); keeps hunt_due from disengaging the hunt that
-    // catch_up raised for it.
-    let mut throughput_bound = false;
+    let mut hunt = HuntState::new(Arc::clone(&discovery_cfg.hunt_boost));
     // Store-progress tracking for the starved-catch-up trigger: any advance
     // of (period, finalized slot) resets the stall clock.
     let mut last_progress = Instant::now();
@@ -1622,26 +1631,25 @@ async fn run_sync(
             last_progress = Instant::now();
         }
         let hunt_now = hunt_due(
-            hunting,
+            hunt.hunting,
             processor.store.is_initialized(),
             sync_started.elapsed(),
             last_progress.elapsed(),
-            throughput_bound,
+            hunt.throughput_bound,
             config.current_slot_estimate(),
             processor.store.current_period(),
             processor.store.finalized_slot(),
             config.slots_per_epoch,
             config.slots_per_period(),
         );
-        if hunt_now != hunting {
-            hunting = hunt_now;
-            discovery_cfg.hunt_boost.store(hunting, Ordering::Relaxed);
-            if hunting {
+        if hunt_now != hunt.hunting {
+            hunt.set_hunting(hunt_now);
+            if hunt.hunting {
                 tracing::info!(pool = pool.len(),
                     "LC hunt engaged — starved of light-client servers \
                      (boosted discovery + unproven-tail probing)");
             } else {
-                tracing::info!(confirmed = hunt_confirmed.len(), "LC hunt disengaged");
+                tracing::info!(confirmed = hunt.confirmed.len(), "LC hunt disengaged");
             }
         }
 
@@ -1684,23 +1692,23 @@ async fn run_sync(
             // Hunting widens the bootstrap fan-out and prefers hunt-confirmed
             // LC servers (a peer that answered ANY light-client request is the
             // best bootstrap bet in a starved pool).
-            let fanout = if hunting { 16 } else { 8 };
+            let fanout = if hunt.hunting { 16 } else { 8 };
             let bootstrapped = try_bootstrap(&config, &client, &mut pool, &mut processor,
-                &mut clcache, fanout, &hunt_confirmed)
+                &mut clcache, fanout, &hunt.confirmed)
                 .await;
             clcache.flush(); // one write per attempt round, win or lose
             if bootstrapped {
                 persist_snapshot(&config, &processor, &mut last_persisted_period);
                 refresh_local_status(&config, &processor, &local_status);
-                publish_status(&config, &client, &processor, &pool, &status_tx, &anchor, hunting).await;
+                publish_status(&config, &client, &processor, &pool, &status_tx, &anchor, hunt.hunting).await;
             } else {
-                if hunting {
+                if hunt.hunting {
                     // Pre-bootstrap the finality probe still classifies: a
                     // decodable response marks the peer lc-confirmed (it can't
                     // APPLY without a committee, and that's fine — the confirm
                     // feeds the next bootstrap round's prefer tier).
                     hunt_round(&client, &mut pool, &mut processor, &mut clcache,
-                        &mut hunt_probed, &mut hunt_confirmed)
+                        &mut hunt.probed, &mut hunt.confirmed)
                         .await;
                     clcache.flush();
                 }
@@ -1709,7 +1717,7 @@ async fn run_sync(
                 // bound raised) — without it the watch keeps the park on display
                 // until the first SUCCESSFUL bootstrap, however long that takes —
                 // and it keeps peer/discovery counts moving during long stalls.
-                publish_status(&config, &client, &processor, &pool, &status_tx, &anchor, hunting).await;
+                publish_status(&config, &client, &processor, &pool, &status_tx, &anchor, hunt.hunting).await;
                 tokio::time::sleep(Duration::from_secs(5)).await;
                 continue;
             }
@@ -1760,19 +1768,18 @@ async fn run_sync(
             }
             let poisoned = catch_up(&config, &client, &mut pool, &mut processor, &status_tx,
                 &mut peer_rx, &mut staged_updates, &mut clcache, &mut resume,
-                &mut last_persisted_period, &anchor, &mut hunt_confirmed, &mut hunt_probed,
-                &mut hunting, &discovery_cfg.hunt_boost, &mut throughput_bound)
+                &mut last_persisted_period, &anchor, &mut hunt)
                 .await;
             // Batch-persist every cache verdict from the catch-up rounds in
             // one write, OFF the per-peer hot path (review: no blocking I/O
             // inside the parallel peer loop).
             clcache.flush();
-            if hunting && processor.store.current_period() == last_seen_progress.0 {
+            if hunt.hunting && processor.store.current_period() == last_seen_progress.0 {
                 // catch_up returned with no period progress while starved —
                 // probe for new servers before the next round (lc-confirms
                 // feed both the cache and catch-up's prefer tier).
                 hunt_round(&client, &mut pool, &mut processor, &mut clcache,
-                    &mut hunt_probed, &mut hunt_confirmed)
+                    &mut hunt.probed, &mut hunt.confirmed)
                     .await;
                 clcache.flush();
             }
@@ -1795,7 +1802,7 @@ async fn run_sync(
                 // Publish the reset immediately: without this the status watch
                 // keeps the DISCARDED snapshot's CATCHING_UP periods frozen on
                 // screen for the whole re-bootstrap.
-                publish_status(&config, &client, &processor, &pool, &status_tx, &anchor, hunting).await;
+                publish_status(&config, &client, &processor, &pool, &status_tx, &anchor, hunt.hunting).await;
                 continue;
             }
             // Backstop only: catch_up persists each applied period itself,
@@ -1803,7 +1810,7 @@ async fn run_sync(
             // with an unpersisted advance.
             persist_snapshot(&config, &processor, &mut last_persisted_period);
             refresh_local_status(&config, &processor, &local_status);
-            publish_status(&config, &client, &processor, &pool, &status_tx, &anchor, hunting).await;
+            publish_status(&config, &client, &processor, &pool, &status_tx, &anchor, hunt.hunting).await;
             if config.wall_clock_period()
                 > processor.store.current_period()
             {
@@ -1817,24 +1824,24 @@ async fn run_sync(
 
         in_catchup = false; // reaching here means the committee is current
         let applied =
-            poll_finality(&client, &mut pool, &mut processor, &mut clcache, &hunt_confirmed)
+            poll_finality(&client, &mut pool, &mut processor, &mut clcache, &hunt.confirmed)
                 .await;
         if applied {
             // A finality update verified against the (possibly restored)
             // committee — the snapshot is genuine.
             resume.confirm();
-        } else if hunting {
+        } else if hunt.hunting {
             // Starved and the proven/preferred tiers came up dry — burst-probe
             // the unproven pool tail for new LC servers.
             hunt_round(&client, &mut pool, &mut processor, &mut clcache,
-                &mut hunt_probed, &mut hunt_confirmed)
+                &mut hunt.probed, &mut hunt.confirmed)
                 .await;
         }
         clcache.flush(); // batch any finality-round evictions into one write
         // No-op unless the period advanced (force-rotate can move it here too).
         persist_snapshot(&config, &processor, &mut last_persisted_period);
         refresh_local_status(&config, &processor, &local_status);
-        publish_status(&config, &client, &processor, &pool, &status_tx, &anchor, hunting).await;
+        publish_status(&config, &client, &processor, &pool, &status_tx, &anchor, hunt.hunting).await;
 
         tokio::time::sleep(Duration::from_secs(config.seconds_per_slot)).await;
     }
@@ -2113,9 +2120,12 @@ const MAX_STAGED_ALTERNATES: usize = 3;
 /// read early with the chunks that DID arrive, so a partial batch applies
 /// instead of timing out and strike-marking the server.
 const UPDATES_BATCH_MAX: u64 = 128;
-/// Peer candidates asked per round — all in parallel, first useful response
-/// wins (Java CATCHUP_FANOUT_MAX is 48; the discovered pool is failure-heavy,
-/// so a wide fan-out is what makes rounds land).
+/// Outstanding `updates_by_range` asks the catch-up pipeline keeps at once
+/// (its in-flight cap, single look-ahead asks and batch asks together).
+/// Nothing is cancelled behind a winner any more: a batch ask streams to
+/// completion while single-period servers fill the periods around it. (Java
+/// CATCHUP_FANOUT_MAX is 48; the discovered pool is failure-heavy, so a wide
+/// set is what makes progress land.)
 const CATCHUP_FANOUT: usize = 32;
 
 // ---------------------------------------------------------------------------
@@ -2202,7 +2212,7 @@ fn hunt_due(
 /// refreshes the discovered-peer pool and republishes status). Rounds inside
 /// retry after a short pause — the Java equivalent is MAX_CATCHUP_BATCHES
 /// per call with a 12 s outer cycle.
-const CATCHUP_MAX_IDLE_ROUNDS: u32 = 6;
+const CATCHUP_MAX_IDLE_WAVES: u32 = 6;
 
 /// Outstanding single-period asks the PREFIX period is allowed at once.
 /// The prefix is the pipeline's bottleneck (the committee chain admits no
@@ -2211,31 +2221,51 @@ const CATCHUP_MAX_IDLE_ROUNDS: u32 = 6;
 /// batch-capable peer asks for it as well; look-ahead periods get one ask.
 const PREFIX_REDUNDANCY: usize = 2;
 
+/// Outstanding multi-count (batch) asks at once. Every batch-capable peer
+/// is asked for the same prefix-anchored span, so beyond a few copies the
+/// extra streams only duplicate data — at up to ~3.5 MiB per 128-period
+/// response, an uncapped fan-out of unknown-agent peers could pull tens of
+/// MiB for one copy's worth. Proven batch servers rank first, so the cap is
+/// spent on them once one is known.
+const CATCHUP_MULTI_MAX: usize = 4;
+
 /// Fewer distinct peers than this serving in the last minute — with no
 /// batch-capable server known and `THROUGHPUT_HUNT_MIN_SPAN` periods still
 /// ahead — means the walk is throughput-bound on a handful of quota-limited
 /// servers, and the LC hunt engages to find more (see
-/// `update_throughput_hunt`). Four single-period servers give ~4 periods per
-/// quota window, a month of mainnet in ~1 minute.
+/// `throughput_bound_verdict`). Four single-period servers give ~4 periods
+/// per quota window, a month of mainnet in ~1 minute.
 const THROUGHPUT_HUNT_MIN_SERVERS: usize = 4;
+
+/// Extra servers above `THROUGHPUT_HUNT_MIN_SERVERS` before an engaged
+/// throughput hunt releases — hysteresis, so one intermittent server at the
+/// threshold does not flap the discovery boost every serve window.
+const THROUGHPUT_HUNT_HYSTERESIS: usize = 2;
 
 /// Periods still ahead below which a throughput-bound walk is left alone:
 /// with two or three periods left, a hunt cannot pay for itself.
 const THROUGHPUT_HUNT_MIN_SPAN: u64 = 3;
 
+/// Floor on the probe budget of a hunt round run inside a quota wait: a
+/// sub-second refill still gets one dial + round-trip's worth of probing.
+const HUNT_PROBE_MIN: Duration = Duration::from_secs(3);
+
 /// Catch the store's committee period up to wall clock.
 ///
 /// A PIPELINE, not a round: one long-lived set of in-flight `updates_by_range`
-/// asks is topped up every time a response lands, so the walk runs at the
-/// POOL's aggregate serve rate instead of one server's. Two ask shapes coexist:
+/// asks is topped up whenever a response lands or a serve quota refills, so
+/// the walk runs at the POOL's aggregate serve rate instead of one server's.
+/// Two ask shapes coexist:
 ///
 /// - **Batch-capable peers** (anything not known to truncate) are asked for
 ///   the PREFIX period with the full remaining span — the Java
 ///   `attemptCatchUpBatch` shape, kept because the prefix is the pipeline's
 ///   bottleneck (the committee chain admits no gaps) and must be redundantly
-///   requested. A multi-count ask is never cancelled behind a faster
-///   single-period answer: it stays in flight across top-ups, so a
-///   Nimbus/roost batch lands whenever it finishes and is drained in order.
+///   requested. At most `CATCHUP_MULTI_MAX` such asks are outstanding (each
+///   can be a multi-MiB stream), and a multi-count ask is never cancelled
+///   behind a faster single-period answer: it stays in flight across top-ups,
+///   so a Nimbus/roost batch lands whenever it finishes and is drained in
+///   order.
 /// - **Single-period servers** (Lighthouse enforces one `updates_by_range`
 ///   per ~10 s per peer, `agent_serves_one_period` / `single_period_peers`)
 ///   each get a DISTINCT look-ahead period: the prefix up to
@@ -2249,7 +2279,13 @@ const THROUGHPUT_HUNT_MIN_SPAN: u64 = 3;
 /// Response chunks are staged at consecutive periods (a mislabeled chunk just
 /// fails verification at apply time and gets refetched) and the contiguous
 /// prefix is verified+applied as it forms, `force_rotate_if_past_period`
-/// after each applied update, exactly like the Java.
+/// after each applied update, exactly like the Java apply path.
+///
+/// DIVERGENCE from the Java engine (`BeaconLightClient.catchUpSyncCommittee`):
+/// the Java engine still asks every peer for the same range and paces the
+/// whole call by `CATCHUP_QUOTA_PACE_MS`; only the apply/credit rules are
+/// mirrored (#342, #410). Expect the Rust engine to catch up faster whenever
+/// the pool holds more than one serving peer.
 ///
 /// The disjoint-range experiment of 2026-07-06 performed worse because it
 /// handed the prefix to ONE mostly-unserving peer. Here the prefix keeps every
@@ -2273,49 +2309,43 @@ async fn catch_up(
     last_persisted_period: &mut u64,
     anchor: &ExecAnchor,
     // Hunt state, shared with the outer loop: `catch_up` runs for many cycles
-    // before returning, so a walk that turns out to be THROUGHPUT-bound (few
-    // servers, none batch-capable, a long span ahead) must engage the hunt
-    // from IN HERE — boost flag plus tail probing in the quota-wait window —
-    // and the outer loop's `hunt_due` must see the verdict
-    // (`throughput_bound`) so its next pass does not disengage it.
-    // `hunt_probed` / `hunt_confirmed` are the probe bookkeeping `hunt_round`
-    // needs.
-    hunt_confirmed: &mut HashSet<PeerId>,
-    hunt_probed: &mut HashMap<PeerId, Instant>,
-    hunting: &mut bool,
-    hunt_boost: &AtomicBool,
-    throughput_bound: &mut bool,
+    // before returning, so a walk that turns out to be THROUGHPUT-bound (a
+    // handful of quota-limited servers, none batch-capable, a long span
+    // ahead) engages the hunt from IN HERE — boost flag plus tail probing in
+    // the quota-wait window — and `hunt.throughput_bound` tells the outer
+    // loop's `hunt_due` so its next pass keeps it engaged.
+    hunt: &mut HuntState,
 ) -> bool {
-    type Answer = (Peer, u64, u64, Result<Vec<u8>, RequestError>);
+    /// One outstanding ask: what was asked of a busy peer.
+    struct Ask {
+        from: u64,
+        /// count=1 ask to a quota-limited server (vs a batch ask) — decided
+        /// at top-up, carried here so the response path never has to infer
+        /// it from `count` (a batch ask with span 1 also has count 1).
+        single: bool,
+    }
+    type Answer = (Peer, bool, u64, u64, Result<Vec<u8>, RequestError>);
     // The pipeline: every outstanding ask, across top-ups. Boxed because each
     // top-up's async block is its own anonymous type.
     let mut in_flight: FuturesUnordered<futures::future::BoxFuture<'static, Answer>> =
         FuturesUnordered::new();
-    // Peers with an ask outstanding — never asked twice concurrently.
-    let mut busy: HashSet<PeerId> = HashSet::new();
-    // Outstanding SINGLE-period asks per target period (multi-count asks all
-    // start at the prefix and are not counted: they are redundancy plus the
-    // batch chance, never something a look-ahead relies on).
-    let mut covered: HashMap<u64, usize> = HashMap::new();
+    // Peers with an ask outstanding — never asked twice concurrently. The
+    // only bookkeeping: `in_flight` and the per-period coverage the top-up
+    // needs are both derived from it.
+    let mut outstanding: HashMap<PeerId, Ask> = HashMap::new();
     // A "wave" is the life of the pipeline from empty to empty again: the
-    // unit of idle/backoff and poison accounting (the old round). Top-ups
-    // inside a wave keep it alive; it ends only when nothing is outstanding
-    // and nobody free is left to ask.
+    // unit of idle/backoff accounting (the old round). Top-ups inside a wave
+    // keep it alive; it ends only when nothing is outstanding and nobody
+    // free is left to ask.
     let mut wave_active = false;
-    let mut wave_progress = false; // staged grew or a period applied
-    let mut wave_applied = 0usize;
-    let mut wave_poisoned = false;
+    let mut wave_progress = false; // net staged growth or a period applied
     let mut wave_rejects = 0usize;
     let mut last_reject_participants: Option<usize> = None;
-    let mut idle_rounds = 0u32;
+    let mut idle_waves = 0u32;
     // Exponential pause after fruitless waves: hammering the whole pool every
     // few seconds is exactly what CL peer scoring penalizes, and it burns
     // request quota on servers that will serve happily a minute later.
     let mut empty_backoff = Duration::from_secs(0);
-    // Whether THIS call raised `hunting`, so it can lower it again when the
-    // pool stops being throughput-bound (a hunt engaged by the outer loop for
-    // another reason stays the outer loop's to disengage).
-    let mut hunt_engaged_here = false;
 
     loop {
         drain_discovered(peer_rx, pool);
@@ -2331,7 +2361,7 @@ async fn catch_up(
             // The walk is over; the outer loop's hunt_due re-evaluates the
             // hunt on its own triggers from here. Outstanding asks are
             // dropped with `in_flight` — their periods are all applied.
-            *throughput_bound = false;
+            hunt.release_throughput(pool, wall_period, committee_period);
             return false;
         }
         *staged = staged.split_off(&committee_period); // drop already-passed periods
@@ -2340,14 +2370,16 @@ async fn catch_up(
         // ── Wave accounting: the pipeline drained without a top-up refilling it.
         if wave_active && in_flight.is_empty() {
             wave_active = false;
-            if wave_poisoned && wave_applied == 0 {
-                return true; // whole wave rejected — restored snapshot can't verify anything
+            if resume.poisoned(0) {
+                // Restored snapshot can't verify anything (no apply confirmed
+                // it, RESUME_REJECTS_MAX rejects did the opposite).
+                return true;
             }
             if wave_progress {
-                idle_rounds = 0;
+                idle_waves = 0;
                 empty_backoff = Duration::from_secs(0);
             } else {
-                idle_rounds += 1;
+                idle_waves += 1;
                 if wave_rejects > 0 {
                     // Loud on purpose (hosts keep info+ only in their log
                     // rings): a wave whose staged update for the target period
@@ -2362,12 +2394,12 @@ async fn catch_up(
                     // rejected, because malformed frames say nothing about our
                     // store or the period's data.)
                     tracing::warn!(period = committee_period, rejects = wave_rejects,
-                        idle_rounds, participants = ?last_reject_participants,
+                        idle_waves, participants = ?last_reject_participants,
                         "catch-up: staged update for the target period failed verification — \
                          below-2/3 participants means the serving peer holds a weak update");
                 }
-                if idle_rounds >= CATCHUP_MAX_IDLE_ROUNDS {
-                    tracing::warn!(period = committee_period, idle_rounds,
+                if idle_waves >= CATCHUP_MAX_IDLE_WAVES {
+                    tracing::warn!(period = committee_period, idle_waves,
                         "catch-up made no progress — returning to the poll loop");
                     return false;
                 }
@@ -2378,14 +2410,14 @@ async fn catch_up(
                 // ceiling meant up to a minute of blindness after a server
                 // RETURNED (droughts dominated measured cold syncs). 25 s
                 // samples recovery twice as fast at bounded quota cost:
-                // CATCHUP_MAX_IDLE_ROUNDS exits to the outer poll loop after
+                // CATCHUP_MAX_IDLE_WAVES exits to the outer poll loop after
                 // 6 fruitless waves either way.
                 empty_backoff = if empty_backoff.is_zero() {
                     Duration::from_secs(5)
                 } else {
                     (empty_backoff * 2).min(Duration::from_secs(25))
                 };
-                tracing::info!(backoff_s = empty_backoff.as_secs(), idle_rounds,
+                tracing::info!(backoff_s = empty_backoff.as_secs(), idle_waves,
                     "catch-up: no progress last wave — backing off before retrying");
                 tokio::time::sleep(empty_backoff).await;
                 continue; // re-read the clock and discovery before asking again
@@ -2393,131 +2425,172 @@ async fn catch_up(
         }
 
         // ── Top-up: hand every free, quota-refilled candidate an ask.
-        let reqresp::CatchupPeerMeta { mut lc_servers, earliest_slots, agents } =
-            client.catchup_peer_meta().await;
-        // Reconcile the deny set against the LIVE Identify signal (same protocol
-        // nolc tracks, self-expiring on disconnect) BEFORE folding in
-        // hunt_confirmed — see clear_no_lc for why the finality-attesting hunt
-        // set must not un-deny updates_by_range. Persist each reversal to the
-        // shared cache so pool and cache never disagree across a restart or an
-        // engine switch (issue #291, PR #322 review).
-        for id in pool.clear_no_lc(&lc_servers) {
-            if let Some(key) = pool.cache_key(&id) {
-                clcache.clear_nolc(&key);
-            }
-        }
-        // Hunt-confirmed servers join the Identify-confirmed prefer tier —
-        // same dial-priority-only trust level (see poll_finality).
-        lc_servers.extend(hunt_confirmed.iter().copied());
-        // Skip peers whose advertised earliest_available_slot proves their
-        // light-client history begins in a LATER period than the one we need —
-        // they'd only return far-future updates the period gate discards (Java
-        // attemptCatchUpBatch's earliestAvailableSlot filter). Compare at
-        // PERIOD granularity: a peer whose earliest slot lands anywhere inside
-        // committee_period can still serve that period's update, so only skip
-        // when its earliest period is strictly greater. Peers not yet
-        // status-exchanged (absent from the map) are unknown and kept; v1 peers
-        // report 0 (genesis history) and are never skipped. This is a STRONG
-        // PREFERENCE, not a veto: candidates() falls back to the shallow peers
-        // when they are all that is left, because earliest_available_slot is a
-        // block floor rather than an LC-update floor and an all-shallow pool is
-        // not proof that nobody serves the period (issue #291). Only a
-        // genuinely empty pool bounces to rediscovery.
-        let too_shallow: HashSet<PeerId> = earliest_slots
-            .into_iter()
-            .filter(|&(_, earliest)| {
-                spec::compute_sync_committee_period_with(earliest, config.slots_per_period())
-                    > committee_period
-            })
-            .map(|(id, _)| id)
-            .collect();
-        let candidates = pool.candidates(CATCHUP_FANOUT, true, true, &lc_servers, &too_shallow);
-        if candidates.is_empty() && in_flight.is_empty() {
-            tracing::warn!("catch-up: no peers available — retrying after discovery");
-            return false;
-        }
-        // Free = not already asked, and outside its serve-quota window.
-        // candidates() respects cooldowns in its main pass but its
-        // never-starve fallback does not, so filter here too: asking a peer
-        // inside its quota window just earns an empty answer and another
-        // cooldown — the self-inflicted drought the old global pace existed
-        // to avoid.
-        let free: Vec<Peer> = candidates
-            .into_iter()
-            .filter(|p| !busy.contains(&p.id) && pool.cooled_down(&p.id))
-            .take(CATCHUP_FANOUT.saturating_sub(in_flight.len()))
-            .collect();
-        let (mut asked_single, mut asked_multi, mut look_ahead_to) = (0usize, 0usize, committee_period);
-        for peer in free {
-            // The COUNT is per-peer: a server that closed on a multi-period ask
-            // (Lighthouse's quota) is asked for exactly one, so it can serve
-            // instead of being struck out. Lighthouse gets count=1 from the
-            // FIRST ask (its quota makes a multi-count request yield one chunk
-            // then a closed stream); the reactive single_period_peers mark
-            // covers clients we don't know.
-            let single = pool.wants_single_period(&peer.id)
-                || agent_serves_one_period(agents.get(&peer.id).map(String::as_str));
-            let (sub_from, sub_count) = if single {
-                match next_single_target(committee_period, span, staged, &covered) {
-                    Some(target) => (target, 1u64),
-                    None => continue, // every period is staged or already asked
+        // Skipped outright when no slot can be filled (every peer busy or
+        // inside its window, or the pipeline full) — the meta round-trip and
+        // candidate ranking are not free, and a burst of responses would
+        // otherwise pay them once each for nothing. Also skipped once the
+        // restored snapshot is poisoned and no apply has confirmed it: the
+        // pipeline then drains within one request timeout and the wave-end
+        // verdict above fires — the old per-round deadline, not a pool-sized
+        // one.
+        let can_ask = in_flight.len() < CATCHUP_FANOUT
+            && pool.has_free_peer(|id| !outstanding.contains_key(id))
+            && !resume.poisoned(0);
+        if can_ask {
+            let reqresp::CatchupPeerMeta { mut lc_servers, earliest_slots, agents } =
+                client.catchup_peer_meta().await;
+            // Reconcile the deny set against the LIVE Identify signal (same
+            // protocol nolc tracks, self-expiring on disconnect) BEFORE folding
+            // in hunt_confirmed — see clear_no_lc for why the finality-attesting
+            // hunt set must not un-deny updates_by_range. Persist each reversal
+            // to the shared cache so pool and cache never disagree across a
+            // restart or an engine switch (issue #291, PR #322 review).
+            for id in pool.clear_no_lc(&lc_servers) {
+                if let Some(key) = pool.cache_key(&id) {
+                    clcache.clear_nolc(&key);
                 }
-            } else {
-                (committee_period, span)
-            };
-            if single {
-                *covered.entry(sub_from).or_insert(0) += 1;
-                asked_single += 1;
-                look_ahead_to = look_ahead_to.max(sub_from);
-            } else {
-                asked_multi += 1;
             }
-            busy.insert(peer.id);
-            let mut ssz_request = Vec::with_capacity(16);
-            ssz_request.extend_from_slice(&sub_from.to_le_bytes());
-            ssz_request.extend_from_slice(&sub_count.to_le_bytes());
-            let wire = codec::encode_request(&ssz_request);
-            tracing::debug!(peer = %peer.id, sub_from, sub_count,
-                agent = agents.get(&peer.id).map(String::as_str).unwrap_or("?"),
-                "catch-up: updates_by_range request");
-            let client = client.clone();
-            in_flight.push(Box::pin(async move {
-                let res = client
-                    .request_raw(peer.id, peer.addr.clone(), protocols::UPDATES_BY_RANGE, wire)
-                    .await;
-                (peer, sub_from, sub_count, res)
-            }));
+            // Hunt-confirmed servers join the Identify-confirmed prefer tier —
+            // same dial-priority-only trust level (see poll_finality).
+            lc_servers.extend(hunt.confirmed.iter().copied());
+            // Skip peers whose advertised earliest_available_slot proves their
+            // light-client history begins in a LATER period than the one we
+            // need — they'd only return far-future updates the period gate
+            // discards (Java attemptCatchUpBatch's earliestAvailableSlot
+            // filter). Compare at PERIOD granularity: a peer whose earliest
+            // slot lands anywhere inside committee_period can still serve that
+            // period's update, so only skip when its earliest period is
+            // strictly greater. Peers not yet status-exchanged (absent from the
+            // map) are unknown and kept; v1 peers report 0 (genesis history)
+            // and are never skipped. This is a STRONG PREFERENCE, not a veto:
+            // candidates() falls back to the shallow peers when they are all
+            // that is left, because earliest_available_slot is a block floor
+            // rather than an LC-update floor and an all-shallow pool is not
+            // proof that nobody serves the period (issue #291). Only a
+            // genuinely empty pool bounces to rediscovery.
+            let too_shallow: HashSet<PeerId> = earliest_slots
+                .into_iter()
+                .filter(|&(_, earliest)| {
+                    spec::compute_sync_committee_period_with(earliest, config.slots_per_period())
+                        > committee_period
+                })
+                .map(|(id, _)| id)
+                .collect();
+            // Busy peers are skipped inside candidates(); the never-starve
+            // fallback there ignores cooldowns, so the quota window is
+            // re-checked here: asking a peer inside its window just earns an
+            // empty answer and another cooldown — the self-inflicted drought
+            // the old global pace existed to avoid.
+            let busy: HashSet<PeerId> = outstanding.keys().copied().collect();
+            let candidates = pool.candidates(CATCHUP_FANOUT, true, true, &lc_servers, &busy);
+            if candidates.is_empty() && in_flight.is_empty() {
+                tracing::warn!("catch-up: no peers available — retrying after discovery");
+                return false;
+            }
+            let free: Vec<Peer> = candidates
+                .into_iter()
+                .filter(|p| pool.cooled_down(&p.id) && !too_shallow.contains(&p.id))
+                .take(CATCHUP_FANOUT - in_flight.len())
+                .collect();
+            // Coverage of the span by outstanding single asks, for the
+            // look-ahead assignment (multi asks all start at the prefix).
+            let mut covered: HashMap<u64, usize> = HashMap::new();
+            for ask in outstanding.values().filter(|a| a.single) {
+                *covered.entry(ask.from).or_insert(0) += 1;
+            }
+            let mut multi_outstanding = outstanding.values().filter(|a| !a.single).count();
+            let (mut asked_single, mut asked_multi, mut look_ahead_to) =
+                (0usize, 0usize, committee_period);
+            for peer in free {
+                // The COUNT is per-peer: a server that closed on a multi-period
+                // ask (Lighthouse's quota) is asked for exactly one, so it can
+                // serve instead of being struck out. Lighthouse gets count=1
+                // from the FIRST ask (its quota makes a multi-count request
+                // yield one chunk then a closed stream); the reactive
+                // single_period_peers mark covers clients we don't know.
+                let single = pool.wants_single_period(&peer.id)
+                    || agent_serves_one_period(agents.get(&peer.id).map(String::as_str));
+                let (from, count) = if single {
+                    match next_single_target(committee_period, span, staged, &covered) {
+                        Some(target) => (target, 1u64),
+                        None => continue, // every period is staged or already asked
+                    }
+                } else {
+                    if multi_outstanding >= CATCHUP_MULTI_MAX {
+                        continue; // enough batch asks streaming for the same data
+                    }
+                    (committee_period, span)
+                };
+                if single {
+                    *covered.entry(from).or_insert(0) += 1;
+                    asked_single += 1;
+                    look_ahead_to = look_ahead_to.max(from);
+                } else {
+                    multi_outstanding += 1;
+                    asked_multi += 1;
+                }
+                outstanding.insert(peer.id, Ask { from, single });
+                tracing::debug!(peer = %peer.id, from, count,
+                    agent = agents.get(&peer.id).map(String::as_str).unwrap_or("?"),
+                    "catch-up: updates_by_range request");
+                let wire = codec::encode_updates_by_range_request(from, count);
+                let client = client.clone();
+                in_flight.push(Box::pin(async move {
+                    let res = client
+                        .request_raw(peer.id, peer.addr.clone(), protocols::UPDATES_BY_RANGE, wire)
+                        .await;
+                    (peer, single, from, count, res)
+                }));
+            }
+            if asked_single + asked_multi > 0 {
+                tracing::info!(from_period = committee_period, wall_period, span,
+                    staged = staged.len(), in_flight = in_flight.len(),
+                    asked_single, asked_multi, look_ahead_to,
+                    "catch-up: requesting updates_by_range");
+            }
         }
-        if asked_single + asked_multi > 0 {
-            tracing::info!(from_period = committee_period, wall_period, span,
-                staged = staged.len(), in_flight = in_flight.len(),
-                asked_single, asked_multi, look_ahead_to,
-                "catch-up: requesting updates_by_range");
-        }
+
+        // The pipeline's next wake-up while a server is inside its quota
+        // window: the earliest refill. With asks outstanding it races the
+        // next response (a refilled server must not idle behind a slow
+        // batch stream); with none outstanding it is the whole wait.
+        let refill = pool.earliest_cooldown_expiry();
 
         if in_flight.is_empty() {
             // Nobody free to ask and nothing outstanding — but servers exist:
             // they are all inside their serve-quota window. Wait for the
-            // earliest refill (the single-server cadence of the old pace),
-            // and use the wait to probe for MORE servers when the walk is
-            // throughput-bound. Not idle: progress is quota-bound, not
-            // server-bound.
+            // earliest refill (the single-server cadence of the old pace), and
+            // — when the walk is throughput-bound — spend the wait probing the
+            // unproven tail for MORE servers. Not idle: progress is
+            // quota-bound, not server-bound.
+            if resume.poisoned(0) {
+                continue; // wave accounting above returns the verdict
+            }
             let now = Instant::now();
-            let wait = pool
-                .earliest_cooldown_expiry()
+            let wait = refill
                 .map(|until| until.saturating_duration_since(now))
                 .unwrap_or(Duration::ZERO)
                 .clamp(Duration::from_millis(250), UPDATES_SERVE_COOLDOWN);
-            update_throughput_hunt(
-                pool, wall_period, hunting, hunt_boost, throughput_bound, &mut hunt_engaged_here,
-                processor.store.current_period(),
-            );
-            if *throughput_bound {
+            // The quota wait IS the throughput-bound signal: the pipeline ran
+            // dry because every server is cooling, not because a batch is
+            // still streaming (that keeps in_flight non-empty).
+            hunt.engage_throughput(pool, wall_period, committee_period);
+            if hunt.throughput_bound {
                 tracing::info!(wait_ms = wait.as_millis() as u64,
                     "catch-up: every server is inside its serve quota — probing for more servers meanwhile");
+                // The probe is bounded by the wait itself (plus a floor so a
+                // sub-second wait still gets one round-trip): a slow tail must
+                // not idle a refilled server, which is the very thing the hunt
+                // is meant to prevent. Confirms harvested before the deadline
+                // are kept; cut-off probes stay marked probed.
+                let probe_budget = wait.max(HUNT_PROBE_MIN);
                 let (_, _) = tokio::join!(
                     tokio::time::sleep(wait),
-                    hunt_round(client, pool, processor, clcache, hunt_probed, hunt_confirmed),
+                    tokio::time::timeout(
+                        probe_budget,
+                        hunt_round(client, pool, processor, clcache, &mut hunt.probed,
+                            &mut hunt.confirmed),
+                    ),
                 );
             } else {
                 tracing::info!(wait_ms = wait.as_millis() as u64,
@@ -2529,25 +2602,24 @@ async fn catch_up(
         if !wave_active {
             wave_active = true;
             wave_progress = false;
-            wave_applied = 0;
-            wave_poisoned = false;
             wave_rejects = 0;
             last_reject_participants = None;
         }
 
-        // ── One response.
-        let Some((peer, sub_from, sub_count, res)) = in_flight.next().await else {
+        // ── One response — or a quota refill, which goes straight back to
+        // the top-up so the refilled server is asked while others stream.
+        let next = match refill {
+            Some(until) => tokio::select! {
+                answer = in_flight.next() => answer,
+                _ = tokio::time::sleep_until(tokio::time::Instant::from_std(until)) => continue,
+            },
+            None => in_flight.next().await,
+        };
+        let Some((peer, single, sub_from, sub_count, res)) = next else {
             continue;
         };
-        busy.remove(&peer.id);
-        if sub_count == 1 {
-            if let Some(n) = covered.get_mut(&sub_from) {
-                *n = n.saturating_sub(1);
-                if *n == 0 {
-                    covered.remove(&sub_from);
-                }
-            }
-        }
+        outstanding.remove(&peer.id);
+        let peer_key = pool.key_for(&peer);
         let raw = match res {
             Ok(raw) => raw,
             Err(e) => {
@@ -2557,12 +2629,15 @@ async fn catch_up(
                     // Both are no-ops for a static peer: the pool exempts it,
                     // and the shared cache is read by the Java engine, which
                     // would otherwise inherit the denial for a curated peer
-                    // (PR #322 review) — so gate the persist on it too.
+                    // (PR #322 review) — so gate the persist on it too. The
+                    // cooldown is what keeps an exempt static peer from being
+                    // re-asked on every top-up.
                     pool.mark_no_lc_updates(peer.id);
+                    pool.set_updates_cooldown(peer.id);
                     if !pool.is_static(&peer.id) {
-                        clcache.mark_nolc(&format!("{}/p2p/{}", peer.addr, peer.id));
+                        clcache.mark_nolc(&peer_key);
                     }
-                } else if e == RequestError::ConnectionClosed && sub_count > 1 {
+                } else if e == RequestError::ConnectionClosed && !single {
                     // NOT a dead peer: Lighthouse enforces its updates_by_range
                     // quota by closing the stream on any multi-count request
                     // while answering count=1 fine (verified live, v8.2.2).
@@ -2576,9 +2651,14 @@ async fn catch_up(
                         "closed on a multi-period ask — will request one period at a time");
                 } else if e != RequestError::Shutdown {
                     // Dial/timeout/connection-closed — count toward eviction
-                    // so dead peers stop occupying MAX_POOL slots.
+                    // so dead peers stop occupying MAX_POOL slots. The
+                    // cooldown spaces the strikes one quota window apart: with
+                    // top-ups running per response, a restarting server would
+                    // otherwise collect its three strikes in well under a
+                    // second and be evicted for a two-second blip.
                     pool.note_failure(peer.id);
-                    clcache.mark_failure(&format!("{}/p2p/{}", peer.addr, peer.id));
+                    pool.set_updates_cooldown(peer.id);
+                    clcache.mark_failure(&peer_key);
                 }
                 tracing::debug!(peer = %peer.id, error = %e, "updates_by_range failed");
                 continue;
@@ -2587,11 +2667,9 @@ async fn catch_up(
         if raw.len() < 64 {
             // Tiny frames are peers closing without serving (0 B) or sending
             // near-empty chunks; dumped verbatim at debug for peer forensics.
-            tracing::debug!(peer = %peer.id, raw_len = raw.len(),
-                hex = %raw.iter().map(|b| format!("{b:02x}")).collect::<String>(),
+            tracing::debug!(peer = %peer.id, raw_len = raw.len(), hex = %hex_str(&raw),
                 "small updates_by_range frame");
         }
-        let peer_key = format!("{}/p2p/{}", peer.addr, peer.id);
         let chunks = match codec::decode_multi_chunk_response(&raw, sub_count as usize) {
             Ok(c) => c,
             Err(e) => {
@@ -2601,12 +2679,14 @@ async fn catch_up(
                 // 3-strike eviction still prunes peers that never produce a
                 // usable chunk.
                 pool.note_failure(peer.id);
+                pool.set_updates_cooldown(peer.id);
                 clcache.mark_failure(&peer_key);
                 tracing::debug!(peer = %peer.id, raw_len = raw.len(), error = %e,
                     "updates_by_range frame invalid");
                 continue;
             }
         };
+        let staged_before = staged.len();
         let mut served = 0usize;
         for (i, chunk) in chunks.into_iter().enumerate() {
             if chunk.is_empty() {
@@ -2645,7 +2725,6 @@ async fn catch_up(
                 "updates_by_range returned no chunks");
             continue;
         }
-        wave_progress = true; // the buffer grew — progress toward the prefix
         tracing::info!(peer = %peer.id, sub_from, sub_count, served, raw_len = raw.len(),
             "updates_by_range served");
         // A peer that answered DOES serve the protocol, so reverse any stale
@@ -2662,12 +2741,12 @@ async fn catch_up(
         // engine never had this stall precisely because it credits
         // verification, not delivery — keep the two in step.
         pool.clear_no_lc_for(peer.id);
-        if sub_count == 1 {
+        if single {
             // Per-peer serve quota: a single-period server that just served
             // answers empty for the next ~10 s (Lighthouse one_every(10s)),
             // so sit it out for one window instead of pacing the WHOLE walk
             // — the other servers' quotas are what the look-ahead spends
-            // meanwhile. Batch servers (multi-count asks) carry no such mark.
+            // meanwhile. Batch servers carry no such mark.
             pool.set_updates_cooldown(peer.id);
         }
 
@@ -2678,9 +2757,12 @@ async fn catch_up(
         // verifications don't pin this worker while the swarm task needs it.
         // Each period is credited to the peer whose response staged it (not
         // necessarily this responder: alternates and look-ahead chunks from
-        // earlier responses apply here too — `applied_from` names the source).
+        // earlier responses apply here too — `applied_from` names the source,
+        // and a source that has since left the pool gets no credit at all;
+        // crediting the responder instead would wipe strikes and grant
+        // priority to a peer that merely delivered bytes, PR #410 review).
         let mut applied_now_total = 0usize;
-        let mut applied_by: HashMap<PeerId, usize> = HashMap::new();
+        let mut from_this_response = 0usize;
         loop {
             let before_period = processor.store.current_period();
             let step = apply_staged_step(processor, staged, slot_estimate);
@@ -2697,112 +2779,144 @@ async fn catch_up(
                     clcache.mark_failure(bad);
                     tracing::warn!(peer = %bad, period = before_period,
                         "catch-up: update failed verification — peer penalised, \
-                         will try another next round");
+                         will try another next ask");
                 }
             }
             if step.applied == 0 {
                 // ORDER MATTERS: an apply BLS-verified against the restored
-                // committee proves the snapshot genuine — confirm() (below,
-                // on the first apply) must win over poison accounting. A
-                // reject with no apply yet is evidence; the verdict is
-                // deferred to wave end so a slower HONEST response can still
-                // confirm the snapshot — a fast bad peer must not win.
-                if applied_now_total == 0
-                    && step.verify_rejects > 0
-                    && resume.poisoned(step.verify_rejects as u32)
-                {
-                    wave_poisoned = true;
-                }
+                // committee proves the snapshot genuine — confirm() (below, on
+                // the first apply) resets the guard, so rejects only count
+                // while nothing has verified yet. The verdict is read at wave
+                // end (`resume.poisoned(0)`), so a slower HONEST response can
+                // still confirm the snapshot — a fast bad peer must not win.
+                let _ = resume.poisoned(step.verify_rejects as u32);
                 break;
             }
             if applied_now_total == 0 {
                 resume.confirm();
             }
             applied_now_total += step.applied;
-            // Promotion belongs to the peer whose update actually VERIFIED —
-            // crediting the responder instead would wipe strikes and grant
-            // priority to a peer that merely delivered bytes (PR #410 review).
-            // Only VERIFIED periods reach the shared cross-engine cache, the
-            // same way (Java applyCatchUpResponses records AFTER processUpdate).
-            let credited = step
-                .applied_from
-                .as_deref()
-                .and_then(|key| pool.id_for_key(key))
-                .unwrap_or(peer.id);
-            pool.mark_proven(credited);
-            pool.note_served(credited); // BLS-verified and applied
-            *applied_by.entry(credited).or_insert(0) += 1;
-            if let Some(key) = step.applied_from.as_deref() {
-                clcache.record_served(key, before_period, before_period);
+            let Some(key) = step.applied_from.as_deref() else { break };
+            if key == peer_key {
+                from_this_response += 1;
             }
+            if let Some(id) = pool.id_for_key(key) {
+                pool.mark_proven(id);
+                pool.note_served(id); // BLS-verified and applied
+            }
+            // Only VERIFIED periods reach the shared cross-engine cache (Java
+            // applyCatchUpResponses records AFTER processUpdate the same way).
+            clcache.record_served(key, before_period, before_period);
             persist_snapshot(config, processor, last_persisted_period);
-            publish_status(config, client, processor, &*pool, status_tx, anchor, *hunting).await;
+            publish_status(config, client, processor, &*pool, status_tx, anchor, hunt.hunting)
+                .await;
             tokio::task::yield_now().await;
+        }
+        // Progress is NET buffer growth after the apply pass (a served-then-
+        // rejected prefix chunk is removed again and does not count — the
+        // weak-update WARN above depends on that) or an applied period.
+        if applied_now_total > 0 || staged.len() > staged_before {
+            wave_progress = true;
         }
         if applied_now_total == 0 {
             continue; // staged a look-ahead period; the prefix is still outstanding
         }
-        wave_applied += applied_now_total;
         tracing::info!(applied = applied_now_total, staged = staged.len(),
             in_flight = in_flight.len(),
             period = processor.store.current_period(),
             finalized_slot = processor.store.finalized_slot(),
             "catch-up applied");
-        // Promote verified batch servers: two or more periods applied from
-        // one peer's response — preferred by candidates() from now on.
-        for (id, n) in &applied_by {
-            if *n >= 2 && pool.mark_batch_server(*id) {
-                tracing::info!(peer = %id, periods = n,
-                    "catch-up: batch-capable LC server confirmed — preferred from now on");
-            }
+        // A verified batch server: two or more periods of THIS multi-count
+        // response applied. Look-ahead chunks from other peers that drained
+        // behind it do not count — a single-period peer must never be
+        // promoted to the batch tier (it would lead selection and silence
+        // the throughput hunt).
+        if !single && from_this_response >= 2 && pool.mark_batch_server(peer.id) {
+            tracing::info!(peer = %peer.id, periods = from_this_response,
+                "catch-up: batch-capable LC server confirmed — preferred from now on");
         }
-        update_throughput_hunt(
-            pool, wall_period, hunting, hunt_boost, throughput_bound, &mut hunt_engaged_here,
-            processor.store.current_period(),
-        );
+        hunt.release_throughput(pool, wall_period, processor.store.current_period());
     }
 }
 
-/// Engage or release the throughput hunt: a walk with a long span ahead, no
-/// batch-capable server in the pool, and fewer than
-/// `THROUGHPUT_HUNT_MIN_SERVERS` peers serving is going as fast as the few
-/// quota-limited servers allow, and only MORE servers (boosted discovery +
-/// probing the unproven tail) can speed it up. Releases the hunt this call
-/// raised as soon as any of the three conditions stops holding.
-fn update_throughput_hunt(
-    pool: &PeerPool,
-    wall_period: u64,
-    hunting: &mut bool,
-    hunt_boost: &AtomicBool,
-    throughput_bound: &mut bool,
-    hunt_engaged_here: &mut bool,
-    store_period: u64,
-) {
-    let remaining = wall_period.saturating_sub(store_period);
-    let servers = pool.served_last_minute();
-    let bound = remaining >= THROUGHPUT_HUNT_MIN_SPAN
-        && !pool.has_batch_server()
-        && servers < THROUGHPUT_HUNT_MIN_SERVERS;
-    if bound && !*throughput_bound {
-        *throughput_bound = true;
-        if !*hunting {
-            *hunting = true;
-            *hunt_engaged_here = true;
-            hunt_boost.store(true, Ordering::Relaxed);
+/// The LC hunt's state, owned by the sync loop and lent to `catch_up`: probe
+/// bookkeeping for `hunt_round`, the engaged flag every status publish
+/// carries, the discovery boost it mirrors, and the throughput-bound verdict
+/// `catch_up` raises for `hunt_due`.
+struct HuntState {
+    probed: HashMap<PeerId, Instant>,
+    confirmed: HashSet<PeerId>,
+    hunting: bool,
+    boost: Arc<AtomicBool>,
+    /// Raised by `catch_up` when the walk is throughput-bound on a few
+    /// quota-limited servers with a long span ahead; keeps `hunt_due` from
+    /// disengaging the hunt that `catch_up` raised for it.
+    throughput_bound: bool,
+}
+
+impl HuntState {
+    fn new(boost: Arc<AtomicBool>) -> Self {
+        Self {
+            probed: HashMap::new(),
+            confirmed: HashSet::new(),
+            hunting: false,
+            boost,
+            throughput_bound: false,
         }
-        tracing::info!(remaining, servers, pool = pool.len(),
-            "LC hunt engaged — catch-up is throughput-bound on a few single-period \
-             servers; searching for more (batch-capable) servers");
-    } else if !bound && *throughput_bound {
-        *throughput_bound = false;
-        if *hunt_engaged_here {
-            *hunt_engaged_here = false;
-            *hunting = false;
-            hunt_boost.store(false, Ordering::Relaxed);
+    }
+
+    /// The one writer of the engaged flag and its discovery-boost mirror.
+    fn set_hunting(&mut self, on: bool) {
+        self.hunting = on;
+        self.boost.store(on, Ordering::Relaxed);
+    }
+
+    /// Called from the quota wait — the moment the pipeline provably ran dry
+    /// on quotas: engage the hunt if the walk is throughput-bound.
+    fn engage_throughput(&mut self, pool: &PeerPool, wall_period: u64, store_period: u64) {
+        let remaining = wall_period.saturating_sub(store_period);
+        let servers = pool.served_last_minute();
+        if !self.throughput_bound
+            && throughput_bound_verdict(false, remaining, pool.has_batch_server(), servers)
+        {
+            self.throughput_bound = true;
+            self.set_hunting(true);
+            tracing::info!(remaining, servers, pool = pool.len(),
+                "LC hunt engaged — catch-up is throughput-bound on a few single-period \
+                 servers; searching for more (batch-capable) servers");
+        }
+    }
+
+    /// Called after every applied period and at the end of the walk: release
+    /// the throughput hunt once any of its conditions stops holding
+    /// (hysteresis on the server count — see `throughput_bound_verdict`).
+    fn release_throughput(&mut self, pool: &PeerPool, wall_period: u64, store_period: u64) {
+        if !self.throughput_bound {
+            return;
+        }
+        let remaining = wall_period.saturating_sub(store_period);
+        let servers = pool.served_last_minute();
+        if !throughput_bound_verdict(true, remaining, pool.has_batch_server(), servers) {
+            self.throughput_bound = false;
+            self.set_hunting(false);
             tracing::info!(remaining, servers, batch = pool.has_batch_server(),
                 "LC hunt disengaged — catch-up is no longer throughput-bound");
         }
     }
+}
+
+/// Is a progressing walk throughput-bound? A long span ahead, no
+/// batch-capable server in the pool, and fewer than
+/// `THROUGHPUT_HUNT_MIN_SERVERS` peers serving — then only MORE servers can
+/// speed it up. `engaged` adds hysteresis on the server count: engage below
+/// the threshold, release only at threshold + `THROUGHPUT_HUNT_HYSTERESIS`,
+/// so a pool flickering around the threshold does not flap the discovery
+/// boost every serve window. Pure so the trigger is unit-testable.
+fn throughput_bound_verdict(engaged: bool, remaining: u64, has_batch: bool, servers: usize) -> bool {
+    let release_at = THROUGHPUT_HUNT_MIN_SERVERS + THROUGHPUT_HUNT_HYSTERESIS;
+    remaining >= THROUGHPUT_HUNT_MIN_SPAN
+        && !has_batch
+        && servers < if engaged { release_at } else { THROUGHPUT_HUNT_MIN_SERVERS }
 }
 
 /// The period a free single-period server should be asked for: the lowest in
@@ -2824,9 +2938,9 @@ fn next_single_target(
 }
 
 /// Verify+apply AT MOST ONE staged update — the one at the store's current
-/// period (the contiguous prefix advances one period per call; callers loop:
-/// the fan-out handler calls once to pick a winner, the post-fan-out drain
-/// loops with a persist+yield between calls). The update is decoded and
+/// period (the contiguous prefix advances one period per call; the catch-up
+/// pipeline loops it after every served response, with a persist+yield
+/// between calls). The update is decoded and
 /// processed, advancing the committee period on success
 /// (`force_rotate_if_past_period` on the recorded wall-clock estimate — Java
 /// `applyCatchUpResponses`). A chunk that fails decode/verify is dropped from
@@ -3958,6 +4072,38 @@ mod tests {
         let left = until.saturating_duration_since(Instant::now());
         assert!(left <= UPDATES_SERVE_COOLDOWN && left > UPDATES_SERVE_COOLDOWN / 2);
         assert!(!pool.cooled_down(&id));
+    }
+
+    #[test]
+    fn throughput_bound_verdict_has_hysteresis() {
+        let min = THROUGHPUT_HUNT_MIN_SERVERS;
+        // Long span, no batch server, few servers → bound.
+        assert!(throughput_bound_verdict(false, 30, false, min - 1));
+        // At the threshold a disengaged hunt stays off…
+        assert!(!throughput_bound_verdict(false, 30, false, min));
+        // …but an engaged one stays on until threshold + hysteresis.
+        assert!(throughput_bound_verdict(true, 30, false, min));
+        assert!(throughput_bound_verdict(true, 30, false, min + THROUGHPUT_HUNT_HYSTERESIS - 1));
+        assert!(!throughput_bound_verdict(true, 30, false, min + THROUGHPUT_HUNT_HYSTERESIS));
+        // A batch server or a short span ends it regardless of server count.
+        assert!(!throughput_bound_verdict(true, 30, true, 0));
+        assert!(!throughput_bound_verdict(false, THROUGHPUT_HUNT_MIN_SPAN - 1, false, 0));
+    }
+
+    #[test]
+    fn evict_clears_batch_and_single_period_marks() {
+        let mut pool = PeerPool::new();
+        let kp = libp2p::identity::Keypair::generate_secp256k1();
+        let id = kp.public().to_peer_id();
+        pool.add(id, "/ip4/10.0.4.1/tcp/9000".parse().unwrap());
+        pool.mark_proven(id);
+        pool.mark_batch_server(id);
+        pool.mark_single_period(id);
+        assert!(pool.has_batch_server());
+        pool.evict(&id);
+        assert!(!pool.has_batch_server());
+        assert!(!pool.wants_single_period(&id));
+        assert!(pool.mark_batch_server(id), "a re-discovered peer starts unmarked");
     }
 
     #[test]

--- a/rust/myotis-net/src/sync.rs
+++ b/rust/myotis-net/src/sync.rs
@@ -2335,8 +2335,8 @@ async fn catch_up(
     let mut outstanding: HashMap<PeerId, Ask> = HashMap::new();
     // A "wave" is the life of the pipeline from empty to empty again: the
     // unit of idle/backoff accounting (the old round). Top-ups inside a wave
-    // keep it alive; it ends only when nothing is outstanding and nobody
-    // free is left to ask.
+    // keep it alive; it ends only when nothing is outstanding AND nobody
+    // free is left to ask (see `can_ask`).
     let mut wave_active = false;
     let mut wave_progress = false; // net staged growth or a period applied
     let mut wave_rejects = 0usize;
@@ -2367,8 +2367,24 @@ async fn catch_up(
         *staged = staged.split_off(&committee_period); // drop already-passed periods
         let span = (wall_period - committee_period).min(UPDATES_BATCH_MAX);
 
-        // ── Wave accounting: the pipeline drained without a top-up refilling it.
-        if wave_active && in_flight.is_empty() {
+        // Can the top-up below hand out an ask at all? Computed first so the
+        // wave verdict is taken only when the pipeline is empty AND nobody
+        // free is left — a transient drain with a free peer (a first-contact
+        // batch ask closed and the peer marked single-period at no cost) is
+        // re-asked at once, not backed off. Skipped outright when every peer
+        // is busy or inside its window, or the pipeline is full — the meta
+        // round-trip and candidate ranking are not free, and a burst of
+        // responses would otherwise pay them once each for nothing. Also
+        // skipped once the restored snapshot is poisoned and no apply has
+        // confirmed it: the pipeline then drains within one request timeout
+        // and the wave-end verdict fires — the old per-round deadline, not a
+        // pool-sized one.
+        let can_ask = in_flight.len() < CATCHUP_FANOUT
+            && pool.has_free_peer(|id| !outstanding.contains_key(id))
+            && !resume.poisoned(0);
+
+        // ── Wave accounting: the pipeline drained and nothing can refill it.
+        if wave_active && in_flight.is_empty() && !can_ask {
             wave_active = false;
             if resume.poisoned(0) {
                 // Restored snapshot can't verify anything (no apply confirmed
@@ -2425,17 +2441,6 @@ async fn catch_up(
         }
 
         // ── Top-up: hand every free, quota-refilled candidate an ask.
-        // Skipped outright when no slot can be filled (every peer busy or
-        // inside its window, or the pipeline full) — the meta round-trip and
-        // candidate ranking are not free, and a burst of responses would
-        // otherwise pay them once each for nothing. Also skipped once the
-        // restored snapshot is poisoned and no apply has confirmed it: the
-        // pipeline then drains within one request timeout and the wave-end
-        // verdict above fires — the old per-round deadline, not a pool-sized
-        // one.
-        let can_ask = in_flight.len() < CATCHUP_FANOUT
-            && pool.has_free_peer(|id| !outstanding.contains_key(id))
-            && !resume.poisoned(0);
         if can_ask {
             let reqresp::CatchupPeerMeta { mut lc_servers, earliest_slots, agents } =
                 client.catchup_peer_meta().await;
@@ -2476,20 +2481,30 @@ async fn catch_up(
                 })
                 .map(|(id, _)| id)
                 .collect();
-            // Busy peers are skipped inside candidates(); the never-starve
-            // fallback there ignores cooldowns, so the quota window is
-            // re-checked here: asking a peer inside its window just earns an
-            // empty answer and another cooldown — the self-inflicted drought
-            // the old global pace existed to avoid.
+            // candidates() honours the busy set as `skip` in its main tiers,
+            // but its LAST-RESORT tier ignores `skip` (issue #291) and its
+            // never-starve tier ignores cooldowns, so both are re-checked
+            // here: a peer with an ask outstanding is never asked twice, and
+            // asking a peer inside its quota window just earns an empty
+            // answer and another cooldown — the self-inflicted drought the
+            // old global pace existed to avoid. The too-shallow filter is
+            // the STRONG PREFERENCE the comment above describes: shallow
+            // peers are asked only when no deeper free peer exists (the #291
+            // fallback the old code got from candidates() itself — a hard
+            // veto here left a pool of checkpoint-synced peers with zero
+            // asks and no exit).
             let busy: HashSet<PeerId> = outstanding.keys().copied().collect();
             let candidates = pool.candidates(CATCHUP_FANOUT, true, true, &lc_servers, &busy);
             if candidates.is_empty() && in_flight.is_empty() {
                 tracing::warn!("catch-up: no peers available — retrying after discovery");
                 return false;
             }
-            let free: Vec<Peer> = candidates
+            let (deep, shallow): (Vec<Peer>, Vec<Peer>) = candidates
                 .into_iter()
-                .filter(|p| pool.cooled_down(&p.id) && !too_shallow.contains(&p.id))
+                .filter(|p| !busy.contains(&p.id) && pool.cooled_down(&p.id))
+                .partition(|p| !too_shallow.contains(&p.id));
+            let free: Vec<Peer> = if deep.is_empty() { shallow } else { deep }
+                .into_iter()
                 .take(CATCHUP_FANOUT - in_flight.len())
                 .collect();
             // Coverage of the span by outstanding single asks, for the
@@ -2637,7 +2652,7 @@ async fn catch_up(
                     if !pool.is_static(&peer.id) {
                         clcache.mark_nolc(&peer_key);
                     }
-                } else if e == RequestError::ConnectionClosed && !single {
+                } else if e == RequestError::ConnectionClosed && !single && sub_count > 1 {
                     // NOT a dead peer: Lighthouse enforces its updates_by_range
                     // quota by closing the stream on any multi-count request
                     // while answering count=1 fine (verified live, v8.2.2).
@@ -2646,6 +2661,10 @@ async fn catch_up(
                     // rotation steers traffic straight at them. Remember to
                     // ask this peer one period at a time instead, and cost it
                     // nothing: the next top-up hands it a look-ahead period.
+                    // The signature is a MULTI-count ask being closed — a
+                    // span-1 batch ask has count 1 and its close is an
+                    // ordinary failure (a batch server that blips at a period
+                    // rollover must not be degraded to count=1 for good).
                     pool.mark_single_period(peer.id);
                     tracing::debug!(peer = %peer.id, sub_count,
                         "closed on a multi-period ask — will request one period at a time");

--- a/rust/myotis-net/src/sync.rs
+++ b/rust/myotis-net/src/sync.rs
@@ -851,6 +851,16 @@ struct PeerPool {
     /// verify-reject rotation steers toward. Nimbus-class servers stay on the
     /// big span (one answered five periods in a single batch).
     single_period_peers: HashSet<PeerId>,
+    /// Peers whose ONE response applied two or more periods (verified) in a
+    /// single catch-up round — Nimbus/Lodestar/roost-class servers with no
+    /// per-request quota. They lead the proven tier in `candidates` so a
+    /// month-long walk rides the batch server instead of the Lighthouse peer
+    /// that happens to have served most recently: the proven tier used to
+    /// rank by recency alone, and a count=1 chunk lands first almost every
+    /// round, so the single-period server kept winning and kept ranking
+    /// first — a stable one-period-per-11-s walk with a batch server sitting
+    /// unused in the same pool.
+    batch_servers: HashSet<PeerId>,
     /// Per-peer "don't re-ask updates_by_range until" marks. Live CL peers
     /// rate-limit that protocol to ~one served update per request window; an
     /// immediate re-ask returns an empty stream, so rotate away for a while.
@@ -918,6 +928,7 @@ impl PeerPool {
             cooldown_until: HashMap::new(),
             fail_counts: HashMap::new(),
             single_period_peers: HashSet::new(),
+            batch_servers: HashSet::new(),
             recent_serves: HashMap::new(),
             discv5_table_size: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             sync_start_period: -1,
@@ -1073,6 +1084,33 @@ impl PeerPool {
         self.single_period_peers.contains(id)
     }
 
+    /// Record a VERIFIED multi-period serve (two or more of one response's
+    /// periods applied in one round). Delivery alone does not qualify — a
+    /// peer that streams many unverifiable chunks must not be promoted, the
+    /// same rule `mark_proven` follows.
+    fn mark_batch_server(&mut self, id: PeerId) -> bool {
+        self.batch_servers.insert(id)
+    }
+
+    /// Any batch-capable server currently in the pool (evicted ones don't
+    /// count — they cannot be asked).
+    fn has_batch_server(&self) -> bool {
+        self.peers.iter().any(|p| self.batch_servers.contains(&p.id))
+    }
+
+    /// When the soonest serve-quota / rotation cooldown among pool peers
+    /// expires — the pipeline's wake-up when every server is inside its
+    /// window. None when nobody is cooling down.
+    fn earliest_cooldown_expiry(&self) -> Option<Instant> {
+        let now = Instant::now();
+        self.peers
+            .iter()
+            .filter_map(|p| self.cooldown_until.get(&p.id))
+            .filter(|until| **until > now)
+            .min()
+            .copied()
+    }
+
     fn set_updates_cooldown(&mut self, id: PeerId) {
         self.cooldown_until.insert(id, Instant::now() + UPDATES_SERVE_COOLDOWN);
     }
@@ -1214,12 +1252,18 @@ impl PeerPool {
         // even when the proven set outgrows `n` and carries servers that are
         // flagged capable but currently at capacity. Never-served proven
         // peers keep their pool order after the recent ones (stable sort).
+        // Proven BATCH servers lead the tier regardless of recency (see
+        // `batch_servers`): a bounded batch must always carry the peer that
+        // can answer the whole span in one response.
         let mut tier1: Vec<&Peer> = self
             .peers
             .iter()
             .filter(|p| self.proven.contains(&p.id) && ok(self, &p.id))
             .collect();
-        tier1.sort_by_key(|p| std::cmp::Reverse(self.recent_serves.get(&p.id).copied()));
+        tier1.sort_by_key(|p| {
+            (!self.batch_servers.contains(&p.id),
+             std::cmp::Reverse(self.recent_serves.get(&p.id).copied()))
+        });
         for p in tier1 {
             if out.len() >= n {
                 break;
@@ -1556,6 +1600,11 @@ async fn run_sync(
     let mut hunt_probed: HashMap<PeerId, Instant> = HashMap::new();
     let mut hunt_confirmed: HashSet<PeerId> = HashSet::new();
     let mut hunting = false;
+    // Raised by catch_up when the walk is throughput-bound on a few
+    // quota-limited servers with a long span ahead (see
+    // update_throughput_hunt); keeps hunt_due from disengaging the hunt that
+    // catch_up raised for it.
+    let mut throughput_bound = false;
     // Store-progress tracking for the starved-catch-up trigger: any advance
     // of (period, finalized slot) resets the stall clock.
     let mut last_progress = Instant::now();
@@ -1577,6 +1626,7 @@ async fn run_sync(
             processor.store.is_initialized(),
             sync_started.elapsed(),
             last_progress.elapsed(),
+            throughput_bound,
             config.current_slot_estimate(),
             processor.store.current_period(),
             processor.store.finalized_slot(),
@@ -1710,7 +1760,8 @@ async fn run_sync(
             }
             let poisoned = catch_up(&config, &client, &mut pool, &mut processor, &status_tx,
                 &mut peer_rx, &mut staged_updates, &mut clcache, &mut resume,
-                &mut last_persisted_period, &anchor, &hunt_confirmed, hunting)
+                &mut last_persisted_period, &anchor, &mut hunt_confirmed, &mut hunt_probed,
+                &mut hunting, &discovery_cfg.hunt_boost, &mut throughput_bound)
                 .await;
             // Batch-persist every cache verdict from the catch-up rounds in
             // one write, OFF the per-peer hot path (review: no blocking I/O
@@ -2096,8 +2147,14 @@ const HUNT_REPROBE: Duration = Duration::from_secs(600);
 /// (the store period falls behind but the starvation is the same).
 const HUNT_CATCHUP_STALL: Duration = Duration::from_secs(120);
 
-/// Should the LC hunt run this cycle? Three triggers, all meaning "we are
-/// starved of light-client servers":
+/// Should the LC hunt run this cycle? Four triggers, all meaning "we are
+/// starved of light-client servers" (or of the RIGHT servers):
+/// - **Throughput-bound catch-up** (`throughput_bound`, raised by
+///   `catch_up` itself): the walk is progressing, but off a handful of
+///   quota-limited single-period servers with a long span still ahead. Not
+///   a stall, so the progress clock never fires — yet only MORE servers
+///   (ideally a batch-capable one) can speed it up, and only discovery +
+///   probing can find them.
 /// - **Bootstrap stall**: the store never initialized and we've been trying
 ///   longer than [`HUNT_BOOTSTRAP_STALL`] — bootstrap itself can't find a
 ///   server.
@@ -2122,6 +2179,7 @@ fn hunt_due(
     store_initialized: bool,
     since_sync_start: Duration,
     since_progress: Duration,
+    throughput_bound: bool,
     wall_slot: u64,
     store_period: u64,
     finalized_slot: u64,
@@ -2133,7 +2191,7 @@ fn hunt_due(
     }
     let wall_period = spec::compute_sync_committee_period_with(wall_slot, slots_per_period);
     if wall_period > store_period {
-        return since_progress >= HUNT_CATCHUP_STALL;
+        return throughput_bound || since_progress >= HUNT_CATCHUP_STALL;
     }
     let slack_epochs =
         if engaged { SYNCED_SLOT_SLACK_EPOCHS - 1 } else { SYNCED_SLOT_SLACK_EPOCHS };
@@ -2146,16 +2204,59 @@ fn hunt_due(
 /// per call with a 12 s outer cycle.
 const CATCHUP_MAX_IDLE_ROUNDS: u32 = 6;
 
-/// Catch the store's committee period up to wall clock — the behavioral twin
-/// of the Java `catchUpSyncCommittee`/`attemptCatchUpBatch`/
-/// `applyCatchUpResponses`: every fan-out peer gets the SAME
-/// `(current_period, count ≤ 128)` range request in parallel, so any single
-/// successful response starts with the EARLIEST missing period (the whole
-/// pipeline's bottleneck — the committee chain admits no gaps). Response
-/// chunks are staged at consecutive periods (a mislabeled chunk just fails
-/// verification at apply time and gets refetched) and the contiguous prefix
-/// is verified+applied as it forms, `force_rotate_if_past_period` after each
-/// applied update, exactly like the Java.
+/// Outstanding single-period asks the PREFIX period is allowed at once.
+/// The prefix is the pipeline's bottleneck (the committee chain admits no
+/// gaps), so it is never left to one server: the 2026-07-06 disjoint-range
+/// experiment did exactly that and stalled on mostly-unserving peers. Every
+/// batch-capable peer asks for it as well; look-ahead periods get one ask.
+const PREFIX_REDUNDANCY: usize = 2;
+
+/// Fewer distinct peers than this serving in the last minute — with no
+/// batch-capable server known and `THROUGHPUT_HUNT_MIN_SPAN` periods still
+/// ahead — means the walk is throughput-bound on a handful of quota-limited
+/// servers, and the LC hunt engages to find more (see
+/// `update_throughput_hunt`). Four single-period servers give ~4 periods per
+/// quota window, a month of mainnet in ~1 minute.
+const THROUGHPUT_HUNT_MIN_SERVERS: usize = 4;
+
+/// Periods still ahead below which a throughput-bound walk is left alone:
+/// with two or three periods left, a hunt cannot pay for itself.
+const THROUGHPUT_HUNT_MIN_SPAN: u64 = 3;
+
+/// Catch the store's committee period up to wall clock.
+///
+/// A PIPELINE, not a round: one long-lived set of in-flight `updates_by_range`
+/// asks is topped up every time a response lands, so the walk runs at the
+/// POOL's aggregate serve rate instead of one server's. Two ask shapes coexist:
+///
+/// - **Batch-capable peers** (anything not known to truncate) are asked for
+///   the PREFIX period with the full remaining span — the Java
+///   `attemptCatchUpBatch` shape, kept because the prefix is the pipeline's
+///   bottleneck (the committee chain admits no gaps) and must be redundantly
+///   requested. A multi-count ask is never cancelled behind a faster
+///   single-period answer: it stays in flight across top-ups, so a
+///   Nimbus/roost batch lands whenever it finishes and is drained in order.
+/// - **Single-period servers** (Lighthouse enforces one `updates_by_range`
+///   per ~10 s per peer, `agent_serves_one_period` / `single_period_peers`)
+///   each get a DISTINCT look-ahead period: the prefix up to
+///   `PREFIX_REDUNDANCY` times, then the lowest period nobody has staged or
+///   asked for (`next_single_target`). After serving they sit out one
+///   `UPDATES_SERVE_COOLDOWN` — a PER-PEER quota mark, which replaces the old
+///   global pace: ten such servers now deliver ten periods per quota window
+///   where the round-and-sleep loop delivered one, and with a single server
+///   the cadence is unchanged (the quota wait below is that server's refill).
+///
+/// Response chunks are staged at consecutive periods (a mislabeled chunk just
+/// fails verification at apply time and gets refetched) and the contiguous
+/// prefix is verified+applied as it forms, `force_rotate_if_past_period`
+/// after each applied update, exactly like the Java.
+///
+/// The disjoint-range experiment of 2026-07-06 performed worse because it
+/// handed the prefix to ONE mostly-unserving peer. Here the prefix keeps every
+/// batch-capable peer plus `PREFIX_REDUNDANCY` single servers; only the
+/// look-ahead is spread, and a look-ahead ask that fails simply frees its
+/// period for the next top-up.
+#[allow(clippy::too_many_arguments)]
 async fn catch_up(
     config: &ChainConfig,
     client: &ReqRespClient,
@@ -2171,53 +2272,127 @@ async fn catch_up(
     resume: &mut ResumeGuard,
     last_persisted_period: &mut u64,
     anchor: &ExecAnchor,
-    hunt_confirmed: &HashSet<PeerId>,
-    hunting: bool,
+    // Hunt state, shared with the outer loop: `catch_up` runs for many cycles
+    // before returning, so a walk that turns out to be THROUGHPUT-bound (few
+    // servers, none batch-capable, a long span ahead) must engage the hunt
+    // from IN HERE — boost flag plus tail probing in the quota-wait window —
+    // and the outer loop's `hunt_due` must see the verdict
+    // (`throughput_bound`) so its next pass does not disengage it.
+    // `hunt_probed` / `hunt_confirmed` are the probe bookkeeping `hunt_round`
+    // needs.
+    hunt_confirmed: &mut HashSet<PeerId>,
+    hunt_probed: &mut HashMap<PeerId, Instant>,
+    hunting: &mut bool,
+    hunt_boost: &AtomicBool,
+    throughput_bound: &mut bool,
 ) -> bool {
+    type Answer = (Peer, u64, u64, Result<Vec<u8>, RequestError>);
+    // The pipeline: every outstanding ask, across top-ups. Boxed because each
+    // top-up's async block is its own anonymous type.
+    let mut in_flight: FuturesUnordered<futures::future::BoxFuture<'static, Answer>> =
+        FuturesUnordered::new();
+    // Peers with an ask outstanding — never asked twice concurrently.
+    let mut busy: HashSet<PeerId> = HashSet::new();
+    // Outstanding SINGLE-period asks per target period (multi-count asks all
+    // start at the prefix and are not counted: they are redundancy plus the
+    // batch chance, never something a look-ahead relies on).
+    let mut covered: HashMap<u64, usize> = HashMap::new();
+    // A "wave" is the life of the pipeline from empty to empty again: the
+    // unit of idle/backoff and poison accounting (the old round). Top-ups
+    // inside a wave keep it alive; it ends only when nothing is outstanding
+    // and nobody free is left to ask.
+    let mut wave_active = false;
+    let mut wave_progress = false; // staged grew or a period applied
+    let mut wave_applied = 0usize;
+    let mut wave_poisoned = false;
+    let mut wave_rejects = 0usize;
+    let mut last_reject_participants: Option<usize> = None;
     let mut idle_rounds = 0u32;
-    // Exponential pause after fruitless rounds: hammering the whole pool every
-    // ~13 s is exactly what CL peer scoring penalizes, and it burns request
-    // quota on servers that will serve happily a minute later.
+    // Exponential pause after fruitless waves: hammering the whole pool every
+    // few seconds is exactly what CL peer scoring penalizes, and it burns
+    // request quota on servers that will serve happily a minute later.
     let mut empty_backoff = Duration::from_secs(0);
-    // Pace after a SUCCESSFUL round instead of re-asking instantly: LC servers
-    // (Lighthouse) serve ~one update per ~10 s quota window, so the instant
-    // re-ask always came back empty — which put the just-serving peer on
-    // cooldown, rotated the fan-out to non-servers, and climbed the 5→40 s
-    // empty-round backoff ladder. Observed on-device: 20–95 s per period
-    // where the quota allows ~11 s. Sleeping one quota window keeps the
-    // serving peer in the next round's fan-out with its quota refilled.
-    let mut pace_after_apply = false;
+    // Whether THIS call raised `hunting`, so it can lower it again when the
+    // pool stops being throughput-bound (a hunt engaged by the outer loop for
+    // another reason stays the outer loop's to disengage).
+    let mut hunt_engaged_here = false;
+
     loop {
         drain_discovered(peer_rx, pool);
         let slot_estimate = config.current_slot_estimate();
         let wall_period =
-        spec::compute_sync_committee_period_with(slot_estimate, config.slots_per_period());
+            spec::compute_sync_committee_period_with(slot_estimate, config.slots_per_period());
         // Start from the committee's own period, NOT the finalized slot's:
         // after a force-rotate the two diverge by one period (see the Java
         // comment in catchUpSyncCommittee).
         let committee_period = processor.store.current_period();
         if wall_period <= committee_period {
             tracing::info!(period = committee_period, "sync committee is current");
+            // The walk is over; the outer loop's hunt_due re-evaluates the
+            // hunt on its own triggers from here. Outstanding asks are
+            // dropped with `in_flight` — their periods are all applied.
+            *throughput_bound = false;
             return false;
-        }
-        // Sleeps AFTER the done-check: the final applied round must not pay
-        // an 11 s pace (or a backoff) just to discover there is no next
-        // request to protect — SYNCED publishes immediately.
-        if pace_after_apply {
-            pace_after_apply = false;
-            tracing::info!(pace_s = UPDATES_SERVE_COOLDOWN.as_secs(),
-                "catch-up: pacing to the LC serve quota before the next round");
-            tokio::time::sleep(UPDATES_SERVE_COOLDOWN).await;
-        } else if !empty_backoff.is_zero() {
-            tracing::info!(backoff_s = empty_backoff.as_secs(),
-                "catch-up: no progress last round — backing off before retrying");
-            tokio::time::sleep(empty_backoff).await;
         }
         *staged = staged.split_off(&committee_period); // drop already-passed periods
         let span = (wall_period - committee_period).min(UPDATES_BATCH_MAX);
-        tracing::info!(from_period = committee_period, wall_period, span,
-            staged = staged.len(), "catch-up: requesting updates_by_range");
 
+        // ── Wave accounting: the pipeline drained without a top-up refilling it.
+        if wave_active && in_flight.is_empty() {
+            wave_active = false;
+            if wave_poisoned && wave_applied == 0 {
+                return true; // whole wave rejected — restored snapshot can't verify anything
+            }
+            if wave_progress {
+                idle_rounds = 0;
+                empty_backoff = Duration::from_secs(0);
+            } else {
+                idle_rounds += 1;
+                if wave_rejects > 0 {
+                    // Loud on purpose (hosts keep info+ only in their log
+                    // rings): a wave whose staged update for the target period
+                    // keeps failing verification is how a serving peer holding
+                    // a weak update stalls catch-up INDEFINITELY — exactly this
+                    // shape hid a server-side weak-participation update
+                    // (113/512 signers at mainnet period 1840) behind
+                    // debug-only logs for days. The per-check reason logs at
+                    // debug in myotis_consensus::store. (Counts verify-rejects
+                    // only; a chunk that fails DECODE stays debug —
+                    // apply_staged_step reports it as neither applied nor
+                    // rejected, because malformed frames say nothing about our
+                    // store or the period's data.)
+                    tracing::warn!(period = committee_period, rejects = wave_rejects,
+                        idle_rounds, participants = ?last_reject_participants,
+                        "catch-up: staged update for the target period failed verification — \
+                         below-2/3 participants means the serving peer holds a weak update");
+                }
+                if idle_rounds >= CATCHUP_MAX_IDLE_ROUNDS {
+                    tracing::warn!(period = committee_period, idle_rounds,
+                        "catch-up made no progress — returning to the poll loop");
+                    return false;
+                }
+                // Grow the pre-wave pause 5s → 25s: rapid-fire empty waves
+                // burn server quota and our own peer score, but with per-peer
+                // quota marks preventing self-inflicted empties, the waves
+                // that reach here are genuine server droughts — and a 60 s
+                // ceiling meant up to a minute of blindness after a server
+                // RETURNED (droughts dominated measured cold syncs). 25 s
+                // samples recovery twice as fast at bounded quota cost:
+                // CATCHUP_MAX_IDLE_ROUNDS exits to the outer poll loop after
+                // 6 fruitless waves either way.
+                empty_backoff = if empty_backoff.is_zero() {
+                    Duration::from_secs(5)
+                } else {
+                    (empty_backoff * 2).min(Duration::from_secs(25))
+                };
+                tracing::info!(backoff_s = empty_backoff.as_secs(), idle_rounds,
+                    "catch-up: no progress last wave — backing off before retrying");
+                tokio::time::sleep(empty_backoff).await;
+                continue; // re-read the clock and discovery before asking again
+            }
+        }
+
+        // ── Top-up: hand every free, quota-refilled candidate an ask.
         let reqresp::CatchupPeerMeta { mut lc_servers, earliest_slots, agents } =
             client.catchup_peer_meta().await;
         // Reconcile the deny set against the LIVE Identify signal (same protocol
@@ -2256,392 +2431,396 @@ async fn catch_up(
             })
             .map(|(id, _)| id)
             .collect();
-        let peers = pool.candidates(CATCHUP_FANOUT, true, true, &lc_servers, &too_shallow);
-        if peers.is_empty() {
+        let candidates = pool.candidates(CATCHUP_FANOUT, true, true, &lc_servers, &too_shallow);
+        if candidates.is_empty() && in_flight.is_empty() {
             tracing::warn!("catch-up: no peers available — retrying after discovery");
             return false;
         }
-
-        // Every peer gets the SAME (committee_period, span) request — the Java
-        // attemptCatchUpBatch fan-out, kept deliberately: the prefix period is
-        // the whole pipeline's bottleneck, so it must be redundantly requested;
-        // any single good response advances it. (A staggered disjoint-range
-        // variant was tried live 2026-07-06 and performed WORSE — it made the
-        // prefix a single point of failure among mostly-unserving peers.)
-        let mut ssz_request = Vec::with_capacity(16);
-        ssz_request.extend_from_slice(&committee_period.to_le_bytes());
-        ssz_request.extend_from_slice(&span.to_le_bytes());
-        let wire = codec::encode_request(&ssz_request);
-
-        // count=1 variant for quota-limited servers (see single_period_peers).
-        let mut single_ssz = Vec::with_capacity(16);
-        single_ssz.extend_from_slice(&committee_period.to_le_bytes());
-        single_ssz.extend_from_slice(&1u64.to_le_bytes());
-        let single_wire = codec::encode_request(&single_ssz);
-        // Snapshot: the closures below cannot borrow `pool` (it is mutated as
-        // responses land).
-        let pool_wants_single: HashSet<PeerId> = peers
-            .iter()
-            .filter(|p| pool.wants_single_period(&p.id))
-            .map(|p| p.id)
-            .collect();
-
-        let staged_before = staged.len();
-        let mut poisoned_this_round = false;
-        let mut round_rejects = 0usize;
-        let mut last_reject_participants: Option<usize> = None;
-        let mut in_flight: FuturesUnordered<_> = peers
+        // Free = not already asked, and outside its serve-quota window.
+        // candidates() respects cooldowns in its main pass but its
+        // never-starve fallback does not, so filter here too: asking a peer
+        // inside its quota window just earns an empty answer and another
+        // cooldown — the self-inflicted drought the old global pace existed
+        // to avoid.
+        let free: Vec<Peer> = candidates
             .into_iter()
-            .map(|peer| {
-                let client = client.clone();
-                // Same START period for every peer — see the fan-out comment
-                // above; the prefix period is the pipeline's bottleneck and must
-                // be redundantly requested. The COUNT is per-peer: a server that
-                // closed on a multi-period ask (Lighthouse's quota) is asked for
-                // exactly one, so it can serve instead of being struck out.
-                // Lighthouse gets count=1 from the FIRST ask (its quota makes a
-                // multi-count request yield one chunk then a closed stream); the
-                // reactive single_period_peers mark covers clients we don't know.
-                let single = pool_wants_single.contains(&peer.id)
-                    || agent_serves_one_period(agents.get(&peer.id).map(String::as_str));
-                let (sub_from, sub_count) = (committee_period, if single { 1 } else { span });
-                tracing::debug!(peer = %peer.id, sub_count,
-                    agent = agents.get(&peer.id).map(String::as_str).unwrap_or("?"),
-                    "catch-up: updates_by_range request");
-                let wire = if single { single_wire.clone() } else { wire.clone() };
-                async move {
-                    let res = client
-                        .request_raw(peer.id, peer.addr.clone(), protocols::UPDATES_BY_RANGE, wire)
-                        .await;
-                    (peer, sub_from, sub_count, res)
-                }
-            })
+            .filter(|p| !busy.contains(&p.id) && pool.cooled_down(&p.id))
+            .take(CATCHUP_FANOUT.saturating_sub(in_flight.len()))
             .collect();
-
-        // Collect responses into the staging buffer: chunk i of a response is
-        // staged at its request's sub_from + i (responses are consecutive per
-        // spec; a peer that violates that just fails verify at apply time).
-        // The contiguous prefix is applied AS RESPONSES ARRIVE; the round runs
-        // until every sub-range answered or the span is fully staged — with
-        // disjoint ranges, stragglers carry periods nobody else was asked for.
-        let mut applied = 0usize;
-        while let Some((peer, sub_from, sub_count, res)) = in_flight.next().await {
-            let raw = match res {
-                Ok(raw) => raw,
-                Err(e) => {
-                    if e == RequestError::UnsupportedProtocol {
-                        // Doesn't serve updates_by_range at all — skip in future
-                        // batches (Java peersNoLcUpdates). Peer is alive, keep it.
-                        // Both are no-ops for a static peer: the pool exempts it,
-                        // and the shared cache is read by the Java engine, which
-                        // would otherwise inherit the denial for a curated peer
-                        // (PR #322 review) — so gate the persist on it too.
-                        pool.mark_no_lc_updates(peer.id);
-                        if !pool.is_static(&peer.id) {
-                            clcache.mark_nolc(&format!("{}/p2p/{}", peer.addr, peer.id));
-                        }
-                    } else if e == RequestError::ConnectionClosed && sub_count > 1 {
-                        // NOT a dead peer: Lighthouse enforces its
-                        // updates_by_range quota by closing the stream on any
-                        // multi-count request while answering count=1 fine
-                        // (verified live, v8.2.2). Charging a failure here would
-                        // three-strike the entire Lighthouse-class population —
-                        // and the verify-reject rotation steers traffic straight
-                        // at them. Remember to ask this peer one period at a
-                        // time instead, and cost it nothing.
-                        pool.mark_single_period(peer.id);
-                        tracing::debug!(peer = %peer.id, sub_count,
-                            "closed on a multi-period ask — will request one period at a time");
-                    } else if e != RequestError::Shutdown {
-                        // Dial/timeout/connection-closed — count toward eviction
-                        // so dead peers stop occupying MAX_POOL slots.
-                        pool.note_failure(peer.id);
-                        clcache.mark_failure(&format!("{}/p2p/{}", peer.addr, peer.id));
-                    }
-                    tracing::debug!(peer = %peer.id, error = %e, "updates_by_range failed");
-                    continue;
+        let (mut asked_single, mut asked_multi, mut look_ahead_to) = (0usize, 0usize, committee_period);
+        for peer in free {
+            // The COUNT is per-peer: a server that closed on a multi-period ask
+            // (Lighthouse's quota) is asked for exactly one, so it can serve
+            // instead of being struck out. Lighthouse gets count=1 from the
+            // FIRST ask (its quota makes a multi-count request yield one chunk
+            // then a closed stream); the reactive single_period_peers mark
+            // covers clients we don't know.
+            let single = pool.wants_single_period(&peer.id)
+                || agent_serves_one_period(agents.get(&peer.id).map(String::as_str));
+            let (sub_from, sub_count) = if single {
+                match next_single_target(committee_period, span, staged, &covered) {
+                    Some(target) => (target, 1u64),
+                    None => continue, // every period is staged or already asked
                 }
+            } else {
+                (committee_period, span)
             };
-            if raw.len() < 64 {
-                // Tiny frames are peers closing without serving (0 B) or sending
-                // near-empty chunks; dumped verbatim at debug for peer forensics.
-                tracing::debug!(peer = %peer.id, raw_len = raw.len(),
-                    hex = %raw.iter().map(|b| format!("{b:02x}")).collect::<String>(),
-                    "small updates_by_range frame");
+            if single {
+                *covered.entry(sub_from).or_insert(0) += 1;
+                asked_single += 1;
+                look_ahead_to = look_ahead_to.max(sub_from);
+            } else {
+                asked_multi += 1;
             }
-            let peer_key = format!("{}/p2p/{}", peer.addr, peer.id);
-            let chunks = match codec::decode_multi_chunk_response(&raw, sub_count as usize) {
-                Ok(c) => c,
-                Err(e) => {
-                    // Undecodable response — with the codec's read budget this
-                    // is also where a byte-dribbling peer lands (it used to hit
-                    // the behaviour timeout instead). Charge it the same way so
-                    // 3-strike eviction still prunes peers that never produce
-                    // a usable chunk.
+            busy.insert(peer.id);
+            let mut ssz_request = Vec::with_capacity(16);
+            ssz_request.extend_from_slice(&sub_from.to_le_bytes());
+            ssz_request.extend_from_slice(&sub_count.to_le_bytes());
+            let wire = codec::encode_request(&ssz_request);
+            tracing::debug!(peer = %peer.id, sub_from, sub_count,
+                agent = agents.get(&peer.id).map(String::as_str).unwrap_or("?"),
+                "catch-up: updates_by_range request");
+            let client = client.clone();
+            in_flight.push(Box::pin(async move {
+                let res = client
+                    .request_raw(peer.id, peer.addr.clone(), protocols::UPDATES_BY_RANGE, wire)
+                    .await;
+                (peer, sub_from, sub_count, res)
+            }));
+        }
+        if asked_single + asked_multi > 0 {
+            tracing::info!(from_period = committee_period, wall_period, span,
+                staged = staged.len(), in_flight = in_flight.len(),
+                asked_single, asked_multi, look_ahead_to,
+                "catch-up: requesting updates_by_range");
+        }
+
+        if in_flight.is_empty() {
+            // Nobody free to ask and nothing outstanding — but servers exist:
+            // they are all inside their serve-quota window. Wait for the
+            // earliest refill (the single-server cadence of the old pace),
+            // and use the wait to probe for MORE servers when the walk is
+            // throughput-bound. Not idle: progress is quota-bound, not
+            // server-bound.
+            let now = Instant::now();
+            let wait = pool
+                .earliest_cooldown_expiry()
+                .map(|until| until.saturating_duration_since(now))
+                .unwrap_or(Duration::ZERO)
+                .clamp(Duration::from_millis(250), UPDATES_SERVE_COOLDOWN);
+            update_throughput_hunt(
+                pool, wall_period, hunting, hunt_boost, throughput_bound, &mut hunt_engaged_here,
+                processor.store.current_period(),
+            );
+            if *throughput_bound {
+                tracing::info!(wait_ms = wait.as_millis() as u64,
+                    "catch-up: every server is inside its serve quota — probing for more servers meanwhile");
+                let (_, _) = tokio::join!(
+                    tokio::time::sleep(wait),
+                    hunt_round(client, pool, processor, clcache, hunt_probed, hunt_confirmed),
+                );
+            } else {
+                tracing::info!(wait_ms = wait.as_millis() as u64,
+                    "catch-up: every server is inside its serve quota — waiting for a refill");
+                tokio::time::sleep(wait).await;
+            }
+            continue;
+        }
+        if !wave_active {
+            wave_active = true;
+            wave_progress = false;
+            wave_applied = 0;
+            wave_poisoned = false;
+            wave_rejects = 0;
+            last_reject_participants = None;
+        }
+
+        // ── One response.
+        let Some((peer, sub_from, sub_count, res)) = in_flight.next().await else {
+            continue;
+        };
+        busy.remove(&peer.id);
+        if sub_count == 1 {
+            if let Some(n) = covered.get_mut(&sub_from) {
+                *n = n.saturating_sub(1);
+                if *n == 0 {
+                    covered.remove(&sub_from);
+                }
+            }
+        }
+        let raw = match res {
+            Ok(raw) => raw,
+            Err(e) => {
+                if e == RequestError::UnsupportedProtocol {
+                    // Doesn't serve updates_by_range at all — skip in future
+                    // asks (Java peersNoLcUpdates). Peer is alive, keep it.
+                    // Both are no-ops for a static peer: the pool exempts it,
+                    // and the shared cache is read by the Java engine, which
+                    // would otherwise inherit the denial for a curated peer
+                    // (PR #322 review) — so gate the persist on it too.
+                    pool.mark_no_lc_updates(peer.id);
+                    if !pool.is_static(&peer.id) {
+                        clcache.mark_nolc(&format!("{}/p2p/{}", peer.addr, peer.id));
+                    }
+                } else if e == RequestError::ConnectionClosed && sub_count > 1 {
+                    // NOT a dead peer: Lighthouse enforces its updates_by_range
+                    // quota by closing the stream on any multi-count request
+                    // while answering count=1 fine (verified live, v8.2.2).
+                    // Charging a failure here would three-strike the entire
+                    // Lighthouse-class population — and the verify-reject
+                    // rotation steers traffic straight at them. Remember to
+                    // ask this peer one period at a time instead, and cost it
+                    // nothing: the next top-up hands it a look-ahead period.
+                    pool.mark_single_period(peer.id);
+                    tracing::debug!(peer = %peer.id, sub_count,
+                        "closed on a multi-period ask — will request one period at a time");
+                } else if e != RequestError::Shutdown {
+                    // Dial/timeout/connection-closed — count toward eviction
+                    // so dead peers stop occupying MAX_POOL slots.
                     pool.note_failure(peer.id);
-                    clcache.mark_failure(&peer_key);
-                    tracing::debug!(peer = %peer.id, raw_len = raw.len(), error = %e,
-                        "updates_by_range frame invalid");
-                    continue;
+                    clcache.mark_failure(&format!("{}/p2p/{}", peer.addr, peer.id));
                 }
-            };
-            let mut served = 0usize;
-            for (i, chunk) in chunks.into_iter().enumerate() {
-                if chunk.is_empty() {
-                    break; // truncated/empty chunk — nothing after it is trustworthy
+                tracing::debug!(peer = %peer.id, error = %e, "updates_by_range failed");
+                continue;
+            }
+        };
+        if raw.len() < 64 {
+            // Tiny frames are peers closing without serving (0 B) or sending
+            // near-empty chunks; dumped verbatim at debug for peer forensics.
+            tracing::debug!(peer = %peer.id, raw_len = raw.len(),
+                hex = %raw.iter().map(|b| format!("{b:02x}")).collect::<String>(),
+                "small updates_by_range frame");
+        }
+        let peer_key = format!("{}/p2p/{}", peer.addr, peer.id);
+        let chunks = match codec::decode_multi_chunk_response(&raw, sub_count as usize) {
+            Ok(c) => c,
+            Err(e) => {
+                // Undecodable response — with the codec's read budget this is
+                // also where a byte-dribbling peer lands (it used to hit the
+                // behaviour timeout instead). Charge it the same way so
+                // 3-strike eviction still prunes peers that never produce a
+                // usable chunk.
+                pool.note_failure(peer.id);
+                clcache.mark_failure(&peer_key);
+                tracing::debug!(peer = %peer.id, raw_len = raw.len(), error = %e,
+                    "updates_by_range frame invalid");
+                continue;
+            }
+        };
+        let mut served = 0usize;
+        for (i, chunk) in chunks.into_iter().enumerate() {
+            if chunk.is_empty() {
+                break; // truncated/empty chunk — nothing after it is trustworthy
+            }
+            served += 1;
+            match staged.entry(sub_from + i as u64) {
+                std::collections::btree_map::Entry::Vacant(v) => {
+                    v.insert(StagedChunk {
+                        ssz: chunk,
+                        from: peer_key.clone(),
+                        alternates: Vec::new(),
+                    });
                 }
-                served += 1;
-                match staged.entry(sub_from + i as u64) {
-                    std::collections::btree_map::Entry::Vacant(v) => {
-                        v.insert(StagedChunk {
-                            ssz: chunk,
-                            from: peer_key.clone(),
-                            alternates: Vec::new(),
-                        });
-                    }
-                    std::collections::btree_map::Entry::Occupied(mut o) => {
-                        // Another peer already staged this period: keep this
-                        // copy as a FALLBACK rather than dropping it, so a
-                        // verify-reject on the leader can try someone else's
-                        // (see StagedChunk::alternates). Skip byte-identical
-                        // copies — they would fail verification identically.
-                        let slot = o.get_mut();
-                        if slot.alternates.len() < MAX_STAGED_ALTERNATES
-                            && slot.ssz != chunk
-                            && !slot.alternates.iter().any(|(ssz, _)| *ssz == chunk)
-                        {
-                            slot.alternates.push((chunk, peer_key.clone()));
-                        }
+                std::collections::btree_map::Entry::Occupied(mut o) => {
+                    // Another peer already staged this period: keep this copy
+                    // as a FALLBACK rather than dropping it, so a verify-reject
+                    // on the leader can try someone else's (see
+                    // StagedChunk::alternates). Skip byte-identical copies —
+                    // they would fail verification identically.
+                    let slot = o.get_mut();
+                    if slot.alternates.len() < MAX_STAGED_ALTERNATES
+                        && slot.ssz != chunk
+                        && !slot.alternates.iter().any(|(ssz, _)| *ssz == chunk)
+                    {
+                        slot.alternates.push((chunk, peer_key.clone()));
                     }
                 }
             }
-            if served > 0 {
-                tracing::info!(peer = %peer.id, sub_from, sub_count, served,
-                    raw_len = raw.len(), "updates_by_range served");
-                // A peer that answered DOES serve the protocol, so reverse any
-                // stale nolc verdict — that part is factual. But it is NOT yet
-                // "proven": mark_proven also grants the preferred tier and
-                // wipes fail_counts, and granting that for mere DELIVERY is
-                // what let a fast peer serving an unverifiable update keep
-                // winning selection forever (mainnet 1840). Promotion now
-                // happens only where the update actually VERIFIES, below.
-                //
-                // PARITY (#342): this mirrors the Java reference, which records
-                // a catch-up server ONLY inside `if (applied > 0)` after
-                // processUpdate returned true (BeaconLightClient
-                // .applyCatchUpResponses). The Java engine never had this stall
-                // precisely because it credits verification, not delivery —
-                // keep the two in step.
-                pool.clear_no_lc_for(peer.id);
-                // Deliberately NO cooldown for a peer that just served: it is
-                // often the only willing server in the pool, and the ~13 s
-                // round cadence sits at Lighthouse's ~1-per-10s quota anyway —
-                // the Java client re-asks its serving peer the same way.
-                // Apply at most ONE staged update here — just enough BLS to
-                // decide this response is the round's winner. The rest of the
-                // staged prefix (up to 128 periods from a generous server) is
-                // drained AFTER the fan-out is dropped, so the stragglers'
-                // redundant multi-MiB streams are cancelled behind one
-                // signature verification instead of a full batch of them.
-                let before_period = processor.store.current_period();
-                let step = apply_staged_step(processor, staged, slot_estimate);
-                let (applied_now, verify_rejects, applied_from) =
-                    (step.applied, step.verify_rejects, step.applied_from.clone());
-                // PR #409: carry the participant count into the round WARN so a
-                // below-2/3 stall explains itself.
-                round_rejects += verify_rejects;
-                if let Some(p) = step.reject_participants {
-                    last_reject_participants = Some(p);
+        }
+        if served == 0 {
+            // Unserving answer — NOW the cooldown applies, so the next top-up
+            // rotates toward peers that might actually serve.
+            pool.set_updates_cooldown(peer.id);
+            tracing::debug!(peer = %peer.id, sub_from, sub_count, raw_len = raw.len(),
+                "updates_by_range returned no chunks");
+            continue;
+        }
+        wave_progress = true; // the buffer grew — progress toward the prefix
+        tracing::info!(peer = %peer.id, sub_from, sub_count, served, raw_len = raw.len(),
+            "updates_by_range served");
+        // A peer that answered DOES serve the protocol, so reverse any stale
+        // nolc verdict — that part is factual. But it is NOT yet "proven":
+        // mark_proven also grants the preferred tier and wipes fail_counts,
+        // and granting that for mere DELIVERY is what let a fast peer serving
+        // an unverifiable update keep winning selection forever (mainnet
+        // 1840). Promotion happens only where the update actually VERIFIES,
+        // below.
+        //
+        // PARITY (#342): this mirrors the Java reference, which records a
+        // catch-up server ONLY inside `if (applied > 0)` after processUpdate
+        // returned true (BeaconLightClient.applyCatchUpResponses). The Java
+        // engine never had this stall precisely because it credits
+        // verification, not delivery — keep the two in step.
+        pool.clear_no_lc_for(peer.id);
+        if sub_count == 1 {
+            // Per-peer serve quota: a single-period server that just served
+            // answers empty for the next ~10 s (Lighthouse one_every(10s)),
+            // so sit it out for one window instead of pacing the WHOLE walk
+            // — the other servers' quotas are what the look-ahead spends
+            // meanwhile. Batch servers (multi-count asks) carry no such mark.
+            pool.set_updates_cooldown(peer.id);
+        }
+
+        // ── Apply the contiguous prefix as far as it now reaches. One update
+        // per iteration: persist after EVERY period so an Android kill
+        // mid-drain loses at most one period's BLS work, publish so the
+        // progress bar tracks the drain, and yield so back-to-back BLS
+        // verifications don't pin this worker while the swarm task needs it.
+        // Each period is credited to the peer whose response staged it (not
+        // necessarily this responder: alternates and look-ahead chunks from
+        // earlier responses apply here too — `applied_from` names the source).
+        let mut applied_now_total = 0usize;
+        let mut applied_by: HashMap<PeerId, usize> = HashMap::new();
+        loop {
+            let before_period = processor.store.current_period();
+            let step = apply_staged_step(processor, staged, slot_estimate);
+            wave_rejects += step.verify_rejects;
+            if let Some(p) = step.reject_participants {
+                last_reject_participants = Some(p);
+            }
+            // Charge every peer whose chunk failed verification — by peer KEY,
+            // so the strike lands on whoever actually served the bad copy
+            // rather than on whoever happened to respond last.
+            for bad in &step.rejected_from {
+                if let Some(id) = pool.id_for_key(bad) {
+                    pool.note_verify_reject(id);
+                    clcache.mark_failure(bad);
+                    tracing::warn!(peer = %bad, period = before_period,
+                        "catch-up: update failed verification — peer penalised, \
+                         will try another next round");
                 }
-                // Charge every peer whose chunk failed verification — by peer
-                // KEY, so the strike lands on whoever actually served the bad
-                // copy rather than on whoever happened to respond last.
-                for bad in &step.rejected_from {
-                    if let Some(id) = pool.id_for_key(bad) {
-                        pool.note_verify_reject(id);
-                        clcache.mark_failure(bad);
-                        tracing::warn!(peer = %bad, period = before_period,
-                            "catch-up: update failed verification — peer penalised, \
-                             will try another next round");
-                    }
-                }
-                // ORDER MATTERS: an apply in this batch BLS-verified against
-                // the restored committee and proves the snapshot genuine —
-                // confirm() must win over poison accounting (a reject in the
-                // same batch is a stale/bad chunk another peer staged, not
-                // evidence against the snapshot; counting it first was
-                // exactly how one bad peer could get a good snapshot
-                // deleted despite an honest serve landing in the same round).
-                if applied_now == 0
-                    && verify_rejects > 0
-                    && resume.poisoned(verify_rejects as u32)
+            }
+            if step.applied == 0 {
+                // ORDER MATTERS: an apply BLS-verified against the restored
+                // committee proves the snapshot genuine — confirm() (below,
+                // on the first apply) must win over poison accounting. A
+                // reject with no apply yet is evidence; the verdict is
+                // deferred to wave end so a slower HONEST response can still
+                // confirm the snapshot — a fast bad peer must not win.
+                if applied_now_total == 0
+                    && step.verify_rejects > 0
+                    && resume.poisoned(step.verify_rejects as u32)
                 {
-                    // Defer the verdict to round end: a slower HONEST response
-                    // in this same round can still apply and confirm the
-                    // snapshot — a fast bad peer must not win the race. If an
-                    // apply lands, confirm() resets the guard and the pending
-                    // flag below is ignored.
-                    poisoned_this_round = true;
-                    continue;
+                    wave_poisoned = true;
                 }
-                if applied_now > 0 {
-                    resume.confirm();
-                    // Promotion belongs HERE — to the peer whose update actually
-                    // VERIFIED, which is not necessarily this responder: with
-                    // alternates (and with chunks lingering from earlier
-                    // responses) the applied copy can be someone else's, and
-                    // `applied_from` names its true source. Crediting the
-                    // responder instead would wipe strikes and grant priority
-                    // to a peer that merely delivered bytes (PR #410 review).
-                    let credited = applied_from
-                        .as_deref()
-                        .and_then(|key| pool.id_for_key(key))
-                        .unwrap_or(peer.id);
-                    pool.mark_proven(credited);
-                    pool.note_served(credited); // BLS-verified and applied
-                    // Only VERIFIED periods reach the shared cross-engine
-                    // cache, credited to the peer whose response STAGED the
-                    // applied chunk — usually this responder, but a chunk
-                    // lingering from an earlier response can be the one that
-                    // applies (Java applyCatchUpResponses records AFTER
-                    // processUpdate the same way — never before verification).
-                    if let Some(key) = applied_from.as_deref() {
-                        clcache.record_served(key, before_period, before_period);
-                    }
-                    applied += applied_now;
-                    empty_backoff = Duration::from_secs(0);
-                    // The fastest serving peer won this round — abandon the
-                    // stragglers (identical requests make them redundant) and
-                    // start the next round from the advanced period.
-                    break;
-                }
-            } else {
-                // Unserving answer — NOW the cooldown applies, so the next
-                // round rotates toward peers that might actually serve.
-                pool.set_updates_cooldown(peer.id);
-                tracing::debug!(peer = %peer.id, sub_from, sub_count, raw_len = raw.len(),
-                    "updates_by_range returned no chunks");
+                break;
+            }
+            if applied_now_total == 0 {
+                resume.confirm();
+            }
+            applied_now_total += step.applied;
+            // Promotion belongs to the peer whose update actually VERIFIED —
+            // crediting the responder instead would wipe strikes and grant
+            // priority to a peer that merely delivered bytes (PR #410 review).
+            // Only VERIFIED periods reach the shared cross-engine cache, the
+            // same way (Java applyCatchUpResponses records AFTER processUpdate).
+            let credited = step
+                .applied_from
+                .as_deref()
+                .and_then(|key| pool.id_for_key(key))
+                .unwrap_or(peer.id);
+            pool.mark_proven(credited);
+            pool.note_served(credited); // BLS-verified and applied
+            *applied_by.entry(credited).or_insert(0) += 1;
+            if let Some(key) = step.applied_from.as_deref() {
+                clcache.record_served(key, before_period, before_period);
+            }
+            persist_snapshot(config, processor, last_persisted_period);
+            publish_status(config, client, processor, &*pool, status_tx, anchor, *hunting).await;
+            tokio::task::yield_now().await;
+        }
+        if applied_now_total == 0 {
+            continue; // staged a look-ahead period; the prefix is still outstanding
+        }
+        wave_applied += applied_now_total;
+        tracing::info!(applied = applied_now_total, staged = staged.len(),
+            in_flight = in_flight.len(),
+            period = processor.store.current_period(),
+            finalized_slot = processor.store.finalized_slot(),
+            "catch-up applied");
+        // Promote verified batch servers: two or more periods applied from
+        // one peer's response — preferred by candidates() from now on.
+        for (id, n) in &applied_by {
+            if *n >= 2 && pool.mark_batch_server(*id) {
+                tracing::info!(peer = %id, periods = n,
+                    "catch-up: batch-capable LC server confirmed — preferred from now on");
             }
         }
-        drop(in_flight);
+        update_throughput_hunt(
+            pool, wall_period, hunting, hunt_boost, throughput_bound, &mut hunt_engaged_here,
+            processor.store.current_period(),
+        );
+    }
+}
 
-        if poisoned_this_round && applied == 0 {
-            return true; // whole round rejected — restored snapshot can't verify anything
+/// Engage or release the throughput hunt: a walk with a long span ahead, no
+/// batch-capable server in the pool, and fewer than
+/// `THROUGHPUT_HUNT_MIN_SERVERS` peers serving is going as fast as the few
+/// quota-limited servers allow, and only MORE servers (boosted discovery +
+/// probing the unproven tail) can speed it up. Releases the hunt this call
+/// raised as soon as any of the three conditions stops holding.
+fn update_throughput_hunt(
+    pool: &PeerPool,
+    wall_period: u64,
+    hunting: &mut bool,
+    hunt_boost: &AtomicBool,
+    throughput_bound: &mut bool,
+    hunt_engaged_here: &mut bool,
+    store_period: u64,
+) {
+    let remaining = wall_period.saturating_sub(store_period);
+    let servers = pool.served_last_minute();
+    let bound = remaining >= THROUGHPUT_HUNT_MIN_SPAN
+        && !pool.has_batch_server()
+        && servers < THROUGHPUT_HUNT_MIN_SERVERS;
+    if bound && !*throughput_bound {
+        *throughput_bound = true;
+        if !*hunting {
+            *hunting = true;
+            *hunt_engaged_here = true;
+            hunt_boost.store(true, Ordering::Relaxed);
         }
-
-        if applied > 0 {
-            // Drain the rest of the contiguous staged prefix — a generous
-            // response stages up to the whole remaining span. One update per
-            // iteration: persist after EVERY period so an Android kill
-            // mid-drain loses at most one period's BLS work, not the whole
-            // batch (the ~50 KiB write+rename is milliseconds next to the
-            // ~100 ms BLS verify it checkpoints), publish so the progress bar
-            // tracks the drain instead of jumping at round end, and yield so
-            // back-to-back BLS verifications don't pin this worker while the
-            // swarm task needs it. A verify-reject here is a stale chunk some
-            // other peer staged earlier — the winner already confirmed the
-            // store, so it is dropped for refetch without poison accounting.
-            // Each period is credited to the peer whose response staged it.
-            let mut drained = 0usize;
-            loop {
-                let before_period = processor.store.current_period();
-                let step = apply_staged_step(processor, staged, slot_estimate);
-                let (applied_now, applied_from) = (step.applied, step.applied_from.clone());
-                // Same accounting AND the same WARN as the first apply path:
-                // future-period chunks retained from earlier responders commonly
-                // reject here, and silencing it would leave the Logs tab without
-                // the peer-and-period line this fix promises (PR #410 review).
-                for bad in &step.rejected_from {
-                    if let Some(id) = pool.id_for_key(bad) {
-                        pool.note_verify_reject(id);
-                        clcache.mark_failure(bad);
-                        tracing::warn!(peer = %bad, period = before_period,
-                            "catch-up: update failed verification — peer penalised, \
-                             will try another next round");
-                    }
-                }
-                if applied_now == 0 {
-                    break;
-                }
-                applied += applied_now;
-                drained += 1;
-                if let Some(key) = applied_from.as_deref() {
-                    if let Some(id) = pool.id_for_key(key) {
-                        pool.mark_proven(id);
-                        pool.note_served(id);
-                    }
-                    clcache.record_served(key, before_period, before_period);
-                }
-                persist_snapshot(config, processor, last_persisted_period);
-                publish_status(config, client, processor, &*pool, status_tx, anchor, hunting).await;
-                tokio::task::yield_now().await;
-            }
-            tracing::info!(applied, staged = staged.len(),
-                period = processor.store.current_period(),
-                finalized_slot = processor.store.finalized_slot(),
-                "catch-up round applied");
-            if drained == 0 {
-                // Single-period round (truncating server): the drain didn't
-                // run, so this is the round's one publish+persist. Persisting
-                // every applied period — not just when catch_up returns —
-                // is what keeps an Android kill (reinstall, OOM, user swipe)
-                // from losing every verified period since bootstrap
-                // (observed: 4 periods re-verified after a reinstall).
-                publish_status(config, client, processor, &*pool, status_tx, anchor, hunting).await;
-                persist_snapshot(config, processor, last_persisted_period);
-            }
-            idle_rounds = 0;
-            pace_after_apply = true;
-        } else if staged.len() > staged_before {
-            // No prefix advance yet, but the buffer grew — that's progress
-            // toward unblocking the earliest period; keep going.
-            tracing::debug!(staged = staged.len(), "catch-up staged new periods");
-            idle_rounds = 0;
-            empty_backoff = Duration::from_secs(0);
-        } else {
-            idle_rounds += 1;
-            if round_rejects > 0 {
-                // Loud on purpose (hosts keep info+ only in their log rings): a
-                // round whose staged update for the target period keeps failing
-                // verification is how a serving peer holding a weak update
-                // stalls catch-up INDEFINITELY — exactly this shape hid a
-                // server-side weak-participation update (113/512 signers at
-                // mainnet period 1840) behind debug-only logs for days. The
-                // per-check reason logs at debug in myotis_consensus::store.
-                // (Counts verify-rejects only; a chunk that fails DECODE stays
-                // debug — apply_staged_step reports it as neither applied nor
-                // rejected, because malformed frames say nothing about our
-                // store or the period's data.)
-                tracing::warn!(period = processor.store.current_period(),
-                    rejects = round_rejects, idle_rounds,
-                    participants = ?last_reject_participants,
-                    "catch-up: staged update for the target period failed verification — \
-                     below-2/3 participants means the serving peer holds a weak update");
-            }
-            if idle_rounds >= CATCHUP_MAX_IDLE_ROUNDS {
-                tracing::warn!(period = processor.store.current_period(), idle_rounds,
-                    "catch-up made no progress — returning to the poll loop");
-                return false;
-            }
-            // Grow the pre-round pause 5s → 25s: rapid-fire empty rounds burn
-            // server quota and our own peer score, but with the post-apply
-            // pacing preventing self-inflicted empties, the rounds that reach
-            // here are genuine server droughts — and a 60 s ceiling meant up
-            // to a minute of blindness after a server RETURNED (droughts
-            // dominated measured cold syncs). 25 s samples recovery twice as
-            // fast at bounded quota cost: CATCHUP_MAX_IDLE_ROUNDS exits to
-            // the outer poll loop after 6 fruitless rounds either way, so a
-            // sustained drought cycles at most ~35% more request bursts than
-            // the 60 s ceiling did — it cannot hammer indefinitely faster.
-            empty_backoff = if empty_backoff.is_zero() {
-                Duration::from_secs(5)
-            } else {
-                (empty_backoff * 2).min(Duration::from_secs(25))
-            };
-            tracing::debug!(period = processor.store.current_period(), idle_rounds,
-                "catch-up round made no progress — retrying after backoff");
+        tracing::info!(remaining, servers, pool = pool.len(),
+            "LC hunt engaged — catch-up is throughput-bound on a few single-period \
+             servers; searching for more (batch-capable) servers");
+    } else if !bound && *throughput_bound {
+        *throughput_bound = false;
+        if *hunt_engaged_here {
+            *hunt_engaged_here = false;
+            *hunting = false;
+            hunt_boost.store(false, Ordering::Relaxed);
+            tracing::info!(remaining, servers, batch = pool.has_batch_server(),
+                "LC hunt disengaged — catch-up is no longer throughput-bound");
         }
     }
+}
+
+/// The period a free single-period server should be asked for: the lowest in
+/// `[from, from + span)` that is neither staged nor already covered by enough
+/// outstanding single asks — `PREFIX_REDUNDANCY` for the prefix (the
+/// bottleneck period stays redundantly requested, the lesson of the
+/// 2026-07-06 disjoint-range experiment), one for every look-ahead period.
+/// None when the whole span is staged or asked.
+fn next_single_target(
+    from: u64,
+    span: u64,
+    staged: &std::collections::BTreeMap<u64, StagedChunk>,
+    covered: &HashMap<u64, usize>,
+) -> Option<u64> {
+    (from..from.saturating_add(span)).find(|p| {
+        let want = if *p == from { PREFIX_REDUNDANCY } else { 1 };
+        !staged.contains_key(p) && covered.get(p).copied().unwrap_or(0) < want
+    })
 }
 
 /// Verify+apply AT MOST ONE staged update — the one at the store's current
@@ -3674,31 +3853,111 @@ mod tests {
         let z = Duration::ZERO;
 
         // Bootstrap stall: only after the stall window.
-        assert!(!hunt_due(false, false, Duration::from_secs(10), z, wall, 0, 0, epoch, 8192));
-        assert!(hunt_due(false, false, HUNT_BOOTSTRAP_STALL, z, wall, 0, 0, epoch, 8192));
+        assert!(!hunt_due(false, false, Duration::from_secs(10), z, false, wall, 0, 0, epoch, 8192));
+        assert!(hunt_due(false, false, HUNT_BOOTSTRAP_STALL, z, false, wall, 0, 0, epoch, 8192));
 
         // Finality starvation: period current + finalized older than slack.
-        assert!(hunt_due(false, true, z, z, wall, period, wall - slack - 1, epoch, 8192));
+        assert!(hunt_due(false, true, z, z, false, wall, period, wall - slack - 1, epoch, 8192));
         // Fresh finality → no hunt.
-        assert!(!hunt_due(false, true, z, z, wall, period, wall - 64, epoch, 8192));
+        assert!(!hunt_due(false, true, z, z, false, wall, period, wall - 64, epoch, 8192));
 
         // PROGRESSING catch-up (period behind, store advancing) → no hunt:
         // catch-up's own wide fan-out covers the pool; hunting double-dials.
-        assert!(!hunt_due(false, true, z, z, wall, period - 1, wall - slack - 1, epoch, 8192));
+        assert!(!hunt_due(false, true, z, z, false, wall, period - 1, wall - slack - 1,
+            epoch, 8192));
+        // THROUGHPUT-BOUND catch-up (progressing, but catch_up says the walk
+        // is limited to a few quota-bound servers) → hunt, even with fresh
+        // progress; and the flag means nothing once the period is current.
+        assert!(hunt_due(false, true, z, z, true, wall, period - 1, wall - slack - 1,
+            epoch, 8192));
+        assert!(!hunt_due(false, true, z, z, true, wall, period, wall - 64, epoch, 8192));
         // STARVED catch-up (no store progress past the stall window) → hunt.
-        assert!(hunt_due(false, true, z, HUNT_CATCHUP_STALL, wall, period - 1,
+        assert!(hunt_due(false, true, z, HUNT_CATCHUP_STALL, false, wall, period - 1,
             wall - slack - 1, epoch, 8192));
         // ...and an ENGAGED hunt survives the period boundary the same way
         // (finality starvation rotating into catch-up must not disengage).
-        assert!(hunt_due(true, true, z, HUNT_CATCHUP_STALL, wall, period - 1,
+        assert!(hunt_due(true, true, z, HUNT_CATCHUP_STALL, false, wall, period - 1,
             wall - slack - 1, epoch, 8192));
 
         // Hysteresis on the finality trigger: at staleness between the
         // engaged and disengaged thresholds, an engaged hunt stays on and a
         // disengaged one stays off (no flapping at the boundary).
         let between = wall - slack + epoch - 1; // stale by SLACK-1 epochs + 1 slot
-        assert!(hunt_due(true, true, z, z, wall, period, between, epoch, 8192));
-        assert!(!hunt_due(false, true, z, z, wall, period, between, epoch, 8192));
+        assert!(hunt_due(true, true, z, z, false, wall, period, between, epoch, 8192));
+        assert!(!hunt_due(false, true, z, z, false, wall, period, between, epoch, 8192));
+    }
+
+    #[test]
+    fn batch_servers_lead_the_proven_tier() {
+        let mut pool = PeerPool::new();
+        let mut ids = Vec::new();
+        for i in 0..3u8 {
+            let kp = libp2p::identity::Keypair::generate_secp256k1();
+            let id = kp.public().to_peer_id();
+            ids.push(id);
+            pool.add(id, format!("/ip4/10.0.2.{i}/tcp/9000").parse().unwrap());
+        }
+        for id in &ids {
+            pool.mark_proven(*id);
+        }
+        // ids[2] served most recently (a Lighthouse count=1 winner); ids[0]
+        // is the batch server that served earlier.
+        pool.note_served(ids[0]);
+        std::thread::sleep(Duration::from_millis(5));
+        pool.note_served(ids[2]);
+        assert!(pool.mark_batch_server(ids[0]));
+        assert!(!pool.mark_batch_server(ids[0]), "idempotent: second mark reports nothing new");
+        assert!(pool.has_batch_server());
+        let got: Vec<PeerId> = pool
+            .candidates(3, true, true, &HashSet::new(), &HashSet::new())
+            .into_iter()
+            .map(|p| p.id)
+            .collect();
+        assert_eq!(got[0], ids[0], "batch server first regardless of serve recency");
+        assert_eq!(got[1], ids[2], "then most-recently-served");
+        assert_eq!(got[2], ids[1]);
+    }
+
+    #[test]
+    fn next_single_target_spreads_lookahead_and_keeps_prefix_redundant() {
+        let mut staged = std::collections::BTreeMap::new();
+        let mut covered: HashMap<u64, usize> = HashMap::new();
+        let chunk = || StagedChunk { ssz: vec![1], from: String::new(), alternates: Vec::new() };
+        // Empty pipeline: the prefix first, PREFIX_REDUNDANCY times.
+        assert_eq!(next_single_target(100, 5, &staged, &covered), Some(100));
+        for _ in 0..PREFIX_REDUNDANCY {
+            *covered.entry(100).or_insert(0) += 1;
+        }
+        // Prefix saturated: look-ahead periods, one ask each, in order.
+        assert_eq!(next_single_target(100, 5, &staged, &covered), Some(101));
+        covered.insert(101, 1);
+        assert_eq!(next_single_target(100, 5, &staged, &covered), Some(102));
+        // A staged period is skipped (a look-ahead chunk already landed).
+        staged.insert(102, chunk());
+        assert_eq!(next_single_target(100, 5, &staged, &covered), Some(103));
+        // Whole span covered or staged → nothing to ask.
+        covered.insert(103, 1);
+        staged.insert(104, chunk());
+        assert_eq!(next_single_target(100, 5, &staged, &covered), None);
+        // An ask that came back frees its period again.
+        covered.remove(&101);
+        assert_eq!(next_single_target(100, 5, &staged, &covered), Some(101));
+        // Zero span never asks.
+        assert_eq!(next_single_target(100, 0, &staged, &covered), None);
+    }
+
+    #[test]
+    fn earliest_cooldown_expiry_is_the_pipelines_wakeup() {
+        let mut pool = PeerPool::new();
+        let kp = libp2p::identity::Keypair::generate_secp256k1();
+        let id = kp.public().to_peer_id();
+        pool.add(id, "/ip4/10.0.3.1/tcp/9000".parse().unwrap());
+        assert!(pool.earliest_cooldown_expiry().is_none());
+        pool.set_updates_cooldown(id);
+        let until = pool.earliest_cooldown_expiry().expect("a cooling peer");
+        let left = until.saturating_duration_since(Instant::now());
+        assert!(left <= UPDATES_SERVE_COOLDOWN && left > UPDATES_SERVE_COOLDOWN / 2);
+        assert!(!pool.cooled_down(&id));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The Rust engine's catch-up walked **one period per ~11 s regardless of pool size**. Every round asked all peers for the same prefix period, the first verified apply won and cancelled the rest (so a Nimbus/roost batch response never landed behind a Lighthouse `count=1` chunk), then the whole loop slept one serve quota. Observed on every cold sync today (sepolia, phone and desktop): 28 rounds × ~11 s with two Lighthouse peers alternating as winner and the second peer's quota never spent.

## Change (`rust/myotis-net/src/sync.rs`, `catch_up`)

A pipeline instead of round-and-sleep:

- **One long-lived in-flight set**, topped up whenever a response lands **or a serve quota refills** (the wait races `in_flight.next()` against the earliest cooldown expiry). Multi-count asks stay in flight across top-ups, so a batch response is drained when it finishes instead of being cancelled.
- **Per-peer quota instead of a global pace.** A single-period server (Lighthouse's `one_every(10s)`) takes an `UPDATES_SERVE_COOLDOWN` mark after it serves; each free single-period server gets a **distinct look-ahead period** (`next_single_target`: the prefix up to `PREFIX_REDUNDANCY=2` times, then the lowest period nobody staged or asked). K such servers now deliver K periods per quota window; one server is unchanged.
- **Batch servers** (two or more periods applied from one multi-count response) are remembered and lead the proven tier. Outstanding batch asks are capped (`CATCHUP_MULTI_MAX=4`).
- **Throughput-bound hunt.** When the pipeline runs dry on quotas with a long span ahead, no batch server, and fewer than 4 peers serving, the LC hunt engages (discovery boost + tail probing bounded by the wait), with hysteresis on release; `hunt_due` keeps it engaged via the new `throughput_bound` input. One `HuntState` owns the flag and its boost mirror.
- Kept: prefix redundancy (the 2026-07-06 disjoint-range lesson), verify-only credit (#342/#410), alternates, poison/resume semantics (per wave), per-period persist+publish, the idle/backoff ladder, nolc/single-period/failure marks and the cache verdicts. Failures and nolc verdicts now take a cooldown so a restarting server is not three-struck in a second.
- `codec::encode_updates_by_range_request` is the one home of the request shape.
- **Java engine untouched**; a DIVERGENCE note sits on `CATCHUP_QUOTA_PACE_MS`.

## Review

Internal 8-angle review of the first cut found five substantive issues (progress credited on delivery, responder-fallback credit promoting single-period peers to batch, refilled servers idling behind a slow batch stream, zero-cost failure re-asks making the idle exit unreachable, split hunt ownership leaking a raised hunt) plus a batch-ask cap and a span-1 ambiguity — all fixed in the second commit.

Unit tests: 355 pass (`cargo test -p myotis-net --lib`), including new ones for `next_single_target`, batch-tier ordering, `earliest_cooldown_expiry`, `throughput_bound_verdict` hysteresis and evict clearing the marks. Clippy could not run locally (the toolchain's clippy resolves to rustc 1.77, below the workspace floor); CI covers it.

## Follow-ups (not in this PR)
- A live/smoke assertion on periods-per-minute with ≥2 servers, so a regression to serial behaviour cannot pass unnoticed.
- Porting the per-peer quota to the Java engine, or accepting the divergence (owner's call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)