### PR TITLE
Android: Rust engine only below API 33, no Java fallback

### DIFF
--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -74,6 +74,9 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: rust
+          # Shared with boot-smoke-api29 (same toolchain, same preBuild chain);
+          # only this job saves it, so the smoke job adds no second cache.
+          shared-key: android-rust
 
       - name: Install cargo-ndk
         uses: taiki-e/install-action@v2
@@ -223,7 +226,10 @@ jobs:
     # download, AVD creation, or an emulator/adb hang (the failure modes named
     # below), which would otherwise run to GitHub's 6-hour default on a job
     # whose failure nothing surfaces.
-    timeout-minutes: 45
+    # 60, not 45: this job now also builds the Rust engine (host bindings +
+    # both Android ABIs), roughly 13 min on the shared warm cache and far more
+    # cold, on top of the emulator run.
+    timeout-minutes: 60
     # NON-BLOCKING for now, deliberately: this is the repo's first emulator job,
     # and hosted-runner emulators are notoriously flaky (boot hangs, adb drops)
     # even with KVM. Job-level continue-on-error semantics: a failure still
@@ -272,6 +278,10 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: rust
+          # The build job's cache (see there); read-only here so a flaky red
+          # emulator run can't churn the repo's cache quota.
+          shared-key: android-rust
+          save-if: false
 
       - name: Install cargo-ndk
         uses: taiki-e/install-action@v2

--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -215,6 +215,12 @@ jobs:
   # build job's static dex scan; its boot is no longer run on an emulator here.
   boot-smoke-api29:
     name: API-29 boot smoke (emulator)
+    # After the build job: this job builds the same Rust engine, and the build
+    # job saves the shared `android-rust` cache at its end, so this job always
+    # restores a warm dependency cache from the same run instead of racing it
+    # cold. It also spends no emulator time on a commit whose build is broken.
+    # The cost is wall-clock: it starts only once the build job finishes.
+    needs: build
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -227,8 +233,8 @@ jobs:
     # below), which would otherwise run to GitHub's 6-hour default on a job
     # whose failure nothing surfaces.
     # 60, not 45: this job now also builds the Rust engine (host bindings +
-    # both Android ABIs), roughly 13 min on the shared warm cache and far more
-    # cold, on top of the emulator run.
+    # both Android ABIs), roughly 13 min on the warm cache `needs: build`
+    # guarantees, on top of the emulator run.
     timeout-minutes: 60
     # NON-BLOCKING for now, deliberately: this is the repo's first emulator job,
     # and hosted-runner emulators are notoriously flaky (boot hangs, adb drops)
@@ -278,8 +284,9 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: rust
-          # The build job's cache (see there); read-only here so a flaky red
-          # emulator run can't churn the repo's cache quota.
+          # The build job's cache, saved by that job earlier in this same run
+          # (needs: build). Read-only here so a flaky red emulator run can't
+          # churn the repo's cache quota.
           shared-key: android-rust
           save-if: false
 

--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -203,12 +203,13 @@ jobs:
   # NoClassDefFoundError/NoSuchMethodError fails here instead of on a user's
   # phone.
   #
-  # -PskipRustEngine: runs on the Java engine. The minSdk-linkage risk this job
-  # hunts lives entirely in the JVM code (the Rust .so has no JDK/ART surface),
-  # it spares this job the whole Android Rust toolchain, and it is exactly the
-  # fallback an APK without the jniLibs uses at runtime. Known gap, accepted:
-  # the Rust engine's own on-device load path (JNA/UniFFI) is not exercised by
-  # any boot test yet.
+  # Built WITH the Rust engine (no -PskipRustEngine): below API 33 the app runs
+  # the Rust engine only, with no Java fallback (EngineGate: the Java engine's
+  # VarHandle users cannot link on Android 10-12), so on this API-29 device it
+  # is the only engine that can boot. That also covers the Rust engine's
+  # on-device load path (JNA + UniFFI + libmyotis_engine.so) on minSdk ART,
+  # which no boot test exercised before. The Java engine's JVM code keeps the
+  # build job's static dex scan; its boot is no longer run on an emulator here.
   boot-smoke-api29:
     name: API-29 boot smoke (emulator)
     runs-on: ubuntu-latest
@@ -260,6 +261,23 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      # The Rust engine, same toolchain as the build job: the app's preBuild runs
+      # cargoNdkAndroid for both APK ABIs (the device itself is x86_64).
+      - name: Set up Rust (Android targets)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-linux-android,x86_64-linux-android
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust
+
+      - name: Install cargo-ndk
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-ndk
+
       # AGP's managed-device setup downloads the emulator + the API-29 system
       # image (several hundred MB, a couple of minutes) into the runner's
       # preinstalled SDK by itself — no sdkmanager steps needed, licenses are
@@ -282,7 +300,7 @@ jobs:
         id: gmd
         continue-on-error: true
         run: |
-          ./gradlew :android-app:api29DebugAndroidTest -PskipRustEngine \
+          ./gradlew :android-app:api29DebugAndroidTest \
             -Pandroid.testoptions.manageddevices.emulator.gpu=swiftshader_indirect \
             --stacktrace
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 # from source — other workflows do NOT, so regenerate them explicitly with
 # `./gradlew uniffiGenerateKotlin` after changing the Rust FFI. Opt out when you
 # lack the toolchain — the build tells you about the switch — with:
-./gradlew :android-app:assembleDebug -PskipRustEngine  # Java engine only (no Rust engine / native BLS)
+./gradlew :android-app:assembleDebug -PskipRustEngine  # Java engine only (no Rust engine / native BLS); boots on API 33+ only
 
 # iOS (macOS only; needs Xcode 26+ and the rustup targets on the toolchain the
 # workspace's rust-toolchain.toml selects — i.e.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 # Build all modules. NOTE: :android-app builds the Rust engine from source by
 # default, so a full build needs the Android Rust toolchain (cargo + cargo-ndk +
 # NDK r28+ + the aarch64/x86_64-linux-android rustup targets). Without it, add
-# -PskipRustEngine to build the app on the Java engine (see the Rust section below).
+# -PskipRustEngine to build the app on the Java engine, which boots only on
+# Android 13 / API 33+ (see the Rust section below).
 ./gradlew build                  # add -PskipRustEngine without the Android Rust toolchain
 
 # Compile only (no tests)

--- a/README.md
+++ b/README.md
@@ -816,7 +816,7 @@ Myotis ships **two engines** behind one contract: the original **Java engine** a
 - **The contract** is `:myotis-api` — zero-dependency Java-17 interfaces (`MyotisEngine`/`ChainHandle`, FFI-portable types only). Hosts (Android app, desktop app, daemon) consume *only* this API and never import engine internals.
 - **The Java engine** is the original implementation (`node-core` adapters over the `networking`/`consensus`/`myotis-evm` modules).
 - **The Rust engine** is the `rust/` Cargo workspace (`myotis-core`, `myotis-net`, `myotis-consensus`, `myotis-bls`, `myotis-evm`, `myotis-engine`): discv4 + discv5 discovery, RLPx/eth/snap, the beacon light client with BLS via blst, a revm-based EVM with the same snap-proof state oracle, ENS incl. CCIP-Read, and multichain (mainnet, Sepolia, Gnosis). It reaches the JVM through UniFFI-generated Kotlin bindings over JNA (the generated bindings are committed in `:myotis-engines`, regenerated via `uniffiGenerateKotlin`); compound values cross as JSON, pinned by golden tests on both sides. The same engine's plain C ABI also serves the two non-JVM hosts: the iOS app (Kotlin/Native cinterop) and the Node.js addon (`rust/myotis-node`, napi-rs) — identical JSON shapes, pinned by the same golden tests.
-- **Selection**: the `:myotis-engines` selector (`Engines.engine()`) routes each network to an engine via the `myotis.engine` property — `auto` (default: the Rust engine where it can serve, Java fallback otherwise), `java`, or `rust` (hard — error when unavailable). On run tasks use `-Pengine=java` to opt out; in the apps it's the "Prefer Java engine" Settings toggle (applies on network restart). The Status screen shows which engine hosts each network — "Mainnet (r)" vs "(j)".
+- **Selection**: the `:myotis-engines` selector (`Engines.engine()`) routes each network to an engine via the `myotis.engine` property — `auto` (default: the Rust engine where it can serve, Java fallback otherwise), `java`, or `rust` (hard — error when unavailable). On run tasks use `-Pengine=java` to opt out; in the apps it's the "Prefer Java engine" Settings toggle (applies on network restart). **Android below API 33 (Android 13) is Rust-only**: the Java engine's EVM (Besu's `UInt256`) and its discv5 (Guava futures) use `VarHandle` APIs that Android 10–12 keep hidden, so the app forces `rust` there with no Java fallback, and Settings explains this instead of offering the toggle. The Status screen shows which engine hosts each network — "Mainnet (r)" vs "(j)".
 - **Parity** is enforced by shared conformance vectors (BLS fixtures, a captured mainnet light-client corpus, the EL verification-ladder vectors) run against both implementations, plus a benchmark gate for the JNI path.
 
 **rustc/cargo are NOT required to build or run the JVM hosts (daemon + desktop).**
@@ -831,7 +831,7 @@ falls back to the Java engine — there is nothing to configure or disable. The
 `cargoNdkAndroid` and regenerates the bindings). There is no committed `.so`, so
 nothing can drift; a missing toolchain fails the build with a message pointing at
 `-PskipRustEngine`, which builds the app without the Rust engine (Java engine at
-runtime). The packaged **desktop installers** also need cargo
+runtime, so such a build can only start networks on Android 13 / API 33 and newer). The packaged **desktop installers** also need cargo
 (`packageDmg`/`packageDeb`/`runDistributable` fail loudly without it, so an
 installed app can always switch engines).
 Release artifacts don't rely on committed binaries — CI builds the Rust engine

--- a/android-app/build.gradle.kts
+++ b/android-app/build.gradle.kts
@@ -166,11 +166,12 @@ android {
         // Gradle Managed Device pinned to minSdk (API 29) for NodeBootSmokeTest
         // (androidTest — its KDoc carries the full why: real-ART boot coverage the
         // static dex scan cannot give). Run it with
-        //   ./gradlew :android-app:api29DebugAndroidTest -PskipRustEngine
+        //   ./gradlew :android-app:api29DebugAndroidTest
         // (CI adds -Pandroid.testoptions.manageddevices.emulator.gpu=
         // swiftshader_indirect for its GPU-less runners — see
-        // .github/workflows/android-apk.yml; without -PskipRustEngine the device
-        // also gets the Rust engine, which the toolchain gate then requires).
+        // .github/workflows/android-apk.yml). It needs the Android Rust toolchain:
+        // below API 33 the app is Rust-engine-only (EngineGate), so a
+        // -PskipRustEngine build cannot boot a network on this device.
         // "aosp", not "aosp-atd": the leaner ATD images only exist for API 30+.
         // x86_64 hosts only — Google never published an API-29 arm64 emulator
         // image, so an Apple-Silicon Mac can't run this device locally; the CI

--- a/android-app/build.gradle.kts
+++ b/android-app/build.gradle.kts
@@ -408,7 +408,8 @@ dependencies {
 // the toolchain present, cargoNdkAndroid cross-compiles the jniLibs and
 // uniffiGenerateKotlin refreshes the committed bindings from the same source;
 // without it, the build fails and names `-PskipRustEngine` (which omits the
-// engine and falls back to the Java engine at runtime). verifyAndroidJniLibs is
+// engine; the app then runs the Java engine, on API 33+ only — EngineGate).
+// verifyAndroidJniLibs is
 // the post-build backstop that the produced .so exports every UniFFI symbol the
 // (now-fresh) bindings require. Auto-regen is scoped to the Android build ON
 // PURPOSE — the JVM hosts must stay buildable without cargo (see
@@ -527,8 +528,8 @@ val extractJnaAndroidNatives = tasks.register<Sync>("extractJnaAndroidNatives") 
         val missing = shippedAbis.filterNot { it in got }
         check(missing.isEmpty()) {
             "jna-$jnaVersion.aar carries no libjnidispatch.so for $missing — those ABIs " +
-                "would ship libmyotis_engine.so with no JNA dispatcher and silently fall " +
-                "back to the Java engine at runtime."
+                "would ship libmyotis_engine.so with no JNA dispatcher, so the Rust engine " +
+                "could not load at runtime (a silent Java fallback on API 33+, a failed boot below)."
         }
     }
 }

--- a/android-app/src/androidTest/java/com/jaeckel/ethp2p/android/NodeBootSmokeTest.kt
+++ b/android-app/src/androidTest/java/com/jaeckel/ethp2p/android/NodeBootSmokeTest.kt
@@ -18,11 +18,11 @@ import java.util.concurrent.TimeUnit
  * [MainActivity], let its fresh-launch path auto-start [NodeService], and wait for the
  * primary network's boot verdict.
  *
- * The point is runtime linkage, not sync: `ChainStack.start()` synchronously walks the
- * whole networking + consensus init sequence — EIP-1459 DNS discovery, the RLPx
- * connector and initial dials, discv4, discv5 + the beacon light client (libp2p, BLS,
- * SSZ), the Ktor JSON-RPC server, the snap-peer maintainer — so a recorded
- * [NodeService.BOOT_STARTED] proves that code actually EXECUTED on this API level.
+ * The point is runtime linkage, not sync: starting the network walks the engine's whole
+ * init sequence — on this device the Rust engine (see the scope notes below): loading
+ * JNA and the native library, the UniFFI ABI handshake, the native engine's start, and
+ * the host's Ktor JSON-RPC server — so a recorded [NodeService.BOOT_STARTED] proves
+ * that code actually EXECUTED on this API level.
  * That is coverage a static bytecode scan cannot give: `android.*` framework APIs
  * above minSdk (`SDK_INT` guards are invisible to a dex scan — only running on real
  * API-29 ART checks they work), `java.*` members the SDK's api-versions.xml has no
@@ -35,10 +35,10 @@ import java.util.concurrent.TimeUnit
  *  - thrown in host/service code or `ENGINE.create()`: the boot worker catches only
  *    `Exception`, so the `Error` crashes the app process and the instrumentation
  *    report carries the crash stack;
- *  - thrown inside `ChainStack.start()`: its internal `catch (Throwable)` converts it
- *    to a `false` return (no crash, stack trace in the log), which [NodeService]
- *    records as a failed boot outcome — this test then FAILS FAST with the app log's
- *    error lines instead of burning the whole deadline.
+ *  - a failure the engine's `start()` reports, as a `false` return or an exception:
+ *    [NodeService] records it as a failed boot outcome (no crash, stack trace in the
+ *    log), and this test then FAILS FAST with the app log's error lines instead of
+ *    burning the whole deadline.
  *
  * Success additionally requires [NodeService.Snapshot.rpcServing]: ChainStack treats
  * the JSON-RPC bring-up as best-effort (an init failure there is swallowed with
@@ -51,9 +51,12 @@ import java.util.concurrent.TimeUnit
  *  - The boot is triggered by MainActivity's fresh-launch auto-start — the real
  *    cold-launch path. If that auto-start is ever gated (onboarding, a setting), this
  *    test must start the service itself instead of timing out.
- *  - Engine-agnostic, but under `-PskipRustEngine` (how CI runs it) the selector
- *    serves the Java engine — exactly the fallback an APK without the Rust jniLibs
- *    uses at runtime. The Rust engine's own load path is NOT covered here.
+ *  - Runs on the Rust engine. Below API 33 the app forces it with no Java fallback
+ *    (EngineGate: the Java engine's VarHandle users cannot link there), so on this
+ *    API-29 device it is the only engine that can boot, and a build without the Rust
+ *    jniLibs (`-PskipRustEngine`) fails this test by design. CI therefore builds WITH
+ *    the Rust engine, which also covers its on-device load path (JNA + the native
+ *    library) on minSdk ART. The Java engine's own boot is covered on API 33+ only.
  *  - Needs no peers and no internet: "started" means local binds and threads are up.
  */
 @RunWith(AndroidJUnit4::class)

--- a/android-app/src/androidTest/java/com/jaeckel/ethp2p/android/NodeBootSmokeTest.kt
+++ b/android-app/src/androidTest/java/com/jaeckel/ethp2p/android/NodeBootSmokeTest.kt
@@ -56,7 +56,8 @@ import java.util.concurrent.TimeUnit
  *    API-29 device it is the only engine that can boot, and a build without the Rust
  *    jniLibs (`-PskipRustEngine`) fails this test by design. CI therefore builds WITH
  *    the Rust engine, which also covers its on-device load path (JNA + the native
- *    library) on minSdk ART. The Java engine's own boot is covered on API 33+ only.
+ *    library) on minSdk ART. The Java engine can only boot on API 33+, and no emulator
+ *    job runs its boot today; it is covered only by the build job's static dex scan.
  *  - Needs no peers and no internet: "started" means local binds and threads are up.
  */
 @RunWith(AndroidJUnit4::class)

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/EngineGate.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/EngineGate.java
@@ -1,0 +1,51 @@
+package com.jaeckel.ethp2p.android;
+
+/**
+ * Which engines this Android device can run, by API level. Pure (no Android imports) so
+ * the policy is unit-testable on the JVM; {@link NodeService} feeds it
+ * {@code Build.VERSION.SDK_INT}.
+ *
+ * <p>The Java engine is disabled below {@link #JAVA_ENGINE_MIN_SDK}. Verified on an
+ * Android 10 (API 29) emulator, 2026-09-11: Besu's {@code UInt256} static initializer
+ * links {@code MethodHandles.byteArrayViewVarHandle}, and the JRE variant of Guava (forced
+ * for Besu) links {@code VarHandle.get/set} in {@code AbstractFutureState$VarHandleAtomicHelper}.
+ * Android 10-12 keep those APIs hidden, and ART refuses to link them for an app targeting
+ * a current SDK ("greylist-max-o" / "blacklist, linking, denied"). The result: every
+ * Java-engine eth_call / ENS lookup fails, its discv5 never starts, and the failed Guava
+ * class poisons every later Guava future in the process. The VarHandle APIs became public
+ * in API 33 (Android 13).
+ *
+ * <p>The Rust engine runs these devices fine, so below the gate every network runs on it
+ * with NO Java fallback: the selector's hard {@code rust} choice fails a boot visibly
+ * instead of handing the network to an engine that cannot work. See issue #402.
+ */
+final class EngineGate {
+
+    /** Android 13 (TIRAMISU): the first API level where the Java engine's VarHandle users link. */
+    static final int JAVA_ENGINE_MIN_SDK = 33;
+
+    private EngineGate() {}
+
+    static boolean javaEngineSupported(int sdkInt) {
+        return sdkInt >= JAVA_ENGINE_MIN_SDK;
+    }
+
+    /**
+     * The {@code Engines} selector choice for this device: a hard {@code rust} (no Java
+     * fallback) below the gate, whatever the stored preference; otherwise {@code java} when
+     * the user prefers it, else {@code auto}.
+     */
+    static String engineChoice(int sdkInt, boolean preferJava) {
+        if (!javaEngineSupported(sdkInt)) return "rust";
+        return preferJava ? "java" : "auto";
+    }
+
+    /** Why the Java engine is unavailable on this device (shown in Settings), or null when it is available. */
+    static String javaEngineUnavailableReason(int sdkInt) {
+        if (javaEngineSupported(sdkInt)) return null;
+        return "This device runs Android API " + sdkInt + ". The Java engine needs API "
+                + JAVA_ENGINE_MIN_SDK + " (Android 13) or newer, so every network runs on the Rust "
+                + "engine, with no Java fallback. The Query tab's transaction-history scan, which "
+                + "only the Java engine serves, is not available here.";
+    }
+}

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/NodeService.java
@@ -513,6 +513,9 @@ public final class NodeService extends Service {
      *  is a user who touched the toggle and deliberately ended on the Java engine — an
      *  expressed opt-out this seeds into the new key rather than silently discarding. */
     public static boolean preferJavaEngine(android.content.Context c) {
+        // Never honoured below the Java-engine gate (EngineGate): the engine cannot link on
+        // that ART. The stored value is kept, so an OS upgrade past the gate restores it.
+        if (!javaEngineSupported()) return false;
         android.content.SharedPreferences p = prefs(c);
         if (!p.contains(K_PREFER_JAVA) && p.contains("rustEngine") && !p.getBoolean("rustEngine", true)) {
             p.edit().putBoolean(K_PREFER_JAVA, true).apply();
@@ -525,14 +528,25 @@ public final class NodeService extends Service {
     }
     /** Apply the engine setting to the process-wide {@code Engines} selector. Maps the
      *  default → {@code auto} (prefer Rust where it can serve, fall back to Java with a
-     *  log), prefer-Java → {@code java}. Unlike the BLS toggle this is NOT live: networks
-     *  keep the engine that created them; the new choice applies on the next network
-     *  (re)start. Returns the applied choice. */
+     *  log), prefer-Java → {@code java}. Below {@link EngineGate#JAVA_ENGINE_MIN_SDK} it is
+     *  always a hard {@code rust}: no fallback to a Java engine that cannot link on that
+     *  ART, so a Rust create() failure fails the boot visibly. Unlike the BLS toggle this
+     *  is NOT live: networks keep the engine that created them; the new choice applies on
+     *  the next network (re)start. Returns the applied choice. */
     public static String applyEngineChoice(android.content.Context c) {
-        String choice = preferJavaEngine(c) ? "java" : "auto";
+        String choice = EngineGate.engineChoice(android.os.Build.VERSION.SDK_INT, preferJavaEngine(c));
         System.setProperty(io.myotis.engines.Engines.PROP, choice);
         io.myotis.engines.Engines.select(choice);
         return choice;
+    }
+    /** Whether this device's ART can run the Java engine at all (see {@link EngineGate}). */
+    public static boolean javaEngineSupported() {
+        return EngineGate.javaEngineSupported(android.os.Build.VERSION.SDK_INT);
+    }
+    /** Settings text explaining why the Java engine is unavailable on this device, or
+     *  null when it is available. */
+    public static String javaEngineUnavailableReason() {
+        return EngineGate.javaEngineUnavailableReason(android.os.Build.VERSION.SDK_INT);
     }
     /** Live-update the snap-peer target (no restart) on every live stack and persist it. */
     public void setTargetSnapPeers(int v) {
@@ -1709,7 +1723,10 @@ public final class NodeService extends Service {
                     + ", rpc port " + rpcPort
                     + ", state-freshness " + (strictStateFreshness(this) ? "strict" : "relaxed")
                     + ", bls " + blsChoice
-                    + ", engine " + engineChoice + ")");
+                    + ", engine " + engineChoice
+                    + (javaEngineSupported() ? "" : " (Java engine needs API "
+                            + EngineGate.JAVA_ENGINE_MIN_SDK + "+, no fallback)")
+                    + ")");
 
             // create() + start() under the per-network bootLock: a Stop→Start / disable→enable
             // has this boot wait for the old instance's teardown (which holds the same lock) to

--- a/android-app/src/main/java/com/jaeckel/ethp2p/android/cmp/AndroidNodeBridge.kt
+++ b/android-app/src/main/java/com/jaeckel/ethp2p/android/cmp/AndroidNodeBridge.kt
@@ -332,6 +332,7 @@ class AndroidSettings(private val ctx: Context) : Settings {
     override fun setNativeBlsEnabled(v: Boolean) = NodeService.setNativeBlsEnabled(ctx, v)
     override fun preferJavaEngine(): Boolean = NodeService.preferJavaEngine(ctx)
     override fun setPreferJavaEngine(v: Boolean) = NodeService.setPreferJavaEngine(ctx, v)
+    override fun javaEngineUnavailableReason(): String? = NodeService.javaEngineUnavailableReason()
 
     override fun idlePauseMinutes(): Int = NodeService.idlePauseMinutes(ctx)
     override fun setIdlePauseMinutes(v: Int) = NodeService.setIdlePauseMinutes(ctx, v)

--- a/android-app/src/test/java/com/jaeckel/ethp2p/android/EngineGateTest.java
+++ b/android-app/src/test/java/com/jaeckel/ethp2p/android/EngineGateTest.java
@@ -1,0 +1,48 @@
+package com.jaeckel.ethp2p.android;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class EngineGateTest {
+
+    @Test
+    public void gateIsAndroid13() {
+        // Pinned: API 33 is where MethodHandles.byteArrayViewVarHandle and VarHandle
+        // became public. Lowering it re-exposes the API-29 crash; raising it needs evidence.
+        assertEquals(33, EngineGate.JAVA_ENGINE_MIN_SDK);
+    }
+
+    @Test
+    public void belowTheGateIsRustOnlyWhateverThePreference() {
+        for (int sdk = 29; sdk < EngineGate.JAVA_ENGINE_MIN_SDK; sdk++) {
+            assertFalse("sdk " + sdk, EngineGate.javaEngineSupported(sdk));
+            assertEquals("sdk " + sdk, "rust", EngineGate.engineChoice(sdk, false));
+            // A stored "prefer Java" must not bring the Java engine (or its fallback) back.
+            assertEquals("sdk " + sdk, "rust", EngineGate.engineChoice(sdk, true));
+        }
+    }
+
+    @Test
+    public void atAndAboveTheGateTheUsersPreferenceApplies() {
+        for (int sdk : new int[] {EngineGate.JAVA_ENGINE_MIN_SDK, 34, 35, 36}) {
+            assertTrue("sdk " + sdk, EngineGate.javaEngineSupported(sdk));
+            assertEquals("sdk " + sdk, "auto", EngineGate.engineChoice(sdk, false));
+            assertEquals("sdk " + sdk, "java", EngineGate.engineChoice(sdk, true));
+        }
+    }
+
+    @Test
+    public void reasonOnlyBelowTheGateAndNamesBothLevels() {
+        assertNull(EngineGate.javaEngineUnavailableReason(EngineGate.JAVA_ENGINE_MIN_SDK));
+        assertNull(EngineGate.javaEngineUnavailableReason(36));
+        String reason = EngineGate.javaEngineUnavailableReason(29);
+        assertNotNull(reason);
+        assertTrue(reason, reason.contains("API 29"));
+        assertTrue(reason, reason.contains("API 33"));
+    }
+}

--- a/app-ios/src/iosMain/kotlin/io/myotis/ios/IosSettings.kt
+++ b/app-ios/src/iosMain/kotlin/io/myotis/ios/IosSettings.kt
@@ -24,7 +24,9 @@ internal data class IosNetworkInfo(
  * The BLS and engine toggles are inert here: blst is compiled INTO the engine
  * static lib and the Rust engine is the only engine, so nativeBls reads as a
  * fixed `true`, preferJavaEngine keeps its inert default `false` (there is no
- * Java engine to prefer), and the setters drop the write.
+ * Java engine to prefer), and the setters drop the write. Settings shows
+ * [javaEngineUnavailableReason] in place of the engine toggle, so iOS never
+ * offers a switch that does nothing.
  */
 class IosSettings : Settings {
 
@@ -125,7 +127,10 @@ class IosSettings : Settings {
     override fun setNativeBlsEnabled(v: Boolean) {}
 
     // The Rust engine is the only engine on iOS: [Settings]' inert defaults for
-    // preferJavaEngine (false / drop-the-write) are exactly this host's semantics.
+    // preferJavaEngine (false / drop-the-write) are exactly this host's semantics,
+    // and the reason below replaces the engine toggle in Settings.
+    override fun javaEngineUnavailableReason(): String =
+        "iOS runs the Rust engine only: there is no Java engine on this platform."
 
     private companion object {
         const val K_ENABLED = "networks.enabled"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -651,7 +651,8 @@ tasks.register("requireAndroidRustEngine") {
     doLast {
         if (skipRustEngine) {
             logger.lifecycle("[rust] -PskipRustEngine set — building :android-app WITHOUT the " +
-                "Rust engine; it will use the Java engine (and JVM BLS) at runtime.")
+                "Rust engine; it will use the Java engine (and JVM BLS) at runtime, which boots only " +
+                "on Android 13 (API 33) and newer — below that the app is Rust-engine-only.")
             return@doLast
         }
         if (!androidRustToolchainReady) {
@@ -668,7 +669,7 @@ tasks.register("requireAndroidRustEngine") {
                     "incomplete — missing: ${missing.joinToString("; ")}.\n" +
                     "  • Install it (one-time setup is documented in rust/build-android.sh), OR\n" +
                     "  • Build WITHOUT the Rust engine: add -PskipRustEngine (the app will use the " +
-                    "Java engine at runtime).",
+                    "Java engine at runtime, which boots only on Android 13 / API 33 and newer).",
             )
         }
     }
@@ -818,7 +819,7 @@ gradle.taskGraph.whenReady {
     } else if (allTasks.any { it.name == "cargoNdkAndroid" } && skipRustEngine) {
         // Missing-toolchain (without the flag) is handled loudly at execution by
         // requireAndroidRustEngine; here we only note the deliberate opt-out.
-        logger.lifecycle("[rust] -PskipRustEngine set — the Android app will omit the Rust engine (Java engine at runtime)")
+        logger.lifecycle("[rust] -PskipRustEngine set — the Android app will omit the Rust engine (Java engine at runtime; boots on API 33+ only)")
     } else if (allTasks.any { it.name == "cargoCheckWasm" } &&
         (!wasmTargetInstalled || !clangAvailable)
     ) {

--- a/docs/react-native.md
+++ b/docs/react-native.md
@@ -26,7 +26,8 @@ The integration builds on three assets:
 
    > **Note (updated):** `:android-app` no longer commits the `.so` binaries.
    > It builds the Rust engine **from source** by default (cargo + cargo-ndk +
-   > NDK required; `-PskipRustEngine` opts out to the Java engine). The
+   > NDK required; `-PskipRustEngine` opts out to the Java engine, which boots
+   > only on Android 13 / API 33 and newer — below that the app is Rust-only). The
    > "committed jniLibs as a no-toolchain fallback" model described in this
    > proposal is stale; an RN package can still ship prebuilt binaries **in its
    > published npm tarball** without committing them to git — decide that

--- a/myotis-engines/src/main/java/io/myotis/engines/SelectorEngine.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/SelectorEngine.java
@@ -133,6 +133,18 @@ public final class SelectorEngine implements MyotisEngine {
                 target = java;
             }
         }
+        if (target != java) {
+            // Explicit rust (auto has returned or switched to java above): never a
+            // fallback, and a failure must still arrive as the EngineException this
+            // class promises, not as a raw LinkageError that takes the host process down.
+            // Android below API 33 runs on this path by default (no Java engine there).
+            try {
+                return createOn(target, canonical, config, ports);
+            } catch (LinkageError e) {
+                throw new EngineException("Rust engine create(" + config.networkName()
+                        + ") failed to link: " + e, e);
+            }
+        }
         return createOn(target, canonical, config, ports);
     }
 

--- a/myotis-engines/src/main/java/io/myotis/engines/SelectorEngine.java
+++ b/myotis-engines/src/main/java/io/myotis/engines/SelectorEngine.java
@@ -105,6 +105,22 @@ public final class SelectorEngine implements MyotisEngine {
         // deciding fallback behavior must not turn an in-flight auto-create into a hard
         // failure (or vice versa).
         String choice = Engines.choice();
+        if (!"rust".equals(choice)) return createFor(choice, config, ports);
+        // Explicit rust: never a fallback, and every failure must arrive as the
+        // EngineException this class promises. Resolving the engine, canonicalizing the
+        // name and creating the network all cross the native boundary, so a LinkageError
+        // from any of them is wrapped here instead of taking the host process down.
+        // Android below API 33 runs on this path by default (no Java engine there).
+        try {
+            return createFor(choice, config, ports);
+        } catch (LinkageError e) {
+            throw new EngineException("Rust engine failed to link while creating "
+                    + config.networkName() + ": " + e, e);
+        }
+    }
+
+    /** The create path for one already-read {@code choice}; runs under {@link #create}'s lock. */
+    private ChainHandle createFor(String choice, EngineConfig config, EnginePorts ports) {
         MyotisEngine target = resolveFor(choice);
         // Cross-engine duplicate guard, BEFORE any create attempt: each engine
         // self-checks only its OWN registry, so without this a choice flip between two
@@ -131,18 +147,6 @@ public final class SelectorEngine implements MyotisEngine {
                 log.warn("[engines] auto: Rust engine create({}) failed ({}); "
                         + "falling back to the Java engine", config.networkName(), e.getMessage());
                 target = java;
-            }
-        }
-        if (target != java) {
-            // Explicit rust (auto has returned or switched to java above): never a
-            // fallback, and a failure must still arrive as the EngineException this
-            // class promises, not as a raw LinkageError that takes the host process down.
-            // Android below API 33 runs on this path by default (no Java engine there).
-            try {
-                return createOn(target, canonical, config, ports);
-            } catch (LinkageError e) {
-                throw new EngineException("Rust engine create(" + config.networkName()
-                        + ") failed to link: " + e, e);
             }
         }
         return createOn(target, canonical, config, ports);

--- a/scripts/min-api-allowlist.txt
+++ b/scripts/min-api-allowlist.txt
@@ -9,8 +9,8 @@
 # three classes, noted per section:
 #   [guarded]  the library probes for the API at runtime and falls back;
 #   [dormant]  the code path is not wired/reachable in this app's configuration;
-#   [LIVE]     reachable on a normal run — a real crash on Android 10/11 (API
-#              29/30, no ART module backports) tracked for an upstream/fork fix.
+#   [LIVE]     reachable on a normal run at an API level where the app still runs
+#              that code — a real crash there, tracked for an upstream/fork fix.
 # Regenerate candidates by running the checker with --allowlist /dev/null.
 
 # desugar_jdk_libs' own j$ wrappers bridge to the platform Flow only on devices
@@ -36,11 +36,16 @@ j$/ java/util/concurrent/Flow$Subscription#<class>
 io/libp2p/ java/util/concurrent/CompletableFuture#failedFuture(Ljava/lang/Throwable;)Ljava/util/concurrent/CompletableFuture;
 io/libp2p/ java/util/concurrent/CompletableFuture#orTimeout(JLjava/util/concurrent/TimeUnit;)Ljava/util/concurrent/CompletableFuture;
 
-# Besu fork + upstream besu jars. UInt256 (unsignedMultiplyHigh, API 35!) and
-# the Eq/Shift256/Exp operations are the EVM interpreter's word arithmetic —
-# [LIVE] for eth_call/ENS on Android 10/11 without ART backports; tracked by
-# issue #402 for the next biafra23/besu fork rebase (<ver>-android.N). Era1Type,
-# RollingFileWriter, LogsBloomFilter.Builder, Merkleizer, PrintWriter/
+# Besu fork + upstream besu jars (Java engine only). UInt256 (byteArrayViewVarHandle
+# in its static initializer, VarHandle get/set) and the Eq/Shift256/Exp operations
+# are the EVM interpreter's word arithmetic. Below API 33 they cannot link at all
+# (hidden VarHandle APIs; verified on an API-29 emulator), so the app disables the
+# Java engine there: EngineGate.JAVA_ENGINE_MIN_SDK forces the Rust engine with no
+# Java fallback, which makes these [dormant] on API 29-32. From API 33 the Java
+# engine runs, and String#formatted (API 34, ExceptionalHaltReason) is still [LIVE]
+# on API 33; tracked by issue #402 for the next biafra23/besu fork rebase
+# (<ver>-android.N). Math#unsignedMultiplyHigh needs no entry: R8 backports it.
+# Era1Type, RollingFileWriter, LogsBloomFilter.Builder, Merkleizer, PrintWriter/
 # BufferedInputStream uses and the xerial-snappy read are era1/util paths the
 # wallet never executes. [dormant]
 org/hyperledger/ java/io/BufferedInputStream#readNBytes(I)[B
@@ -48,7 +53,6 @@ org/hyperledger/ java/io/BufferedInputStream#skipNBytes(J)V
 org/hyperledger/ java/io/ByteArrayInputStream#readNBytes(I)[B
 org/hyperledger/ java/io/ByteArrayOutputStream#toString(Ljava/nio/charset/Charset;)Ljava/lang/String;
 org/hyperledger/ java/io/PrintWriter#<init>(Ljava/io/OutputStream;ZLjava/nio/charset/Charset;)V
-org/hyperledger/ java/lang/Math#unsignedMultiplyHigh(JJ)J
 org/hyperledger/ java/lang/String#formatted([Ljava/lang/Object;)Ljava/lang/String;
 org/hyperledger/ java/lang/invoke/MethodHandles#byteArrayViewVarHandle(Ljava/lang/Class;Ljava/nio/ByteOrder;)Ljava/lang/invoke/VarHandle;
 org/hyperledger/ java/math/BigInteger#TWO
@@ -81,6 +85,12 @@ com/github/benmanes/caffeine/ java/util/stream/Stream#takeWhile(Ljava/util/funct
 # hits are its capability-probing enum holders (AbstractFutureState atomic
 # helpers, UnsignedBytes comparator, LittleEndianByteArray, FuturesGetChecked),
 # each loaded reflectively inside try/catch with a pure-Java fallback. [guarded]
+# Except below API 33: there AbstractFutureState$VarHandleAtomicHelper fails
+# VERIFICATION (VarHandle get/set are hidden), which escapes the probe and
+# leaves SettableFuture unusable for the whole process — observed on an API-29
+# emulator, where it killed the Java engine's discv5 (the discovery fork's Guava
+# cache). Harmless now because EngineGate disables the Java engine below 33;
+# no first-party or Rust-engine path uses Guava futures.
 com/google/ java/lang/ClassValue#get(Ljava/lang/Class;)Ljava/lang/Object;
 com/google/ java/lang/ClassValue#<class>
 com/google/ java/lang/ClassValue#<init>()V

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeController.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeController.kt
@@ -253,6 +253,15 @@ interface Settings {
     fun setPreferJavaEngine(v: Boolean) {}
 
     /**
+     * Why this host cannot run the Java engine at all, or null when it can (the default,
+     * e.g. desktop). Non-null hides the "Prefer Java engine" toggle and shows this text in
+     * its place, so Settings never offers an engine the host would refuse to start. Android
+     * returns a reason below API 33, where the Java engine's EVM and discv5 fail to link and
+     * every network runs on the Rust engine with no Java fallback.
+     */
+    fun javaEngineUnavailableReason(): String? = null
+
+    /**
      * true = route verified reads over Tor (docs/privacy-and-tor.md) — experimental, and
      * Rust-engine-only (Arti is embedded in the Rust engine). Default false. Hosts that
      * can't support it keep the default no-op getter/setter so Android/iOS still compile;

--- a/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
+++ b/ui/src/commonMain/kotlin/io/myotis/ui/NodeScreen.kt
@@ -560,28 +560,40 @@ private fun SettingsTab(
         )
 
         // Engine choice applies per network (re)start — running networks keep their engine.
-        SwitchRow(
-            label = "Prefer Java engine",
-            checked = preferJava,
-            onChange = { on ->
-                preferJava = on; settings.setPreferJavaEngine(on); controller.applyEngineChoice()
-                onLogIndexChanged()
-            },
-        )
-        Text(
-            "Off (default): the Rust engine runs each network where it can serve, " +
-                "falling back to the Java engine otherwise. The Rust engine is the " +
-                "primary engine — the log index (Index tab) and Tor routing run on it " +
-                "only. On: force the original Java engine everywhere, giving up those " +
-                "features — currently the only way to use the Query tab's " +
-                "transaction-history scan (mainnet, Java engine only). Applies when a " +
-                "network is (re)started, not to already-running networks. Note: " +
-                "Rust-hosted networks do NOT idle-sleep yet — they stay always-on " +
-                "regardless of the idle-sleep setting (the Status screen's Sleep row " +
-                "says so per network).",
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
+        // A host that cannot run the Java engine at all (Android below API 33) shows why
+        // instead of a toggle it would refuse to honour.
+        val javaUnavailable = remember { settings.javaEngineUnavailableReason() }
+        if (javaUnavailable != null) {
+            Text("Engine: Rust only")
+            Text(
+                javaUnavailable,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        } else {
+            SwitchRow(
+                label = "Prefer Java engine",
+                checked = preferJava,
+                onChange = { on ->
+                    preferJava = on; settings.setPreferJavaEngine(on); controller.applyEngineChoice()
+                    onLogIndexChanged()
+                },
+            )
+            Text(
+                "Off (default): the Rust engine runs each network where it can serve, " +
+                    "falling back to the Java engine otherwise. The Rust engine is the " +
+                    "primary engine — the log index (Index tab) and Tor routing run on it " +
+                    "only. On: force the original Java engine everywhere, giving up those " +
+                    "features — currently the only way to use the Query tab's " +
+                    "transaction-history scan (mainnet, Java engine only). Applies when a " +
+                    "network is (re)started, not to already-running networks. Note: " +
+                    "Rust-hosted networks do NOT idle-sleep yet — they stay always-on " +
+                    "regardless of the idle-sleep setting (the Status screen's Sleep row " +
+                    "says so per network).",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
 
         // Tor routing — shown only on hosts that can actually route over Tor
         // (controller.supportsTor; a privacy switch that flips ON while reads keep

--- a/ui/src/desktopTest/kotlin/io/myotis/ui/JavaEngineAvailabilityTest.kt
+++ b/ui/src/desktopTest/kotlin/io/myotis/ui/JavaEngineAvailabilityTest.kt
@@ -1,0 +1,64 @@
+package io.myotis.ui
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isSelectable
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Pins the Settings rule for hosts that cannot run the Java engine at all (Android
+ * below API 33): the "Prefer Java engine" toggle is replaced by the host's reason, so
+ * Settings never offers an engine the host would refuse to start. Hosts that can run
+ * it (the default) keep the toggle.
+ */
+class JavaEngineAvailabilityTest {
+
+    private class EngineSettings(private val reason: String?) : Settings by FakeSettings() {
+        override fun javaEngineUnavailableReason(): String? = reason
+    }
+
+    @get:Rule
+    val rule = createComposeRule()
+
+    @Test
+    fun toggleIsReplacedByTheReasonWhenTheJavaEngineIsUnavailable() {
+        val reason = "This device runs Android API 29. The Java engine needs API 33."
+        show(EngineSettings(reason))
+        tab("Settings").performClick()
+
+        rule.onNodeWithText("Engine: Rust only").performScrollTo().assertIsDisplayed()
+        rule.onNodeWithText(reason).performScrollTo().assertIsDisplayed()
+        rule.onNodeWithText("Prefer Java engine").assertDoesNotExist()
+    }
+
+    @Test
+    fun toggleIsOfferedWhenTheHostCanRunTheJavaEngine() {
+        show(EngineSettings(null))
+        tab("Settings").performClick()
+
+        rule.onNodeWithText("Prefer Java engine").performScrollTo().assertIsDisplayed()
+        rule.onNodeWithText("Engine: Rust only").assertDoesNotExist()
+    }
+
+    private fun show(settings: Settings) {
+        rule.setContent {
+            NodeScreen(controller = FakeController(), settings = settings, logs = FakeLogs())
+        }
+    }
+
+    /** The tab bar's tabs are the only selectable nodes on the screen. */
+    private fun tab(label: String) = rule.onNode(isSelectable() and hasText(label))
+
+    private class FakeLogs : LogSource {
+        override fun version(): Long = 0L
+        override fun snapshot(): List<LogLine> = emptyList()
+        override fun clear() {}
+        override fun level(): LogLevel = LogLevel.DEBUG
+        override fun setLevel(level: LogLevel) {}
+    }
+}


### PR DESCRIPTION
## Summary

On Android 10–12 (API 29–32) the Java engine cannot run. This makes those phones **Rust-engine-only, with no automatic Java fallback**. Refs #402.

**Why.** Besu's `UInt256` static initializer calls `MethodHandles.byteArrayViewVarHandle`. Guava's JRE variant, which the Android build forces for Besu, calls `VarHandle.get`/`set` in `AbstractFutureState$VarHandleAtomicHelper`. Android keeps these APIs hidden until API 33, and ART refuses to link them for an app targeting SDK 34. On a real API-29 emulator this showed up as:

- **At install:** the compiler logged `byteArrayViewVarHandle (greylist-max-o, linking, denied)`, `VarHandle.get/set (blacklist, linking, denied)`, and two `UInt256` methods failing verification.
- **At runtime:** the Java engine's discv5 failed with a `VerifyError` on mainnet, gnosis and sepolia. The failed Guava class then stayed unusable for the whole process (`Rejecting re-init on previously-failed class SettableFuture`).

**The Rust engine runs the same device fine.** It synced all three networks, resolved ENS, and passed every read method of the JSON-RPC router. Pause and wakeup, trim-memory, backgrounding, rotation and a force-stop restart all worked.

## Changes

- **`EngineGate` (new).** Holds the API-33 gate. Below it:
  - the selector gets a hard `rust` choice, so a failed Rust create fails the boot visibly instead of falling back;
  - a stored "prefer Java" preference is ignored but kept, so an OS upgrade restores it;
  - the boot log line names the gate.
- **Settings seam.** `Settings.javaEngineUnavailableReason()` defaults to null, so desktop and iOS are unchanged. Android returns a reason below API 33, and the Settings tab shows it in place of the "Prefer Java engine" toggle.
- **CI.** The API-29 boot smoke job used to build with `-PskipRustEngine`, which put the Java engine on the device. It now builds with the Rust engine, because the Java engine can no longer boot there. This also covers the Rust engine's on-device load path, which no boot test exercised before.
- **Allowlist.** The gated Besu and Guava entries are reclassified. The stale `Math#unsignedMultiplyHigh` entry is dropped: R8 backports it, and the checker already reported it stale.
- **Docs.** The README and the smoke test's KDoc now describe the gate.

## Residual risk on API 33 and 34

- **API 33:** Besu's `ExceptionalHaltReason` still calls `String#formatted`, which only arrives in API 34. That path is caught in the RPC backend, so it degrades an error message rather than crashing.
- **API 33 and 34:** `List#getFirst` sits in Besu's logs-bloom builder, which the allowlist classifies as a path the wallet never runs.
- Neither is verified on a device. #402 stays open for these.

## Forks

The gate makes no fork unnecessary:

- **biafra23/besu** is needed on every Android version the Java engine still runs on. Its patches fix APIs missing on all ART versions: the three-String `Provider` constructor and Caffeine's `threadLocalRandomProbe`.
- **biafra23/discovery** is still needed on API 33 and 34, because it fixes API-34/35 calls in `KBucket`.

## Test plan

Tested on a real **Android 10 (API 29) emulator** (Google APIs, arm64):

- [x] **This branch's Rust APK, "prefer Java" stored as `true`:**
  - the selector logs `engine choice set to rust (rust available: true)`;
  - all three networks boot on Rust, and each boot line ends `engine rust (Java engine needs API 33+, no fallback)`;
  - mainnet reaches SYNCED under "Mainnet (r)";
  - Settings shows "Engine: Rust only" with the reason, and no toggle.
- [x] **This branch built with `-PskipRustEngine`:**
  - every boot fails with `EngineException: myotis.engine=rust but libmyotis_engine is not available`;
  - there is no Java fallback, and the app stays up.
- [x] **Before the change, same emulator, Rust engine:**
  - every read method of the JSON-RPC router passed on mainnet and gnosis;
  - sepolia works too, but slowly, because it has only one snap peer;
  - `myotis_pause`/`myotis_wakeup`, trim-memory, home and back, rotation, and a force-stop restart all worked.
- [x] **Before the change, same emulator, Java engine:** reproduced the denied links and the discv5 `VerifyError` on all three networks.
- [x] **Unit tests:**

  | Suite | Result |
  |---|---|
  | `EngineGateTest` | 4 of 4 |
  | `JavaEngineAvailabilityTest` | 2 of 2 |
  | `IndexTabVisibilityTest` | 4 of 4 |
  | `SelectorEngineTest` | 8 tests, 2 skipped (they need the native library) |

- [x] **`scripts/check_apk_min_api.py`:** passes on both APKs with the edited allowlist, with no stale-entry note.
- [ ] **CI `boot-smoke-api29` on the Rust engine.** It now runs after the build job (`needs: build`) and restores that job's Rust cache from the same run.
- [ ] **Not tested:** API 31/32 devices, which updated ART modules might cover, and API 33/34 devices.

## Internal review

A no-context review found no correctness bugs. It confirmed that nothing below API 33 can reach the Java engine and that nothing crashes at startup. Its three findings are fixed in the second commit:

1. **CI cost.** The smoke job now shares the build job's Rust cache through one key, and only the build job saves it. Its timeout went from 45 to 60 minutes.
2. **Build messages.** The build-gate messages and the CLAUDE.md build line still said `-PskipRustEngine` means "Java engine at runtime". They now say such an APK boots only on API 33 and newer.
3. **Linkage errors.** `SelectorEngine` now wraps a `LinkageError` from an explicit `rust` create as the `EngineException` its class comment promises. Below API 33 that path is now the default, so a raw `Error` would otherwise crash the app instead of failing the boot. There is no seam to inject a failing Rust engine, so this branch has no unit test.

## PR review (claude[bot], Copilot)

- **Copilot, linkage errors:** the explicit-rust guard in `SelectorEngine` now covers name canonicalization too, which crosses the native boundary (7a1e8c0b).

- **Smoke-test KDoc:** no longer implies API 33+ Java-engine boot coverage.
- **CI:** the smoke job now has `needs: build`, so it never starts on a cold Rust cache.
- **iOS:** returns a reason through the new seam, so it shows "Engine: Rust only" instead of an inert toggle.
- **Docs:** `docs/react-native.md` and CLAUDE.md now carry the API-33 caveat for `-PskipRustEngine`.

## Follow-ups, not in this PR

- **Failed boots** show only "Node stopped" on the Status tab. The reason is in the Logs tab only. This matters more now that a Rust load failure below API 33 has no fallback.
- **Stale Settings text:** the toggle's description says Rust networks don't idle-sleep yet. That is out of date since 96af1c81, and they paused on the emulator.
- **Stale comments:** "our tuweni fork" in `android-app/build.gradle.kts` and `myotis-evm/build.gradle.kts`. Tuweni is upstream 2.7.2 now.
- **Unpinned Besu tag:** biafra23/besu `26.4.0-android.2` exists but isn't pinned. It touches the #402 files, which could matter for the API-33/34 residuals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)