### PR TITLE
rpc: hold verified reads only while the node is waking; slow-call watchdog (#312)

### DIFF
--- a/app-desktop/src/main/resources/logback-desktop.xml
+++ b/app-desktop/src/main/resources/logback-desktop.xml
@@ -59,6 +59,10 @@
          already; pinned here so it's discoverable and can go to DEBUG (full req/resp
          bodies) independently of the app/wire levels. In the Logs tab, filter on "rpc". -->
     <logger name="io.myotis.jsonrpc.access" level="INFO"/>
+    <!-- Slow-call watchdog (#312): a JSON-RPC call still unanswered after ~1 s is logged at
+         WARN while it is stuck (method/id/phase) and again when it finishes. Pinned so it
+         stays visible whatever the app level. In the Logs tab, filter on "slow call". -->
+    <logger name="io.myotis.jsonrpc.slow" level="WARN"/>
 
     <!-- Third-party noise stays pinned regardless of APP_LEVEL. -->
     <logger name="io.netty" level="WARN"/>

--- a/app/src/main/resources/logback-daemon.xml
+++ b/app/src/main/resources/logback-daemon.xml
@@ -20,6 +20,9 @@
          com.jaeckel.ethp2p=DEBUG wire flood with `grep 'jsonrpc.access' devp2p.log`.
          Bump to DEBUG to also log the full request+response bodies. -->
     <logger name="io.myotis.jsonrpc.access" level="INFO"/>
+    <!-- Slow-call watchdog (#312): a JSON-RPC call still unanswered after ~1 s is logged at
+         WARN while it is stuck (method/id/phase) and again when it finishes. -->
+    <logger name="io.myotis.jsonrpc.slow" level="WARN"/>
     <logger name="io.netty" level="WARN"/>
     <logger name="org.apache.tuweni" level="WARN"/>
     <logger name="io.libp2p" level="WARN"/>

--- a/docs/disk-and-network-usage.md
+++ b/docs/disk-and-network-usage.md
@@ -281,7 +281,12 @@ is in the serving pool. A wallet resuming from background should therefore:
 Skipping the wake entirely still works — the first verified read on a paused stack
 wakes it on its own and is held (bounded, ~90 s) until the node can answer — but an
 explicit `myotis_wakeup` + status poll overlaps the multi-second rebuild with the UI
-transition instead of stalling the first read. When the seam isn't wired (a host that
+transition instead of stalling the first read. That hold is reserved for a node that
+is *waking*: paused, or climbing back to ready after a start or resume (for at most
+~90 s). A node that has been serving and then loses readiness — its light client
+catching up a sync-committee period, its snap pool momentarily empty — answers every
+read at once, with the retryable `-32000` when it cannot serve verified, instead of
+parking them all until it recovers (#312). When the seam isn't wired (a host that
 didn't provide a lifecycle source) both methods return `-32601`.
 
 Availability: every host that serves the JSON-RPC endpoint wires these — the daemon,

--- a/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/MethodLogger.kt
+++ b/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/MethodLogger.kt
@@ -149,7 +149,7 @@ class MethodLogger(
         val what = "method=$method id=$id" + (batchPos?.let { " batch=$it" } ?: "")
         val watchdog = launch {
             delay(slowCallWarnMs)
-            rpcLogWarn(SLOW_LOGGER, "[rpc] slow call: $what still unanswered after " +
+            warnSlow("[rpc] slow call: $what still unanswered after " +
                 "${t0.elapsedNow().inWholeMilliseconds}ms (phase=${phase.name})")
         }
         var ending = "finished"
@@ -163,8 +163,20 @@ class MethodLogger(
             watchdog.cancel()
             val ms = t0.elapsedNow().inWholeMilliseconds
             if (ms >= slowCallWarnMs) {
-                rpcLogWarn(SLOW_LOGGER, "[rpc] slow call: $what $ending after ${ms}ms (phase=${phase.name})")
+                warnSlow("[rpc] slow call: $what $ending after ${ms}ms (phase=${phase.name})")
             }
+        }
+    }
+
+    /** A slow-call line that can never fail the request it describes: the watchdog is a
+     *  child of the request's scope, so a throwing log sink (iOS hosts supply their own)
+     *  would otherwise cancel the request — diagnostics must never change outcomes (the
+     *  rule WakeGate's holdReason follows too). */
+    private fun warnSlow(message: String) {
+        try {
+            rpcLogWarn(SLOW_LOGGER, message)
+        } catch (_: Exception) {
+            // a broken log sink is not the request's problem
         }
     }
 }

--- a/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/MethodLogger.kt
+++ b/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/MethodLogger.kt
@@ -1,11 +1,16 @@
 package io.myotis.jsonrpc
 
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlin.concurrent.Volatile
+import kotlin.time.TimeSource
 
 /**
  * Per-request access log + an in-memory coverage map. Emits one concise line per
@@ -26,18 +31,35 @@ import kotlin.concurrent.Volatile
  * Full request/response bodies are logged separately at DEBUG by [MyotisRpcServer]
  * under the same logger name.
  *
+ * It also runs every request under a slow-call watchdog ([watch]): a request still
+ * unanswered after [SLOW_CALL_WARN_MS] is logged at WARN under [SLOW_LOGGER] while it
+ * is stuck, with the phase it is in, and again when it ends.
+ *
  * Multiplatform note: counters were ConcurrentHashMap+AtomicLong on the JVM;
  * commonMain has neither, so the map is copy-on-write behind a [Mutex] (record
  * is only ever called from the router's suspend paths) with a [Volatile]
  * snapshot for the lock-free readers ([coverage]/[logSummary]).
  */
-class MethodLogger {
+class MethodLogger(
+    /** How long a request may stay unanswered before [watch] logs it; tests shorten it. */
+    private val slowCallWarnMs: Long = SLOW_CALL_WARN_MS,
+) {
 
     companion object {
         /** Dedicated logger name for the RPC access log (concise INFO + full-body DEBUG).
          *  Namespaced under io.myotis.jsonrpc so every host's log config / Logs-tab filter
          *  can target it; filter the Logs tab on "rpc" (the [rpc] message prefix) to isolate it. */
         const val ACCESS_LOGGER = "io.myotis.jsonrpc.access"
+
+        /** Dedicated logger for the slow-call watchdog ([watch]) — deliberately NOT
+         *  [ACCESS_LOGGER], whose stream stays uniformly INFO. Its lines are WARN, so a
+         *  log quieted to WARN still shows every stall. */
+        const val SLOW_LOGGER = "io.myotis.jsonrpc.slow"
+
+        /** Default slow-call threshold: an order of magnitude above a healthy verified
+         *  read, and far enough under the ~10 s timeout browser wallets abort at that a
+         *  stall is on record long before the wallet gives up. */
+        const val SLOW_CALL_WARN_MS = 1_000L
     }
 
     private data class Stat(
@@ -106,4 +128,54 @@ class MethodLogger {
     fun logSummary() {
         rpcLogInfo(ACCESS_LOGGER, "[rpc] coverage summary: ${coverage()}")
     }
+
+    /**
+     * Run one request's dispatch under the slow-call watchdog (#312). A request still
+     * unanswered after [slowCallWarnMs] is logged at WARN under [SLOW_LOGGER] while it
+     * is stuck — method, id, batch position and the [CallPhase] it is in — and every
+     * request that took that long is logged again when it ends, with its total time.
+     * The access line records only completions, so a stall used to surface only once
+     * it was over: the 2-minute freeze this was added for looked like a burst of
+     * completions at one instant.
+     */
+    internal suspend fun <T> watch(
+        method: String,
+        id: String,
+        batchPos: String?,
+        phase: CallPhase,
+        block: suspend () -> T,
+    ): T = coroutineScope {
+        val t0 = TimeSource.Monotonic.markNow()
+        val what = "method=$method id=$id" + (batchPos?.let { " batch=$it" } ?: "")
+        val watchdog = launch {
+            delay(slowCallWarnMs)
+            rpcLogWarn(SLOW_LOGGER, "[rpc] slow call: $what still unanswered after " +
+                "${t0.elapsedNow().inWholeMilliseconds}ms (phase=${phase.name})")
+        }
+        var ending = "finished"
+        try {
+            block()
+        } catch (e: Throwable) {
+            ending = if (e is CancellationException) "abandoned (request cancelled)"
+                else "failed (${e::class.simpleName})"
+            throw e
+        } finally {
+            watchdog.cancel()
+            val ms = t0.elapsedNow().inWholeMilliseconds
+            if (ms >= slowCallWarnMs) {
+                rpcLogWarn(SLOW_LOGGER, "[rpc] slow call: $what $ending after ${ms}ms (phase=${phase.name})")
+            }
+        }
+    }
+}
+
+/**
+ * Where one request is right now — `dispatch`, `status`, `lifecycle`, `backend` or
+ * `proxy` — for the slow-call watchdog ([MethodLogger.watch]). Written by the
+ * dispatching coroutine, read by the watchdog's. What a backend does INSIDE its phase
+ * (e.g. a wake-gate hold) is the backend's to log.
+ */
+internal class CallPhase {
+    @Volatile
+    var name: String = "dispatch"
 }

--- a/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/RpcPlatform.kt
+++ b/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/RpcPlatform.kt
@@ -14,6 +14,9 @@ internal expect val rpcIoDispatcher: CoroutineDispatcher
 /** INFO-level line under [logger] (a dotted logger name, e.g. MethodLogger.ACCESS_LOGGER). */
 internal expect fun rpcLogInfo(logger: String, message: String)
 
+/** WARN-level line under [logger] (the slow-call watchdog's, MethodLogger.SLOW_LOGGER). */
+internal expect fun rpcLogWarn(logger: String, message: String)
+
 /** Whether DEBUG is enabled for [logger] — gates building the full-body access line. */
 internal expect fun rpcLogDebugEnabled(logger: String): Boolean
 

--- a/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/RpcRouter.kt
+++ b/jsonrpc-server/src/commonMain/kotlin/io/myotis/jsonrpc/RpcRouter.kt
@@ -76,8 +76,8 @@ class RpcRouter(
                     logger.record("<empty-batch>", "null", "ERROR", elapsedMs(t0), -32600)
                     return errorEnvelope(JsonNull, -32600, "Invalid Request")
                 }
-                val responses = root.map { el ->
-                    (el as? JsonObject)?.let { handleOne(it, null) }
+                val responses = root.mapIndexed { i, el ->
+                    (el as? JsonObject)?.let { handleOne(it, null, "${i + 1}/${root.size}") }
                         ?: run {
                             logger.record("<invalid>", "null", "ERROR", 0, -32600)
                             errorEnvelope(JsonNull, -32600, "Invalid Request")
@@ -197,12 +197,29 @@ class RpcRouter(
     /**
      * Handle one request object, returning its complete JSON-RPC response envelope.
      * [wholeBody] is the original request text used for the single-request proxy path;
-     * null for a batch element (re-serialized and proxied individually).
+     * null for a batch element (re-serialized and proxied individually). [batchPos]
+     * ("2/5") places a batch element in the slow-call watchdog's WARN; null for a
+     * single request.
      */
-    private suspend fun handleOne(root: JsonObject, wholeBody: String?): String {
+    private suspend fun handleOne(root: JsonObject, wholeBody: String?, batchPos: String? = null): String {
         val method = root["method"]?.jsonPrimitive?.contentOrNull
         val id = root["id"] ?: JsonNull
         val idStr = idString(id)
+        val phase = CallPhase()
+        return logger.watch(method ?: "request", idStr, batchPos, phase) {
+            dispatchOne(root, wholeBody, method, id, idStr, phase)
+        }
+    }
+
+    /** [handleOne]'s body: route one request, keeping [phase] current for the watchdog. */
+    private suspend fun dispatchOne(
+        root: JsonObject,
+        wholeBody: String?,
+        method: String?,
+        id: JsonElement,
+        idStr: String,
+        phase: CallPhase,
+    ): String {
         if (method == "myotis_rpcCoverage") {
             logger.record(method, idStr, "LOCAL", 0)
             return resultEnvelope(id, logger.coverage())
@@ -217,6 +234,7 @@ class RpcRouter(
                 logger.record(method, idStr, "ERROR", 0, -32601)
                 return errorEnvelope(id, -32601, "method '$method' is not supported by this node")
             }
+            phase.name = "status"
             // Isolate the read like the IPC command does (CommandHandler wraps dispatch in
             // try/catch): a throw becomes a JSON-RPC error envelope, never a raw Ktor 500.
             return try {
@@ -252,6 +270,7 @@ class RpcRouter(
             }
             // Isolate the transition like the status reads / IPC command do: a throw
             // becomes a JSON-RPC error envelope, never a raw Ktor 500.
+            phase.name = "lifecycle"
             val tLc = TimeSource.Monotonic.markNow()
             return try {
                 // pause()/wakeUp() tear down / rebuild networking (seconds) and can
@@ -276,6 +295,7 @@ class RpcRouter(
                 errorEnvelope(id, -32603, "lifecycle op failed: $detail")
             }
         }
+        phase.name = "backend"
         val t0 = TimeSource.Monotonic.markNow()
         val verified = try {
             tryVerified(method, id, root)
@@ -402,6 +422,7 @@ class RpcRouter(
             }
         }
         // Dev-only proxy fallback (never used in production / strict mode).
+        phase.name = "proxy"
         val pt0 = TimeSource.Monotonic.markNow()
         val forwardBody = wholeBody ?: json.encodeToString(JsonObject.serializer(), root)
         return try {
@@ -506,8 +527,12 @@ class RpcRouter(
                     })
                 }
             }
-            // Verified beacon head; null (not synced) -> proxy.
-            "eth_blockNumber" -> b.headBlockNumber()?.let { resultEnvelope(id, JsonPrimitive(hexQuantity(it))) }
+            // Verified beacon head; null (not synced) -> proxy. BLOCKING like every read
+            // below (a paused or warming stack holds it in the wake gate), so it runs on
+            // the IO dispatcher too — which also leaves the slow-call watchdog free to
+            // report it while it is held.
+            "eth_blockNumber" -> withContext(rpcIoDispatcher) { b.headBlockNumber() }
+                ?.let { resultEnvelope(id, JsonPrimitive(hexQuantity(it))) }
 
             "eth_call" -> {
                 val p = root.params()

--- a/jsonrpc-server/src/iosMain/kotlin/io/myotis/jsonrpc/RpcPlatform.ios.kt
+++ b/jsonrpc-server/src/iosMain/kotlin/io/myotis/jsonrpc/RpcPlatform.ios.kt
@@ -27,6 +27,10 @@ internal actual fun rpcLogInfo(logger: String, message: String) {
     IosRpcLog.sink('I', logger, message)
 }
 
+internal actual fun rpcLogWarn(logger: String, message: String) {
+    IosRpcLog.sink('W', logger, message)
+}
+
 internal actual fun rpcLogDebugEnabled(logger: String): Boolean = false
 
 internal actual fun rpcLogDebug(logger: String, message: String) {

--- a/jsonrpc-server/src/jvmMain/kotlin/io/myotis/jsonrpc/RpcPlatform.jvm.kt
+++ b/jsonrpc-server/src/jvmMain/kotlin/io/myotis/jsonrpc/RpcPlatform.jvm.kt
@@ -11,6 +11,10 @@ internal actual fun rpcLogInfo(logger: String, message: String) {
     LoggerFactory.getLogger(logger).info(message)
 }
 
+internal actual fun rpcLogWarn(logger: String, message: String) {
+    LoggerFactory.getLogger(logger).warn(message)
+}
+
 internal actual fun rpcLogDebugEnabled(logger: String): Boolean =
     LoggerFactory.getLogger(logger).isDebugEnabled
 

--- a/jsonrpc-server/src/jvmTest/kotlin/io/myotis/jsonrpc/RpcSlowCallLogTest.kt
+++ b/jsonrpc-server/src/jvmTest/kotlin/io/myotis/jsonrpc/RpcSlowCallLogTest.kt
@@ -70,10 +70,12 @@ class RpcSlowCallLogTest {
         access.stop()
     }
 
-    private fun route(body: String) {
+    /** The stalled call sleeps 700 ms against a 100 ms threshold: the watchdog has
+     *  600 ms of margin to fire while the call is still stuck, even on a loaded CI box. */
+    private fun route(body: String, slowCallWarnMs: Long = 100) {
         runBlocking {
-            RpcRouter(null, MethodLogger(slowCallWarnMs = 100),
-                VerifiedReadsBackend(SlowBalanceBackend(balanceDelayMs = 400))).handle(body)
+            RpcRouter(null, MethodLogger(slowCallWarnMs = slowCallWarnMs),
+                VerifiedReadsBackend(SlowBalanceBackend(balanceDelayMs = 700))).handle(body)
         }
     }
 
@@ -94,7 +96,9 @@ class RpcSlowCallLogTest {
     }
 
     @Test fun fastCall_logsNothingOnTheSlowLogger() {
-        route("""{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}""")
+        // A generous threshold: the claim is "a call under it logs nothing", not a race
+        // between a 100 ms budget and a cold JVM's first call (class loading, Json init).
+        route("""{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}""", slowCallWarnMs = 10_000)
         assertTrue(slowLines().isEmpty(), slowLines().toString())
     }
 

--- a/jsonrpc-server/src/jvmTest/kotlin/io/myotis/jsonrpc/RpcSlowCallLogTest.kt
+++ b/jsonrpc-server/src/jvmTest/kotlin/io/myotis/jsonrpc/RpcSlowCallLogTest.kt
@@ -104,8 +104,11 @@ class RpcSlowCallLogTest {
 
     @Test fun stalledBatchElement_namesItsPosition() {
         route("""[{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}, $balance]""")
+        // Only the stalled element can log "still unanswered" (eth_chainId never suspends,
+        // so its watchdog can't run before it ends). Whether eth_chainId itself crosses
+        // 100 ms on a cold JVM is not this test's business — fastCall_logsNothingOnTheSlowLogger
+        // pins the under-threshold case with a threshold no cold start can reach.
         val stuck = slowLines().first { it.contains("still unanswered") }
         assertTrue(stuck.contains("method=eth_getBalance") && stuck.contains("batch=2/2"), stuck)
-        assertTrue(slowLines().none { it.contains("method=eth_chainId") }, slowLines().toString())
     }
 }

--- a/jsonrpc-server/src/jvmTest/kotlin/io/myotis/jsonrpc/RpcSlowCallLogTest.kt
+++ b/jsonrpc-server/src/jvmTest/kotlin/io/myotis/jsonrpc/RpcSlowCallLogTest.kt
@@ -1,0 +1,107 @@
+package io.myotis.jsonrpc
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
+
+/**
+ * Pins the slow-call watchdog (#312): a request still unanswered past the threshold
+ * is logged at WARN under [MethodLogger.SLOW_LOGGER] WHILE it is stuck — method, id,
+ * batch position and phase — and again when it finishes. A fast request logs nothing
+ * there, and the access stream keeps its single INFO level even for a slow call.
+ */
+class RpcSlowCallLogTest {
+
+    private lateinit var slowLogger: Logger
+    private lateinit var accessLogger: Logger
+    private lateinit var slow: ListAppender<ILoggingEvent>
+    private lateinit var access: ListAppender<ILoggingEvent>
+
+    /** eth_getBalance blocks for [balanceDelayMs]; everything else answers at once. */
+    private class SlowBalanceBackend(private val balanceDelayMs: Long) : io.myotis.api.VerifiedReads {
+        override fun chainId() = 1L
+        override fun headBlockNumber() = 0x1L
+        override fun syncState() = io.myotis.api.SyncState.SYNCED
+        override fun call(from: ByteArray?, to: ByteArray?, data: ByteArray, valueWei: String?, block: String): ByteArray? = null
+        override fun getBalance(address: ByteArray, block: String): String? {
+            Thread.sleep(balanceDelayMs)
+            return "1"
+        }
+        override fun getTransactionCount(address: ByteArray, block: String): Long? = null
+        override fun getCode(address: ByteArray, block: String): ByteArray? = null
+        override fun getStorageAt(address: ByteArray, slot32: ByteArray, block: String): ByteArray? = null
+        override fun sendRawTransaction(rawTx: ByteArray): ByteArray? = null
+        override fun getTransactionReceipt(txHash: ByteArray): String? = null
+        override fun getTransactionByHash(txHash: ByteArray): String? = null
+        override fun getBlockByNumber(block: String, fullTransactions: Boolean): String? = null
+        override fun getBlockByHash(blockHash32: ByteArray, fullTransactions: Boolean): String? = null
+        override fun getBlockReceipts(blockSelector: String): String? = null
+        override fun gasPrice(): String? = null
+        override fun maxPriorityFeePerGas(): String? = null
+        override fun feeHistory(blockCount: Long, newestBlock: String, rewardPercentiles: DoubleArray?): String? = null
+        override fun estimateGas(from: ByteArray?, to: ByteArray?, data: ByteArray?, valueWei: String?): Long? = null
+    }
+
+    private val balance =
+        """{"jsonrpc":"2.0","id":7,"method":"eth_getBalance",
+           "params":["0x00000000219ab540356cBB839Cbe05303d7705Fa","latest"]}"""
+
+    @BeforeEach fun setUp() {
+        slowLogger = LoggerFactory.getLogger(MethodLogger.SLOW_LOGGER) as Logger
+        accessLogger = LoggerFactory.getLogger(MethodLogger.ACCESS_LOGGER) as Logger
+        slow = ListAppender<ILoggingEvent>().apply { start() }
+        access = ListAppender<ILoggingEvent>().apply { start() }
+        slowLogger.addAppender(slow)
+        accessLogger.addAppender(access)
+    }
+
+    @AfterEach fun tearDown() {
+        slowLogger.detachAppender(slow)
+        accessLogger.detachAppender(access)
+        slow.stop()
+        access.stop()
+    }
+
+    private fun route(body: String) {
+        runBlocking {
+            RpcRouter(null, MethodLogger(slowCallWarnMs = 100),
+                VerifiedReadsBackend(SlowBalanceBackend(balanceDelayMs = 400))).handle(body)
+        }
+    }
+
+    private fun slowLines(): List<String> = slow.list.map { it.formattedMessage }
+
+    @Test fun stalledCall_isWarnedWhileStuck_andAgainWhenItFinishes() {
+        route(balance)
+        val lines = slowLines()
+        assertEquals(2, lines.size, lines.toString())
+        assertTrue(slow.list.all { it.level == Level.WARN }, "slow-call lines are WARN")
+        val stuck = lines[0]
+        assertTrue(stuck.contains("method=eth_getBalance") && stuck.contains("id=7"), stuck)
+        assertTrue(stuck.contains("still unanswered") && stuck.contains("phase=backend"), stuck)
+        assertTrue(lines[1].contains("finished after"), lines[1])
+        // The access stream is untouched: one line, INFO, even for a slow call.
+        assertTrue(access.list.isNotEmpty() && access.list.all { it.level == Level.INFO },
+            access.list.toString())
+    }
+
+    @Test fun fastCall_logsNothingOnTheSlowLogger() {
+        route("""{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}""")
+        assertTrue(slowLines().isEmpty(), slowLines().toString())
+    }
+
+    @Test fun stalledBatchElement_namesItsPosition() {
+        route("""[{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}, $balance]""")
+        val stuck = slowLines().first { it.contains("still unanswered") }
+        assertTrue(stuck.contains("method=eth_getBalance") && stuck.contains("batch=2/2"), stuck)
+        assertTrue(slowLines().none { it.contains("method=eth_chainId") }, slowLines().toString())
+    }
+}

--- a/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
@@ -125,14 +125,17 @@ final class RustChainHandle implements ChainHandle, NodeStatusReads, io.myotis.a
         // Entry stamp for uptime: count from the start request, including the native
         // boot itself — anchored below only when the start succeeds.
         long startRequestNs = System.nanoTime();
+        // Warm-up window BEFORE the native flip (WakeGate#beginWarmup), as resume() does:
+        // reads that arrive while the fresh stack climbs to SYNCED + snap peers are held
+        // (bounded), and one racing this start on another thread (a UI / IPC operator query;
+        // the listener itself only starts below) never sees RUNNING without a window. Only
+        // from STOPPED, the one state a start can succeed from, so a refused start() can't
+        // reopen a window over a serving node; a window a failed start leaves behind closes
+        // at the watcher's first poll (still STOPPED).
+        if (lifecycle() == LifecycleState.STOPPED) wakeGate.beginWarmup(WAKE_WAIT_CAP_MS);
         boolean ok = RustEngineNative.nativeStart(handle);
         // Only expose the verified JSON-RPC endpoint once the native stack is up.
         if (ok) {
-            // Warm-up window before the listener exists (WakeGate#beginWarmup): reads that
-            // arrive while the fresh stack climbs to SYNCED + snap peers are held (bounded),
-            // as after a wake. Only on success, so a start() refused because the handle is
-            // already running can't reopen a window over a node that is serving.
-            wakeGate.beginWarmup(WAKE_WAIT_CAP_MS);
             // Anchor uptime to this successful start (cleared in stop() so a restart re-anchors).
             if (!started) { startedAtNs = startRequestNs; started = true; }
             startRpc();

--- a/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
@@ -251,10 +251,12 @@ final class RustChainHandle implements ChainHandle, NodeStatusReads, io.myotis.a
     /**
      * Wake-and-wait shared by every verified read / operator query below: a query
      * on a paused stack triggers the (single-flight) resume and waits up to the cap
-     * for readiness. A RUNNING-but-cold stack proceeds at the deadline — the native
-     * query produces its own precise bounded errors. Only PAUSED-at-deadline
-     * (resume kept failing) throws; a STOPPED stack falls through to the native's
-     * "handle not started"/"unknown handle" error (mirrors JavaChainHandle.awaitWake).
+     * for readiness, as does one arriving during a start/resume warm-up. A RUNNING
+     * stack that isn't ready proceeds — at once outside a warm-up (#312), at the
+     * deadline inside one — and the native query produces its own precise bounded
+     * errors. Only PAUSED-at-deadline (resume kept failing) throws; a STOPPED stack
+     * falls through to the native's "handle not started"/"unknown handle" error
+     * (mirrors JavaChainHandle.awaitWake).
      */
     private void awaitWake() {
         // Fast-fail the unrecoverable-while-RUNNING state (the twin of
@@ -293,8 +295,9 @@ final class RustChainHandle implements ChainHandle, NodeStatusReads, io.myotis.a
      * The wake-on-request choke point every verified read crosses before its JNI
      * call (the Rust-engine twin of ChainStack.awaitReadyForReads + the
      * begin/endRequest in-flight guard): stamps activity, wakes a paused stack,
-     * holds bounded until reads are answerable, and marks the request in flight so
-     * the host idle timer can't pause the stack mid-query.
+     * holds (bounded) while the stack is waking — paused, or in a start/resume
+     * warm-up — and marks the request in flight so the host idle timer can't pause
+     * the stack mid-query.
      */
     private <T> T gated(java.util.function.Supplier<T> nativeCall) {
         awaitWake();
@@ -1115,15 +1118,15 @@ final class RustChainHandle implements ChainHandle, NodeStatusReads, io.myotis.a
     public String logIndexStatusJson() {
         // NOT gated(): this is a STATUS PROBE the hosts poll every ~2s for the UI
         // snapshot (Android AndroidNodeBridge.snapshots, desktop DesktopNode). The
-        // gated() wake-and-hold waits up to WAKE_WAIT_CAP_MS for readyForReads() —
-        // which a booting, catching-up, or STALE_ANCHOR-parked chain never
-        // satisfies — so gating here stalled every snapshot emission ~90s per
-        // unready chain and froze the whole UI at its previous state (chains
-        // rendered "stopped" while running; the stale-anchor consent appeared to
-        // do nothing). It also stamped activity + woke paused stacks on every
-        // poll, fighting the idle-pause controller. The native answers with
-        // {"error":...} on its own when the gate is down — exactly the not-ready
-        // shape this method documents — so no readiness hold is needed.
+        // gated() wake-and-hold waits up to WAKE_WAIT_CAP_MS for readyForReads() on
+        // a waking chain — a booting one's whole warm-up (and, before #312, ANY
+        // unready chain: catching-up, STALE_ANCHOR-parked) — so gating here stalled
+        // snapshot emissions ~90s per such chain and froze the whole UI at its
+        // previous state (chains rendered "stopped" while running; the stale-anchor
+        // consent appeared to do nothing). It also stamped activity + woke paused
+        // stacks on every poll, fighting the idle-pause controller. The native
+        // answers with {"error":...} on its own when the gate is down — exactly the
+        // not-ready shape this method documents — so no readiness hold is needed.
         return RustEngineNative.nativeLogIndexStatusJson(handle);
     }
 

--- a/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/RustChainHandle.java
@@ -108,8 +108,8 @@ final class RustChainHandle implements ChainHandle, NodeStatusReads, io.myotis.a
         // Wake-on-request over the NATIVE lifecycle: the same primitive ChainStack
         // wires, so the two engines share the hold/single-flight semantics.
         this.wakeGate = new io.myotis.node.WakeGate(this::lifecycle, this::readyForReads,
-                () -> resume(io.myotis.api.WakeReason.REQUEST),
-                System::currentTimeMillis, WAKE_POLL_MS, "wake-resume-" + networkName);
+                this::notReadyDetail, () -> resume(io.myotis.api.WakeReason.REQUEST),
+                System::currentTimeMillis, WAKE_POLL_MS, networkName);
     }
 
     io.myotis.api.ports.HttpGateway httpGateway() {
@@ -128,6 +128,11 @@ final class RustChainHandle implements ChainHandle, NodeStatusReads, io.myotis.a
         boolean ok = RustEngineNative.nativeStart(handle);
         // Only expose the verified JSON-RPC endpoint once the native stack is up.
         if (ok) {
+            // Warm-up window before the listener exists (WakeGate#beginWarmup): reads that
+            // arrive while the fresh stack climbs to SYNCED + snap peers are held (bounded),
+            // as after a wake. Only on success, so a start() refused because the handle is
+            // already running can't reopen a window over a node that is serving.
+            wakeGate.beginWarmup(WAKE_WAIT_CAP_MS);
             // Anchor uptime to this successful start (cleared in stop() so a restart re-anchors).
             if (!started) { startedAtNs = startRequestNs; started = true; }
             startRpc();
@@ -161,7 +166,8 @@ final class RustChainHandle implements ChainHandle, NodeStatusReads, io.myotis.a
     // can't drift.
 
     /** Max time a verified read arriving on a paused stack is held while the wake
-     *  completes (mirrors ChainStack.WAKE_WAIT_CAP_MS). */
+     *  completes — and the warm-up window every (re)start opens, the only other time
+     *  a read is held (mirrors ChainStack.WAKE_WAIT_CAP_MS). */
     static final long WAKE_WAIT_CAP_MS = 90_000L;
     /** Wake-wait poll interval (mirrors ChainStack.WAKE_POLL_MS). */
     private static final long WAKE_POLL_MS = 250L;
@@ -198,6 +204,11 @@ final class RustChainHandle implements ChainHandle, NodeStatusReads, io.myotis.a
     @Override
     public synchronized boolean resume(String reason) {
         if (isRunning()) return true; // no-op success, no accounting (mirrors ChainStack)
+        // Open the warm-up window BEFORE the native flip (WakeGate#beginWarmup): the reads
+        // held through the pause keep holding while the light client re-anchors and the pool
+        // re-dials, instead of being released the instant the native entry reads Running. A
+        // failed resume stays PAUSED, where the gate holds regardless of the window.
+        wakeGate.beginWarmup(WAKE_WAIT_CAP_MS);
         if (RustEngineNative.nativeResume(handle)) {
             // Foreground (observation) wakes count toward the total but must not
             // overwrite the last-wake reason — see WakeReason / SleepMetrics.
@@ -300,20 +311,41 @@ final class RustChainHandle implements ChainHandle, NodeStatusReads, io.myotis.a
      *  (the Rust twin of ChainStack.readyForReads). */
     private boolean readyForReads() {
         try {
-            ParsedStatus s = readStatus();
-            // RUNNING with no EL reader is terminal-until-pause/resume (the CL-only
-            // degraded mode): more waiting cannot help, so report "attempt the read
-            // now" and let the native surface its precise "EL reader unavailable"
-            // error. The pre-gate probe in awaitWake covers the already-RUNNING
-            // case without stamping activity; this covers a wake whose resume
-            // lands in the degraded mode MID-HOLD, which would otherwise park the
-            // request for the full cap.
-            if (s.running() && !s.elReaderAvailable()) return true;
-            return s.running() && s.beaconState() == BeaconState.SYNCED
-                    && s.optimisticBlockNumber() > 0 && s.snapPeers() > 0;
+            return readyForReads(readStatus());
         } catch (RuntimeException e) {
             return false; // an unreadable status is "not ready", never a wake-loop crash
         }
+    }
+
+    /** {@link #readyForReads()} over one parsed status — pure, so it is testable
+     *  without JNI ({@link #readyForReadsFromJson}). */
+    private static boolean readyForReads(ParsedStatus s) {
+        // RUNNING with no EL reader is terminal-until-pause/resume (the CL-only
+        // degraded mode): more waiting cannot help, so report "attempt the read
+        // now" and let the native surface its precise "EL reader unavailable"
+        // error. The pre-gate probe in awaitWake covers the already-RUNNING
+        // case without stamping activity; this covers a wake whose resume
+        // lands in the degraded mode MID-HOLD, which would otherwise park the
+        // request for the rest of the warm-up.
+        if (s.running() && !s.elReaderAvailable()) return true;
+        // A STALE_ANCHOR park is the same kind of state: only a human moves it (raise
+        // the bound or accept the risk), so attempt now — the refusal comes back at
+        // once as the router's curated STALE_ANCHOR message (ChainStack's rule too).
+        if (s.running() && s.beaconState() == BeaconState.STALE_ANCHOR) return true;
+        return s.running() && s.beaconState() == BeaconState.SYNCED
+                && s.optimisticBlockNumber() > 0 && s.snapPeers() > 0;
+    }
+
+    /** Package-private test seam: the readiness predicate over a status JSON, without JNI. */
+    static boolean readyForReadsFromJson(String json) {
+        return readyForReads(ParsedStatus.parse(json));
+    }
+
+    /** Why reads aren't answerable yet, for the wake gate's slow-hold WARN. */
+    private String notReadyDetail() {
+        ParsedStatus s = readStatus();
+        return "beacon " + s.beaconState() + ", snapPeers " + s.snapPeers()
+                + ", head " + s.optimisticBlockNumber();
     }
 
     /** {@link NodeStatusReads}: node uptime for the JSON-RPC myotis_status result. Monotonic

--- a/myotis-engines/src/test/java/io/myotis/engines/RustReadyForReadsTest.java
+++ b/myotis-engines/src/test/java/io/myotis/engines/RustReadyForReadsTest.java
@@ -1,0 +1,58 @@
+package io.myotis.engines;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The Rust handle's readiness predicate — what the wake gate holds a warming stack
+ * for — over status JSON, without JNI. "Ready" means "attempt the read now": the
+ * handle can serve, or it sits in a state no amount of holding fixes (#312).
+ */
+class RustReadyForReadsTest {
+
+    private static String status(boolean running, String beaconState, long head, int snapPeers,
+                                 boolean elReader) {
+        return "{\"running\":" + running + ",\"paused\":false,\"network\":\"sepolia\","
+                + "\"beaconState\":\"" + beaconState + "\",\"elReaderAvailable\":" + elReader
+                + ",\"optimisticBlockNumber\":" + head + ",\"snapPeers\":" + snapPeers + "}";
+    }
+
+    private static boolean ready(String json) {
+        return RustChainHandle.readyForReadsFromJson(json);
+    }
+
+    @Test
+    void syncedWithAnAnchoredHeadAndSnapPeersIsReady() {
+        assertTrue(ready(status(true, "SYNCED", 9_000_000, 4, true)));
+    }
+
+    @Test
+    void catchingUpNoSnapPeerOrNoHeadIsNotReady() {
+        assertFalse(ready(status(true, "CATCHING_UP", 9_000_000, 4, true)));
+        assertFalse(ready(status(true, "SYNCED", 9_000_000, 0, true)));
+        assertFalse(ready(status(true, "SYNCED", 0, 4, true)));
+    }
+
+    @Test
+    void aStaleAnchorParkIsAttemptedAtOnce() {
+        // Only a human moves it (raise the bound / accept the risk): holding can't help,
+        // and the router answers the park with its curated message straight away.
+        assertTrue(ready(status(true, "STALE_ANCHOR", 0, 0, true)));
+    }
+
+    @Test
+    void runningWithoutAnElReaderIsAttemptedAtOnce() {
+        // The CL-only degraded mode: only a pause→resume rebuilds the reader.
+        assertTrue(ready(status(true, "SYNCING", 0, 0, false)));
+    }
+
+    @Test
+    void aHandleThatIsNotRunningIsNeverReady() {
+        assertFalse(ready(status(false, "SYNCED", 9_000_000, 4, true)));
+        assertFalse(ready("{}"));
+        assertFalse(ready("{\"running\":false,\"paused\":true,\"beaconState\":\"STALE_ANCHOR\","
+                + "\"elReaderAvailable\":false}"));
+    }
+}

--- a/node-core/src/main/java/io/myotis/node/ChainStack.java
+++ b/node-core/src/main/java/io/myotis/node/ChainStack.java
@@ -104,7 +104,9 @@ public final class ChainStack implements io.myotis.api.NodeLifecycle {
      *  Undercounting while online merely slows demotion, which is fine. */
     private static final long ONLINE_SIGNAL_MAX_AGE_MS = 2 * 60 * 1000L;
 
-    /** Max time a verified read arriving on a paused stack is held while the wake completes. */
+    /** Max time a verified read arriving on a paused stack is held while the wake completes —
+     *  and the warm-up window every (re)start opens (WakeGate#beginWarmup), the only other
+     *  time a read is held. */
     public static final long WAKE_WAIT_CAP_MS = 90_000L;
     /** Wake-wait poll interval. */
     private static final long WAKE_POLL_MS = 250L;
@@ -197,9 +199,9 @@ public final class ChainStack implements io.myotis.api.NodeLifecycle {
         this.clPeerCache = clPeerCache;
         this.ccipGateway = ccipGateway;
         this.syncSnapshotFile = syncSnapshotFile;
-        this.wakeGate = new WakeGate(phase::get, this::readyForReads,
+        this.wakeGate = new WakeGate(phase::get, this::readyForReads, this::notReadyDetail,
                 () -> resume(io.myotis.api.WakeReason.REQUEST),
-                System::currentTimeMillis, WAKE_POLL_MS, "wake-resume-" + network.name());
+                System::currentTimeMillis, WAKE_POLL_MS, network.name());
         this.gatedReads = new GatedVerifiedReads(this);
     }
 
@@ -327,6 +329,9 @@ public final class ChainStack implements io.myotis.api.NodeLifecycle {
             buildAndStartBeacon(dnsClEnrs);
 
             // 5. Verified JSON-RPC (best-effort; a bind failure here does not fail the stack).
+            //    Warm-up window first (WakeGate#beginWarmup): reads that arrive while the
+            //    fresh stack climbs to SYNCED + a warm head are held (bounded), as after a wake.
+            wakeGate.beginWarmup(WAKE_WAIT_CAP_MS);
             startRpc();
 
             // 6. Snap-peer maintainer (optional): keep snap peers topped up from cache +
@@ -422,6 +427,10 @@ public final class ChainStack implements io.myotis.api.NodeLifecycle {
                 startRpc();
             }
             if (maintainerEnabled) startPeerMaintainer();
+            // Open the warm-up window BEFORE publishing RUNNING (WakeGate#beginWarmup): the
+            // reads held through the pause keep holding while the light client re-anchors and
+            // the pool re-dials, instead of being released into a cold backend at the flip.
+            wakeGate.beginWarmup(WAKE_WAIT_CAP_MS);
             phase.set(RUNNING);
             // Foreground (observation) wakes count toward the total but must not overwrite
             // the last-wake reason — see WakeReason / SleepMetrics.
@@ -572,15 +581,30 @@ public final class ChainStack implements io.myotis.api.NodeLifecycle {
     public long lastResumeEpochMs() { return sleepMetrics.lastResumeEpochMs(); }
     public String lastWakeReason() { return sleepMetrics.lastWakeReason(); }
 
-    /** Readiness for verified reads: beacon SYNCED and the head warmer has an anchored head. */
+    /** Readiness for verified reads — what the wake gate holds a warming stack for: beacon
+     *  SYNCED and the head warmer has an anchored head. Also true ("attempt the read now")
+     *  for a STALE_ANCHOR park, which only a human moves (raise the bound or accept the
+     *  risk): holding could never help, and the backend's refusal comes back at once as
+     *  the router's curated STALE_ANCHOR message — the Rust handle's rule too. */
     private boolean readyForReads() {
         if (phase.get() != RUNNING) return false;
         BeaconSyncState bss = beaconSyncState;
         io.myotis.rpc.VerifiedRpcBackend b = rpcBackend;
-        return bss != null && b != null
-                && bss.getSyncState(network.clGenesisTime(), network.secondsPerSlot())
-                        == BeaconSyncState.State.SYNCED
-                && b.verifiedHeadAgeMs() != Long.MAX_VALUE;
+        if (bss == null || b == null) return false;
+        BeaconSyncState.State s = bss.getSyncState(network.clGenesisTime(), network.secondsPerSlot());
+        if (s == BeaconSyncState.State.STALE_ANCHOR) return true;
+        return s == BeaconSyncState.State.SYNCED && b.verifiedHeadAgeMs() != Long.MAX_VALUE;
+    }
+
+    /** Why reads aren't answerable yet, for the wake gate's slow-hold WARN. */
+    private String notReadyDetail() {
+        BeaconSyncState bss = beaconSyncState;
+        io.myotis.rpc.VerifiedRpcBackend b = rpcBackend;
+        String beacon = bss == null ? "no beacon client"
+                : "beacon " + bss.getSyncState(network.clGenesisTime(), network.secondsPerSlot());
+        String head = b == null ? "no RPC backend"
+                : b.verifiedHeadAgeMs() == Long.MAX_VALUE ? "no verified head yet" : "verified head warm";
+        return beacon + ", " + head;
     }
 
     // -------------------------------------------------------------------------

--- a/node-core/src/main/java/io/myotis/node/ChainStack.java
+++ b/node-core/src/main/java/io/myotis/node/ChainStack.java
@@ -521,14 +521,16 @@ public final class ChainStack implements io.myotis.api.NodeLifecycle {
     /**
      * The wake-on-request choke point every verified read goes through: notes
      * host-visible activity, triggers a single-flight async {@link #resume()}
-     * when paused, and blocks until reads are answerable or {@code capMs}
-     * elapses.
+     * when paused, and — only while the stack is waking (paused, or inside the
+     * warm-up window a start/resume opens) — blocks until reads are answerable or
+     * {@code capMs} elapses. A RUNNING stack outside a warm-up returns at once,
+     * ready or not (#312).
      *
      * @return the live backend to query, or {@code null} when no verified answer
      *         is possible (stack stopped, RPC never started / failed to bind, or
-     *         still paused at the deadline). A stack that is RUNNING but still cold
-     *         at the deadline returns the backend anyway — it produces its own
-     *         precise bounded errors.
+     *         still paused at the deadline). A RUNNING stack that isn't ready —
+     *         outside a warm-up, or still warming at the deadline — returns the
+     *         backend anyway: it produces its own precise bounded errors.
      */
     public io.myotis.rpc.VerifiedRpcBackend awaitReadyForReads(long capMs) {
         // RUNNING with no backend means the JSON-RPC bind failed at start (the failure

--- a/node-core/src/main/java/io/myotis/node/WakeGate.java
+++ b/node-core/src/main/java/io/myotis/node/WakeGate.java
@@ -20,17 +20,18 @@ import java.util.function.Supplier;
  * <p><b>Only a WAKING stack holds requests.</b> A request is parked while the
  * stack is {@code PAUSED} (the wake is in flight), or {@code RUNNING} but not
  * yet ready inside a <em>warm-up window</em> — opened by every (re)entry into
- * {@code RUNNING} ({@link #beginWarmup}) and closed by the first poll that finds
- * the stack ready, or when the window elapses. That is the climb the hold exists
- * for: a start or a wake re-anchoring the light client and re-dialing snap peers,
- * seconds away from answering. A {@code RUNNING} stack outside a warm-up is never
- * held, ready or not: a node that WAS serving and then lost readiness (the light
- * client catching up a sync-committee period, the snap pool momentarily empty)
- * hands the request straight to the backend, which answers or fails with its own
- * precise, bounded error. Holding those parked every verified read —
- * {@code eth_blockNumber} included — on one shared readiness predicate for the
- * full cap and released them all at the same instant: wallets with a 10 s timeout
- * reported the node offline for minutes while every request eventually
+ * {@code RUNNING} ({@link #beginWarmup}) and closed as soon as the stack is first
+ * ready (a watcher polls through the warm-up, so that doesn't depend on a request
+ * being there to see it), or when the window elapses. That is the climb the hold
+ * exists for: a start or a wake re-anchoring the light client and re-dialing snap
+ * peers, seconds away from answering. A {@code RUNNING} stack outside a warm-up
+ * is never held, ready or not: a node that WAS serving and then lost readiness
+ * (the light client catching up a sync-committee period, the snap pool
+ * momentarily empty) hands the request straight to the backend, which answers or
+ * fails with its own precise, bounded error. Holding those parked every verified
+ * read — {@code eth_blockNumber} included — on one shared readiness predicate for
+ * the full cap and released them all at the same instant: wallets with a 10 s
+ * timeout reported the node offline for minutes while every request eventually
  * "succeeded" (#312).
  *
  * <p>Extracted from {@code ChainStack} so the wait/single-flight behavior is
@@ -63,9 +64,10 @@ public final class WakeGate {
     private final AtomicLong lastActivityMs = new AtomicLong(0);
 
     /** The open warm-up window, or null. A holder object rather than a bare
-     *  deadline: a poll that finds the stack ready closes exactly the window it
-     *  read (CAS) — never a newer one a racing resume opened — and no nanoTime
-     *  value has to double as a "none" sentinel (any long is a valid reading). */
+     *  deadline: closing it is a CAS on the exact window read, so neither a ready
+     *  poll nor a finishing watcher can close a newer window a racing resume
+     *  opened — and no nanoTime value has to double as a "none" sentinel (any
+     *  long is a valid reading). */
     private final AtomicReference<Warmup> warmup = new AtomicReference<>();
 
     private record Warmup(long deadlineNanos) {}
@@ -104,7 +106,42 @@ public final class WakeGate {
      * stack with no warm-up and be released into a cold backend.
      */
     public void beginWarmup(long windowMs) {
-        warmup.set(new Warmup(System.nanoTime() + windowMs * 1_000_000L));
+        Warmup w = new Warmup(System.nanoTime() + windowMs * 1_000_000L);
+        warmup.set(w);
+        // End the window the moment the stack is first ready, whether or not a request is
+        // there to see it: a window no poll saw complete would stay open, and a readiness
+        // blip later in it (a snap-pool reshuffle after a resume) would park every read until
+        // it ran out — the #312 freeze again, bounded by the window instead of the cap.
+        Thread t = new Thread(() -> watchWarmup(w), "wake-warmup-" + name);
+        t.setDaemon(true);
+        t.start();
+    }
+
+    /** Poll through one warm-up window and close it at the stack's first readiness, when
+     *  it stops, or when the window runs out; exits early once a newer window replaces it. */
+    private void watchWarmup(Warmup w) {
+        while (warmup.get() == w && System.nanoTime() - w.deadlineNanos() < 0) {
+            try {
+                LifecycleState p = phase.get();
+                if (p == LifecycleState.STOPPED) break; // nothing holds; a later start reopens
+                if (p == LifecycleState.RUNNING && ready.getAsBoolean()) break;
+            } catch (RuntimeException e) {
+                // An unreadable status is "not ready yet" — never a dead watcher.
+            }
+            try {
+                Thread.sleep(pollMs);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+        }
+        warmup.compareAndSet(w, null); // a no-op once superseded
+    }
+
+    /** Whether a warm-up window is open right now (test seam). */
+    boolean warmingUp() {
+        Warmup w = warmup.get();
+        return w != null && System.nanoTime() - w.deadlineNanos() < 0;
     }
 
     /**
@@ -143,6 +180,10 @@ public final class WakeGate {
                 }
                 if (w == null || System.nanoTime() - w.deadlineNanos() >= 0) {
                     if (w != null) warmup.compareAndSet(w, null);
+                    // A pause (or stop) that landed between the phase read and the
+                    // readiness check is handled as one — re-poll, which wakes a PAUSED
+                    // stack — not waved through as a running stack short of readiness.
+                    if (phase.get() != LifecycleState.RUNNING) continue;
                     // Not waking: a running stack that lost readiness (or whose warm-up
                     // ran out). Hand the request to the backend now instead of parking it
                     // on a predicate that can stay false for minutes (#312).

--- a/node-core/src/main/java/io/myotis/node/WakeGate.java
+++ b/node-core/src/main/java/io/myotis/node/WakeGate.java
@@ -1,9 +1,12 @@
 package io.myotis.node;
 
 import io.myotis.api.LifecycleState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
@@ -13,6 +16,22 @@ import java.util.function.Supplier;
  * stamps host-visible activity, triggers a single-flight asynchronous resume
  * when the stack is {@code PAUSED}, and parks the calling (request) thread
  * until the stack can answer verified reads or a deadline passes.
+ *
+ * <p><b>Only a WAKING stack holds requests.</b> A request is parked while the
+ * stack is {@code PAUSED} (the wake is in flight), or {@code RUNNING} but not
+ * yet ready inside a <em>warm-up window</em> — opened by every (re)entry into
+ * {@code RUNNING} ({@link #beginWarmup}) and closed by the first poll that finds
+ * the stack ready, or when the window elapses. That is the climb the hold exists
+ * for: a start or a wake re-anchoring the light client and re-dialing snap peers,
+ * seconds away from answering. A {@code RUNNING} stack outside a warm-up is never
+ * held, ready or not: a node that WAS serving and then lost readiness (the light
+ * client catching up a sync-committee period, the snap pool momentarily empty)
+ * hands the request straight to the backend, which answers or fails with its own
+ * precise, bounded error. Holding those parked every verified read —
+ * {@code eth_blockNumber} included — on one shared readiness predicate for the
+ * full cap and released them all at the same instant: wallets with a 10 s timeout
+ * reported the node offline for minutes while every request eventually
+ * "succeeded" (#312).
  *
  * <p>Extracted from {@code ChainStack} so the wait/single-flight behavior is
  * hermetically testable — every dependency (phase, readiness, resume action,
@@ -25,44 +44,80 @@ import java.util.function.Supplier;
  */
 public final class WakeGate {
 
+    private static final Logger log = LoggerFactory.getLogger(WakeGate.class);
+
+    /** A hold still parked after this long is logged once at WARN, with why the
+     *  stack isn't ready — the "which phase is this request stuck in" half of the
+     *  #312 instrumentation (the router's slow-call WARN names the request). */
+    static final long SLOW_HOLD_WARN_MS = 1_000L;
+
     private final Supplier<LifecycleState> phase;
     private final BooleanSupplier ready;
+    private final Supplier<String> notReadyDetail;
     private final Runnable resume;
     private final LongSupplier clock;
     private final long pollMs;
-    private final String wakeThreadName;
+    private final String name;
 
     private final AtomicBoolean wakeInFlight = new AtomicBoolean(false);
     private final AtomicLong lastActivityMs = new AtomicLong(0);
 
+    /** The open warm-up window, or null. A holder object rather than a bare
+     *  deadline: a poll that finds the stack ready closes exactly the window it
+     *  read (CAS) — never a newer one a racing resume opened — and no nanoTime
+     *  value has to double as a "none" sentinel (any long is a valid reading). */
+    private final AtomicReference<Warmup> warmup = new AtomicReference<>();
+
+    private record Warmup(long deadlineNanos) {}
+
     /**
      * @param phase          live lifecycle state of the guarded stack
      * @param ready          true when verified reads are answerable (only consulted while RUNNING)
+     * @param notReadyDetail short reason the stack isn't ready yet (e.g. its beacon state and
+     *                       snap-peer count) for the slow-hold WARN; null — or a supplier that
+     *                       throws — just leaves the detail out
      * @param resume         the blocking resume action; run on a fresh daemon thread, single-flight
      * @param clock          wall-clock epoch-millis source for activity stamping (injected for
      *                       tests); the wait DEADLINE uses monotonic {@code System.nanoTime}
      * @param pollMs         wait-loop poll interval
-     * @param wakeThreadName name for the spawned resume thread
+     * @param name           the guarded network, for logs; the resume thread is
+     *                       {@code wake-resume-<name>}
      */
-    public WakeGate(Supplier<LifecycleState> phase, BooleanSupplier ready, Runnable resume,
-                    LongSupplier clock, long pollMs, String wakeThreadName) {
+    public WakeGate(Supplier<LifecycleState> phase, BooleanSupplier ready,
+                    Supplier<String> notReadyDetail, Runnable resume,
+                    LongSupplier clock, long pollMs, String name) {
         this.phase = phase;
         this.ready = ready;
+        this.notReadyDetail = notReadyDetail;
         this.resume = resume;
         this.clock = clock;
         this.pollMs = pollMs;
-        this.wakeThreadName = wakeThreadName;
+        this.name = name;
     }
 
     /**
-     * Note activity, kick a wake if paused, and block until the stack is ready
-     * for verified reads or {@code capMs} elapses.
+     * Open (or restart) the warm-up window: for the next {@code windowMs}, a request
+     * that finds the stack RUNNING but not yet ready is held until it is (each hold
+     * still bounded by its own cap). Call on every (re)entry into RUNNING — start and
+     * resume, whatever woke the stack — and BEFORE that RUNNING can be observed: a
+     * waiter polling between the flip and the open would see a running, unready
+     * stack with no warm-up and be released into a cold backend.
+     */
+    public void beginWarmup(long windowMs) {
+        warmup.set(new Warmup(System.nanoTime() + windowMs * 1_000_000L));
+    }
+
+    /**
+     * Note activity, kick a wake if paused, and — only while the stack is waking (see
+     * the class doc) — block until it is ready for verified reads or {@code capMs}
+     * elapses.
      *
-     * @return {@code true} when reads should be attempted: the stack is ready, or
-     *         it is {@code RUNNING} but still cold at the deadline (the backend
-     *         produces its own precise bounded errors). {@code false} when the
-     *         stack is {@code STOPPED}, still {@code PAUSED} at the deadline
-     *         (resume kept failing), or the wait was interrupted.
+     * @return {@code true} when reads should be attempted: the stack is ready; it is
+     *         {@code RUNNING} outside a warm-up (the backend answers, or produces its
+     *         own precise bounded errors); or it is {@code RUNNING} but still warming
+     *         up at the deadline. {@code false} when the stack is {@code STOPPED},
+     *         still {@code PAUSED} at the deadline (resume kept failing), or the wait
+     *         was interrupted.
      */
     public boolean await(long capMs) {
         noteActivity();
@@ -70,24 +125,74 @@ public final class WakeGate {
         // NTP / manual wall-clock step must not extend or prematurely expire the hold. The
         // injected wall-clock `clock` is used only for activity stamping (noteActivity),
         // which the host idle timer compares against its own wall clock.
-        long deadlineNanos = System.nanoTime() + capMs * 1_000_000L;
+        long startNanos = System.nanoTime();
+        long deadlineNanos = startNanos + capMs * 1_000_000L;
+        boolean warned = false;
         while (true) {
             LifecycleState p = phase.get();
-            if (p == LifecycleState.STOPPED) return false;
+            if (p == LifecycleState.STOPPED) return released(warned, startNanos, "stopped", false);
             if (p == LifecycleState.PAUSED) triggerWake();
-            if (p == LifecycleState.RUNNING && ready.getAsBoolean()) return true;
-            if (System.nanoTime() - deadlineNanos >= 0) return p == LifecycleState.RUNNING;
+            if (p == LifecycleState.RUNNING) {
+                // Read the window BEFORE readiness, so a ready poll closes exactly the
+                // window it saw (a resume racing in after it has opened a fresh one).
+                Warmup w = warmup.get();
+                if (ready.getAsBoolean()) {
+                    // Warmed up: from here on a readiness loss is the backend's to report.
+                    if (w != null) warmup.compareAndSet(w, null);
+                    return released(warned, startNanos, "ready", true);
+                }
+                if (w == null || System.nanoTime() - w.deadlineNanos() >= 0) {
+                    if (w != null) warmup.compareAndSet(w, null);
+                    // Not waking: a running stack that lost readiness (or whose warm-up
+                    // ran out). Hand the request to the backend now instead of parking it
+                    // on a predicate that can stay false for minutes (#312).
+                    return released(warned, startNanos, "not warming up", true);
+                }
+            }
+            long now = System.nanoTime();
+            if (now - deadlineNanos >= 0) {
+                return released(warned, startNanos, "cap reached", p == LifecycleState.RUNNING);
+            }
+            if (!warned && now - startNanos >= SLOW_HOLD_WARN_MS * 1_000_000L) {
+                warned = true;
+                log.warn("[wake-gate:{}] verified read held {} ms: {}; holding up to {} s",
+                        name, (now - startNanos) / 1_000_000L, holdReason(p), capMs / 1000);
+            }
             try {
                 Thread.sleep(pollMs);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                return false;
+                return released(warned, startNanos, "interrupted", false);
             }
             // Still parked: this request IS ongoing activity. Re-stamp every poll so a
             // wake-hold longer than the host's idle window can't leave the activity
             // clock stale and let the idle controller re-pause the stack under the
             // parked request (a wake/pause ping-pong until the cap expires).
             noteActivity();
+        }
+    }
+
+    /** The single exit of {@link #await}: a hold long enough to have been WARNed about
+     *  also logs how it ended, so a stall reads as a bounded episode in the log. */
+    private boolean released(boolean warned, long startNanos, String how, boolean attempt) {
+        if (warned) {
+            log.info("[wake-gate:{}] verified read released after {} ms ({})",
+                    name, (System.nanoTime() - startNanos) / 1_000_000L, how);
+        }
+        return attempt;
+    }
+
+    /** Why a hold is still parked, for the slow-hold WARN. */
+    private String holdReason(LifecycleState p) {
+        String why = p == LifecycleState.PAUSED
+                ? "stack PAUSED, wake in progress"
+                : "stack RUNNING but still warming up after a start/wake";
+        if (notReadyDetail == null) return why;
+        try {
+            String detail = notReadyDetail.get();
+            return detail == null || detail.isBlank() ? why : why + " (" + detail + ")";
+        } catch (RuntimeException e) {
+            return why; // diagnostics must never break the hold itself
         }
     }
 
@@ -119,7 +224,7 @@ public final class WakeGate {
             } finally {
                 wakeInFlight.set(false);
             }
-        }, wakeThreadName);
+        }, "wake-resume-" + name);
         t.setDaemon(true);
         t.start();
     }

--- a/node-core/src/main/java/io/myotis/node/api/JavaChainHandle.java
+++ b/node-core/src/main/java/io/myotis/node/api/JavaChainHandle.java
@@ -81,10 +81,11 @@ public final class JavaChainHandle implements ChainHandle, NodeStatusReads {
 
     /**
      * Wake-and-wait shared by the verified operator queries: a query on a paused
-     * stack triggers resume and waits up to the cap for readiness. A RUNNING-but-cold
-     * stack does NOT block to full readiness — it proceeds and the query/backend emits
-     * its own bounded errors. Only a PAUSED-at-deadline (resume kept failing) throws;
-     * a STOPPED stack falls through to each query's existing "Node is not running" guard.
+     * stack triggers resume and waits up to the cap for readiness, as does one
+     * arriving during a start/resume warm-up. Otherwise a RUNNING stack that isn't
+     * ready does NOT block — it proceeds and the query/backend emits its own bounded
+     * errors (#312). Only a PAUSED-at-deadline (resume kept failing) throws; a
+     * STOPPED stack falls through to each query's existing "Node is not running" guard.
      */
     private void awaitWake() {
         stack.awaitReadyForReads(ChainStack.WAKE_WAIT_CAP_MS);

--- a/node-core/src/test/java/io/myotis/node/WakeGateTest.java
+++ b/node-core/src/test/java/io/myotis/node/WakeGateTest.java
@@ -10,6 +10,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -29,8 +30,12 @@ class WakeGateTest {
     /** A gate over the real clock, without a not-ready detail. */
     private static WakeGate gate(AtomicReference<LifecycleState> phase, BooleanSupplier ready,
                                  Runnable resume) {
-        return new WakeGate(phase::get, ready, null, resume, System::currentTimeMillis, POLL_MS,
-                "test");
+        return gate(phase::get, ready, resume);
+    }
+
+    private static WakeGate gate(Supplier<LifecycleState> phase, BooleanSupplier ready,
+                                 Runnable resume) {
+        return new WakeGate(phase, ready, null, resume, System::currentTimeMillis, POLL_MS, "test");
     }
 
     private static long msSince(long t0Nanos) {
@@ -52,7 +57,10 @@ class WakeGateTest {
         AtomicInteger resumeRuns = new AtomicInteger();
         CountDownLatch resumeEntered = new CountDownLatch(1);
         CountDownLatch releaseResume = new CountDownLatch(1);
+        AtomicReference<WakeGate> self = new AtomicReference<>();
 
+        // The production order: warm-up opened before RUNNING is published, then a cold
+        // stretch before the stack is ready — so a waiter released early would be caught.
         WakeGate gate = gate(phase, ready::get, () -> {
             resumeRuns.incrementAndGet();
             resumeEntered.countDown();
@@ -61,16 +69,21 @@ class WakeGateTest {
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }
+            self.get().beginWarmup(10_000);
             phase.set(LifecycleState.RUNNING);
+            sleep(POLL_MS * 10); // RUNNING but cold
             ready.set(true);
         });
+        self.set(gate);
 
         int waiters = 8;
         CountDownLatch done = new CountDownLatch(waiters);
-        AtomicInteger successes = new AtomicInteger();
+        AtomicInteger answeredReady = new AtomicInteger();
         for (int i = 0; i < waiters; i++) {
             Thread t = new Thread(() -> {
-                if (gate.await(10_000)) successes.incrementAndGet();
+                // Read readiness the instant the hold ends: a waiter let go before the
+                // stack was ready must not count.
+                if (gate.await(10_000) && ready.get()) answeredReady.incrementAndGet();
                 done.countDown();
             });
             t.setDaemon(true);
@@ -84,7 +97,7 @@ class WakeGateTest {
 
         assertTrue(done.await(10, TimeUnit.SECONDS));
         assertEquals(1, resumeRuns.get(), "N concurrent waiters must produce exactly one resume");
-        assertEquals(waiters, successes.get(), "all held requests answer after the wake");
+        assertEquals(waiters, answeredReady.get(), "every held request is released only once ready");
     }
 
     @Test
@@ -147,11 +160,35 @@ class WakeGateTest {
     }
 
     @Test
+    void aPauseRacingTheReadinessCheckStillWakesTheStack() {
+        // The first phase read sees RUNNING, then a pause lands before the readiness
+        // check (which therefore fails). That must be handled as the pause it is — wake
+        // the stack and hold — not waved through as a running stack short of readiness.
+        AtomicReference<LifecycleState> phase = new AtomicReference<>(LifecycleState.PAUSED);
+        AtomicBoolean firstRead = new AtomicBoolean(true);
+        AtomicBoolean ready = new AtomicBoolean(false);
+        AtomicInteger resumeRuns = new AtomicInteger();
+        AtomicReference<WakeGate> self = new AtomicReference<>();
+        WakeGate gate = gate(() -> firstRead.getAndSet(false) ? LifecycleState.RUNNING : phase.get(),
+                ready::get, () -> {
+                    resumeRuns.incrementAndGet();
+                    self.get().beginWarmup(10_000);
+                    phase.set(LifecycleState.RUNNING);
+                    ready.set(true);
+                });
+        self.set(gate);
+
+        assertTrue(gate.await(10_000));
+        assertEquals(1, resumeRuns.get(), "the racing pause triggered the wake");
+        assertTrue(ready.get(), "released once the woken stack was ready");
+    }
+
+    @Test
     void aWarmupHoldsARunningStackUntilItIsReady() {
         AtomicReference<LifecycleState> phase = new AtomicReference<>(LifecycleState.RUNNING);
         AtomicBoolean ready = new AtomicBoolean(false);
         WakeGate gate = gate(phase, ready::get, () -> { });
-        gate.beginWarmup(60_000);
+        gate.beginWarmup(10_000);
 
         Thread warmer = new Thread(() -> {
             sleep(200);
@@ -160,7 +197,7 @@ class WakeGateTest {
         warmer.setDaemon(true);
         long t0 = System.nanoTime();
         warmer.start();
-        assertTrue(gate.await(60_000));
+        assertTrue(gate.await(10_000));
         assertTrue(msSince(t0) >= 150, "held through the warm-up until ready: " + msSince(t0));
     }
 
@@ -183,13 +220,33 @@ class WakeGateTest {
         AtomicReference<LifecycleState> phase = new AtomicReference<>(LifecycleState.RUNNING);
         AtomicBoolean ready = new AtomicBoolean(true);
         WakeGate gate = gate(phase, ready::get, () -> { });
-        gate.beginWarmup(60_000);
-        assertTrue(gate.await(60_000));
+        gate.beginWarmup(10_000);
+        assertTrue(gate.await(10_000));
 
         ready.set(false);
         long t0 = System.nanoTime();
-        assertTrue(gate.await(60_000));
+        assertTrue(gate.await(10_000));
         assertTrue(msSince(t0) < 5_000, "no hold once the node has warmed up");
+    }
+
+    @Test
+    void aWarmupNobodyWaitedOnStillEndsAtReadiness() {
+        // The stack gets ready with no request around to see it, then loses readiness later
+        // in the window. That later read must not be held: the window closed at the first
+        // readiness, observed by a request or not — otherwise the #312 freeze comes back,
+        // bounded by the window instead of the cap.
+        AtomicReference<LifecycleState> phase = new AtomicReference<>(LifecycleState.RUNNING);
+        AtomicBoolean ready = new AtomicBoolean(true);
+        WakeGate gate = gate(phase, ready::get, () -> { });
+        gate.beginWarmup(10_000);
+        long give = System.nanoTime() + 5_000_000_000L;
+        while (gate.warmingUp() && System.nanoTime() - give < 0) sleep(POLL_MS);
+        assertFalse(gate.warmingUp(), "the watcher closed the window at readiness");
+
+        ready.set(false);
+        long t0 = System.nanoTime();
+        assertTrue(gate.await(10_000));
+        assertTrue(msSince(t0) < 5_000, "a later readiness loss is not held");
     }
 
     @Test
@@ -202,7 +259,7 @@ class WakeGateTest {
         AtomicBoolean ready = new AtomicBoolean(false);
         AtomicReference<WakeGate> self = new AtomicReference<>();
         WakeGate gate = gate(phase, ready::get, () -> {
-            self.get().beginWarmup(60_000);
+            self.get().beginWarmup(10_000);
             phase.set(LifecycleState.RUNNING);
             sleep(200); // RUNNING but cold
             ready.set(true);
@@ -210,7 +267,7 @@ class WakeGateTest {
         self.set(gate);
 
         long t0 = System.nanoTime();
-        assertTrue(gate.await(60_000));
+        assertTrue(gate.await(10_000));
         assertTrue(ready.get(), "released only once the woken stack was ready");
         assertTrue(msSince(t0) >= 150, "held through the cold start: " + msSince(t0) + " ms");
     }
@@ -219,7 +276,7 @@ class WakeGateTest {
     void runningButStillWarmingAtTheCapReturnsTrue() {
         AtomicReference<LifecycleState> phase = new AtomicReference<>(LifecycleState.RUNNING);
         WakeGate gate = gate(phase, () -> false, () -> { });
-        gate.beginWarmup(60_000);
+        gate.beginWarmup(2_000);
 
         // Warming but never ready: at the cap the request is handed to the backend
         // anyway (it produces its own precise bounded errors).
@@ -234,7 +291,7 @@ class WakeGateTest {
         WakeGate gate = new WakeGate(phase::get, () -> false,
                 () -> { throw new IllegalStateException("status unreadable"); },
                 () -> { }, System::currentTimeMillis, POLL_MS, "test");
-        gate.beginWarmup(60_000);
+        gate.beginWarmup(5_000);
 
         long t0 = System.nanoTime();
         assertTrue(gate.await(WakeGate.SLOW_HOLD_WARN_MS + 300));

--- a/node-core/src/test/java/io/myotis/node/WakeGateTest.java
+++ b/node-core/src/test/java/io/myotis/node/WakeGateTest.java
@@ -9,6 +9,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BooleanSupplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -16,12 +17,33 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Hermetic tests for the wake-on-request primitive: single-flight resume,
- * bounded holds, activity stamping, and fast-fail on STOPPED.
+ * bounded holds, activity stamping, fast-fail on STOPPED — and that only a
+ * WAKING stack holds (PAUSED, or RUNNING inside a warm-up window): a running
+ * stack that lost readiness hands requests straight to the backend (#312).
  */
 @Timeout(value = 30, unit = TimeUnit.SECONDS)
 class WakeGateTest {
 
     private static final long POLL_MS = 5;
+
+    /** A gate over the real clock, without a not-ready detail. */
+    private static WakeGate gate(AtomicReference<LifecycleState> phase, BooleanSupplier ready,
+                                 Runnable resume) {
+        return new WakeGate(phase::get, ready, null, resume, System::currentTimeMillis, POLL_MS,
+                "test");
+    }
+
+    private static long msSince(long t0Nanos) {
+        return (System.nanoTime() - t0Nanos) / 1_000_000;
+    }
+
+    private static void sleep(long ms) {
+        try {
+            Thread.sleep(ms);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
 
     @Test
     void concurrentWaitersTriggerExactlyOneResume() throws Exception {
@@ -31,7 +53,7 @@ class WakeGateTest {
         CountDownLatch resumeEntered = new CountDownLatch(1);
         CountDownLatch releaseResume = new CountDownLatch(1);
 
-        WakeGate gate = new WakeGate(phase::get, ready::get, () -> {
+        WakeGate gate = gate(phase, ready::get, () -> {
             resumeRuns.incrementAndGet();
             resumeEntered.countDown();
             try {
@@ -41,7 +63,7 @@ class WakeGateTest {
             }
             phase.set(LifecycleState.RUNNING);
             ready.set(true);
-        }, System::currentTimeMillis, POLL_MS, "test-wake");
+        });
 
         int waiters = 8;
         CountDownLatch done = new CountDownLatch(waiters);
@@ -71,8 +93,7 @@ class WakeGateTest {
         AtomicInteger resumeRuns = new AtomicInteger();
 
         // Resume that fails: runs, but leaves the phase PAUSED.
-        WakeGate gate = new WakeGate(phase::get, () -> false, resumeRuns::incrementAndGet,
-                System::currentTimeMillis, POLL_MS, "test-wake");
+        WakeGate gate = gate(phase, () -> false, resumeRuns::incrementAndGet);
 
         assertFalse(gate.await(50), "still PAUSED at the deadline → false");
         int runsAfterFirst = resumeRuns.get();
@@ -87,8 +108,8 @@ class WakeGateTest {
     void everyCallBumpsLastActivity() {
         AtomicReference<LifecycleState> phase = new AtomicReference<>(LifecycleState.RUNNING);
         long[] now = {1_000L};
-        WakeGate gate = new WakeGate(phase::get, () -> true, () -> { },
-                () -> now[0], POLL_MS, "test-wake");
+        WakeGate gate = new WakeGate(phase::get, () -> true, null, () -> { },
+                () -> now[0], POLL_MS, "test");
 
         assertEquals(0, gate.lastActivityMs());
         assertTrue(gate.await(1_000));
@@ -103,24 +124,120 @@ class WakeGateTest {
     void stoppedReturnsImmediately() {
         AtomicReference<LifecycleState> phase = new AtomicReference<>(LifecycleState.STOPPED);
         AtomicInteger resumeRuns = new AtomicInteger();
-        WakeGate gate = new WakeGate(phase::get, () -> true, resumeRuns::incrementAndGet,
-                System::currentTimeMillis, POLL_MS, "test-wake");
+        WakeGate gate = gate(phase, () -> true, resumeRuns::incrementAndGet);
 
         long t0 = System.nanoTime();
         assertFalse(gate.await(60_000));
-        long elapsedMs = (System.nanoTime() - t0) / 1_000_000;
-        assertTrue(elapsedMs < 5_000, "STOPPED must not hold the request");
+        assertTrue(msSince(t0) < 5_000, "STOPPED must not hold the request");
         assertEquals(0, resumeRuns.get(), "STOPPED never triggers a wake");
     }
 
     @Test
-    void runningButColdAtDeadlineReturnsTrue() {
+    void runningNotReadyOutsideAWarmupIsHandedToTheBackendAtOnce() {
+        // #312: a node that was serving and then lost readiness (light client catching
+        // up a period, snap pool empty) must not park reads on the readiness predicate —
+        // every read, eth_blockNumber included, froze for the full cap and they all
+        // drained at the instant readiness came back.
         AtomicReference<LifecycleState> phase = new AtomicReference<>(LifecycleState.RUNNING);
-        WakeGate gate = new WakeGate(phase::get, () -> false, () -> { },
-                System::currentTimeMillis, POLL_MS, "test-wake");
+        WakeGate gate = gate(phase, () -> false, () -> { });
 
-        // RUNNING but never ready: at the cap the request is handed to the backend
+        long t0 = System.nanoTime();
+        assertTrue(gate.await(60_000), "attempted: the backend reports why it can't answer");
+        assertTrue(msSince(t0) < 5_000, "…without holding the request");
+    }
+
+    @Test
+    void aWarmupHoldsARunningStackUntilItIsReady() {
+        AtomicReference<LifecycleState> phase = new AtomicReference<>(LifecycleState.RUNNING);
+        AtomicBoolean ready = new AtomicBoolean(false);
+        WakeGate gate = gate(phase, ready::get, () -> { });
+        gate.beginWarmup(60_000);
+
+        Thread warmer = new Thread(() -> {
+            sleep(200);
+            ready.set(true);
+        });
+        warmer.setDaemon(true);
+        long t0 = System.nanoTime();
+        warmer.start();
+        assertTrue(gate.await(60_000));
+        assertTrue(msSince(t0) >= 150, "held through the warm-up until ready: " + msSince(t0));
+    }
+
+    @Test
+    void theWarmupWindowBoundsTheHold() {
+        AtomicReference<LifecycleState> phase = new AtomicReference<>(LifecycleState.RUNNING);
+        WakeGate gate = gate(phase, () -> false, () -> { });
+        gate.beginWarmup(100);
+
+        long t0 = System.nanoTime();
+        assertTrue(gate.await(60_000), "the window ran out: attempt the read");
+        long ms = msSince(t0);
+        assertTrue(ms >= 80 && ms < 5_000, "held for the window, not the cap: " + ms + " ms");
+    }
+
+    @Test
+    void readinessClosesTheWarmup() {
+        // Once a warm-up is seen to complete, a later readiness loss belongs to a running
+        // node: not held, although the window's time hasn't run out.
+        AtomicReference<LifecycleState> phase = new AtomicReference<>(LifecycleState.RUNNING);
+        AtomicBoolean ready = new AtomicBoolean(true);
+        WakeGate gate = gate(phase, ready::get, () -> { });
+        gate.beginWarmup(60_000);
+        assertTrue(gate.await(60_000));
+
+        ready.set(false);
+        long t0 = System.nanoTime();
+        assertTrue(gate.await(60_000));
+        assertTrue(msSince(t0) < 5_000, "no hold once the node has warmed up");
+    }
+
+    @Test
+    void aWakeHoldsThroughTheColdStartThatFollowsIt() {
+        // The production order: the resume opens the warm-up BEFORE it publishes RUNNING,
+        // then the stack sits RUNNING-but-cold (re-anchoring, re-dialing) for a while. The
+        // request that triggered the wake must stay held through that, not be released
+        // into a cold backend the moment the phase flips.
+        AtomicReference<LifecycleState> phase = new AtomicReference<>(LifecycleState.PAUSED);
+        AtomicBoolean ready = new AtomicBoolean(false);
+        AtomicReference<WakeGate> self = new AtomicReference<>();
+        WakeGate gate = gate(phase, ready::get, () -> {
+            self.get().beginWarmup(60_000);
+            phase.set(LifecycleState.RUNNING);
+            sleep(200); // RUNNING but cold
+            ready.set(true);
+        });
+        self.set(gate);
+
+        long t0 = System.nanoTime();
+        assertTrue(gate.await(60_000));
+        assertTrue(ready.get(), "released only once the woken stack was ready");
+        assertTrue(msSince(t0) >= 150, "held through the cold start: " + msSince(t0) + " ms");
+    }
+
+    @Test
+    void runningButStillWarmingAtTheCapReturnsTrue() {
+        AtomicReference<LifecycleState> phase = new AtomicReference<>(LifecycleState.RUNNING);
+        WakeGate gate = gate(phase, () -> false, () -> { });
+        gate.beginWarmup(60_000);
+
+        // Warming but never ready: at the cap the request is handed to the backend
         // anyway (it produces its own precise bounded errors).
         assertTrue(gate.await(50));
+    }
+
+    @Test
+    void aThrowingNotReadyDetailNeverBreaksAHold() {
+        // The slow-hold WARN asks for the not-ready detail; a diagnostics failure (e.g.
+        // an unreadable native status) must stay inside the log line.
+        AtomicReference<LifecycleState> phase = new AtomicReference<>(LifecycleState.RUNNING);
+        WakeGate gate = new WakeGate(phase::get, () -> false,
+                () -> { throw new IllegalStateException("status unreadable"); },
+                () -> { }, System::currentTimeMillis, POLL_MS, "test");
+        gate.beginWarmup(60_000);
+
+        long t0 = System.nanoTime();
+        assertTrue(gate.await(WakeGate.SLOW_HOLD_WARN_MS + 300));
+        assertTrue(msSince(t0) >= WakeGate.SLOW_HOLD_WARN_MS, "held past the WARN point");
     }
 }


### PR DESCRIPTION
Fixes #312.

## What the freeze was

Not a lock. It was the **wake gate** (`WakeGate`, shared by both engines) holding every verified read on a node that was **RUNNING but not ready**.

`WakeGate.await(90 s)` parks a read until `readyForReads()` is true (Rust: beacon `SYNCED` && optimistic head > 0 && `snapPeers > 0`; Java: `SYNCED` && a warm verified head) or the 90 s cap expires. The hold was built for wake-on-request (an idle-paused Android node), but it also applied to a node that had been running the whole time and had only *lost* readiness. In the report that was the sepolia light client catching up a period (`catch-up: requesting updates_by_range` every ~5 s). Every request polled the same predicate every 250 ms, `eth_blockNumber` included (it gates too), so they all released within one poll of readiness returning at ~14:56:30Z.

The numbers in the report line up with this:

| report | explanation |
|---|---|
| `eth_blockNumber … latencyMs=90013` | the 90 s `WAKE_WAIT_CAP_MS` expiring, then one status read |
| `[eth_blockNumber, eth_gasPrice]` batch, 123.9 s | batch elements run one after another: 90 s cap for `eth_blockNumber`, then `eth_gasPrice`'s own 34 s hold until readiness |
| `eth_call`, 93 s | two gate crossings: a number-pinned call goes through `RustVerifiedReads.isServableBlock` → `headBlockNumber()` (held to the cap), then the gated native call (3 s more, until readiness) |

It was not a pause or wake. The desktop host has no idle controller (`supportsIdleSleep()=false`), and `myotis_pause` wasn't in the reported build (3f5f66f3, 2026-08-07; it landed in 3c2b4e0f on 2026-08-16). The same problem was fixed once before for the UI status probe; see the comment on `RustChainHandle.logIndexStatusJson`.

## Fix

1. **`WakeGate` only holds a stack that is waking up.** That means `PAUSED` (wake in flight), or RUNNING-but-not-ready inside a **warm-up window**.
   - Every time the stack enters RUNNING, start() and resume() in both engines call `WakeGate.beginWarmup` before RUNNING becomes visible.
   - The window closes as soon as the stack is first ready, or after 90 s. A watcher polls through the warm-up, so the window closes even if no request is waiting to see it.
   - A running node that loses readiness hands the request straight to its backend. That is what already happened once the 90 s cap expired, so the hold only changed when the answer arrived, not what it was. Rust native reads fail fast (`beacon not synced`, `no snap peer available`) or serve against the anchored head. The Java backend's own head wait is bounded (5 s, or 25 s while a head build is in flight).
   - If a pause lands between the gate's phase read and its readiness check, the gate still wakes the node and holds the read. It doesn't mistake that for a running node that is merely not ready.
2. **`STALE_ANCHOR` is "attempt now" in both engines' readiness predicates**, like the existing EL-reader-unavailable fast path. Only a human can clear the park, so holding never helps. The router's curated STALE_ANCHOR message now comes back immediately.
3. **Instrumentation (issue item 1):**
   - *Router slow-call watchdog:* any request still unanswered after 1 s logs `WARN [rpc] slow call: method=… id=… [batch=i/n] still unanswered after …ms (phase=backend|status|lifecycle|proxy)`. It logs again when the request finishes, fails or is abandoned.
     - It uses its own logger, `io.myotis.jsonrpc.slow`, so the access stream stays uniformly INFO (as `RpcAccessLogTest` pins).
     - It is pinned at WARN in the desktop and daemon logback configs.
     - On iOS it goes through the Logs-tab sink as `W`.
   - *Wake gate:* a hold longer than 1 s logs `WARN [wake-gate:<net>] verified read held …: stack PAUSED, wake in progress | stack RUNNING but still warming up after a start/wake (beacon …, snapPeers …, head …)`, then INFO on release. The router line says which request is stuck; the gate line says why.
   - `eth_blockNumber`'s head read now runs on the IO dispatcher like every other blocking backend read. In production this changes nothing, because the router already runs on IO, but it lets the watchdog fire even under a single-threaded caller.

## Audit (issue item 2)

- **`engine.handles.lock()` in `rust/myotis-engine/src/host.rs`, all 12 sites:** each does O(1) work under the guard: insert/remove/get, `Arc` clones, `SyncHandle::status()` (a `watch::Receiver::borrow().clone()`), atomic stores, and the cheap served-window setter. Every `block_on` (start, stop and pause teardown, EL status counts, verified reads) runs after the guard is dropped. No change needed. `status_json`'s EL counts take the pool's short tokio mutexes outside `handles`.
- **Kotlin dispatch path:** `MethodLogger`'s mutex guards only an O(1) map update, and the log line is written outside it. There is no other shared mutex. Two serialization points exist and are left as they are:
  - Batch elements are handled one after another. JSON-RPC 2.0 allows this, but it amplified the report: 90 s + 34 s for a 2-element batch.
  - Every request runs on `Dispatchers.IO` (64 threads), and a blocked backend call holds one thread. Before this fix, the gate could park all 64 threads for 90 s, after which even `eth_chainId` would have queued.

## Not done: a per-request deadline (issue item 3, owner's call)

- The whitespace heartbeat exists so that slow legitimate calls can outlive OkHttp's per-read timeout; a sweep of ~1000 tokens over devp2p takes more than 30 s on mobile. A server deadline shorter than a browser's 10 s timeout would cut those calls off.
- The router can't cancel a blocking backend call, so a deadline would only drop the answer, not the work.
- With the running-node hold gone, the remaining long waits are inside the backends and already budgeted: Rust `REQUEST_BUDGET` 90 s, Java `RPC_CALL_TIMEOUT` 120 s. #320 tracks fast-fail on the interactive path.
- Processing batch elements concurrently would be the next latency win for wallets that batch (Kohaku sent 26 of its 66 requests as batches). That should be a separate change.

## Tests

- `WakeGateTest`:
  - A running node that isn't ready and has no warm-up window is handed to the backend at once (the #312 regression).
  - A warm-up holds until the stack is ready.
  - The window bounds the hold.
  - Readiness closes the window, whether a request saw it or only the watcher did.
  - A wake holds through the cold start that follows it, including for 8 concurrent waiters: each counts only if the stack was ready at the moment it was released.
  - A pause that races the readiness check still wakes the stack.
  - A stack still warming at the cap returns "attempt".
  - A not-ready detail supplier that throws never breaks a hold.
- `RustReadyForReadsTest`: the Rust readiness predicate, tested over status JSON through a JNI-free seam, including STALE_ANCHOR and EL-reader-unavailable returning "attempt now".
- `RpcSlowCallLogTest`:
  - A stuck call logs WARN while it is stuck (method, id, phase) and again when it completes.
  - Batch elements carry their position.
  - A fast call logs nothing.
  - The access stream stays INFO.

Run locally: `./gradlew :node-core:test :myotis-engines:test :jsonrpc-server:jvmTest`. Result: BUILD SUCCESSFUL, all passing (node-core 34, myotis-engines 128, jsonrpc-server 124). `:jsonrpc-server:compileKotlinIosSimulatorArm64` also passed; it covers the new `rpcLogWarn` iOS actual. Before this PR, an independent no-context reviewer made two passes. It raised 1 medium and 6 low findings, and the two follow-up commits address all of them:
- the watcher that closes the window at readiness (the medium);
- the racing-pause wake;
- stale docs in `ChainStack`, `RustChainHandle` and `JavaChainHandle`;
- test strength, and test timing on a cold JVM.

After the second pass nothing medium or high remained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
