### PR TITLE
test: cold-start regressions + a pin/bootnode liveness check for releases

### DIFF
--- a/.github/workflows/cold-start-regression.yml
+++ b/.github/workflows/cold-start-regression.yml
@@ -15,10 +15,13 @@
 #                 not enough and catch-up must actually walk periods. A
 #                 release-fresh anchor walks 0-2 periods and proves little,
 #                 which is why the anchor is an input rather than the embedded
-#                 one. A good source is the PREVIOUS release's checkpoint: it
-#                 was a real finalized root and is one release old by
-#                 construction —
-#                   git show v0.1.8:rust/myotis-net/src/sync.rs \
+#                 one. It must be further behind than the network's
+#                 weak-subjectivity bound (gnosis 3 periods, mainnet/sepolia
+#                 13); the test asserts that. Take it from a release OLDER than
+#                 the current one — the newest tag is usually the release whose
+#                 anchor is the one on main, so it is no good:
+#                   prev=$(git tag --sort=-v:refname | sed -n 2p)
+#                   git show "$prev":rust/myotis-net/src/sync.rs \
 #                     | grep -A6 '@checkpoint:gnosis:begin'
 name: cold-start regression
 
@@ -31,7 +34,7 @@ on:
         options: [gnosis, mainnet, sepolia]
         default: gnosis
       anchor_root:
-        description: "Old anchor block root (64 hex). Empty = skip the old-anchor test."
+        description: "Old anchor block root (64 hex). Empty = run only the no-pins test."
         type: string
         default: ""
       anchor_slot:
@@ -39,9 +42,14 @@ on:
         type: string
         default: ""
 
+# Keyed by network as well as ref: these are dispatched by hand, and running
+# gnosis then mainnet must not silently kill the first run.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.network }}
   cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   cold-start:
@@ -75,10 +83,11 @@ jobs:
           cargo test --release -p myotis-net --test live_cold_start -- \
             --ignored --nocapture cold_start_without_static_peers
 
-      # Deep catch-up: only when an anchor was supplied — without one the test
-      # skips itself rather than passing vacuously.
+      # Deep catch-up: only when BOTH anchor inputs are supplied. The test
+      # itself fails rather than skipping if they are missing, so the guard is
+      # here to keep "no anchor given" from looking like a failure.
       - name: Cold start from an old anchor
-        if: inputs.anchor_root != ''
+        if: inputs.anchor_root != '' && inputs.anchor_slot != ''
         working-directory: rust
         env:
           NET: ${{ inputs.network }}

--- a/.github/workflows/cold-start-regression.yml
+++ b/.github/workflows/cold-start-regression.yml
@@ -1,0 +1,90 @@
+# The two cold-start regressions issue #422 asked us to keep.
+#
+# MANUAL ONLY (workflow_dispatch), deliberately: both tests dial live
+# third-party light-client servers, and both are peer-quota-bound — a serving
+# peer answers roughly one update per 10 s — so they take minutes and can fail
+# for reasons that are not our bug (every server busy, a network blip). Gating
+# merges on that would train everyone to ignore a red check. Run it before a
+# release, or when changing discovery, the peer pool, or the catch-up loop.
+#
+# What each proves, and why a green pipeline elsewhere does not:
+#   * no-pins:    every pinned server removed, so DISCOVERY alone has to find a
+#                 light-client server. The dispatched smoke job dials a warm
+#                 peer cache, which hides exactly this.
+#   * old-anchor: the trust anchor is several periods behind, so bootstrap is
+#                 not enough and catch-up must actually walk periods. A
+#                 release-fresh anchor walks 0-2 periods and proves little,
+#                 which is why the anchor is an input rather than the embedded
+#                 one. A good source is the PREVIOUS release's checkpoint: it
+#                 was a real finalized root and is one release old by
+#                 construction —
+#                   git show v0.1.8:rust/myotis-net/src/sync.rs \
+#                     | grep -A6 '@checkpoint:gnosis:begin'
+name: cold-start regression
+
+on:
+  workflow_dispatch:
+    inputs:
+      network:
+        description: "Network to cold-start (gnosis is where #422 bit hardest)"
+        type: choice
+        options: [gnosis, mainnet, sepolia]
+        default: gnosis
+      anchor_root:
+        description: "Old anchor block root (64 hex). Empty = skip the old-anchor test."
+        type: string
+        default: ""
+      anchor_slot:
+        description: "Old anchor slot (must accompany the root)"
+        type: string
+        default: ""
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cold-start:
+    name: cold start (${{ inputs.network }})
+    runs-on: ubuntu-latest
+    # Both budgets plus the build, with headroom: the old-anchor test alone
+    # allows 30 minutes of walking.
+    timeout-minutes: 75
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust
+
+      - name: Build the tests
+        working-directory: rust
+        run: cargo test --release -p myotis-net --test live_cold_start --no-run
+
+      # Discovery-only: no pinned peers at all.
+      - name: Cold start without any pinned peer
+        working-directory: rust
+        env:
+          NET: ${{ inputs.network }}
+          RUST_LOG: info,myotis_net=debug
+        run: |
+          cargo test --release -p myotis-net --test live_cold_start -- \
+            --ignored --nocapture cold_start_without_static_peers
+
+      # Deep catch-up: only when an anchor was supplied — without one the test
+      # skips itself rather than passing vacuously.
+      - name: Cold start from an old anchor
+        if: inputs.anchor_root != ''
+        working-directory: rust
+        env:
+          NET: ${{ inputs.network }}
+          MYOTIS_TEST_ANCHOR_ROOT: ${{ inputs.anchor_root }}
+          MYOTIS_TEST_ANCHOR_SLOT: ${{ inputs.anchor_slot }}
+          RUST_LOG: info,myotis_net=debug
+        run: |
+          cargo test --release -p myotis-net --test live_cold_start -- \
+            --ignored --nocapture cold_start_from_an_old_anchor

--- a/.github/workflows/cold-start-regression.yml
+++ b/.github/workflows/cold-start-regression.yml
@@ -8,9 +8,16 @@
 # release, or when changing discovery, the peer pool, or the catch-up loop.
 #
 # What each proves, and why a green pipeline elsewhere does not:
-#   * no-pins:    every pinned server removed, so DISCOVERY alone has to find a
-#                 light-client server. The dispatched smoke job dials a warm
-#                 peer cache, which hides exactly this.
+#   * pins-alive: do the shipped pins and bootnodes actually answer? Seconds,
+#                 and the one that would have caught #422 before it shipped.
+#                 A CI runner is a clean host, which matters: a Lighthouse node
+#                 that banned a dev box's IP looks dead from there and is fine
+#                 from here.
+#   * dead-pins:  every pinned server still CONFIGURED but unreachable — the
+#                 #422 shape. Pinned peers are exempt from eviction, so they
+#                 hold their pool slots and keep steering targeted lookups;
+#                 discovery has to find a real server anyway. The dispatched
+#                 smoke job dials a warm peer cache, which hides this.
 #   * old-anchor: the trust anchor is several periods behind, so bootstrap is
 #                 not enough and catch-up must actually walk periods. A
 #                 release-fresh anchor walks 0-2 periods and proves little,
@@ -71,17 +78,30 @@ jobs:
 
       - name: Build the tests
         working-directory: rust
-        run: cargo test --release -p myotis-net --test live_cold_start --no-run
+        run: |
+          cargo test --release -p myotis-net --test live_cold_start --no-run
+          cargo test --release -p myotis-net --test live_pins_alive --no-run
+
+      # Cheap and first: if the shipped pins are dead, say so before spending
+      # 15 minutes proving the wallet copes without them.
+      - name: Are the shipped pins and bootnodes alive?
+        working-directory: rust
+        env:
+          NET: ${{ inputs.network }}
+          RUST_LOG: warn,myotis_net=info
+        run: |
+          cargo test --release -p myotis-net --test live_pins_alive -- \
+            --ignored --nocapture
 
       # Discovery-only: no pinned peers at all.
-      - name: Cold start without any pinned peer
+      - name: Cold start with every pinned peer unreachable
         working-directory: rust
         env:
           NET: ${{ inputs.network }}
           RUST_LOG: info,myotis_net=debug
         run: |
           cargo test --release -p myotis-net --test live_cold_start -- \
-            --ignored --nocapture cold_start_without_static_peers
+            --ignored --nocapture cold_start_with_every_pinned_peer_unreachable
 
       # Deep catch-up: skipped only when NEITHER anchor input is supplied, so
       # "no anchor given" does not look like a failure. A HALF-supplied anchor

--- a/.github/workflows/cold-start-regression.yml
+++ b/.github/workflows/cold-start-regression.yml
@@ -91,7 +91,7 @@ jobs:
           RUST_LOG: warn,myotis_net=info
         run: |
           cargo test --release -p myotis-net --test live_pins_alive -- \
-            --ignored --nocapture
+            --ignored --nocapture --test-threads=1
 
       # Discovery-only: no pinned peers at all.
       - name: Cold start with every pinned peer unreachable

--- a/.github/workflows/cold-start-regression.yml
+++ b/.github/workflows/cold-start-regression.yml
@@ -40,8 +40,13 @@ on:
         type: choice
         options: [gnosis, mainnet, sepolia]
         default: gnosis
+      scope:
+        description: "full = all three checks (release). pins-only = skip the deep walk."
+        type: choice
+        options: [full, pins-only]
+        default: full
       anchor_root:
-        description: "Old anchor block root (64 hex). Empty = run only the no-pins test."
+        description: "Old anchor block root (64 hex). Required when scope is full."
         type: string
         default: ""
       anchor_slot:
@@ -60,7 +65,7 @@ permissions:
 
 jobs:
   cold-start:
-    name: cold start (${{ inputs.network }})
+    name: cold start (${{ inputs.network }}, ${{ inputs.scope }})
     runs-on: ubuntu-latest
     # Both budgets plus the build, with headroom: the old-anchor test alone
     # allows 30 minutes of walking.
@@ -75,6 +80,17 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: rust
+
+      # A green tick must not mean "the release check ran" when the deep walk
+      # was silently skipped for want of an anchor. Skipping is a CHOICE
+      # (scope: pins-only), never an accident of leaving a field blank.
+      - name: Refuse a full run without an anchor
+        if: inputs.scope == 'full' && (inputs.anchor_root == '' || inputs.anchor_slot == '')
+        run: |
+          echo "::error::scope=full runs the old-anchor regression, which needs both" \
+               "anchor_root and anchor_slot. Supply them, or dispatch with scope=pins-only" \
+               "to deliberately run only the pin census and the dead-pins cold start."
+          exit 1
 
       - name: Build the tests
         working-directory: rust
@@ -103,14 +119,11 @@ jobs:
           cargo test --release -p myotis-net --test live_cold_start -- \
             --ignored --nocapture cold_start_with_every_pinned_peer_unreachable
 
-      # Deep catch-up: skipped only when NEITHER anchor input is supplied, so
-      # "no anchor given" does not look like a failure. A HALF-supplied anchor
-      # still runs the test, which fails loudly on its own must-accompany
-      # guards — an operator who typed a root meant this to run, and skipping
-      # there would be the job-level version of the fake green the test itself
-      # refuses.
+      # Runs for every scope except an explicit pins-only, so a missing or
+      # half-supplied anchor reaches the test's own loud guards rather than
+      # skipping green. The gate above already refused a blank full run.
       - name: Cold start from an old anchor
-        if: inputs.anchor_root != '' || inputs.anchor_slot != ''
+        if: inputs.scope != 'pins-only'
         working-directory: rust
         env:
           NET: ${{ inputs.network }}

--- a/.github/workflows/cold-start-regression.yml
+++ b/.github/workflows/cold-start-regression.yml
@@ -83,11 +83,14 @@ jobs:
           cargo test --release -p myotis-net --test live_cold_start -- \
             --ignored --nocapture cold_start_without_static_peers
 
-      # Deep catch-up: only when BOTH anchor inputs are supplied. The test
-      # itself fails rather than skipping if they are missing, so the guard is
-      # here to keep "no anchor given" from looking like a failure.
+      # Deep catch-up: skipped only when NEITHER anchor input is supplied, so
+      # "no anchor given" does not look like a failure. A HALF-supplied anchor
+      # still runs the test, which fails loudly on its own must-accompany
+      # guards — an operator who typed a root meant this to run, and skipping
+      # there would be the job-level version of the fake green the test itself
+      # refuses.
       - name: Cold start from an old anchor
-        if: inputs.anchor_root != '' && inputs.anchor_slot != ''
+        if: inputs.anchor_root != '' || inputs.anchor_slot != ''
         working-directory: rust
         env:
           NET: ${{ inputs.network }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,14 +210,15 @@ rulings, 2026-09-02 and 2026-09-11):
 
    ```bash
    cd rust
-   # 3a. are the shipped pins and bootnodes alive? (seconds)
-   NET=gnosis cargo test -p myotis-net --test live_pins_alive -- --ignored --nocapture
+   # 3a. are the shipped pins and bootnodes alive? (seconds when healthy)
+   NET=gnosis cargo test --release -p myotis-net --test live_pins_alive -- \
+       --ignored --nocapture --test-threads=1
    # 3b. dead pins: every pinned CL server configured but unreachable
-   NET=gnosis cargo test -p myotis-net --test live_cold_start -- \
+   NET=gnosis cargo test --release -p myotis-net --test live_cold_start -- \
        --ignored --nocapture cold_start_with_every_pinned_peer_unreachable
    # 3c. deep catch-up: an anchor further behind than the network's ws bound
    NET=gnosis MYOTIS_TEST_ANCHOR_ROOT=<64 hex> MYOTIS_TEST_ANCHOR_SLOT=<slot> \
-     cargo test -p myotis-net --test live_cold_start -- \
+     cargo test --release -p myotis-net --test live_cold_start -- \
        --ignored --nocapture cold_start_from_an_old_anchor
    ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,14 +223,18 @@ rulings, 2026-09-02 and 2026-09-11):
    ```
 
    Run each for every network you are shipping (`NET=mainnet|sepolia|gnosis`).
+   The workflow takes a `scope`: `full` is the release check and REFUSES to run
+   without an anchor rather than skipping the deep walk green; `pins-only` is
+   for when you deliberately want just 3a and 3b.
 
    **3a is the one that would have caught #422 before it shipped**, and it is
    the one whose OUTPUT you read rather than just its exit code. It asks every
    pinned CL peer for a `light_client_bootstrap` at this build's own embedded
-   anchor — one request that proves the host is up, the peer id still matches,
-   the fork digest agrees, it still serves light clients, and it still holds
-   the anchor a fresh install starts from — then checks the bootnodes can seed
-   discv5 at all. It gates on a FLOOR (at least two pins serving), not a clean
+   anchor and applies the SAME acceptance the production path does (checkpoint
+   pin plus both Merkle branches), then asks for one period of
+   `updates_by_range` — so a pin counts as alive only if a fresh install would
+   accept what it serves AND could catch up from it. Then it checks the
+   bootnodes can seed discv5 at all. It gates on a FLOOR (at least two pins serving), not a clean
    sweep, because these are third-party hosts and demanding perfection makes a
    check people skip. Individual dead pins are a re-census signal
    (`examples/period_census.rs`), not automatically a blocker.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,8 +176,8 @@ explicitly says not to open one.
 ## Releases — ask before cutting one
 
 When the user asks for a release (a `v*` tag, a version bump, "cut a release"),
-**ask these two questions first and act only on what they choose** (owner
-ruling, 2026-09-02):
+**ask these three questions first and act only on what they choose** (owner
+rulings, 2026-09-02 and 2026-09-11):
 
 1. **Refresh the trust checkpoints?** The embedded checkpoints (`@checkpoint:*`
    blocks in `NetworkConfig.java`, mirrored in `rust/myotis-net/src/sync.rs`;
@@ -199,6 +199,63 @@ ruling, 2026-09-02):
    never seeds EL discovery and never holds a snap peer (#414, 2026-09-02).
    Warm profiles and the dispatched smoke job hide this because they dial
    their peer cache directly.
+3. **Run the cold-start checks?** (owner ruling, 2026-09-11.) Three live
+   tests, all `#[ignore]`d so nothing else ever runs them, and together the
+   only coverage of what a FRESH INSTALL does. Ordinary CI, the emulator smoke
+   and the dispatched node smoke all dial a warm peer cache or a release-fresh
+   anchor, which is exactly what hides this class of failure — in #422 a
+   shipped build could not catch up at all while every automated check was
+   green. Dispatch the `cold-start regression` workflow from the Actions tab
+   (preferred — a CI runner is a clean host, see the caveat below), or locally:
+
+   ```bash
+   cd rust
+   # 3a. are the shipped pins and bootnodes alive? (seconds)
+   NET=gnosis cargo test -p myotis-net --test live_pins_alive -- --ignored --nocapture
+   # 3b. dead pins: every pinned CL server configured but unreachable
+   NET=gnosis cargo test -p myotis-net --test live_cold_start -- \
+       --ignored --nocapture cold_start_with_every_pinned_peer_unreachable
+   # 3c. deep catch-up: an anchor further behind than the network's ws bound
+   NET=gnosis MYOTIS_TEST_ANCHOR_ROOT=<64 hex> MYOTIS_TEST_ANCHOR_SLOT=<slot> \
+     cargo test -p myotis-net --test live_cold_start -- \
+       --ignored --nocapture cold_start_from_an_old_anchor
+   ```
+
+   Run each for every network you are shipping (`NET=mainnet|sepolia|gnosis`).
+
+   **3a is the one that would have caught #422 before it shipped**, and it is
+   the one whose OUTPUT you read rather than just its exit code. It asks every
+   pinned CL peer for a `light_client_bootstrap` at this build's own embedded
+   anchor — one request that proves the host is up, the peer id still matches,
+   the fork digest agrees, it still serves light clients, and it still holds
+   the anchor a fresh install starts from — then checks the bootnodes can seed
+   discv5 at all. It gates on a FLOOR (at least two pins serving), not a clean
+   sweep, because these are third-party hosts and demanding perfection makes a
+   check people skip. Individual dead pins are a re-census signal
+   (`examples/period_census.rs`), not automatically a blocker.
+
+   **Caveat that will bite you: the result is only as good as the host.** A
+   Lighthouse node that has banned your IP reports as `dial failed` while being
+   perfectly healthy for everyone else — and any machine that ran a
+   pre-gossipsub build carries those bans for 12 h (that ban IS #422). Measured
+   2026-09-11 from a dev box: 18 of 23 gnosis pins looked dead from home and
+   answered fine through a VPN minutes earlier. So prefer the dispatched
+   workflow, and before believing a bad census, check whether your host is the
+   outlier.
+
+   The old-anchor run needs an anchor from a release OLDER than the current
+   one — the newest tag is usually the release whose checkpoint is already on
+   `main`, so it proves nothing, and the test refuses an anchor within the
+   network's weak-subjectivity bound:
+
+   ```bash
+   prev=$(git tag --sort=-v:refname | sed -n 2p)
+   git show "$prev":rust/myotis-net/src/sync.rs | grep -A6 '@checkpoint:gnosis:begin'
+   ```
+
+   Run them AFTER any checkpoint refresh from question 1, so the build under
+   test is the one being shipped. A failure here is release-blocking: it means
+   a fresh install cannot sync, which is the one thing a wallet must do.
 
 ## Pull requests and code review
 

--- a/rust/myotis-net/examples/live_sync.rs
+++ b/rust/myotis-net/examples/live_sync.rs
@@ -68,7 +68,7 @@ async fn main() {
             std::process::exit(0);
         }
         if once && tokio::time::Instant::now() > deadline {
-            tracing::error!("not SYNCED within 15 minutes");
+            tracing::error!(budget_s = 1500, "not SYNCED within the budget");
             handle.stop().await;
             std::process::exit(1);
         }

--- a/rust/myotis-net/examples/live_sync.rs
+++ b/rust/myotis-net/examples/live_sync.rs
@@ -17,6 +17,10 @@ use std::time::Duration;
 
 use myotis_net::{ChainConfig, SyncHandle, SyncState};
 
+/// How long `--once` waits for SYNCED before failing. Named so the value and
+/// the message it is reported in cannot drift apart again.
+const ONCE_BUDGET: Duration = Duration::from_secs(1500);
+
 #[tokio::main]
 async fn main() {
     // The binary installs a subscriber; the library itself only emits tracing.
@@ -51,7 +55,7 @@ async fn main() {
         }
     };
 
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(1500);
+    let deadline = tokio::time::Instant::now() + ONCE_BUDGET;
     let mut last_status = None;
     loop {
         tokio::time::sleep(Duration::from_secs(3)).await;
@@ -68,7 +72,7 @@ async fn main() {
             std::process::exit(0);
         }
         if once && tokio::time::Instant::now() > deadline {
-            tracing::error!(budget_s = 1500, "not SYNCED within the budget");
+            tracing::error!(budget_s = ONCE_BUDGET.as_secs(), "not SYNCED within the budget");
             handle.stop().await;
             std::process::exit(1);
         }

--- a/rust/myotis-net/tests/live_cold_start.rs
+++ b/rust/myotis-net/tests/live_cold_start.rs
@@ -7,11 +7,14 @@
 //! hides. Each test then removes ONE crutch and asserts the wallet still
 //! reaches SYNCED:
 //!
-//! * `cold_start_without_static_peers_syncs_through_discovery` — every pinned
-//!   server is gone, so discovery alone has to find light-client servers.
-//!   This is the "recovery when the preferred static endpoint is unavailable"
-//!   case: in the reported incident the pins were stale AND roost was down, and
-//!   nothing else got the wallet a usable peer.
+//! * `cold_start_with_every_pinned_peer_unreachable_syncs_through_discovery` —
+//!   the pins are still CONFIGURED but every address is a black hole, which is
+//!   the shape #422 reported: stale pins plus roost down. Keeping the peer ids
+//!   matters and is why this does not simply clear the list — a pinned peer is
+//!   exempt from eviction (`PeerPool::evict` returns early for `static_ids`),
+//!   so a dead pin stays in the pool for the life of the process, keeps being
+//!   handed to every catch-up fan-out, and keeps steering targeted discovery
+//!   lookups at a server that will never answer. Discovery has to win anyway.
 //!
 //! * `cold_start_from_an_old_anchor_walks_periods_to_head` — the trust anchor
 //!   is several periods behind, so bootstrap is not enough and catch-up must
@@ -19,9 +22,9 @@
 //!   proves almost nothing, which is why the anchor is a parameter.
 //!
 //! ```bash
-//! # discovery-only (default network: gnosis — where #422 bit hardest)
+//! # dead pins (default network: gnosis — where #422 bit hardest)
 //! cargo test -p myotis-net --test live_cold_start -- --ignored --nocapture \
-//!     cold_start_without_static_peers
+//!     cold_start_with_every_pinned_peer_unreachable
 //!
 //! # Old anchor: it must be MORE THAN the network's weak-subjectivity bound
 //! # behind the wall clock (gnosis 3 periods, mainnet/sepolia 13) — the test
@@ -68,7 +71,7 @@ fn config_for_env() -> ChainConfig {
     }
 }
 
-/// How long the discovery-only cold start may take. Named, with the prose
+/// How long the dead-pins cold start may take. Named, with the prose
 /// derived from it, so the budget and the message reporting it cannot drift
 /// apart — the bug this PR fixes in `examples/live_sync.rs`.
 const NO_PINS_BUDGET: Duration = Duration::from_secs(900);
@@ -123,26 +126,51 @@ fn assert_no_cl_env_overrides() {
     }
 }
 
+/// RFC 5737 TEST-NET-3, reserved for documentation: nothing routes there, so a
+/// dial fails the way a decommissioned or firewalled server's does.
+const BLACKHOLE_PREFIX: &str = "203.0.113.";
+
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "live network test: cold start with NO pinned peers, takes minutes"]
-async fn cold_start_without_static_peers_syncs_through_discovery() {
+#[ignore = "live network test: cold start with every pin DEAD, takes minutes"]
+async fn cold_start_with_every_pinned_peer_unreachable_syncs_through_discovery() {
     init_tracing();
     assert_no_cl_env_overrides();
     let mut config = config_for_env();
+
+    // Keep every pinned peer ID, point it at a black hole. NOT a cleared list:
+    // pinned peers are exempt from eviction, so these stay in the pool, keep
+    // taking fan-out slots in every catch-up round, and keep aiming targeted
+    // discovery lookups at servers that will never answer. That is the #422
+    // shape, and it is strictly harder than having no pins at all.
     let pinned = config.static_peers.len();
-    // The crutch under test. Discovery keeps its bootnodes — removing those
-    // would test nothing but "a node with no way in cannot get in".
-    config.static_peers.clear();
+    assert!(pinned > 0, "this network pins no CL peers, so there is nothing to kill");
+    config.static_peers = config
+        .static_peers
+        .iter()
+        .enumerate()
+        .map(|(i, p)| {
+            let id = p.rsplit("/p2p/").next().expect("pinned multiaddr carries a peer id");
+            // A distinct address each, so none can collide with a live host.
+            format!("/ip4/{BLACKHOLE_PREFIX}{}/tcp/9000/p2p/{id}", i % 254 + 1)
+        })
+        .collect();
+    assert!(
+        config.static_peers.iter().all(|p| p.contains(BLACKHOLE_PREFIX)),
+        "every pin must be blackholed, or this measures a live server"
+    );
+    // Discovery keeps its bootnodes — removing those would test nothing but
+    // "a node with no way in cannot get in".
     assert!(!config.bootstrap_enrs.is_empty(), "discovery needs its bootnodes");
 
     let handle = SyncHandle::start(config).expect("sync start");
-    let synced = run_to_synced(&handle, "no-pins", NO_PINS_BUDGET).await;
+    let synced = run_to_synced(&handle, "dead-pins", NO_PINS_BUDGET).await;
     handle.stop().await;
 
     assert!(
         synced.is_some(),
-        "cold start with all {pinned} pinned peers removed did not reach SYNCED in {} min — \
-         discovery alone could not find a light-client server, which is the #422 condition",
+        "cold start with all {pinned} pinned peers unreachable did not reach SYNCED in {} min — \
+         discovery could not find a light-client server while the dead pins held their \
+         un-evictable pool slots, which is the #422 condition",
         NO_PINS_BUDGET.as_secs() / 60
     );
 }

--- a/rust/myotis-net/tests/live_cold_start.rs
+++ b/rust/myotis-net/tests/live_cold_start.rs
@@ -23,10 +23,20 @@
 //! cargo test -p myotis-net --test live_cold_start -- --ignored --nocapture \
 //!     cold_start_without_static_peers
 //!
-//! # old anchor: pass one that is genuinely behind. A good source is the
-//! # PREVIOUS release's embedded checkpoint, which was a real finalized root
-//! # and is one release old by construction:
-//! #   git show v0.1.8:rust/myotis-net/src/sync.rs | grep -A6 '@checkpoint:gnosis:begin'
+//! # Old anchor: it must be MORE THAN the network's weak-subjectivity bound
+//! # behind the wall clock (gnosis 3 periods, mainnet/sepolia 13) — the test
+//! # asserts that, because a shallower anchor walks a period or two and would
+//! # have survived the bug this guards.
+//! #
+//! # Take it from a release OLDER than the current one. Note the newest tag is
+//! # usually the release whose anchor is the one on main, so it is no good:
+//! #   prev=$(git tag --sort=-v:refname | sed -n 2p)
+//! #   git show "$prev":rust/myotis-net/src/sync.rs | grep -A6 '@checkpoint:gnosis:begin'
+//! #
+//! # Worked example, measured 2026-09-11 — v0.1.7's gnosis anchor, 70 periods
+//! # behind, walked to head in 170 s:
+//! #   MYOTIS_TEST_ANCHOR_ROOT=5387a11e014d8d4a9e8ca072ccd6639be912ab9a15b14b3b1f2d49b79551d954
+//! #   MYOTIS_TEST_ANCHOR_SLOT=29458656
 //! NET=gnosis \
 //! MYOTIS_TEST_ANCHOR_ROOT=<64 hex> MYOTIS_TEST_ANCHOR_SLOT=<slot> \
 //! cargo test -p myotis-net --test live_cold_start -- --ignored --nocapture \
@@ -62,38 +72,48 @@ fn init_tracing() {
         .try_init();
 }
 
-/// Drive the handle to SYNCED or the deadline. Returns the first synced status
-/// and the period the store held once it had bootstrapped, so a caller can
-/// assert the catch-up actually walked.
+/// Drive the handle to SYNCED or the deadline.
 async fn run_to_synced(
     handle: &SyncHandle,
     label: &str,
     budget: Duration,
-) -> (Option<myotis_net::SyncStatus>, Option<u64>) {
+) -> Option<myotis_net::SyncStatus> {
     let deadline = tokio::time::Instant::now() + budget;
-    let mut period_after_bootstrap = None;
     while tokio::time::Instant::now() < deadline {
         tokio::time::sleep(Duration::from_secs(5)).await;
         let s = handle.status();
         eprintln!(
-            "[{label}] state={} period={} finalized_slot={} peers={} served/min={}",
-            s.state, s.period, s.finalized_slot, s.peer_count, s.served_peers_last_min
+            "[{label}] state={} period={} start_period={} finalized_slot={} peers={} served/min={}",
+            s.state, s.period, s.sync_start_period, s.finalized_slot, s.peer_count,
+            s.served_peers_last_min
         );
-        // First status with a committee in hand: the bootstrap landed.
-        if period_after_bootstrap.is_none() && s.period > 0 {
-            period_after_bootstrap = Some(s.period);
-        }
         if s.state == SyncState::Synced {
-            return (Some(s), period_after_bootstrap);
+            return Some(s);
         }
     }
-    (None, period_after_bootstrap)
+    None
+}
+
+/// The CL source-selection overrides are applied in the `ChainConfig`
+/// constructors, so a stray one silently changes what a test dials — setting
+/// `MYOTIS_CL_STATIC_PEERS` to a known-good server is exactly how #422's
+/// reporter built their *control*, which is the opposite of what these
+/// regressions measure.
+fn assert_no_cl_env_overrides() {
+    for var in ["MYOTIS_CL_STATIC_PEERS", "MYOTIS_CL_DISABLE_DISCV5"] {
+        assert!(
+            std::env::var_os(var).is_none(),
+            "{var} is set — it changes which peers this test dials, so the result \
+             would not mean what the test claims. Unset it."
+        );
+    }
 }
 
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "live network test: cold start with NO pinned peers, takes minutes"]
 async fn cold_start_without_static_peers_syncs_through_discovery() {
     init_tracing();
+    assert_no_cl_env_overrides();
     let mut config = config_for_env();
     let pinned = config.static_peers.len();
     // The crutch under test. Discovery keeps its bootnodes — removing those
@@ -102,7 +122,7 @@ async fn cold_start_without_static_peers_syncs_through_discovery() {
     assert!(!config.bootstrap_enrs.is_empty(), "discovery needs its bootnodes");
 
     let handle = SyncHandle::start(config).expect("sync start");
-    let (synced, _) = run_to_synced(&handle, "no-pins", Duration::from_secs(900)).await;
+    let synced = run_to_synced(&handle, "no-pins", Duration::from_secs(900)).await;
     handle.stop().await;
 
     assert!(
@@ -116,22 +136,27 @@ async fn cold_start_without_static_peers_syncs_through_discovery() {
 #[ignore = "live network test: cold start from an OLD anchor, takes many minutes"]
 async fn cold_start_from_an_old_anchor_walks_periods_to_head() {
     init_tracing();
+    assert_no_cl_env_overrides();
     let mut config = config_for_env();
 
-    // An anchor that is genuinely behind. Without one the walk is 0-2 periods
-    // and the test passes vacuously, so require it rather than defaulting.
-    let Ok(root_hex) = std::env::var("MYOTIS_TEST_ANCHOR_ROOT") else {
-        eprintln!(
-            "skipping: set MYOTIS_TEST_ANCHOR_ROOT + MYOTIS_TEST_ANCHOR_SLOT to an anchor \
-             that is several periods behind (see this file's header for where to get one)"
-        );
-        return;
-    };
-    let slot: u64 = std::env::var("MYOTIS_TEST_ANCHOR_SLOT")
+    // The anchor is required, and a missing one FAILS rather than returning:
+    // this test only runs when someone asked for it by name (it is #[ignore]d),
+    // and a green "1 passed" for a run that did nothing is how a regression
+    // quietly stops being one.
+    let env_non_empty = |k: &str| std::env::var(k).ok().filter(|v| !v.trim().is_empty());
+    let root_hex = env_non_empty("MYOTIS_TEST_ANCHOR_ROOT").unwrap_or_else(|| {
+        panic!(
+            "set MYOTIS_TEST_ANCHOR_ROOT + MYOTIS_TEST_ANCHOR_SLOT to an anchor further \
+             behind than this network's weak-subjectivity bound — see this file's header \
+             for where to get one"
+        )
+    });
+    let slot: u64 = env_non_empty("MYOTIS_TEST_ANCHOR_SLOT")
         .expect("MYOTIS_TEST_ANCHOR_SLOT must accompany MYOTIS_TEST_ANCHOR_ROOT")
+        .trim()
         .parse()
         .expect("anchor slot must be a number");
-    let root_hex = root_hex.trim_start_matches("0x");
+    let root_hex = root_hex.trim().trim_start_matches("0x");
     assert_eq!(root_hex.len(), 64, "anchor root must be 32 bytes of hex");
     let mut root = [0u8; 32];
     for (i, b) in root.iter_mut().enumerate() {
@@ -140,13 +165,17 @@ async fn cold_start_from_an_old_anchor_walks_periods_to_head() {
 
     let anchor_period = slot / config.slots_per_period();
     let wall_period = config.wall_clock_period();
+    let bound = config.effective_ws_bound_periods();
     assert!(
-        wall_period > anchor_period,
-        "anchor period {anchor_period} is not behind the wall clock ({wall_period}) — \
-         this test would prove nothing"
+        wall_period > anchor_period && wall_period - anchor_period > bound,
+        "anchor period {anchor_period} is only {} behind the wall clock ({wall_period}), \
+         which is within this network's weak-subjectivity bound of {bound} periods — a walk \
+         that short would have survived the #422 bug, so the test would prove nothing",
+        wall_period.saturating_sub(anchor_period)
     );
     let behind = wall_period - anchor_period;
-    eprintln!("[old-anchor] anchor period {anchor_period}, wall {wall_period} ({behind} behind)");
+    eprintln!("[old-anchor] anchor period {anchor_period}, wall {wall_period} ({behind} behind, \
+               ws bound {bound})");
 
     config.checkpoint_root = root;
     config.checkpoint_slot = slot;
@@ -158,8 +187,7 @@ async fn cold_start_from_an_old_anchor_walks_periods_to_head() {
 
     let handle = SyncHandle::start(config).expect("sync start");
     // Peer-quota-bound: ~1 update per 10 s per serving peer, fanned out.
-    let (synced, after_bootstrap) =
-        run_to_synced(&handle, "old-anchor", Duration::from_secs(1800)).await;
+    let synced = run_to_synced(&handle, "old-anchor", Duration::from_secs(1800)).await;
     handle.stop().await;
 
     let synced = synced.unwrap_or_else(|| {
@@ -169,10 +197,16 @@ async fn cold_start_from_an_old_anchor_walks_periods_to_head() {
              exactly the #422 stall"
         )
     });
-    let start = after_bootstrap.expect("a synced store must have bootstrapped");
+    // `sync_start_period` is the period this run's catch-up started from (-1
+    // until bootstrap), so this is exact rather than sampled: the walk has to
+    // have covered the whole gap, not merely moved.
+    assert!(synced.sync_start_period >= 0, "a synced store must have bootstrapped");
+    assert_eq!(
+        synced.sync_start_period as u64, anchor_period,
+        "catch-up started from a different period than the anchor we pinned"
+    );
     assert!(
-        synced.period > start,
-        "reached SYNCED without advancing a single period (bootstrapped at {start}) — \
-         the anchor was not actually behind, so the catch-up walk went untested"
+        synced.period > synced.sync_start_period as u64,
+        "reached SYNCED without advancing a period, so the catch-up walk went untested"
     );
 }

--- a/rust/myotis-net/tests/live_cold_start.rs
+++ b/rust/myotis-net/tests/live_cold_start.rs
@@ -1,0 +1,178 @@
+//! The two cold-start regressions issue #422 asked us to keep.
+//!
+//! Both are live-network tests, ignored by default. `SyncHandle::start` is
+//! already a cold start — the `ChainConfig` constructors set `snapshot_path:
+//! None`, so there is no sync snapshot and no CL peer cache — which is exactly
+//! the profile a fresh install has and the one a warm dispatched smoke run
+//! hides. Each test then removes ONE crutch and asserts the wallet still
+//! reaches SYNCED:
+//!
+//! * `cold_start_without_static_peers_syncs_through_discovery` — every pinned
+//!   server is gone, so discovery alone has to find light-client servers.
+//!   This is the "recovery when the preferred static endpoint is unavailable"
+//!   case: in the reported incident the pins were stale AND roost was down, and
+//!   nothing else got the wallet a usable peer.
+//!
+//! * `cold_start_from_an_old_anchor_walks_periods_to_head` — the trust anchor
+//!   is several periods behind, so bootstrap is not enough and catch-up must
+//!   actually walk. A release-fresh anchor makes the walk 0–2 periods and
+//!   proves almost nothing, which is why the anchor is a parameter.
+//!
+//! ```bash
+//! # discovery-only (default network: gnosis — where #422 bit hardest)
+//! cargo test -p myotis-net --test live_cold_start -- --ignored --nocapture \
+//!     cold_start_without_static_peers
+//!
+//! # old anchor: pass one that is genuinely behind. A good source is the
+//! # PREVIOUS release's embedded checkpoint, which was a real finalized root
+//! # and is one release old by construction:
+//! #   git show v0.1.8:rust/myotis-net/src/sync.rs | grep -A6 '@checkpoint:gnosis:begin'
+//! NET=gnosis \
+//! MYOTIS_TEST_ANCHOR_ROOT=<64 hex> MYOTIS_TEST_ANCHOR_SLOT=<slot> \
+//! cargo test -p myotis-net --test live_cold_start -- --ignored --nocapture \
+//!     cold_start_from_an_old_anchor
+//! ```
+//!
+//! NOTE both tests are peer-quota-bound, not CPU-bound: light-client servers
+//! serve roughly one update per 10 s each, so a deep walk takes minutes. The
+//! budgets below are generous for that reason, and a failure means "no peer
+//! would serve us in N minutes", which is the condition #422 reported.
+
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+use myotis_net::{ChainConfig, SyncHandle, SyncState};
+
+/// Network under test. Gnosis by default: its light-client servers are almost
+/// all Lighthouse, which is the population that stopped answering in #422.
+fn config_for_env() -> ChainConfig {
+    match std::env::var("NET").unwrap_or_else(|_| "gnosis".into()).as_str() {
+        "mainnet" => ChainConfig::mainnet(),
+        "sepolia" => ChainConfig::sepolia(),
+        _ => ChainConfig::gnosis(),
+    }
+}
+
+fn init_tracing() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info,myotis_net=debug".into()),
+        )
+        .try_init();
+}
+
+/// Drive the handle to SYNCED or the deadline. Returns the first synced status
+/// and the period the store held once it had bootstrapped, so a caller can
+/// assert the catch-up actually walked.
+async fn run_to_synced(
+    handle: &SyncHandle,
+    label: &str,
+    budget: Duration,
+) -> (Option<myotis_net::SyncStatus>, Option<u64>) {
+    let deadline = tokio::time::Instant::now() + budget;
+    let mut period_after_bootstrap = None;
+    while tokio::time::Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_secs(5)).await;
+        let s = handle.status();
+        eprintln!(
+            "[{label}] state={} period={} finalized_slot={} peers={} served/min={}",
+            s.state, s.period, s.finalized_slot, s.peer_count, s.served_peers_last_min
+        );
+        // First status with a committee in hand: the bootstrap landed.
+        if period_after_bootstrap.is_none() && s.period > 0 {
+            period_after_bootstrap = Some(s.period);
+        }
+        if s.state == SyncState::Synced {
+            return (Some(s), period_after_bootstrap);
+        }
+    }
+    (None, period_after_bootstrap)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "live network test: cold start with NO pinned peers, takes minutes"]
+async fn cold_start_without_static_peers_syncs_through_discovery() {
+    init_tracing();
+    let mut config = config_for_env();
+    let pinned = config.static_peers.len();
+    // The crutch under test. Discovery keeps its bootnodes — removing those
+    // would test nothing but "a node with no way in cannot get in".
+    config.static_peers.clear();
+    assert!(!config.bootstrap_enrs.is_empty(), "discovery needs its bootnodes");
+
+    let handle = SyncHandle::start(config).expect("sync start");
+    let (synced, _) = run_to_synced(&handle, "no-pins", Duration::from_secs(900)).await;
+    handle.stop().await;
+
+    assert!(
+        synced.is_some(),
+        "cold start with all {pinned} pinned peers removed did not reach SYNCED in 15 min — \
+         discovery alone could not find a light-client server, which is the #422 condition"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "live network test: cold start from an OLD anchor, takes many minutes"]
+async fn cold_start_from_an_old_anchor_walks_periods_to_head() {
+    init_tracing();
+    let mut config = config_for_env();
+
+    // An anchor that is genuinely behind. Without one the walk is 0-2 periods
+    // and the test passes vacuously, so require it rather than defaulting.
+    let Ok(root_hex) = std::env::var("MYOTIS_TEST_ANCHOR_ROOT") else {
+        eprintln!(
+            "skipping: set MYOTIS_TEST_ANCHOR_ROOT + MYOTIS_TEST_ANCHOR_SLOT to an anchor \
+             that is several periods behind (see this file's header for where to get one)"
+        );
+        return;
+    };
+    let slot: u64 = std::env::var("MYOTIS_TEST_ANCHOR_SLOT")
+        .expect("MYOTIS_TEST_ANCHOR_SLOT must accompany MYOTIS_TEST_ANCHOR_ROOT")
+        .parse()
+        .expect("anchor slot must be a number");
+    let root_hex = root_hex.trim_start_matches("0x");
+    assert_eq!(root_hex.len(), 64, "anchor root must be 32 bytes of hex");
+    let mut root = [0u8; 32];
+    for (i, b) in root.iter_mut().enumerate() {
+        *b = u8::from_str_radix(&root_hex[i * 2..i * 2 + 2], 16).expect("anchor root hex");
+    }
+
+    let anchor_period = slot / config.slots_per_period();
+    let wall_period = config.wall_clock_period();
+    assert!(
+        wall_period > anchor_period,
+        "anchor period {anchor_period} is not behind the wall clock ({wall_period}) — \
+         this test would prove nothing"
+    );
+    let behind = wall_period - anchor_period;
+    eprintln!("[old-anchor] anchor period {anchor_period}, wall {wall_period} ({behind} behind)");
+
+    config.checkpoint_root = root;
+    config.checkpoint_slot = slot;
+    // An anchor this old is past the weak-subjectivity bound, so the engine
+    // parks in STALE_ANCHOR until a host consents. Consent here: the point of
+    // the test is the catch-up walk behind that gate, and the gate itself has
+    // its own coverage.
+    config.ws_policy.accept_stale_anchor.store(true, Ordering::Relaxed);
+
+    let handle = SyncHandle::start(config).expect("sync start");
+    // Peer-quota-bound: ~1 update per 10 s per serving peer, fanned out.
+    let (synced, after_bootstrap) =
+        run_to_synced(&handle, "old-anchor", Duration::from_secs(1800)).await;
+    handle.stop().await;
+
+    let synced = synced.unwrap_or_else(|| {
+        panic!(
+            "cold start {behind} periods behind did not reach SYNCED in 30 min — \
+             the bootstrap may have landed but catch-up made no progress, which is \
+             exactly the #422 stall"
+        )
+    });
+    let start = after_bootstrap.expect("a synced store must have bootstrapped");
+    assert!(
+        synced.period > start,
+        "reached SYNCED without advancing a single period (bootstrapped at {start}) — \
+         the anchor was not actually behind, so the catch-up walk went untested"
+    );
+}

--- a/rust/myotis-net/tests/live_cold_start.rs
+++ b/rust/myotis-net/tests/live_cold_start.rs
@@ -53,15 +53,29 @@ use std::time::Duration;
 
 use myotis_net::{ChainConfig, SyncHandle, SyncState};
 
-/// Network under test. Gnosis by default: its light-client servers are almost
+/// Network under test. Gnosis when unset: its light-client servers are almost
 /// all Lighthouse, which is the population that stopped answering in #422.
+/// An unrecognised value REFUSES rather than falling back — a cold-start run
+/// against a network the operator did not ask for is a green result that means
+/// something else (CLAUDE.md: a parameter that can change the answer must be
+/// applied or refused, never accepted and silently ignored).
 fn config_for_env() -> ChainConfig {
     match std::env::var("NET").unwrap_or_else(|_| "gnosis".into()).as_str() {
         "mainnet" => ChainConfig::mainnet(),
         "sepolia" => ChainConfig::sepolia(),
-        _ => ChainConfig::gnosis(),
+        "gnosis" => ChainConfig::gnosis(),
+        other => panic!("unknown NET {other:?} (want mainnet, sepolia or gnosis)"),
     }
 }
+
+/// How long the discovery-only cold start may take. Named, with the prose
+/// derived from it, so the budget and the message reporting it cannot drift
+/// apart — the bug this PR fixes in `examples/live_sync.rs`.
+const NO_PINS_BUDGET: Duration = Duration::from_secs(900);
+
+/// How long the deep catch-up may take. Peer-quota-bound: a serving peer
+/// answers roughly one update per 10 s, so a 70-period walk is minutes.
+const OLD_ANCHOR_BUDGET: Duration = Duration::from_secs(1800);
 
 fn init_tracing() {
     let _ = tracing_subscriber::fmt()
@@ -122,13 +136,14 @@ async fn cold_start_without_static_peers_syncs_through_discovery() {
     assert!(!config.bootstrap_enrs.is_empty(), "discovery needs its bootnodes");
 
     let handle = SyncHandle::start(config).expect("sync start");
-    let synced = run_to_synced(&handle, "no-pins", Duration::from_secs(900)).await;
+    let synced = run_to_synced(&handle, "no-pins", NO_PINS_BUDGET).await;
     handle.stop().await;
 
     assert!(
         synced.is_some(),
-        "cold start with all {pinned} pinned peers removed did not reach SYNCED in 15 min — \
-         discovery alone could not find a light-client server, which is the #422 condition"
+        "cold start with all {pinned} pinned peers removed did not reach SYNCED in {} min — \
+         discovery alone could not find a light-client server, which is the #422 condition",
+        NO_PINS_BUDGET.as_secs() / 60
     );
 }
 
@@ -186,15 +201,15 @@ async fn cold_start_from_an_old_anchor_walks_periods_to_head() {
     config.ws_policy.accept_stale_anchor.store(true, Ordering::Relaxed);
 
     let handle = SyncHandle::start(config).expect("sync start");
-    // Peer-quota-bound: ~1 update per 10 s per serving peer, fanned out.
-    let synced = run_to_synced(&handle, "old-anchor", Duration::from_secs(1800)).await;
+    let synced = run_to_synced(&handle, "old-anchor", OLD_ANCHOR_BUDGET).await;
     handle.stop().await;
 
     let synced = synced.unwrap_or_else(|| {
         panic!(
-            "cold start {behind} periods behind did not reach SYNCED in 30 min — \
+            "cold start {behind} periods behind did not reach SYNCED in {} min — \
              the bootstrap may have landed but catch-up made no progress, which is \
-             exactly the #422 stall"
+             exactly the #422 stall",
+            OLD_ANCHOR_BUDGET.as_secs() / 60
         )
     });
     // `sync_start_period` is the period this run's catch-up started from (-1

--- a/rust/myotis-net/tests/live_pins_alive.rs
+++ b/rust/myotis-net/tests/live_pins_alive.rs
@@ -43,7 +43,7 @@ use std::time::Duration;
 
 use libp2p::Multiaddr;
 use myotis_consensus::store::LightClientProcessor;
-use myotis_consensus::types::LightClientBootstrap;
+use myotis_consensus::types::{LightClientBootstrap, LightClientUpdate};
 use myotis_consensus::{spec, ssz};
 use myotis_net::codec;
 use myotis_net::reqresp::{self, LocalStatus};
@@ -113,6 +113,23 @@ fn assert_no_cl_env_overrides() {
             "{var} is set — it replaces the shipped configuration, so this census would \
              not be about the peers this build ships. Unset it."
         );
+    }
+}
+
+/// Did this `updates_by_range` response actually carry an update a wallet
+/// could apply? A success byte is not enough — a truncated or malformed frame
+/// (even a bare `[0]`) would otherwise count as "serves catch-up", letting the
+/// census meet its floor on peers that cannot advance a stale install. Mirrors
+/// the real catch-up path: split the chunks, then decode one.
+fn served_an_update(raw: &[u8]) -> bool {
+    if raw.first() != Some(&codec::RESULT_SUCCESS) {
+        return false;
+    }
+    match codec::decode_multi_chunk_response(raw, 1) {
+        Ok(chunks) => chunks
+            .first()
+            .is_some_and(|c| !c.is_empty() && LightClientUpdate::decode(c).is_ok()),
+        Err(_) => false,
     }
 }
 
@@ -219,13 +236,16 @@ async fn every_pinned_cl_peer_serves_this_builds_anchor() {
                     // bootstrap for some other anchor, or bytes that merely
                     // decompress, would count as a healthy pin that a fresh
                     // install then rejects.
-                    let ours = config.current_fork_digest();
-                    let verdict = if d.fork_digest != ours {
-                        Err(format!(
-                            "served a bootstrap framed for fork {:02x?}, we speak {ours:02x?}",
-                            d.fork_digest
-                        ))
-                    } else {
+                    // Deliberately NOT compared against current_fork_digest():
+                    // a bootstrap's context bytes follow the slot of the block
+                    // it anchors to, not the wall clock, and a still-valid
+                    // checkpoint can sit behind a fork boundary — roost stamps
+                    // them that way on purpose (`roost/src/serve.rs`, "stamping
+                    // it with head's digest would be wrong for exactly the
+                    // wallets that are furthest behind"). The production
+                    // bootstrap path does not check it either; the checkpoint
+                    // pin and the two branches below are the real proof.
+                    let verdict = {
                         match LightClientBootstrap::decode(&d.ssz_payload) {
                             Err(e) => Err(format!("bootstrap did not decode: {e}")),
                             Ok(b) if b.header.beacon.hash_tree_root() != config.checkpoint_root => {
@@ -296,14 +316,12 @@ async fn every_pinned_cl_peer_serves_this_builds_anchor() {
                                     Err(_) => Err("timeout".to_string()),
                                 },
                             );
-                            if matches!(&updates, Some(Ok(raw))
-                                if raw.first() == Some(&codec::RESULT_SUCCESS))
-                            {
+                            if matches!(&updates, Some(Ok(raw)) if served_an_update(raw)) {
                                 break;
                             }
                         }
                         match updates.expect("the loop always sets it") {
-                            Ok(raw) if raw.first() == Some(&codec::RESULT_SUCCESS) => {
+                            Ok(raw) if served_an_update(&raw) => {
                                 alive += 1;
                                 eprintln!(
                                     "[pins] OK   {addr} (bootstrap {} B, serves period {period})",
@@ -313,8 +331,9 @@ async fn every_pinned_cl_peer_serves_this_builds_anchor() {
                             other => {
                                 let why = match other {
                                     Ok(raw) => format!(
-                                        "result code {}",
-                                        raw.first().copied().unwrap_or(255)
+                                        "result code {}, {} B, no decodable update",
+                                        raw.first().copied().unwrap_or(255),
+                                        raw.len()
                                     ),
                                     Err(e) => e,
                                 };

--- a/rust/myotis-net/tests/live_pins_alive.rs
+++ b/rust/myotis-net/tests/live_pins_alive.rs
@@ -7,7 +7,9 @@
 //! be: the shipped build's servers had moved or gone, every automated check was
 //! green, and a fresh install could not catch up at all.
 //!
-//! It is fast (seconds) and deterministic enough to read at release time:
+//! Seconds when the pins are healthy; a sick one costs up to its retries
+//! (`3 x PIN_TIMEOUT`), and the bootnode test has its own 60 s budget, so a bad
+//! list on a 23-pin network is minutes, not seconds.
 //!
 //! ```bash
 //! NET=gnosis cargo test -p myotis-net --test live_pins_alive -- --ignored --nocapture
@@ -40,9 +42,10 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use libp2p::Multiaddr;
+use myotis_net::codec;
 use myotis_net::reqresp::{self, LocalStatus};
 use myotis_net::status::StatusMessage;
-use myotis_net::{protocols, ChainConfig, SyncHandle};
+use myotis_net::{protocols, ChainConfig, SyncHandle, SyncState};
 
 /// Per-peer dial + identify budget. Generous: a healthy server answers in well
 /// under a second, and a slow-but-alive one must not be reported as dead.
@@ -56,14 +59,27 @@ const PIN_TIMEOUT: Duration = Duration::from_secs(20);
 /// cached bootstraps whenever the fork/blob schedule changes, and starts empty
 /// after a restart, so a single-shot check reports the project's own primary
 /// server as dead on a cold cache. Retry the way a wallet does.
+/// One full roost REFRESH tick (12 s, `roost/src/serve.rs`) plus fetch
+/// headroom: `fill_bootstrap_misses` runs once per tick, so a shorter backoff
+/// retries BEFORE the fill it is waiting for and reports a cold-but-healthy
+/// server as dead — the false reading this retry exists to remove.
 const MISS_RETRIES: usize = 2;
-const MISS_BACKOFF: Duration = Duration::from_secs(6);
+const MISS_BACKOFF: Duration = Duration::from_secs(15);
+
+/// Gap before re-asking for updates. Light-client servers rate-limit each
+/// protocol separately (Lighthouse: one request per 10 s), so a request issued
+/// immediately after the bootstrap can be closed for quota rather than for
+/// capability — one probe must not condemn a pin.
+const UPDATES_RETRY_BACKOFF: Duration = Duration::from_secs(11);
 
 /// How long discovery gets to seed its routing table from the bootnodes.
 const DISCOVERY_BUDGET: Duration = Duration::from_secs(60);
 
 /// A routing table this size proves the bootnodes answered and the walk began.
-/// Deliberately low: this asserts "discovery can seed", not "discovery is fast".
+/// Deliberately low: this asserts "discovery can seed", not "discovery is fast"
+/// — and not "this network's peers are findable" either, since the eth2 DHT is
+/// shared and table membership is not fork-filtered (the fork gate applies to
+/// what reaches the pool). The no-pins cold start is what proves findability.
 const MIN_TABLE_ENTRIES: usize = 8;
 
 /// How many pinned peers must serve the anchor for the list to be doing its
@@ -79,6 +95,21 @@ fn config_for_env() -> ChainConfig {
         "sepolia" => ChainConfig::sepolia(),
         "gnosis" => ChainConfig::gnosis(),
         other => panic!("unknown NET {other:?} (want mainnet, sepolia or gnosis)"),
+    }
+}
+
+/// The CL source-selection overrides are applied inside the `ChainConfig`
+/// constructors, so `MYOTIS_CL_STATIC_PEERS` REPLACES the shipped pin list —
+/// a census run with it set is green about peers this build does not ship.
+/// `MYOTIS_CL_DISABLE_DISCV5` likewise empties the bootnodes and makes the
+/// second test panic with the wrong diagnosis.
+fn assert_no_cl_env_overrides() {
+    for var in ["MYOTIS_CL_STATIC_PEERS", "MYOTIS_CL_DISABLE_DISCV5"] {
+        assert!(
+            std::env::var_os(var).is_none(),
+            "{var} is set — it replaces the shipped configuration, so this census would \
+             not be about the peers this build ships. Unset it."
+        );
     }
 }
 
@@ -99,6 +130,7 @@ fn init_tracing() {
 #[ignore = "live network test: dials this build's pinned CL servers"]
 async fn every_pinned_cl_peer_serves_this_builds_anchor() {
     init_tracing();
+    assert_no_cl_env_overrides();
     let config = config_for_env();
     assert!(!config.static_peers.is_empty(), "this network pins no CL peers");
 
@@ -115,7 +147,13 @@ async fn every_pinned_cl_peer_serves_this_builds_anchor() {
     let mut dead = Vec::new();
     let mut alive = 0usize;
     for pin in &config.static_peers {
-        let full: Multiaddr = pin.parse().expect("pinned multiaddr parses");
+        // A malformed pin is a finding, not a reason to lose the other 22 —
+        // `run_sync` itself only warns and skips one.
+        let Ok(full) = pin.parse::<Multiaddr>() else {
+            dead.push(format!("{pin} — unparseable multiaddr"));
+            eprintln!("[pins] BAD  {pin} — unparseable");
+            continue;
+        };
         let mut addr = Multiaddr::empty();
         let mut peer = None;
         for proto in full.iter() {
@@ -125,7 +163,11 @@ async fn every_pinned_cl_peer_serves_this_builds_anchor() {
                 addr.push(proto);
             }
         }
-        let peer = peer.expect("pinned multiaddr carries a peer id");
+        let Some(peer) = peer else {
+            dead.push(format!("{pin} — no /p2p/ peer id"));
+            eprintln!("[pins] BAD  {pin} — no peer id");
+            continue;
+        };
         // `None` until the first attempt runs; the loop below always sets it.
         let mut outcome = None;
         for attempt in 0..=MISS_RETRIES {
@@ -141,31 +183,121 @@ async fn every_pinned_cl_peer_serves_this_builds_anchor() {
                 )
                 .await,
             );
-            // Only a cache MISS is worth retrying: a real bootstrap, a dial
-            // failure and a timeout are all final answers.
+            // Only a cache MISS is worth retrying. Decide that on the eth2
+            // RESULT CODE, never on the response's length: an error chunk is
+            // `code || varint || snappy(msg)`, about 20 B of framing plus the
+            // message, so a 45-character error outweighs any length threshold
+            // — myotis-net's own responder answers
+            // "InvalidRequest: bootstrap root must be 32 bytes" in 65 B.
+            // InvalidRequest and ServerError are final answers; only
+            // ResourceUnavailable is the miss roost fills in the background.
+            // Byte 0 of an eth2 response frame IS the result code, so read it
+            // rather than measuring the frame: an error chunk is
+            // `code || varint || snappy(msg)`, roughly 20 B of framing plus the
+            // message, so a 45-character error outweighs any length threshold
+            // — myotis-net's own responder answers
+            // "InvalidRequest: bootstrap root must be 32 bytes" in 65 B.
+            // InvalidRequest and ServerError are final; only
+            // ResourceUnavailable is the miss roost fills in the background.
             match &outcome {
-                Some(Ok(Ok(raw))) if raw.len() <= 64 => continue,
+                Some(Ok(Ok(raw))) if raw.first() == Some(&codec::RESULT_RESOURCE_UNAVAILABLE) => {
+                    continue
+                }
                 _ => break,
             }
         }
         match outcome.expect("the retry loop always runs at least once") {
-            Ok(Ok(raw)) if raw.len() > 64 => {
-                alive += 1;
-                eprintln!("[pins] OK   {addr} ({} B bootstrap)", raw.len());
-            }
-            Ok(Ok(raw)) => {
-                // Answered, but never with a bootstrap even after the retries:
-                // it does not hold our anchor, or it refuses light-client
-                // requests. `raw[0]` is the eth2 result code (3 =
-                // ResourceUnavailable, which for roost means a cache miss its
-                // background fetch did not fill in time).
-                let code = raw.first().copied().unwrap_or(255);
-                dead.push(format!(
-                    "{pin} — answered {} B with result code {code}, not a bootstrap",
-                    raw.len()
-                ));
-                eprintln!("[pins] THIN {addr} ({} B, code {code})", raw.len());
-            }
+            Ok(Ok(raw)) => match codec::decode_response(&raw, true) {
+                Ok(d) if !d.ssz_payload.is_empty() => {
+                    // A decodable success chunk, and its context bytes name the
+                    // fork it was framed under — check that too, or "the fork
+                    // digest agrees" is a claim nothing verifies.
+                    let ours = config.current_fork_digest();
+                    if d.fork_digest != ours {
+                        dead.push(format!(
+                            "{pin} — served a bootstrap framed for fork {:02x?}, we speak {ours:02x?}",
+                            d.fork_digest
+                        ));
+                        eprintln!("[pins] FORK {addr} ({:02x?} != {ours:02x?})", d.fork_digest);
+                    } else {
+                        // #422 was "cannot CATCH UP", which needs
+                        // updates_by_range — a server that bootstraps and then
+                        // refuses updates strands a stale install just as
+                        // thoroughly, so ask for one period before calling it
+                        // alive. count=1: Lighthouse's quota refuses more.
+                        let period = config.checkpoint_slot / config.slots_per_period();
+                        let mut req = Vec::with_capacity(16);
+                        req.extend_from_slice(&period.to_le_bytes());
+                        req.extend_from_slice(&1u64.to_le_bytes());
+                        // Retry once: these servers rate-limit per protocol
+                        // and a request issued straight after the bootstrap can
+                        // be closed for quota rather than capability. One
+                        // probe must not condemn a pin.
+                        // `Ok(bytes)` once a server answered, `Err(reason)`
+                        // otherwise; the loop always sets it.
+                        let mut updates: Option<Result<Vec<u8>, String>> = None;
+                        for attempt in 0..2 {
+                            if attempt > 0 {
+                                tokio::time::sleep(UPDATES_RETRY_BACKOFF).await;
+                            }
+                            updates = Some(
+                                match tokio::time::timeout(
+                                    PIN_TIMEOUT,
+                                    client.request_raw(
+                                        peer,
+                                        addr.clone(),
+                                        protocols::UPDATES_BY_RANGE,
+                                        codec::encode_request(&req),
+                                    ),
+                                )
+                                .await
+                                {
+                                    Ok(Ok(raw)) => Ok(raw),
+                                    Ok(Err(e)) => Err(e.to_string()),
+                                    Err(_) => Err("timeout".to_string()),
+                                },
+                            );
+                            if matches!(&updates, Some(Ok(raw))
+                                if raw.first() == Some(&codec::RESULT_SUCCESS))
+                            {
+                                break;
+                            }
+                        }
+                        match updates.expect("the loop always sets it") {
+                            Ok(raw) if raw.first() == Some(&codec::RESULT_SUCCESS) => {
+                                alive += 1;
+                                eprintln!(
+                                    "[pins] OK   {addr} (bootstrap {} B, serves period {period})",
+                                    d.ssz_payload.len()
+                                );
+                            }
+                            other => {
+                                let why = match other {
+                                    Ok(raw) => format!(
+                                        "result code {}",
+                                        raw.first().copied().unwrap_or(255)
+                                    ),
+                                    Err(e) => e,
+                                };
+                                dead.push(format!(
+                                    "{pin} — bootstraps, but refused updates_by_range({period}): {why}"
+                                ));
+                                eprintln!("[pins] HALF {addr} — bootstrap ok, no updates ({why})");
+                            }
+                        }
+                    }
+                }
+                Ok(_) => {
+                    dead.push(format!("{pin} — success code with an empty payload"));
+                    eprintln!("[pins] THIN {addr} — empty payload");
+                }
+                Err(e) => {
+                    // Includes ResourceUnavailable that the retries did not
+                    // outlast: roost's background fill is not keeping up.
+                    dead.push(format!("{pin} — {e}"));
+                    eprintln!("[pins] THIN {addr} — {e}");
+                }
+            },
             Ok(Err(e)) => {
                 dead.push(format!("{pin} — {e}"));
                 eprintln!("[pins] DEAD {addr} — {e}");
@@ -209,6 +341,7 @@ async fn every_pinned_cl_peer_serves_this_builds_anchor() {
 #[ignore = "live network test: seeds discv5 from this build's bootnodes"]
 async fn the_bootnodes_can_seed_discovery() {
     init_tracing();
+    assert_no_cl_env_overrides();
     let mut config = config_for_env();
     let bootnodes = config.bootstrap_enrs.len();
     assert!(bootnodes > 0, "this network configures no CL bootnodes");
@@ -220,16 +353,28 @@ async fn the_bootnodes_can_seed_discovery() {
     let handle = SyncHandle::start(config).expect("sync start");
     let deadline = tokio::time::Instant::now() + DISCOVERY_BUDGET;
     let mut best = 0usize;
+    let mut parked = false;
     while tokio::time::Instant::now() < deadline {
         tokio::time::sleep(Duration::from_secs(5)).await;
-        best = best.max(handle.status().discv5_table_size);
-        eprintln!("[bootnodes] discv5 table: {best}");
+        let s = handle.status();
+        // A stale-anchor park publishes a fresh status whose table size is 0,
+        // so without this the run would report healthy discovery as dead —
+        // and this test is run beside the release's checkpoint question,
+        // which is exactly when the anchor may be past the bound.
+        parked |= s.state == SyncState::StaleAnchor;
+        best = best.max(s.discv5_table_size);
+        eprintln!("[bootnodes] state={} discv5 table: {best}", s.state);
         if best >= MIN_TABLE_ENTRIES {
             break;
         }
     }
     handle.stop().await;
 
+    assert!(
+        !parked || best >= MIN_TABLE_ENTRIES,
+        "parked in STALE_ANCHOR, which publishes an empty table, so discovery was never \
+         measured — refresh this network's checkpoint (release question 1) and re-run"
+    );
     assert!(
         best >= MIN_TABLE_ENTRIES,
         "discv5 reached only {best} routing-table entries in {:?} from {bootnodes} configured \

--- a/rust/myotis-net/tests/live_pins_alive.rs
+++ b/rust/myotis-net/tests/live_pins_alive.rs
@@ -1,0 +1,206 @@
+//! Are this build's configured CL peers and bootnodes actually alive?
+//!
+//! This is NOT a cold-start test and does not overlap `live_cold_start.rs`,
+//! which deliberately blackholes every pin to prove discovery survives without
+//! them. That test is blind to whether the real pins answer. This one asks
+//! exactly that, because a silently rotted pin list is what #422 turned out to
+//! be: the shipped build's servers had moved or gone, every automated check was
+//! green, and a fresh install could not catch up at all.
+//!
+//! It is fast (seconds) and deterministic enough to read at release time:
+//!
+//! ```bash
+//! NET=gnosis cargo test -p myotis-net --test live_pins_alive -- --ignored --nocapture
+//! ```
+//!
+//! **Read the census, do not just read the exit code.** These are third-party
+//! servers, so some are always down, and the run is only as trustworthy as the
+//! host it runs from: a machine whose IP a Lighthouse node has banned sees that
+//! node as `dial failed` even though it is healthy for everyone else (that ban
+//! is what #422 was about, and a developer box that ran a pre-gossipsub build
+//! carries it for 12 h). So the gate is a FLOOR — enough pins alive to
+//! actually bootstrap a fresh install — and the per-pin lines above it are the
+//! part a human acts on.
+//!
+//! What each line means:
+//!
+//! * a pin that does not answer — decommissioned, firewalled, or its address
+//!   moved. Re-census it (`examples/period_census.rs`) or drop it.
+//! * a pin that answers but does NOT advertise the light-client protocols —
+//!   it is a beacon node that stopped serving light clients, so it occupies an
+//!   un-evictable pool slot for nothing.
+//! * a pin whose peer ID does not match — the server minted a new key (Nimbus
+//!   does this per restart without `--netkey-file`); the pin is dead even
+//!   though the host is up, and the dial reports `InvalidRemotePubKey` or a
+//!   failed handshake rather than a clean refusal.
+//! * bootnodes below the floor — discovery cannot seed, which strands a fresh
+//!   install even when the pins are fine.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use libp2p::Multiaddr;
+use myotis_net::reqresp::{self, LocalStatus};
+use myotis_net::status::StatusMessage;
+use myotis_net::{protocols, ChainConfig, SyncHandle};
+
+/// Per-peer dial + identify budget. Generous: a healthy server answers in well
+/// under a second, and a slow-but-alive one must not be reported as dead.
+const PIN_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// How long discovery gets to seed its routing table from the bootnodes.
+const DISCOVERY_BUDGET: Duration = Duration::from_secs(60);
+
+/// A routing table this size proves the bootnodes answered and the walk began.
+/// Deliberately low: this asserts "discovery can seed", not "discovery is fast".
+const MIN_TABLE_ENTRIES: usize = 8;
+
+/// How many pinned peers must serve the anchor for the list to be doing its
+/// job. A floor, not "all of them": pins are third-party hosts that come and
+/// go, and requiring a clean sweep would fail for reasons that are not the
+/// pin list's fault — which is how a release check becomes one people skip.
+/// Two is the smallest number that is not a single point of failure.
+const MIN_ALIVE_PINS: usize = 2;
+
+fn config_for_env() -> ChainConfig {
+    match std::env::var("NET").unwrap_or_else(|_| "gnosis".into()).as_str() {
+        "mainnet" => ChainConfig::mainnet(),
+        "sepolia" => ChainConfig::sepolia(),
+        "gnosis" => ChainConfig::gnosis(),
+        other => panic!("unknown NET {other:?} (want mainnet, sepolia or gnosis)"),
+    }
+}
+
+fn init_tracing() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "warn,myotis_net=info".into()),
+        )
+        .try_init();
+}
+
+/// Every pinned CL peer must answer a `light_client_bootstrap` for this build's
+/// own embedded checkpoint root. That is the strongest cheap check: it proves
+/// the host is up, the peer ID still matches, the fork digest agrees, it serves
+/// light clients, AND it still holds the anchor a fresh install starts from.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "live network test: dials this build's pinned CL servers"]
+async fn every_pinned_cl_peer_serves_this_builds_anchor() {
+    init_tracing();
+    let config = config_for_env();
+    assert!(!config.static_peers.is_empty(), "this network pins no CL peers");
+
+    let local = LocalStatus::new(StatusMessage {
+        fork_digest: config.current_fork_digest(),
+        finalized_root: config.checkpoint_root,
+        finalized_epoch: config.checkpoint_slot / config.slots_per_epoch.max(1),
+        head_root: config.checkpoint_root,
+        head_slot: config.checkpoint_slot,
+        earliest_available_slot: 0,
+    });
+    let client = reqresp::start_host(Arc::clone(&local)).expect("host");
+
+    let mut dead = Vec::new();
+    let mut alive = 0usize;
+    for pin in &config.static_peers {
+        let full: Multiaddr = pin.parse().expect("pinned multiaddr parses");
+        let mut addr = Multiaddr::empty();
+        let mut peer = None;
+        for proto in full.iter() {
+            if let libp2p::multiaddr::Protocol::P2p(id) = proto {
+                peer = Some(id);
+            } else {
+                addr.push(proto);
+            }
+        }
+        let peer = peer.expect("pinned multiaddr carries a peer id");
+        let req = myotis_net::codec::encode_request(&config.checkpoint_root);
+        let outcome = tokio::time::timeout(
+            PIN_TIMEOUT,
+            client.request_raw(peer, addr.clone(), protocols::BOOTSTRAP, req),
+        )
+        .await;
+        match outcome {
+            Ok(Ok(raw)) if raw.len() > 64 => {
+                alive += 1;
+                eprintln!("[pins] OK   {addr} ({} B bootstrap)", raw.len());
+            }
+            Ok(Ok(raw)) => {
+                // Answered, but not with a bootstrap: it no longer holds our
+                // anchor, or it refuses light-client requests.
+                dead.push(format!("{pin} — answered {} B, not a bootstrap", raw.len()));
+                eprintln!("[pins] THIN {addr} ({} B)", raw.len());
+            }
+            Ok(Err(e)) => {
+                dead.push(format!("{pin} — {e}"));
+                eprintln!("[pins] DEAD {addr} — {e}");
+            }
+            Err(_) => {
+                dead.push(format!("{pin} — no answer in {PIN_TIMEOUT:?}"));
+                eprintln!("[pins] DEAD {addr} — timeout");
+            }
+        }
+    }
+    client.shutdown().await;
+
+    let total = config.static_peers.len();
+    eprintln!("[pins] {alive} of {total} pinned {} peers served the anchor", config.name);
+    if !dead.is_empty() {
+        // Not a failure by itself — see the header — but always worth a human
+        // look, because a dead pin is not free: it is exempt from eviction, so
+        // it holds a pool slot and a targeted discovery lookup for the life of
+        // the process.
+        eprintln!(
+            "[pins] {} did not serve it; re-census (examples/period_census.rs) or drop them:\n  {}",
+            dead.len(),
+            dead.join("\n  ")
+        );
+    }
+    assert!(
+        alive >= MIN_ALIVE_PINS,
+        "only {alive} of {total} pinned CL peers on {} served this build's anchor (want at \
+         least {MIN_ALIVE_PINS}) — a fresh install would depend entirely on discovery. \
+         Before treating this as a pin-list problem, check whether THIS host is the \
+         outlier: a Lighthouse node that has banned your IP reports as `dial failed` while \
+         being healthy for everyone else. Dead pins:\n  {}",
+        config.name,
+        dead.join("\n  ")
+    );
+}
+
+/// The bootnodes must be able to seed discovery. Without this a fresh install
+/// has no way into the DHT, which no amount of working pins would fix.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "live network test: seeds discv5 from this build's bootnodes"]
+async fn the_bootnodes_can_seed_discovery() {
+    init_tracing();
+    let mut config = config_for_env();
+    let bootnodes = config.bootstrap_enrs.len();
+    assert!(bootnodes > 0, "this network configures no CL bootnodes");
+    // Remove the pins so the routing table can only have come from bootnodes:
+    // a pinned server's targeted lookup would otherwise mask a dead bootnode
+    // list entirely.
+    config.static_peers.clear();
+
+    let handle = SyncHandle::start(config).expect("sync start");
+    let deadline = tokio::time::Instant::now() + DISCOVERY_BUDGET;
+    let mut best = 0usize;
+    while tokio::time::Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_secs(5)).await;
+        best = best.max(handle.status().discv5_table_size);
+        eprintln!("[bootnodes] discv5 table: {best}");
+        if best >= MIN_TABLE_ENTRIES {
+            break;
+        }
+    }
+    handle.stop().await;
+
+    assert!(
+        best >= MIN_TABLE_ENTRIES,
+        "discv5 reached only {best} routing-table entries in {:?} from {bootnodes} configured \
+         bootnodes (want >= {MIN_TABLE_ENTRIES}) — a fresh install cannot seed discovery, so it \
+         depends entirely on the pins being alive",
+        DISCOVERY_BUDGET
+    );
+}

--- a/rust/myotis-net/tests/live_pins_alive.rs
+++ b/rust/myotis-net/tests/live_pins_alive.rs
@@ -48,6 +48,17 @@ use myotis_net::{protocols, ChainConfig, SyncHandle};
 /// under a second, and a slow-but-alive one must not be reported as dead.
 const PIN_TIMEOUT: Duration = Duration::from_secs(20);
 
+/// A first bootstrap request may legitimately MISS. roost's handler is a pure
+/// cache read — the design forbids I/O on the swarm task — so an uncached root
+/// answers `ResourceUnavailable` and queues a background fetch, expecting the
+/// wallet to retry (`rust/roost/src/store.rs`, "a miss stays
+/// ResourceUnavailable, with a background task filling it"). roost drops its
+/// cached bootstraps whenever the fork/blob schedule changes, and starts empty
+/// after a restart, so a single-shot check reports the project's own primary
+/// server as dead on a cold cache. Retry the way a wallet does.
+const MISS_RETRIES: usize = 2;
+const MISS_BACKOFF: Duration = Duration::from_secs(6);
+
 /// How long discovery gets to seed its routing table from the bootnodes.
 const DISCOVERY_BUDGET: Duration = Duration::from_secs(60);
 
@@ -115,22 +126,45 @@ async fn every_pinned_cl_peer_serves_this_builds_anchor() {
             }
         }
         let peer = peer.expect("pinned multiaddr carries a peer id");
-        let req = myotis_net::codec::encode_request(&config.checkpoint_root);
-        let outcome = tokio::time::timeout(
-            PIN_TIMEOUT,
-            client.request_raw(peer, addr.clone(), protocols::BOOTSTRAP, req),
-        )
-        .await;
-        match outcome {
+        // `None` until the first attempt runs; the loop below always sets it.
+        let mut outcome = None;
+        for attempt in 0..=MISS_RETRIES {
+            if attempt > 0 {
+                eprintln!("[pins] .... {addr} retrying after a miss ({attempt}/{MISS_RETRIES})");
+                tokio::time::sleep(MISS_BACKOFF).await;
+            }
+            let req = myotis_net::codec::encode_request(&config.checkpoint_root);
+            outcome = Some(
+                tokio::time::timeout(
+                    PIN_TIMEOUT,
+                    client.request_raw(peer, addr.clone(), protocols::BOOTSTRAP, req),
+                )
+                .await,
+            );
+            // Only a cache MISS is worth retrying: a real bootstrap, a dial
+            // failure and a timeout are all final answers.
+            match &outcome {
+                Some(Ok(Ok(raw))) if raw.len() <= 64 => continue,
+                _ => break,
+            }
+        }
+        match outcome.expect("the retry loop always runs at least once") {
             Ok(Ok(raw)) if raw.len() > 64 => {
                 alive += 1;
                 eprintln!("[pins] OK   {addr} ({} B bootstrap)", raw.len());
             }
             Ok(Ok(raw)) => {
-                // Answered, but not with a bootstrap: it no longer holds our
-                // anchor, or it refuses light-client requests.
-                dead.push(format!("{pin} — answered {} B, not a bootstrap", raw.len()));
-                eprintln!("[pins] THIN {addr} ({} B)", raw.len());
+                // Answered, but never with a bootstrap even after the retries:
+                // it does not hold our anchor, or it refuses light-client
+                // requests. `raw[0]` is the eth2 result code (3 =
+                // ResourceUnavailable, which for roost means a cache miss its
+                // background fetch did not fill in time).
+                let code = raw.first().copied().unwrap_or(255);
+                dead.push(format!(
+                    "{pin} — answered {} B with result code {code}, not a bootstrap",
+                    raw.len()
+                ));
+                eprintln!("[pins] THIN {addr} ({} B, code {code})", raw.len());
             }
             Ok(Err(e)) => {
                 dead.push(format!("{pin} — {e}"));

--- a/rust/myotis-net/tests/live_pins_alive.rs
+++ b/rust/myotis-net/tests/live_pins_alive.rs
@@ -42,6 +42,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use libp2p::Multiaddr;
+use myotis_consensus::store::LightClientProcessor;
+use myotis_consensus::types::LightClientBootstrap;
+use myotis_consensus::{spec, ssz};
 use myotis_net::codec;
 use myotis_net::reqresp::{self, LocalStatus};
 use myotis_net::status::StatusMessage;
@@ -209,16 +212,52 @@ async fn every_pinned_cl_peer_serves_this_builds_anchor() {
         match outcome.expect("the retry loop always runs at least once") {
             Ok(Ok(raw)) => match codec::decode_response(&raw, true) {
                 Ok(d) if !d.ssz_payload.is_empty() => {
-                    // A decodable success chunk, and its context bytes name the
-                    // fork it was framed under — check that too, or "the fork
-                    // digest agrees" is a claim nothing verifies.
+                    // Framing alone is not evidence. Apply the SAME acceptance
+                    // the production bootstrap path does (sync.rs): the
+                    // checkpoint pin — we chose the root, the peer chose the
+                    // payload — plus both Merkle branches. Without it a
+                    // bootstrap for some other anchor, or bytes that merely
+                    // decompress, would count as a healthy pin that a fresh
+                    // install then rejects.
                     let ours = config.current_fork_digest();
-                    if d.fork_digest != ours {
-                        dead.push(format!(
-                            "{pin} — served a bootstrap framed for fork {:02x?}, we speak {ours:02x?}",
+                    let verdict = if d.fork_digest != ours {
+                        Err(format!(
+                            "served a bootstrap framed for fork {:02x?}, we speak {ours:02x?}",
                             d.fork_digest
-                        ));
-                        eprintln!("[pins] FORK {addr} ({:02x?} != {ours:02x?})", d.fork_digest);
+                        ))
+                    } else {
+                        match LightClientBootstrap::decode(&d.ssz_payload) {
+                            Err(e) => Err(format!("bootstrap did not decode: {e}")),
+                            Ok(b) if b.header.beacon.hash_tree_root() != config.checkpoint_root => {
+                                Err(format!(
+                                    "served a bootstrap for root {}, not our anchor",
+                                    b.header.beacon.hash_tree_root()[..8]
+                                        .iter()
+                                        .map(|x| format!("{x:02x}"))
+                                        .collect::<String>()
+                                ))
+                            }
+                            Ok(b) => {
+                                let depth = b.current_sync_committee_branch.len();
+                                if !ssz::verify_merkle_branch(
+                                    &b.current_sync_committee.hash_tree_root(),
+                                    &b.current_sync_committee_branch,
+                                    depth,
+                                    spec::sync_committee_gindex(depth),
+                                    &b.header.beacon.state_root,
+                                ) {
+                                    Err("sync-committee branch does not verify".to_string())
+                                } else if !LightClientProcessor::verify_execution_branch(&b.header) {
+                                    Err("execution branch does not verify".to_string())
+                                } else {
+                                    Ok(())
+                                }
+                            }
+                        }
+                    };
+                    if let Err(why) = verdict {
+                        dead.push(format!("{pin} — {why}"));
+                        eprintln!("[pins] BAD  {addr} — {why}");
                     } else {
                         // #422 was "cannot CATCH UP", which needs
                         // updates_by_range — a server that bootstraps and then


### PR DESCRIPTION
Closes the two open test items on #422, and adds the check that would have caught it before it shipped. The stall itself was fixed in #424 / #425 / #427; this is what keeps it fixed.

## Three live tests, cheapest first

| Test | What it removes or asks | Measured on gnosis |
|---|---|---|
| `live_pins_alive` | nothing — asks the **real** pins and bootnodes whether they answer | seconds |
| `cold_start_with_every_pinned_peer_unreachable` | every pin configured but blackholed | SYNCED in **95 s** |
| `cold_start_from_an_old_anchor_walks_periods_to_head` | a release-fresh anchor | v0.1.7's anchor, **70 periods walked in 170 s** |

`SyncHandle::start` is already a cold start — the `ChainConfig` constructors set no snapshot path and no CL peer cache, a fresh install's profile and exactly what a warm dispatched smoke run hides — so the cold-start pair needed no new harness, only one crutch removed each.

For scale on the third: #422's own control measured 68 periods in ~280 s against a single dedicated endpoint.

## Why the pins are blackholed, not cleared

A pinned peer is exempt from eviction (`PeerPool::evict` returns early for `static_ids`, clearing only `fail_counts`). So a dead-but-configured pin keeps its pool slot for the life of the process, keeps taking catch-up fan-out slots, and keeps steering targeted discovery lookups at a server that will never answer. Clearing the list would test a strictly easier case than #422's. The test keeps every peer id and points it at RFC 5737 TEST-NET-3.

## Why `live_pins_alive` exists

Neither cold-start test can tell you whether your **real** pins are alive: one blackholes them deliberately, the other only notices if literally every bootnode is dead. Nothing else did either — and a silently rotted pin list is what #422 turned out to be. So this asks every pinned CL peer for a `light_client_bootstrap` at this build's own embedded anchor. One request proves the host is up, the peer id still matches, the fork digest agrees, it still serves light clients, and it still holds the anchor a fresh install starts from. Then it checks the bootnodes can seed discv5, with the pins removed so a targeted lookup cannot mask a dead list.

**It gates on a floor of two serving pins, not a clean sweep, and the census it prints is the part a human reads.** Running it while writing this showed why: from a dev box 18 of 23 gnosis pins looked dead, and the same servers had answered through a VPN minutes earlier. A Lighthouse node that has banned your IP is indistinguishable from a dead one, and any machine that ran a pre-gossipsub build carries those bans for 12 h — that ban *is* #422. Demanding perfection would make a check people skip.

One finding survived that caveat and is worth a look independently of this PR: **roost answers on all three networks but returns a 39-byte error rather than a bootstrap for the current embedded anchor.**

## What stops these rotting into fake green

Two review rounds' worth, and the branch failed that bar twice before passing it:

- **Anchor depth is asserted against the network's weak-subjectivity bound.** Verified negatively: main's own anchor (3 behind, gnosis bound 3) is rejected with *"a walk that short would have survived the #422 bug"*.
- **The walk is measured off `sync_start_period`**, pinned to the anchor period — not a 5 s poll a fast walk could slip between.
- **A missing anchor fails; it does not return a green `1 passed`.** Empty strings count as missing, and a half-supplied anchor reaches that failure rather than silently skipping the step.
- **A typo'd `NET` refuses** instead of quietly running gnosis. Verified: `NET=mainet` dies with `unknown NET "mainet"`.
- **Both cold-start tests refuse to run with `MYOTIS_CL_STATIC_PEERS` or `MYOTIS_CL_DISABLE_DISCV5` set** — pointing at a known-good server is how #422's reporter built their *control*.
- The documented way to get an old anchor was **wrong in the first revision**: it cited the newest tag, whose checkpoint is the one already on main. It now states the requirement and shows how to find an older release.

## Release routine

All three are now question 3 in CLAUDE.md's release checklist, to be asked before cutting a tag, with the host caveat spelled out and the dispatched workflow preferred because a CI runner is a clean host.

## CI posture

`workflow_dispatch` only, **no schedule**. These dial third-party servers and the sync tests are peer-quota-bound at roughly one update per 10 s per serving peer, so a merge gate would go red for reasons that are not our bug. If you would rather have it scheduled, that is a one-line change.

## Scope limit

Nothing here covers recovery from a **relay address move** — that remains operator-driven by design, and no test can assert otherwise without changing that design.

Also fixes `live_sync`'s `--once` timeout message, which said 15 minutes for a 1500 s budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNMr2LJJVj42AoFLuUk35a
